### PR TITLE
fix(agent, forge): Silence Pydantic v2 protected namespace `model_` warning

### DIFF
--- a/autogpt/autogpt/agent_factory/profile_generator.py
+++ b/autogpt/autogpt/agent_factory/profile_generator.py
@@ -12,7 +12,6 @@ from forge.llm.providers.schema import (
 )
 from forge.models.config import SystemConfiguration, UserConfigurable
 from forge.models.json_schema import JSONSchema
-from pydantic import ConfigDict
 
 from autogpt.app.config import AppConfig
 
@@ -20,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class AgentProfileGeneratorConfiguration(SystemConfiguration):
-    model_classification: LanguageModelClassification = UserConfigurable(
+    llm_classification: LanguageModelClassification = UserConfigurable(
         default=LanguageModelClassification.SMART_MODEL
     )
     _example_call: object = {
@@ -141,8 +140,6 @@ class AgentProfileGeneratorConfiguration(SystemConfiguration):
         ).model_dump()
     )
 
-    model_config = ConfigDict(protected_namespaces=())
-
 
 class AgentProfileGenerator(PromptStrategy):
     default_configuration: AgentProfileGeneratorConfiguration = (
@@ -151,12 +148,12 @@ class AgentProfileGenerator(PromptStrategy):
 
     def __init__(
         self,
-        model_classification: LanguageModelClassification,
+        llm_classification: LanguageModelClassification,
         system_prompt: str,
         user_prompt_template: str,
         create_agent_function: dict,
     ):
-        self._model_classification = model_classification
+        self._llm_classification = llm_classification
         self._system_prompt_message = system_prompt
         self._user_prompt_template = user_prompt_template
         self._create_agent_function = CompletionModelFunction.model_validate(
@@ -164,8 +161,8 @@ class AgentProfileGenerator(PromptStrategy):
         )
 
     @property
-    def model_classification(self) -> LanguageModelClassification:
-        return self._model_classification
+    def llm_classification(self) -> LanguageModelClassification:
+        return self._llm_classification
 
     def build_prompt(self, user_objective: str = "", **kwargs) -> ChatPrompt:
         system_message = ChatMessage.system(self._system_prompt_message)

--- a/autogpt/autogpt/agent_factory/profile_generator.py
+++ b/autogpt/autogpt/agent_factory/profile_generator.py
@@ -12,6 +12,7 @@ from forge.llm.providers.schema import (
 )
 from forge.models.config import SystemConfiguration, UserConfigurable
 from forge.models.json_schema import JSONSchema
+from pydantic import ConfigDict
 
 from autogpt.app.config import AppConfig
 
@@ -139,6 +140,8 @@ class AgentProfileGeneratorConfiguration(SystemConfiguration):
             },
         ).model_dump()
     )
+
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class AgentProfileGenerator(PromptStrategy):

--- a/autogpt/autogpt/agents/agent.py
+++ b/autogpt/autogpt/agents/agent.py
@@ -119,7 +119,7 @@ class Agent(BaseAgent[OneShotAgentActionProposal], Configurable[AgentSettings]):
                 lambda x: self.llm_provider.count_tokens(x, self.llm.name),
                 llm_provider,
                 ActionHistoryConfiguration(
-                    model_name=app_config.fast_llm, max_tokens=self.send_token_limit
+                    llm_name=app_config.fast_llm, max_tokens=self.send_token_limit
                 ),
             )
             .run_after(WatchdogComponent)

--- a/autogpt/autogpt/agents/prompt_strategies/one_shot.py
+++ b/autogpt/autogpt/agents/prompt_strategies/one_shot.py
@@ -100,7 +100,7 @@ class OneShotAgentPromptStrategy(PromptStrategy):
         self.logger = logger
 
     @property
-    def model_classification(self) -> LanguageModelClassification:
+    def llm_classification(self) -> LanguageModelClassification:
         return LanguageModelClassification.FAST_MODEL  # FIXME: dynamic switching
 
     def build_prompt(

--- a/docs/content/forge/components/built-in-components.md
+++ b/docs/content/forge/components/built-in-components.md
@@ -40,7 +40,7 @@ Necessary for saving and loading agent's state (preserving session).
 
 | Config variable  | Details                                | Type  | Default                            |
 | ---------------- | -------------------------------------- | ----- | ---------------------------------- |
-| `storage_path`     | Path to agent files, e.g. state        | `str` | `agents/{agent_id}/`[^1]           |
+| `storage_path`   | Path to agent files, e.g. state        | `str` | `agents/{agent_id}/`[^1]           |
 | `workspace_path` | Path to files that agent has access to | `str` | `agents/{agent_id}/workspace/`[^1] |
 
 [^1] This option is set dynamically during component construction as opposed to by default inside the configuration model, `{agent_id}` is replaced with the agent's unique identifier.
@@ -84,7 +84,7 @@ Keeps track of agent's actions and their outcomes. Provides their summary to the
 
 | Config variable        | Details                                                 | Type        | Default            |
 | ---------------------- | ------------------------------------------------------- | ----------- | ------------------ |
-| `model_name`           | Name of the llm model used to compress the history      | `ModelName` | `"gpt-3.5-turbo"`  |
+| `llm_name`             | Name of the llm model used to compress the history      | `ModelName` | `"gpt-3.5-turbo"`  |
 | `max_tokens`           | Maximum number of tokens to use for the history summary | `int`       | `1024`             |
 | `spacy_language_model` | Language model used for summary chunking using spacy    | `str`       | `"en_core_web_sm"` |
 | `full_message_count`   | Number of cycles to include unsummarized in the prompt  | `int`       | `4`                |
@@ -178,7 +178,7 @@ Allows agent to read websites using Selenium.
 
 | Config variable               | Details                                     | Type                                          | Default                                                                                                                      |
 | ----------------------------- | ------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `model_name`                  | Name of the llm model used to read websites | `ModelName`                                   | `"gpt-3.5-turbo"`                                                                                                            |
+| `llm_name`                    | Name of the llm model used to read websites | `ModelName`                                   | `"gpt-3.5-turbo"`                                                                                                            |
 | `web_browser`                 | Web browser used by Selenium                | `"chrome" \| "firefox" \| "safari" \| "edge"` | `"chrome"`                                                                                                                   |
 | `headless`                    | Run browser in headless mode                | `bool`                                        | `True`                                                                                                                       |
 | `user_agent`                  | User agent used by the browser              | `str`                                         | `"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36"` |

--- a/forge/forge/components/README.md
+++ b/forge/forge/components/README.md
@@ -116,7 +116,7 @@ You can set sensitive variables in the `.json` file as well but it's recommended
         "github_username": null
     },
     "ActionHistoryConfiguration": {
-        "model_name": "gpt-3.5-turbo",
+        "llm_name": "gpt-3.5-turbo",
         "max_tokens": 1024,
         "spacy_language_model": "en_core_web_sm"
     },
@@ -129,7 +129,7 @@ You can set sensitive variables in the `.json` file as well but it's recommended
         "duckduckgo_max_attempts": 3
     },
     "WebSeleniumConfiguration": {
-        "model_name": "gpt-3.5-turbo",
+        "llm_name": "gpt-3.5-turbo",
         "web_browser": "chrome",
         "headless": true,
         "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36",

--- a/forge/forge/components/action_history/action_history.py
+++ b/forge/forge/components/action_history/action_history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Iterator, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from forge.agent.components import ConfigurableComponent
 from forge.agent.protocols import AfterExecute, AfterParse, MessageProvider
@@ -24,6 +24,8 @@ class ActionHistoryConfiguration(BaseModel):
     """Language model used for summary chunking using spacy"""
     full_message_count: int = 4
     """Number of latest non-summarized messages to include in the history"""
+
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class ActionHistoryComponent(

--- a/forge/forge/components/action_history/action_history.py
+++ b/forge/forge/components/action_history/action_history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, Iterator, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from forge.agent.components import ConfigurableComponent
 from forge.agent.protocols import AfterExecute, AfterParse, MessageProvider
@@ -16,7 +16,7 @@ from .model import ActionResult, AnyProposal, Episode, EpisodicActionHistory
 
 
 class ActionHistoryConfiguration(BaseModel):
-    model_name: ModelName = OpenAIModelName.GPT3
+    llm_name: ModelName = OpenAIModelName.GPT3
     """Name of the llm model used to compress the history"""
     max_tokens: int = 1024
     """Maximum number of tokens to use up with generated history messages"""
@@ -24,8 +24,6 @@ class ActionHistoryConfiguration(BaseModel):
     """Language model used for summary chunking using spacy"""
     full_message_count: int = 4
     """Number of latest non-summarized messages to include in the history"""
-
-    model_config = ConfigDict(protected_namespaces=())
 
 
 class ActionHistoryComponent(
@@ -99,7 +97,7 @@ class ActionHistoryComponent(
     async def after_execute(self, result: ActionResult) -> None:
         self.event_history.register_result(result)
         await self.event_history.handle_compression(
-            self.llm_provider, self.config.model_name, self.config.spacy_language_model
+            self.llm_provider, self.config.llm_name, self.config.spacy_language_model
         )
 
     @staticmethod

--- a/forge/forge/components/web/selenium.py
+++ b/forge/forge/components/web/selenium.py
@@ -7,7 +7,7 @@ from typing import Iterator, Literal, Optional, Type
 from urllib.request import urlretrieve
 
 from bs4 import BeautifulSoup
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeDriverService
@@ -68,6 +68,8 @@ class WebSeleniumConfiguration(BaseModel):
     """User agent used by the browser"""
     browse_spacy_language_model: str = "en_core_web_sm"
     """Spacy language model used for chunking text"""
+
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class WebSeleniumComponent(

--- a/forge/forge/components/web/selenium.py
+++ b/forge/forge/components/web/selenium.py
@@ -7,7 +7,7 @@ from typing import Iterator, Literal, Optional, Type
 from urllib.request import urlretrieve
 
 from bs4 import BeautifulSoup
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeDriverService
@@ -55,7 +55,7 @@ class BrowsingError(CommandExecutionError):
 
 
 class WebSeleniumConfiguration(BaseModel):
-    model_name: ModelName = OpenAIModelName.GPT3
+    llm_name: ModelName = OpenAIModelName.GPT3
     """Name of the llm model used to read websites"""
     web_browser: Literal["chrome", "firefox", "safari", "edge"] = "chrome"
     """Web browser used by Selenium"""
@@ -68,8 +68,6 @@ class WebSeleniumConfiguration(BaseModel):
     """User agent used by the browser"""
     browse_spacy_language_model: str = "en_core_web_sm"
     """Spacy language model used for chunking text"""
-
-    model_config = ConfigDict(protected_namespaces=())
 
 
 class WebSeleniumComponent(
@@ -166,7 +164,7 @@ class WebSeleniumComponent(
             elif get_raw_content:
                 if (
                     output_tokens := self.llm_provider.count_tokens(
-                        text, self.config.model_name
+                        text, self.config.llm_name
                     )
                 ) > MAX_RAW_CONTENT_LENGTH:
                     oversize_factor = round(output_tokens / MAX_RAW_CONTENT_LENGTH, 1)
@@ -384,7 +382,7 @@ class WebSeleniumComponent(
                 text,
                 topics_of_interest=topics_of_interest,
                 llm_provider=self.llm_provider,
-                model_name=self.config.model_name,
+                model_name=self.config.llm_name,
                 spacy_model=self.config.browse_spacy_language_model,
             )
             return "\n".join(f"* {i}" for i in information)
@@ -393,7 +391,7 @@ class WebSeleniumComponent(
                 text,
                 question=question,
                 llm_provider=self.llm_provider,
-                model_name=self.config.model_name,
+                model_name=self.config.llm_name,
                 spacy_model=self.config.browse_spacy_language_model,
             )
             return result

--- a/forge/forge/llm/prompting/base.py
+++ b/forge/forge/llm/prompting/base.py
@@ -10,7 +10,7 @@ from .schema import ChatPrompt, LanguageModelClassification
 class PromptStrategy(abc.ABC):
     @property
     @abc.abstractmethod
-    def model_classification(self) -> LanguageModelClassification:
+    def llm_classification(self) -> LanguageModelClassification:
         ...
 
     @abc.abstractmethod

--- a/forge/forge/llm/providers/_openai_base.py
+++ b/forge/forge/llm/providers/_openai_base.py
@@ -224,7 +224,7 @@ class BaseOpenAIChatProvider(
                         tool_calls=tool_calls or None,
                     ),
                     parsed_result=parsed_result,
-                    model_info=self.CHAT_MODELS[model_name],
+                    llm_info=self.CHAT_MODELS[model_name],
                     prompt_tokens_used=t_input,
                     completion_tokens_used=t_output,
                 )
@@ -457,7 +457,7 @@ class BaseOpenAIEmbeddingProvider(
 
         return EmbeddingModelResponse(
             embedding=embedding_parser(response.data[0].embedding),
-            model_info=self.EMBEDDING_MODELS[model_name],
+            llm_info=self.EMBEDDING_MODELS[model_name],
             prompt_tokens_used=response.usage.prompt_tokens,
         )
 

--- a/forge/forge/llm/providers/anthropic.py
+++ b/forge/forge/llm/providers/anthropic.py
@@ -309,7 +309,7 @@ class AnthropicProvider(BaseChatModelProvider[AnthropicModelName, AnthropicSetti
         return ChatModelResponse(
             response=assistant_msg,
             parsed_result=parsed_result,
-            model_info=ANTHROPIC_CHAT_MODELS[model_name],
+            llm_info=ANTHROPIC_CHAT_MODELS[model_name],
             prompt_tokens_used=t_input,
             completion_tokens_used=t_output,
         )

--- a/forge/forge/llm/providers/schema.py
+++ b/forge/forge/llm/providers/schema.py
@@ -186,9 +186,7 @@ class ModelResponse(BaseModel):
 
     prompt_tokens_used: int
     completion_tokens_used: int
-    model_info: ModelInfo
-
-    model_config = ConfigDict(protected_namespaces=())
+    llm_info: ModelInfo
 
 
 class ModelProviderConfiguration(SystemConfiguration):

--- a/forge/forge/llm/providers/schema.py
+++ b/forge/forge/llm/providers/schema.py
@@ -188,6 +188,8 @@ class ModelResponse(BaseModel):
     completion_tokens_used: int
     model_info: ModelInfo
 
+    model_config = ConfigDict(protected_namespaces=())
+
 
 class ModelProviderConfiguration(SystemConfiguration):
     retries_per_request: int = UserConfigurable(7)


### PR DESCRIPTION
### Background

After [updating to Pydantic v2](https://github.com/Significant-Gravitas/AutoGPT/pull/7280) Pydantic complains about model fields with `model_` prefix as it's a Pydantic protected namespace:
```
UserWarning: Field "model_info" has conflict with protected namespace "model_".
```
To silence this warning fields need to be renamed or namespace need to be removed from `protected_namespaces`.

### Changes 🏗️

This PR renames `model_*` fields to `llm_*` in affected models.

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
