### PR TITLE
dx: Set Python type checking mode to "basic" for all subprojects

### DIFF
--- a/.vscode/all-projects.code-workspace
+++ b/.vscode/all-projects.code-workspace
@@ -33,7 +33,9 @@
       "path": ".."
     }
   ],
-  "settings": {},
+  "settings": {
+    "python.analysis.typeCheckingMode": "basic",
+  },
   "extensions": {
     "recommendations": [
       "charliermarsh.ruff",

--- a/autogpt/.vscode/settings.json
+++ b/autogpt/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.analysis.typeCheckingMode": "basic",
+}

--- a/benchmark/.vscode/settings.json
+++ b/benchmark/.vscode/settings.json
@@ -2,5 +2,5 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
-  "python.formatting.provider": "none"
+  "python.analysis.typeCheckingMode": "basic",
 }

--- a/forge/.vscode/settings.json
+++ b/forge/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.analysis.typeCheckingMode": "basic",
+}

--- a/rnd/autogpt_server/.vscode/settings.json
+++ b/rnd/autogpt_server/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.analysis.typeCheckingMode": "basic",
+}


### PR DESCRIPTION
After talking to Craig (@Swiftyos) yesterday, I realized our Python type checking issues may be aggravated because we haven't set the type checking mode for the repo.

### Changes 🏗️

- Set `python.analysis.typeCheckingMode` to `basic` in all subprojects' `.vscode/settings.json` + `all-projects.code-workspace`

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
