### PR TITLE
fix(builder): Added header background and moved some styling to tailwind

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -314,15 +314,15 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
 
   return (
     <div
-      className={`custom-node dark-theme ${data.status?.toLowerCase() ?? ""}`}
+      className={`custom-node overflow-hidden dark-theme border-4 rounded-xl ${data.status?.toLowerCase() ?? ""}`}
       onMouseEnter={handleHovered}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="mb-2">
-        <div className="text-lg font-bold">
+      <div className="mb-2 p-3 bg-gray-300">
+        <div className="p-3 text-lg font-bold">
           {beautifyString(data.blockType?.replace(/Block$/, "") || data.title)}
         </div>
-        <div className="flex gap-[5px]">
+        <div className="flex gap-[5px] ">
           {isHovered && (
             <>
               <Button
@@ -345,7 +345,7 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
           )}
         </div>
       </div>
-      <div className="flex justify-between items-start gap-2">
+      <div className="p-3 flex justify-between items-start gap-2">
         <div>
           {data.inputSchema &&
             Object.entries(data.inputSchema.properties).map(

--- a/rnd/autogpt_builder/src/components/customnode.css
+++ b/rnd/autogpt_builder/src/components/customnode.css
@@ -1,7 +1,5 @@
 .custom-node {
-  @apply p-3;
-  border: 3px solid #4b5563;
-  border-radius: 12px;
+  border: 4px solid #4b5563;
   background: #ffffff;
   color: #000000;
   width: 500px;


### PR DESCRIPTION
### **User description**
### **Description**
- Enhanced the styling of the `CustomNode` component by moving some styles to Tailwind CSS classes.
- Added `overflow-hidden`, `border-4`, and `rounded-xl` classes to the main container.
- Updated padding and background color for better visual hierarchy.
- Adjusted CSS properties to maintain consistency with the new Tailwind styles.


### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the styling of the `CustomNode` component by moving some styles to Tailwind CSS classes.
- Added `overflow-hidden`, `border-4`, and `rounded-xl` classes to the main container.
- Updated padding and background color for better visual hierarchy.
- Adjusted CSS properties to maintain consistency with the new Tailwind styles.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomNode.tsx</strong><dd><code>Enhance node styling with Tailwind CSS classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/CustomNode.tsx

<li>Added <code>overflow-hidden</code>, <code>border-4</code>, and <code>rounded-xl</code> classes to the main <br>div.<br> <li> Added padding and background color to header div.<br> <li> Added padding to the title div.<br> <li> Added padding to the container div.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7756/files#diff-ce37ba33e874cc42255fda0cd2a16758a94a6e68606d513b7018c1cc68193146">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>customnode.css</strong><dd><code>Update node CSS properties for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/customnode.css

<li>Removed padding and border-radius properties.<br> <li> Updated border width.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7756/files#diff-5bd354fa19e27aa2784e3ffea64648f1b39295a4507fb1d63f84e17cd8ec2b48">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

