### PR TITLE
feat(autogpt_builder) Hook up execution progress animation to live execution data

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -344,7 +344,6 @@ const FlowEditor: React.FC<{ flowID?: string }> = ({ flowID }) => {
 
 
 const updateNodesWithExecutionData = (executionData: any[]) => {
-  console.log("Execution Data:", executionData);
   setNodes((nds) =>
     nds.map((node) => {
       const nodeExecution = executionData.find((exec) => exec.node_id === node.id);


### PR DESCRIPTION
### **User description**
### Background

We want to clearly show the user the progress of each node as the agent is running. I have added visual elements to ensure it is clear (Green for completed, Yellow for Running etc). Previously this animation was not hooked up to the live data. This PR changes that, and links the animation to the actual progress of the node from the backend

### Changes 🏗️

Map backend node id to frontend node id.

<img width="1323" alt="Screenshot 2024-07-08 at 10 47 33 PM" src="https://github.com/Significant-Gravitas/AutoGPT/assets/50577581/d2f5a1dd-4870-4869-a72d-783a80f8b83f">


### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [x] Have you changed or added a feature? &ensp; `-4 pts`
  - [x] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Added a mapping from backend node IDs to frontend node IDs to synchronize the frontend with the backend.
- Updated the frontend node IDs and positions based on the backend response to ensure accurate tracking of execution progress.
- Included logging for execution data to aid in debugging and monitoring.
- Modified the logic to update nodes with execution data, reflecting the real-time progress of the agent.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Link animation to live execution data and update node IDs</code></dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Added a mapping from backend node IDs to frontend node IDs.<br> <li> Updated node IDs in the frontend based on backend data.<br> <li> Added logging for execution data.<br> <li> Modified node update logic to reflect execution progress.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7347/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

