### PR TITLE
fix(rnd): Fix execution error on non-saved agent

### DIFF
--- a/rnd/autogpt_builder/src/components/Flow.tsx
+++ b/rnd/autogpt_builder/src/components/Flow.tsx
@@ -550,9 +550,14 @@ const FlowEditor: React.FC<{
       onClick: handleRedo,
     },
     {
-      label: !isRunning ? "Run" : "Stop",
+      label: !savedAgent
+        ? "Please save the agent to run"
+        : !isRunning
+          ? "Run"
+          : "Stop",
       icon: !isRunning ? <IconPlay /> : <IconSquare />,
       onClick: !isRunning ? requestSaveAndRun : requestStopRun,
+      disabled: !savedAgent,
     },
   ];
 

--- a/rnd/autogpt_builder/src/components/edit/control/ControlPanel.tsx
+++ b/rnd/autogpt_builder/src/components/edit/control/ControlPanel.tsx
@@ -19,6 +19,7 @@ import React from "react";
 export type Control = {
   icon: React.ReactNode;
   label: string;
+  disabled?: boolean;
   onClick: () => void;
 };
 
@@ -50,15 +51,18 @@ export const ControlPanel = ({
           {controls.map((control, index) => (
             <Tooltip key={index} delayDuration={500}>
               <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => control.onClick()}
-                  data-id={`control-button-${index}`}
-                >
-                  {control.icon}
-                  <span className="sr-only">{control.label}</span>
-                </Button>
+                <div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => control.onClick()}
+                    data-id={`control-button-${index}`}
+                    disabled={control.disabled || false}
+                  >
+                    {control.icon}
+                    <span className="sr-only">{control.label}</span>
+                  </Button>
+                </div>
               </TooltipTrigger>
               <TooltipContent side="right">{control.label}</TooltipContent>
             </Tooltip>

--- a/rnd/autogpt_builder/src/components/node-input-components.tsx
+++ b/rnd/autogpt_builder/src/components/node-input-components.tsx
@@ -380,7 +380,7 @@ const NodeKeyValueInput: FC<{
                 <Input
                   type="text"
                   placeholder="Value"
-                  value={value ?? ""}
+                  defaultValue={value ?? ""}
                   onBlur={(e) =>
                     updateKeyValuePairs(
                       keyValuePairs.toSpliced(index, 1, {
@@ -563,7 +563,7 @@ const NodeStringInput: FC<{
           <Input
             type="text"
             id={selfKey}
-            value={schema.secret && value ? "********" : value}
+            defaultValue={schema.secret && value ? "********" : value}
             readOnly={schema.secret}
             placeholder={
               schema?.placeholder || `Enter ${beautifyString(displayName)}`
@@ -658,7 +658,7 @@ const NodeNumberInput: FC<{
         <Input
           type="number"
           id={selfKey}
-          value={value}
+          defaultValue={value}
           onBlur={(e) => handleInputChange(selfKey, parseFloat(e.target.value))}
           placeholder={
             schema.placeholder || `Enter ${beautifyString(displayName)}`

--- a/rnd/autogpt_builder/src/components/ui/input.tsx
+++ b/rnd/autogpt_builder/src/components/ui/input.tsx
@@ -6,20 +6,7 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, value, ...props }, ref) => {
-    // This ref allows the `Input` component to be both controlled and uncontrolled.
-    // The HTMLvalue will only be updated if the value prop changes, but the user can still type in the input.
-    ref = ref || React.createRef<HTMLInputElement>();
-    React.useEffect(() => {
-      if (
-        ref &&
-        ref.current &&
-        ref.current.value !== value &&
-        type !== "file"
-      ) {
-        ref.current.value = value;
-      }
-    }, [value, type, ref]);
+  ({ className, type, ...props }, ref) => {
     return (
       <input
         type={type}
@@ -29,7 +16,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           className,
         )}
         ref={ref}
-        defaultValue={type !== "file" ? value : undefined}
         {...props}
       />
     );

--- a/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
+++ b/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
@@ -648,12 +648,27 @@ export default function useAgentGraph(
       // Differences in IDs are ignored.
       const comparedPayload = {
         ...(({ id, ...rest }) => rest)(payload),
-        nodes: payload.nodes.map(({ id, ...rest }) => rest),
+        nodes: payload.nodes.map(
+          ({ id, data, input_nodes, output_nodes, ...rest }) => rest,
+        ),
         links: payload.links.map(({ source_id, sink_id, ...rest }) => rest),
+      };
+      const comparedSavedAgent = {
+        name: savedAgent?.name,
+        description: savedAgent?.description,
+        nodes: savedAgent?.nodes.map((v) => ({
+          block_id: v.block_id,
+          input_default: v.input_default,
+          metadata: v.metadata,
+        })),
+        links: savedAgent?.links.map((v) => ({
+          sink_name: v.sink_name,
+          source_name: v.source_name,
+        })),
       };
 
       let newSavedAgent = null;
-      if (savedAgent && deepEquals(comparedPayload, savedAgent, true)) {
+      if (savedAgent && deepEquals(comparedPayload, comparedSavedAgent)) {
         console.warn("No need to save: Graph is the same as version on server");
         newSavedAgent = savedAgent;
       } else {

--- a/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
+++ b/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
@@ -648,8 +648,12 @@ export default function useAgentGraph(
       // Differences in IDs are ignored.
       const comparedPayload = {
         ...(({ id, ...rest }) => rest)(payload),
-        nodes: payload.nodes.map(({ id, ...rest }) => rest),
-        links: payload.links.map(({ source_id, sink_id, ...rest }) => rest),
+        nodes: payload.nodes.map(
+          ({ id, ...rest }) => rest
+        ),
+        links: payload.links.map(
+          ({ source_id, sink_id, ...rest }) => rest
+        ),
       };
       if (savedAgent && deepEquals(comparedPayload, savedAgent, true)) {
         console.warn("No need to save: Graph is the same as version on server");

--- a/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
+++ b/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
@@ -679,7 +679,7 @@ export default function useAgentGraph(
       if (!savedAgent) {
         const path = new URLSearchParams(searchParams);
         path.set("flowID", newSavedAgent.id);
-        router.replace(`${pathname}?${path.toString()}`);
+        router.push(`${pathname}?${path.toString()}`);
         return;
       }
 

--- a/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
+++ b/rnd/autogpt_builder/src/hooks/useAgentGraph.ts
@@ -647,10 +647,10 @@ export default function useAgentGraph(
       // To avoid saving the same graph, we compare the payload with the saved agent.
       // Differences in IDs are ignored.
       const comparedPayload = {
-        ...((({ id, ...rest }) => rest)(payload)),
-        nodes: payload.nodes.map(({ id, ...nodeRest }) => nodeRest),
-        links: payload.links.map(({ source_id, sink_id, ...linkRest }) => linkRest),
-      };      
+        ...(({ id, ...rest }) => rest)(payload),
+        nodes: payload.nodes.map(({ id, ...rest }) => rest),
+        links: payload.links.map(({ source_id, sink_id, ...rest }) => rest),
+      };
       if (savedAgent && deepEquals(comparedPayload, savedAgent, true)) {
         console.warn("No need to save: Graph is the same as version on server");
         // Trigger state change

--- a/rnd/autogpt_builder/src/lib/utils.ts
+++ b/rnd/autogpt_builder/src/lib/utils.ts
@@ -185,7 +185,7 @@ export const categoryColorMap: Record<string, string> = {
   SEARCH: "bg-blue-300/[.7]",
   BASIC: "bg-purple-300/[.7]",
   INPUT: "bg-cyan-300/[.7]",
-  OUTPUT: "bg-brown-300/[.7]",
+  OUTPUT: "bg-red-300/[.7]",
   LOGIC: "bg-teal-300/[.7]",
 };
 

--- a/rnd/autogpt_builder/src/lib/utils.ts
+++ b/rnd/autogpt_builder/src/lib/utils.ts
@@ -20,21 +20,18 @@ export function hashString(str: string): number {
 }
 
 /** Derived from https://stackoverflow.com/a/32922084 */
-export function deepEquals(x: any, y: any, allowMissingKeys = false): boolean {
+export function deepEquals(x: any, y: any): boolean {
   const ok = Object.keys,
     tx = typeof x,
     ty = typeof y;
-
-  const sk = (a: object, b: object) => ok(a).filter((k) => k in b);
-  const skipLengthCheck = allowMissingKeys && !Array.isArray(x);
 
   const res =
     x &&
     y &&
     tx === ty &&
     (tx === "object"
-      ? (skipLengthCheck || ok(x).length === ok(y).length) &&
-        sk(x, y).every((key) => deepEquals(x[key], y[key], allowMissingKeys))
+      ? ok(x).length === ok(y).length &&
+        ok(x).every((key) => deepEquals(x[key], y[key]))
       : x === y);
   return res;
 }

--- a/rnd/autogpt_server/autogpt_server/executor/manager.py
+++ b/rnd/autogpt_server/autogpt_server/executor/manager.py
@@ -155,7 +155,7 @@ def execute_node(
     try:
         credit = wait(user_credit.get_or_refill_credit(user_id))
         if credit < 0:
-            raise ValueError("Insufficient credit: {credit}")
+            raise ValueError(f"Insufficient credit: {credit}")
 
         for output_name, output_data in node_block.execute(input_data):
             output_size += len(json.dumps(output_data))


### PR DESCRIPTION
### Background

https://github.com/Significant-Gravitas/AutoGPT/pull/8052#discussion_r1759764573
Introduced a new execution bug in which the node that hasn't been saved is unable to execute.

<img width="924" alt="image" src="https://github.com/user-attachments/assets/5b82d176-3e33-4536-a8ad-99846a63a880">


### Changes 🏗️

The change reverts the change introduced in the mentioned PR and does it differently to avoid impacting the saved node id.
And fix the behaviour of running an agent that is not saved yet by disabling it.

### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
