### PR TITLE
chore(docs): update readme with links to roadmap and contributing guidelines for ease of developer discovery. Resolves #5658

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Want to build your own groundbreaking agent using AutoGPT? 🛠️ There are thr
 
 To report a bug or request a feature, create a [GitHub Issue](https://github.com/Significant-Gravitas/AutoGPT/issues/new/choose). Please ensure someone else hasn’t created an issue for the same topic.
 
+This is an active project and many things are in the works! Find out what's _todo_ and _in progress_ by [checking the roadmap](https://github.com/orgs/Significant-Gravitas/projects/2) or [making a contribution](./CONTRIBUTING.md).
+
 <p align="center">
   <a href="https://star-history.com/#Significant-Gravitas/AutoGPT&Date">
     <img src="https://api.star-history.com/svg?repos=Significant-Gravitas/AutoGPT&type=Date" alt="Star History Chart">

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Want to build your own groundbreaking agent using AutoGPT? 🛠️ There are thr
 
 To report a bug or request a feature, create a [GitHub Issue](https://github.com/Significant-Gravitas/AutoGPT/issues/new/choose). Please ensure someone else hasn’t created an issue for the same topic.
 
-This is an active project and many things are in the works! Find out what's _todo_ and _in progress_ by [checking the roadmap](https://github.com/orgs/Significant-Gravitas/projects/2) or [making a contribution](./CONTRIBUTING.md).
+This is an active project and many things are in the works! Find out what's _todo_ and _in progress_ by [checking the roadmap](https://github.com/orgs/Significant-Gravitas/projects/2) or [making a contribution](https://github.com/Significant-Gravitas/AutoGPT/blob/master/CONTRIBUTING.md).
 
 <p align="center">
   <a href="https://star-history.com/#Significant-Gravitas/AutoGPT&Date">


### PR DESCRIPTION
### Background

I was unable to easily discover the `roadmap` for AutoGPT as I expected it to be found in the `readme` and believe others will have the same experience looking for it at the top level instead of only in `contribution guidelines`. 

[see issue](https://github.com/Significant-Gravitas/AutoGPT/issues/5658)

### Changes 🏗️

Adds the roadmap hyperlink and contribution guidelines file link to the README for ease of discovery. 

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [x] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
