### PR TITLE
feat(builder): Resizable input modal

### DIFF
--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -499,7 +499,7 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSave={handleModalSave}
-        initialValue={inputModalValue}
+        defaultValue={inputModalValue}
         key={activeKey}
       />
       <OutputModalComponent

--- a/rnd/autogpt_builder/src/components/CustomNode.tsx
+++ b/rnd/autogpt_builder/src/components/CustomNode.tsx
@@ -495,10 +495,11 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
         )}
       </div>
       <InputModalComponent
+        title={activeKey ? `Enter ${beautifyString(activeKey)}` : undefined}
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onSave={handleModalSave}
-        value={inputModalValue}
+        initialValue={inputModalValue}
         key={activeKey}
       />
       <OutputModalComponent

--- a/rnd/autogpt_builder/src/components/InputModalComponent.tsx
+++ b/rnd/autogpt_builder/src/components/InputModalComponent.tsx
@@ -1,59 +1,106 @@
-import React, { FC, useEffect, useRef } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { Button } from "./ui/button";
 import { Textarea } from "./ui/textarea";
+import { Maximize2, Minimize2, Clipboard } from "lucide-react";
+import { createPortal } from "react-dom";
+import { toast } from "./ui/use-toast";
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (value: string) => void;
-  value: string;
+  title?: string;
+  initialValue: string;
 }
 
 const InputModalComponent: FC<ModalProps> = ({
   isOpen,
   onClose,
   onSave,
-  value,
+  title,
+  initialValue,
 }) => {
-  const [tempValue, setTempValue] = React.useState(value);
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const [tempValue, setTempValue] = useState(initialValue);
+  const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setTempValue(value);
-      if (textAreaRef.current) {
-        textAreaRef.current.select();
-      }
+      setTempValue(initialValue);
+      setIsMaximized(false);
     }
-  }, [isOpen, value]);
+  }, [isOpen, initialValue]);
 
   const handleSave = () => {
     onSave(tempValue);
     onClose();
   };
 
+  const toggleSize = () => {
+    setIsMaximized(!isMaximized);
+  };
+
+  const copyValue = () => {
+    navigator.clipboard.writeText(tempValue).then(() => {
+      toast({
+        title: "Input value copied to clipboard!",
+        duration: 2000,
+      });
+    });
+  };
+
   if (!isOpen) {
     return null;
   }
 
-  return (
-    <div className="nodrag fixed inset-0 flex items-center justify-center bg-white bg-opacity-60">
-      <div className="w-[500px] max-w-[90%] rounded-lg border-[1.5px] bg-white p-5">
-        <center>
-          <h1>Enter input text</h1>
-        </center>
+  const modalContent = (
+    <div
+      id="modal-content"
+      className={`fixed rounded-lg border-[1.5px] bg-white p-5 ${
+        isMaximized ? "inset-[128px] flex flex-col" : `w-[90%] max-w-[800px]`
+      }`}
+    >
+      <h2 className="mb-4 text-center text-lg font-semibold">
+        {title || "Enter input text"}
+      </h2>
+      <div className="relative flex-grow">
         <Textarea
-          ref={textAreaRef}
-          className="h-[200px] w-full rounded border border-[#dfdfdf] bg-[#dfdfdf] p-2.5 text-black"
+          className="h-full min-h-[200px] w-full resize-none"
           value={tempValue}
           onChange={(e) => setTempValue(e.target.value)}
         />
-        <div className="mt-2.5 flex justify-end gap-2.5">
-          <Button onClick={onClose}>Cancel</Button>
-          <Button onClick={handleSave}>Save</Button>
+        <div className="absolute bottom-2 right-2 flex space-x-2">
+          <Button onClick={copyValue} size="icon" variant="outline">
+            <Clipboard size={18} />
+          </Button>
+          <Button onClick={toggleSize} size="icon" variant="outline">
+            {isMaximized ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
+          </Button>
         </div>
       </div>
+      <div className="mt-4 flex justify-end space-x-2">
+        <Button onClick={onClose} variant="outline">
+          Cancel
+        </Button>
+        <Button onClick={handleSave}>Save</Button>
+      </div>
     </div>
+  );
+
+  return (
+    <>
+      {isMaximized ? (
+        createPortal(
+          <div className="fixed inset-0 flex items-center justify-center bg-white bg-opacity-60">
+            {modalContent}
+          </div>,
+          document.body,
+        )
+      ) : (
+        <div className="nodrag fixed inset-0 flex items-center justify-center bg-white bg-opacity-60">
+          {modalContent}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/rnd/autogpt_builder/src/components/InputModalComponent.tsx
+++ b/rnd/autogpt_builder/src/components/InputModalComponent.tsx
@@ -10,7 +10,7 @@ interface ModalProps {
   onClose: () => void;
   onSave: (value: string) => void;
   title?: string;
-  initialValue: string;
+  defaultValue: string;
 }
 
 const InputModalComponent: FC<ModalProps> = ({
@@ -18,17 +18,17 @@ const InputModalComponent: FC<ModalProps> = ({
   onClose,
   onSave,
   title,
-  initialValue,
+  defaultValue,
 }) => {
-  const [tempValue, setTempValue] = useState(initialValue);
+  const [tempValue, setTempValue] = useState(defaultValue);
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      setTempValue(initialValue);
+      setTempValue(defaultValue);
       setIsMaximized(false);
     }
-  }, [isOpen, initialValue]);
+  }, [isOpen, defaultValue]);
 
   const handleSave = () => {
     onSave(tempValue);


### PR DESCRIPTION
### **User description**
### Background

Long text in input modals is hard to read. Ticket: https://github.com/Significant-Gravitas/AutoGPT/issues/7833

### Changes 🏗️

- Add minimize/maximize button in the corner of modal to make it significantly larger and centered
- Add copy button to copy all text
- Add optional `title` to display as a modal header

Maximized:
<img width="1479" alt="Screenshot 2024-09-02 at 8 21 58 PM" src="https://github.com/user-attachments/assets/b547149c-9427-44c4-b116-be747a3e365e">


### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `InputModalComponent` to include maximize/minimize functionality, allowing users to resize the modal.
- Added a copy button to the `InputModalComponent` to enable copying of text to the clipboard.
- Introduced an optional `title` prop to display a header in the modal.
- Updated the `CustomNode` component to pass the new `title` and `initialValue` props to the `InputModalComponent`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomNode.tsx</strong><dd><code>Update InputModalComponent props for enhanced functionality</code></dd></summary>
<hr>

rnd/autogpt_builder/src/components/CustomNode.tsx

<li>Added <code>title</code> prop to <code>InputModalComponent</code>.<br> <li> Changed <code>value</code> prop to <code>initialValue</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7955/files#diff-ce37ba33e874cc42255fda0cd2a16758a94a6e68606d513b7018c1cc68193146">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>InputModalComponent.tsx</strong><dd><code>Enhance InputModalComponent with resizing and copy features</code></dd></summary>
<hr>

rnd/autogpt_builder/src/components/InputModalComponent.tsx

<li>Added maximize/minimize functionality for modal.<br> <li> Introduced copy button to copy text to clipboard.<br> <li> Added optional <code>title</code> prop for modal header.<br> <li> Utilized <code>createPortal</code> for rendering maximized modal.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7955/files#diff-87e464827b53323e65c24ba2e399c83c2dfd0d09b18d5ae9675495a4dec6991b">+68/-21</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

