### PR TITLE
feat(rnd): Add postgres schema check on linting step + auto gen migration and schema sync command (poetry run schema)

### DIFF
--- a/rnd/autogpt_server/linter.py
+++ b/rnd/autogpt_server/linter.py
@@ -35,8 +35,6 @@ def format():
 
 
 def schema():
-    run("prisma", "migrate", "dev")
-
     file = os.path.join(directory, "schema.prisma")
     text = open(file, "r").read()
     text = re.sub(r'provider\s+=\s+".*"', 'provider = "postgresql"', text, 1)
@@ -47,6 +45,8 @@ def schema():
 
     run("prisma", "format", "--schema", "schema.prisma")
     run("prisma", "format", "--schema", "postgres/schema.prisma")
+    run("prisma", "migrate", "dev", "--schema", "schema.prisma")
+    run("prisma", "migrate", "dev", "--schema", "postgres/schema.prisma")
 
 
 def schema_lint():

--- a/rnd/autogpt_server/linter.py
+++ b/rnd/autogpt_server/linter.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 
 directory = os.path.dirname(os.path.realpath(__file__))
@@ -19,9 +20,43 @@ def lint():
         print("Lint failed, try running `poetry run format` to fix the issues: ", e)
         raise e
 
+    try:
+        run("schema_lint")
+    except subprocess.CalledProcessError as e:
+        print("Lint failed, try running `poetry run schema` to fix the issues: ", e)
+        raise e
+
 
 def format():
     run("ruff", "check", "--fix", ".")
     run("isort", "--profile", "black", ".")
     run("black", ".")
     run("pyright", ".")
+
+
+def schema():
+    run("prisma", "migrate", "dev")
+
+    file = os.path.join(directory, "schema.prisma")
+    text = open(file, "r").read()
+    text = re.sub(r'provider\s+=\s+".*"', 'provider = "postgresql"', text, 1)
+    text = re.sub(r'url\s+=\s+".*"', 'url = env("DATABASE_URL")', text, 1)
+    text = "// THIS FILE IS AUTO-GENERATED, RUN `poetry run schema` TO UPDATE\n" + text
+    with open(os.path.join(directory, "postgres", "schema.prisma"), "w") as f:
+        f.write(text)
+
+    run("prisma", "format", "--schema", "schema.prisma")
+    run("prisma", "format", "--schema", "postgres/schema.prisma")
+
+
+def schema_lint():
+    def read_schema(path: str) -> str:
+        with open(path, "r") as f:
+            return "\n".join(v for v in f.read().splitlines() if not v.startswith("//"))
+
+    sqlite_schema = read_schema(os.path.join(directory, "schema.prisma"))
+    postgres_schema = read_schema(os.path.join(directory, "postgres", "schema.prisma"))
+    diff = [line.strip() for line in set(sqlite_schema) ^ set(postgres_schema)]
+
+    if line := next((v for v in diff if not v.startswith(("provider", "url"))), None):
+        raise Exception(f"schema.prisma & postgres/schema.prisma mismatch: {line}")

--- a/rnd/autogpt_server/linter.py
+++ b/rnd/autogpt_server/linter.py
@@ -50,9 +50,9 @@ def schema():
 
 
 def schema_lint():
-    def read_schema(path: str) -> str:
+    def read_schema(path: str) -> list[str]:
         with open(path, "r") as f:
-            return "\n".join(v for v in f.read().splitlines() if not v.startswith("//"))
+            return [v for v in f.read().splitlines() if not v.startswith("//")]
 
     sqlite_schema = read_schema(os.path.join(directory, "schema.prisma"))
     postgres_schema = read_schema(os.path.join(directory, "postgres", "schema.prisma"))

--- a/rnd/autogpt_server/postgres/schema.prisma
+++ b/rnd/autogpt_server/postgres/schema.prisma
@@ -1,3 +1,4 @@
+// THIS FILE IS AUTO-GENERATED, RUN `poetry run schema` TO UPDATE
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")

--- a/rnd/autogpt_server/pyproject.toml
+++ b/rnd/autogpt_server/pyproject.toml
@@ -60,6 +60,8 @@ app = "autogpt_server.app:main"
 cli = "autogpt_server.cli:main"
 format = "linter:format"
 lint = "linter:lint"
+schema = "linter:schema"
+schema_lint = "linter:schema_lint"
 
 # https://poethepoet.natn.io/index.html
 [tool.poe]

--- a/rnd/autogpt_server/schema.prisma
+++ b/rnd/autogpt_server/schema.prisma
@@ -65,7 +65,7 @@ model AgentNodeLink {
   agentNodeSinkId String
   AgentNodeSink   AgentNode @relation("AgentNodeSink", fields: [agentNodeSinkId], references: [id])
   sinkName        String
-  
+
   // Default: the data coming from the source can only be consumed by the sink once, Static: input data will be reused.
   isStatic Boolean @default(false)
 }


### PR DESCRIPTION
### Background

Migration not being synced has caused issues and CI is not catching this yet.

### Changes 🏗️

* Added schema check in both sqlite & postgres prisma.schema on linting step.
* Introduced `poetry run schema` for syncing prisma.schema + generating migration in both files.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
