### PR TITLE
Please do not 'rm -rf <unquoted variable>. Also please do not 'rm -rf' without confirmation, use 'rm -r' instead!

### DIFF
--- a/forge/setup
+++ b/forge/setup
@@ -2,8 +2,12 @@
 
  ENV_PATH=$(poetry env info --path)
  if [ -d "$ENV_PATH" ]; then
-     echo "Press ENTER to remove $ENV_PATH"
-     read && { rm -r "$ENV_PATH" && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
+     if [ -e delete ]; then
+         rm -rf "$ENV_PATH" || { echo "Please manually remove $ENV_PATH"; exit 1; }
+     else 
+       echo "Press ENTER to remove $ENV_PATH"
+       read && { rm -r "$ENV_PATH" && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
+     fi 
  else
      echo "No poetry environment found."
  fi

--- a/forge/setup
+++ b/forge/setup
@@ -3,9 +3,7 @@
  ENV_PATH=$(poetry env info --path)
  if [ -d "$ENV_PATH" ]; then
      echo "Press ENTER to rm -rf $ENV_PATH"
-     read
-     rm -rf $ENV_PATH
-     echo "Removed the poetry environment at $ENV_PATH."
+     read && { rm -rf $ENV_PATH && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
  else
      echo "No poetry environment found."
  fi

--- a/forge/setup
+++ b/forge/setup
@@ -3,7 +3,7 @@
  ENV_PATH=$(poetry env info --path)
  if [ -d "$ENV_PATH" ]; then
      echo "Press ENTER to rm -rf $ENV_PATH"
-     read && { rm -rf $ENV_PATH && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
+     read && { rm -rf "$ENV_PATH" && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
  else
      echo "No poetry environment found."
  fi

--- a/forge/setup
+++ b/forge/setup
@@ -2,8 +2,8 @@
 
  ENV_PATH=$(poetry env info --path)
  if [ -d "$ENV_PATH" ]; then
-     echo "Press ENTER to rm -rf $ENV_PATH"
-     read && { rm -rf "$ENV_PATH" && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
+     echo "Press ENTER to remove $ENV_PATH"
+     read && { rm -r "$ENV_PATH" && echo "Removed the poetry environment at $ENV_PATH."; } || { echo "Please manually remove $ENV_PATH."; exit 1; }
  else
      echo "No poetry environment found."
  fi

--- a/forge/setup
+++ b/forge/setup
@@ -2,6 +2,8 @@
 
  ENV_PATH=$(poetry env info --path)
  if [ -d "$ENV_PATH" ]; then
+     echo "Press ENTER to rm -rf $ENV_PATH"
+     read
      rm -rf $ENV_PATH
      echo "Removed the poetry environment at $ENV_PATH."
  else


### PR DESCRIPTION
### Background

I just did the "tutorial" and thankfully I implemented this change before I did, because I would've been MOST unhappy if this happened:

```
[coenraad@r2t2 AutoGPT]$ ./run agent create test
🎉 New agent 'test' created. The code for your new agent is in: agents/test
[coenraad@r2t2 AutoGPT]$ ./run agent start test
⌛ Running setup for agent 'test'...
Path /home/coenraad/AutoGPT/agents/benchmark for agbenchmark does not exist
Press ENTER to remove /home/coenraad/.venv
^C

$ /usr/bin/du $(poetry env info --path) --max-depth=0 -h|sort -h
14G	/home/coenraad/.venv
```

My connectivity isn't that great, and this environment, being my development environment, has packages accumulated over months. This is not my reproducible production machine, it's my personal dev machine...  maybe I shouldn't try out new projects outside of a sandbox.... but a lot of people do, and this can really bite them.

### Changes 🏗️

Quoted the "$ENV_PATH". Also made sure the script fails, if the rm command fails.
Also added a double confirmation.
Also added a way to skip the confirmation: `touch delete`. We can add that to the docs or any CI, if confirmed safe.

This also closes #7404

### PR Quality Scorecard ✨

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [x] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [x] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [x] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [x] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
