### PR TITLE
Fix pylint warning `unspecified-encoding`

### DIFF
--- a/autogpt/agbenchmark_config/analyze_reports.py
+++ b/autogpt/agbenchmark_config/analyze_reports.py
@@ -36,7 +36,7 @@ grouped_success_values = defaultdict[str, list[str]](list[str])
 
 # Loop through each JSON file to collect suffixes and success values
 for report_file in sorted(report_files):
-    with open(report_file) as f:
+    with open(report_file, encoding='utf-8') as f:
         logger.info(f"Loading {report_file}...")
 
         data = json.load(f)

--- a/benchmark/agbenchmark/__main__.py
+++ b/benchmark/agbenchmark/__main__.py
@@ -143,7 +143,7 @@ def run(
     exit_code = None
 
     if backend:
-        with open("backend/backend_stdout.txt", "w") as f:
+        with open("backend/backend_stdout.txt", "w", encoding="utf-8") as f:
             sys.stdout = f
             exit_code = run_benchmark(
                 config=agbenchmark_config,

--- a/benchmark/agbenchmark/app.py
+++ b/benchmark/agbenchmark/app.py
@@ -56,7 +56,8 @@ while challenge_spec_files:
     except ValidationError as e:
         if logging.getLogger().level == logging.DEBUG:
             logger.warning(f"Spec file {challenge_relpath} failed to load:\n{e}")
-        logger.debug(f"Invalid challenge spec: {challenge_spec_file.read_text()}")
+        with open(challenge_spec_file, 'r', encoding='utf-8') as f:
+            logger.debug(f"Invalid challenge spec: {f.read_text()}")
         continue
     challenge_info.spec_file = challenge_spec_file
 

--- a/benchmark/agbenchmark/challenges/__init__.py
+++ b/benchmark/agbenchmark/challenges/__init__.py
@@ -34,7 +34,7 @@ def get_unique_categories() -> set[str]:
     glob_path = f"{challenges_dir}/**/data.json"
 
     for data_file in glob.glob(glob_path, recursive=True):
-        with open(data_file, "r") as f:
+        with open(data_file, "r", encoding="utf-8") as f:
             try:
                 challenge_data = json.load(f)
                 categories.update(challenge_data.get("category", []))

--- a/benchmark/reports/json_to_base_64.py
+++ b/benchmark/reports/json_to_base_64.py
@@ -2,7 +2,7 @@ import base64
 import json
 
 # Load JSON data from a file
-with open("secrets.json", "r") as f:
+with open("secrets.json", "r", encoding="utf-8") as f:
     data = json.load(f)
 
 # Convert the JSON object into a string

--- a/benchmark/reports/match_records.py
+++ b/benchmark/reports/match_records.py
@@ -95,8 +95,8 @@ def get_reports():
             for report_file in report_files:
                 # Check if the report.json file exists
                 if os.path.isfile(report_file):
-                    # Open the report.json file
-                    with open(report_file, "r") as f:
+                    # Open the report.json file with UTF-8 encoding
+                    with open(report_file, "r", encoding="utf-8") as f:
                         # Load the JSON data from the file
                         json_data = json.load(f)
                         print(f"Processing {report_file}")

--- a/benchmark/reports/send_to_googledrive.py
+++ b/benchmark/reports/send_to_googledrive.py
@@ -118,7 +118,7 @@ for agent_dir in os.listdir(base_dir):
 
                 if os.path.exists(report_path):
                     # Load the JSON data from the file
-                    with open(report_path, "r") as f:
+                    with open(report_path, "r", encoding="utf-8") as f:
                         data = json.load(f)
                     benchmark_start_time = data.get("benchmark_start_time", "")
 

--- a/cli.py
+++ b/cli.py
@@ -296,7 +296,7 @@ def benchmark_categories_list():
     # Use it as the base for the glob pattern, excluding 'deprecated' directory
     for data_file in glob.glob(glob_path, recursive=True):
         if "deprecated" not in data_file:
-            with open(data_file, "r") as f:
+            with open(data_file, "r", encoding="utf-8") as f:
                 try:
                     data = json.load(f)
                     categories.update(data.get("category", []))
@@ -340,7 +340,7 @@ def benchmark_tests_list():
     # Use it as the base for the glob pattern, excluding 'deprecated' directory
     for data_file in glob.glob(glob_path, recursive=True):
         if "deprecated" not in data_file:
-            with open(data_file, "r") as f:
+            with open(data_file, "r", encoding="utf-8") as f:
                 try:
                     data = json.load(f)
                     category = data.get("category", [])
@@ -389,7 +389,7 @@ def benchmark_tests_details(test_name):
     )
     # Use it as the base for the glob pattern, excluding 'deprecated' directory
     for data_file in glob.glob(glob_path, recursive=True):
-        with open(data_file, "r") as f:
+        with open(data_file, "r", encoding="utf-8") as f:
             try:
                 data = json.load(f)
                 if data.get("name") == test_name:

--- a/forge/forge/file_storage/local.py
+++ b/forge/forge/file_storage/local.py
@@ -77,7 +77,7 @@ class LocalFileStorage(FileStorage):
         full_path = self.get_path(path)
         if any(m in mode for m in ("w", "a", "x")):
             full_path.parent.mkdir(parents=True, exist_ok=True)
-        return open(full_path, mode)  # type: ignore
+        return open(full_path, mode, encoding='utf-8')
 
     @overload
     def read_file(self, path: str | Path, binary: Literal[False] = False) -> str:

--- a/forge/forge/llm/providers/openai.py
+++ b/forge/forge/llm/providers/openai.py
@@ -260,7 +260,7 @@ class OpenAICredentials(ModelProviderCredentials):
         return kwargs
 
     def load_azure_config(self, config_file: Path) -> None:
-        with open(config_file) as file:
+        with open(config_file, 'r', encoding='utf-8') as file:
             config_params = yaml.load(file, Loader=yaml.SafeLoader) or {}
 
         try:


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning “unspecified-encoding”.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.
