### PR TITLE
fix(server): Improve logging consistency

### DIFF
--- a/rnd/autogpt_server/autogpt_server/executor/manager.py
+++ b/rnd/autogpt_server/autogpt_server/executor/manager.py
@@ -638,7 +638,7 @@ class ExecutionManager(AppService):
         ) as executor:
             sync_manager = multiprocessing.Manager()
             logger.info(
-                f"Execution manager started with max-{self.pool_size} graph workers."
+                f"[{self.service_name}] Started with max-{self.pool_size} graph workers"
             )
             while True:
                 graph_exec_data = self.queue.get()

--- a/rnd/autogpt_server/autogpt_server/server/rest_api.py
+++ b/rnd/autogpt_server/autogpt_server/server/rest_api.py
@@ -200,7 +200,7 @@ class AgentServer(AppService):
 
         app.include_router(router)
 
-        uvicorn.run(app, host="0.0.0.0", port=8000)
+        uvicorn.run(app, host="0.0.0.0", port=8000, log_config=None)
 
     def set_test_dependency_overrides(self, overrides: dict):
         self._test_dependency_overrides = overrides

--- a/rnd/autogpt_server/autogpt_server/util/process.py
+++ b/rnd/autogpt_server/autogpt_server/util/process.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from abc import ABC, abstractmethod
@@ -6,6 +7,8 @@ from typing import Optional
 
 from autogpt_server.util.logging import configure_logging
 from autogpt_server.util.metrics import sentry_init
+
+logger = logging.getLogger(__name__)
 
 
 class AppProcess(ABC):
@@ -37,9 +40,10 @@ class AppProcess(ABC):
             if silent:
                 sys.stdout = open(os.devnull, "w")
                 sys.stderr = open(os.devnull, "w")
+            logger.info(f"[{self.__class__.__name__}] Starting...")
             self.run()
         except KeyboardInterrupt or SystemExit as e:
-            print(f"Process terminated: {e}")
+            logger.warning(f"[{self.__class__.__name__}] Terminated: {e}")
 
     def __enter__(self):
         self.start(background=True)

--- a/rnd/autogpt_server/autogpt_server/util/service.py
+++ b/rnd/autogpt_server/autogpt_server/util/service.py
@@ -44,19 +44,15 @@ def expose(func: C) -> C:
 
 class PyroNameServer(AppProcess):
     def run(self):
-        try:
-            print("Starting NameServer loop")
-            nameserver.start_ns_loop(host=pyro_host, port=9090)
-        except KeyboardInterrupt:
-            print("Shutting down NameServer")
+        nameserver.start_ns_loop(host=pyro_host, port=9090)
 
     @conn_retry
     def _wait_for_ns(self):
         pyro.locate_ns(host="localhost", port=9090)
-        print("NameServer is ready")
 
     def health_check(self):
         self._wait_for_ns()
+        logger.info(f"{__class__.__name__} is ready")
 
 
 class AppService(AppProcess):
@@ -108,7 +104,7 @@ class AppService(AppProcess):
         ns = pyro.locate_ns(host=pyro_host, port=9090)
         uri = daemon.register(self)
         ns.register(self.service_name, uri)
-        logger.info(f"Service [{self.service_name}] Ready. Object URI = {uri}")
+        logger.info(f"[{self.service_name}] Connected to Pyro; URI = {uri}")
         daemon.requestLoop()
 
     def __start_async_loop(self):


### PR DESCRIPTION
- Resolves #8011

### Changes 🏗️

- Make process/service startup/shutdown messages consistent
- Configure `uvicorn` to use our logging config instead of its own
- Replace `print(..)` statements in ws_api.py with log statements
- Improve log statements in ws_api.py

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
