### PR TITLE
fix(platform): Reset Block Control filters on popover close

### DIFF
--- a/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
@@ -45,6 +45,13 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [filteredBlocks, setFilteredBlocks] = useState<Block[]>(blocks);
+
+  const resetFilters = React.useCallback(() => {
+    setSearchQuery("");
+    setSelectedCategory(null);
+    setFilteredBlocks(blocks);
+  }, [blocks]);
 
   // Extract unique categories from blocks
   const categories = Array.from(
@@ -53,18 +60,29 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
     ),
   );
 
-  const filteredBlocks = blocks.filter(
-    (block: Block) =>
-      (block.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        beautifyString(block.name)
-          .toLowerCase()
-          .includes(searchQuery.toLowerCase())) &&
-      (!selectedCategory ||
-        block.categories.some((cat) => cat.category === selectedCategory)),
-  );
+  React.useEffect(() => {
+    setFilteredBlocks(
+      blocks.filter(
+        (block: Block) =>
+          (block.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            beautifyString(block.name)
+              .toLowerCase()
+              .includes(searchQuery.toLowerCase())) &&
+          (!selectedCategory ||
+            block.categories.some((cat) => cat.category === selectedCategory)),
+      ),
+    );
+  }, [blocks, searchQuery, selectedCategory]);
 
   return (
-    <Popover open={pinBlocksPopover ? true : undefined}>
+    <Popover
+      open={pinBlocksPopover ? true : undefined}
+      onOpenChange={(open) => {
+        if (!open) {
+          resetFilters();
+        }
+      }}
+    >
       <Tooltip delayDuration={500}>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>


### PR DESCRIPTION
### Background

When you close the blocks panel, the filter does not reset. This PR fixes that

### Changes 🏗️

https://github.com/user-attachments/assets/fa7c6c29-16bf-49a3-b798-ea8395909b2d



### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
