### PR TITLE
Feat(Builder): Add Video and Image Rendering to Block outputs

### DIFF
--- a/autogpt_platform/frontend/src/components/DataTable.tsx
+++ b/autogpt_platform/frontend/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import { beautifyString } from "@/lib/utils";
 import { Button } from "./ui/button";
 import {
@@ -20,9 +20,10 @@ type DataTableProps = {
 
 const VideoRenderer: React.FC<{ videoUrl: string }> = ({ videoUrl }) => {
   const getYouTubeVideoId = (url: string) => {
-    const regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
+    const regExp =
+      /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
     const match = url.match(regExp);
-    return (match && match[7].length === 11) ? match[7] : null;
+    return match && match[7].length === 11 ? match[7] : null;
   };
 
   const videoId = getYouTubeVideoId(videoUrl);
@@ -50,7 +51,7 @@ const VideoRenderer: React.FC<{ videoUrl: string }> = ({ videoUrl }) => {
 
 const ImageRenderer: React.FC<{ imageUrl: string }> = ({ imageUrl }) => (
   <div className="w-full p-2">
-    <img src={imageUrl} alt="Image" className="max-w-full h-auto" />
+    <img src={imageUrl} alt="Image" className="h-auto max-w-full" />
   </div>
 );
 
@@ -125,9 +126,11 @@ export default function DataTable({
                         beautifyString(key),
                         value
                           .map((i) =>
-                            typeof i === "object" ? JSON.stringify(i) : String(i)
+                            typeof i === "object"
+                              ? JSON.stringify(i)
+                              : String(i),
                           )
-                          .join(", ")
+                          .join(", "),
                       )
                     }
                     title="Copy Data"

--- a/autogpt_platform/frontend/src/components/DataTable.tsx
+++ b/autogpt_platform/frontend/src/components/DataTable.tsx
@@ -11,59 +11,12 @@ import {
 } from "./ui/table";
 import { Clipboard } from "lucide-react";
 import { useToast } from "./ui/use-toast";
+import { ContentRenderer } from "./ui/render";
 
 type DataTableProps = {
   title?: string;
   truncateLongData?: boolean;
   data: { [key: string]: Array<any> };
-};
-
-const VideoRenderer: React.FC<{ videoUrl: string }> = ({ videoUrl }) => {
-  const getYouTubeVideoId = (url: string) => {
-    const regExp =
-      /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
-    const match = url.match(regExp);
-    return match && match[7].length === 11 ? match[7] : null;
-  };
-
-  const videoId = getYouTubeVideoId(videoUrl);
-
-  return (
-    <div className="w-full p-2">
-      {videoId ? (
-        <iframe
-          width="100%"
-          height="315"
-          src={`https://www.youtube.com/embed/${videoId}`}
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-        ></iframe>
-      ) : (
-        <video controls width="100%" height="315">
-          <source src={videoUrl} type="video/mp4" />
-          Your browser does not support the video tag.
-        </video>
-      )}
-    </div>
-  );
-};
-
-const ImageRenderer: React.FC<{ imageUrl: string }> = ({ imageUrl }) => (
-  <div className="w-full p-2">
-    <img src={imageUrl} alt="Image" className="h-auto max-w-full" />
-  </div>
-);
-
-const isValidVideoUrl = (url: string): boolean => {
-  const videoExtensions = /\.(mp4|webm|ogg)$/i;
-  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/.+$/;
-  return videoExtensions.test(url) || youtubeRegex.test(url);
-};
-
-const isValidImageUrl = (url: string): boolean => {
-  const imageExtensions = /\.(jpeg|jpg|gif|png|svg|webp)$/i;
-  return imageExtensions.test(url);
 };
 
 export default function DataTable({
@@ -81,24 +34,6 @@ export default function DataTable({
         duration: 2000,
       });
     });
-  };
-
-  const renderCellContent = (value: any) => {
-    if (typeof value === "string") {
-      if (isValidVideoUrl(value)) {
-        return <VideoRenderer videoUrl={value} />;
-      } else if (isValidImageUrl(value)) {
-        return <ImageRenderer imageUrl={value} />;
-      }
-    }
-
-    const text =
-      typeof value === "object"
-        ? JSON.stringify(value, null, 2)
-        : String(value);
-    return truncateLongData && text.length > maxChars
-      ? text.slice(0, maxChars) + "..."
-      : text;
   };
 
   return (
@@ -141,7 +76,10 @@ export default function DataTable({
                   </Button>
                   {value.map((item, index) => (
                     <React.Fragment key={index}>
-                      {renderCellContent(item)}
+                      <ContentRenderer
+                        value={item}
+                        truncateLongData={truncateLongData}
+                      />
                       {index < value.length - 1 && ", "}
                     </React.Fragment>
                   ))}

--- a/autogpt_platform/frontend/src/components/DataTable.tsx
+++ b/autogpt_platform/frontend/src/components/DataTable.tsx
@@ -48,10 +48,21 @@ const VideoRenderer: React.FC<{ videoUrl: string }> = ({ videoUrl }) => {
   );
 };
 
+const ImageRenderer: React.FC<{ imageUrl: string }> = ({ imageUrl }) => (
+  <div className="w-full p-2">
+    <img src={imageUrl} alt="Image" className="max-w-full h-auto" />
+  </div>
+);
+
 const isValidVideoUrl = (url: string): boolean => {
   const videoExtensions = /\.(mp4|webm|ogg)$/i;
   const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/.+$/;
   return videoExtensions.test(url) || youtubeRegex.test(url);
+};
+
+const isValidImageUrl = (url: string): boolean => {
+  const imageExtensions = /\.(jpeg|jpg|gif|png|svg|webp)$/i;
+  return imageExtensions.test(url);
 };
 
 export default function DataTable({
@@ -72,11 +83,16 @@ export default function DataTable({
   };
 
   const renderCellContent = (value: any) => {
-    if (typeof value === 'string' && isValidVideoUrl(value)) {
-      return <VideoRenderer videoUrl={value} />;
+    if (typeof value === "string") {
+      if (isValidVideoUrl(value)) {
+        return <VideoRenderer videoUrl={value} />;
+      } else if (isValidImageUrl(value)) {
+        return <ImageRenderer imageUrl={value} />;
+      }
     }
 
-    const text = typeof value === "object" ? JSON.stringify(value) : String(value);
+    const text =
+      typeof value === "object" ? JSON.stringify(value) : String(value);
     return truncateLongData && text.length > maxChars
       ? text.slice(0, maxChars) + "..."
       : text;
@@ -109,11 +125,9 @@ export default function DataTable({
                         beautifyString(key),
                         value
                           .map((i) =>
-                            typeof i === "object"
-                              ? JSON.stringify(i)
-                              : String(i),
+                            typeof i === "object" ? JSON.stringify(i) : String(i)
                           )
-                          .join(", "),
+                          .join(", ")
                       )
                     }
                     title="Copy Data"

--- a/autogpt_platform/frontend/src/components/ui/render.tsx
+++ b/autogpt_platform/frontend/src/components/ui/render.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+
+const getYouTubeVideoId = (url: string) => {
+  const regExp =
+    /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
+  const match = url.match(regExp);
+  return match && match[7].length === 11 ? match[7] : null;
+};
+
+const isValidVideoUrl = (url: string): boolean => {
+  const videoExtensions = /\.(mp4|webm|ogg)$/i;
+  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/.+$/;
+  return videoExtensions.test(url) || youtubeRegex.test(url);
+};
+
+const isValidImageUrl = (url: string): boolean => {
+  const imageExtensions = /\.(jpeg|jpg|gif|png|svg|webp)$/i;
+  return imageExtensions.test(url);
+};
+
+const VideoRenderer: React.FC<{ videoUrl: string }> = ({ videoUrl }) => {
+  const videoId = getYouTubeVideoId(videoUrl);
+  return (
+    <div className="w-full p-2">
+      {videoId ? (
+        <iframe
+          width="100%"
+          height="315"
+          src={`https://www.youtube.com/embed/${videoId}`}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        ></iframe>
+      ) : (
+        <video controls width="100%" height="315">
+          <source src={videoUrl} type="video/mp4" />
+          Your browser does not support the video tag.
+        </video>
+      )}
+    </div>
+  );
+};
+
+const ImageRenderer: React.FC<{ imageUrl: string }> = ({ imageUrl }) => (
+  <div className="w-full p-2">
+    <img
+      src={imageUrl}
+      alt="Image"
+      className="h-auto max-w-full"
+      width="100%"
+      height="auto"
+    />
+  </div>
+);
+
+const TextRenderer: React.FC<{ value: any; truncateLongData?: boolean }> = ({
+  value,
+  truncateLongData,
+}) => {
+  const maxChars = 100;
+  const text =
+    typeof value === "object" ? JSON.stringify(value, null, 2) : String(value);
+  return truncateLongData && text.length > maxChars
+    ? text.slice(0, maxChars) + "..."
+    : text;
+};
+
+export const ContentRenderer: React.FC<{
+  value: any;
+  truncateLongData?: boolean;
+}> = ({ value, truncateLongData }) => {
+  if (typeof value === "string") {
+    if (isValidVideoUrl(value)) {
+      return <VideoRenderer videoUrl={value} />;
+    } else if (isValidImageUrl(value)) {
+      return <ImageRenderer imageUrl={value} />;
+    }
+  }
+  return <TextRenderer value={value} truncateLongData={truncateLongData} />;
+};


### PR DESCRIPTION
### Background

We want to be able to previous images and videos in the Builder.

### Changes 🏗️
This change checks if an output url points to an image or a video, and renders it in the output table rather than displaying the url.
This works for raw video urls and YouTube urls.

### Testing 🔍

![image](https://github.com/user-attachments/assets/72da65de-a6c5-48eb-a67a-b28b240f9ef1)


https://github.com/user-attachments/assets/7ecf4e77-cbf9-4475-859e-e8417ce8d728
