### PR TITLE
docs(server): add docs link to server readme

### DIFF
--- a/docs/content/server/advanced_setup.md
+++ b/docs/content/server/advanced_setup.md
@@ -39,3 +39,31 @@ my_secret_value
 ```
 
 This is useful when running on docker so you can copy the secrets into the container without exposing them in the Dockerfile.
+
+## Database selection
+
+### SQLite
+
+By default, the server uses SQLite as the database. SQLite is a file-based database that is easy to set up and use. However, it is not recommended for production use.
+
+### PostgreSQL
+
+For production use, it is recommended to use PostgreSQL as the database. You will swap the commands you use to generate and run prisma to the following
+
+```bash
+poetry run prisma generate --schema postgres/schema.prisma
+```
+
+This will generate the Prisma client for PostgreSQL. You will also need to run the PostgreSQL database in a separate container. You can use the `docker-compose.yml` file in the `rnd` directory to run the PostgreSQL database.
+
+```bash
+cd rnd/
+docker compose up -d
+```
+
+You can then run the migrations from the `autogpt_server` directory.
+
+```bash
+cd ../autogpt_server
+prisma migrate dev --schema postgres/schema.prisma
+```

--- a/rnd/autogpt_server/README.md
+++ b/rnd/autogpt_server/README.md
@@ -3,6 +3,10 @@
 This is an initial project for creating the next generation of agent execution, which is an AutoGPT agent server.
 The agent server will enable the creation of composite multi-agent systems that utilize AutoGPT agents and other non-agent components as its primitives.
 
+## Docs
+
+You can access the docs for the [AutoGPT Agent Server here](https://docs.agpt.co/server/setup).
+
 ## Setup
 
 We use the Poetry to manage the dependencies. To set up the project, follow these steps inside this directory:


### PR DESCRIPTION
### Background
There's no link from the rnd/agent_server to the docs to set it up
<!-- Clearly explain the need for these changes: -->

### Changes 🏗️
Adds that link and migrates the advanced setup details over
<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
