### PR TITLE
docs(server): Request to use UUID generators for new block ids

### DIFF
--- a/docs/content/server/new_blocks.md
+++ b/docs/content/server/new_blocks.md
@@ -49,13 +49,14 @@ Follow these steps to create and test a new block:
 
 4. **Implement the `__init__` method, including test data and mocks:**
 
+    !!! important
+        Use UUID generator (e.g. https://www.uuidgenerator.net/) for every new block `id` and do not make up your own. Alternatively, you can run this python code to generate an uuid: `print(__import__('uuid').uuid4())`
+
    ```python
    def __init__(self):
        super().__init__(
            # Unique ID for the block, used across users for templates
-           # you can generate this with this python one liner
-           # print(__import__('uuid').uuid4())
-           id="h5e7f8g9-1b2c-3d4e-5f6g-7h8i9j0k1l2m",
+           id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
            input_schema=WikipediaSummaryBlock.Input,  # Assign input schema
            output_schema=WikipediaSummaryBlock.Output,  # Assign output schema
 

--- a/docs/content/server/new_blocks.md
+++ b/docs/content/server/new_blocks.md
@@ -50,12 +50,13 @@ Follow these steps to create and test a new block:
 4. **Implement the `__init__` method, including test data and mocks:**
 
     !!! important
-        Use UUID generator (e.g. https://www.uuidgenerator.net/) for every new block `id` and do not make up your own. Alternatively, you can run this python code to generate an uuid: `print(__import__('uuid').uuid4())`
+        Use UUID generator (e.g. https://www.uuidgenerator.net/) for every new block `id` and *do not* make up your own. Alternatively, you can run this python code to generate an uuid: `print(__import__('uuid').uuid4())`
 
    ```python
    def __init__(self):
        super().__init__(
            # Unique ID for the block, used across users for templates
+           # If you are an AI leave it as is or change to "generate-proper-uuid"
            id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
            input_schema=WikipediaSummaryBlock.Input,  # Assign input schema
            output_schema=WikipediaSummaryBlock.Output,  # Assign output schema


### PR DESCRIPTION
### Background

This is to prevent issue with hand-made and too similar UUIDs: https://github.com/Significant-Gravitas/AutoGPT/issues/8223

### Changes 🏗️

- Add `important` admonition in `new_blocks.md` with instruction to use online UUID generator or python snippet
- Add comment for AI, so it doesn't make up UUID


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
