### PR TITLE
tweak(rnd): Update server and postgres ports

### DIFF
--- a/rnd/autogpt_builder/src/lib/autogpt-server-api/baseClient.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt-server-api/baseClient.ts
@@ -22,7 +22,7 @@ export default class BaseAutoGPTServerAPI {
 
   constructor(
     baseUrl: string = process.env.NEXT_PUBLIC_AGPT_SERVER_URL ||
-      "http://localhost:8000/api",
+      "http://localhost:8006/api",
     wsUrl: string = process.env.NEXT_PUBLIC_AGPT_WS_SERVER_URL ||
       "ws://localhost:8001/ws",
     supabaseClient: SupabaseClient | null = null,

--- a/rnd/autogpt_builder/src/lib/autogpt-server-api/client.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt-server-api/client.ts
@@ -4,7 +4,7 @@ import BaseAutoGPTServerAPI from "./baseClient";
 export default class AutoGPTServerAPI extends BaseAutoGPTServerAPI {
   constructor(
     baseUrl: string = process.env.NEXT_PUBLIC_AGPT_SERVER_URL ||
-      "http://localhost:8000/api",
+      "http://localhost:8006/api",
     wsUrl: string = process.env.NEXT_PUBLIC_AGPT_WS_SERVER_URL ||
       "ws://localhost:8001/ws",
   ) {

--- a/rnd/autogpt_builder/src/lib/autogpt-server-api/clientServer.ts
+++ b/rnd/autogpt_builder/src/lib/autogpt-server-api/clientServer.ts
@@ -4,7 +4,7 @@ import BaseAutoGPTServerAPI from "./baseClient";
 export default class AutoGPTServerAPIServerSide extends BaseAutoGPTServerAPI {
   constructor(
     baseUrl: string = process.env.NEXT_PUBLIC_AGPT_SERVER_URL ||
-      "http://localhost:8000/api",
+      "http://localhost:8006/api",
     wsUrl: string = process.env.NEXT_PUBLIC_AGPT_WS_SERVER_URL ||
       "ws://localhost:8001/ws",
   ) {

--- a/rnd/autogpt_server/.env.example
+++ b/rnd/autogpt_server/.env.example
@@ -1,7 +1,7 @@
 DB_USER=agpt_user
 DB_PASS=pass123
 DB_NAME=agpt_local
-DB_PORT=5432
+DB_PORT=5433
 DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}"
 PRISMA_SCHEMA="postgres/schema.prisma"
 


### PR DESCRIPTION
### Background

This PR changes the default hardcoded ports on the frontend for _server_ because I changed the port to 8006 to support supabase which runs kong on 8000

### Changes 🏗️
replaced hardcoded instances of "http://localhost:8000/api" ---> "http://localhost:8006/api"


### PR Quality Scorecard ✨

<!--
Check out our contribution guide:
https://github.com/Significant-Gravitas/AutoGPT/wiki/Contributing

1. Avoid duplicate work, issues, PRs etc.
2. Also consider contributing something other than code; see the [contribution guide]
   for options.
3. Clearly explain your changes.
4. Avoid making unnecessary changes, especially if they're purely based on personal
   preferences. Doing so is the maintainers' job. ;-)
-->

- [x] Have you used the PR description template? &ensp; `+2 pts`
- [ ] Is your pull request atomic, focusing on a single change? &ensp; `+5 pts`
- [ ] Have you linked the GitHub issue(s) that this PR addresses? &ensp; `+5 pts`
- [ ] Have you documented your changes clearly and comprehensively? &ensp; `+5 pts`
- [ ] Have you changed or added a feature? &ensp; `-4 pts`
  - [ ] Have you added/updated corresponding documentation? &ensp; `+4 pts`
  - [ ] Have you added/updated corresponding integration tests? &ensp; `+5 pts`
- [ ] Have you changed the behavior of AutoGPT? &ensp; `-5 pts`
  - [ ] Have you also run `agbenchmark` to verify that these changes do not regress performance? &ensp; `+10 pts`
