### PR TITLE
fix(builder): Always show connected optional pins on node

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -221,7 +221,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     setActiveKey(key);
     const value = getValue(key);
     setModalValue(
-      typeof value === "object" ? JSON.stringify(value, null, 2) : value
+      typeof value === "object" ? JSON.stringify(value, null, 2) : value,
     );
     setIsModalOpen(true);
   };
@@ -244,7 +244,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     setModalValue(
       data.output_data
         ? JSON.stringify(data.output_data, null, 2)
-        : "[no output (yet)]"
+        : "[no output (yet)]",
     );
   };
 
@@ -269,7 +269,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
 
     // Get all edges connected to this node
     const connectedEdges = getEdges().filter(
-      (edge) => edge.source === id || edge.target === id
+      (edge) => edge.source === id || edge.target === id,
     );
 
     // For each connected edge, update the connected node's state
@@ -283,7 +283,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
             if (node.id === connectedNodeId) {
               // Update the node's data to reflect the disconnection
               const updatedConnections = node.data.connections.filter(
-                (conn) => !(conn.source === id || conn.target === id)
+                (conn) => !(conn.source === id || conn.target === id),
               );
               return {
                 ...node,
@@ -294,7 +294,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
               };
             }
             return node;
-          })
+          }),
         );
       }
     });
@@ -302,7 +302,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     // Remove the node and its connected edges
     setNodes((nodes) => nodes.filter((node) => node.id !== id));
     setEdges((edges) =>
-      edges.filter((edge) => edge.source !== id && edge.target !== id)
+      edges.filter((edge) => edge.source !== id && edge.target !== id),
     );
   }, [id, setNodes, setEdges, getNode, getEdges]);
 
@@ -379,7 +379,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
                     </div>
                   )
                 );
-              }
+              },
             )}
         </div>
         <div className="flex-none">

--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -58,9 +58,10 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
   const [isOutputModalOpen, setIsOutputModalOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
-  const {
-    getNode, setNodes, getEdges, setEdges
-  } = useReactFlow<CustomNodeData, CustomEdgeData>();
+  const { getNode, setNodes, getEdges, setEdges } = useReactFlow<
+    CustomNodeData,
+    CustomEdgeData
+  >();
 
   const outputDataRef = useRef<HTMLDivElement>(null);
   const isInitialSetup = useRef(true);
@@ -91,12 +92,11 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     setIsAdvancedOpen(checked);
   };
 
-  const hasOptionalFields = (
+  const hasOptionalFields =
     data.inputSchema &&
     Object.keys(data.inputSchema.properties).some((key) => {
       return !data.inputSchema.required?.includes(key);
-    })
-  );
+    });
 
   const generateOutputHandles = (schema: BlockIORootSchema) => {
     if (!schema?.properties) return null;
@@ -221,7 +221,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     setActiveKey(key);
     const value = getValue(key);
     setModalValue(
-      typeof value === "object" ? JSON.stringify(value, null, 2) : value,
+      typeof value === "object" ? JSON.stringify(value, null, 2) : value
     );
     setIsModalOpen(true);
   };
@@ -244,7 +244,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     setModalValue(
       data.output_data
         ? JSON.stringify(data.output_data, null, 2)
-        : "[no output (yet)]",
+        : "[no output (yet)]"
     );
   };
 
@@ -269,7 +269,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
 
     // Get all edges connected to this node
     const connectedEdges = getEdges().filter(
-      (edge) => edge.source === id || edge.target === id,
+      (edge) => edge.source === id || edge.target === id
     );
 
     // For each connected edge, update the connected node's state
@@ -283,7 +283,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
             if (node.id === connectedNodeId) {
               // Update the node's data to reflect the disconnection
               const updatedConnections = node.data.connections.filter(
-                (conn) => !(conn.source === id || conn.target === id),
+                (conn) => !(conn.source === id || conn.target === id)
               );
               return {
                 ...node,
@@ -294,7 +294,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
               };
             }
             return node;
-          }),
+          })
         );
       }
     });
@@ -302,7 +302,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     // Remove the node and its connected edges
     setNodes((nodes) => nodes.filter((node) => node.id !== id));
     setEdges((edges) =>
-      edges.filter((edge) => edge.source !== id && edge.target !== id),
+      edges.filter((edge) => edge.source !== id && edge.target !== id)
     );
   }, [id, setNodes, setEdges, getNode, getEdges]);
 
@@ -379,7 +379,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
                     </div>
                   )
                 );
-              },
+              }
             )}
         </div>
         <div className="flex-none">

--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -21,6 +21,7 @@ import { Switch } from "@/components/ui/switch";
 import { Copy, Trash2 } from "lucide-react";
 import { history } from "./history";
 import NodeHandle from "./NodeHandle";
+import { CustomEdgeData } from "./CustomEdge";
 import { NodeGenericInputField } from "./node-input-components";
 
 type ParsedKey = { key: string; index?: number };
@@ -57,7 +58,9 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
   const [isOutputModalOpen, setIsOutputModalOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
-  const { getNode, setNodes, getEdges, setEdges } = useReactFlow();
+  const {
+    getNode, setNodes, getEdges, setEdges
+  } = useReactFlow<CustomNodeData, CustomEdgeData>();
 
   const outputDataRef = useRef<HTMLDivElement>(null);
   const isInitialSetup = useRef(true);
@@ -88,14 +91,12 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
     setIsAdvancedOpen(checked);
   };
 
-  const hasOptionalFields = () => {
-    return (
-      data.inputSchema &&
-      Object.keys(data.inputSchema.properties).some((key) => {
-        return !data.inputSchema.required?.includes(key);
-      })
-    );
-  };
+  const hasOptionalFields = (
+    data.inputSchema &&
+    Object.keys(data.inputSchema.properties).some((key) => {
+      return !data.inputSchema.required?.includes(key);
+    })
+  );
 
   const generateOutputHandles = (schema: BlockIORootSchema) => {
     if (!schema?.properties) return null;
@@ -350,17 +351,18 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
             Object.entries(data.inputSchema.properties).map(
               ([propKey, propSchema]) => {
                 const isRequired = data.inputSchema.required?.includes(propKey);
+                const isConnected = isHandleConnected(propKey);
                 return (
-                  (isRequired || isAdvancedOpen) && (
+                  (isRequired || isAdvancedOpen || isConnected) && (
                     <div key={propKey} onMouseOver={() => {}}>
                       <NodeHandle
                         keyName={propKey}
-                        isConnected={isHandleConnected(propKey)}
+                        isConnected={isConnected}
                         isRequired={isRequired}
                         schema={propSchema}
                         side="left"
                       />
-                      {!isHandleConnected(propKey) && (
+                      {!isConnected && (
                         <NodeGenericInputField
                           className="mt-1 mb-2"
                           propKey={propKey}
@@ -412,7 +414,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
       <div className="flex items-center mt-2.5">
         <Switch onCheckedChange={toggleOutput} />
         <span className="m-1 mr-4">Output</span>
-        {hasOptionalFields() && (
+        {hasOptionalFields && (
           <>
             <Switch onCheckedChange={toggleAdvancedSettings} />
             <span className="m-1">Advanced</span>


### PR DESCRIPTION
- Resolves #7598

### Changes 🏗️

- Always show connected optional pins on node
- Refactor `hasOptionalFields()` to a constant `hasOptionalFields`

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
