### PR TITLE
fix No modules named 'forge.sdk.abilities' and 'forge.sdk' #6537 #5810

### DIFF
--- a/autogpts/forge/forge/actions/finish.py
+++ b/autogpts/forge/forge/actions/finish.py
@@ -1,4 +1,4 @@
-from sdk.forge_log import ForgeLogger
+from forge.sdk.forge_log import ForgeLogger
 from .registry import action
 
 logger = ForgeLogger(__name__)

--- a/autogpts/forge/forge/actions/registry.py
+++ b/autogpts/forge/forge/actions/registry.py
@@ -117,7 +117,7 @@ class ActionRegister:
                 ).replace("/", ".")
                 try:
                     module = importlib.import_module(
-                        f".{action[:-3]}", package="forge.sdk.abilities"
+                        f".{action[:-3]}", package="forge.actions"
                     )
                     for attr in dir(module):
                         func = getattr(module, attr)


### PR DESCRIPTION
This PR fix #6537 and #5810 issues as described in https://github.com/Significant-Gravitas/AutoGPT/issues/6537#issuecomment-1851207577

### Background

 ./run agent start forge doesn`t work without this changes

### Changes 🏗️

1. in registry.py, forge.sdk.abilities needs to be replaced with forge.actions. 
2. in finish.py in the same folder the first import needs to be changed from from sdk.forge_log import ForgeLogger to from forge.sdk.forge_log import ForgeLogger

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
3. Also consider contributing something other than code; see the [contribution guide]
   for options.
4. Clearly explain your changes.
5. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
