### PR TITLE
fix(platform): UI fixes; Fix disabled Run/Stop button

### DIFF
--- a/autogpt_platform/frontend/src/components/Flow.tsx
+++ b/autogpt_platform/frontend/src/components/Flow.tsx
@@ -34,21 +34,16 @@ import ConnectionLine from "./ConnectionLine";
 import { Control, ControlPanel } from "@/components/edit/control/ControlPanel";
 import { SaveControl } from "@/components/edit/control/SaveControl";
 import { BlocksControl } from "@/components/edit/control/BlocksControl";
-import {
-  IconPlay,
-  IconUndo2,
-  IconRedo2,
-  IconSquare,
-} from "@/components/ui/icons";
+import { IconUndo2, IconRedo2 } from "@/components/ui/icons";
 import { startTutorial } from "./tutorial";
 import useAgentGraph from "@/hooks/useAgentGraph";
 import { v4 as uuidv4 } from "uuid";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import { LogOut } from "lucide-react";
+import { useRouter, usePathname } from "next/navigation";
 import RunnerUIWrapper, {
   RunnerUIWrapperRef,
 } from "@/components/RunnerUIWrapper";
 import PrimaryActionBar from "@/components/PrimaryActionButton";
+import { useToast } from "@/components/ui/use-toast";
 
 // This is for the history, this is the minimum distance a block must move before it is logged
 // It helps to prevent spamming the history with small movements especially when pressing on a input in a block
@@ -107,6 +102,8 @@ const FlowEditor: React.FC<{
   const [pinBlocksPopover, setPinBlocksPopover] = useState(false);
 
   const runnerUIRef = useRef<RunnerUIWrapperRef>(null);
+
+  const { toast } = useToast();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -601,9 +598,10 @@ const FlowEditor: React.FC<{
             onClickAgentOutputs={() => runnerUIRef.current?.openRunnerOutput()}
             onClickRunAgent={() => {
               if (!savedAgent) {
-                alert(
-                  "Please save the agent to run, by clicking the save button in the left sidebar.",
-                );
+                toast({
+                  title: `Please save the agent using the button in the left sidebar before running it.`,
+                  duration: 2000,
+                });
                 return;
               }
               if (!isRunning) {
@@ -612,15 +610,10 @@ const FlowEditor: React.FC<{
                 requestStopRun();
               }
             }}
+            isDisabled={!savedAgent}
             isRunning={isRunning}
             requestStopRun={requestStopRun}
-            runAgentTooltip={
-              !savedAgent
-                ? "Please save the agent to run"
-                : !isRunning
-                  ? "Run Agent"
-                  : "Stop Agent"
-            }
+            runAgentTooltip={!isRunning ? "Run Agent" : "Stop Agent"}
           />
         </ReactFlow>
       </div>

--- a/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
+++ b/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
@@ -20,6 +20,7 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
   onClickAgentOutputs,
   onClickRunAgent,
   isRunning,
+  isDisabled,
   requestStopRun,
   runAgentTooltip,
 }) => {
@@ -56,7 +57,7 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
               size="primary"
               style={{
                 background: isRunning ? "#FFB3BA" : "#7544DF",
-                opacity: 1,
+                opacity: isDisabled ? 0.5 : 1,
               }}
             >
               {runButtonIcon}

--- a/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
+++ b/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
@@ -12,6 +12,7 @@ interface PrimaryActionBarProps {
   onClickAgentOutputs: () => void;
   onClickRunAgent: () => void;
   isRunning: boolean;
+  isDisabled: boolean;
   requestStopRun: () => void;
   runAgentTooltip: string;
 }


### PR DESCRIPTION
### Background

Recent UI change on the Run/Stop removes the UI notion of a disabled button on the unsaved agent.
It also replaces the disabled button with an intrusive browser alert, many browser users block this alert (and the browser auto blocks it after several alerts).

### Changes 🏗️

* Reduce button opacity on an unsaved agent.
* Replace browser alert with auto-disappearing toast.

https://github.com/user-attachments/assets/f76f03b6-0d1c-431f-b7e4-5d1f4e302110



### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
