### PR TITLE
fix(rnd): avoid duplicating name on input/output pin for blocks

### DIFF
--- a/rnd/autogpt_server/autogpt_server/blocks/__init__.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/__init__.py
@@ -54,6 +54,15 @@ for cls in all_subclasses(Block):
     if block.id in AVAILABLE_BLOCKS:
         raise ValueError(f"Block ID {block.name} error: {block.id} is already in use")
 
+    # Prevent duplicate field name in input_schema and output_schema
+    duplicate_field_names = set(block.input_schema.__fields__.keys()) & set(
+        block.output_schema.__fields__.keys()
+    )
+    if duplicate_field_names:
+        raise ValueError(
+            f"{block.name} has duplicate field names in input_schema and output_schema: {duplicate_field_names}"
+        )
+
     for field in block.input_schema.__fields__.values():
         if field.annotation is bool and field.default not in (True, False):
             raise ValueError(f"{block.name} has a boolean field with no default value")

--- a/rnd/autogpt_server/autogpt_server/blocks/basic.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/basic.py
@@ -140,7 +140,7 @@ class InputOutputBlockInput(BlockSchema, Generic[T]):
 
 
 class InputOutputBlockOutput(BlockSchema, Generic[T]):
-    value: T = Field(description="The value passed as input/output.")
+    result: T = Field(description="The value passed as input/output.")
 
 
 class InputOutputBlockBase(Block, ABC, Generic[T]):
@@ -162,8 +162,8 @@ class InputOutputBlockBase(Block, ABC, Generic[T]):
                 {"value": MockObject(value="!!", key="key"), "name": "input_2"},
             ],
             test_output=[
-                ("value", {"apple": 1, "banana": 2, "cherry": 3}),
-                ("value", MockObject(value="!!", key="key")),
+                ("result", {"apple": 1, "banana": 2, "cherry": 3}),
+                ("result", MockObject(value="!!", key="key")),
             ],
             static_output=True,
             *args,
@@ -171,7 +171,7 @@ class InputOutputBlockBase(Block, ABC, Generic[T]):
         )
 
     def run(self, input_data: InputOutputBlockInput[T]) -> BlockOutput:
-        yield "value", input_data.value
+        yield "result", input_data.value
 
 
 class InputBlock(InputOutputBlockBase[Any]):

--- a/rnd/autogpt_server/autogpt_server/blocks/medium.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/medium.py
@@ -57,7 +57,6 @@ class PublishToMediumBlock(Block):
     class Output(BlockSchema):
         post_id: str = SchemaField(description="The ID of the created Medium post")
         post_url: str = SchemaField(description="The URL of the created Medium post")
-        author_id: str = SchemaField(description="The Medium user ID of the author")
         published_at: int = SchemaField(
             description="The timestamp when the post was published"
         )
@@ -85,7 +84,6 @@ class PublishToMediumBlock(Block):
             test_output=[
                 ("post_id", "e6f36a"),
                 ("post_url", "https://medium.com/@username/test-post-e6f36a"),
-                ("author_id", "1234567890abcdef"),
                 ("published_at", 1626282600),
             ],
             test_mock={
@@ -156,7 +154,6 @@ class PublishToMediumBlock(Block):
             if "data" in response:
                 yield "post_id", response["data"]["id"]
                 yield "post_url", response["data"]["url"]
-                yield "author_id", response["data"]["authorId"]
                 yield "published_at", response["data"]["publishedAt"]
             else:
                 error_message = response.get("errors", [{}])[0].get(

--- a/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
+++ b/rnd/autogpt_server/autogpt_server/blocks/time_blocks.py
@@ -103,14 +103,14 @@ class GetCurrentDateAndTimeBlock(Block):
 
 class CountdownTimerBlock(Block):
     class Input(BlockSchema):
-        message: Any = "timer finished"
+        input_message: Any = "timer finished"
         seconds: Union[int, str] = 0
         minutes: Union[int, str] = 0
         hours: Union[int, str] = 0
         days: Union[int, str] = 0
 
     class Output(BlockSchema):
-        message: str
+        output_message: str
 
     def __init__(self):
         super().__init__(
@@ -121,11 +121,11 @@ class CountdownTimerBlock(Block):
             output_schema=CountdownTimerBlock.Output,
             test_input=[
                 {"seconds": 1},
-                {"message": "Custom message"},
+                {"input_message": "Custom message"},
             ],
             test_output=[
-                ("message", "timer finished"),
-                ("message", "Custom message"),
+                ("output_message", "timer finished"),
+                ("output_message", "Custom message"),
             ],
         )
 
@@ -139,4 +139,4 @@ class CountdownTimerBlock(Block):
         total_seconds = seconds + minutes * 60 + hours * 3600 + days * 86400
 
         time.sleep(total_seconds)
-        yield "message", input_data.message
+        yield "output_message", input_data.input_message

--- a/rnd/autogpt_server/autogpt_server/usecases/sample.py
+++ b/rnd/autogpt_server/autogpt_server/usecases/sample.py
@@ -48,13 +48,13 @@ def create_test_graph() -> graph.Graph:
         graph.Link(
             source_id=nodes[0].id,
             sink_id=nodes[2].id,
-            source_name="value",
+            source_name="result",
             sink_name="values_#_a",
         ),
         graph.Link(
             source_id=nodes[1].id,
             sink_id=nodes[2].id,
-            source_name="value",
+            source_name="result",
             sink_name="values_#_b",
         ),
         graph.Link(

--- a/rnd/autogpt_server/test/executor/test_manager.py
+++ b/rnd/autogpt_server/test/executor/test_manager.py
@@ -39,7 +39,7 @@ async def assert_sample_graph_executions(
         test_graph.id, graph_exec_id, test_user.id
     )
 
-    output_list = [{"value": ["Hello"]}, {"value": ["World"]}]
+    output_list = [{"result": ["Hello"]}, {"result": ["World"]}]
     input_list = [
         {"value": "Hello", "name": "input_1"},
         {"value": "World", "name": "input_2"},


### PR DESCRIPTION
### **User description**
### Background

![image](https://github.com/user-attachments/assets/62acb183-98ab-498c-a707-7887f8c770f1)

This happens here because both the input and the output pins have the same name: Value.

### Changes 🏗️

Avoid duplicating pin-names.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`


___

### **PR Type**
Bug fix


___

### **Description**
- Added a check to prevent duplicate field names in `input_schema` and `output_schema` in blocks, raising a `ValueError` if duplicates are found.
- Renamed fields in `InputOutputBlockOutput` and `CountdownTimerBlock` to avoid duplication and improve clarity.
- Removed `author_id` from the Medium block output schema.
- Updated test cases and graph links to reflect the changes in field names.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Prevent duplicate field names in block schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/blocks/__init__.py

<li>Added a check to prevent duplicate field names in <code>input_schema</code> and <br><code>output_schema</code>.<br> <li> Raised a <code>ValueError</code> if duplicate field names are found.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7979/files#diff-756ef9b539a693fecd75f540e54cc46dc57d3bb9e8b14abd6fe75a320fd50afa">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>basic.py</strong><dd><code>Rename field in InputOutputBlockOutput and update tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/blocks/basic.py

<li>Renamed <code>value</code> to <code>result</code> in <code>InputOutputBlockOutput</code>.<br> <li> Updated test cases to reflect the renaming.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7979/files#diff-fd165de859043484585a7af9f38dcca0fd532ce08acfb3c8984fe0f08596e485">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>medium.py</strong><dd><code>Remove author_id from Medium block output schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/blocks/medium.py

<li>Removed <code>author_id</code> from the <code>Output</code> schema.<br> <li> Updated test cases to reflect the removal.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7979/files#diff-9ce4fa79010fdaaf73a61762ea2bf282f826426f07817666027e6daf7dd1f749">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>time_blocks.py</strong><dd><code>Rename message fields in CountdownTimerBlock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/blocks/time_blocks.py

<li>Renamed <code>message</code> to <code>input_message</code> in <code>Input</code>.<br> <li> Renamed <code>message</code> to <code>output_message</code> in <code>Output</code>.<br> <li> Updated test cases to reflect the renaming.<br>


</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7979/files#diff-517f426b70e52ebfc1fe2a4014bb8c36e985b3aa7244937c5b8bd8cf2b22159a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sample.py</strong><dd><code>Update graph links to use result field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/autogpt_server/usecases/sample.py

- Changed `source_name` from `value` to `result` in graph links.



</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7979/files#diff-ff5b3bb46fbf748b57bc41edd7664458914a0029bc0d8781ca608246c767bc1f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_manager.py</strong><dd><code>Update test manager to use result field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rnd/autogpt_server/test/executor/test_manager.py

- Updated `output_list` to use `result` instead of `value`.



</details>


  </td>
  <td><a href="https://github.com/Significant-Gravitas/AutoGPT/pull/7979/files#diff-8cad7aeebbd383a922d3c99d5d7036ae717371aacf54237c3e91d4009f9ed725">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

