### PR TITLE
tweak(docs): Make link to The AutoGPT Server more prominant in docs navbar.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,6 +5,9 @@ docs_dir: content
 nav:
   - Home: index.md
 
+  - The AutoGPT Server 🆕: 
+    - Build your own Node: server/new_nodes.md
+
   - AutoGPT Agent:
       - Introduction: AutoGPT/index.md
       - Setup:
@@ -41,9 +44,6 @@ nav:
 
   - Docs: docs/index.md
     
-  - Server: 
-      - Build your own Node: server/new_nodes.md
-
   # - Challenges:
   #     - Introduction: challenges/introduction.md
   #     - List of Challenges:


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Added a new prominent link to "The AutoGPT Server" in the documentation navbar.
- Removed the old "Server" link from the navbar to avoid redundancy.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdocs.yml</strong><dd><code>Make "The AutoGPT Server" link more prominent in docs navbar</code></dd></summary>
<hr>

docs/mkdocs.yml

<li>Added a new prominent link to "The AutoGPT Server" in the docs navbar.<br> <li> Removed the old "Server" link from the navbar.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7402/files#diff-7618337a88ea47f9b778a21f0e17d43eab2aba4880c6be2d95a7bf95e4b8b2df">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

