### PR TITLE
fix(tests): Ensure user ID is not None on schedule in tests

### DIFF
--- a/rnd/autogpt_server/autogpt_server/data/schedule.py
+++ b/rnd/autogpt_server/autogpt_server/data/schedule.py
@@ -64,6 +64,7 @@ async def add_schedule(schedule: ExecutionSchedule) -> ExecutionSchedule:
     obj = await AgentGraphExecutionSchedule.prisma().create(
         data={
             "id": schedule.id,
+            "userId": schedule.user_id,
             "agentGraphId": schedule.graph_id,
             "agentGraphVersion": schedule.graph_version,
             "schedule": schedule.schedule,

--- a/rnd/autogpt_server/test/executor/test_scheduler.py
+++ b/rnd/autogpt_server/test/executor/test_scheduler.py
@@ -6,7 +6,7 @@ from autogpt_server.usecases.sample import create_test_graph, create_test_user
 from autogpt_server.util.service import get_service_client
 
 
-@pytest.mark.skip(reason="flakey test, needs to be investigated")
+# @pytest.mark.skip(reason="flakey test, needs to be investigated")
 @pytest.mark.asyncio(scope="session")
 async def test_agent_schedule(server):
     await db.connect()
@@ -31,6 +31,6 @@ async def test_agent_schedule(server):
     assert len(schedules) == 1
     assert schedules[schedule_id] == "0 0 * * *"
 
-    scheduler.update_schedule(schedule_id, is_enabled=False)
-    schedules = scheduler.get_execution_schedules(test_graph.id)
+    scheduler.update_schedule(schedule_id, is_enabled=False, user_id=test_user.id)
+    schedules = scheduler.get_execution_schedules(test_graph.id, user_id=test_user.id)
     assert len(schedules) == 0

--- a/rnd/autogpt_server/test/executor/test_scheduler.py
+++ b/rnd/autogpt_server/test/executor/test_scheduler.py
@@ -6,7 +6,6 @@ from autogpt_server.usecases.sample import create_test_graph, create_test_user
 from autogpt_server.util.service import get_service_client
 
 
-# @pytest.mark.skip(reason="flakey test, needs to be investigated")
 @pytest.mark.asyncio(scope="session")
 async def test_agent_schedule(server):
     await db.connect()


### PR DESCRIPTION
### **User description**
### Background

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `userId` field to the schedule creation data to ensure it is never None.
- Uncommented and updated the test for agent schedule to include `user_id` in schedule update and retrieval.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schedule.py</strong><dd><code>Ensure `userId` is included in schedule creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/data/schedule.py

- Added `userId` field to the schedule creation data.



</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7749/files#diff-ede26f9fd5df807a42873b67234428b3febdbbe31df616fd9e7ea6892db7898f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scheduler.py</strong><dd><code>Fix and update test for agent schedule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/test/executor/test_scheduler.py

<li>Uncommented flaky test for agent schedule.<br> <li> Updated test to include <code>user_id</code> in schedule update and retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7749/files#diff-41b2bf2d4a912b3895d3a63a21804c4ef1fcf27aab8169e851c02c86b30e4ba4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

