### PR TITLE
feat(agent): Update component ordering

### DIFF
--- a/autogpts/autogpt/autogpt/agents/agent.py
+++ b/autogpts/autogpt/autogpt/agents/agent.py
@@ -120,7 +120,7 @@ class Agent(BaseAgent, Configurable[AgentSettings]):
             lambda x: self.llm_provider.count_tokens(x, self.llm.name),
             legacy_config,
             llm_provider,
-        )
+        ).run_after(WatchdogComponent)
         self.user_interaction = UserInteractionComponent(legacy_config)
         self.file_manager = FileManagerComponent(settings, file_storage)
         self.code_executor = CodeExecutorComponent(
@@ -135,7 +135,9 @@ class Agent(BaseAgent, Configurable[AgentSettings]):
         self.web_search = WebSearchComponent(legacy_config)
         self.web_selenium = WebSeleniumComponent(legacy_config, llm_provider, self.llm)
         self.context = ContextComponent(self.file_manager.workspace, settings.context)
-        self.watchdog = WatchdogComponent(settings.config, settings.history)
+        self.watchdog = WatchdogComponent(settings.config, settings.history).run_after(
+            ContextComponent
+        )
 
         self.created_at = datetime.now().strftime("%Y%m%d_%H%M%S")
         """Timestamp the agent was created; only used for structured debug logging."""

--- a/autogpts/autogpt/autogpt/agents/base.py
+++ b/autogpts/autogpt/autogpt/agents/base.py
@@ -300,7 +300,7 @@ class BaseAgent(Configurable[BaseAgentSettings], metaclass=AgentMeta):
         ]
 
         if self.components:
-            # Check if any coponent is missed (added to Agent but not to components)
+            # Check if any component is missing (added to Agent but not to components)
             for component in components:
                 if component not in self.components:
                     logger.warning(
@@ -321,12 +321,11 @@ class BaseAgent(Configurable[BaseAgentSettings], metaclass=AgentMeta):
             if node in visited:
                 return
             visited.add(node)
-            for neighbor_class in node.__class__.run_after:
-                # Find the instance of neighbor_class in components
+            for neighbor_class in node._run_after:
                 neighbor = next(
                     (m for m in components if isinstance(m, neighbor_class)), None
                 )
-                if neighbor:
+                if neighbor and neighbor not in visited:
                     visit(neighbor)
             stack.append(node)
 

--- a/autogpts/autogpt/autogpt/agents/components.py
+++ b/autogpts/autogpt/autogpt/agents/components.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 from abc import ABC
-from typing import Callable
+from typing import Callable, TypeVar
+
+T = TypeVar("T", bound="AgentComponent")
 
 
 class AgentComponent(ABC):
-    run_after: list[type["AgentComponent"]] = []
+    """Base class for all agent components."""
+
+    _run_after: list[type[AgentComponent]] = []
     _enabled: Callable[[], bool] | bool = True
     _disabled_reason: str = ""
 
@@ -15,7 +21,16 @@ class AgentComponent(ABC):
 
     @property
     def disabled_reason(self) -> str:
+        """Return the reason this component is disabled."""
         return self._disabled_reason
+
+    def run_after(self: T, *components: type[AgentComponent] | AgentComponent) -> T:
+        """Set the components that this component should run after."""
+        for component in components:
+            t = component if isinstance(component, type) else type(component)
+            if t not in self._run_after and t is not self.__class__:
+                self._run_after.append(t)
+        return self
 
 
 class ComponentEndpointError(Exception):

--- a/autogpts/autogpt/autogpt/agents/features/watchdog.py
+++ b/autogpts/autogpt/autogpt/agents/features/watchdog.py
@@ -2,7 +2,6 @@ import logging
 
 from autogpt.agents.base import BaseAgentActionProposal, BaseAgentConfiguration
 from autogpt.agents.components import ComponentSystemError
-from autogpt.agents.features.context import ContextComponent
 from autogpt.agents.protocols import AfterParse
 from autogpt.models.action_history import EpisodicActionHistory
 
@@ -14,8 +13,6 @@ class WatchdogComponent(AfterParse):
     Adds a watchdog feature to an agent class. Whenever the agent starts
     looping, the watchdog will switch from the FAST_LLM to the SMART_LLM and re-think.
     """
-
-    run_after = [ContextComponent]
 
     def __init__(
         self,

--- a/autogpts/autogpt/autogpt/commands/README.md
+++ b/autogpts/autogpt/autogpt/commands/README.md
@@ -32,21 +32,30 @@ class MyAgent(Agent):
 
 ## Ordering components
 
-The execution order of components is important because the latter ones may depend on the results of the former ones.
+The execution order of components is important because some may depend on the results of the previous ones.
+**By default, components are ordered alphabetically.**
 
-### Implicit order
+### Ordering individual components
 
-Components can be ordered implicitly by the agent; each component can set `run_after` list to specify which components should run before it. This is useful when components rely on each other or need to be executed in a specific order. Otherwise, the order of components is alphabetical.
+You can order a single component by passing other components (or their types) to the `run_after` method. This way you can ensure that the component will be executed after the specified one.
+The `run_after` method returns the component itself, so you can call it when assigning the component to a variable:
 
 ```py
-# This component will run after HelloComponent
-class CalculatorComponent(AgentComponent):
-    run_after = [HelloComponent]
+class MyAgent(Agent):
+    def __init__(self):
+        self.hello_component = HelloComponent()
+        self.calculator_component = CalculatorComponent().run_after(self.hello_component)
+        # This is equivalent to passing a type:
+        # self.calculator_component = CalculatorComponent().run_after(HelloComponent)
 ```
 
-### Explicit order
+!!! warning
+    Be sure not to make circular dependencies when ordering components!
 
-Sometimes it may be easier to order components explicitly by setting `self.components` list in the agent's `__init__` method. This way you can also ensure there's no circular dependencies and `run_after` is ignored.
+### Ordering all components
+
+You can also order all components by setting `self.components` list in the agent's `__init__` method.
+This way ensures that there's no circular dependencies and any `run_after` calls are ignored.
 
 !!! warning
     Be sure to include all components - by setting `self.components` list, you're overriding the default behavior of discovering components automatically. Since it's usually not intended agent will inform you in the terminal if some components were skipped.
@@ -55,7 +64,7 @@ Sometimes it may be easier to order components explicitly by setting `self.compo
 class MyAgent(Agent):
     def __init__(self):
         self.hello_component = HelloComponent()
-        self.calculator_component = CalculatorComponent(self.hello_component)
+        self.calculator_component = CalculatorComponent()
         # Explicitly set components list
         self.components = [self.hello_component, self.calculator_component]
 ```

--- a/autogpts/autogpt/autogpt/components/event_history.py
+++ b/autogpts/autogpt/autogpt/components/event_history.py
@@ -1,6 +1,5 @@
 from typing import Callable, Generic, Iterator, Optional
 
-from autogpt.agents.features.watchdog import WatchdogComponent
 from autogpt.agents.protocols import AfterExecute, AfterParse, MessageProvider
 from autogpt.config.config import Config
 from autogpt.core.resource.model_providers.schema import ChatMessage, ChatModelProvider
@@ -15,8 +14,6 @@ from autogpt.prompts.utils import indent
 
 class EventHistoryComponent(MessageProvider, AfterParse, AfterExecute, Generic[AP]):
     """Keeps track of the event history and provides a summary of the steps."""
-
-    run_after = [WatchdogComponent]
 
     def __init__(
         self,


### PR DESCRIPTION
### **User description**
### Background

Refactor https://github.com/Significant-Gravitas/AutoGPT/pull/7106 is causing many problems with circular imports.
Static `run_after` inside component classes needlessely couples components to each other and hides ordering from the developer. And it's only useful for internal components as the exact type needs to be known.

### Changes 🏗️

Removed usage of static `run_after` field and introduced `run_after` method that allows defining ordering at the agent level (local & clear). This also allows user to order specific components (without defining order for all components).

- Introduced `run_after` method in `ComponentAgent`
- Updated relevant code and docs
- Added code comments

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [x] Have you changed or added a feature? &ensp; `-4 pts`
  - [x] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced a dynamic `run_after` method to replace static ordering in components, enhancing flexibility and clarity in component execution order.
- Updated agent initialization in `agent.py` to use the new dynamic `run_after` method for `WatchdogComponent` and `ContextComponent`.
- Removed outdated static `run_after` lists from `WatchdogComponent` and `EventHistoryComponent`.
- Documentation in `README.md` updated to guide on using the new dynamic ordering method and to warn about potential circular dependencies.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Implement dynamic component ordering in Agent initialization</code></dd></summary>
<hr>
      
autogpts/autogpt/autogpt/agents/agent.py

<li>Replaced static <code>run_after</code> with dynamic <code>run_after</code> method calls for <br><code>WatchdogComponent</code> and <code>ContextComponent</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7148/files#diff-9224bfb0fac9d6e9ef7e4533bacf7dee4f89ba02339088c95f5e7cfc3455dd94">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Refine component collection and fix comment typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
autogpts/autogpt/autogpt/agents/base.py

<li>Fixed typo in a comment.<br> <li> Updated component collection logic to prevent revisiting components.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7148/files#diff-a0a9fb0388413a4926ab73838636d31fcd967cd62744c05820dfb387a2c9f3f9">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>components.py</strong><dd><code>Add dynamic ordering method to AgentComponent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
autogpts/autogpt/autogpt/agents/components.py

<li>Added <code>run_after</code> method to dynamically set component execution order.<br> <li> Removed static <code>run_after</code> list.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7148/files#diff-8014aefc9c39845ce024a4f86316aa8e8eff15a7aebb3ad35b86fb4877ab3d87">+17/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>watchdog.py</strong><dd><code>Remove static ordering from WatchdogComponent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
autogpts/autogpt/autogpt/agents/features/watchdog.py

- Removed static `run_after` list from `WatchdogComponent`.



</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7148/files#diff-6037b84435aa76e0bde54bb588a0411e3b174a4aec7a17c1499b04754017a647">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>event_history.py</strong><dd><code>Remove static ordering from EventHistoryComponent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
autogpts/autogpt/autogpt/components/event_history.py

- Removed static `run_after` list from `EventHistoryComponent`.



</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7148/files#diff-b8e2023ebed59f067945504b7f64ff80d8e03be95fc0538bc8f7484f5d0644c9">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to document dynamic component ordering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
autogpts/autogpt/autogpt/commands/README.md

<li>Updated documentation to reflect dynamic component ordering.<br> <li> Added warnings about circular dependencies.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7148/files#diff-a854a2a97136b7b58e5128ef3dcbd82fd3648a3198efce7403354c7f5d37a733">+18/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

