### PR TITLE
Fix for agent_name regex

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -219,7 +219,7 @@ def create(agent_name):
     import re
     import shutil
 
-    if not re.match("\W*$", agent_name):
+    if not re.match("\w*$", agent_name):
         click.echo(
             click.style(
                 f"😞 Agent name '{agent_name}' is not valid. It should not contain spaces or special characters other than -_",


### PR DESCRIPTION
### Background

The improved regex was introduced with: https://github.com/Significant-Gravitas/AutoGPT/pull/6096

However, there seems to be an issue with the updated regex. 
The uppercase meta-character `\W` only matches non-word characters, i.e. everything that is NOT `[A-Za-z0-9_]`.

This leads to issues when choosing an agent name, where basically all names get rejected. Example: https://github.com/Significant-Gravitas/AutoGPT/issues/6106

What you actually want is to use the lowercase `\w` character.


### Changes 🏗️

Change regex to use `\w` instead of `\W` meta-character.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
