### PR TITLE
feat(autogpt_builer) Fix vanishing data when executing agent

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -74,6 +74,8 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
   const [availableNodes, setAvailableNodes] = useState<Block[]>([]);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [agentDescription, setAgentDescription] = useState<string>('');
+  const [agentName, setAgentName] = useState<string>('');
 
   const apiUrl = process.env.AGPT_SERVER_URL!;
   const api = new AutoGPTServerAPI(apiUrl);
@@ -302,8 +304,8 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
 
       const payload = {
         id: agentId || '',
-        name: 'Agent Name',
-        description: 'Agent Description',
+        name: agentName || 'Agent Name',
+        description: agentDescription || 'Agent Description',
         nodes: formattedNodes,
         links: links  // Ensure this field is included
       };
@@ -358,8 +360,6 @@ const updateNodesWithExecutionData = (executionData: any[]) => {
     nds.map((node) => {
       const nodeExecution = executionData.find((exec) => exec.node_id === node.data.backend_id);
       if (nodeExecution) {
-        console.log("node block id", node.data.backend_id)
-        console.log("node backend id", nodeExecution.node_id)
         return {
           ...node,
           data: {
@@ -379,33 +379,45 @@ const updateNodesWithExecutionData = (executionData: any[]) => {
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 
   return (
-    <div className={className}>
-      <Button
-        onClick={toggleSidebar}
-        style={{
-          position: 'absolute',
-          left: isSidebarOpen ? '260px' : '10px',
-          top: '10px',
-          zIndex: 10000,
-          transition: 'left 0.3s'
-        }}
-      >
-        {isSidebarOpen ? 'Hide Sidebar' : 'Show Sidebar'}
-      </Button>
-      <Sidebar isOpen={isSidebarOpen} availableNodes={availableNodes} addNode={addNode} />
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onConnect={onConnect}
-        nodeTypes={nodeTypes}
-      >
-        <div style={{ position: 'absolute', right: 10, top: 10, zIndex: 4 }}>
-          <Button onClick={runAgent}>Run Agent</Button>
-        </div>
-      </ReactFlow>
-    </div>
+      <div className={className}>
+        <Button
+            onClick={toggleSidebar}
+            style={{
+              position: 'absolute',
+              left: isSidebarOpen ? '260px' : '10px',
+              top: '10px',
+              zIndex: 10000,
+              transition: 'left 0.3s'
+            }}
+        >
+          {isSidebarOpen ? 'Hide Sidebar' : 'Show Sidebar'}
+        </Button>
+        <Sidebar isOpen={isSidebarOpen} availableNodes={availableNodes} addNode={addNode}/>
+        <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            nodeTypes={nodeTypes}
+        >
+          <div style={{position: 'absolute', right: 10, zIndex: 4}}>
+            <Input
+                type="text"
+                placeholder="Agent Name"
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+            />
+            <Input
+                type="text"
+                placeholder="Agent Description"
+                value={agentDescription}
+                onChange={(e) => setAgentDescription(e.target.value)}
+            />
+            <Button onClick={runAgent}>Run Agent</Button>
+          </div>
+        </ReactFlow>
+      </div>
   );
 };
 


### PR DESCRIPTION
### **User description**
### Background

After executing the agent, data such as connections was vanishing. This was because of the node id being replaced with the backend id. This change keeps id as is and adds one more field, backend_id to track the corresponding id in the backend.

### Changes 🏗️

Adding backend_id to CustomNode
Filtering based on backend_id when updating nodes with their respective execution data. 

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a new `backend_id` field to `CustomNodeData` to track the corresponding ID in the backend.
- Removed unused state variables `agentName` and `agentDescription` from `FlowEditor`.
- Updated the logic to map backend node IDs to frontend nodes using the new `backend_id`.
- Simplified the agent payload by using static values for name and description.
- Adjusted the UI to remove input fields for agent name and description, keeping only the "Run Agent" button.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Fix data vanishing issue and enhance node ID handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Added <code>backend_id</code> field to <code>CustomNodeData</code> type.<br> <li> Removed unused state variables <code>agentName</code> and <code>agentDescription</code>.<br> <li> Updated node ID handling to use <code>backend_id</code> for tracking.<br> <li> Simplified agent payload by removing dynamic name and description.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7359/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+22/-26</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

