### PR TITLE
Fixed typo in registry.py

### DIFF
--- a/autogpts/forge/forge/sdk/abilities/registry.py
+++ b/autogpts/forge/forge/sdk/abilities/registry.py
@@ -84,7 +84,7 @@ def ability(
         func_param_names = set(func_params.keys())
         if param_names != func_param_names:
             raise ValueError(
-                f"Mismatch in parameter names. Ability Annotation includes {param_names}, but function acatually takes {func_param_names} in function {func.__name__} signature"
+                f"Mismatch in parameter names. Ability Annotation includes {param_names}, but function actually takes {func_param_names} in function {func.__name__} signature"
             )
         func.ability = Ability(
             name=name,


### PR DESCRIPTION
### Background

Fixing a typo in an error message displayed to users.

### Changes 🏗️

Fixed the misspelling of the word "actually"

### PR Quality Scorecard ✨

- [✅] Have you used the PR description template? &ensp; `+2 pts`
- [✅] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [NA] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [✅] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [❎] Have you changed or added a feature? &ensp; `-4 pts`
  - [NA] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [NA] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [❎] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [NA] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
