### PR TITLE
More control over flow ( interrupt command JIT  + choose commands to ignore/stop on + stop when looping )

### DIFF
--- a/autogpt/app/spinner.py
+++ b/autogpt/app/spinner.py
@@ -1,8 +1,33 @@
 """A simple spinner module"""
+import io
 import itertools
+import os
+import select
 import sys
 import threading
-import time
+import types
+from typing import Any, Callable, List, Optional
+
+if os.name == "nt":
+    import keyboard
+
+
+class SpinnerInterrupted(Exception):
+    pass
+
+
+class RaisingThread(threading.Thread):
+    def run(self) -> None:
+        self._exc = None
+        try:
+            super().run()
+        except Exception as e:
+            self._exc = e
+
+    def join(self, timeout=None) -> None:  # type: ignore
+        super().join(timeout=timeout)
+        if self._exc:
+            raise self._exc
 
 
 class Spinner:
@@ -13,6 +38,8 @@ class Spinner:
         message: str = "Loading...",
         delay: float = 0.1,
         plain_output: bool = False,
+        interruptable: bool = False,
+        on_soft_interrupt: Optional[Callable] = None,
     ) -> None:
         """Initialize the spinner class
 
@@ -26,45 +53,107 @@ class Spinner:
         self.delay = delay
         self.message = message
         self.running = False
-        self.spinner_thread = None
+        self.spinner_thread: Optional[RaisingThread] = None
+        self.interruptable = interruptable
+        self.on_soft_interrupt = on_soft_interrupt
+        self.ended = threading.Event()
 
     def spin(self) -> None:
         """Spin the spinner"""
+
+        def key_pressed(
+            pressed_key: Optional[str],
+            key_to_check: Optional[str],
+            keyboard_key: Optional[str] = None,
+        ) -> bool:
+            if keyboard_key is None:
+                keyboard_key = key_to_check
+            if (
+                pressed_key
+                and pressed_key == key_to_check
+                or (os.name == "nt" and keyboard.is_pressed(keyboard_key))
+            ):
+                return True
+            return False
+
         if self.plain_output:
             self.print_message()
             return
         while self.running:
             self.print_message()
-            time.sleep(self.delay)
+            if self.interruptable:
+                if (self.oldtty) and sys.stdin in select.select(
+                    [sys.stdin], [], [], 0.0
+                )[0]:
+                    key = sys.stdin.read(1)
+                else:
+                    key = None
+                if key_pressed(key, " ", "space"):
+                    if self.on_soft_interrupt is not None:
+                        self.on_soft_interrupt()
+                elif key_pressed(key, "q"):
+                    self.ended.set()
+                    raise SpinnerInterrupted("Spinner interrupted")
 
-    def print_message(self):
+            if self.ended.wait(self.delay):
+                break
+
+    def print_message(self) -> None:
         sys.stdout.write(f"\r{' ' * (len(self.message) + 2)}\r")
         sys.stdout.write(f"{next(self.spinner)} {self.message}\r")
         sys.stdout.flush()
 
-    def start(self):
+    def start(self) -> None:
+        self.ended.clear()
         self.running = True
-        self.spinner_thread = threading.Thread(target=self.spin)
+        try:
+            import tty
+
+            self.oldtty: Optional[List[Any]] = None
+
+            self.stdin_no = sys.stdin.fileno()
+            tty.setcbreak(self.stdin_no)
+        except io.UnsupportedOperation:
+            self.oldtty = None  #
+        except ModuleNotFoundError:
+            self.oldtty = None
+        except:
+            self.oldtty = None
+
+        self.spinner_thread = RaisingThread(target=self.spin)
         self.spinner_thread.start()
 
-    def stop(self):
-        self.running = False
-        if self.spinner_thread is not None:
-            self.spinner_thread.join()
-        sys.stdout.write(f"\r{' ' * (len(self.message) + 2)}\r")
-        sys.stdout.flush()
+    def stop(self) -> None:
+        self.ended.set()
+        try:
+            if self.spinner_thread is not None:
+                self.spinner_thread.join()
+            self.running = False
+            if self.spinner_thread is not None:
+                self.spinner_thread.join()
+            sys.stdout.write(f"\r{' ' * (len(self.message) + 2)}\r")
+            sys.stdout.flush()
+        finally:
+            if self.oldtty:
+                while sys.stdin in select.select([sys.stdin], [], [], 0.0)[0]:
+                    sys.stdin.read(1)
 
-    def __enter__(self):
+    def __enter__(self) -> "Spinner":
         """Start the spinner"""
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        exc_traceback: Optional[types.TracebackType] = None,
+    ) -> None:
         """Stop the spinner
 
         Args:
-            exc_type (Exception): The exception type.
-            exc_value (Exception): The exception value.
-            exc_traceback (Exception): The exception traceback.
+            exc_type (type[BaseException]): The exception type.
+            exc_value (BaseException): The exception value.
+            exc_traceback (types.TracebackType): The exception traceback.
         """
         self.stop()

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -16,6 +16,8 @@ from autogpt.core.configuration.schema import Configurable, SystemSettings
 from autogpt.llm.providers.openai import OPEN_AI_CHAT_MODELS
 from autogpt.plugins.plugins_config import PluginsConfig
 
+splitifnotnone = lambda x: (x.split(",") if x is not None else [])
+
 AI_SETTINGS_FILE = "ai_settings.yaml"
 AZURE_CONFIG_FILE = "azure.yaml"
 PLUGINS_CONFIG_FILE = "plugins_config.yaml"
@@ -79,6 +81,8 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
     ############
     # General
     disabled_command_categories: list[str] = Field(default_factory=list)
+    commands_to_ignore: list[str] = Field(default_factory=list)
+    commands_to_stop: list[str] = Field(default_factory=list)
     # File ops
     restrict_to_workspace: bool = True
     allow_downloads: bool = False
@@ -275,6 +279,8 @@ class ConfigBuilder(Configurable[Config]):
                 "PLUGINS_CONFIG_FILE", PLUGINS_CONFIG_FILE
             ),
             "chat_messages_enabled": os.getenv("CHAT_MESSAGES_ENABLED") == "True",
+            "commands_to_ignore": splitifnotnone(os.getenv("COMMANDS_TO_IGNORE")),
+            "commands_to_stop": splitifnotnone(os.getenv("COMMANDS_TO_STOP")),
         }
 
         config_dict["disabled_command_categories"] = _safe_split(


### PR DESCRIPTION
<!-- ⚠️ At the moment any non-essential commands are not being merged.
If you want to add non-essential commands to Auto-GPT, please create a plugin instead.
We are expecting to ship plugin support within the week (PR #757).
Resources:
* https://github.com/Significant-Gravitas/Auto-GPT-Plugin-Template
-->

<!-- 📢 Announcement
We've recently noticed an increase in pull requests focusing on combining multiple changes. While the intentions behind these PRs are appreciated, it's essential to maintain a clean and manageable git history. To ensure the quality of our repository, we kindly ask you to adhere to the following guidelines when submitting PRs:

Focus on a single, specific change.
Do not include any unrelated or "extra" modifications.
Provide clear documentation and explanations of the changes made.
Ensure diffs are limited to the intended lines — no applying preferred formatting styles or line endings (unless that's what the PR is about).
For guidance on committing only the specific lines you have changed, refer to this helpful video: https://youtu.be/8-hSNHHbiZg

Check out our [wiki page on Contributing](https://github.com/Significant-Gravitas/Auto-GPT/wiki/Contributing)

By following these guidelines, your PRs are more likely to be merged quickly after testing, as long as they align with the project's overall direction. -->

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
Now it is quite challenging to control the flow. You would need to assume the next N authorised commands are OK, beforehand. If it goes astray, you have nothing to do, but to wait after the batch. 
This commit make it possible to interrupt just in time and define commands that are more and less relevant with regard to batch.
 
### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->
1. Added` config.commands_to_stop` and `config.commands_to_ignore`.

`config.commands_to_stop` would stop after the command anyway.  For example, you might want to stop on task completion, anyway. 

 `config.commands_to_ignore` are commands that authorized automatically and don't increase the counter.

2.  Changed spinner class to allow for interruption

  *  `<space>` in the middle of thinking means soft-interrupt complete execution and ask for user input after execution).  
  * `<q>` means abort - exit task immediately and ask for user input.

  Have two implementation for linux and windows.

  Introduced a function `async_task_and_spin`  to wait for either task completion or interrupt. 

3. Stop if already executed a command

  To do so, it keeps all previously executed commands in set. 

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->
In code 

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->
I just checked the code on my own, saw that both soft and hard interrupts working.
commands_to_stop and to_ignore seems to be working.
There was an error in test_memory_trimmed_from_context that seem unrelated.
```
    memory_found = memory.get_relevant("Important Information", 5)
    assert memory_found[0] == expected_permanent_memory
```
Want to see if it fails on workflow.
### PR Quality Checklist
- [ ] My pull request is atomic and focuses on a single change. (Arguably, you could split this into adding ignore/to stop and adding spinner. But it is part of whole. )
- [x] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->
I didn't add tests because of lack of time. A bit of help is wanted, if you think testing is required for it. 

This is how soft interrupt looks like. It keeps thinking afterwards. 
![image](https://user-images.githubusercontent.com/72234965/236655300-fd7a5eeb-b405-41eb-82b1-c225c9386ef4.png)
