### PR TITLE
Add wildcard support for shell deny/allow lists

### DIFF
--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -281,12 +281,12 @@ def validate_command(command_line: str, config: Config) -> tuple[bool, bool]:
 
     if config.shell_command_control == ALLOWLIST_CONTROL:
         if any(wildcard_shell_allowlist):
-            if any(fnmatch(pattern, command_name) for pattern in wildcard_shell_allowlist):
+            if any(fnmatch(command_name, pattern) for pattern in wildcard_shell_allowlist):
                 return True, False
         return command_name in config.shell_allowlist, False
     elif config.shell_command_control == DENYLIST_CONTROL:
         if any(wildcard_shell_denylist):
-            if any(fnmatch(pattern, command_name) for pattern in wildcard_shell_denylist):
+            if any(fnmatch(command_name, pattern) for pattern in wildcard_shell_denylist):
                 return False, False
         return command_name not in config.shell_denylist, False
     else:

--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -280,14 +280,12 @@ def validate_command(command_line: str, config: Config) -> tuple[bool, bool]:
     command_name = command.split()[0]
 
     if config.shell_command_control == ALLOWLIST_CONTROL:
-        if any(wildcard_shell_allowlist):
-            if any(fnmatch(command_name, pattern) for pattern in wildcard_shell_allowlist):
-                return True, False
+        if any(fnmatch(command_name, pattern) for pattern in wildcard_shell_allowlist):
+            return True, False
         return command_name in config.shell_allowlist, False
     elif config.shell_command_control == DENYLIST_CONTROL:
-        if any(wildcard_shell_denylist):
-            if any(fnmatch(command_name, pattern) for pattern in wildcard_shell_denylist):
-                return False, False
+        if any(fnmatch(command_name, pattern) for pattern in wildcard_shell_denylist):
+            return False, False
         return command_name not in config.shell_denylist, False
     else:
         return True, True

--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -274,8 +274,12 @@ def validate_command(command_line: str, config: Config) -> tuple[bool, bool]:
     if not command_line:
         return False, False
 
-    wildcard_shell_denylist = [x for x in config.shell_denylist if any(c in x for c in "*[]?")]
-    wildcard_shell_allowlist = [x for x in config.shell_allowlist if any(c in x for c in "*[]?")]
+    wildcard_shell_denylist = [
+        cmd for cmd in config.shell_denylist if any(c in cmd for c in "*[]?")
+    ]
+    wildcard_shell_allowlist = [
+        cmd for cmd in config.shell_allowlist if any(c in cmd for c in "*[]?")
+    ]
 
     command_name = command.split()[0]
 


### PR DESCRIPTION
This Pull Request introduces an enhancement in the mechanism we use to control shell commands. Specifically, in the way we handle the allowlist and denylist of commands in the `config`.

The changes are as follows:

1. A new process is introduced to identify shell commands in both the allowlist (shell_allowlist) and the denylist (shell_denylist) that contains wildcard characters (`*`, `[`, `]`, `?`). These identified commands are placed into two new lists: `wildcard_shell_allowlist` and `wildcard_shell_denylist`.

2. The new logic first checks if there are any wildcard commands in the allowlist or denylist. If there are:

    - For allowlist control mechanism, it checks if the given command matches any pattern in the `wildcard_shell_allowlist`. If it does, it returns True, indicating this command is allowed to run. If not, it returns whether the command is in the non-wildcard allowlist.
   
    - For other mechanisms, it checks if the given command matches any pattern in the `wildcard_shell_denylist`. If it does, it returns False, indicating this command is forbidden. If not, it returns whether the command is not in the non-wildcard denylist.

This change aims to improve the flexibility of the shell command control.

For example previously adding `npm start` to deny list would have no effect. Since AG only look at the first part of the `command` here that would simply be `npm` therefore a match would not happen, unless `npm` itself is banned completelty, which is not desirable for things that do not require use interaction like `npm install`. After this PR you can add `npm start*` to the deny list, it detects the wildcard `*` character and it tries to match this item in the deny list against the entire `command` not just the fist part of it. So if the command were `npm start --abc` it would still be denied.

Example denylist in `.env`

```yaml
SHELL_DENYLIST=sudo,su,npm start*
```

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [ ] I have considered potential risks and mitigations for my changes.
- [ ] I have documented my changes clearly and comprehensively.
- [ ] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [ ] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring autogpt tests --in-place
    ```

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
