### PR TITLE
tweak(platform) Add frontendconfig for redirect

### DIFF
--- a/autogpt_platform/infra/helm/autogpt-builder/templates/frontendconfig.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/templates/frontendconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ include "autogpt-builder.fullname" . }}-frontend-config
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: 301

--- a/autogpt_platform/infra/helm/autogpt-builder/values.dev.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/values.dev.yaml
@@ -25,6 +25,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: "agpt-dev-agpt-builder-ip"
     networking.gke.io/managed-certificates: "autogpt-builder-cert"
     kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: "autogpt-builder-frontend-config"
   hosts:
     - host: dev-builder.agpt.co
       paths:


### PR DESCRIPTION
### Background
Not all browsers automatically redirect to https. Adding a frontend config to force a redirect at the ingress level

### Changes 🏗️
Created frontend config
Added annotation to ingress

### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
