### PR TITLE
fixing files attribute to look for file name specificed in instructions

### DIFF
--- a/benchmark/agbenchmark/challenges/verticals/code/1_three_sum/data.json
+++ b/benchmark/agbenchmark/challenges/verticals/code/1_three_sum/data.json
@@ -14,7 +14,7 @@
             "type": "python"
         },
         "files": [
-            "test.py"
+            "sample_code.py"
         ],
         "should_contain": [
             "[0, 1, 2]",


### PR DESCRIPTION
### Background

The three sum benchmark is looking for the wrong file, instead of "sample_code.py" it looks for "test.py"

Referencing Issue #5466 

### Changes 🏗️

Updates files attribute in challenge json to proper filename

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
