### PR TITLE
test(server): Fix `test_service_creation`

### DIFF
--- a/rnd/autogpt_server/test/util/test_service.py
+++ b/rnd/autogpt_server/test/util/test_service.py
@@ -1,13 +1,11 @@
 from autogpt_server.util.service import (
     AppService,
-    PyroNameServer,
     expose,
     get_service_client,
 )
 
 
 class TestService(AppService):
-
     def run_service(self):
         super().run_service()
 
@@ -28,9 +26,8 @@ class TestService(AppService):
 
 
 def test_service_creation():
-    with PyroNameServer():
-        with TestService():
-            client = get_service_client(TestService)
-            assert client.add(5, 3) == 8
-            assert client.subtract(10, 4) == 6
-            assert client.fun_with_async(5, 3) == 8
+    with TestService():
+        client = get_service_client(TestService)
+        assert client.add(5, 3) == 8
+        assert client.subtract(10, 4) == 6
+        assert client.fun_with_async(5, 3) == 8

--- a/rnd/autogpt_server/test/util/test_service.py
+++ b/rnd/autogpt_server/test/util/test_service.py
@@ -1,8 +1,4 @@
-from autogpt_server.util.service import (
-    AppService,
-    expose,
-    get_service_client,
-)
+from autogpt_server.util.service import AppService, expose, get_service_client
 
 
 class TestService(AppService):


### PR DESCRIPTION
Starting Pyro within the test isn't necessary because a Pyro instance is already running due to the session-level `server` fixture. It currently raises a non-breaking error in the background which pops up when console output is enabled.

### Changes 🏗️

- Remove `with PyroNameServer():` in `test_service_creation()`

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
