### PR TITLE
feat(rnd): Add node metadata on Agent Server Node object

### DIFF
--- a/rnd/autogpt_server/autogpt_server/data/graph.py
+++ b/rnd/autogpt_server/autogpt_server/data/graph.py
@@ -15,6 +15,7 @@ class Node(BaseDbModel):
     # TODO: Make it `dict[str, list[str]]`, output can be connected to multiple blocks.
     #       Other option is to use an edge-list, but it will complicate the rest code.
     output_nodes: dict[str, str] = {}  # dict[output_name, node_id]
+    metadata: dict[str, Any] = {}
 
     @staticmethod
     def from_db(node: AgentNode):
@@ -27,6 +28,7 @@ class Node(BaseDbModel):
             input_default=json.loads(node.constantInput),
             input_nodes={v.sinkName: v.agentNodeSourceId for v in node.Input or []},
             output_nodes={v.sourceName: v.agentNodeSinkId for v in node.Output or []},
+            metadata=json.loads(node.metadata),
         )
 
     def connect(self, node: "Node", source_name: str, sink_name: str):
@@ -133,6 +135,7 @@ async def create_graph(graph: Graph) -> Graph:
             "agentBlockId": node.block_id,
             "agentGraphId": graph.id,
             "constantInput": json.dumps(node.input_default),
+            "metadata": json.dumps(node.metadata),
         }) for node in graph.nodes
     ])
 

--- a/rnd/autogpt_server/schema.prisma
+++ b/rnd/autogpt_server/schema.prisma
@@ -37,6 +37,9 @@ model AgentNode {
   // JSON serialized dict[str, str] containing predefined input values.
   constantInput String @default("{}")
 
+  // JSON serialized dict[str, str] containing the node metadata.
+  metadata String @default("{}")
+
   ExecutionHistory AgentNodeExecution[]
 }
 


### PR DESCRIPTION
### Background

AgentServer node will require additional metadata for the UI related purpose.
The scope of this change is introducing a generic metadata field for the Node.

### Changes 🏗️

Add `metadata` field on AgentNode.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
