### PR TITLE
feat(builder): Apply standard theming for shadCn and centralize providers

### DIFF
--- a/rnd/autogpt_builder/src/app/globals.css
+++ b/rnd/autogpt_builder/src/app/globals.css
@@ -7,3 +7,60 @@
     text-wrap: balance;
   }
 }
+
+
+
+:root  {
+  --background: 180 100% 95%;
+  --foreground: 180 5% 0%;
+  --card: 180 50% 90%;
+  --card-foreground: 180 5% 10%;
+  --popover: 180 100% 95%;
+  --popover-foreground: 180 100% 0%;
+  --primary: 180 76.5% 30%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 180 30% 70%;
+  --secondary-foreground: 0 0% 0%;
+  --muted: 142 30% 85%;
+  --muted-foreground: 180 5% 35%;
+  --accent: 142 30% 80%;
+  --accent-foreground: 180 5% 10%;
+  --destructive: 0 100% 30%;
+  --destructive-foreground: 180 5% 90%;
+  --border: 180 30% 50%;
+  --input: 180 30% 18%;
+  --ring: 180 76.5% 30%;
+  --radius: 0.5rem;
+}
+.dark  {
+  --background: 180 50% 5%;
+  --foreground: 180 5% 90%;
+  --card: 180 50% 0%;
+  --card-foreground: 180 5% 90%;
+  --popover: 180 50% 5%;
+  --popover-foreground: 180 5% 90%;
+  --primary: 180 76.5% 30%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 180 30% 10%;
+  --secondary-foreground: 0 0% 100%;
+  --muted: 142 30% 15%;
+  --muted-foreground: 180 5% 60%;
+  --accent: 142 30% 15%;
+  --accent-foreground: 180 5% 90%;
+  --destructive: 0 100% 30%;
+  --destructive-foreground: 180 5% 90%;
+  --border: 180 30% 18%;
+  --input: 180 30% 18%;
+  --ring: 180 76.5% 30%;
+  --radius: 0.5rem;
+}
+
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/rnd/autogpt_builder/src/app/layout.tsx
+++ b/rnd/autogpt_builder/src/app/layout.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import type { Metadata } from "next";
-import { ThemeProvider as NextThemeProvider } from "next-themes";
-import { type ThemeProviderProps } from "next-themes/dist/types";
 import { Inter } from "next/font/google";
 import Link from "next/link";
-import { CubeIcon, Pencil1Icon, ReaderIcon, TimerIcon } from "@radix-ui/react-icons";
+import { Pencil1Icon, TimerIcon } from "@radix-ui/react-icons";
 
 import "./globals.css";
 
@@ -13,6 +11,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
+import { Providers } from "@/app/providers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -21,60 +20,58 @@ export const metadata: Metadata = {
   description: "Your one stop shop to creating AI Agents",
 };
 
-function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemeProvider {...props}>{children}</NextThemeProvider>
-}
-
 const NavBar = () => (
-  <nav className="bg-white dark:bg-slate-800 p-4 flex justify-between items-center shadow">
-    <div className="flex space-x-4">
-      <Link href="/monitor" className={buttonVariants({ variant: "ghost" })}>
-        <TimerIcon className="mr-1" /> Monitor
-      </Link>
-      <Link href="/build" className={buttonVariants({ variant: "ghost" })}>
-        <Pencil1Icon className="mr-1" /> Build
-      </Link>
-    </div>
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-8 w-8 rounded-full">
-          <Avatar>
-            <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-            <AvatarFallback>CN</AvatarFallback>
-          </Avatar>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem>Profile</DropdownMenuItem>
-        <DropdownMenuItem>Settings</DropdownMenuItem>
-        <DropdownMenuItem>Switch Workspace</DropdownMenuItem>
-        <DropdownMenuItem>Log out</DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  </nav>
+    <nav className="bg-white dark:bg-slate-800 p-4 flex justify-between items-center shadow">
+      <div className="flex space-x-4">
+        <Link href="/monitor" className={buttonVariants({ variant: "ghost" })}>
+          <TimerIcon className="mr-1" /> Monitor
+        </Link>
+        <Link href="/build" className={buttonVariants({ variant: "ghost" })}>
+          <Pencil1Icon className="mr-1" /> Build
+        </Link>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 rounded-full">
+            <Avatar>
+              <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
+              <AvatarFallback>CN</AvatarFallback>
+            </Avatar>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>Profile</DropdownMenuItem>
+          <DropdownMenuItem>Settings</DropdownMenuItem>
+          <DropdownMenuItem>Switch Workspace</DropdownMenuItem>
+          <DropdownMenuItem>Log out</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </nav>
 );
 
 export default function RootLayout({
-  children,
-}: Readonly<{
+                                     children,
+                                   }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+      <html lang="en">
       <body className={inter.className}>
-        <ThemeProvider
+      <Providers
           attribute="class"
           defaultTheme="light"
+          // Feel free to remove this line if you want to use the system theme by default
+          // enableSystem
           disableTransitionOnChange
-        >
-          <div className="min-h-screen bg-gray-200 text-gray-900">
-            <NavBar />
-            <main className="mx-auto p-4">
-              {children}
-            </main>
-          </div>
-        </ThemeProvider>
+      >
+        <div className="min-h-screen bg-gray-200 text-gray-900">
+          <NavBar />
+          <main className="mx-auto p-4">
+            {children}
+          </main>
+        </div>
+      </Providers>
       </body>
-    </html>
+      </html>
   );
 }

--- a/rnd/autogpt_builder/src/app/layout.tsx
+++ b/rnd/autogpt_builder/src/app/layout.tsx
@@ -22,36 +22,35 @@ export const metadata: Metadata = {
 
 const NavBar = () => (
     <nav className="bg-white dark:bg-slate-800 p-4 flex justify-between items-center shadow">
-      <div className="flex space-x-4">
-        <Link href="/monitor" className={buttonVariants({ variant: "ghost" })}>
-          <TimerIcon className="mr-1" /> Monitor
-        </Link>
-        <Link href="/build" className={buttonVariants({ variant: "ghost" })}>
-          <Pencil1Icon className="mr-1" /> Build
-        </Link>
-      </div>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" className="h-8 w-8 rounded-full">
-            <Avatar>
-              <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
-              <AvatarFallback>CN</AvatarFallback>
-            </Avatar>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem>Profile</DropdownMenuItem>
-          <DropdownMenuItem>Settings</DropdownMenuItem>
-          <DropdownMenuItem>Switch Workspace</DropdownMenuItem>
-          <DropdownMenuItem>Log out</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        <div className="flex space-x-4">
+            <Link href="/monitor" className={buttonVariants({ variant: "ghost" })}>
+                <TimerIcon className="mr-1" /> Monitor
+            </Link>
+            <Link href="/build" className={buttonVariants({ variant: "ghost" })}>
+                <Pencil1Icon className="mr-1" /> Build
+            </Link>
+        </div>
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-8 w-8 rounded-full">
+                    <Avatar>
+                        <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
+                        <AvatarFallback>CN</AvatarFallback>
+                    </Avatar>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+                <DropdownMenuItem>Profile</DropdownMenuItem>
+                <DropdownMenuItem>Settings</DropdownMenuItem>
+                <DropdownMenuItem>Switch Workspace</DropdownMenuItem>
+                <DropdownMenuItem>Log out</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
     </nav>
 );
-
 export default function RootLayout({
-                                     children,
-                                   }: Readonly<{
+ children,
+}: Readonly<{
   children: React.ReactNode;
 }>) {
   return (

--- a/rnd/autogpt_builder/src/app/providers.tsx
+++ b/rnd/autogpt_builder/src/app/providers.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import * as React from 'react'
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import { ThemeProviderProps } from 'next-themes/dist/types'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+export function Providers({ children, ...props }: ThemeProviderProps) {
+    return (
+        <NextThemesProvider {...props}>
+            <TooltipProvider>{children}</TooltipProvider>
+        </NextThemesProvider>
+    )
+}

--- a/rnd/autogpt_builder/tailwind.config.ts
+++ b/rnd/autogpt_builder/tailwind.config.ts
@@ -3,7 +3,9 @@ import type { Config } from "tailwindcss";
 const config = {
   darkMode: ["class"],
   content: [
-    './src/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}'
   ],
   prefix: "",
   theme: {
@@ -15,21 +17,65 @@ const config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ['var(--font-geist-sans)'],
+        mono: ['var(--font-geist-mono)']
+      },
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
       keyframes: {
-        "accordion-down": {
-          from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height)" },
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' }
         },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: "0" },
-        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' }
+        }
       },
       animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
-      },
-    },
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out'
+      }
+    }
   },
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;

--- a/rnd/autogpt_builder/tailwind.config.ts
+++ b/rnd/autogpt_builder/tailwind.config.ts
@@ -3,9 +3,7 @@ import type { Config } from "tailwindcss";
 const config = {
   darkMode: ["class"],
   content: [
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}'
+    './src/**/*.{ts,tsx}',
   ],
   prefix: "",
   theme: {


### PR DESCRIPTION
**User description**
### Background
The current implementation of the ShadCn components is in need of a theme standardization. When developing front-end solutions it is essential that we stay in alignment on styles, themes, and ux. 

By implementing this change we can allow developers to use class names such as "bg-background", "bg-accent", etc. This will remove complexity and drive easy development of new additions to the solution. 

The only other change was a consolidation of providers. This will keep our root layout clean and robust. Allowing for the focus of the layout.tsx to be components and not to be overflowing with providers as the frontend continues to scale. 

With these small changes we can better support our developer's experience and drive a better development experience. 

### Changes 🏗️

- Addition of a basic theme from shadCn as mentioned here in there docs: [ShadCN Theming Documentation](https://ui.shadcn.com/docs/theming)
- Addition of tailwind configuration's for shadCn's theming class names. 
- Addition of `providers.tsx` this file will house the providers leveraged by the frontend solution. 
- Addition but commented until further confirmation of setting the theme based off of the system's preference. This could be a good call for a user preference setting in our settings dropdown. 
```
      <Providers
          attribute="class"
          defaultTheme="light"
          // Feel free to remove this line if you want to use the system theme by default
          // enableSystem
          disableTransitionOnChange
      >
```


Resolves : [Standardize Frontend Theme](https://github.com/Significant-Gravitas/AutoGPT/issues/7624) #7624 
- 
### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->
- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Centralized theme and tooltip providers into a new `Providers` component to simplify the root layout.
- Updated Tailwind configuration to support new theme settings, including colors and fonts.
- Defined CSS variables for light and dark themes and applied them to base styles.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>layout.tsx</strong><dd><code>Centralize theme and tooltip providers in layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/app/layout.tsx

<li>Removed individual theme provider in favor of centralized <code>Providers</code> <br>component.<br> <li> Simplified imports by removing unused icons.<br> <li> Updated <code>RootLayout</code> to use the new <code>Providers</code> component.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7622/files#diff-7c8736b609b98c456d0903f1b1f50296e2143f00d6530475522bc96d62481097">+43/-46</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>providers.tsx</strong><dd><code>Create centralized Providers component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/app/providers.tsx

<li>Added new <code>Providers</code> component to centralize theme and tooltip <br>providers.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7622/files#diff-04a63f04b59a0a6bc3538188241289f779ce2885023746f6a1230cfd1928e212">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tailwind.config.ts</strong><dd><code>Update Tailwind configuration for new theme settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/tailwind.config.ts

<li>Updated Tailwind configuration to include new theme colors and font <br>settings.<br> <li> Added new content paths for Tailwind to scan.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7622/files#diff-7b06c9faf80ca70e561949e468f496bccb6f7a2528a153f2e359511f1975ea73">+58/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Define and apply CSS variables for theming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/app/globals.css

<li>Added CSS variables for light and dark themes.<br> <li> Applied base styles using new theme variables.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7622/files#diff-f831c19bcd908988823cf77817854d3467f6b1c1d1cee65a51105c0b01c3bf82">+57/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

