### PR TITLE
feat(builder): fix sidebar scroll issue

### DIFF
--- a/rnd/autogpt_builder/src/components/flow.css
+++ b/rnd/autogpt_builder/src/components/flow.css
@@ -88,16 +88,17 @@ input::placeholder, textarea::placeholder {
 
 .sidebar {
   position: fixed;
-  top: 68px;
+  top: 0;
   left: -600px;
   width: 350px;
-  height: 100%;
+  height: calc(100vh - 68px); /* Full height minus top offset */
   background-color: #ffffff;
   color: #000000;
   padding: 20px;
   transition: left 0.3s ease;
   z-index: 1000;
   overflow-y: auto;
+  margin-top: 68px; /* Margin to push content below the top fixed area */
 }
 
 .sidebar.open {


### PR DESCRIPTION
### Background

My latest change broke the scroll so this should updated the sidebar to now properly scroll down all the way to show all the blocks 

Currently this happens, i cant scroll down any more
![image](https://github.com/user-attachments/assets/fc0feef9-2661-4304-86b7-18c7cdef9bd3)

With this fix now we can 
![image](https://github.com/user-attachments/assets/3802d167-828b-4ee3-8b06-4968c1b670f6)


### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
