### PR TITLE
fix(rnd): Fix broken server execution update due to split prisma connection to different loops

### DIFF
--- a/rnd/autogpt_server/autogpt_server/server/server.py
+++ b/rnd/autogpt_server/autogpt_server/server/server.py
@@ -23,10 +23,8 @@ from autogpt_server.data import graph as graph_db
 from autogpt_server.data.block import BlockInput, CompletedBlockOutput
 from autogpt_server.data.execution import (
     ExecutionResult,
-    ExecutionStatus,
     get_execution_results,
     list_executions,
-    update_execution_status,
 )
 from autogpt_server.executor import ExecutionManager, ExecutionScheduler
 from autogpt_server.server.conn_manager import ConnectionManager
@@ -599,9 +597,9 @@ class AgentServer(AppService):
         return execution_scheduler.get_execution_schedules(graph_id)  # type: ignore
 
     @expose
-    def update_execution_status(self, exec_id: str, status: ExecutionStatus):
-        exec_result = self.run_and_wait(update_execution_status(exec_id, status))
-        self.run_and_wait(self.event_queue.put(exec_result))
+    def send_execution_update(self, execution_result_dict: dict[Any, Any]):
+        execution_result = ExecutionResult(**execution_result_dict)
+        self.run_and_wait(self.event_queue.put(execution_result))
 
     @expose
     def acquire_lock(self, key: Any):

--- a/rnd/autogpt_server/autogpt_server/util/service.py
+++ b/rnd/autogpt_server/autogpt_server/util/service.py
@@ -51,11 +51,11 @@ class AppService(AppProcess):
         while True:
             time.sleep(10)
 
-    def run_async(self, coro: Coroutine[T, Any, T]):
+    def __run_async(self, coro: Coroutine[T, Any, T]):
         return asyncio.run_coroutine_threadsafe(coro, self.shared_event_loop)
 
     def run_and_wait(self, coro: Coroutine[T, Any, T]) -> T:
-        future = self.run_async(coro)
+        future = self.__run_async(coro)
         return future.result()
 
     def run(self):
@@ -85,7 +85,6 @@ class AppService(AppProcess):
         daemon.requestLoop()
 
     def __start_async_loop(self):
-        # asyncio.set_event_loop(self.shared_event_loop)
         self.shared_event_loop.run_forever()
 
 


### PR DESCRIPTION
### Background

Currently we are running two 2 threads within the API process:
1. pyro thread
2. fast API

The latest change makes it both thread requires prisma connection, while prisma is not multi threaded and should be handled within only a single event loop. 

### Changes 🏗️

In the scope: the fix is to revert the change that makes pyro requires prima.
Out of scope: Fix the Prisma usage in AppServer by making pyro & fast API shares the same event loop.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
4. Also consider contributing something other than code; see the [contribution guide]
   for options.
5. Clearly explain your changes.
6. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
