### PR TITLE
Feat(Builder): Fix block menu width

### DIFF
--- a/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
+++ b/rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx
@@ -75,7 +75,7 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
         side="right"
         sideOffset={22}
         align="start"
-        className="w-96 p-0"
+        className="w-[30rem] p-0"
         data-id="blocks-control-popover-content"
       >
         <Card className="border-none shadow-md">

--- a/rnd/autogpt_builder/src/components/ui/card.tsx
+++ b/rnd/autogpt_builder/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "min-w-fit rounded-xl border border-neutral-200 bg-white text-neutral-950 shadow dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
+      "rounded-xl border border-neutral-200 bg-white text-neutral-950 shadow dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-50",
       className,
     )}
     {...props}


### PR DESCRIPTION
### Background

This fixes the block menu width as for the tutorial this happens
![image](https://github.com/user-attachments/assets/d042fb65-bdc1-42e7-9b23-ba76e5160387)
now with the fix it properly highlights the area
![image](https://github.com/user-attachments/assets/d942c952-cb62-4e76-afa4-a4816556f0b0)


### Changes 🏗️
Inside of ``rnd/autogpt_builder/src/components/edit/control/BlocksControl.tsx`` I updated the width
```diff
-- className="w-96 p-0"
++ className="w-[30rem] p-0"
```
and then i had to remove ``min-w-fit`` from ``rnd/autogpt_builder/src/components/ui/card.tsx``

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
