### PR TITLE
Added tooltips for blocks

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -23,12 +23,14 @@ import { history } from "./history";
 import NodeHandle from "./NodeHandle";
 import { CustomEdgeData } from "./CustomEdge";
 import { NodeGenericInputField } from "./node-input-components";
+import SchemaTooltip from "./SchemaTooltip";
 
 type ParsedKey = { key: string; index?: number };
 
 export type CustomNodeData = {
   blockType: string;
   title: string;
+  description: string;
   inputSchema: BlockIORootSchema;
   outputSchema: BlockIORootSchema;
   hardcodedValues: { [key: string]: any };
@@ -282,8 +284,13 @@ const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {
       onMouseLeave={handleMouseLeave}
     >
       <div className="mb-2 p-3 bg-gray-300/[.7] rounded-t-xl">
-        <div className="p-3 text-lg font-semibold font-roboto">
-          {beautifyString(data.blockType?.replace(/Block$/, "") || data.title)}
+        <div className="flex items-center justify-between">
+          <div className="p-3 text-lg font-semibold font-roboto">
+            {beautifyString(
+              data.blockType?.replace(/Block$/, "") || data.title,
+            )}
+          </div>
+          <SchemaTooltip description={data.description} />
         </div>
         <div className="flex gap-[5px] ">
           {isHovered && (

--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -380,6 +380,7 @@ const FlowEditor: React.FC<{
         data: {
           blockType: nodeType,
           title: `${nodeType} ${nodeId}`,
+          description: nodeSchema.description,
           inputSchema: nodeSchema.inputSchema,
           outputSchema: nodeSchema.outputSchema,
           hardcodedValues: {},
@@ -459,6 +460,7 @@ const FlowEditor: React.FC<{
           data: {
             block_id: block.id,
             blockType: block.name,
+            description: block.description,
             title: `${block.name} ${node.id}`,
             inputSchema: block.inputSchema,
             outputSchema: block.outputSchema,

--- a/rnd/autogpt_builder/src/components/NodeHandle.tsx
+++ b/rnd/autogpt_builder/src/components/NodeHandle.tsx
@@ -60,7 +60,7 @@ const NodeHandle: FC<HandleProps> = ({
             {label}
           </div>
         </Handle>
-        <SchemaTooltip schema={schema} />
+        <SchemaTooltip description={schema.description} />
       </div>
     );
   } else {

--- a/rnd/autogpt_builder/src/components/SchemaTooltip.tsx
+++ b/rnd/autogpt_builder/src/components/SchemaTooltip.tsx
@@ -4,12 +4,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { BlockIOSubSchema } from "@/lib/autogpt-server-api/types";
 import { Info } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 
-const SchemaTooltip: React.FC<{ schema: BlockIOSubSchema }> = ({ schema }) => {
-  if (!schema.description) return null;
+const SchemaTooltip: React.FC<{ description?: string }> = ({ description }) => {
+  if (!description) return null;
 
   return (
     <TooltipProvider delayDuration={400}>
@@ -25,7 +24,7 @@ const SchemaTooltip: React.FC<{ schema: BlockIOSubSchema }> = ({ schema }) => {
               ),
             }}
           >
-            {schema.description}
+            {description}
           </ReactMarkdown>
         </TooltipContent>
       </Tooltip>

--- a/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
+++ b/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
@@ -14,6 +14,7 @@ import {
 import { Block } from "@/lib/autogpt-server-api";
 import { PlusIcon } from "@radix-ui/react-icons";
 import { IconToyBrick } from "@/components/ui/icons";
+import SchemaTooltip from "@/components/SchemaTooltip";
 
 interface BlocksControlProps {
   blocks: Block[];
@@ -80,6 +81,7 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
                         {beautifyString(block.name)}
                       </span>
                     </div>
+                    <SchemaTooltip description={block.description} />
                     <div className="flex items-center gap-1 flex-shrink-0">
                       <Button
                         variant="ghost"


### PR DESCRIPTION
### **User description**
### Background

Added tooltips to blocks and the blocks controller
<img width="1500" alt="Screenshot 2024-08-13 at 17 52 40" src="https://github.com/user-attachments/assets/85b1aa3b-509f-49c6-b12e-ec59ae0ef6a3">


### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Enhancement


___

### **Description**
- Added `SchemaTooltip` component to display block descriptions as tooltips.
- Updated `CustomNode`, `FlowEditor`, `NodeHandle`, and `BlocksControl` components to integrate `SchemaTooltip`.
- Modified `SchemaTooltip` to accept a `description` prop instead of `schema`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomNode.tsx</strong><dd><code>Add tooltips to CustomNode component for block descriptions</code></dd></summary>
<hr>

rnd/autogpt_builder/src/components/CustomNode.tsx

<li>Imported <code>SchemaTooltip</code> component.<br> <li> Added <code>description</code> field to <code>CustomNodeData</code> type.<br> <li> Integrated <code>SchemaTooltip</code> in the <code>CustomNode</code> component to display block <br>descriptions.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7793/files#diff-ce37ba33e874cc42255fda0cd2a16758a94a6e68606d513b7018c1cc68193146">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Flow.tsx</strong><dd><code>Include block descriptions in node data for FlowEditor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/Flow.tsx

- Added `description` field to node data in `FlowEditor` component.



</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7793/files#diff-31d9430263189bf5d64454c82b2151fe2b4198ea7c8b3beb36a99563c5dcc00d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>NodeHandle.tsx</strong><dd><code>Update NodeHandle to use description in SchemaTooltip</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/NodeHandle.tsx

<li>Updated <code>SchemaTooltip</code> usage to pass <code>description</code> instead of <code>schema</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7793/files#diff-399c720b0288f820c7afe3d2e66bd7638f09b49060d268d5ff2a03d902dc6724">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SchemaTooltip.tsx</strong><dd><code>Refactor SchemaTooltip component to use description prop</code>&nbsp; </dd></summary>
<hr>

rnd/autogpt_builder/src/components/SchemaTooltip.tsx

<li>Modified <code>SchemaTooltip</code> to accept <code>description</code> prop instead of <code>schema</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7793/files#diff-c02f5cd8279cb21947b3488c5f89880b915b7627ead8a21d3299acd74a18e275">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BlocksControl.tsx</strong><dd><code>Add tooltips to BlocksControl component for block descriptions</code></dd></summary>
<hr>

rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx

<li>Integrated <code>SchemaTooltip</code> in <code>BlocksControl</code> component to display block <br>descriptions.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7793/files#diff-28b4290fb343f3ffa516349fb003a22574e34bdf3749704ee9eeeba9644c03b9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

