### PR TITLE
Fixing --speak error from docker compose (no module named GI)

### DIFF
--- a/autogpts/autogpt/Dockerfile
+++ b/autogpts/autogpt/Dockerfile
@@ -14,6 +14,18 @@ RUN apt-get update && apt-get install -y \
     curl jq wget git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && apt-get install -y \
+    libgirepository1.0-dev \
+    gcc \
+    libcairo2-dev \
+    pkg-config \
+    python3-dev \
+    gir1.2-gtk-3.0 \
+    && apt-get clean
+
+RUN pip install pycairo
+RUN pip install PyGObject    
+
 # Set environment variables
 ENV PIP_NO_CACHE_DIR=yes \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
Issue:

Exception in thread Thread-1 (speak):
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/app/autogpt/speech/say.py", line 27, in speak
    success = voice_engine.say(text, voice_index)
  File "/app/autogpt/speech/base.py", line 45, in say
    return self._speech(text, voice_index)
  File "/app/autogpt/speech/gtts.py", line 21, in _speech
    playsound("speech.mp3", True)
  File "/usr/local/lib/python3.10/site-packages/playsound.py", line 91, in _playsoundNix
    import gi
ModuleNotFoundError: No module named 'gi'

This error was caused because there's not an RUN for the needed packages (which firstly are pycairo and PyGObject).

Other packages are just for good measuring and avoiding other kind of exceptions.

### Background

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [ ] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [x] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of Auto-GPT? &ensp; `-5 pts`
  - [x] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
