### PR TITLE
Fix regex warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -219,7 +219,7 @@ def create(agent_name):
     import re
     import shutil
 
-    if not re.match("\w*$", agent_name):
+    if not re.match(r"\w*$", agent_name):
         click.echo(
             click.style(
                 f"😞 Agent name '{agent_name}' is not valid. It should not contain spaces or special characters other than -_",


### PR DESCRIPTION
### Background

<!-- Clearly explain the need for these changes: -->
Solving #6215 

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
Fixing an issue where regular expression caused a SyntaxWarning. Replacing the regular expression "\w*$" with a raw string (r"\w*$") to ensure proper handling of the regular expression in cli.py.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
