### PR TITLE
Add --continuous-count <N> alias for # of cmds to run continuously

### DIFF
--- a/autogpt/app/cli.py
+++ b/autogpt/app/cli.py
@@ -28,7 +28,9 @@ import click
 )
 @click.option(
     "-l",
+    "-n",
     "--continuous-limit",
+    "--continuous-count",
     type=int,
     help="Defines the number of times to run in continuous mode",
 )

--- a/autogpt/app/cli.py
+++ b/autogpt/app/cli.py
@@ -32,7 +32,10 @@ import click
     "--continuous-limit",
     "--continuous-count",
     type=int,
-    help="Defines the number of times to run in continuous mode",
+    help=(
+        "Defines the number of times to run in continuous mode. Example:"
+        " ./run.sh -c -n 10"
+    ),
 )
 @click.option("--speak", is_flag=True, help="Enable Speak Mode")
 @click.option("--debug", is_flag=True, help="Enable Debug Mode")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,12 @@ Here are some common arguments you can use when running Auto-GPT:
 ./run.sh --use-memory  <memory-backend>
 ```
 
+* Specify the number of commands to run continuously
+
+```shell
+./run.sh --continuous-count <N>
+```
+
 !!! note
     There are shorthands for some of these flags, for example `-m` for `--use-memory`.  
     Use `./run.sh --help` for more information.


### PR DESCRIPTION
This adds a new alias flag `--continuous-count <N>` and `-n <N>` to the existing `--continuous-limit <N>` as a more expected alternative to denote the number of commands to be run continuously. Also added usage documentation, which was missing previously.

### Test Plan
I tested this flag using `run.sh` with the new alias and old flags.

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [ ] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
