### PR TITLE
fix(platform): UI fixes; Fix block note UI displayed as normal block;Json-prettify execution output

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -4,13 +4,7 @@ from typing import Any, List
 from jinja2 import BaseLoader, Environment
 from pydantic import Field
 
-from backend.data.block import (
-    Block,
-    BlockCategory,
-    BlockOutput,
-    BlockSchema,
-    BlockUIType,
-)
+from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema, BlockType
 from backend.data.model import SchemaField
 from backend.util.mock import MockObject
 
@@ -197,7 +191,7 @@ class AgentInputBlock(Block):
                 ("result", "Hello, World!"),
             ],
             categories={BlockCategory.INPUT, BlockCategory.BASIC},
-            ui_type=BlockUIType.INPUT,
+            block_type=BlockType.INPUT,
         )
 
     def run(self, input_data: Input) -> BlockOutput:
@@ -280,7 +274,7 @@ class AgentOutputBlock(Block):
                 ("output", MockObject(value="!!", key="key")),
             ],
             categories={BlockCategory.OUTPUT, BlockCategory.BASIC},
-            ui_type=BlockUIType.OUTPUT,
+            block_type=BlockType.OUTPUT,
         )
 
     def run(self, input_data: Input) -> BlockOutput:
@@ -452,7 +446,7 @@ class NoteBlock(Block):
             test_output=[
                 ("output", "Hello, World!"),
             ],
-            ui_type=BlockUIType.NOTE,
+            block_type=BlockType.NOTE,
         )
 
     def run(self, input_data: Input) -> BlockOutput:

--- a/autogpt_platform/backend/backend/data/block.py
+++ b/autogpt_platform/backend/backend/data/block.py
@@ -16,11 +16,7 @@ BlockOutput = Generator[BlockData, None, None]  # Output: 1 output pin produces 
 CompletedBlockOutput = dict[str, list[Any]]  # Completed stream, collected as a dict.
 
 
-class BlockUIType(Enum):
-    """
-    The type of Node UI to be displayed in the builder for this block.
-    """
-
+class BlockType(Enum):
     STANDARD = "Standard"
     INPUT = "Input"
     OUTPUT = "Output"
@@ -145,7 +141,7 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
         test_mock: dict[str, Any] | None = None,
         disabled: bool = False,
         static_output: bool = False,
-        ui_type: BlockUIType = BlockUIType.STANDARD,
+        block_type: BlockType = BlockType.STANDARD,
     ):
         """
         Initialize the block with the given schema.
@@ -175,7 +171,7 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
         self.contributors = contributors or set()
         self.disabled = disabled
         self.static_output = static_output
-        self.ui_type = ui_type
+        self.block_type = block_type
 
     @abstractmethod
     def run(self, input_data: BlockSchemaInputType) -> BlockOutput:
@@ -206,7 +202,7 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
                 contributor.model_dump() for contributor in self.contributors
             ],
             "staticOutput": self.static_output,
-            "uiType": self.ui_type.value,
+            "uiType": self.block_type.value,
         }
 
     def execute(self, input_data: BlockInput) -> BlockOutput:

--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -534,7 +534,6 @@ export function CustomNode({ data, id, width, height }: NodeProps<CustomNode>) {
           value === inputValues[key] || (!value && !inputValues[key]),
       ),
     );
-  console.debug(`Block cost ${inputValues}|${data.blockCosts}=${blockCost}`);
 
   return (
     <div

--- a/autogpt_platform/frontend/src/components/DataTable.tsx
+++ b/autogpt_platform/frontend/src/components/DataTable.tsx
@@ -51,7 +51,7 @@ export default function DataTable({
                 {beautifyString(key)}
               </TableCell>
               <TableCell className="cursor-text">
-                <div className="flex min-h-9 items-center">
+                <div className="flex min-h-9 items-center whitespace-pre-wrap">
                   <Button
                     className="absolute right-1 top-auto m-1 hidden p-2 group-hover:block"
                     variant="outline"
@@ -62,7 +62,7 @@ export default function DataTable({
                         value
                           .map((i) =>
                             typeof i === "object"
-                              ? JSON.stringify(i)
+                              ? JSON.stringify(i, null, 2)
                               : String(i),
                           )
                           .join(", "),
@@ -75,7 +75,9 @@ export default function DataTable({
                   {value
                     .map((i) => {
                       const text =
-                        typeof i === "object" ? JSON.stringify(i) : String(i);
+                        typeof i === "object"
+                          ? JSON.stringify(i, null, 2)
+                          : String(i);
                       return truncateLongData && text.length > maxChars
                         ? text.slice(0, maxChars) + "..."
                         : text;

--- a/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
+++ b/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
@@ -8,7 +8,7 @@ import RunnerInputUI from "./runner-ui/RunnerInputUI";
 import RunnerOutputUI from "./runner-ui/RunnerOutputUI";
 import { Node } from "@xyflow/react";
 import { filterBlocksByType } from "@/lib/utils";
-import { BlockIORootSchema } from "@/lib/autogpt-server-api/types";
+import { BlockIORootSchema, BlockUIType } from "@/lib/autogpt-server-api/types";
 
 interface RunnerUIWrapperProps {
   nodes: Node[];
@@ -31,12 +31,12 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
     const getBlockInputsAndOutputs = useCallback(() => {
       const inputBlocks = filterBlocksByType(
         nodes,
-        (node) => node.data.block_id === "c0a8e994-ebf1-4a9c-a4d8-89d09c86741b",
+        (node) => node.data.block_id === BlockUIType.INPUT,
       );
 
       const outputBlocks = filterBlocksByType(
         nodes,
-        (node) => node.data.block_id === "363ae599-353e-4804-937e-b2ee3cef3da4",
+        (node) => node.data.block_id === BlockUIType.OUTPUT,
       );
 
       const inputs = inputBlocks.map((node) => ({

--- a/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
+++ b/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
@@ -31,12 +31,12 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
     const getBlockInputsAndOutputs = useCallback(() => {
       const inputBlocks = filterBlocksByType(
         nodes,
-        (node) => node.data.block_id === BlockUIType.INPUT,
+        (node) => node.data.uiType === BlockUIType.INPUT,
       );
 
       const outputBlocks = filterBlocksByType(
         nodes,
-        (node) => node.data.block_id === BlockUIType.OUTPUT,
+        (node) => node.data.uiType === BlockUIType.OUTPUT,
       );
 
       const inputs = inputBlocks.map((node) => ({

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
@@ -152,6 +152,7 @@ export default function useAgentGraph(
               inputSchema: block.inputSchema,
               outputSchema: block.outputSchema,
               hardcodedValues: node.input_default,
+              uiType: block.uiType,
               connections: graph.links
                 .filter((l) => [l.source_id, l.sink_id].includes(node.id))
                 .map((link) => ({


### PR DESCRIPTION
### Background

Expected:
![image](https://github.com/user-attachments/assets/3e4c67d4-52fe-4e6e-8a51-91261c2e3ee5)

When it's executed:
![image](https://github.com/user-attachments/assets/758ce507-0ce9-4c87-96e9-d970023d975a)

### Changes 🏗️

* Re-purposed backend BlockUIType to generic BlockType.
* Avoid note block to be executed by the backend.
* Fix UI bug showing note block as a normal block.
* Prettify JSON output 
<img width="558" alt="image" src="https://github.com/user-attachments/assets/3883e4d6-aafe-45e5-9d82-c7479571d72b">



### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
