### PR TITLE
tweak(blocks): Simplify iteration block to output list items

### DIFF
--- a/autogpt_platform/backend/backend/blocks/iteration.py
+++ b/autogpt_platform/backend/backend/blocks/iteration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any
 
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import SchemaField
@@ -13,6 +13,9 @@ class ListIteratorBlock(Block):
 
     class Output(BlockSchema):
         item: Any = SchemaField(description="The current item in the iteration")
+        key: Any = SchemaField(
+            description="The key or index of the current item in the iteration",
+        )
 
     def __init__(self):
         super().__init__(
@@ -21,12 +24,16 @@ class ListIteratorBlock(Block):
             output_schema=ListIteratorBlock.Output,
             categories={BlockCategory.LOGIC},
             description="Iterates over a list or dictionary and outputs each item.",
-            test_input={"items": [1, 2, 3, {"key": "value", "key2": "value2"}]},
+            test_input={"items": [1, 2, 3, {"key1": "value1", "key2": "value2"}]},
             test_output=[
                 ("item", 1),
+                ("key", 0),
                 ("item", 2),
+                ("key", 1),
                 ("item", 3),
-                ("item", {"key": "value", "key2": "value2"}),
+                ("key", 2),
+                ("item", {"key1": "value1", "key2": "value2"}),
+                ("key", 3),
             ],
             test_mock={},
         )
@@ -37,7 +44,9 @@ class ListIteratorBlock(Block):
             # If items is a dictionary, iterate over its values
             for item in items.values():
                 yield "item", item
+                yield "key", item
         else:
             # If items is a list, iterate over the list
-            for item in items:
+            for index, item in enumerate(items):
                 yield "item", item
+                yield "key", index

--- a/autogpt_platform/backend/backend/blocks/iteration.py
+++ b/autogpt_platform/backend/backend/blocks/iteration.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Union
 
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import SchemaField
@@ -6,32 +6,38 @@ from backend.data.model import SchemaField
 
 class ListIteratorBlock(Block):
     class Input(BlockSchema):
-        items: List[Any] = SchemaField(
-            description="The list of items to iterate over",
-            placeholder="[1, 2, 3, 4, 5]",
+        items: Union[List[Any], Dict[Any, Any]] = SchemaField(
+            description="The list or dictionary of items to iterate over",
+            placeholder="[1, 2, 3, 4, 5] or {'key1': 'value1', 'key2': 'value2'}",
         )
 
     class Output(BlockSchema):
-        item: Tuple[int, Any] = SchemaField(
-            description="A tuple with the index and current item in the iteration"
-        )
+        item: Any = SchemaField(description="The current item in the iteration")
 
     def __init__(self):
         super().__init__(
             id="f8e7d6c5-b4a3-2c1d-0e9f-8g7h6i5j4k3l",
             input_schema=ListIteratorBlock.Input,
             output_schema=ListIteratorBlock.Output,
-            description="Iterates over a list of items and outputs each item with its index.",
             categories={BlockCategory.LOGIC},
-            test_input={"items": [1, "two", {"three": 3}, [4, 5]]},
+            description="Iterates over a list or dictionary and outputs each item.",
+            test_input={"items": [1, 2, 3, {"key": "value", "key2": "value2"}]},
             test_output=[
-                ("item", (0, 1)),
-                ("item", (1, "two")),
-                ("item", (2, {"three": 3})),
-                ("item", (3, [4, 5])),
+                ("item", 1),
+                ("item", 2),
+                ("item", 3),
+                ("item", {"key": "value", "key2": "value2"}),
             ],
+            test_mock={},
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        for index, item in enumerate(input_data.items):
-            yield "item", (index, item)
+        items = input_data.items
+        if isinstance(items, dict):
+            # If items is a dictionary, iterate over its values
+            for item in items.values():
+                yield "item", item
+        else:
+            # If items is a list, iterate over the list
+            for item in items:
+                yield "item", item

--- a/autogpt_platform/backend/backend/blocks/iteration.py
+++ b/autogpt_platform/backend/backend/blocks/iteration.py
@@ -4,7 +4,7 @@ from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import SchemaField
 
 
-class ListIteratorBlock(Block):
+class StepThroughItemsBlock(Block):
     class Input(BlockSchema):
         items: list | dict = SchemaField(
             description="The list or dictionary of items to iterate over",
@@ -20,8 +20,8 @@ class ListIteratorBlock(Block):
     def __init__(self):
         super().__init__(
             id="f8e7d6c5-b4a3-2c1d-0e9f-8g7h6i5j4k3l",
-            input_schema=ListIteratorBlock.Input,
-            output_schema=ListIteratorBlock.Output,
+            input_schema=StepThroughItemsBlock.Input,
+            output_schema=StepThroughItemsBlock.Output,
             categories={BlockCategory.LOGIC},
             description="Iterates over a list or dictionary and outputs each item.",
             test_input={"items": [1, 2, 3, {"key1": "value1", "key2": "value2"}]},

--- a/autogpt_platform/backend/backend/blocks/iteration.py
+++ b/autogpt_platform/backend/backend/blocks/iteration.py
@@ -6,7 +6,7 @@ from backend.data.model import SchemaField
 
 class ListIteratorBlock(Block):
     class Input(BlockSchema):
-        items: Union[List[Any], Dict[Any, Any]] = SchemaField(
+        items: list | dict = SchemaField(
             description="The list or dictionary of items to iterate over",
             placeholder="[1, 2, 3, 4, 5] or {'key1': 'value1', 'key2': 'value2'}",
         )


### PR DESCRIPTION
### Background

The ListIteratorBlock is currently very hard to work with, as it constructs and returns dictionaries (iirc - or it could be Tuples?) with an added index.

For most use-cases this makes the outputs very cumbersome to work with, requiring subsequent data processing blocks.

The block should be simplified to just output the list items.

https://github.com/user-attachments/assets/cf5fe2a3-4cba-47b3-b491-51d5ba6f7913
