### PR TITLE
multiline prompt with "--path"  and .txt file

### DIFF
--- a/autogpt/setup.py
+++ b/autogpt/setup.py
@@ -59,6 +59,30 @@ def prompt_user() -> AIConfig:
             speak_text=True,
         )
         return generate_aiconfig_manual()
+    
+    if "--path" in user_desire:
+        #remove the --path from the user desire
+        user_desire = user_desire.replace("--path", "")
+        user_desire = user_desire.strip()
+
+        logger.typewriter_log(
+            "Path Mode Selected",
+            Fore.GREEN,
+            speak_text=True,
+        )
+        #try opening the file
+        try:
+            with open(user_desire, "r") as f:
+                true_user_desire = f.read()
+                return generate_aiconfig_automatic(true_user_desire)
+        except Exception as e:
+            logger.typewriter_log(
+                "Unable to open file",
+                Fore.RED,
+                "Falling back to manual mode.",
+                speak_text=True,
+            )
+            return generate_aiconfig_manual()
 
     else:
         try:


### PR DESCRIPTION

### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->

Needed to paste a multline prompt into AutoGPT and didn't want to waste inference steps by telling it to go to a specific file path. 

Added a "--path" command where AutoGPT ask you what you want it to do that accepts that flag and a path to a .txt. file.


I created a .txt file and copied its path, and pasted that path after the --path flag. It worked great.