### PR TITLE
feat(builder, server): hide secrets from the UI and mark them as secrets in the api

### DIFF
--- a/rnd/autogpt_builder/.vscode/launch.json
+++ b/rnd/autogpt_builder/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "msedge",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev",
+      "serverReadyAction": {
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithEdge"
+      }
+    },
+
+  ]
+}

--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -162,11 +162,19 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
       return <div className="connected-input">Connected</div>;
     }
 
-    const renderClickableInput = (value: string | null = null, placeholder: string = "") => (
-      <div className="clickable-input" onClick={() => handleInputClick(fullKey)}>
-        {value || <i className="text-gray-500">{placeholder}</i>}
-      </div>
-    );
+    const renderClickableInput = (value: string | null = null, placeholder: string = "", secret: boolean = false) => {
+
+      // if secret is true, then the input field will be a password field if the value is not null
+      return secret ? (
+        <div className="clickable-input" onClick={() => handleInputClick(fullKey)}>
+          {value ? <i className="text-gray-500">********</i> : <i className="text-gray-500">{placeholder}</i>}
+        </div>
+      ) : (
+        <div className="clickable-input" onClick={() => handleInputClick(fullKey)}>
+          {value || <i className="text-gray-500">{placeholder}</i>}
+        </div>
+      )
+    };
 
     if (schema.type === 'object' && schema.properties) {
       return (
@@ -288,28 +296,42 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
 
     switch (schema.type) {
       case 'string':
-        return schema.enum ? (
-          <div key={fullKey} className="input-container">
-            <select
-              value={value || ''}
-              onChange={(e) => handleInputChange(fullKey, e.target.value)}
-              className="select-input"
-            >
-              <option value="">Select {displayKey}</option>
-              {schema.enum.map((option: string) => (
-                <option key={option} value={option}>
-                  {beautifyString(option)}
-                </option>
-              ))}
-            </select>
+        if (schema.enum) {
+
+          return (
+            <div key={fullKey} className="input-container">
+              <select
+                value={value || ''}
+                onChange={(e) => handleInputChange(fullKey, e.target.value)}
+                className="select-input"
+              >
+                <option value="">Select {displayKey}</option>
+                {schema.enum.map((option: string) => (
+                  <option key={option} value={option}>
+                    {beautifyString(option)}
+                  </option>
+                ))}
+              </select>
+              {error && <span className="error-message">{error}</span>}
+            </div>
+          )
+        }
+
+        else if (schema.secret) {
+          return (<div key={fullKey} className="input-container">
+            {renderClickableInput(value, schema.placeholder || `Enter ${displayKey}`, true)}
             {error && <span className="error-message">{error}</span>}
-          </div>
-        ) : (
-          <div key={fullKey} className="input-container">
-            {renderClickableInput(value, schema.placeholder || `Enter ${displayKey}`)}
-            {error && <span className="error-message">{error}</span>}
-          </div>
-        );
+          </div>)
+
+        }
+        else {
+          return (
+            <div key={fullKey} className="input-container">
+              {renderClickableInput(value, schema.placeholder || `Enter ${displayKey}`)}
+              {error && <span className="error-message">{error}</span>}
+            </div>
+          );
+        }
       case 'boolean':
         return (
           <div key={fullKey} className="input-container">

--- a/rnd/autogpt_server/autogpt_server/data/model.py
+++ b/rnd/autogpt_server/autogpt_server/data/model.py
@@ -84,6 +84,7 @@ def SecretField(
         title=title,
         description=description,
         placeholder=placeholder,
+        secret=True,
         **kwargs,
     )
 
@@ -95,12 +96,15 @@ def SchemaField(
     title: Optional[str] = None,
     description: Optional[str] = None,
     placeholder: Optional[str] = None,
+    secret: bool = False,
     exclude: bool = False,
     **kwargs,
 ) -> T:
     json_extra: dict[str, Any] = {}
     if placeholder:
         json_extra["placeholder"] = placeholder
+    if secret: 
+        json_extra["secret"] = True
 
     return Field(
         default,


### PR DESCRIPTION
### **User description**
### Background

<!-- Clearly explain the need for these changes: -->
If you screenshot or record the builder, your API keys will be leaked. This change is designed to ensure that does not happen.

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
- Adds a launch.json for debugging the frontend
- Adds a parameter to the API to mark something secret
- Adds a toggle to the frontend to show something is secret

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `secret` parameter to `SchemaField` and `SecretField` functions in the backend to mark fields as secret.
- Modified the `CustomNode` component in the frontend to handle and display secret fields as masked.
- Added a `launch.json` configuration file for debugging Next.js applications, including server-side, client-side, and full-stack debugging options.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model.py</strong><dd><code>Add secret parameter to SchemaField and SecretField functions</code></dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/data/model.py

<li>Added <code>secret</code> parameter to <code>SchemaField</code> and <code>SecretField</code> functions.<br> <li> Included logic to handle <code>secret</code> parameter in <code>json_extra</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7490/files#diff-2bb846d80ae85f951ecd4beb9837cc39b112b6a1970e2f90cf95b29f987925af">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CustomNode.tsx</strong><dd><code>Implement secret field handling in CustomNode component</code>&nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/CustomNode.tsx

<li>Modified <code>renderClickableInput</code> to handle secret fields.<br> <li> Updated input rendering logic to display secret fields as masked.<br> <li> Added conditional checks for <code>schema.secret</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7490/files#diff-ce37ba33e874cc42255fda0cd2a16758a94a6e68606d513b7018c1cc68193146">+48/-26</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.json</strong><dd><code>Add launch configurations for Next.js debugging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/.vscode/launch.json

<li>Added launch configurations for debugging Next.js applications.<br> <li> Included configurations for server-side, client-side, and full-stack <br>debugging.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7490/files#diff-528e2e75abb5cf4c430a2721063ab9e57d0b405efd0bcfa59c2a81b20cf1850c">+30/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

