### PR TITLE
docs+fix(agent): Update LLM setup instructions & remove GPT-specific flags

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -90,7 +90,7 @@ body:
     attributes:
       label: Do you use OpenAI GPT-3 or GPT-4?
       description: >
-        If you are using AutoGPT with `--gpt3only`, your problems may be caused by
+        If you are using AutoGPT with `SMART_LLM=gpt-3.5-turbo`, your problems may be caused by
         the [limitations](https://github.com/Significant-Gravitas/AutoGPT/issues?q=is%3Aissue+label%3A%22AI+model+limitation%22) of GPT-3.5.
       options:
         - GPT-3.5

--- a/autogpt/README.md
+++ b/autogpt/README.md
@@ -68,8 +68,6 @@ Options:
                                   continuous mode
   --speak                         Enable Speak Mode
   --debug                         Enable Debug Mode
-  --gpt3only                      Enable GPT3.5 Only Mode
-  --gpt4only                      Enable GPT4 Only Mode
   -b, --browser-name TEXT         Specifies which web-browser to use when
                                   using selenium to scrape the web.
   --allow-downloads               Dangerous: Allows AutoGPT to download files
@@ -113,8 +111,6 @@ Usage: python -m autogpt serve [OPTIONS]
 
 Options:
   --debug                     Enable Debug Mode
-  --gpt3only                  Enable GPT3.5 Only Mode
-  --gpt4only                  Enable GPT4 Only Mode
   -b, --browser-name TEXT     Specifies which web-browser to use when using
                               selenium to scrape the web.
   --allow-downloads           Dangerous: Allows AutoGPT to download files

--- a/autogpt/autogpt/app/cli.py
+++ b/autogpt/autogpt/app/cli.py
@@ -28,8 +28,6 @@ def cli(ctx: click.Context):
     help="Defines the number of times to run in continuous mode",
 )
 @click.option("--speak", is_flag=True, help="Enable Speak Mode")
-@click.option("--gpt3only", is_flag=True, help="Enable GPT3.5 Only Mode")
-@click.option("--gpt4only", is_flag=True, help="Enable GPT4 Only Mode")
 @click.option(
     "-b",
     "--browser-name",
@@ -134,8 +132,6 @@ def run(
     continuous: bool,
     continuous_limit: Optional[int],
     speak: bool,
-    gpt3only: bool,
-    gpt4only: bool,
     browser_name: Optional[str],
     allow_downloads: bool,
     workspace_directory: Optional[Path],
@@ -169,8 +165,6 @@ def run(
         log_level=log_level,
         log_format=log_format,
         log_file_format=log_file_format,
-        gpt3only=gpt3only,
-        gpt4only=gpt4only,
         browser_name=browser_name,
         allow_downloads=allow_downloads,
         skip_news=skip_news,
@@ -186,8 +180,6 @@ def run(
 
 
 @cli.command()
-@click.option("--gpt3only", is_flag=True, help="Enable GPT3.5 Only Mode")
-@click.option("--gpt4only", is_flag=True, help="Enable GPT4 Only Mode")
 @click.option(
     "-b",
     "--browser-name",
@@ -225,8 +217,6 @@ def run(
     type=click.Choice([i.value for i in LogFormatName]),
 )
 def serve(
-    gpt3only: bool,
-    gpt4only: bool,
     browser_name: Optional[str],
     allow_downloads: bool,
     install_plugin_deps: bool,
@@ -247,8 +237,6 @@ def serve(
         log_level=log_level,
         log_format=log_format,
         log_file_format=log_file_format,
-        gpt3only=gpt3only,
-        gpt4only=gpt4only,
         browser_name=browser_name,
         allow_downloads=allow_downloads,
         install_plugin_deps=install_plugin_deps,

--- a/autogpt/autogpt/app/configurator.py
+++ b/autogpt/autogpt/app/configurator.py
@@ -6,7 +6,7 @@ from typing import Literal, Optional
 
 import click
 from colorama import Back, Style
-from forge.config.config import GPT_3_MODEL, GPT_4_MODEL, Config
+from forge.config.config import GPT_3_MODEL, Config
 from forge.llm.providers import ModelName, MultiProvider
 
 logger = logging.getLogger(__name__)
@@ -17,8 +17,6 @@ async def apply_overrides_to_config(
     continuous: bool = False,
     continuous_limit: Optional[int] = None,
     skip_reprompt: bool = False,
-    gpt3only: bool = False,
-    gpt4only: bool = False,
     browser_name: Optional[str] = None,
     allow_downloads: bool = False,
     skip_news: bool = False,
@@ -35,8 +33,6 @@ async def apply_overrides_to_config(
         log_level (int): The global log level for the application.
         log_format (str): The format for the log(s).
         log_file_format (str): Override the format for the log file.
-        gpt3only (bool): Whether to enable GPT3.5 only mode.
-        gpt4only (bool): Whether to enable GPT4 only mode.
         browser_name (str): The name of the browser to use for scraping the web.
         allow_downloads (bool): Whether to allow AutoGPT to download files natively.
         skips_news (bool): Whether to suppress the output of latest news on startup.
@@ -58,21 +54,9 @@ async def apply_overrides_to_config(
     if continuous_limit and not continuous:
         raise click.UsageError("--continuous-limit can only be used with --continuous")
 
-    # Set the default LLM models
-    if gpt3only:
-        # --gpt3only should always use gpt-3.5-turbo, despite user's FAST_LLM config
-        config.fast_llm = GPT_3_MODEL
-        config.smart_llm = GPT_3_MODEL
-    elif (
-        gpt4only
-        and (await check_model(GPT_4_MODEL, model_type="smart_llm")) == GPT_4_MODEL
-    ):
-        # --gpt4only should always use gpt-4, despite user's SMART_LLM config
-        config.fast_llm = GPT_4_MODEL
-        config.smart_llm = GPT_4_MODEL
-    else:
-        config.fast_llm = await check_model(config.fast_llm, "fast_llm")
-        config.smart_llm = await check_model(config.smart_llm, "smart_llm")
+    # Check availability of configured LLMs; fallback to other LLM if unavailable
+    config.fast_llm = await check_model(config.fast_llm, "fast_llm")
+    config.smart_llm = await check_model(config.smart_llm, "smart_llm")
 
     if skip_reprompt:
         config.skip_reprompt = True

--- a/autogpt/autogpt/app/main.py
+++ b/autogpt/autogpt/app/main.py
@@ -62,8 +62,6 @@ async def run_auto_gpt(
     log_level: Optional[str] = None,
     log_format: Optional[str] = None,
     log_file_format: Optional[str] = None,
-    gpt3only: bool = False,
-    gpt4only: bool = False,
     browser_name: Optional[str] = None,
     allow_downloads: bool = False,
     skip_news: bool = False,
@@ -108,8 +106,6 @@ async def run_auto_gpt(
         continuous=continuous,
         continuous_limit=continuous_limit,
         skip_reprompt=skip_reprompt,
-        gpt3only=gpt3only,
-        gpt4only=gpt4only,
         browser_name=browser_name,
         allow_downloads=allow_downloads,
         skip_news=skip_news,
@@ -357,8 +353,6 @@ async def run_auto_gpt_server(
     log_level: Optional[str] = None,
     log_format: Optional[str] = None,
     log_file_format: Optional[str] = None,
-    gpt3only: bool = False,
-    gpt4only: bool = False,
     browser_name: Optional[str] = None,
     allow_downloads: bool = False,
     install_plugin_deps: bool = False,
@@ -391,8 +385,6 @@ async def run_auto_gpt_server(
 
     await apply_overrides_to_config(
         config=config,
-        gpt3only=gpt3only,
-        gpt4only=gpt4only,
         browser_name=browser_name,
         allow_downloads=allow_downloads,
     )

--- a/autogpt/tests/unit/test_config.py
+++ b/autogpt/tests/unit/test_config.py
@@ -8,13 +8,12 @@ from typing import Any
 from unittest import mock
 
 import pytest
-from forge.config.config import Config, ConfigBuilder
-from forge.llm.providers.schema import ChatModelInfo, ModelProviderName
+from forge.config.config import GPT_3_MODEL, GPT_4_MODEL, Config, ConfigBuilder
 from openai.pagination import AsyncPage
 from openai.types import Model
 from pydantic import SecretStr
 
-from autogpt.app.configurator import GPT_3_MODEL, GPT_4_MODEL, apply_overrides_to_config
+from autogpt.app.configurator import apply_overrides_to_config
 
 
 def test_initial_values(config: Config) -> None:
@@ -46,11 +45,7 @@ async def test_fallback_to_gpt3_if_gpt4_not_available(
         )
     )
 
-    await apply_overrides_to_config(
-        config=config,
-        gpt3only=False,
-        gpt4only=False,
-    )
+    await apply_overrides_to_config(config=config)
 
     assert config.fast_llm == GPT_3_MODEL
     assert config.smart_llm == GPT_3_MODEL
@@ -139,43 +134,3 @@ def test_azure_config(config_with_azure: Config) -> None:
         credentials.get_model_access_kwargs(config_with_azure.smart_llm)["model"]
         == "FAST-LLM_ID"
     )
-
-
-@pytest.mark.asyncio
-async def test_create_config_gpt4only(config: Config) -> None:
-    with mock.patch(
-        "forge.llm.providers.multi.MultiProvider.get_available_chat_models"
-    ) as mock_get_models:
-        mock_get_models.return_value = [
-            ChatModelInfo(
-                name=GPT_4_MODEL,
-                provider_name=ModelProviderName.OPENAI,
-                max_tokens=4096,
-            )
-        ]
-        await apply_overrides_to_config(
-            config=config,
-            gpt4only=True,
-        )
-        assert config.fast_llm == GPT_4_MODEL
-        assert config.smart_llm == GPT_4_MODEL
-
-
-@pytest.mark.asyncio
-async def test_create_config_gpt3only(config: Config) -> None:
-    with mock.patch(
-        "forge.llm.providers.multi.MultiProvider.get_available_chat_models"
-    ) as mock_get_models:
-        mock_get_models.return_value = [
-            ChatModelInfo(
-                name=GPT_3_MODEL,
-                provider_name=ModelProviderName.OPENAI,
-                max_tokens=4096,
-            )
-        ]
-        await apply_overrides_to_config(
-            config=config,
-            gpt3only=True,
-        )
-        assert config.fast_llm == GPT_3_MODEL
-        assert config.smart_llm == GPT_3_MODEL

--- a/docs/content/AutoGPT/setup/docker.md
+++ b/docs/content/AutoGPT/setup/docker.md
@@ -77,7 +77,7 @@
 
 4. Download [`.env.template`][.env.template] and save it as `.env` in the AutoGPT folder.
 5. Follow the standard [configuration instructions](../index.md#completing-the-setup),
-   from step 3 onwards.
+   from step 3 onwards and excluding `poetry install` steps.
 6. Pull the latest image from [Docker Hub]
 
     ```shell
@@ -99,7 +99,7 @@
 
 1. Copy `.env.template` to `.env`.
 2. Follow the standard [configuration instructions](../index.md#completing-the-setup),
-   from step 3 onwards.
+   from step 3 onwards and excluding `poetry install` steps.
 
 ## Running AutoGPT with Docker
 

--- a/docs/content/AutoGPT/setup/docker.md
+++ b/docs/content/AutoGPT/setup/docker.md
@@ -76,7 +76,8 @@
 
 
 4. Download [`.env.template`][.env.template] and save it as `.env` in the AutoGPT folder.
-5. Follow the [configuration](#configuration) steps.
+5. Follow the standard [configuration instructions](../index.md#completing-the-setup),
+   from step 3 onwards.
 6. Pull the latest image from [Docker Hub]
 
     ```shell
@@ -90,47 +91,6 @@
 [.env.template]: https://github.com/Significant-Gravitas/AutoGPT/tree/master/autogpt/.env.template
 [Docker Hub]: https://hub.docker.com/r/significantgravitas/auto-gpt
 
-## Configuration
-
-1. Open the `.env` file in a text editor. This file may
-    be hidden by default in some operating systems due to the dot prefix. To reveal
-    hidden files, follow the instructions for your specific operating system:
-    [Windows][show hidden files/Windows], [macOS][show hidden files/macOS].
-2. Find the line that says `OPENAI_API_KEY=`.
-3. After the `=`, enter your unique OpenAI API Key *without any quotes or spaces*.
-4. Enter any other API keys or tokens for services you would like to use.
-
-    !!! note
-        To activate and adjust a setting, remove the `# ` prefix.
-
-5. Save and close the `.env` file.
-
-!!! info "Using a GPT Azure-instance"
-    If you want to use GPT on an Azure instance, set `USE_AZURE` to `True` and
-    make an Azure configuration file:
-
-    - Rename `azure.yaml.template` to `azure.yaml` and provide the relevant `azure_api_base`, `azure_api_version` and all the deployment IDs for the relevant models in the `azure_model_map` section.
-
-    Example:
-
-    ```yaml
-    # Please specify all of these values as double-quoted strings
-    # Replace string in angled brackets (<>) to your own deployment Name
-    azure_model_map:
-        gpt-4-turbo-preview: "<gpt-4-turbo deployment ID>"
-        ...
-    ```
-
-    Details can be found in the [openai-python docs], and in the [Azure OpenAI docs] for the embedding model.
-    If you're on Windows you may need to install an [MSVC library](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
-
-    **Note:** Azure support has been dropped in `master`, so these instructions will only work with v0.4.7 (or earlier).
-
-[show hidden files/Windows]: https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5
-[show hidden files/macOS]: https://www.pcmag.com/how-to/how-to-access-your-macs-hidden-files
-[openai-python docs]: https://github.com/openai/openai-python#microsoft-azure-endpoints
-[Azure OpenAI docs]: https://learn.microsoft.com/en-us/azure/cognitive-services/openai/tutorials/embeddings?tabs=command-line
-
 ## Developer Setup
 
 !!! tip
@@ -138,7 +98,8 @@
     changes to the codebase.
 
 1. Copy `.env.template` to `.env`.
-2. Follow the standard [configuration](#configuration) steps above.
+2. Follow the standard [configuration instructions](../index.md#completing-the-setup),
+   from step 3 onwards.
 
 ## Running AutoGPT with Docker
 

--- a/docs/content/AutoGPT/setup/index.md
+++ b/docs/content/AutoGPT/setup/index.md
@@ -82,6 +82,15 @@ See the [user guide](../usage.md) for further instructions.
 
 ## Setting up LLM providers
 
+You can use AutoGPT with any of the following LLM providers.
+Each of them comes with its own setup instructions.
+
+AutoGPT was originally built on top of OpenAI's GPT-4, but now you can get
+similar and interesting results using other models/providers too.
+If you don't know which to choose, you can safely go with OpenAI*.
+
+<small>* subject to change</small>
+
 ### OpenAI
 
 !!! attention

--- a/docs/content/AutoGPT/setup/index.md
+++ b/docs/content/AutoGPT/setup/index.md
@@ -79,27 +79,22 @@ See the [user guide](../usage.md) for further instructions.
 [show hidden files/Windows]: https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5
 [show hidden files/macOS]: https://www.pcmag.com/how-to/how-to-access-your-macs-hidden-files
 
+
 ## Setting up LLM providers
 
 ### OpenAI
 
-Get your OpenAI API key from:
-[https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
-
 !!! attention
-    To use AutoGPT with GPT-4, you need to set up a paid OpenAI account with some money
-    in it. Please refer to OpenAI for further instructions ([link][openai/gpt-4-access]).
-    Free accounts are [limited][openai/api limits] to GPT-3.5 with only 3 requests per minute.
+    To use AutoGPT with GPT-4 (recommended), you need to set up a paid OpenAI account
+    with some money in it. Please refer to OpenAI for further instructions ([link][openai/help-gpt-4-access]).
+    Free accounts are [limited][openai/api-limits] to GPT-3.5 with only 3 requests per minute.
 
-    You can set up a paid account at [Manage account > Billing > Overview](https://platform.openai.com/account/billing/overview).
-
-[openai/gpt-4-access]: https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4-gpt-4-turbo-and-gpt-4o#h_9bddcd317c
-[openai/api limits]: https://platform.openai.com/docs/guides/rate-limits/free-tier-rate-limits
-
-1. Open `.env`
-4. Find the line that says `OPENAI_API_KEY=`.
-5. Insert your OpenAI API Key directly after = without quotes or spaces..
-    ```yaml
+1. Make sure you have a paid account with some credits set up: [Settings > Organization > Billing][openai/billing]
+1. Get your OpenAI API key from: [API keys][openai/api-keys]
+2. Open `.env`
+3. Find the line that says `OPENAI_API_KEY=`
+4. Insert your OpenAI API Key directly after = without quotes or spaces:
+    ```ini
     OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     ```
 
@@ -122,10 +117,40 @@ Get your OpenAI API key from:
             ...
         ```
 
-        Details can be found in the [openai-python docs], and in the [Azure OpenAI docs] for the embedding model.
+        Details can be found in the [openai/python-sdk/azure], and in the [Azure OpenAI docs] for the embedding model.
         If you're on Windows you may need to install an [MSVC library](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
 
 !!! important
     Keep an eye on your API costs on [the Usage page](https://platform.openai.com/account/usage).
 
-[openai-python docs]: https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai
+
+[openai/billing]: https://platform.openai.com/account/billing/overview
+[openai/api-keys]: https://platform.openai.com/account/api-keys
+[openai/api-limits]: https://platform.openai.com/docs/guides/rate-limits/free-tier-rate-limits
+[openai/help-gpt-4-access]: https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4-gpt-4-turbo-and-gpt-4o#h_9bddcd317c
+[openai/python-sdk/azure]: https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai
+
+
+### Anthropic
+
+1. Make sure you have credits in your account: [Settings > Plans & billing][anthropic/billing]
+2. Get your Anthropic API key from [Settings > API keys][anthropic/api-keys]
+3. Open `.env`
+4. Find the line that says `ANTHROPIC_API_KEY=`
+5. Insert your Anthropic API Key directly after = without quotes or spaces:
+    ```ini
+    ANTHROPIC_API_KEY=sk-ant-api03-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    ```
+6. Set `SMART_LLM` and/or `FAST_LLM` to the Claude 3 model you want to use.
+   See Anthropic's [models overview][anthropic/models] for info on the available models.
+   Example:
+    ```ini
+    SMART_LLM=claude-3-opus-20240229
+    ```
+
+!!! important
+    Keep an eye on your API costs on [the Usage page](https://console.anthropic.com/settings/usage).
+
+[anthropic/billing]: https://console.anthropic.com/settings/plans
+[anthropic/api-keys]: https://console.anthropic.com/settings/keys
+[anthropic/models]: https://docs.anthropic.com/en/docs/models-overview

--- a/docs/content/AutoGPT/setup/index.md
+++ b/docs/content/AutoGPT/setup/index.md
@@ -28,27 +28,6 @@
 - [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/)
 
 
-### 🗝️ Getting an OpenAI API key
-
-Get your OpenAI API key from:
-[https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
-
-!!! attention
-    To use the OpenAI API with AutoGPT, we strongly recommend **setting up billing**
-    (AKA paid account). Free accounts are [limited][openai/api limits] to 3 API calls per
-    minute, which can cause the application to crash.
-
-    You can set up a paid account at [Manage account > Billing > Overview](https://platform.openai.com/account/billing/overview).
-
-[openai/api limits]: https://platform.openai.com/docs/guides/rate-limits/free-tier-rate-limits
-
-!!! important
-    It's highly recommended that you keep track of your API costs on [the Usage page](https://platform.openai.com/account/usage).
-    You can also set limits on how much you spend on [the Usage limits page](https://platform.openai.com/account/billing/limits).
-
-![For OpenAI API key to work, set up paid account at OpenAI API > Billing](../../imgs/openai-api-key-billing-paid-account.png)
-
-
 ## Setting up AutoGPT
 
 ### Getting AutoGPT
@@ -83,10 +62,45 @@ Once you have cloned or downloaded the project, you can find the AutoGPT Agent i
     cp .env.template .env
     ```
 3. Open the `.env` file in a text editor.
+4. Set API keys for the LLM providers that you want to use: see [below](#setting-up-llm-providers).
+5. Enter any other API keys or tokens for services you would like to use.
+
+    !!! note
+        To activate and adjust a setting, remove the `# ` prefix.
+
+6. Save and close the `.env` file.
+7. _Optional: run `poetry install` to install all required dependencies._ The
+    application also checks for and installs any required dependencies when it starts.
+
+You should now be able to explore the CLI (`./autogpt.sh --help`) and run the application.
+
+See the [user guide](../usage.md) for further instructions.
+
+[show hidden files/Windows]: https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5
+[show hidden files/macOS]: https://www.pcmag.com/how-to/how-to-access-your-macs-hidden-files
+
+## Setting up LLM providers
+
+### OpenAI
+
+Get your OpenAI API key from:
+[https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys).
+
+!!! attention
+    To use AutoGPT with GPT-4, you need to set up a paid OpenAI account with some money
+    in it. Please refer to OpenAI for further instructions ([link][openai/gpt-4-access]).
+    Free accounts are [limited][openai/api limits] to GPT-3.5 with only 3 requests per minute.
+
+    You can set up a paid account at [Manage account > Billing > Overview](https://platform.openai.com/account/billing/overview).
+
+[openai/gpt-4-access]: https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4-gpt-4-turbo-and-gpt-4o#h_9bddcd317c
+[openai/api limits]: https://platform.openai.com/docs/guides/rate-limits/free-tier-rate-limits
+
+1. Open `.env`
 4. Find the line that says `OPENAI_API_KEY=`.
 5. Insert your OpenAI API Key directly after = without quotes or spaces..
     ```yaml
-    OPENAI_API_KEY=sk-qwertykeys123456
+    OPENAI_API_KEY=sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     ```
 
     !!! info "Using a GPT Azure-instance"
@@ -97,31 +111,21 @@ Once you have cloned or downloaded the project, you can find the AutoGPT Agent i
         `azure_api_base`, `azure_api_version` and deployment IDs for the models that you
         want to use.
 
-        E.g. if you want to use `gpt-3.5-turbo-16k` and `gpt-4-0314`:
+        E.g. if you want to use `gpt-3.5-turbo` and `gpt-4-turbo`:
 
         ```yaml
         # Please specify all of these values as double-quoted strings
         # Replace string in angled brackets (<>) to your own deployment Name
         azure_model_map:
-            gpt-3.5-turbo-16k: "<auto-gpt-deployment>"
+            gpt-3.5-turbo: "<gpt-35-turbo-deployment-id>"
+            gpt-4-turbo: "<gpt-4-turbo-deployment-id>"
             ...
         ```
 
         Details can be found in the [openai-python docs], and in the [Azure OpenAI docs] for the embedding model.
         If you're on Windows you may need to install an [MSVC library](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
 
-6. Enter any other API keys or tokens for services you would like to use.
+!!! important
+    Keep an eye on your API costs on [the Usage page](https://platform.openai.com/account/usage).
 
-    !!! note
-        To activate and adjust a setting, remove the `# ` prefix.
-
-7. Save and close the `.env` file.
-8. _Optional: run `poetry install` to install all required dependencies._ The
-    application also checks for and installs any required dependencies when it starts.
-
-You should now be able to explore the CLI (`./autogpt.sh --help`) and run the application.
-
-See the [user guide](../usage.md) for further instructions.
-
-[show hidden files/Windows]: https://support.microsoft.com/en-us/windows/view-hidden-files-and-folders-in-windows-97fbc472-c603-9d90-91d0-1166d1d9f4b5
-[show hidden files/macOS]: https://www.pcmag.com/how-to/how-to-access-your-macs-hidden-files
+[openai-python docs]: https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai

--- a/docs/content/AutoGPT/setup/index.md
+++ b/docs/content/AutoGPT/setup/index.md
@@ -121,11 +121,12 @@ See the [user guide](../usage.md) for further instructions.
         If you're on Windows you may need to install an [MSVC library](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170).
 
 !!! important
-    Keep an eye on your API costs on [the Usage page](https://platform.openai.com/account/usage).
+    Keep an eye on your API costs on [the Usage page][openai/usage].
 
 
-[openai/billing]: https://platform.openai.com/account/billing/overview
 [openai/api-keys]: https://platform.openai.com/account/api-keys
+[openai/billing]: https://platform.openai.com/account/billing/overview
+[openai/usage]: https://platform.openai.com/account/usage
 [openai/api-limits]: https://platform.openai.com/docs/guides/rate-limits/free-tier-rate-limits
 [openai/help-gpt-4-access]: https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4-gpt-4-turbo-and-gpt-4o#h_9bddcd317c
 [openai/python-sdk/azure]: https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai
@@ -149,8 +150,34 @@ See the [user guide](../usage.md) for further instructions.
     ```
 
 !!! important
-    Keep an eye on your API costs on [the Usage page](https://console.anthropic.com/settings/usage).
+    Keep an eye on your API costs on [the Usage page][anthropic/usage].
 
-[anthropic/billing]: https://console.anthropic.com/settings/plans
 [anthropic/api-keys]: https://console.anthropic.com/settings/keys
+[anthropic/billing]: https://console.anthropic.com/settings/plans
+[anthropic/usage]: https://console.anthropic.com/settings/usage
 [anthropic/models]: https://docs.anthropic.com/en/docs/models-overview
+
+
+### Groq
+
+!!! note
+    Although Groq is supported, its built-in function calling API isn't mature.
+    Any features using this API may experience degraded performance.
+    Let us know your experience!
+
+1. Get your Groq API key from [Settings > API keys][groq/api-keys]
+2. Open `.env`
+3. Find the line that says `GROQ_API_KEY=`
+4. Insert your Anthropic API Key directly after = without quotes or spaces:
+    ```ini
+    GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    ```
+5. Set `SMART_LLM` and/or `FAST_LLM` to the Groq model you want to use.
+   See Groq's [models overview][groq/models] for info on the available models.
+   Example:
+    ```ini
+    SMART_LLM=llama3-70b-8192
+    ```
+
+[groq/api-keys]: https://console.groq.com/keys
+[groq/models]: https://console.groq.com/docs/models


### PR DESCRIPTION
* Update instructions to set up OpenAI / GPT-4 access
* Add instructions to set up Anthropic access
* Add instructions to set up Groq access
* Remove GPT-specific `--gpt3only`, `--gpt4only` CLI flags and related logic
* Remove duplicate config instructions from the docker setup page, replace by a link to the regular setup instructions

Blocks #7091 