### PR TITLE
feat(builder): allow deletion of nodes and edges via del key

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -457,6 +457,7 @@ const FlowEditor: React.FC<{
         onConnect={onConnect}
         nodeTypes={nodeTypes}
         onEdgesDelete={onEdgesDelete}
+        deleteKeyCode={["Backspace", "Delete"]}
       >
         <div style={{ position: 'absolute', right: 10, zIndex: 4 }}>
           <Input


### PR DESCRIPTION
### **User description**
### Background

<!-- Clearly explain the need for these changes: -->
Deleting nodes is currently unclear. This is a stopgap to allow deletion using the Delete key present on many keyboards

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

Specifies that Backspace and delete are both valid options to delete nodes and edges

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for the 'Delete' key to delete nodes and edges in the Flow editor.
- Updated the `deleteKeyCode` property to accept both 'Backspace' and 'Delete' keys.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Allow deletion of nodes and edges using 'Delete' key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Added support for 'Delete' key to delete nodes and edges.<br> <li> Updated <code>deleteKeyCode</code> property to include both 'Backspace' and <br>'Delete'.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7483/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

