### PR TITLE
Feat(Builder): Enhance AITextSummarizerBlock with configurable summary style and focus

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -368,6 +368,7 @@ class SummaryStyle(Enum):
     BULLET_POINTS = "bullet points"
     NUMBERED_LIST = "numbered list"
 
+
 class AITextSummarizerBlock(Block):
     class Input(BlockSchema):
         text: str
@@ -465,9 +466,7 @@ class AITextSummarizerBlock(Block):
         combined_text = "\n\n".join(summaries)
 
         if len(combined_text.split()) <= input_data.max_tokens:
-            prompt = (
-                f"Provide a final summary of the following section summaries in a {input_data.style} form, focus your summary on the topic of `{input_data.focus}` if present:\n\n ```{combined_text}```\n\n Just respond with the final_summary in the format specified."
-            )
+            prompt = f"Provide a final summary of the following section summaries in a {input_data.style} form, focus your summary on the topic of `{input_data.focus}` if present:\n\n ```{combined_text}```\n\n Just respond with the final_summary in the format specified."
 
             llm_response = self.llm_call(
                 AIStructuredResponseGeneratorBlock.Input(


### PR DESCRIPTION
### Background

This was requested by a couple of users and I've felt the need two when building agents.

### Changes 🏗️

The AITextSummarizerBlock in the autogpt_platform/backend/backend/blocks/llm.py file has been enhanced to include the following changes:
- Added a new enum class, SummaryStyle, with options for `concise`, `detailed`, `bullet points`, and `numbered list` styles.
- Added a new input parameter, `focus`, to specify the topic of the summary.
- Modified the _summarize_chunk method to include the style and focus in the prompt.
- Modified the _combine_summaries method to include the style and focus in the prompt.

These changes allow users to customize the style and focus of the generated summaries, providing more flexibility and control.
