### PR TITLE
Reads data from .env

### DIFF
--- a/rnd/autogpt_builder/next.config.js
+++ b/rnd/autogpt_builder/next.config.js
@@ -1,0 +1,8 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+module.exports = {
+  env: {
+    AGPT_SERVER_URL: process.env.AGPT_SERVER_URL,
+  },
+};

--- a/rnd/autogpt_builder/package.json
+++ b/rnd/autogpt_builder/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "dotenv": "^16.4.5",
     "next": "14.2.4",
     "next-themes": "^0.3.0",
     "react": "^18",

--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -73,7 +73,7 @@ const FlowEditor: React.FC<{ flowID?: string }> = ({ flowID }) => {
   const [agentName, setAgentName] = useState<string>('');
   const [agentDescription, setAgentDescription] = useState<string>('');
 
-  const apiUrl = 'http://localhost:8000';
+  const apiUrl = process.env.AGPT_SERVER_URL!;
   const api = new AutoGPTServerAPI(apiUrl);
 
   useEffect(() => {


### PR DESCRIPTION
### Background

The project now reads the AGPT_SERVER_URL thats setup in the .env and uses that
This fixes #7324 

Make sure to run ``npm install dotenv`` just incase you dont have it


### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
