### PR TITLE
feat(rnd): Add staticOutput field on block API

### DIFF
--- a/rnd/autogpt_server/autogpt_server/blocks/basic.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/basic.py
@@ -12,20 +12,7 @@ class ValueBlock(Block):
     """
     This block allows you to provide a constant value as a block, in a stateless manner.
     The common use-case is simply pass the `input` data, it will `output` the same data.
-    But this will not retain the state, once it is executed, the output is consumed.
-
-    To retain the state, you can feed the `output` to the `data` input, so that the data
-    is retained in the block for the next execution. You can then trigger the block by
-    feeding the `input` pin with any data, and the block will produce value of `data`.
-
-    Ex:
-         <constant_data>  <any_trigger>
-                ||           ||
-       =====> `data`      `input`
-      ||        \\         //
-      ||          ValueBlock
-      ||             ||
-       ========= `output`
+    The block output will be static, the output can be consumed multiple times.
     """
 
     class Input(BlockSchema):
@@ -46,9 +33,7 @@ class ValueBlock(Block):
         super().__init__(
             id="1ff065e9-88e8-4358-9d82-8dc91f622ba9",
             description="This block forwards the `input` pin to `output` pin. "
-            "If the `data` is provided, it will prioritize forwarding `data` "
-            "over `input`. By connecting the `output` pin to `data` pin, "
-            "you can retain a constant value for the next executions.",
+            "This block output will be static, the output can be consumed many times.",
             categories={BlockCategory.BASIC},
             input_schema=ValueBlock.Input,
             output_schema=ValueBlock.Output,
@@ -60,6 +45,7 @@ class ValueBlock(Block):
                 ("output", "Hello, World!"),  # No data provided, so trigger is returned
                 ("output", "Existing Data"),  # Data is provided, so data is returned.
             ],
+            static_output=True,
         )
 
     def run(self, input_data: Input) -> BlockOutput:

--- a/rnd/autogpt_server/autogpt_server/data/block.py
+++ b/rnd/autogpt_server/autogpt_server/data/block.py
@@ -127,6 +127,7 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
         test_output: BlockData | list[BlockData] | None = None,
         test_mock: dict[str, Any] | None = None,
         disabled: bool = False,
+        static_output: bool = False,
     ):
         """
         Initialize the block with the given schema.
@@ -143,6 +144,7 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
             test_output: The list or single expected output if the test_input is run.
             test_mock: function names on the block implementation to mock on test run.
             disabled: If the block is disabled, it will not be available for execution.
+            static_output: Whether the output links of the block are static by default.
         """
         self.id = id
         self.input_schema = input_schema
@@ -154,6 +156,7 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
         self.categories = categories or set()
         self.contributors = contributors or set()
         self.disabled = disabled
+        self.static_output = static_output
 
     @abstractmethod
     def run(self, input_data: BlockSchemaInputType) -> BlockOutput:
@@ -180,7 +183,10 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
             "outputSchema": self.output_schema.jsonschema(),
             "description": self.description,
             "categories": [category.dict() for category in self.categories],
-            "contributors": [contributor.dict() for contributor in self.contributors],
+            "contributors": [
+                contributor.model_dump() for contributor in self.contributors
+            ],
+            "staticOutput": self.static_output,
         }
 
     def execute(self, input_data: BlockInput) -> BlockOutput:

--- a/rnd/autogpt_server/autogpt_server/data/graph.py
+++ b/rnd/autogpt_server/autogpt_server/data/graph.py
@@ -7,7 +7,7 @@ import prisma.types
 from prisma.models import AgentGraph, AgentNode, AgentNodeLink
 from pydantic import PrivateAttr
 
-from autogpt_server.blocks.basic import InputBlock, OutputBlock, ValueBlock
+from autogpt_server.blocks.basic import InputBlock, OutputBlock
 from autogpt_server.data.block import BlockInput, get_block, get_blocks
 from autogpt_server.data.db import BaseDbModel, transaction
 from autogpt_server.data.user import DEFAULT_USER_ID
@@ -175,10 +175,10 @@ class Graph(GraphMeta):
                     )
         node_map = {v.id: v for v in self.nodes}
 
-        def is_value_block(nid: str) -> bool:
+        def is_static_output_block(nid: str) -> bool:
             bid = node_map[nid].block_id
             b = get_block(bid)
-            return isinstance(b, ValueBlock)
+            return b.static_output if b else False
 
         def is_input_output_block(nid: str) -> bool:
             bid = node_map[nid].block_id
@@ -227,7 +227,7 @@ class Graph(GraphMeta):
             ):
                 raise ValueError(f"{suffix}, Connecting nodes from different subgraph.")
 
-            if is_value_block(link.source_id):
+            if is_static_output_block(link.source_id):
                 link.is_static = True  # Each value block output should be static.
 
             # TODO: Add type compatibility check here.


### PR DESCRIPTION
### Background

We need some way to distinguish blocks that should have a static link on their output (currently ValueBlock).

### Changes 🏗️

Add a static output field to the `GET /blocks` API.
Update ValueBlock description, make ValueBlock as staticOutput == true.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
