### PR TITLE
feat(builder): Draw selected edges above nodes

### DIFF
--- a/rnd/autogpt_builder/src/components/customedge.css
+++ b/rnd/autogpt_builder/src/components/customedge.css
@@ -39,6 +39,6 @@
   cursor: pointer;
 }
 
-.react-flow__edges>svg:has(> g.selected) {
+.react-flow__edges > svg:has(> g.selected) {
   z-index: 10 !important;
 }

--- a/rnd/autogpt_builder/src/components/customedge.css
+++ b/rnd/autogpt_builder/src/components/customedge.css
@@ -38,3 +38,7 @@
 .react-flow__edge-interaction {
   cursor: pointer;
 }
+
+.react-flow__edges>svg:has(> g.selected) {
+  z-index: 10 !important;
+}


### PR DESCRIPTION
### Background

Normally edges are always drawn below nodes, so sometimes if may be hard to see how they connect and impossible to delete on mobile devices.

### Changes 🏗️
- Draw selected edges above nodes
