### PR TITLE
fix(Builder): fixes to copy and pasted blocks

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -490,6 +490,8 @@ const FlowEditor: React.FC<{
               },
               data: {
                 ...node.data,
+                status: undefined, // Reset status
+                output_data: undefined, // Clear output data
                 setHardcodedValues: (values: { [key: string]: any }) => {
                   setNodes((nds) => nds.map((n) =>
                     n.id === newNodeId


### PR DESCRIPTION
### Background

@Torantulino found a bug where if you copy and paste a block, when you edit the pasted block's hard coded input it updates the original blocks input, this is to fix it

## Video of bug from @Torantulino 

https://github.com/user-attachments/assets/f2962349-dcd2-4510-9cab-52df983ee6fe

## Video of it being fixed

https://github.com/user-attachments/assets/6fe9991c-fe31-4dd7-be5e-7071564c7fc6

### Changes 🏗️

made sure it makes a brand new copy of the block with its own ID so the edits are seperated



### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
