### PR TITLE
feat(autogpt_builder) Add logic for node disconnection

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -137,6 +137,30 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
     [setEdges, setNodes]
   );
 
+  const onEdgesDelete = useCallback(
+  (edgesToDelete: Edge[]) => {
+    setNodes((nds) =>
+      nds.map((node) => ({
+        ...node,
+        data: {
+          ...node.data,
+          connections: node.data.connections.filter(
+            (conn: any) =>
+              !edgesToDelete.some(
+                (edge) =>
+                  edge.source === conn.source &&
+                  edge.target === conn.target &&
+                  edge.sourceHandle === conn.sourceHandle &&
+                  edge.targetHandle === conn.targetHandle
+              )
+          ),
+        },
+      }))
+    );
+  },
+  [setNodes]
+);
+
   const addNode = (blockId: string, nodeType: string) => {
     const nodeSchema = availableNodes.find(node => node.id === blockId);
     if (!nodeSchema) {
@@ -433,6 +457,7 @@ const FlowEditor: React.FC<{ flowID?: string; className?: string }> = ({
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         nodeTypes={nodeTypes}
+        onEdgesDelete={onEdgesDelete}
       >
         <div style={{ position: 'absolute', right: 10, zIndex: 4 }}>
           <Input


### PR DESCRIPTION
### **User description**
### Background

Bug fix, when disconnecting two nodes, the sink node's input field wasn't reappearing. This PR fixes that

### Changes 🏗️
Added a callback to handle disconnection

https://github.com/user-attachments/assets/c175229c-1730-4460-bde5-96980526fa18



### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Bug fix


___

### **Description**
- Added a new `onEdgesDelete` callback function to handle the deletion of edges in the flow editor.
- Updated the node state to filter out connections related to the deleted edges, ensuring the sink node's input field reappears correctly.
- Integrated the `onEdgesDelete` callback with the Flow component to ensure it is called when edges are deleted.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Add edge deletion logic and update node connections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Added <code>onEdgesDelete</code> callback to handle edge deletion.<br> <li> Updated node state to remove connections related to deleted edges.<br> <li> Integrated <code>onEdgesDelete</code> with the Flow component.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7386/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+25/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

