### PR TITLE
bug(infra): Add frontend config to ingres

### DIFF
--- a/rnd/infra/helm/autogpt-server/templates/frontendconfig.yaml
+++ b/rnd/infra/helm/autogpt-server/templates/frontendconfig.yaml
@@ -1,6 +1,6 @@
 kind: FrontendConfig
 metadata:
-  name: {{ include "autogpt-server.fullname" . }}
+  name: {{ include "autogpt-server.fullname" . }}-frontend-config
 spec:
   redirectToHttps:
     enabled: true

--- a/rnd/infra/helm/autogpt-server/values.dev.yaml
+++ b/rnd/infra/helm/autogpt-server/values.dev.yaml
@@ -24,7 +24,7 @@ ingress:
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: "agpt-dev-agpt-server-ip"
     networking.gke.io/managed-certificates: "autogpt-server-cert"
-    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: "autogpt-server-frontend-config"
   hosts:
     - host: dev-server.agpt.co
       paths:


### PR DESCRIPTION
### Background

I forgot to actually add the config to the ingress from this PR https://github.com/Significant-Gravitas/AutoGPT/pull/7853
without it, it won't work
### Changes 🏗️

Added the frontend config as an annotation on the ingress and add a suffix to the config "frontend-conifg" to make it clear what it is

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
