### PR TITLE
fix(server): Add missing PG migrations

### DIFF
--- a/rnd/autogpt_server/postgres/migrations/20240726131311_node_input_unique_constraint/migration.sql
+++ b/rnd/autogpt_server/postgres/migrations/20240726131311_node_input_unique_constraint/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[referencedByInputExecId,referencedByOutputExecId,name]` on the table `AgentNodeExecutionInputOutput` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentNodeExecutionInputOutput_referencedByInputExecId_refer_key" ON "AgentNodeExecutionInputOutput"("referencedByInputExecId", "referencedByOutputExecId", "name");

--- a/rnd/autogpt_server/postgres/schema.prisma
+++ b/rnd/autogpt_server/postgres/schema.prisma
@@ -127,6 +127,9 @@ model AgentNodeExecutionInputOutput {
   ReferencedByInputExec    AgentNodeExecution? @relation("AgentNodeExecutionInput", fields: [referencedByInputExecId], references: [id])
   referencedByOutputExecId String?
   ReferencedByOutputExec   AgentNodeExecution? @relation("AgentNodeExecutionOutput", fields: [referencedByOutputExecId], references: [id])
+
+  // Input and Output pin names are unique for each AgentNodeExecution.
+  @@unique([referencedByInputExecId, referencedByOutputExecId, name])
 }
 
 // This model describes the recurring execution schedule of an Agent.


### PR DESCRIPTION
### **User description**
### Background

We made DB schema changes here: https://github.com/Significant-Gravitas/AutoGPT/commit/d2a5bb286f615f00f47a1d497b7296c3de4d3e83 and added SQLite migrations, but not PG (we support both dbs). 

### Changes 🏗️

This PR adds those migrations

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a unique constraint on columns `referencedByInputExecId`, `referencedByOutputExecId`, and `name` in the `AgentNodeExecutionInputOutput` table to ensure data integrity.
- Created a unique index `AgentNodeExecutionInputOutput_referencedByInputExecId_refer_key` in the PostgreSQL migration script.
- Updated the Prisma schema to reflect the new unique constraint on the `AgentNodeExecutionInputOutput` model.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>migration.sql</strong><dd><code>Add unique constraint and index to AgentNodeExecutionInputOutput table</code></dd></summary>
<hr>

rnd/autogpt_server/postgres/migrations/20240726131311_node_input_unique_constraint/migration.sql

<li>Added a unique constraint on columns <code>referencedByInputExecId</code>, <br><code>referencedByOutputExecId</code>, and <code>name</code> in the <br><code>AgentNodeExecutionInputOutput</code> table.<br> <li> Created a unique index <br><code>AgentNodeExecutionInputOutput_referencedByInputExecId_refer_key</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7619/files#diff-bee4359fb26474e2ab0dce71e0bae267f402895e30dc8a30134d3eb20ece0f48">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.prisma</strong><dd><code>Add unique constraint to AgentNodeExecutionInputOutput model</code></dd></summary>
<hr>

rnd/autogpt_server/postgres/schema.prisma

<li>Added a unique constraint on <code>referencedByInputExecId</code>, <br><code>referencedByOutputExecId</code>, and <code>name</code> in the <br><code>AgentNodeExecutionInputOutput</code> model.<br> <li> Ensured input and output pin names are unique for each <br><code>AgentNodeExecution</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7619/files#diff-f106cebc3f2a45af35741032a9df158c0a5e518ea962a6acdaa134ca559dc17e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

