### PR TITLE
[WIP]Feature, configurable network port

### DIFF
--- a/autogpts/autogpt/autogpt/app/main.py
+++ b/autogpts/autogpt/autogpt/app/main.py
@@ -333,7 +333,7 @@ async def run_auto_gpt_server(
 
     # TODO: fill in llm values here
     assert_config_has_openai_api_key(config)
-    print(config)
+
     apply_overrides_to_config(
         config=config,
         prompt_settings_file=prompt_settings,

--- a/autogpts/autogpt/autogpt/app/main.py
+++ b/autogpts/autogpt/autogpt/app/main.py
@@ -333,7 +333,7 @@ async def run_auto_gpt_server(
 
     # TODO: fill in llm values here
     assert_config_has_openai_api_key(config)
-
+    print(config)
     apply_overrides_to_config(
         config=config,
         prompt_settings_file=prompt_settings,
@@ -368,7 +368,7 @@ async def run_auto_gpt_server(
     server = AgentProtocolServer(
         app_config=config, database=database, llm_provider=llm_provider
     )
-    await server.start()
+    await server.start(port=config.serving_port)
 
 
 def _configure_openai_provider(config: Config) -> OpenAIProvider:

--- a/autogpts/autogpt/autogpt/config/config.py
+++ b/autogpts/autogpt/autogpt/config/config.py
@@ -115,6 +115,10 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
         default=6379,
         from_env=lambda: int(v) if (v := os.getenv("REDIS_PORT")) else None,
     )
+    serving_port: int = UserConfigurable(
+        default=8000,
+        from_env=lambda: int(v) if (v := os.getenv("PORT")) else None,
+    )
     redis_password: str = UserConfigurable("", from_env="REDIS_PASSWORD")
     wipe_redis_on_start: bool = UserConfigurable(
         default=True,

--- a/autogpts/autogpt/autogpt/config/config.py
+++ b/autogpts/autogpt/autogpt/config/config.py
@@ -115,9 +115,9 @@ class Config(SystemSettings, arbitrary_types_allowed=True):
         default=6379,
         from_env=lambda: int(v) if (v := os.getenv("REDIS_PORT")) else None,
     )
-    serving_port: int = UserConfigurable(
+    agent_port: int = UserConfigurable(
         default=8000,
-        from_env=lambda: int(v) if (v := os.getenv("PORT")) else None,
+        from_env=lambda: int(v) if (v := os.getenv("AGENT_PORT")) else None,
     )
     redis_password: str = UserConfigurable("", from_env="REDIS_PASSWORD")
     wipe_redis_on_start: bool = UserConfigurable(

--- a/autogpts/autogpt/run
+++ b/autogpts/autogpt/run
@@ -1,6 +1,5 @@
 #!/bin/sh
-
-kill $(lsof -t -i :8000)
+kill $(lsof -t -i :${AGENT_PORT:-8080})
 
 if [ ! -f .env ] && [ -z "$OPENAI_API_KEY" ]; then
   cp .env.example .env

--- a/autogpts/autogpt/run
+++ b/autogpts/autogpt/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 kill $(lsof -t -i :${AGENT_PORT:-8080})
 
 if [ ! -f .env ] && [ -z "$OPENAI_API_KEY" ]; then

--- a/autogpts/autogpt/run_benchmark
+++ b/autogpts/autogpt/run_benchmark
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Kill processes using port 8080 if any.
-if lsof -t -i :8080; then
-    kill $(lsof -t -i :8080)
+if lsof -t -i :${BENCHMARK_PORT:-8000}; then
+    kill $(lsof -t -i :${BENCHMARK_PORT:-8000})
 fi
 # This is the cli entry point for the benchmarking tool.
 # To run this in server mode pass in `serve` as the first argument.

--- a/cli.py
+++ b/cli.py
@@ -303,8 +303,11 @@ def stop():
     import signal
     import subprocess
 
+    port = os.getenv('PORT', 8000)
+    agent_port = os.getenv('AGENT_PORT', 8080)
+
     try:
-        pids = subprocess.check_output(["lsof", "-t", "-i", ":8000"]).split()
+        pids = subprocess.check_output(["lsof", "-t", "-i", ":"+str(agent_port)]).split()
         if isinstance(pids, int):
             os.kill(int(pids), signal.SIGTERM)
         else:
@@ -314,7 +317,7 @@ def stop():
         click.echo("No process is running on port 8000")
 
     try:
-        pids = int(subprocess.check_output(["lsof", "-t", "-i", ":8080"]))
+        pids = int(subprocess.check_output(["lsof", "-t", "-i", ":"+str(port)]))
         if isinstance(pids, int):
             os.kill(int(pids), signal.SIGTERM)
         else:

--- a/run
+++ b/run
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -a
 source .env
 set +a

--- a/run
+++ b/run
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -a
+source .env
+set +a
 python3 cli.py "$@"


### PR DESCRIPTION
### Background

This implements a configurable network port. I often have other stuff running locally on port 8000 and I wanted to be able to change this default.

### Changes 🏗️

This only adds a config option named serving_port which reads the environment variable PORT, if this is not present it defaults to 8000.

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [x] Have you changed or added a feature? &ensp; `-4 pts`
- [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
- [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
- [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
