### PR TITLE
Include poetry install step in dockerless setup instructions

### DIFF
--- a/docs/content/AutoGPT/Setups/nogit-setup.md
+++ b/docs/content/AutoGPT/Setups/nogit-setup.md
@@ -58,9 +58,10 @@
 First we need to create a virtual environment to run in.
 
 ```shell
+pip3 install poetry
 python -m venv .venv
 source .venv/bin/activate
-pip3 install --upgrade pip
+poetry install
 ```
 
 !!! warning


### PR DESCRIPTION
### Background

Without that step, I got this error:

```
"ModuleNotFoundError: No module named
'auto_gpt_plugin_template'"
```

### Changes 🏗️

Updated the `setup.md` instructions file to include the `poetry install` command in dockerless setup. Also removed a couple of stray whitespaces on that page.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [x] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
