### PR TITLE
fix(agent/execute_code): Disable code execution commands when Docker is unavailable

### DIFF
--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -66,9 +66,9 @@ def is_docker_available() -> bool:
             required=True,
         ),
     },
-    disabled_reason="""To execute python code agent
-    must be running in a Docker container or
-    Docker must be available on the system.""",
+    disabled_reason="To execute python code agent "
+    "must be running in a Docker container or "
+    "Docker must be available on the system.",
     available=we_are_running_in_a_docker_container() or is_docker_available(),
 )
 def execute_python_code(code: str, agent: Agent) -> str:
@@ -117,9 +117,9 @@ def execute_python_code(code: str, agent: Agent) -> str:
             items=JSONSchema(type=JSONSchema.Type.STRING),
         ),
     },
-    disabled_reason="""To execute python code agent
-    must be running in a Docker container or
-    Docker must be available on the system.""",
+    disabled_reason="To execute python code agent "
+    "must be running in a Docker container or "
+    "Docker must be available on the system.",
     available=we_are_running_in_a_docker_container() or is_docker_available(),
 )
 @sanitize_path_arg("filename")
@@ -368,12 +368,3 @@ def execute_shell_popen(command_line: str, agent: Agent) -> str:
     os.chdir(current_dir)
 
     return f"Subprocess started with PID:'{str(process.pid)}'"
-
-
-def we_are_running_in_a_docker_container() -> bool:
-    """Check if we are running in a Docker container
-
-    Returns:
-        bool: True if we are running in a Docker container, False otherwise
-    """
-    return os.path.exists("/.dockerenv")

--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -32,6 +32,27 @@ logger = logging.getLogger(__name__)
 ALLOWLIST_CONTROL = "allowlist"
 DENYLIST_CONTROL = "denylist"
 
+def we_are_running_in_a_docker_container() -> bool:
+    """Check if we are running in a Docker container
+
+    Returns:
+        bool: True if we are running in a Docker container, False otherwise
+    """
+    return os.path.exists("/.dockerenv")
+
+
+def is_docker_available() -> bool:
+    """Check if Docker is available
+    
+    Returns:
+        bool: True if Docker is available, False otherwise"""
+    try:
+        client = docker.from_env()
+        client.ping()
+        return True
+    except Exception:
+        return False
+
 
 @command(
     "execute_python_code",
@@ -44,6 +65,9 @@ DENYLIST_CONTROL = "denylist"
             required=True,
         ),
     },
+    disabled_reason="""To execute python code agent must be running in a Docker container or
+    Docker must be available on the system.""",
+    available=we_are_running_in_a_docker_container() or is_docker_available()
 )
 def execute_python_code(code: str, agent: Agent) -> str:
     """
@@ -91,6 +115,9 @@ def execute_python_code(code: str, agent: Agent) -> str:
             items=JSONSchema(type=JSONSchema.Type.STRING),
         ),
     },
+    disabled_reason="""To execute python code agent must be running in a Docker container or
+    Docker must be available on the system.""",
+    available=we_are_running_in_a_docker_container() or is_docker_available()
 )
 @sanitize_path_arg("filename")
 def execute_python_file(

--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 ALLOWLIST_CONTROL = "allowlist"
 DENYLIST_CONTROL = "denylist"
 
+
 def we_are_running_in_a_docker_container() -> bool:
     """Check if we are running in a Docker container
 
@@ -43,7 +44,7 @@ def we_are_running_in_a_docker_container() -> bool:
 
 def is_docker_available() -> bool:
     """Check if Docker is available
-    
+
     Returns:
         bool: True if Docker is available, False otherwise"""
     try:
@@ -65,7 +66,8 @@ def is_docker_available() -> bool:
             required=True,
         ),
     },
-    disabled_reason="""To execute python code agent must be running in a Docker container or
+    disabled_reason="""To execute python code agent
+    must be running in a Docker container or
     Docker must be available on the system.""",
     available=we_are_running_in_a_docker_container() or is_docker_available()
 )
@@ -115,7 +117,8 @@ def execute_python_code(code: str, agent: Agent) -> str:
             items=JSONSchema(type=JSONSchema.Type.STRING),
         ),
     },
-    disabled_reason="""To execute python code agent must be running in a Docker container or
+    disabled_reason="""To execute python code agent
+    must be running in a Docker container or
     Docker must be available on the system.""",
     available=we_are_running_in_a_docker_container() or is_docker_available()
 )

--- a/autogpts/autogpt/autogpt/commands/execute_code.py
+++ b/autogpts/autogpt/autogpt/commands/execute_code.py
@@ -69,7 +69,7 @@ def is_docker_available() -> bool:
     disabled_reason="""To execute python code agent
     must be running in a Docker container or
     Docker must be available on the system.""",
-    available=we_are_running_in_a_docker_container() or is_docker_available()
+    available=we_are_running_in_a_docker_container() or is_docker_available(),
 )
 def execute_python_code(code: str, agent: Agent) -> str:
     """
@@ -120,7 +120,7 @@ def execute_python_code(code: str, agent: Agent) -> str:
     disabled_reason="""To execute python code agent
     must be running in a Docker container or
     Docker must be available on the system.""",
-    available=we_are_running_in_a_docker_container() or is_docker_available()
+    available=we_are_running_in_a_docker_container() or is_docker_available(),
 )
 @sanitize_path_arg("filename")
 def execute_python_file(


### PR DESCRIPTION
### Background

Fix

### Changes 🏗️

- Disable `execute_python_code` and `execute_python_file` if running outside Docker and Docker is unavailable. 

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
