### PR TITLE
feat(autogpt_builder): Add simple `AutoGPTServerAPI` client

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -15,13 +15,14 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import CustomNode from './CustomNode';
 import './flow.css';
-import AutoGPTServerAPI, { Block, Schema } from '@/lib/autogpt_server_api';
+import AutoGPTServerAPI, { Block } from '@/lib/autogpt_server_api';
+import { ObjectSchema } from '@/lib/types';
 
 type CustomNodeData = {
   blockType: string;
   title: string;
-  inputSchema: Schema;
-  outputSchema: Schema;
+  inputSchema: ObjectSchema;
+  outputSchema: ObjectSchema;
   hardcodedValues: { [key: string]: any };
   setHardcodedValues: (values: { [key: string]: any }) => void;
   connections: Array<{ source: string; sourceHandle: string; target: string; targetHandle: string }>;
@@ -162,7 +163,7 @@ const Flow: React.FC = () => {
     return {};
   }
 
-  const getNestedData = (schema: Schema, values: { [key: string]: any }): { [key: string]: any } => {
+  const getNestedData = (schema: ObjectSchema, values: { [key: string]: any }): { [key: string]: any } => {
     let inputData: { [key: string]: any } = {};
 
     if (schema.properties) {

--- a/rnd/autogpt_builder/src/lib/autogpt_server_api.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt_server_api.ts
@@ -1,0 +1,184 @@
+import { XYPosition } from "reactflow";
+
+export default class AutoGPTServerAPI {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = "http://localhost:8000") {
+    this.baseUrl = baseUrl;
+  }
+
+  async getBlocks(): Promise<Block[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/blocks`);
+      if (!response.ok) {
+        console.warn("GET /blocks returned non-OK response:", response);
+        throw new Error(`HTTP error ${response.status}!`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error('Error fetching blocks:', error);
+      throw error;
+    }
+  }
+
+  async listFlowIDs(): Promise<string[]> {
+    try {
+      const response = await fetch(`${this.baseUrl}/graphs`);
+      if (!response.ok) {
+        console.warn("GET /graphs returned non-OK response:", response);
+        throw new Error(`HTTP error ${response.status}!`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error('Error fetching flows:', error);
+      throw error;
+    }
+  }
+
+  async getFlow(id: string): Promise<Flow> {
+    const path = `/graphs/${id}`;
+    try {
+      const response = await fetch(this.baseUrl + path);
+      if (!response.ok) {
+        console.warn(`GET ${path} returned non-OK response:`, response);
+        throw new Error(`HTTP error ${response.status}!`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error('Error fetching flow:', error);
+      throw error;
+    }
+  }
+
+  async createFlow(flowCreateBody: FlowCreateBody): Promise<Flow> {
+    console.debug("POST /graphs payload:", flowCreateBody);
+    try {
+      const response = await fetch(`${this.baseUrl}/graphs`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(flowCreateBody),
+      });
+      if (!response.ok) {
+        console.warn("POST /graphs returned non-OK response:", response);
+        throw new Error(`HTTP error ${response.status}!`)
+      }
+      return await response.json();
+    } catch (error) {
+      console.error("Error storing flow:", error);
+      throw error;
+    }
+  }
+
+  async executeFlow(flowId: string): Promise<FlowExecuteResponse> {
+    const path = `/graphs/${flowId}/execute`;
+    console.debug(`POST ${path}`);
+    try {
+      const response = await fetch(this.baseUrl + path, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+      if (!response.ok) {
+        console.warn(
+          `POST /graphs/${flowId}/execute returned non-OK response:`, response
+        );
+        throw new Error(`HTTP error ${response.status}!`)
+      }
+      return await response.json();
+    } catch (error) {
+      console.error("Error executing flow:", error);
+      throw error;
+    }
+  }
+
+  async getFlowExecutionInfo(flowId: string, runId: string): Promise<NodeExecutionResult[]> {
+    const path = `/graphs/${flowId}/executions/${runId}`;
+    try {
+      const response = await fetch(this.baseUrl + path);
+      if (!response.ok) {
+        console.warn(`GET ${path} returned non-OK response:`, response);
+        throw new Error(`HTTP error ${response.status}!`);
+      }
+      return await response.json();
+    } catch (error) {
+      console.error('Error fetching execution status:', error);
+      throw error;
+    }
+  }
+}
+
+export type Schema = {
+  type: string;
+  properties: { [key: string]: any };
+  additionalProperties?: { type: string };
+  required?: string[];
+};
+
+/* Mirror of autogpt_server/data/block.py:Block */
+export type Block = {
+  id: string;
+  name: string;
+  description: string;
+  inputSchema: Schema;
+  outputSchema: Schema;
+};
+
+/* Mirror of autogpt_server/data/graph.py:Node */
+export type Node = {
+  id: string;
+  block_id: string;
+  input_default: Map<string, any>;
+  input_nodes: Array<{ name: string, node_id: string }>;
+  output_nodes: Array<{ name: string, node_id: string }>;
+  metadata: {
+    position: XYPosition;
+    [key: string]: any;
+  };
+};
+
+/* Mirror of autogpt_server/data/graph.py:Link */
+export type Link = {
+  source_id: string;
+  sink_id: string;
+  source_name: string;
+  sink_name: string;
+}
+
+/* Mirror of autogpt_server/data/graph.py:Graph */
+export type Flow = {
+  id: string;
+  name: string;
+  description: string;
+  nodes: Array<Node>;
+  links: Array<Link>;
+};
+
+export type FlowCreateBody = Flow | {
+  id?: string;
+}
+
+/* Derived from autogpt_server/executor/manager.py:ExecutionManager.add_execution */
+export type FlowExecuteResponse = {
+  /* ID of the initiated run */
+  id: string;
+  /* List of node executions */
+  executions: Array<{ id: string, node_id: string }>;
+};
+
+/* Mirror of autogpt_server/data/execution.py:ExecutionResult */
+export type NodeExecutionResult = {
+  graph_exec_id: string;
+  node_exec_id: string;
+  node_id: string;
+  status: 'INCOMPLETE' | 'QUEUED' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+  input_data: Map<string, any>;
+  output_data: Map<string, any[]>;
+  add_time: Date;
+  queue_time?: Date;
+  start_time?: Date;
+  end_time?: Date;
+};

--- a/rnd/autogpt_builder/src/lib/autogpt_server_api.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt_server_api.ts
@@ -1,4 +1,5 @@
 import { XYPosition } from "reactflow";
+import { ObjectSchema } from "./types";
 
 export default class AutoGPTServerAPI {
   private baseUrl: string;
@@ -111,20 +112,13 @@ export default class AutoGPTServerAPI {
   }
 }
 
-export type Schema = {
-  type: string;
-  properties: { [key: string]: any };
-  additionalProperties?: { type: string };
-  required?: string[];
-};
-
 /* Mirror of autogpt_server/data/block.py:Block */
 export type Block = {
   id: string;
   name: string;
   description: string;
-  inputSchema: Schema;
-  outputSchema: Schema;
+  inputSchema: ObjectSchema;
+  outputSchema: ObjectSchema;
 };
 
 /* Mirror of autogpt_server/data/graph.py:Node */

--- a/rnd/autogpt_builder/src/lib/types.ts
+++ b/rnd/autogpt_builder/src/lib/types.ts
@@ -1,0 +1,6 @@
+export type ObjectSchema = {
+    type: string;
+    properties: { [key: string]: any };
+    additionalProperties?: { type: string };
+    required?: string[];
+  };


### PR DESCRIPTION
API logic is currently scattered throughout `Flow.tsx` and only partially implemented. This is a first shot at a simple API client with fully typed inputs and outputs, to make all our lives a bit easier :)

* Resolves #7327

### Changes
- feat(autogpt_builder): Add `AutoGPTServerAPI` client
- Migrate API calls in `Flow.tsx` to new API client
