### PR TITLE
test(agent): Fix VCRpy request filter for cross-platform use

### DIFF
--- a/autogpts/autogpt/tests/vcr/__init__.py
+++ b/autogpts/autogpt/tests/vcr/__init__.py
@@ -10,7 +10,6 @@ from openai._utils import is_given
 from pytest_mock import MockerFixture
 
 from .vcr_filter import (
-    PROXY,
     before_record_request,
     before_record_response,
     freeze_request_body,
@@ -20,15 +19,6 @@ DEFAULT_RECORD_MODE = "new_episodes"
 BASE_VCR_CONFIG = {
     "before_record_request": before_record_request,
     "before_record_response": before_record_response,
-    "filter_headers": [
-        "Authorization",
-        "AGENT-MODE",
-        "AGENT-TYPE",
-        "Cookie",
-        "OpenAI-Organization",
-        "X-OpenAI-Client-User-Agent",
-        "User-Agent",
-    ],
     "match_on": ["method", "headers"],
 }
 
@@ -69,10 +59,6 @@ def cached_openai_client(mocker: MockerFixture) -> OpenAI:
         options.headers = headers
         data: dict = options.json_data
 
-        if PROXY:
-            headers["AGENT-MODE"] = os.environ.get("AGENT_MODE", Omit())
-            headers["AGENT-TYPE"] = os.environ.get("AGENT_TYPE", Omit())
-
         logging.getLogger("cached_openai_client").debug(
             f"Outgoing API request: {headers}\n{data if data else None}"
         )
@@ -82,8 +68,6 @@ def cached_openai_client(mocker: MockerFixture) -> OpenAI:
             freeze_request_body(data), usedforsecurity=False
         ).hexdigest()
 
-    if PROXY:
-        client.base_url = f"{PROXY}/v1"
     mocker.patch.object(
         client,
         "_prepare_options",


### PR DESCRIPTION
- Move filtering logic from tests/vcr/__init__.py to tests/vcr/vcr_filter.py
- Ignore all `X-Stainless-*` headers for cassette matching, e.g. `X-Stainless-OS` and `X-Stainless-Runtime-Version`
- Remove deprecated OpenAI proxy logic
- Reorder methods in vcr_filter.py for readability

### Background

CI for PRs from forks works on Linux but fails on macOS and Windows:
![image](https://github.com/Significant-Gravitas/AutoGPT/assets/12185583/0c84bfff-2a35-46a8-b49a-7354743aa868)

This is because the OpenAI library includes platform- and version-specific headers in requests:
```
x-stainless-arch:
- x64
x-stainless-async:
- 'false'
x-stainless-lang:
- python
x-stainless-os:
- Linux
x-stainless-package-version:
- 1.8.0
x-stainless-runtime:
- CPython
x-stainless-runtime-version:
- 3.10.13
```

We can fix this by ignoring (= filtering out) those headers before saving/retrieving the request to/from a cassette.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/Nexus/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
