### PR TITLE
refactor(Blocks): Simplify `MathsBlock` and `CounterBlock` to Return Numeric Results Only

### DIFF
--- a/rnd/autogpt_server/autogpt_server/blocks/maths.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/maths.py
@@ -1,6 +1,6 @@
 import operator
 from enum import Enum
-from typing import Any, Union
+from typing import Any
 
 import pydantic
 
@@ -14,6 +14,7 @@ class Operation(Enum):
     MULTIPLY = "Multiply"
     DIVIDE = "Divide"
     POWER = "Power"
+
 
 class CounterResult(pydantic.BaseModel):
     count: int | None = None
@@ -84,9 +85,10 @@ class MathsBlock(Block):
             yield "result", result
 
         except ZeroDivisionError:
-            yield "result", float('inf')  # Return infinity for division by zero
-        except Exception as e:
-            yield "result", float('nan')  # Return NaN for other errors
+            yield "result", float("inf")  # Return infinity for division by zero
+        except Exception:
+            yield "result", float("nan")  # Return NaN for other errors
+
 
 class CounterBlock(Block):
     class Input(BlockSchema):


### PR DESCRIPTION
## Description
This PR simplifies both the MathsBlock and CounterBlock by removing the explanation functionality and returning numeric results directly. The change aims to streamline the blocks' outputs and make them more focused on their primary functions of performing mathematical operations and counting items in collections.

## Changes
### MathsBlock
- Removed `MathsResult` class
- Updated `Output` schema to use `float` type directly
- Simplified `run` method to yield numeric result without explanation
- Modified error handling to return `float('inf')` for division by zero and `float('nan')` for other errors

### CounterBlock
- Removed `CounterResult` class
- Updated `Output` schema to use `int` type directly
- Simplified `run` method to yield count without explanation or type information
- Modified error handling to return `-1` for any errors

- Updated test cases for both blocks to reflect the new output structures

## Motivation
The explanation features, while informative, were deemed unnecessary for most use cases. This simplification makes the blocks more straightforward to use and integrate with other components that expect numeric outputs without the need of `ObjectLookup` Blocks.

## Impact
This change may impact any existing workflows or blocks that depend on the explanation fields or custom result classes of the MathsBlock and CounterBlock outputs. Users of these blocks will need to update their implementations to handle the direct numeric outputs. This essentially means ObjectLookup blocks are no longer required to do Maths.

## Testing
The existing test cases have been updated to reflect the new output structures. Additional testing in various scenarios is recommended to ensure compatibility with existing systems.