### PR TITLE
feat(market): swap to prisma direct query

### DIFF
--- a/autogpt_platform/market/market/db.py
+++ b/autogpt_platform/market/market/db.py
@@ -593,24 +593,24 @@ async def get_not_featured_agents(
         agents = await prisma.client.get_client().query_raw(
             query=f"""
             SELECT 
-                "Agents".id, 
-                "Agents"."createdAt", 
-                "Agents"."updatedAt", 
-                "Agents".version, 
-                "Agents".name, 
-                LEFT("Agents".description, 500) AS description, 
-                "Agents".author, 
-                "Agents".keywords, 
-                "Agents".categories, 
-                "Agents".graph,
-                "Agents"."submissionStatus",
-                "Agents"."submissionDate",
-                "Agents".search::text AS search
-            FROM "Agents"
-            LEFT JOIN "FeaturedAgent" ON "Agents"."id" = "FeaturedAgent"."agentId"
-            WHERE ("FeaturedAgent"."agentId" IS NULL OR "FeaturedAgent"."featuredCategories" = '{{}}')
-                AND "Agents"."submissionStatus" = 'APPROVED'
-            ORDER BY "Agents"."createdAt" DESC
+                "market"."Agents".id, 
+                "market"."Agents"."createdAt", 
+                "market"."Agents"."updatedAt", 
+                "market"."Agents".version, 
+                "market"."Agents".name, 
+                LEFT("market"."Agents".description, 500) AS description, 
+                "market"."Agents".author, 
+                "market"."Agents".keywords, 
+                "market"."Agents".categories, 
+                "market"."Agents".graph,
+                "market"."Agents"."submissionStatus",
+                "market"."Agents"."submissionDate",
+                "market"."Agents".search::text AS search
+            FROM "market"."Agents"
+            LEFT JOIN "market"."FeaturedAgent" ON "market"."Agents"."id" = "market"."FeaturedAgent"."agentId"
+            WHERE ("market"."FeaturedAgent"."agentId" IS NULL OR "market"."FeaturedAgent"."featuredCategories" = '{{}}')
+                AND "market"."Agents"."submissionStatus" = 'APPROVED'
+            ORDER BY "market"."Agents"."createdAt" DESC
             LIMIT {page_size} OFFSET {page_size * (page - 1)}
             """,
             model=prisma.models.Agents,


### PR DESCRIPTION
### Background

<!-- Clearly explain the need for these changes: -->
@aarushik93 requested this change for debugging marketplace issues


### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

swaps from a prisma raw query to a structured prisma query


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
