### PR TITLE
Allow port numbers to be used in local host names. e.g. localhost:8888

### DIFF
--- a/autogpts/forge/forge/sdk/abilities/web/web_selenium.py
+++ b/autogpts/forge/forge/sdk/abilities/web/web_selenium.py
@@ -150,35 +150,31 @@ def check_local_file_access(url: str) -> bool:
     Returns:
         bool: True if the URL is a local file, False otherwise
     """
-    local_prefixes = [
+    # List of local file prefixes
+    local_file_prefixes = [
         "file:///",
-        "file://localhost/",
         "file://localhost",
-        "http://localhost",
-        "http://localhost/",
-        "https://localhost",
-        "https://localhost/",
-        "http://2130706433",
-        "http://2130706433/",
-        "https://2130706433",
-        "https://2130706433/",
-        "http://127.0.0.1/",
-        "http://127.0.0.1",
-        "https://127.0.0.1/",
-        "https://127.0.0.1",
-        "https://0.0.0.0/",
-        "https://0.0.0.0",
-        "http://0.0.0.0/",
-        "http://0.0.0.0",
-        "http://0000",
-        "http://0000/",
-        "https://0000",
-        "https://0000/",
     ]
-    return any(url.startswith(prefix) for prefix in local_prefixes)
+    if any(url.startswith(prefix) for prefix in local_file_prefixes):
+        return True
 
+    # Parse the URL
+    parsed = urlparse(url)
 
+    # List of local hostnames/IPs without considering ports
+    local_domains = [
+        "localhost",
+        "2130706433",     # IP representation of 127.0.0.1
+        "127.0.0.1",
+        "0.0.0.0",
+        "0000"            # Not sure what this is for, but keeping it as in original
+    ]
+    # Check if the domain part of the URL is in local_domains
+    if parsed.hostname in local_domains:
+        return False  # We don't restrict localhost access on different ports
 
+    # Return True for anything else that is deemed "local"
+    return True
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
allow ports to be used in host names. e.g. localhost:8888.  Note: code copied from pull request 5318, https://github.com/Significant-Gravitas/AutoGPT/pull/5318. I did not test this.

### Background

There are scenarios where local development or specific server configurations require non-standard ports to be used in conjunction with hostnames such as localhost. The current implementation of check_local_file_access does not allow for URLs with such ports, making it inconvenient or impossible for developers and users to utilize the software in some local environments. This pull request updates the function to be more accommodating to such URLs, enhancing the tool's flexibility.

### Changes 🏗️

Modified the check_local_file_access function in to accommodate URLs with ports in host names.
Removed redundant entries in the local_prefixes list.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
