### PR TITLE
fix: create run_benchmark which is missing

### DIFF
--- a/autogpts/evo.ninja/run_benchmark
+++ b/autogpts/evo.ninja/run_benchmark
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Kill processes using port 8080 if any.
+if lsof -t -i :8080; then
+    kill $(lsof -t -i :8080)
+fi
+# This is the cli entry point for the benchmarking tool.
+# To run this in server mode pass in `serve` as the first argument.
+poetry run agbenchmark "$@"


### PR DESCRIPTION
### Background
Since there is no run_benchmark file, running the agent 'evo.ninja' will throw out an error.

![image](https://github.com/Significant-Gravitas/AutoGPT/assets/31075337/4554e760-e081-4aa9-9c1c-1d5ffbb6654c)
![image](https://github.com/Significant-Gravitas/AutoGPT/assets/31075337/5845431a-ec59-4cbe-8c50-e43839cbccd2)

### Changes 🏗️
Add a new run_benchmark file under the evo.ninja folder.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
