### PR TITLE
feat(Builder): Implement undo/redo functionality

### DIFF
--- a/rnd/autogpt_builder/src/components/history.ts
+++ b/rnd/autogpt_builder/src/components/history.ts
@@ -1,0 +1,44 @@
+// history.ts
+
+type Action = {
+    type: 'ADD_NODE' | 'DELETE_NODE' | 'ADD_EDGE' | 'DELETE_EDGE' | 'UPDATE_NODE' | 'MOVE_NODE' | 'UPDATE_INPUT' | 'UPDATE_NODE_POSITION';
+    payload: any;
+    undo: () => void;
+    redo: () => void;
+};
+
+class History {
+    private past: Action[] = [];
+    private future: Action[] = [];
+
+    push(action: Action) {
+      this.past.push(action);
+      this.future = [];
+    }
+
+    undo() {
+      const action = this.past.pop();
+      if (action) {
+        action.undo();
+        this.future.push(action);
+      }
+    }
+
+    redo() {
+      const action = this.future.pop();
+      if (action) {
+        action.redo();
+        this.past.push(action);
+      }
+    }
+
+    canUndo(): boolean {
+      return this.past.length > 0;
+    }
+
+    canRedo(): boolean {
+      return this.future.length > 0;
+    }
+}
+
+export const history = new History();


### PR DESCRIPTION
### Background

This is to add Undo and Redo functionality to the builder UI, this needs more testing and work so placing as draft for now

https://github.com/user-attachments/assets/fe6f5223-a2ef-4b9f-8a58-91b91a8eb4f8

### Changes 🏗️

I created a ``history.ts`` file which contains the actions to log to history, then they are called through out the ``Flow.tsx`` based on actions that happen, i.e blocks being moved, wire connections, text that is input to blocks ect
Here is the list of actions it stores
```python
'ADD_NODE' | 'DELETE_NODE' | 'ADD_EDGE' | 'DELETE_EDGE' | 'UPDATE_NODE' | 'MOVE_NODE' | 'UPDATE_INPUT' | 'UPDATE_NODE_POSITION';
```

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
