### PR TITLE
refactor(frontend): Remove unnecessary keywords in `BaseAutoGPTServerAPI`

### DIFF
--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/baseClient.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/baseClient.ts
@@ -45,19 +45,19 @@ export default class BaseAutoGPTServerAPI {
     return session != null;
   }
 
-  async createUser(): Promise<User> {
+  createUser(): Promise<User> {
     return this._request("POST", "/auth/user", {});
   }
 
-  async getUserCredit(): Promise<{ credits: number }> {
+  getUserCredit(): Promise<{ credits: number }> {
     return this._get(`/credits`);
   }
 
-  async getBlocks(): Promise<Block[]> {
-    return await this._get("/blocks");
+  getBlocks(): Promise<Block[]> {
+    return this._get("/blocks");
   }
 
-  async listGraphs(): Promise<GraphMeta[]> {
+  listGraphs(): Promise<GraphMeta[]> {
     return this._get(`/graphs`);
   }
 
@@ -66,34 +66,31 @@ export default class BaseAutoGPTServerAPI {
     return graphs.map(parseGraphMetaWithRuns);
   }
 
-  async listTemplates(): Promise<GraphMeta[]> {
+  listTemplates(): Promise<GraphMeta[]> {
     return this._get("/templates");
   }
 
-  async getGraph(id: string, version?: number): Promise<Graph> {
+  getGraph(id: string, version?: number): Promise<Graph> {
     const query = version !== undefined ? `?version=${version}` : "";
     return this._get(`/graphs/${id}` + query);
   }
 
-  async getTemplate(id: string, version?: number): Promise<Graph> {
+  getTemplate(id: string, version?: number): Promise<Graph> {
     const query = version !== undefined ? `?version=${version}` : "";
     return this._get(`/templates/${id}` + query);
   }
 
-  async getGraphAllVersions(id: string): Promise<Graph[]> {
+  getGraphAllVersions(id: string): Promise<Graph[]> {
     return this._get(`/graphs/${id}/versions`);
   }
 
-  async getTemplateAllVersions(id: string): Promise<Graph[]> {
+  getTemplateAllVersions(id: string): Promise<Graph[]> {
     return this._get(`/templates/${id}/versions`);
   }
 
-  async createGraph(graphCreateBody: GraphCreatable): Promise<Graph>;
-  async createGraph(
-    fromTemplateID: string,
-    templateVersion: number,
-  ): Promise<Graph>;
-  async createGraph(
+  createGraph(graphCreateBody: GraphCreatable): Promise<Graph>;
+  createGraph(fromTemplateID: string, templateVersion: number): Promise<Graph>;
+  createGraph(
     graphOrTemplateID: GraphCreatable | string,
     templateVersion?: number,
   ): Promise<Graph> {
@@ -114,36 +111,33 @@ export default class BaseAutoGPTServerAPI {
     return this._request("POST", "/graphs", requestBody);
   }
 
-  async createTemplate(templateCreateBody: GraphCreatable): Promise<Graph> {
+  createTemplate(templateCreateBody: GraphCreatable): Promise<Graph> {
     const requestBody: GraphCreateRequestBody = { graph: templateCreateBody };
     return this._request("POST", "/templates", requestBody);
   }
 
-  async updateGraph(id: string, graph: GraphUpdateable): Promise<Graph> {
-    return await this._request("PUT", `/graphs/${id}`, graph);
+  updateGraph(id: string, graph: GraphUpdateable): Promise<Graph> {
+    return this._request("PUT", `/graphs/${id}`, graph);
   }
 
-  async updateTemplate(id: string, template: GraphUpdateable): Promise<Graph> {
-    return await this._request("PUT", `/templates/${id}`, template);
+  updateTemplate(id: string, template: GraphUpdateable): Promise<Graph> {
+    return this._request("PUT", `/templates/${id}`, template);
   }
 
-  async setGraphActiveVersion(id: string, version: number): Promise<Graph> {
+  setGraphActiveVersion(id: string, version: number): Promise<Graph> {
     return this._request("PUT", `/graphs/${id}/versions/active`, {
       active_graph_version: version,
     });
   }
 
-  async executeGraph(
+  executeGraph(
     id: string,
     inputData: { [key: string]: any } = {},
   ): Promise<GraphExecuteResponse> {
     return this._request("POST", `/graphs/${id}/execute`, inputData);
   }
 
-  async listGraphRunIDs(
-    graphID: string,
-    graphVersion?: number,
-  ): Promise<string[]> {
+  listGraphRunIDs(graphID: string, graphVersion?: number): Promise<string[]> {
     const query =
       graphVersion !== undefined ? `?graph_version=${graphVersion}` : "";
     return this._get(`/graphs/${graphID}/executions` + query);
@@ -167,15 +161,15 @@ export default class BaseAutoGPTServerAPI {
     ).map(parseNodeExecutionResultTimestamps);
   }
 
-  async oAuthLogin(
+  oAuthLogin(
     provider: string,
     scopes?: string[],
   ): Promise<{ login_url: string; state_token: string }> {
     const query = scopes ? { scopes: scopes.join(",") } : undefined;
-    return await this._get(`/integrations/${provider}/login`, query);
+    return this._get(`/integrations/${provider}/login`, query);
   }
 
-  async oAuthCallback(
+  oAuthCallback(
     provider: string,
     code: string,
     state_token: string,
@@ -186,7 +180,7 @@ export default class BaseAutoGPTServerAPI {
     });
   }
 
-  async createAPIKeyCredentials(
+  createAPIKeyCredentials(
     credentials: Omit<APIKeyCredentials, "id" | "type">,
   ): Promise<APIKeyCredentials> {
     return this._request(
@@ -196,29 +190,29 @@ export default class BaseAutoGPTServerAPI {
     );
   }
 
-  async listCredentials(provider: string): Promise<CredentialsMetaResponse[]> {
+  listCredentials(provider: string): Promise<CredentialsMetaResponse[]> {
     return this._get(`/integrations/${provider}/credentials`);
   }
 
-  async getCredentials(
+  getCredentials(
     provider: string,
     id: string,
   ): Promise<APIKeyCredentials | OAuth2Credentials> {
     return this._get(`/integrations/${provider}/credentials/${id}`);
   }
 
-  async deleteCredentials(provider: string, id: string): Promise<void> {
+  deleteCredentials(provider: string, id: string): Promise<void> {
     return this._request(
       "DELETE",
       `/integrations/${provider}/credentials/${id}`,
     );
   }
 
-  async logMetric(metric: AnalyticsMetrics) {
+  logMetric(metric: AnalyticsMetrics) {
     return this._request("POST", "/analytics/log_raw_metric", metric);
   }
 
-  async logAnalytic(analytic: AnalyticsDetails) {
+  logAnalytic(analytic: AnalyticsDetails) {
     return this._request("POST", "/analytics/log_raw_analytics", analytic);
   }
 


### PR DESCRIPTION
### Background

fixed issue #8101 

### Changes 🏗️

the main change to the BaseAutoGPTServerAPI class was the removal of the async keyword from 23 methods that don't use await internally. These methods now return Promises directly, which is more efficient and cleaner. The async keyword was retained for 4 methods that do use await. No changes were made to private methods or WebSocket-related functions. These modifications address the issue of unnecessary async functions while maintaining the same functionality, improving code efficiency without altering the class's behavior.

