### PR TITLE
Agent Server: Add Events and CLI

### DIFF
--- a/rnd/autogpt_server/autogpt_server/cli.py
+++ b/rnd/autogpt_server/autogpt_server/cli.py
@@ -1,0 +1,19 @@
+import click
+
+
+@click.group()
+def main():
+    """AutoGPT Server CLI Tool"""
+    pass
+
+
+@main.command()
+def event():
+    """
+    Send an event to the running server
+    """
+    print("Event sent")
+
+
+if __name__ == "__main__":
+    main()

--- a/rnd/autogpt_server/autogpt_server/data.py
+++ b/rnd/autogpt_server/autogpt_server/data.py
@@ -9,16 +9,9 @@ class Event:
     executor manager (EM) and for the EM to send to the executors.
     """
     
-    def __init__(self, etype: str, data: Any):
-        self.etype = etype
-        self.data = data
-
-
-class Execution:
-    """Data model for an execution of an Agent"""
-
-    def __init__(self, execution_id: str, data: str):
+    def __init__(self, execution_id: str, etype: str, data: Any):
         self.execution_id = execution_id
+        self.etype = etype
         self.data = data
 
 
@@ -34,14 +27,14 @@ class ExecutionQueue:
     """
 
     def __init__(self):
-        self.queue: Queue[Execution] = Queue()
+        self.queue: Queue[Event] = Queue()
 
-    def add(self, data: str) -> str:
+    def add(self, etype: str, data: Any) -> str:
         execution_id = uuid.uuid4()
-        self.queue.put(Execution(str(execution_id), data))
+        self.queue.put(Event(str(execution_id), etype, data))
         return str(execution_id)
 
-    def get(self) -> Execution | None:
+    def get(self) -> Event | None:
         return self.queue.get()
 
     def empty(self) -> bool:

--- a/rnd/autogpt_server/autogpt_server/data.py
+++ b/rnd/autogpt_server/autogpt_server/data.py
@@ -5,10 +5,10 @@ from multiprocessing import Queue
 
 class Event:
     """
-    Defines an event type for tiggers to send to the 
+    Defines an event type for tiggers to send to the
     executor manager (EM) and for the EM to send to the executors.
     """
-    
+
     def __init__(self, execution_id: str, etype: str, data: Any):
         self.execution_id = execution_id
         self.etype = etype

--- a/rnd/autogpt_server/autogpt_server/data.py
+++ b/rnd/autogpt_server/autogpt_server/data.py
@@ -1,5 +1,17 @@
 import uuid
+from typing import Any
 from multiprocessing import Queue
+
+
+class Event:
+    """
+    Defines an event type for tiggers to send to the 
+    executor manager (EM) and for the EM to send to the executors.
+    """
+    
+    def __init__(self, etype: str, data: Any):
+        self.etype = etype
+        self.data = data
 
 
 class Execution:

--- a/rnd/autogpt_server/autogpt_server/executor/executor.py
+++ b/rnd/autogpt_server/autogpt_server/executor/executor.py
@@ -3,7 +3,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Process
 
-from autogpt_server.data import Execution, ExecutionQueue
+from autogpt_server.data import Event, ExecutionQueue
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def execute_node(id: str, data: str) -> None:
 def start_executor(pool_size: int, queue: ExecutionQueue) -> None:
     with ThreadPoolExecutor(max_workers=pool_size) as executor:
         while True:
-            execution: Execution | None = queue.get()
+            execution: Event | None = queue.get()
             if not execution:
                 time.sleep(1)
                 continue

--- a/rnd/autogpt_server/autogpt_server/server/server.py
+++ b/rnd/autogpt_server/autogpt_server/server/server.py
@@ -27,7 +27,7 @@ class AgentServer:
         self.app.include_router(self.router)
 
     def execute_agent(self, agent_id: str):
-        execution_id = self.execution_queue.add(agent_id)
+        execution_id = self.execution_queue.add("Execution", {"agent_id", agent_id})
         return {"execution_id": execution_id, "agent_id": agent_id}
 
 

--- a/rnd/autogpt_server/setup.py
+++ b/rnd/autogpt_server/setup.py
@@ -22,7 +22,10 @@ setup(
     url="https://agpt.co",
     executables=[
         Executable(
-            "autogpt_server/app.py", target_name="server", base="console", icon=icon
+            "autogpt_server/app.py", target_name="agpt_server", base="console", icon=icon
+        ),
+        Executable(
+            "autogpt_server/cli.py", target_name="agpt_scli", base="console", icon=icon
         ),
     ],
     options={


### PR DESCRIPTION
### Background

The agent server is going to need a way of passing messages between the api and the agents. The agent block are also going to need to be able to pass messages around as well.

We are also going to need to have an easy way testing and debugging the server, a cli will be added for this purpose. 

### Changes 🏗️

This PR does the following:

- Adds the concept of events. For now it is expected there will only be two main categories of events. API Server <> Executor Manager for Triggers and Agent responses and Executor Manager <> Blocks messages for managing the running of Agent Graphs.
- Adds a CLI for the agent server. The CLI is for starting, stopping, and interacting with the agent server. 
- Adds commands for starting, stopping and sending test events. 
