### PR TITLE
Feat(Builder): Fix delete block is non-undoable

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -167,19 +167,29 @@ const FlowEditor: React.FC<{
 
       // Remove all edges that were connected to deleted nodes
       nodeChanges
-        .filter((change) => change.type == "remove")
+        .filter((change) => change.type === "remove")
         .forEach((deletedNode) => {
           const nodeID = deletedNode.id;
+          const deletedNodeData = nodes.find((node) => node.id === nodeID);
+
+          if (deletedNodeData) {
+            history.push({
+              type: "DELETE_NODE",
+              payload: { node: deletedNodeData },
+              undo: () => addNodes(deletedNodeData),
+              redo: () => deleteElements({ nodes: [{ id: nodeID }] }),
+            });
+          }
 
           const connectedEdges = edges.filter((edge) =>
-            [edge.source, edge.target].includes(nodeID),
+            [edge.source, edge.target].includes(nodeID)
           );
           deleteElements({
             edges: connectedEdges.map((edge) => ({ id: edge.id })),
           });
         });
     },
-    [deleteElements, setNodes],
+    [deleteElements, setNodes, nodes, edges, addNodes]
   );
 
   const formatEdgeID = useCallback((conn: Link | Connection): string => {

--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -182,14 +182,14 @@ const FlowEditor: React.FC<{
           }
 
           const connectedEdges = edges.filter((edge) =>
-            [edge.source, edge.target].includes(nodeID)
+            [edge.source, edge.target].includes(nodeID),
           );
           deleteElements({
             edges: connectedEdges.map((edge) => ({ id: edge.id })),
           });
         });
     },
-    [deleteElements, setNodes, nodes, edges, addNodes]
+    [deleteElements, setNodes, nodes, edges, addNodes],
   );
 
   const formatEdgeID = useCallback((conn: Link | Connection): string => {


### PR DESCRIPTION
### Background

When we delete a block undoing it would not bring it back, this is to fix that. we where not properly adding the deleted block to history so it was not logged

https://github.com/user-attachments/assets/8ab8096f-65b9-44a3-9853-407cde0cb159

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
