### PR TITLE
fix(market): the database url schema should be market

### DIFF
--- a/autogpt_platform/market/.env.example
+++ b/autogpt_platform/market/.env.example
@@ -2,7 +2,7 @@ DB_USER=postgres
 DB_PASS=your-super-secret-and-long-postgres-password
 DB_NAME=postgres
 DB_PORT=5432
-DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}?connect_timeout=60&schema=marketplace"
+DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}?connect_timeout=60&schema=market"
 SENTRY_DSN=https://11d0640fef35640e0eb9f022eb7d7626@o4505260022104064.ingest.us.sentry.io/4507890252447744
 
 ENABLE_AUTH=true


### PR DESCRIPTION
### Background

<!-- Clearly explain the need for these changes: -->

The supabase updates mount the marketplace schema at market, but the .env.example checks marketplace

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

`marketplace` -> `market` for the `DATABASE_URL`


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
