### PR TITLE
tweak(builder) Changes to transparency, connector color and title boldness

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -314,12 +314,12 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
 
   return (
     <div
-      className={`custom-node dark-theme border rounded-xl shandow-md bg-white/[.8] ${data.status?.toLowerCase() ?? ""}`}
+      className={`custom-node dark-theme border rounded-xl shandow-md bg-white/[.9] ${data.status?.toLowerCase() ?? ""}`}
       onMouseEnter={handleHovered}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="mb-2 p-3 bg-gray-300 rounded-t-xl">
-        <div className="p-3 text-lg font-bold">
+      <div className="mb-2 p-3 bg-gray-300/[.7] rounded-t-xl">
+        <div className="p-3 text-lg font-semibold font-roboto">
           {beautifyString(data.blockType?.replace(/Block$/, "") || data.title)}
         </div>
         <div className="flex gap-[5px] ">

--- a/rnd/autogpt_builder/src/components/NodeHandle.tsx
+++ b/rnd/autogpt_builder/src/components/NodeHandle.tsx
@@ -42,7 +42,7 @@ const NodeHandle: FC<HandleProps> = ({
 
   const dot = (
     <div
-      className={`w-4 h-4 m-1 border-2 bg-white ${isConnected ? getTypeBgColor(schema.type || "any") : "border-gray-600"} rounded-full transition-colors duration-100 group-hover:bg-gray-300`}
+      className={`w-4 h-4 m-1 border-2 bg-white ${isConnected ? getTypeBgColor(schema.type || "any") : "border-gray-300"} rounded-full transition-colors duration-100 group-hover:bg-gray-300`}
     />
   );
 


### PR DESCRIPTION
### **User description**
### Background

<!-- Clearly explain the need for these changes: -->
<img width="751" alt="Screenshot 2024-08-08 at 15 15 31" src="https://github.com/user-attachments/assets/23db455c-2cef-409f-98e0-ee945b1d9826">


### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Increased the background transparency of the node container from `.8` to `.9` for better visibility.
- Changed the title background transparency to `.7` and updated the title font weight to `font-semibold` and font family to `font-roboto`.
- Modified the border color of the node handle when not connected from `border-gray-600` to `border-gray-300`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomNode.tsx</strong><dd><code>Adjust node container and title styles for better visibility</code></dd></summary>
<hr>

rnd/autogpt_builder/src/components/CustomNode.tsx

<li>Increased background transparency of the node container.<br> <li> Changed title background transparency.<br> <li> Updated title font weight and font family.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7766/files#diff-ce37ba33e874cc42255fda0cd2a16758a94a6e68606d513b7018c1cc68193146">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NodeHandle.tsx</strong><dd><code>Update node handle border color for disconnected state</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/NodeHandle.tsx

- Modified border color of the node handle when not connected.



</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7766/files#diff-399c720b0288f820c7afe3d2e66bd7638f09b49060d268d5ff2a03d902dc6724">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

