### PR TITLE
dx: Auto-label block PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,3 +25,8 @@ platform/frontend:
 platform/backend:
 - changed-files:
   - any-glob-to-any-file: autogpt_platform/backend/**
+  - all-globs-to-all-files: '!autogpt_platform/backend/backend/blocks/**'
+
+platform/blocks:
+- changed-files:
+  - any-glob-to-any-file: autogpt_platform/backend/backend/blocks/**


### PR DESCRIPTION
Automatically apply the `platform/blocks` label to PRs that change files in `backend/blocks/`
