### PR TITLE
fix(builder): Correctly display static links on new edges

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -52,6 +52,7 @@ export type CustomNodeData = {
   errors?: { [key: string]: string | null };
   setErrors: (errors: { [key: string]: string | null }) => void;
   setIsAnyModalOpen?: (isOpen: boolean) => void;
+  isOutputStatic?: boolean;
 };
 
 const CustomNode: FC<NodeProps<CustomNodeData>> = ({ data, id }) => {

--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -274,8 +274,7 @@ const FlowEditor: React.FC<{
       const edgeColor = getTypeColor(
         getOutputType(connection.source!, connection.sourceHandle!),
       );
-      const sourcePos = getNode(connection.source!)?.position;
-      console.log("sourcePos", sourcePos);
+      const sourceNode = getNode(connection.source!);
       const newEdge: Edge<CustomEdgeData> = {
         id: formatEdgeID(connection),
         type: "custom",
@@ -284,7 +283,11 @@ const FlowEditor: React.FC<{
           strokeWidth: 2,
           color: edgeColor,
         },
-        data: { edgeColor, sourcePos },
+        data: {
+          edgeColor,
+          sourcePos: sourceNode!.position,
+          isStatic: sourceNode!.data.isOutputStatic,
+        },
         ...connection,
         source: connection.source!,
         target: connection.target!,
@@ -431,6 +434,7 @@ const FlowEditor: React.FC<{
               ),
             );
           },
+          isOutputStatic: nodeSchema.staticOutput,
         },
       };
 

--- a/rnd/autogpt_builder/src/lib/autogpt-server-api/types.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt-server-api/types.ts
@@ -12,6 +12,7 @@ export type Block = {
   categories: Category[];
   inputSchema: BlockIORootSchema;
   outputSchema: BlockIORootSchema;
+  staticOutput: boolean;
 };
 
 export type BlockIORootSchema = {


### PR DESCRIPTION
### Changes 🏗️

Make static connections correctly displayed on newly connected edges. Previously, static connection were only correctly displayed when loading an existing graph. This is currently relevant only to `ValueBlock` output.

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
