### PR TITLE
fix(rnd): Fix flaky CurrentDateAndTimeBlock test

### DIFF
--- a/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
@@ -53,7 +53,8 @@ class CurrentDateBlock(Block):
             test_output=[
                 (
                     "date",
-                    lambda _: (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d"),
+                    lambda t: abs(datetime.now() - datetime.strptime(t, "%Y-%m-%d"))
+                    < timedelta(days=8),  # 7 days difference + 1 day error margin.
                 ),
             ],
         )

--- a/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
@@ -51,7 +51,10 @@ class CurrentDateBlock(Block):
                 {"trigger": "Hello", "format": "{date}", "offset": "7"},
             ],
             test_output=[
-                ("date", (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")),
+                (
+                    "date",
+                    lambda _: (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d"),
+                ),
             ],
         )
 
@@ -82,7 +85,7 @@ class CurrentDateAndTimeBlock(Block):
                 {"trigger": "Hello", "format": "{date_time}"},
             ],
             test_output=[
-                ("date_time", time.strftime("%Y-%m-%d %H:%M:%S")),
+                ("date_time", str),
             ],
         )
 

--- a/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
@@ -85,7 +85,13 @@ class CurrentDateAndTimeBlock(Block):
                 {"trigger": "Hello", "format": "{date_time}"},
             ],
             test_output=[
-                ("date_time", str),
+                (
+                    "date_time",
+                    lambda t: abs(
+                        datetime.now() - datetime.strptime(t, "%Y-%m-%d %H:%M:%S")
+                    )
+                    < timedelta(seconds=10),  # 10 seconds error margin.
+                ),
             ],
         )
 

--- a/rnd/autogpt_server/autogpt_server/util/test.py
+++ b/rnd/autogpt_server/autogpt_server/util/test.py
@@ -96,10 +96,14 @@ def execute_block_test(block: Block):
             ex_output_name, ex_output_data = block.test_output[output_index]
 
             def compare(data, expected_data):
-                if isinstance(expected_data, type):
+                if data == expected_data:
+                    is_matching = True
+                elif isinstance(expected_data, type):
                     is_matching = isinstance(data, expected_data)
+                elif callable(expected_data):
+                    is_matching = expected_data(data)
                 else:
-                    is_matching = data == expected_data
+                    is_matching = False
 
                 mark = "✅" if is_matching else "❌"
                 log(f"{prefix} {mark} comparing `{data}` vs `{expected_data}`")


### PR DESCRIPTION
### Background

CurrentDateAndTimeBlock would fail if the test is not complete within 1-second wall-time.
In the case a test started at the second 00:00:01:59:59, it becomes flaky.

We can change the test to only assert the type. But this is also a good chance to add more assertion options for Block: a custom function.

### Changes 🏗️

Change assertion for the time block using an additional margin of error.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
