### PR TITLE
feat(builder, server): Add advanced block inputs

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -111,12 +111,6 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
     setIsAdvancedOpen(checked);
   };
 
-  const hasOptionalFields =
-    data.inputSchema &&
-    Object.keys(data.inputSchema.properties).some((key) => {
-      return !data.inputSchema.required?.includes(key);
-    });
-
   const generateOutputHandles = (schema: BlockIORootSchema) => {
     if (!schema?.properties) return null;
     const keys = Object.keys(schema.properties);
@@ -366,10 +360,19 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
 
   const errorClass =
     hasConfigErrors || hasOutputError ? "border-red-500 border-2" : "";
+
   const statusClass =
     hasConfigErrors || hasOutputError
       ? "failed"
       : (data.status?.toLowerCase() ?? "");
+
+  const hasAdvancedFields =
+    data.inputSchema &&
+    Object.entries(data.inputSchema.properties).some(([key, value]) => {
+      return (
+        value.nonAdvanced !== true && !data.inputSchema.required?.includes(key)
+      );
+    });
 
   return (
     <div
@@ -419,8 +422,12 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
               ([propKey, propSchema]) => {
                 const isRequired = data.inputSchema.required?.includes(propKey);
                 const isConnected = isHandleConnected(propKey);
+                const isAdvanced = !propSchema.nonAdvanced;
                 return (
-                  (isRequired || isAdvancedOpen || isConnected) && (
+                  (isRequired ||
+                    (isAdvancedOpen && isAdvanced) ||
+                    isConnected ||
+                    !isAdvanced) && (
                     <div key={propKey} onMouseOver={() => {}}>
                       <NodeHandle
                         keyName={propKey}
@@ -482,7 +489,7 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
       <div className="mt-2.5 flex items-center pb-4 pl-4">
         <Switch onCheckedChange={toggleOutput} />
         <span className="m-1 mr-4">Output</span>
-        {hasOptionalFields && (
+        {hasAdvancedFields && (
           <>
             <Switch onCheckedChange={toggleAdvancedSettings} />
             <span className="m-1">Advanced</span>

--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -370,7 +370,7 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
     data.inputSchema &&
     Object.entries(data.inputSchema.properties).some(([key, value]) => {
       return (
-        value.nonAdvanced !== true && !data.inputSchema.required?.includes(key)
+        value.advanced === true && !data.inputSchema.required?.includes(key)
       );
     });
 
@@ -422,10 +422,10 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
               ([propKey, propSchema]) => {
                 const isRequired = data.inputSchema.required?.includes(propKey);
                 const isConnected = isHandleConnected(propKey);
-                const isAdvanced = !propSchema.nonAdvanced;
+                const isAdvanced = propSchema.advanced;
                 return (
                   (isRequired ||
-                    (isAdvancedOpen && isAdvanced) ||
+                    isAdvancedOpen ||
                     isConnected ||
                     !isAdvanced) && (
                     <div key={propKey} onMouseOver={() => {}}>

--- a/rnd/autogpt_builder/src/lib/autogpt-server-api/types.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt-server-api/types.ts
@@ -39,6 +39,7 @@ export type BlockIOSubSchemaMeta = {
   title?: string;
   description?: string;
   placeholder?: string;
+  nonAdvanced?: boolean;
 };
 
 export type BlockIOObjectSubSchema = BlockIOSubSchemaMeta & {

--- a/rnd/autogpt_builder/src/lib/autogpt-server-api/types.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt-server-api/types.ts
@@ -39,7 +39,7 @@ export type BlockIOSubSchemaMeta = {
   title?: string;
   description?: string;
   placeholder?: string;
-  nonAdvanced?: boolean;
+  advanced?: boolean;
 };
 
 export type BlockIOObjectSubSchema = BlockIOSubSchemaMeta & {

--- a/rnd/autogpt_server/autogpt_server/data/model.py
+++ b/rnd/autogpt_server/autogpt_server/data/model.py
@@ -109,6 +109,7 @@ def SchemaField(
     title: Optional[str] = None,
     description: Optional[str] = None,
     placeholder: Optional[str] = None,
+    non_advanced: Optional[bool] = None,
     secret: bool = False,
     exclude: bool = False,
     **kwargs,
@@ -118,6 +119,8 @@ def SchemaField(
         json_extra["placeholder"] = placeholder
     if secret:
         json_extra["secret"] = True
+    if non_advanced:
+        json_extra["nonAdvanced"] = True
 
     return Field(
         default,

--- a/rnd/autogpt_server/autogpt_server/data/model.py
+++ b/rnd/autogpt_server/autogpt_server/data/model.py
@@ -109,7 +109,7 @@ def SchemaField(
     title: Optional[str] = None,
     description: Optional[str] = None,
     placeholder: Optional[str] = None,
-    non_advanced: Optional[bool] = None,
+    advanced: Optional[bool] = None,
     secret: bool = False,
     exclude: bool = False,
     **kwargs,
@@ -119,8 +119,8 @@ def SchemaField(
         json_extra["placeholder"] = placeholder
     if secret:
         json_extra["secret"] = True
-    if non_advanced:
-        json_extra["nonAdvanced"] = True
+    if advanced:
+        json_extra["advanced"] = True
 
     return Field(
         default,


### PR DESCRIPTION
### Background

Currently all non-required inputs are considered advanced and hidden by default but sometimes it's desirable to always show a non-required input.

### Changes 🏗️

- Add `advanced` to `SchemaField` and pass it to `json_extra`
- Add `advanced` to `BlockIOSubSchemaMeta` type
- Update `CustomNode`, so that:
  - non-required advanced inputs are hidden
  - non-advanced and required inputs are always shown
