### PR TITLE
Add concept of multiple LLM providers and add anthropic as example

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,11 @@ AI_SETTINGS_FILE=ai_settings.yaml
 ### LLM PROVIDER
 ################################################################################
 
+## LLM Provider type
+# openai - Default
+# anthropic - Anthropic (if configured)
+LLM_PROVIDER=openai
+
 ### OPENAI
 # OPENAI_API_KEY - OpenAI API Key (Example: my-openai-api-key)
 # TEMPERATURE - Sets temperature in OpenAI (Default: 0)
@@ -24,6 +29,10 @@ AI_SETTINGS_FILE=ai_settings.yaml
 OPENAI_API_KEY=your-openai-api-key
 TEMPERATURE=0
 USE_AZURE=False
+
+### ANTHROPIC
+# ANTHROPIC_API_KEY - Anthropic API Key (Example: my-openai-api-key)
+ANTHROPIC_API_KEY=your-anthropic-api-key
 
 ### AZURE
 # cleanup azure env as already moved to `azure.yaml.template`

--- a/autogpt/cli.py
+++ b/autogpt/cli.py
@@ -77,7 +77,9 @@ def main(
     if ctx.invoked_subcommand is None:
         cfg = Config()
         # TODO: fill in llm values here
-        check_openai_api_key()
+        if cfg.llm_provider == 'openai':
+            check_openai_api_key()
+
         create_config(
             continuous,
             continuous_limit,

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -33,7 +33,11 @@ class Config(metaclass=Singleton):
         self.smart_token_limit = int(os.getenv("SMART_TOKEN_LIMIT", 8000))
         self.browse_chunk_max_length = int(os.getenv("BROWSE_CHUNK_MAX_LENGTH", 8192))
 
+        self.llm_provider = os.getenv("LLM_PROVIDER", "openai")
+
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+
         self.temperature = float(os.getenv("TEMPERATURE", "1"))
         self.use_azure = os.getenv("USE_AZURE") == "True"
         self.execute_local_commands = (

--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -105,7 +105,7 @@ def create_chat_completion(
                     prompt=f"{anthropic.HUMAN_PROMPT} {messages} {anthropic.AI_PROMPT}",
                     stop_sequences = [anthropic.HUMAN_PROMPT],
                     model="claude-v1",
-                    max_tokens_to_sample=10000000000,
+                    max_tokens_to_sample=1500,
                 )
             break
         except RateLimitError:

--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -104,7 +104,7 @@ def create_chat_completion(
                 response = anthropic_client.completion(
                     prompt=f"{anthropic.HUMAN_PROMPT} {messages} {anthropic.AI_PROMPT}",
                     stop_sequences = [anthropic.HUMAN_PROMPT],
-                    model="claude-v1.3",
+                    model="claude-v1",
                     max_tokens_to_sample=10000000000,
                 )
             break

--- a/autogpt/llm_utils.py
+++ b/autogpt/llm_utils.py
@@ -149,7 +149,7 @@ def create_chat_completion(
     if CFG.llm_provider == "openai":
         return response.choices[0].message["content"]
     if CFG.llm_provider == "anthropic":
-        return response['completion'][0]
+        return response['completion']
 
 
 def create_embedding_with_ada(text) -> list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4
 colorama==0.4.6
 openai==0.27.2
+anthropic
 playsound==1.2.2
 python-dotenv==1.0.0
 pyyaml==6.0


### PR DESCRIPTION
Add general ability to have more than one LLM provider. Tried to keep to current code pattern.

### Background
There is support for multiple memory providers (pinecone, etc.), but there is currently only support for OpenAI.
There are lots of open alternatives and discussion around that, but those all take more effort to add.
As a V1 of next step in supporting more LLM providers, adding a similar company.
This should align with overall direction of not being tied to one provider (OpenAI)

### Changes
-> Adds config for llm_provider
-> Adds Anthropic 

### Documentation
-> Follows same Env template documentation, and similar code patterns, does not create any new functions only adding within existing pattern.
-> Left openai as default, so no changes by default
-> JSON formatting limitations, the JSON clean up / response expectations may be different from GPT / may fail in different ways

### Test Plan
Manually tested. There are some issues with the JSON formatting sometimes, but this appears to be a more general issue and this change should still be aligned with next steps to expand that.

### PR Quality Checklist
- [X] My pull request is atomic and focuses on a single change.
- [X] I have thoroughly tested my changes with multiple different prompts.
- [X] I have considered potential risks and mitigations for my changes.
- [X] I have documented my changes clearly and comprehensively.
- [X] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

