### PR TITLE
tweak(builder) block control styling

### DIFF
--- a/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
+++ b/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
@@ -50,7 +50,7 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
         side="right"
         sideOffset={22}
         align="start"
-        className="w-80 p-0"
+        className="w-96 p-0"
       >
         <Card className="border-none shadow-none">
           <CardHeader className="p-4">

--- a/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
+++ b/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
@@ -52,10 +52,10 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
         align="start"
         className="w-96 p-0"
       >
-        <Card className="border-none shadow-none">
-          <CardHeader className="p-4">
-            <div className="flex flex-row justify-between items-center">
-              <Label htmlFor="search-blocks">Blocks</Label>
+        <Card className="border-none shadow-md">
+          <CardHeader className="flex px-2 flex-col p-3 gap-x-8 gap-y-2">
+            <div className="justify-between items-center ">
+              <Label htmlFor="search-blocks" className="text-base 2xl:text-xl font-semibold whitespace-nowrap text-black border-b-2 border-violet-500" >Blocks</Label>
             </div>
             <Input
               id="search-blocks"

--- a/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
+++ b/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
@@ -55,7 +55,12 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
         <Card className="border-none shadow-md">
           <CardHeader className="flex px-2 flex-col p-3 gap-x-8 gap-y-2">
             <div className="justify-between items-center ">
-              <Label htmlFor="search-blocks" className="text-base 2xl:text-xl font-semibold whitespace-nowrap text-black border-b-2 border-violet-500" >Blocks</Label>
+              <Label
+                htmlFor="search-blocks"
+                className="text-base 2xl:text-xl font-semibold whitespace-nowrap text-black border-b-2 border-violet-500"
+              >
+                Blocks
+              </Label>
             </div>
             <Input
               id="search-blocks"

--- a/rnd/autogpt_builder/src/components/ui/input.tsx
+++ b/rnd/autogpt_builder/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-gray-200 bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-950 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-800 dark:placeholder:text-gray-400 dark:focus-visible:ring-gray-300",
+          "flex h-9 w-full rounded-md border border-gray-200 bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-800 dark:placeholder:text-gray-400 dark:focus-visible:ring-gray-300",
           type == "file" ? "pt-1.5 pb-0.5" : "", // fix alignment
           className,
         )}


### PR DESCRIPTION
### **User description**
### Background

<img width="411" alt="Screenshot 2024-08-08 at 13 39 58" src="https://github.com/user-attachments/assets/7679fdf7-b4f9-4cd9-95a7-ffc82e07a6f9">

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the `BlocksControl` component by increasing the width of the popover content and updating the styling of the `Card` and `Label` components for better visual hierarchy and user experience.
- Adjusted the focus-visible ring color for input fields to improve accessibility and visual consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BlocksControl.tsx</strong><dd><code>Update BlocksControl component styling for better UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx

<li>Increased width of the popover content.<br> <li> Updated <code>Card</code> component styling to include shadow and padding <br>adjustments.<br> <li> Enhanced <code>Label</code> styling with new classes for better visual hierarchy.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7762/files#diff-28b4290fb343f3ffa516349fb003a22574e34bdf3749704ee9eeeba9644c03b9">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>input.tsx</strong><dd><code>Adjust input field focus-visible ring color</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/ui/input.tsx

- Modified focus-visible ring color for input fields.



</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7762/files#diff-cfa024aca703792f8f5d4d84f50f196ea01dcb596f0ef0442679a0476a56eb69">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

