### PR TITLE
feat(autogpt_builder) Remove saving of execution data into sink node

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -243,16 +243,6 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
 
     let inputData = getNestedData(blockSchema, node.data.hardcodedValues);
 
-    // Get data from connected nodes
-    const incomingEdges = allEdges.filter(edge => edge.target === node.id);
-    incomingEdges.forEach(edge => {
-      const sourceNode = allNodes.find(n => n.id === edge.source);
-      if (sourceNode && sourceNode.data.output_data) {
-        const outputKey = Object.keys(sourceNode.data.output_data)[0]; // Assuming single output
-        inputData[edge.targetHandle as string] = sourceNode.data.output_data[outputKey];
-      }
-    });
-
     // Filter out any inputs that are not in the block's schema
     Object.keys(inputData).forEach(key => {
       if (!blockSchema.properties[key]) {

--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -243,13 +243,6 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
 
     let inputData = getNestedData(blockSchema, node.data.hardcodedValues);
 
-    // Filter out any inputs that are not in the block's schema
-    Object.keys(inputData).forEach(key => {
-      if (!blockSchema.properties[key]) {
-        delete inputData[key];
-      }
-    });
-
     console.log(`Final prepared input for ${node.data.blockType} (${node.id}):`, inputData);
     return inputData;
   };


### PR DESCRIPTION
### **User description**
### Background

We shouldn't be saving the execution data into the input_default when connecting nodes. Just input data on the backend is fine for it to be saved when running. 

### Changes 🏗️
Removed the logic that was saving the output data from source node into the sink node when saving.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Removed the logic that saved the output data from the source node into the sink node when saving.
- Simplified the input data handling by removing the merging of execution data from connected nodes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Remove saving of execution data into sink node</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Removed logic that saved output data from source node into sink node.<br> <li> Simplified input data handling by removing unnecessary data merging.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7383/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+0/-10</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

