### PR TITLE
Feat(Builder): Make blocks spawn in the center of the screen not at 0,0

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -26,6 +26,7 @@ import ReactFlow, {
   useReactFlow,
   applyEdgeChanges,
   applyNodeChanges,
+  useViewport,
 } from "reactflow";
 import "reactflow/dist/style.css";
 import CustomNode, { CustomNodeData } from "./CustomNode";
@@ -378,6 +379,8 @@ const FlowEditor: React.FC<{
     [getEdges, _setEdges, setNodes, clearNodesStatusAndOutput],
   );
 
+  const { x, y, zoom } = useViewport();
+
   const addNode = useCallback(
     (blockId: string, nodeType: string) => {
       const nodeSchema = availableNodes.find((node) => node.id === blockId);
@@ -386,10 +389,16 @@ const FlowEditor: React.FC<{
         return;
       }
 
+      // Calculate the center of the viewport considering zoom
+      const viewportCenter = {
+        x: (window.innerWidth / 2 - x) / zoom,
+        y: (window.innerHeight / 2 - y) / zoom,
+      };
+
       const newNode: Node<CustomNodeData> = {
         id: nodeId.toString(),
         type: "custom",
-        position: { x: Math.random() * 400, y: Math.random() * 400 },
+        position: viewportCenter, // Set the position to the calculated viewport center
         data: {
           blockType: nodeType,
           title: `${nodeType} ${nodeId}`,
@@ -443,6 +452,9 @@ const FlowEditor: React.FC<{
       setNodes,
       deleteElements,
       clearNodesStatusAndOutput,
+      x,
+      y,
+      zoom,
     ],
   );
 


### PR DESCRIPTION
### Background

This makes it so the blocks spawn at the center of the screen instead of at 0,0 / off the screen

https://github.com/user-attachments/assets/85f13a65-ac3f-47d0-a3fc-0c1e7ed1002e

### Changes 🏗️

Had to add ``useViewport`` and updated the add node to use the current useViewport and half it to get the center! 

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
