### PR TITLE
feat: push the limit for open handles

### DIFF
--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -215,7 +215,7 @@ jobs:
         if: runner.os == 'macOS'
         working-directory: ${{ runner.temp }}
         run: |
-          zip -r AutoGPTServer.app.zip /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app
+          zip -r autogptserver-app-${{ matrix.platform-os }}.app.zip /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app
           ls -lah
           pwd
 
@@ -224,7 +224,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: autogptserver-app-${{ matrix.platform-os }}
-          path: AutoGPTServer.app.zip
+          path: /Users/runner/work/_temp/autogptserver-app-${{ matrix.platform-os }}.app.zip
 
       - name: Upload dmg artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -216,8 +216,6 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: |
           zip -r autogptserver-app-${{ matrix.platform-os }}.app.zip /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app
-          ls -lah
-          pwd
 
       # break this into seperate steps each with their own name that matches the file
       - name: Upload App artifact

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -227,7 +227,7 @@ jobs:
 
       # break this into seperate steps each with their own name that matches the file
       - name: Upload App artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: autogptserver-app-${{ matrix.platform-os }}
           path: /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -67,7 +67,6 @@ jobs:
           ulimit -a
           ulimit -n unlimited
 
-          
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -160,6 +159,13 @@ jobs:
       - id: get_date
         name: Get date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Set max open files limit
+        if: runner.os == 'macOS'
+        working-directory: ${{ runner.temp }}
+        run: |
+          ulimit -a
+          ulimit -n unlimited
 
       - name: Set up Python dependency cache
         # On Windows, unpacking cached dependencies takes longer than just installing them

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -216,6 +216,8 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: |
           zip -r AutoGPTServer.app.zip /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app
+          ls -lah
+          pwd
 
       # break this into seperate steps each with their own name that matches the file
       - name: Upload App artifact

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -67,6 +67,7 @@ jobs:
           ulimit -a
           ulimit -n unlimited
 
+          
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -60,13 +60,6 @@ jobs:
       #   killed after the step returns.
       #   See: https://github.com/actions/runner/issues/598#issuecomment-2011890429
 
-      - name: Set max open files limit
-        if: runner.os == 'macOS'
-        working-directory: ${{ runner.temp }}
-        run: |
-          ulimit -a
-          ulimit -n unlimited
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -160,13 +153,6 @@ jobs:
         name: Get date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: Set max open files limit
-        if: runner.os == 'macOS'
-        working-directory: ${{ runner.temp }}
-        run: |
-          ulimit -a
-          ulimit -n unlimited
-
       - name: Set up Python dependency cache
         # On Windows, unpacking cached dependencies takes longer than just installing them
         if: runner.os != 'Windows'
@@ -225,12 +211,18 @@ jobs:
           WINDOWS_COMMAND: "poetry run poe dist_msi"
           LINUX_COMMAND: "poetry run poe dist_appimage"
 
+      - name: Zip the .app directory
+        if: runner.os == 'macOS'
+        working-directory: ${{ runner.temp }}
+        run: |
+          zip -r AutoGPTServer.app.zip /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app
+
       # break this into seperate steps each with their own name that matches the file
       - name: Upload App artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: autogptserver-app-${{ matrix.platform-os }}
-          path: /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/*.app
+          path: /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/AutoGPTServer.app.zip
 
       - name: Upload dmg artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -60,6 +60,13 @@ jobs:
       #   killed after the step returns.
       #   See: https://github.com/actions/runner/issues/598#issuecomment-2011890429
 
+      - name: Set max open files limit
+        if: runner.os == 'macOS'
+        working-directory: ${{ runner.temp }}
+        run: |
+          ulimit -a
+          ulimit -n unlimited
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/autogpt-server-ci.yml
+++ b/.github/workflows/autogpt-server-ci.yml
@@ -222,7 +222,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: autogptserver-app-${{ matrix.platform-os }}
-          path: /Users/runner/work/AutoGPT/AutoGPT/rnd/autogpt_server/build/AutoGPTServer.app.zip
+          path: AutoGPTServer.app.zip
 
       - name: Upload dmg artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### **User description**
### Background

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a new step in the GitHub Actions workflow to set the maximum open files limit on macOS runners.
- This change uses `ulimit -n unlimited` to remove the limit on the number of open files, which helps in preventing issues related to open file handle limits during CI runs.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>autogpt-server-ci.yml</strong><dd><code>Set max open files limit in CI workflow for macOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/autogpt-server-ci.yml

<li>Added a step to set the maximum open files limit on macOS runners.<br> <li> Used <code>ulimit -n unlimited</code> to remove the limit on the number of open <br>files.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7390/files#diff-be2c4106e439333623427dccd03a5208c025493d5d67025bf67c23134c2058bd">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

