### PR TITLE
feat(server): Add settings with secrets and configuration with API updating and Saving to file

### DIFF
--- a/rnd/autogpt_server/.gitignore
+++ b/rnd/autogpt_server/.gitignore
@@ -1,3 +1,6 @@
 database.db
 database.db-journal
 build/
+config.json
+secrets/*
+!secrets/.gitkeep

--- a/rnd/autogpt_server/autogpt_server/app.py
+++ b/rnd/autogpt_server/autogpt_server/app.py
@@ -1,7 +1,15 @@
 from autogpt_server.executor import ExecutionManager, ExecutionScheduler
 from autogpt_server.server import AgentServer
+from autogpt_server.util.data import get_data_path, get_config_path
 from autogpt_server.util.process import AppProcess
 from autogpt_server.util.service import PyroNameServer
+
+
+def get_config_and_secrets():
+    from autogpt_server.util.settings import Settings
+
+    settings = Settings()
+    return settings
 
 
 def run_processes(processes: list[AppProcess], **kwargs):
@@ -19,10 +27,11 @@ def run_processes(processes: list[AppProcess], **kwargs):
 
 
 def main(**kwargs):
+    settings = get_config_and_secrets()
     run_processes(
         [
             PyroNameServer(),
-            ExecutionManager(pool_size=5),
+            ExecutionManager(pool_size=settings.config.num_workers),
             ExecutionScheduler(),
             AgentServer(),
         ],

--- a/rnd/autogpt_server/autogpt_server/server/server.py
+++ b/rnd/autogpt_server/autogpt_server/server/server.py
@@ -1,8 +1,10 @@
+from typing import Annotated, Any, Dict
 import uuid
+from fastapi.responses import JSONResponse
 import uvicorn
 
 from contextlib import asynccontextmanager
-from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi import APIRouter, Body, FastAPI, HTTPException
 
 from autogpt_server.data import db, execution, block
 from autogpt_server.data.graph import (
@@ -15,6 +17,7 @@ from autogpt_server.data.graph import (
 from autogpt_server.executor import ExecutionManager, ExecutionScheduler
 from autogpt_server.util.process import AppProcess
 from autogpt_server.util.service import get_service_client
+from autogpt_server.util.settings import Settings
 
 
 class AgentServer(AppProcess):
@@ -84,6 +87,11 @@ class AgentServer(AppProcess):
             endpoint=self.update_schedule,
             methods=["PUT"],
         )
+        router.add_api_route(
+            path="/settings",
+            endpoint=self.update_configuration,
+            methods=["POST"],
+        )
 
         app.include_router(router)
         uvicorn.run(app, host="0.0.0.0", port=8000)
@@ -123,11 +131,12 @@ class AgentServer(AppProcess):
         try:
             return self.execution_manager_client.add_execution(graph_id, node_input)
         except Exception as e:
-            msg = e.__str__().encode().decode('unicode_escape')
+            msg = e.__str__().encode().decode("unicode_escape")
             raise HTTPException(status_code=400, detail=msg)
 
     async def get_executions(
-            self, graph_id: str, run_id: str) -> list[execution.ExecutionResult]:
+        self, graph_id: str, run_id: str
+    ) -> list[execution.ExecutionResult]:
         graph = await get_graph(graph_id)
         if not graph:
             raise HTTPException(status_code=404, detail=f"Agent #{graph_id} not found.")
@@ -152,3 +161,31 @@ class AgentServer(AppProcess):
     def get_execution_schedules(self, graph_id: str) -> dict[str, str]:
         execution_scheduler = self.execution_scheduler_client
         return execution_scheduler.get_execution_schedules(graph_id)
+
+    def update_configuration(
+        self,
+        updated_settings: Annotated[
+            Dict[str, Any], Body(examples=[{"config": {"num_workers": 10}}])
+        ],
+    ):
+        settings = Settings()
+        try:
+            updated_fields = {"config": [], "secrets": []}
+            for key, value in updated_settings.get("config", {}).items():
+                if hasattr(settings.config, key):
+                    setattr(settings.config, key, value)
+                    updated_fields["config"].append(key)
+            for key, value in updated_settings.get("secrets", {}).items():
+                if hasattr(settings.secrets, key):
+                    setattr(settings.secrets, key, value)
+                    updated_fields["secrets"].append(key)
+            settings.save()
+            return JSONResponse(
+                content={
+                    "message": "Settings updated successfully",
+                    "updated_fields": updated_fields,
+                },
+                status_code=200,
+            )
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e))

--- a/rnd/autogpt_server/autogpt_server/util/data.py
+++ b/rnd/autogpt_server/autogpt_server/util/data.py
@@ -3,6 +3,14 @@ import pathlib
 import sys
 
 
+def get_secrets_path() -> pathlib.Path:
+    return get_data_path() / "secrets"
+
+
+def get_config_path() -> pathlib.Path:
+    return get_data_path()
+
+
 def get_data_path() -> pathlib.Path:
     if getattr(sys, "frozen", False):
         # The application is frozen
@@ -10,5 +18,6 @@ def get_data_path() -> pathlib.Path:
     else:
         # The application is not frozen
         # Change this bit to match where you store your data files:
-        datadir = os.path.dirname(__file__)
+        filedir = os.path.dirname(__file__)
+        datadir = pathlib.Path(filedir).parent.parent
     return pathlib.Path(datadir)

--- a/rnd/autogpt_server/autogpt_server/util/settings.py
+++ b/rnd/autogpt_server/autogpt_server/util/settings.py
@@ -1,0 +1,110 @@
+import json
+import os
+from re import A
+import sys
+from typing import Any, Dict, Generic, Set, Tuple, Type, TypeVar
+from pydantic import BaseModel, Field, PrivateAttr, computed_field
+from pydantic_settings import (
+    BaseSettings,
+    JsonConfigSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+from autogpt_server.util.data import get_config_path, get_data_path, get_secrets_path
+
+T = TypeVar("T", bound=BaseSettings)
+
+
+class UpdateTrackingModel(BaseModel, Generic[T]):
+    _updated_fields: Set[str] = PrivateAttr(default_factory=set)
+
+    def __setattr__(self, name: str, value) -> None:
+        if name in self.model_fields:
+            self._updated_fields.add(name)
+        super().__setattr__(name, value)
+
+
+    def mark_updated(self, field_name: str) -> None:
+        if field_name in self.model_fields:
+            self._updated_fields.add(field_name)
+
+    def clear_updates(self) -> None:
+        self._updated_fields.clear()
+
+    def get_updates(self) -> Dict[str, Any]:
+        return {field: getattr(self, field) for field in self._updated_fields}
+
+
+class Config(UpdateTrackingModel["Config"], BaseSettings):
+    """Config for the server."""
+
+    num_workers: int = Field(
+        default=9, ge=1, le=100, description="Number of workers to use for execution."
+    )
+    # Add more configuration fields as needed
+
+    model_config = SettingsConfigDict(
+        json_file=[
+            get_config_path() / "config.default.json",
+            get_config_path() / "config.json",
+        ],
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="allow",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        return (JsonConfigSettingsSource(settings_cls),)
+
+
+class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
+    """Secrets for the server."""
+
+    database_password: str = ""
+    # Add more secret fields as needed
+
+    model_config = SettingsConfigDict(
+        secrets_dir=get_secrets_path(),
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="allow",
+    )
+
+
+class Settings(BaseModel):
+    config: Config = Config()
+    secrets: Secrets = Secrets()
+
+    def save(self) -> None:
+        # Save updated config to JSON file
+        if self.config._updated_fields:
+            config_to_save = self.config.get_updates()
+            config_path = os.path.join(get_data_path(), "config.json")
+            if os.path.exists(config_path):
+                with open(config_path, "r+") as f:
+                    existing_config: Dict[str, Any] = json.load(f)
+                    existing_config.update(config_to_save)
+                    f.seek(0)
+                    json.dump(existing_config, f, indent=2)
+                    f.truncate()
+            else:
+                with open(config_path, "w") as f:
+                    json.dump(config_to_save, f, indent=2)
+            self.config.clear_updates()
+
+        # Save updated secrets to individual files
+        secrets_dir = get_secrets_path()
+        for key in self.secrets._updated_fields:
+            secret_file = os.path.join(secrets_dir, key)
+            with open(secret_file, "w") as f:
+                f.write(str(getattr(self.secrets, key)))
+        self.secrets.clear_updates()

--- a/rnd/autogpt_server/config.default.json
+++ b/rnd/autogpt_server/config.default.json
@@ -1,0 +1,3 @@
+{
+  "num_workers": 5
+}

--- a/rnd/autogpt_server/poetry.lock
+++ b/rnd/autogpt_server/poetry.lock
@@ -869,6 +869,25 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.3.4"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_settings-2.3.4-py3-none-any.whl", hash = "sha256:11ad8bacb68a045f00e4f862c7a718c8a9ec766aa8fd4c32e39a0594b207b53a"},
+    {file = "pydantic_settings-2.3.4.tar.gz", hash = "sha256:c5802e3d62b78e82522319bbc9b8f8ffb28ad1c988a99311d04f2a6051fca0a7"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+
+[package.extras]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pyflakes"
 version = "3.2.0"
 description = "passive checker of Python programs"
@@ -1653,4 +1672,4 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e47373e09c6fad86251acdb49fb781c4d8690d6c20c453a06d29c4cec7f24b5f"
+content-hash = "a243c28b48b60e14513fc18629096a7f9d1c60ae7b05a6c50125c1d4c045033e"

--- a/rnd/autogpt_server/pyproject.toml
+++ b/rnd/autogpt_server/pyproject.toml
@@ -25,6 +25,7 @@ tenacity = "^8.3.0"
 apscheduler = "^3.10.4"
 croniter = "^2.0.5"
 pytest-asyncio = "^0.23.7"
+pydantic-settings = "^2.3.4"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### **User description**
### Background

<!-- Clearly explain the need for these changes: -->

We need a way to configure the agent server for two types of things: 
- configurations
- secrets

The typical way we configure is to use a `.env,` but this is difficult for users to handle.

Generally, we need to keep defaults that are overridden at runtime, and this can be pretty confusing for users. It is also difficult for them to share their configurations with us as we require them to mix their secrets with their other config settings. In the past, this has led to leaked API keys and more.

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
- Add support for Pydantic Settings
- Add a `config.default.json` to keep the default settings (can be deleted in favor of keeping them in code, but I think the JSON files will be useful long term for defaults at different install levels like single user, server, etc and environments like staging, prod, etc). More can be added to the array and will be picked up automatically. Order provided is the stacking override order. 
- Add support for loading `config.json` on top of values set in `config.default.json`
- Add support for loading secrets from `secrets/` directory with the key as the file name and the secret as the value
- Add support for updating the secrets and configs via API, with example
- Add a few example items to the config and secret settings
- Set the execution pool size via the settings

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [x] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Added support for Pydantic Settings to manage configurations and secrets.
- Introduced a default configuration file (`config.default.json`) and support for loading additional configurations from `config.json`.
- Implemented functionality to load secrets from a `secrets/` directory.
- Added an API endpoint to update configurations and secrets at runtime.
- Modified the application to use settings for configuring the execution pool size.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Load settings and use them in main application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rnd/autogpt_server/autogpt_server/app.py

<li>Added function <code>get_config_and_secrets</code> to load settings.<br> <li> Modified <code>main</code> function to use settings for <code>ExecutionManager</code> pool size.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7272/files#diff-dc711625831f8d64dd1f36f49a8ab2ee02eadf6b01169c0b248f9617c40d4e18">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add API endpoint for updating configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rnd/autogpt_server/autogpt_server/server/server.py

<li>Added endpoint for updating configuration via API.<br> <li> Introduced <code>update_configuration</code> method to handle settings updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7272/files#diff-94fec4bd2ec2c2e02a2e106e1ebcdce2d819c8c7fc0a30561d31fabb0e82d1ee">+40/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>data.py</strong><dd><code>Add utility functions for configuration paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rnd/autogpt_server/autogpt_server/util/data.py

<li>Added functions to get paths for secrets and config.<br> <li> Modified <code>get_data_path</code> to handle different execution contexts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7272/files#diff-019a3872ef69e84942b9ccdbd847fb9c1d5ed5163a21ea5ac5d442fe4294ec99">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Implement settings management with Pydantic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rnd/autogpt_server/autogpt_server/util/settings.py

<li>Introduced <code>Settings</code>, <code>Config</code>, and <code>Secrets</code> classes for managing <br>settings.<br> <li> Implemented methods to save updated settings and secrets.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7272/files#diff-281666fe9783cb96474f35739db160eceb136aca260e20e73990edc91f19610a">+110/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.default.json</strong><dd><code>Add default configuration file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rnd/autogpt_server/config.default.json

- Added default configuration file with `num_workers` setting.



</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7272/files#diff-f25bda01e703dff580303d43a5ecc903f355a6845b2a51cdc7f7a6dd4f17e3cb">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add pydantic-settings dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
rnd/autogpt_server/pyproject.toml

- Added `pydantic-settings` dependency.



</details>
    

  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7272/files#diff-adb694b1ef2fb9dabbdd0efe486d08bc9336bcd7b824f13f4125228d70cd4d7a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

