### PR TITLE
Introduce TestOption Enum for Enhanced Test Selection Clarity

### DIFF
--- a/frontend/lib/models/test_option.dart
+++ b/frontend/lib/models/test_option.dart
@@ -1,0 +1,65 @@
+/// `TestOption` is an enumeration of the available test options that can be selected in the skill tree view.
+///
+/// Each value of this enum represents a distinct test option that can be executed.
+/// The `description` getter can be used to get the string representation of each test option.
+enum TestOption {
+  /// Represents the option to run a single test.
+  runSingleTest,
+
+  /// Represents the option to run a test suite including the selected node and its ancestors.
+  runTestSuiteIncludingSelectedNodeAndAncestors,
+
+  /// Represents the option to run all tests in a category.
+  runAllTestsInCategory,
+}
+
+/// An extension on the `TestOption` enum to provide a string representation for each test option.
+///
+/// This extension adds a `description` getter on `TestOption` to easily retrieve the human-readable
+/// string associated with each option. This is particularly helpful for UI display purposes.
+extension TestOptionExtension on TestOption {
+  /// Gets the string representation of the test option.
+  ///
+  /// Returns a human-readable string that describes the test option. This string is intended
+  /// to be displayed in the UI for user selection.
+  String get description {
+    switch (this) {
+      /// In case of a single test option, return the corresponding string.
+      case TestOption.runSingleTest:
+        return 'Run single test';
+
+      /// In case of a test suite option that includes selected node and ancestors, return the corresponding string.
+      case TestOption.runTestSuiteIncludingSelectedNodeAndAncestors:
+        return 'Run test suite including selected node and ancestors';
+
+      /// In case of an option to run all tests in a category, return the corresponding string.
+      case TestOption.runAllTestsInCategory:
+        return 'Run all tests in category';
+
+      /// In case of an undefined or unknown test option, return a generic unknown string.
+      /// This case should ideally never be hit if all enum values are handled.
+      default:
+        return 'Unknown';
+    }
+  }
+
+  /// Converts a [description] string to its corresponding [TestOption] enum value.
+  ///
+  /// This method is helpful for converting string representations of test options
+  /// received from various sources (like user input or server responses) into
+  /// their type-safe enum equivalents.
+  ///
+  /// Returns the matching [TestOption] enum value if found, otherwise returns `null`.
+  static TestOption? fromDescription(String description) {
+    switch (description) {
+      case 'Run single test':
+        return TestOption.runSingleTest;
+      case 'Run test suite including selected node and ancestors':
+        return TestOption.runTestSuiteIncludingSelectedNodeAndAncestors;
+      case 'Run all tests in category':
+        return TestOption.runAllTestsInCategory;
+      default:
+        return null; // or throw an exception, or provide a default value, as per your requirement
+    }
+  }
+}

--- a/frontend/lib/viewmodels/skill_tree_viewmodel.dart
+++ b/frontend/lib/viewmodels/skill_tree_viewmodel.dart
@@ -8,6 +8,7 @@ import 'package:auto_gpt_flutter_client/models/skill_tree/skill_tree_edge.dart';
 import 'package:auto_gpt_flutter_client/models/skill_tree/skill_tree_node.dart';
 import 'package:auto_gpt_flutter_client/models/step.dart';
 import 'package:auto_gpt_flutter_client/models/task.dart';
+import 'package:auto_gpt_flutter_client/models/test_option.dart';
 import 'package:auto_gpt_flutter_client/models/test_suite.dart';
 import 'package:auto_gpt_flutter_client/services/benchmark_service.dart';
 import 'package:auto_gpt_flutter_client/services/leaderboard_service.dart';
@@ -39,8 +40,8 @@ class SkillTreeViewModel extends ChangeNotifier {
   // TODO: Potentially move to task queue view model when we create one
   List<SkillTreeNode>? _selectedNodeHierarchy;
 
-  String _selectedOption = 'Run single test';
-  String get selectedOption => _selectedOption;
+  TestOption _selectedOption = TestOption.runSingleTest;
+  TestOption get selectedOption => _selectedOption;
 
   List<SkillTreeNode> get skillTreeNodes => _skillTreeNodes;
   List<SkillTreeEdge> get skillTreeEdges => _skillTreeEdges;
@@ -110,21 +111,20 @@ class SkillTreeViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void updateSelectedNodeHierarchyBasedOnOption(String selectedOption) {
+  void updateSelectedNodeHierarchyBasedOnOption(TestOption selectedOption) {
     _selectedOption = selectedOption;
     switch (selectedOption) {
-      // TODO: Turn this into enum
-      case 'Run single test':
+      case TestOption.runSingleTest:
         _selectedNodeHierarchy = _selectedNode != null ? [_selectedNode!] : [];
         break;
 
-      case 'Run test suite including selected node and ancestors':
+      case TestOption.runTestSuiteIncludingSelectedNodeAndAncestors:
         if (_selectedNode != null) {
           populateSelectedNodeHierarchy(_selectedNode!.id);
         }
         break;
 
-      case 'Run all tests in category':
+      case TestOption.runAllTestsInCategory:
         if (_selectedNode != null) {
           _getAllNodesInDepthFirstOrderEnsuringParents();
         }

--- a/frontend/lib/views/task_queue/task_queue_view.dart
+++ b/frontend/lib/views/task_queue/task_queue_view.dart
@@ -1,4 +1,5 @@
 import 'package:auto_gpt_flutter_client/models/benchmark/benchmark_task_status.dart';
+import 'package:auto_gpt_flutter_client/models/test_option.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/chat_viewmodel.dart';
 import 'package:auto_gpt_flutter_client/viewmodels/task_viewmodel.dart';
 import 'package:auto_gpt_flutter_client/views/task_queue/leaderboard_submission_button.dart';
@@ -98,11 +99,11 @@ class TaskQueueView extends StatelessWidget {
                 // TestSuiteButton
                 TestSuiteButton(
                   isDisabled: viewModel.isBenchmarkRunning,
-                  selectedOption: viewModel.selectedOption,
+                  selectedOptionString: viewModel.selectedOption.description,
                   onOptionSelected: (selectedOption) {
                     print('Option Selected: $selectedOption');
                     viewModel.updateSelectedNodeHierarchyBasedOnOption(
-                        selectedOption);
+                        TestOptionExtension.fromDescription(selectedOption)!);
                   },
                   onPlayPressed: (selectedOption) {
                     print('Starting benchmark with option: $selectedOption');

--- a/frontend/lib/views/task_queue/test_suite_button.dart
+++ b/frontend/lib/views/task_queue/test_suite_button.dart
@@ -1,17 +1,18 @@
 import 'package:auto_gpt_flutter_client/constants/app_colors.dart';
+import 'package:auto_gpt_flutter_client/models/test_option.dart';
 import 'package:flutter/material.dart';
 
 class TestSuiteButton extends StatefulWidget {
   final bool isDisabled;
   final Function(String) onOptionSelected;
   final Function(String) onPlayPressed;
-  String selectedOption;
+  String selectedOptionString;
 
   TestSuiteButton({
     this.isDisabled = false,
     required this.onOptionSelected,
     required this.onPlayPressed,
-    required this.selectedOption,
+    required this.selectedOptionString,
   });
 
   @override
@@ -30,24 +31,27 @@ class _TestSuiteButtonState extends State<TestSuiteButton> {
             enabled: !widget.isDisabled,
             onSelected: (value) {
               setState(() {
-                widget.selectedOption = value;
+                widget.selectedOptionString = value;
               });
-              widget.onOptionSelected(widget.selectedOption);
+              widget.onOptionSelected(widget.selectedOptionString);
             },
             itemBuilder: (BuildContext context) {
               return [
-                const PopupMenuItem(
-                  value: 'Run single test',
-                  child: Text('Run single test'),
+                PopupMenuItem(
+                  value: TestOption.runSingleTest.description,
+                  child: Text(TestOption.runSingleTest.description),
                 ),
-                const PopupMenuItem(
-                  value: 'Run test suite including selected node and ancestors',
-                  child: Text(
-                      'Run test suite including selected node and ancestors'),
+                PopupMenuItem(
+                  value: TestOption
+                      .runTestSuiteIncludingSelectedNodeAndAncestors
+                      .description,
+                  child: Text(TestOption
+                      .runTestSuiteIncludingSelectedNodeAndAncestors
+                      .description),
                 ),
-                const PopupMenuItem(
-                  value: 'Run all tests in category',
-                  child: Text('Run all tests in category'),
+                PopupMenuItem(
+                  value: TestOption.runAllTestsInCategory.description,
+                  child: Text(TestOption.runAllTestsInCategory.description),
                 ),
               ];
             },
@@ -63,7 +67,7 @@ class _TestSuiteButtonState extends State<TestSuiteButton> {
                 children: [
                   Flexible(
                     child: Text(
-                      widget.selectedOption,
+                      widget.selectedOptionString,
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: 12.50,
@@ -100,7 +104,7 @@ class _TestSuiteButtonState extends State<TestSuiteButton> {
             onPressed: widget.isDisabled
                 ? null
                 : () {
-                    widget.onPlayPressed(widget.selectedOption);
+                    widget.onPlayPressed(widget.selectedOptionString);
                   },
             child: const Icon(
               Icons.play_arrow,


### PR DESCRIPTION
### Background:
In the skill tree view of our application, users have the option to select among various test execution strategies, such as running a single test, a suite of tests, or all tests in a category. Previously, these options were represented and managed using strings, leading to potential issues with type safety, code readability, and maintenance. There was a need to enforce a more structured and type-safe approach to handle these test options.

### Changes 🏗️
In this pull request, we introduce a new `TestOption` enum to represent the different test execution options in a more structured and type-safe manner. We have also updated the relevant parts of the code where these test options are used, enhancing the clarity and maintainability of the code.

#### Added:
- `TestOption` enum with values representing the distinct test execution options.
- `TestOptionExtension` to provide a string description for each enum value, facilitating easy display in the UI.

#### Updated:
- Modified the `SkillTreeViewModel` to use the `TestOption` enum instead of strings for handling test options.
- Updated the `TestSuiteButton` widget to utilize the `TestOption` enum and the associated extension for displaying options in the UI.
- Refactored code where test options are processed to use the new enum, enhancing type safety and code clarity.

By transitioning to the `TestOption` enum, we eliminate the risk of typos and string inconsistencies, promote type safety, and make the code more self-documenting and easier to maintain. This change lays a foundation for more robust and clear code handling for test execution options in the skill tree view.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
