### PR TITLE
fix(autogpt): Fix GCS and S3 root path issue

### DIFF
--- a/autogpts/autogpt/autogpt/file_storage/gcs.py
+++ b/autogpts/autogpt/autogpt/file_storage/gcs.py
@@ -33,7 +33,9 @@ class GCSFileStorage(FileStorage):
     def __init__(self, config: GCSFileStorageConfiguration):
         self._bucket_name = config.bucket
         self._root = config.root
-        assert self._root.is_absolute()
+        # Add / at the beginning of the root path
+        if not self._root.is_absolute():
+            self._root = Path("/").joinpath(self._root)
 
         self._gcs = storage.Client()
         super().__init__()

--- a/autogpts/autogpt/autogpt/file_storage/s3.py
+++ b/autogpts/autogpt/autogpt/file_storage/s3.py
@@ -42,7 +42,9 @@ class S3FileStorage(FileStorage):
     def __init__(self, config: S3FileStorageConfiguration):
         self._bucket_name = config.bucket
         self._root = config.root
-        assert self._root.is_absolute()
+        # Add / at the beginning of the root path
+        if not self._root.is_absolute():
+            self._root = Path("/").joinpath(self._root)
 
         # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
         self._s3 = boto3.resource(


### PR DESCRIPTION
Make GCS and S3 FileStorage root path absolute if it isn't in `__init__`.