### PR TITLE
feat(builder): Fix message covering navbar on < lg screen size

### DIFF
--- a/rnd/autogpt_builder/src/app/build/page.tsx
+++ b/rnd/autogpt_builder/src/app/build/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
           <div className="z-10 w-full flex items-center justify-between font-mono text-sm relative">
               <p className="border border-gray-600 rounded-xl pb-4 pt-4 p-4">
                   Get started by adding a&nbsp;
-                  <code className="font-mono font-bold">node</code>
+                  <code className="font-mono font-bold">block</code>
               </p>
               <div className="absolute top-0 right-0 p-4">
                   <a

--- a/rnd/autogpt_builder/src/app/build/page.tsx
+++ b/rnd/autogpt_builder/src/app/build/page.tsx
@@ -5,17 +5,15 @@ import FlowEditor from '@/components/Flow';
 
 export default function Home() {
   return (
-      <div className="flex flex-col items-center px-12">
-          <div className="z-10 w-full items-center justify-between font-mono text-sm lg:flex">
-              <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-600 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-900 dark:bg-zinc-900 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
+      <div className="flex flex-col items-center min-h-screen">
+          <div className="z-10 w-full flex items-center justify-between font-mono text-sm relative">
+              <p className="border border-gray-600 rounded-xl pb-4 pt-4 p-4">
                   Get started by adding a&nbsp;
                   <code className="font-mono font-bold">node</code>
               </p>
-              <div
-                  className="fixed bottom-0 left-0 flex h-48 w-full items-end justify-center bg-gradient-to-t from-white via-white dark:from-black dark:via-black lg:static lg:size-auto lg:bg-none"
-              >
+              <div className="absolute top-0 right-0 p-4">
                   <a
-                      className="pointer-events-none flex place-items-center gap-2 p-8 lg:pointer-events-auto lg:p-0"
+                      className="pointer-events-auto flex place-items-center gap-2"
                       href="https://news.agpt.co/"
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
### Background

Removed excess tailwind from page.tsx which seems to be causing the issue, now no-matter the screen size, everything should stay the same size, If there is a better way to go about this/if there where a reason for having LG screen size set please let me know, but this seems to work better

Also updated "node" to "block"

Addresses: https://github.com/Significant-Gravitas/AutoGPT/issues/7417

### Changes 🏗️
Screen size < LG
![image](https://github.com/user-attachments/assets/f0baa27f-c99b-47bd-9569-9129a4a711bb)
Screen size > LG
![image](https://github.com/user-attachments/assets/4b6d326c-1abd-40c8-8d22-ea1e9c565224)


### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
