### PR TITLE
LangChain tool support, file_search as example

### DIFF
--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -8,9 +8,9 @@ import os.path
 from pathlib import Path
 from typing import Generator, Literal
 
-from autogpt.agent.agent import Agent
 from langchain.tools import FileSearchTool
 
+from autogpt.agents import Agent
 from autogpt.command_decorator import command
 from autogpt.logs import logger
 from autogpt.memory.vector import MemoryItem, VectorMemory

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -15,6 +15,7 @@ from autogpt.command_decorator import command
 from autogpt.logs import logger
 from autogpt.memory.vector import MemoryItem, VectorMemory
 from autogpt.models.command import Command
+
 from .decorators import sanitize_path_arg
 from .file_operations_utils import read_textual_file
 

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -8,11 +8,13 @@ import os.path
 from pathlib import Path
 from typing import Generator, Literal
 
-from autogpt.agents.agent import Agent
+from autogpt.agent.agent import Agent
+from langchain.tools import FileSearchTool
+
 from autogpt.command_decorator import command
 from autogpt.logs import logger
 from autogpt.memory.vector import MemoryItem, VectorMemory
-
+from autogpt.models.command import Command
 from .decorators import sanitize_path_arg
 from .file_operations_utils import read_textual_file
 
@@ -338,3 +340,15 @@ def list_files(directory: str, agent: Agent) -> list[str]:
             found_files.append(relative_path)
 
     return found_files
+
+
+def file_search_args(input_args: dict[str, any], agent: Agent):
+    # Force only searching in the workspace root
+    input_args["dir_path"] = str(agent.workspace.root)
+
+    return input_args
+
+
+file_search = Command.generate_from_langchain_tool(
+    tool=FileSearchTool(), arg_converter=file_search_args
+)

--- a/autogpt/commands/file_operations.py
+++ b/autogpt/commands/file_operations.py
@@ -344,7 +344,7 @@ def list_files(directory: str, agent: Agent) -> list[str]:
 
 def file_search_args(input_args: dict[str, any], agent: Agent):
     # Force only searching in the workspace root
-    input_args["dir_path"] = str(agent.workspace.root)
+    input_args["dir_path"] = str(agent.workspace.get_path(input_args["dir_path"]))
 
     return input_args
 

--- a/autogpt/models/command.py
+++ b/autogpt/models/command.py
@@ -1,7 +1,9 @@
 from typing import Any, Callable, Optional
 
-from autogpt.config import Config
+from langchain.tools import BaseTool
 
+from autogpt.config import Config
+from autogpt.logs import logger
 from .command_parameter import CommandParameter
 
 
@@ -47,3 +49,49 @@ class Command:
             for param in self.parameters
         ]
         return f"{self.name}: {self.description}, params: ({', '.join(params)})"
+
+       @classmethod
+    def generate_from_langchain_tool(
+        cls, tool: BaseTool, arg_converter: Optional[Callable] = None
+    ) -> "Command":
+        def wrapper(*args, **kwargs):
+            # a Tool's run function doesn't take an agent as an arg, so just remove that
+            agent = kwargs.pop("agent")
+
+            # Allow the command to do whatever arg conversion it needs
+            if arg_converter:
+                tool_input = arg_converter(kwargs, agent)
+            else:
+                tool_input = kwargs
+
+            logger.debug(f"Running LangChain tool {tool.name} with arguments {kwargs}")
+
+            return tool.run(tool_input=tool_input)
+
+        command = cls(
+            name=tool.name,
+            description=tool.description,
+            method=wrapper,
+            parameters=[
+                CommandParameter(
+                    name=name,
+                    type=schema.get("type"),
+                    description=schema.get("description", schema.get("title")),
+                    required=bool(
+                        tool.args_schema.__fields__[name].required
+                    )  # gives True if `field.required == pydantic.Undefined``
+                    if tool.args_schema
+                    else True,
+                )
+                for name, schema in tool.args.items()
+            ],
+        )
+
+        # Avoid circular import
+        from autogpt.command_decorator import AUTO_GPT_COMMAND_IDENTIFIER
+
+        # Set attributes on the command so that our import module scanner will recognize it
+        setattr(command, AUTO_GPT_COMMAND_IDENTIFIER, True)
+        setattr(command, "command", command)
+
+        return command

--- a/autogpt/models/command.py
+++ b/autogpt/models/command.py
@@ -4,7 +4,7 @@ from langchain.tools import BaseTool
 
 from autogpt.config import Config
 from autogpt.logs import logger
-from .command_parameter import CommandParameter
+from autogpt.models.command_parameter import CommandParameter
 
 
 class Command:
@@ -50,7 +50,7 @@ class Command:
         ]
         return f"{self.name}: {self.description}, params: ({', '.join(params)})"
 
-       @classmethod
+    @classmethod
     def generate_from_langchain_tool(
         cls, tool: BaseTool, arg_converter: Optional[Callable] = None
     ) -> "Command":

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ inflection
 # web server
 fastapi
 uvicorn
+langchain>=0.0.233
 
 ##Dev
 coverage

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -6,13 +6,8 @@ from pathlib import Path
 import pytest
 from langchain.tools import ListDirectoryTool, StructuredTool
 
-<<<<<<< HEAD
+from autogpt.agents.agent import Agent, execute_command
 from autogpt.models.command import Command, CommandParameter
-=======
-from autogpt.agent import Agent
-from autogpt.app import execute_command
-from autogpt.models.command import Command
->>>>>>> 4d35111d (LangChain tool support, file_search as example)
 from autogpt.models.command_registry import CommandRegistry
 
 PARAMETERS = [
@@ -126,7 +121,6 @@ def test_command_in_registry(example_command_with_aliases: Command):
     registry = CommandRegistry()
     command = example_command_with_aliases
 
-<<<<<<< HEAD
     assert command.name not in registry
     assert "nonexistent_command" not in registry
 
@@ -238,26 +232,28 @@ def test_import_temp_command_file_module(tmp_path: Path):
         registry.commands["function_based"].description == "Function-based test command"
     )
 
-    def test_generate_from_langchain_tool_simple_function(self, agent: Agent):
-        def string_length(input_str: str) -> int:
-            return len(input_str)
 
-        langchain_tool = StructuredTool.from_function(
-            string_length, description="useful to get the length of a string"
-        )
-        command = Command.generate_from_langchain_tool(langchain_tool)
-        agent.command_registry.register(command)
+def test_generate_from_langchain_tool_simple_function(agent: Agent):
+    def string_length(input_str: str) -> int:
+        return len(input_str)
 
-        result = execute_command(
-            command_name="string_length", arguments={"input_str": "12345"}, agent=agent
-        )
-        assert result == 5
+    langchain_tool = StructuredTool.from_function(
+        string_length, description="useful to get the length of a string"
+    )
+    command = Command.generate_from_langchain_tool(langchain_tool)
+    agent.command_registry.register(command)
 
-    def test_execute_langchain_list_directory(self, agent: Agent):
-        command = Command.generate_from_langchain_tool(ListDirectoryTool())
-        agent.command_registry.register(command)
+    result = execute_command(
+        command_name="string_length", arguments={"input_str": "12345"}, agent=agent
+    )
+    assert result == 5
 
-        result = execute_command(
-            command_name="list_directory", arguments={"dir_path": "."}, agent=agent
-        )
-        assert "README.md" in result
+
+def test_execute_langchain_list_directory(agent: Agent):
+    command = Command.generate_from_langchain_tool(ListDirectoryTool())
+    agent.command_registry.register(command)
+
+    result = execute_command(
+        command_name="list_directory", arguments={"dir_path": "."}, agent=agent
+    )
+    assert "README.md" in result

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -4,8 +4,15 @@ import sys
 from pathlib import Path
 
 import pytest
+from langchain.tools import ListDirectoryTool, StructuredTool
 
+<<<<<<< HEAD
 from autogpt.models.command import Command, CommandParameter
+=======
+from autogpt.agent import Agent
+from autogpt.app import execute_command
+from autogpt.models.command import Command
+>>>>>>> 4d35111d (LangChain tool support, file_search as example)
 from autogpt.models.command_registry import CommandRegistry
 
 PARAMETERS = [
@@ -119,6 +126,7 @@ def test_command_in_registry(example_command_with_aliases: Command):
     registry = CommandRegistry()
     command = example_command_with_aliases
 
+<<<<<<< HEAD
     assert command.name not in registry
     assert "nonexistent_command" not in registry
 
@@ -229,3 +237,27 @@ def test_import_temp_command_file_module(tmp_path: Path):
     assert (
         registry.commands["function_based"].description == "Function-based test command"
     )
+
+    def test_generate_from_langchain_tool_simple_function(self, agent: Agent):
+        def string_length(input_str: str) -> int:
+            return len(input_str)
+
+        langchain_tool = StructuredTool.from_function(
+            string_length, description="useful to get the length of a string"
+        )
+        command = Command.generate_from_langchain_tool(langchain_tool)
+        agent.command_registry.register(command)
+
+        result = execute_command(
+            command_name="string_length", arguments={"input_str": "12345"}, agent=agent
+        )
+        assert result == 5
+
+    def test_execute_langchain_list_directory(self, agent: Agent):
+        command = Command.generate_from_langchain_tool(ListDirectoryTool())
+        agent.command_registry.register(command)
+
+        result = execute_command(
+            command_name="list_directory", arguments={"dir_path": "."}, agent=agent
+        )
+        assert "README.md" in result

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -333,3 +333,35 @@ def test_list_files(workspace: Workspace, test_directory: Path, agent: Agent):
     non_existent_file = "non_existent_file.txt"
     files = file_ops.list_files("", agent=agent)
     assert non_existent_file not in files
+
+
+def test_file_search(workspace: Workspace, test_directory: Path, agent: Agent):
+    # Case 1: Create files A and B, search for A, and ensure we don't return A and B
+    file_a = workspace.get_path("file_a.txt")
+    file_b = workspace.get_path("file_b.txt")
+
+    with open(file_a, "w") as f:
+        f.write("This is file A.")
+
+    with open(file_b, "w") as f:
+        f.write("This is file B.")
+
+    # Create a subdirectory and place a copy of file_a in it
+    if not os.path.exists(test_directory):
+        os.makedirs(test_directory)
+
+    with open(os.path.join(test_directory, file_a.name), "w") as f:
+        f.write("This is file A in the subdirectory.")
+
+    files = file_ops.file_search(
+        pattern="*.txt", dir_path=str(workspace.root), agent=agent
+    )
+    assert file_a.name in files
+    assert file_b.name in files
+    assert os.path.join(Path(test_directory).name, file_a.name) in files
+
+    # Clean up
+    os.remove(file_a)
+    os.remove(file_b)
+    os.remove(os.path.join(test_directory, file_a.name))
+    os.rmdir(test_directory)


### PR DESCRIPTION
This PR adds support for creating Commands based on LangChain Tools.

Opening up this discussion first to decide whether we want to do this at all.

Pros:
- LangChain has >30 tools that we'll get access to immediately
- Future work from LangChain can benefit Auto-GPT
- Reduces competitive nature between Auto-GPT and LangChain. IMO we should be working together not separately.

Cons:
- Includes LangChain dependency, moving us away from being a LangChain alternative (if that's what we want to do)
- We need to be vigilant of tool changes in LangChain to make sure that Auto-GPT can use those tools as effectively as before. Freezing the pip version helps mitigate this somewhat.

# Changes
- Adds class method to `Command` to create a command and generate the wrappers for it
- Adds the `file_search` tool as an example of how it would work, including the arg converter