### PR TITLE
feat(autogpt_builder): Fix Read API base URL from `.env`

### DIFF
--- a/rnd/autogpt_builder/next.config.js
+++ b/rnd/autogpt_builder/next.config.js
@@ -1,8 +1,0 @@
-const dotenv = require('dotenv');
-dotenv.config();
-
-module.exports = {
-  env: {
-    AGPT_SERVER_URL: process.env.AGPT_SERVER_URL,
-  },
-};

--- a/rnd/autogpt_builder/next.config.mjs
+++ b/rnd/autogpt_builder/next.config.mjs
@@ -1,5 +1,13 @@
+import dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config();
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    env: {
+        AGPT_SERVER_URL: process.env.AGPT_SERVER_URL,
+    },
     async redirects() {
         return [
             {
@@ -7,8 +15,8 @@ const nextConfig = {
                 destination: '/build',
                 permanent: false,
             },
-        ]
-    }
+        ];
+    },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### Background

The changes made here are to fix the things i broke in #7357 in this https://github.com/Significant-Gravitas/AutoGPT/pull/7357#issuecomment-2227111627

### Changes 🏗️

I moved everything inside the original .mjs file and it seems to all work and / redirects to /build like it should, the env file is still read

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
