### PR TITLE
docs: AI Companion Integration

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
 
 theme:
   name: material
+  custom_dir: overrides
   icon:
     logo: material/book-open-variant
   favicon: favicon.png

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+
+{% block extrahead %}
+<style>
+  svg.ms-w-12 {
+    width: 2rem !important;
+  }
+  svg.ms-h-12 {
+    height: 2rem !important;
+  }
+  /* Temporary solution for the font sizes  */
+  #headlessui-dialog-panel-2 p{
+    font-size: 16px;
+  }
+  #headlessui-dialog-panel-2 textarea{
+    font-size: 16px;
+  }
+  #headlessui-dialog-panel-2 span{
+    font-size: 14px;
+
+  }
+  #headlessui-dialog-panel-2 div{
+    font-size: 16px;
+  }
+  #headlessui-dialog-panel-2 a{
+    font-size: 14px;
+    line-height: 1rem;
+  }
+  #headlessui-dialog-panel-2 button{
+    border: 1px solid #0000001d;
+    line-height: 1rem;
+
+}
+  /* Temporary solution for the font size  */
+  #headlessui-dialog-panel-2 > div > div > div > div.ms-w-full.ms-rounded-xl.ms-flex.ms-flex-col.ms-relative > div > div > div > div > div.ms-flex.ms-flex-row.ms-items-center.ms-justify-between.ms-gap-1 > p{
+    font-size: 14px;
+    line-height: 1rem;
+  }
+
+</style>
+
+<div id="my-component-root" class="mendable-search"></div>
+
+<script src="https://unpkg.com/@mendable/search@0.0.155/dist/umd/mendable-bundle.min.js"></script>
+{% raw %}
+<script>
+    Mendable.initialize({
+      anon_key: 'a0bd44db-eb3b-412f-8924-b31c58244a64',
+      type: 'floatingButton',
+      style : { accentColor: '#3F51B5', darkMode: false },
+      floatingButtonStyle:{
+        backgroundColor: '#3F51B5',
+        color: '#fff',
+      },
+      icon: "https://mendable-storage.s3.amazonaws.com/autoGPT.gif",
+      botIcon: "https://mendable-storage.s3.amazonaws.com/autoGPTbot.gif",
+    })
+  </script>
+{% endraw %}
+{% endblock %}


### PR DESCRIPTION
### Background

Hey team,

I've been a big fan of AutoGPT and agents in general since the beginning.

Recently, we have been playing around with AutoGPT/Agents and I thought it would be awesome to integrate a Mendable AI companion into your docs. So, I went ahead and implemented it similar to how we implemented it in Langchain, Snapchat, and Llama index.

This can give you the data you need to improve the docs and also get some visibility on what users are asking and wondering about.

Ps. I even did a little 🐙 animation that matches the logo, hope you like it!

Here is a demo video of the implementation: https://www.youtube.com/watch?v=Nb299ahQJEU

Please let me know any changes, or suggestions that you might have. It would be super awesome to implement with you all.

Hopefully, you like it!

A bit more background: I am one of the co-founders of Mendable.ai. We are supporters of open-source projects and we'd love to offer Mendable at no cost.

### Changes 🏗️

- Implements an animated AI companion on the bottom right of the documentation page that answers users' questions about the AutoGPT docs.
