### PR TITLE
tweak(platform): Remove unused supabase services in docker compose

### DIFF
--- a/autogpt_platform/docker-compose.yml
+++ b/autogpt_platform/docker-compose.yml
@@ -96,36 +96,6 @@ services:
       file: ./supabase/docker/docker-compose.yml
       service: rest
 
-  realtime:
-    <<: *supabase-services
-    extends:
-      file: ./supabase/docker/docker-compose.yml
-      service: realtime
-
-  storage:
-    <<: *supabase-services
-    extends:
-      file: ./supabase/docker/docker-compose.yml
-      service: storage
-
-  imgproxy:
-    <<: *supabase-services
-    extends:
-      file: ./supabase/docker/docker-compose.yml
-      service: imgproxy
-
-  meta:
-    <<: *supabase-services
-    extends:
-      file: ./supabase/docker/docker-compose.yml
-      service: meta
-
-  functions:
-    <<: *supabase-services
-    extends:
-      file: ./supabase/docker/docker-compose.yml
-      service: functions
-
   analytics:
     <<: *supabase-services
     extends:


### PR DESCRIPTION
### Background

Now that we've added supabase, we have soo many services, many that we dont use. Unpick and remove the ones we don't need.

### Changes 🏗️

Removed realtime, storage, imgproxy, meta, functions


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
