### PR TITLE
Make get_datetime as a Command for Improved Plugin Integration

### DIFF
--- a/autogpt/cli.py
+++ b/autogpt/cli.py
@@ -141,6 +141,7 @@ def main(
         command_registry.import_commands("autogpt.commands.twitter")
         command_registry.import_commands("autogpt.commands.web_selenium")
         command_registry.import_commands("autogpt.commands.write_tests")
+        command_registry.import_commands("autogpt.commands.times")
         command_registry.import_commands("autogpt.app")
         ai_name = ""
         ai_config = construct_main_ai_config()

--- a/autogpt/commands/times.py
+++ b/autogpt/commands/times.py
@@ -1,6 +1,12 @@
 from datetime import datetime
 
+from autogpt.commands.command import command
 
+
+@command(
+    "get_times",
+    "Get Times",
+)
 def get_datetime() -> str:
     """Return the current date and time
 


### PR DESCRIPTION
### Background
In the current implementation of the plugin support system, there are two functions called `pre_command` and `post_command`. The `pre_command` function is used to process a command before it is executed, and the `post_command` function is called after the command is executed. To use a plugin for a specific task, such as using other search engines to search the internet, the search result should be sent to the bot, but the command is still required to be returned for the `pre_command` function.

I tried to return the command "do_nothing," but the problem is when the returned command is "do_nothing," it prevents any message from being sent to the AI bot or any further operations. Also, other registered commands in the program are unrelated to the desired task. 

To address this issue, this pull request converts the existing get_datetime function into a command. For plugin developers, returning `get_times` in the `pre_command` function can be used as a void return but continue performing the following task(unlike `do_nothing`). Without changing the structure of the main repo or the plugin repo, this approach minimizes the changes required to the existing codebase while providing the desired functionality.

### Changes
1. Converted the existing get_datetime function into a command in the command folder.
2. Updated the configuration file to import the "autogpt.commands.times" command module

### Documentation

### Test Plan
I have used a developed plugin to test the modification.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes