### PR TITLE
feat(builder) Add save Agent functionality 

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -34,34 +34,34 @@ type CustomNodeData = {
   block_id: string;
 };
 
-const Sidebar: React.FC<{isOpen: boolean, availableNodes: Block[], addNode: (id: string, name: string) => void}> =
-  ({isOpen, availableNodes, addNode}) => {
-  const [searchQuery, setSearchQuery] = useState('');
+const Sidebar: React.FC<{ isOpen: boolean, availableNodes: Block[], addNode: (id: string, name: string) => void }> =
+  ({ isOpen, availableNodes, addNode }) => {
+    const [searchQuery, setSearchQuery] = useState('');
 
-  if (!isOpen) return null;
+    if (!isOpen) return null;
 
-  const filteredNodes = availableNodes.filter(node =>
-    node.name.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+    const filteredNodes = availableNodes.filter(node =>
+      node.name.toLowerCase().includes(searchQuery.toLowerCase())
+    );
 
-  return (
-    <div className={`sidebar dark-theme ${isOpen ? 'open' : ''}`}>
-      <h3>Nodes</h3>
-      <Input
-        type="text"
-        placeholder="Search nodes..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-      />
-      {filteredNodes.map((node) => (
-        <div key={node.id} className="sidebarNodeRowStyle dark-theme">
-          <span>{node.name}</span>
-          <Button onClick={() => addNode(node.id, node.name)}>Add</Button>
-        </div>
-      ))}
-    </div>
-  );
-};
+    return (
+      <div className={`sidebar dark-theme ${isOpen ? 'open' : ''}`}>
+        <h3>Nodes</h3>
+        <Input
+          type="text"
+          placeholder="Search nodes..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+        {filteredNodes.map((node) => (
+          <div key={node.id} className="sidebarNodeRowStyle dark-theme">
+            <span>{node.name}</span>
+            <Button onClick={() => addNode(node.id, node.name)}>Add</Button>
+          </div>
+        ))}
+      </div>
+    );
+  };
 
 const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
   flowID,
@@ -261,8 +261,7 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
     return inputData;
   };
 
-
-  const runAgent = async () => {
+  const saveAgent = async () => {
     try {
       console.log("All nodes before formatting:", nodes);
       const blockIdToNodeIdMap = {};
@@ -326,6 +325,20 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
 
       setNodes(updatedNodes);
 
+      return newAgentId;
+    } catch (error) {
+      console.error('Error running agent:', error);
+    }
+  };
+
+  const runAgent = async () => {
+    try {
+      const newAgentId = await saveAgent();
+      if (!newAgentId) {
+        console.error('Error saving agent');
+        return;
+      }
+
       const executeData = await api.executeFlow(newAgentId);
       const runId = executeData.id;
 
@@ -348,25 +361,25 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
   };
 
 
-const updateNodesWithExecutionData = (executionData: any[]) => {
-  setNodes((nds) =>
-    nds.map((node) => {
-      const nodeExecution = executionData.find((exec) => exec.node_id === node.id);
-      if (nodeExecution) {
-        return {
-          ...node,
-          data: {
-            ...node.data,
-            status: nodeExecution.status,
-            output_data: nodeExecution.output_data,
-            isPropertiesOpen: true,
-          },
-        };
-      }
-      return node;
-    })
-  );
-};
+  const updateNodesWithExecutionData = (executionData: any[]) => {
+    setNodes((nds) =>
+      nds.map((node) => {
+        const nodeExecution = executionData.find((exec) => exec.node_id === node.id);
+        if (nodeExecution) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              status: nodeExecution.status,
+              output_data: nodeExecution.output_data,
+              isPropertiesOpen: true,
+            },
+          };
+        }
+        return node;
+      })
+    );
+  };
 
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 
@@ -394,19 +407,22 @@ const updateNodesWithExecutionData = (executionData: any[]) => {
         nodeTypes={nodeTypes}
       >
         <div style={{ position: 'absolute', right: 10, zIndex: 4 }}>
-          <Input 
-            type="text" 
-            placeholder="Agent Name" 
-            value={agentName} 
-            onChange={(e) => setAgentName(e.target.value)} 
+          <Input
+            type="text"
+            placeholder="Agent Name"
+            value={agentName}
+            onChange={(e) => setAgentName(e.target.value)}
           />
-          <Input 
-            type="text" 
-            placeholder="Agent Description" 
-            value={agentDescription} 
-            onChange={(e) => setAgentDescription(e.target.value)} 
+          <Input
+            type="text"
+            placeholder="Agent Description"
+            value={agentDescription}
+            onChange={(e) => setAgentDescription(e.target.value)}
           />
-          <Button onClick={runAgent}>Run Agent</Button>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>  {/* Added gap for spacing */}
+            <Button onClick={saveAgent}>Save Agent</Button>
+            <Button onClick={runAgent}>Save & Run Agent</Button>
+          </div>
         </div>
       </ReactFlow>
     </div>


### PR DESCRIPTION
### **User description**
### Background

Add the ability to just save an agent without running it.

<img width="272" alt="Screenshot 2024-07-10 at 10 49 59" src="https://github.com/Significant-Gravitas/AutoGPT/assets/10382233/1761fe2c-8ba5-4e8f-90f5-3a0f137a3f9f">


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `saveAgent` function to allow saving an agent without executing it.
- Modified the existing `runAgent` function to call `saveAgent` first and then execute the agent.
- Updated the UI to include two separate buttons: one for saving the agent and another for saving and running the agent.
- Improved code formatting and readability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Add functionality to save an agent without running it</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Added <code>saveAgent</code> function to save an agent without running it.<br> <li> Modified <code>runAgent</code> function to utilize <code>saveAgent</code> and then execute the <br>agent.<br> <li> Updated UI to include separate buttons for "Save Agent" and "Save & <br>Run Agent".<br> <li> Minor formatting changes for better code readability.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7361/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+76/-60</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

