### PR TITLE
fix(rnd): Fix decorator function type hint

### DIFF
--- a/rnd/autogpt_server/autogpt_server/util/decorator.py
+++ b/rnd/autogpt_server/autogpt_server/util/decorator.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import os
 import time
-from typing import Callable, Tuple, TypeVar, ParamSpec
+from typing import Callable, ParamSpec, Tuple, TypeVar
 
 from pydantic import BaseModel
 
@@ -36,7 +36,7 @@ def time_measured(func: Callable[P, T]) -> Callable[P, Tuple[TimingInfo, T]]:
     """
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs) -> Tuple[TimingInfo, T]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Tuple[TimingInfo, T]:
         start_wall_time, start_cpu_time = _start_measurement()
         try:
             result = func(*args, **kwargs)
@@ -56,7 +56,7 @@ def error_logged(func: Callable[P, T]) -> Callable[P, T | None]:
     """
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs) -> T | None:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T | None:
         try:
             return func(*args, **kwargs)
         except Exception as e:

--- a/rnd/autogpt_server/autogpt_server/util/decorator.py
+++ b/rnd/autogpt_server/autogpt_server/util/decorator.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import os
 import time
-from typing import Callable, Tuple, TypeVar
+from typing import Callable, Tuple, TypeVar, ParamSpec
 
 from pydantic import BaseModel
 
@@ -24,12 +24,13 @@ def _end_measurement(
     return end_wall_time - start_wall_time, end_cpu_time - start_cpu_time
 
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
 
-def time_measured(func: Callable[..., T]) -> Callable[..., Tuple[TimingInfo, T]]:
+def time_measured(func: Callable[P, T]) -> Callable[P, Tuple[TimingInfo, T]]:
     """
     Decorator to measure the time taken by a function to execute.
     """
@@ -49,7 +50,7 @@ def time_measured(func: Callable[..., T]) -> Callable[..., Tuple[TimingInfo, T]]
     return wrapper
 
 
-def error_logged(func: Callable[..., T]) -> Callable[..., T | None]:
+def error_logged(func: Callable[P, T]) -> Callable[P, T | None]:
     """
     Decorator to suppress and log any exceptions raised by a function.
     """


### PR DESCRIPTION
### Background

Fix type hinting created by the function decorator.

### Changes 🏗️

Fixed type hinting for `@time_measured` and `@error_logged`.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
