### PR TITLE
fix(platform): Update Backend .env.example BACKEND_CORS_ALLOW_ORIGINS to be a list

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -5,7 +5,7 @@ DB_PORT=5432
 DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}?connect_timeout=60&schema=platform"
 PRISMA_SCHEMA="postgres/schema.prisma"
 
-BACKEND_CORS_ALLOW_ORIGINS="http://localhost:3000"
+BACKEND_CORS_ALLOW_ORIGINS=["http://localhost:3000"]
 
 REDIS_HOST=localhost
 REDIS_PORT=6379


### PR DESCRIPTION
### Background

BACKEND_CORS_ALLOW_ORIGINS as introduced in #8140 should be a list

### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
