### PR TITLE
fix(autogpt_builder): Restore node input presets when loading a flow

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -186,7 +186,7 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
           title: `${block.name} ${node.id}`,
           inputSchema: block.inputSchema,
           outputSchema: block.outputSchema,
-          hardcodedValues: {},
+          hardcodedValues: node.input_default,
           setHardcodedValues: (values: { [key: string]: any; }) => {
             setNodes((nds) => nds.map((node) => node.id === newNode.id
               ? { ...node, data: { ...node.data, hardcodedValues: values } }


### PR DESCRIPTION
### Background

When opening an existing flow with `<FlowEditor flowID={flowID} />`, it doesn't load the preset input values:
![image](https://github.com/Significant-Gravitas/AutoGPT/assets/12185583/b208a172-1c34-41c4-bb82-34fd357c022d)
(📸 @aarushik93)

### Changes 🏗️

- Assign `node.input_default` to `hardcodedValues` in `FlowEditor:loadFlow(..)`

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
