### PR TITLE
fix: cast port to int

### DIFF
--- a/autogpts/forge/forge/__main__.py
+++ b/autogpts/forge/forge/__main__.py
@@ -41,5 +41,5 @@ if __name__ == "__main__":
     forge.sdk.forge_log.setup_logger()
 
     uvicorn.run(
-        "forge.app:app", host="localhost", port=port, log_level="error", reload=True
+        "forge.app:app", host="localhost", port=int(port), log_level="error", reload=True
     )


### PR DESCRIPTION
### Background

When executing `port = os.getenv("PORT", 8000)` if the port is being fetched from a `.env` file it is fetched as a string.

This causes an error: `TypeError: 'str' object cannot be interpreted as an integer`

### Changes 🏗️

The port is casted to int before passed to uvicorn

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
