### PR TITLE
Remove export from dev command

### DIFF
--- a/autogpt_platform/frontend/package.json
+++ b/autogpt_platform/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "export NODE_ENV=development && next dev",
-    "dev:test": "export NODE_ENV=test && next dev",
+    "dev": "next dev",
+    "dev:test": "NODE_ENV=test && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
### Background

<!-- Clearly explain the need for these changes: -->

Windows doesn’t support export commands. The only place this is used is sentry which Craig has a PR for disabling the popup

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

removes the environment variable from dev


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
