### PR TITLE
fix(agent, forge): Make LLM API key check provider-agnostic

### DIFF
--- a/autogpt/autogpt/app/main.py
+++ b/autogpt/autogpt/app/main.py
@@ -21,7 +21,11 @@ from forge.components.code_executor.code_executor import (
 )
 from forge.config.ai_directives import AIDirectives
 from forge.config.ai_profile import AIProfile
-from forge.config.config import Config, ConfigBuilder, assert_config_has_openai_api_key
+from forge.config.config import (
+    Config,
+    ConfigBuilder,
+    assert_config_has_required_llm_api_keys,
+)
 from forge.file_storage import FileStorageBackendName, get_storage
 from forge.llm.providers import MultiProvider
 from forge.logging.config import configure_logging
@@ -98,8 +102,7 @@ async def run_auto_gpt(
         tts_config=config.tts_config,
     )
 
-    # TODO: fill in llm values here
-    assert_config_has_openai_api_key(config)
+    await assert_config_has_required_llm_api_keys(config)
 
     await apply_overrides_to_config(
         config=config,
@@ -380,8 +383,7 @@ async def run_auto_gpt_server(
         tts_config=config.tts_config,
     )
 
-    # TODO: fill in llm values here
-    assert_config_has_openai_api_key(config)
+    await assert_config_has_required_llm_api_keys(config)
 
     await apply_overrides_to_config(
         config=config,

--- a/forge/forge/config/__init__.py
+++ b/forge/forge/config/__init__.py
@@ -3,10 +3,10 @@ This module contains configuration models and helpers for AutoGPT Forge.
 """
 from .ai_directives import AIDirectives
 from .ai_profile import AIProfile
-from .config import Config, ConfigBuilder, assert_config_has_openai_api_key
+from .config import Config, ConfigBuilder, assert_config_has_required_llm_api_keys
 
 __all__ = [
-    "assert_config_has_openai_api_key",
+    "assert_config_has_required_llm_api_keys",
     "AIProfile",
     "AIDirectives",
     "Config",


### PR DESCRIPTION
The application currently checks whether a valid OpenAI API key is set, even if `SMART_LLM` and `FAST_LLM` are set to models from other providers.

The check needs to support other providers as well, and shouldn't break the app if someone tries to use a different provider.

Related:
- #25
- #7214

### Changes 🏗️

* Rename `assert_config_has_openai_api_key` to `assert_config_has_required_llm_api_keys`
* Make OpenAI credential check conditional (only if an OpenAI model is selected in the config)
* Implement checks for Groq and Anthropic credentials
* Use API calls for Groq and OpenAI credential checks to make sure the keys are valid

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
