### PR TITLE
feat(rnd): Add support for dynamic input as list for AgentServer Block

### DIFF
--- a/rnd/autogpt_server/autogpt_server/data/block.py
+++ b/rnd/autogpt_server/autogpt_server/data/block.py
@@ -94,6 +94,9 @@ class BlockSchema(BaseModel):
     def get_fields(self) -> set[str]:
         return set(self.jsonschema["properties"].keys())
 
+    def get_required_fields(self) -> set[str]:
+        return set(self.jsonschema["required"])
+
 
 BlockOutput = Generator[tuple[str, Any], None, None]
 
@@ -190,12 +193,15 @@ class ParrotBlock(Block):
         yield "output", input_data["input"]
 
 
-class TextCombinerBlock(Block):
+class TextFormatterBlock(Block):
     id: ClassVar[str] = "db7d8f02-2f44-4c55-ab7a-eae0941f0c30"  # type: ignore
     input_schema: ClassVar[BlockSchema] = BlockSchema(  # type: ignore
         {
-            "text1": "string",
-            "text2": "string",
+            "texts": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+            },
             "format": "string",
         }
     )
@@ -206,10 +212,7 @@ class TextCombinerBlock(Block):
     )
 
     def run(self, input_data: BlockData) -> BlockOutput:
-        yield "combined_text", input_data["format"].format(
-            text1=input_data["text1"],
-            text2=input_data["text2"],
-        )
+        yield "combined_text", input_data["format"].format(texts=input_data["texts"])
 
 
 class PrintingBlock(Block):

--- a/rnd/autogpt_server/autogpt_server/data/execution.py
+++ b/rnd/autogpt_server/autogpt_server/data/execution.py
@@ -240,12 +240,23 @@ async def get_node_execution_input(node_exec_id: str) -> dict[str, Any]:
     return merge_execution_input(exec_input)
 
 
+SPLIT = "_$_"
+
+
 def merge_execution_input(data: dict[str, Any]) -> dict[str, Any]:
-    for key, value in sorted(data.items() or [], key=lambda x: x[0]):
-        if "_$_" not in key:
+    list_input = []
+    for key, value in data.items():
+        if SPLIT not in key:
             continue
-        # Special handling for list, merge <input_name>_$_<index> into [input_name].
-        name, _ = key.split("_$_")
+
+        name, index = key.split(SPLIT)
+        if not index.isdigit():
+            list_input.append((name, value, 0))
+        else:
+            list_input.append((name, value, int(index)))
+
+    for name, value, _ in sorted(list_input, key=lambda x: x[2]):
         data[name] = data.get(name, [])
         data[name].append(value)
+
     return data

--- a/rnd/autogpt_server/autogpt_server/data/execution.py
+++ b/rnd/autogpt_server/autogpt_server/data/execution.py
@@ -236,4 +236,16 @@ async def get_node_execution_input(node_exec_id: str) -> dict[str, Any]:
     exec_input = json.loads(execution.AgentNode.constantInput)
     for input_data in execution.Input or []:
         exec_input[input_data.name] = json.loads(input_data.data)
-    return exec_input
+
+    return merge_execution_input(exec_input)
+
+
+def merge_execution_input(data: dict[str, Any]) -> dict[str, Any]:
+    for key, value in sorted(data.items() or [], key=lambda x: x[0]):
+        if "_$_" not in key:
+            continue
+        # Special handling for list, merge <input_name>_$_<index> into [input_name].
+        name, _ = key.split("_$_")
+        data[name] = data.get(name, [])
+        data[name].append(value)
+    return data

--- a/rnd/autogpt_server/test/executor/test_manager.py
+++ b/rnd/autogpt_server/test/executor/test_manager.py
@@ -12,7 +12,7 @@ async def create_test_graph() -> graph.Graph:
     """
     ParrotBlock
                 \
-                 ---- TextCombinerBlock ---- PrintingBlock
+                 ---- TextFormatterBlock ---- PrintingBlock
                 /
     ParrotBlock
     """
@@ -20,13 +20,16 @@ async def create_test_graph() -> graph.Graph:
         graph.Node(block_id=block.ParrotBlock.id),
         graph.Node(block_id=block.ParrotBlock.id),
         graph.Node(
-            block_id=block.TextCombinerBlock.id,
-            input_default={"format": "{text1},{text2}"},
+            block_id=block.TextFormatterBlock.id,
+            input_default={
+                "format": "{texts[0]},{texts[1]},{texts[2]}",
+                "texts_$_3": "!!!",
+            },
         ),
         graph.Node(block_id=block.PrintingBlock.id),
     ]
-    nodes[0].connect(nodes[2], "output", "text1")
-    nodes[1].connect(nodes[2], "output", "text2")
+    nodes[0].connect(nodes[2], "output", "texts_$_1")
+    nodes[1].connect(nodes[2], "output", "texts_$_2")
     nodes[2].connect(nodes[3], "combined_text", "text")
 
     test_graph = graph.Graph(
@@ -85,14 +88,14 @@ async def execute_graph(test_manager: ExecutionManager, test_graph: graph.Graph)
     assert exec.input_data == {"input": text}
     assert exec.node_id == test_graph.nodes[1].id
 
-    # Executing TextCombinerBlock
+    # Executing TextFormatterBlock
     exec = executions[2]
     assert exec.status == execution.ExecutionStatus.COMPLETED
     assert exec.graph_exec_id == graph_exec_id
-    assert exec.output_data == {"combined_text": ["Hello, World!,Hello, World!"]}
+    assert exec.output_data == {"combined_text": ["Hello, World!,Hello, World!,!!!"]}
     assert exec.input_data == {
-        "text1": "Hello, World!",
-        "text2": "Hello, World!",
+        "texts_$_1": "Hello, World!",
+        "texts_$_2": "Hello, World!",
     }
     assert exec.node_id == test_graph.nodes[2].id
 
@@ -101,7 +104,7 @@ async def execute_graph(test_manager: ExecutionManager, test_graph: graph.Graph)
     assert exec.status == execution.ExecutionStatus.COMPLETED
     assert exec.graph_exec_id == graph_exec_id
     assert exec.output_data == {"status": ["printed"]}
-    assert exec.input_data == {"text": "Hello, World!,Hello, World!"}
+    assert exec.input_data == {"text": "Hello, World!,Hello, World!,!!!"}
     assert exec.node_id == test_graph.nodes[3].id
 
 


### PR DESCRIPTION
### Background

On AgentServer, To create a `Block` like `StringFormatterBlock` or `LllmCallBlock`, we need some way to dynamically link input pins and aggregate them into a single list input. This will give a better experience for the user to construct an input and link it from the output of the other nodes. The scope of this change is adding support for that in the least intrusive way.

*Proposal*
To differentiate the input list name and its singular entry we are using the `$_<index>` prefix. For example:
For the input `items`: `list[int]`, you can set a pin `items` with values like `[1,2,3,4]`. But you can also add input pins like `items_$_0` or `items_$_4` with values `1` or `2`, which will be appended to the `items` input in alphabetical order.
The execution engine will guarantee to wait for the execution until all the input pin value is produced, so input pin with list input will produce fix-sized list.

### Changes 🏗️

* Add list input pin grouping logic.
* Update existing test to verify the grouping logic.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
