### PR TITLE
parallelize summarizations, add async llm utils with retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pinecone-client==2.2.1
 redis
 orjson
 Pillow
+pydantic==1.10.7
+tenacity==8.2.1

--- a/scripts/llm_utils.py
+++ b/scripts/llm_utils.py
@@ -1,12 +1,56 @@
+from typing import List, Dict, Optional, Any
+
 import openai
 from config import Config
+import logging
+from pydantic import BaseModel
+from tenacity import retry, wait_random_exponential, stop_after_attempt
+
 cfg = Config()
 
 openai.api_key = cfg.openai_api_key
 
-# Overly simple abstraction until we create something better
-def create_chat_completion(messages, model=None, temperature=None, max_tokens=None)->str:
-    """Create a chat completion using the OpenAI API"""
+
+class ChatRequest(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    message_list: List[Dict[str, str]]
+    model: str = cfg.fast_llm_model
+    max_tokens: Optional[int] = None
+    temperature: float = 0.0
+    deployment_id: Optional[str] = cfg.openai_deployment_id
+    key: Optional[Any] = None
+
+    @classmethod
+    def from_messages(cls, messages: List[Dict[str, str]] | str, model: str = cfg.fast_llm_model,
+                      system_role: Optional[str] = None, key: Optional[Any] = None,
+                      deployment_id: Optional[str] = cfg.openai_deployment_id, max_tokens: Optional[int] = None,
+                      temperature: float = 0.0):
+        if isinstance(messages, str):
+            messages = [{"role": "user", "content": messages}]
+        if system_role:
+            messages.insert(0, {
+                'role': 'system',
+                'content': system_role
+            })
+        return ChatRequest(message_list=messages, model=model, max_tokens=max_tokens, temperature=temperature,
+                           deployment_id=deployment_id, key=key)
+
+
+class ChatResponse(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    request: ChatRequest
+    reply: Optional[str]
+    exception: Optional[BaseException] = None
+
+    def key(self) -> Optional[Any]:
+        return self.request.key
+
+
+def create_chat_completion(messages, model=None, temperature=None, max_tokens=None) -> str:
     if cfg.use_azure:
         response = openai.ChatCompletion.create(
             deployment_id=cfg.openai_deployment_id,
@@ -24,3 +68,48 @@ def create_chat_completion(messages, model=None, temperature=None, max_tokens=No
         )
 
     return response.choices[0].message["content"]
+
+
+async def async_chat_completion(request: ChatRequest, return_exceptions: bool = True) -> ChatResponse:
+    try:
+        logging.debug(f"creating completion for {request.key or request.message_list[-1]['content'][-50:]}")
+        return await _async_chat_completion(request)
+    except Exception as e:
+        if return_exceptions:
+            return ChatResponse(request=request, reply=None, exception=e)
+        else:
+            logging.exception(f'async_chat_completion {e}')
+            raise e
+
+
+@retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
+async def _async_chat_completion(request: ChatRequest) -> ChatResponse:
+    if request.deployment_id:
+        response = openai.ChatCompletion.create(
+            deployment_id=request.deployment_id,
+            temperature=request.temperature,
+            max_tokens=request.max_tokens,
+            top_p=1,
+            frequency_penalty=0,
+            presence_penalty=0,
+            model=request.model,
+            messages=request.message_list,
+        )
+    else:
+        response = openai.ChatCompletion.create(
+            temperature=request.temperature,
+            max_tokens=request.max_tokens,
+            top_p=1,
+            frequency_penalty=0,
+            presence_penalty=0,
+            model=request.model,
+            messages=request.message_list,
+        )
+    content = dict(list(dict(response.items())["choices"])[0])["message"]["content"]
+    return ChatResponse(request=request, reply=content)
+
+
+@retry(wait=wait_random_exponential(min=1, max=60), stop=stop_after_attempt(6))
+def get_embedding(text, model="text-embedding-ada-002"):
+    text = text.replace("\n", " ")
+    return openai.Embedding.create(input=[text], model=model)["data"][0]["embedding"]

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import random
 import commands as cmd
@@ -27,6 +28,8 @@ def configure_logging():
                     level=logging.DEBUG)
     return logging.getLogger('AutoGPT')
 
+logger = configure_logging()
+
 def check_openai_api_key():
     """Check if the OpenAI API key is set in config.py or as an environment variable."""
     if not cfg.openai_api_key:
@@ -45,8 +48,7 @@ def print_to_console(
         min_typing_speed=0.05,
         max_typing_speed=0.01):
     """Prints text to the console with a typing effect"""
-    global cfg
-    global logger
+
     if speak_text and cfg.speak_mode:
         speak.say_text(f"{title}. {content}")
     print(title_color + title + " " + Style.RESET_ALL, end="")
@@ -293,7 +295,7 @@ def parse_arguments():
     if args.gpt3only:
         print_to_console("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_smart_llm_model(cfg.fast_llm_model)
-    
+
     if args.gpt4only:
         print_to_console("GPT4 Only Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_fast_llm_model(cfg.smart_llm_model)
@@ -302,94 +304,94 @@ def parse_arguments():
         print_to_console("Debug Mode: ", Fore.GREEN, "ENABLED")
         cfg.set_debug_mode(True)
 
+async def main_loop():
+    # TODO: fill in llm values here
+    check_openai_api_key()
+    cfg = Config()
 
-# TODO: fill in llm values here
-check_openai_api_key()
-cfg = Config()
-logger = configure_logging()
-parse_arguments()
-ai_name = ""
-prompt = construct_prompt()
-# print(prompt)
-# Initialize variables
-full_message_history = []
-result = None
-next_action_count = 0
-# Make a constant:
-user_input = "Determine which next command to use, and respond using the format specified above:"
+    parse_arguments()
+    ai_name = ""
+    prompt = construct_prompt()
+    # print(prompt)
+    # Initialize variables
+    full_message_history = []
+    result = None
+    next_action_count = 0
+    # Make a constant:
+    user_input = "Determine which next command to use, and respond using the format specified above:"
 
-# Initialize memory and make sure it is empty.
-# this is particularly important for indexing and referencing pinecone memory
-memory = get_memory(cfg, init=True)
-print('Using memory of type: ' + memory.__class__.__name__)
+    # Initialize memory and make sure it is empty.
+    # this is particularly important for indexing and referencing pinecone memory
+    memory = get_memory(cfg, init=True)
+    print('Using memory of type: ' + memory.__class__.__name__)
 
-# Interaction Loop
-while True:
-    # Send message to AI, get response
-    with Spinner("Thinking... "):
-        assistant_reply = chat.chat_with_ai(
-            prompt,
-            user_input,
-            full_message_history,
-            memory,
-            cfg.fast_token_limit) # TODO: This hardcodes the model to use GPT3.5. Make this an argument
+    # Interaction Loop
+    while True:
+        # Send message to AI, get response
+        with Spinner("Thinking... "):
+            assistant_reply = await chat.chat_with_ai(
+                prompt,
+                user_input,
+                full_message_history,
+                memory,
+                cfg.fast_token_limit) # TODO: This hardcodes the model to use GPT3.5. Make this an argument
 
-    # Print Assistant thoughts
-    print_assistant_thoughts(assistant_reply)
+        # Print Assistant thoughts
+        print_assistant_thoughts(assistant_reply)
 
-    # Get command name and arguments
-    try:
-        command_name, arguments = cmd.get_command(assistant_reply)
-    except Exception as e:
-        print_to_console("Error: \n", Fore.RED, str(e))
+        # Get command name and arguments
+        try:
+            command_name, arguments = cmd.get_command(assistant_reply)
+        except Exception as e:
+            print_to_console("Error: \n", Fore.RED, str(e))
 
-    if not cfg.continuous_mode and next_action_count == 0:
-        ### GET USER AUTHORIZATION TO EXECUTE COMMAND ###
-        # Get key press: Prompt the user to press enter to continue or escape
-        # to exit
-        user_input = ""
-        print_to_console(
-            "NEXT ACTION: ",
-            Fore.CYAN,
-            f"COMMAND = {Fore.CYAN}{command_name}{Style.RESET_ALL}  ARGUMENTS = {Fore.CYAN}{arguments}{Style.RESET_ALL}")
-        print(
-            f"Enter 'y' to authorise command, 'y -N' to run N continuous commands, 'n' to exit program, or enter feedback for {ai_name}...",
-            flush=True)
-        while True:
-            console_input = utils.clean_input(Fore.MAGENTA + "Input:" + Style.RESET_ALL)
-            if console_input.lower() == "y":
-                user_input = "GENERATE NEXT COMMAND JSON"
-                break
-            elif console_input.lower().startswith("y -"):
-                try:
-                    next_action_count = abs(int(console_input.split(" ")[1]))
-                    user_input = "GENERATE NEXT COMMAND JSON"
-                except ValueError:
-                    print("Invalid input format. Please enter 'y -n' where n is the number of continuous tasks.")
-                    continue
-                break
-            elif console_input.lower() == "n":
-                user_input = "EXIT"
-                break
-            else:
-                user_input = console_input
-                command_name = "human_feedback"
-                break
-
-        if user_input == "GENERATE NEXT COMMAND JSON":
+        if not cfg.continuous_mode and next_action_count == 0:
+            ### GET USER AUTHORIZATION TO EXECUTE COMMAND ###
+            # Get key press: Prompt the user to press enter to continue or escape
+            # to exit
+            user_input = ""
             print_to_console(
-            "-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-=",
-            Fore.MAGENTA,
-            "")
-        elif user_input == "EXIT":
-            print("Exiting...", flush=True)
-            break
-    else:
-        # Print command
-        print_to_console(
-            "NEXT ACTION: ",
-            Fore.CYAN,
-            f"COMMAND = {Fore.CYAN}{command_name}{Style.RESET_ALL}  ARGUMENTS = {Fore.CYAN}{arguments}{Style.RESET_ALL}")
+                "NEXT ACTION: ",
+                Fore.CYAN,
+                f"COMMAND = {Fore.CYAN}{command_name}{Style.RESET_ALL}  ARGUMENTS = {Fore.CYAN}{arguments}{Style.RESET_ALL}")
+            print(
+                f"Enter 'y' to authorise command, 'y -N' to run N continuous commands, 'n' to exit program, or enter feedback for {ai_name}...",
+                flush=True)
+            while True:
+                console_input = utils.clean_input(Fore.MAGENTA + "Input:" + Style.RESET_ALL)
+                if console_input.lower() == "y":
+                    user_input = "GENERATE NEXT COMMAND JSON"
+                    break
+                elif console_input.lower().startswith("y -"):
+                    try:
+                        next_action_count = abs(int(console_input.split(" ")[1]))
+                        user_input = "GENERATE NEXT COMMAND JSON"
+                    except ValueError:
+                        print("Invalid input format. Please enter 'y -n' where n is the number of continuous tasks.")
+                        continue
+                    break
+                elif console_input.lower() == "n":
+                    user_input = "EXIT"
+                    break
+                else:
+                    user_input = console_input
+                    command_name = "human_feedback"
+                    break
+
+            if user_input == "GENERATE NEXT COMMAND JSON":
+                print_to_console(
+                "-=-=-=-=-=-=-= COMMAND AUTHORISED BY USER -=-=-=-=-=-=-=",
+                Fore.MAGENTA,
+                "")
+            elif user_input == "EXIT":
+                print("Exiting...", flush=True)
+                break
+        else:
+            # Print command
+            print_to_console(
+                "NEXT ACTION: ",
+                Fore.CYAN,
+                f"COMMAND = {Fore.CYAN}{command_name}{Style.RESET_ALL}  ARGUMENTS = {Fore.CYAN}{arguments}{Style.RESET_ALL}")
 
     # Execute command
     if command_name is not None and command_name.lower().startswith( "error" ):
@@ -397,23 +399,27 @@ while True:
     elif command_name == "human_feedback":
         result = f"Human feedback: {user_input}"
     else:
-        result = f"Command {command_name} returned: {cmd.execute_command(command_name, arguments)}"
+        command_result = await cmd.execute_command(command_name, arguments)
+        result = f"Command {command_name} returned: {command_result}"
         if next_action_count > 0:
             next_action_count -= 1
 
-    memory_to_add = f"Assistant Reply: {assistant_reply} " \
-                    f"\nResult: {result} " \
-                    f"\nHuman Feedback: {user_input} "
+        memory_to_add = f"Assistant Reply: {assistant_reply} " \
+                        f"\nResult: {result} " \
+                        f"\nHuman Feedback: {user_input} "
 
-    memory.add(memory_to_add)
+        memory.add(memory_to_add)
 
-    # Check if there's a result from the command append it to the message
-    # history
-    if result is not None:
-        full_message_history.append(chat.create_chat_message("system", result))
-        print_to_console("SYSTEM: ", Fore.YELLOW, result)
-    else:
-        full_message_history.append(
-            chat.create_chat_message(
-                "system", "Unable to execute command"))
-        print_to_console("SYSTEM: ", Fore.YELLOW, "Unable to execute command")
+        # Check if there's a result from the command append it to the message
+        # history
+        if result is not None:
+            full_message_history.append(chat.create_chat_message("system", result))
+            print_to_console("SYSTEM: ", Fore.YELLOW, result)
+        else:
+            full_message_history.append(
+                chat.create_chat_message(
+                    "system", "Unable to execute command"))
+            print_to_console("SYSTEM: ", Fore.YELLOW, "Unable to execute command")
+
+if __name__ == "__main__":
+    asyncio.run(main_loop())

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,0 +1,135 @@
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import List, Optional
+
+from browse import scrape_text, scrape_links, summarize_text, TextSummary
+from config import Config
+from duckduckgo_search import ddg
+import logging
+
+cfg = Config()
+
+
+@dataclass
+class SearchResult:
+    query: str
+    answer: str
+    source: str
+
+
+def google_search(query, num_results=8):
+    search_results = []
+    for j in ddg(query, max_results=num_results):
+        search_results.append(j)
+
+    return json.dumps(search_results, ensure_ascii=False, indent=4)
+
+
+def google_official_search(query, num_results=8) -> Optional[List[str]]:
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+    import json
+
+    try:
+        # Get the Google API key and Custom Search Engine ID from the config file
+        api_key = cfg.google_api_key
+        custom_search_engine_id = cfg.custom_search_engine_id
+
+        # Initialize the Custom Search API service
+        service = build("customsearch", "v1", developerKey=api_key)
+
+        # Send the search query and retrieve the results
+        result = service.cse().list(q=query, cx=custom_search_engine_id, num=num_results).execute()
+
+        # Extract the search result items from the response
+        search_results = result.get("items", [])
+
+        # Create a list of only the URLs from the search results
+        search_results_links = [item["link"] for item in search_results]
+        # Return the list of search result URLs
+        return search_results_links
+    except HttpError as e:
+        # Handle errors in the API call
+        error_details = json.loads(e.content.decode())
+
+        # Check if the error is related to an invalid or missing API key
+        if error_details.get("error", {}).get("code") == 403 and "invalid API key" in error_details.get("error",
+                                                                                                        {}).get(
+            "message", ""):
+            logging.error("Error: The provided Google API key is invalid or missing.")
+        else:
+            logging.error(f"Error: {e}")
+        return None
+
+
+async def browse_website(url, question):
+    summary = await get_text_summary(url, question)
+    links = get_hyperlinks(url)
+
+    # Limit links to 5
+    if len(links) > 5:
+        links = links[:5]
+
+    result = f"""Website Content Summary: {summary}\n\nLinks: {links}"""
+
+    return result
+
+
+async def get_text_summary(url, question) -> str:
+    result = await get_text_summaries(url, question)
+    if result:
+        return """ "Result" : """ + result.answer
+    else:
+        return """ "Result" : """ + 'Failed'
+
+
+async def get_text_summaries(urls: List[str] | str, question: str, num_sources: int = 1, max_tokens: int = 300) -> \
+        Optional[
+            List[SearchResult] | SearchResult]:
+    results = []
+    if isinstance(urls, str):
+        urls = [urls]
+
+    async def summarize_source(url: str):
+        text = scrape_text(url)
+        if not text:
+            return None
+        logging.debug(f'Summarizing {url}')
+        return await summarize_text(text=text, question=question, source=url, max_tokens=max_tokens)
+
+    results = []
+
+    async def add_summaries(start: int, end: int):
+        tasks = [
+            summarize_source(url) for url in urls[start:end]]
+        gathered_results = await asyncio.gather(*tasks, return_exceptions=True)
+        results.extend([
+            SearchResult(source=r.source, query=question, answer=r.summary) for r in gathered_results if
+            isinstance(r, TextSummary)
+        ])
+
+    start_source_index = 0
+    for end_source_index in range(min(len(urls), num_sources), len(urls) + 1):
+        await add_summaries(start_source_index, end_source_index)
+        if len(results) >= num_sources:
+            break
+        start_source_index = end_source_index
+
+    if not results:
+        return None
+    elif len(results) == 1:
+        return results[0]
+    else:
+        return results
+
+
+def get_hyperlinks(url):
+    link_list = scrape_links(url)
+    return link_list
+
+
+async def get_search_results(query, return_results: int = 1, num_search: int = 8, max_tokens=300) -> Optional[
+    List[SearchResult] | SearchResult]:
+    links = google_official_search(query, num_search)
+    return await get_text_summaries(links, question=query, num_sources=return_results, max_tokens=max_tokens)

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,19 @@
+import unittest
+
+from config import Config
+from dotenv import load_dotenv
+import logging
+from scripts.llm_utils import create_chat_completion
+
+load_dotenv()
+
+cfg = Config()
+
+
+class TestLLMUtils(unittest.TestCase):
+
+    def test_create_completion(self):
+        messages = [{"role": "user", "content": "Give a brief overview of GPT Large Language Models"}, ]
+        result = create_chat_completion(model=cfg.fast_llm_model, messages=messages)
+        logging.info(result)
+        assert len(result) > 200

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,29 @@
+import asyncio
+import pprint
+import unittest
+import logging
+from dotenv import load_dotenv
+from scripts.search import google_official_search, get_text_summaries, get_text_summary
+
+load_dotenv()
+
+
+class TestSearch(unittest.TestCase):
+
+    def test_google_official_search(self):
+        links = google_official_search('What is the situation with Trump indictments?', 3)
+        assert len(links) == 3
+
+    def test_search_and_summarize(self):
+        question = 'What is the situation with the Trump indictments?'
+        links = google_official_search(question, 3)
+        answer = asyncio.run(get_text_summary(links[1], question=question))
+
+        assert "Result" in answer
+
+    def test_search_and_summarize_multiple_sources(self):
+        question = 'What is the situation with the Trump indictments?'
+        links = google_official_search(question, num_results=5)
+        answers = asyncio.run(get_text_summaries(links, question=question, num_sources=3))
+        logging.info(pprint.pformat(answers))
+        assert len(answers) == 3


### PR DESCRIPTION
### Background

I am using Auto-GPT search, browse and summarize code in another project and using this parallelization of single url summarization and summarizing multiple urls. 
As most of the processing is IO bound I find this approach to be useful.


### Changes

* Added ChatRequest class which encapsulates openai.ChatCompletion parameters and adds an optional key to requests.
* Added ChatResponse class which encapsulates a ChatRequest and its reply (or Exception)
* Added async_chat_completion to llm_utils with ChatRequest input ChatResponse output
* Changed summarize_text to be async, parallelizing chunks summarizations.
* Created a search file and moved relevant functions into it from commands
* Made get_text_summary async. Can be used to summarize multiple urls in parallel depending on num_sources requested (default is 1)
* Moved main loop into an async function to be asyncio.run from  main.
* Had an issue with Pinecone memory clear() so put it in try/except

### Test Plan

test_search - test_search_and_summarize_multiple_sources get 5 links from google_official_search and creates summaries from 3. It fails on the NYT and generates the third summary from the 4th url. (can't really build on this flow)


### Change Safety

- [x] I have added tests to cover my changes
- [x] I have considered potential risks and mitigations for my changes

I ran main with --continuous for a while it was stable.

