### PR TITLE
fix(builder): Set default `value` in `NodeStringInput` to silence uncontrolled input warning

### DIFF
--- a/rnd/autogpt_builder/src/components/node-input-components.tsx
+++ b/rnd/autogpt_builder/src/components/node-input-components.tsx
@@ -522,7 +522,7 @@ const NodeStringInput: FC<{
 }> = ({
   selfKey,
   schema,
-  value,
+  value = "",
   error,
   handleInputChange,
   handleInputClick,


### PR DESCRIPTION
### Background

We where having a issue when editing the input of a block because it did not have a default value, by adding a empty default it fixes it

This is a fix for https://github.com/Significant-Gravitas/AutoGPT/issues/7908 the original video of the bug is also in the same issue 

https://github.com/user-attachments/assets/c0216a22-966b-479e-bd15-181bea36a293

### Changes 🏗️

Simply set value to be ``value = "",``

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
