### PR TITLE
fix(builder): Added option to pan view to center agents on build screen

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -17,6 +17,7 @@ import ReactFlow, {
   Connection,
   EdgeTypes,
   MarkerType,
+  Controls,
 } from "reactflow";
 import "reactflow/dist/style.css";
 import CustomNode, { CustomNodeData } from "./CustomNode";
@@ -880,6 +881,7 @@ const FlowEditor: React.FC<{
         onNodeDragStart={onNodesChangeStart}
         onNodeDragStop={onNodesChangeEnd}
       >
+        <Controls />
         <ControlPanel className="absolute z-10" controls={editorControls}>
           <BlocksControl blocks={availableNodes} addBlock={addNode} />
           <SaveControl


### PR DESCRIPTION
### **User description**
### Background

Resolves: [Add "Pan to Center" for the view on Build Screen/#7627](https://github.com/Significant-Gravitas/AutoGPT/issues/7627)

Users can lose track of their agents if they move the view too far away on the build screen, disrupting their workflow. To enhance usability, a feature is needed to quickly reorient the view to center on the agents, allowing users to regain focus efficiently.

### Changes 🏗️

- Introduced the < Controls /> component to the build screen.
- Added buttons for zooming in, zooming out, fitting the view to center on all agents, and locking the viewport.
- Ensured smooth transitions for fitting the view, enhancing user experience and usability.

### Screenshots
<img width="1680" alt="Screenshot 2024-08-07 at 10 23 14 PM" src="https://github.com/user-attachments/assets/62252d8a-d612-4813-adda-97aa6211d95d">
<img width="260" alt="Screenshot 2024-08-07 at 10 23 37 PM" src="https://github.com/user-attachments/assets/d2fb1bfb-6237-40a6-bbe5-6ec29a9994a5">


### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced the `<Controls />` component to the Flow editor in the build screen.
- Added buttons for zooming in, zooming out, fitting the view to center on all agents, and locking the viewport.
- Enhanced user experience by ensuring smooth transitions for fitting the view.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Added viewport control options to Flow editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

<li>Imported <code>Controls</code> from <code>reactflow</code>.<br> <li> Added <code><Controls /></code> component to the <code>ReactFlow</code> component.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7742/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

