### PR TITLE
feat(platform): Add Graph Execution error data & status

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -268,10 +268,29 @@ async def update_graph_execution_start_time(graph_exec_id: str):
     )
 
 
-async def update_graph_execution_stats(graph_exec_id: str, stats: dict[str, Any]):
+async def update_graph_execution_stats(
+    graph_exec_id: str,
+    error: Exception | None,
+    wall_time: float,
+    cpu_time: float,
+    node_count: int,
+):
+    status = ExecutionStatus.FAILED if error else ExecutionStatus.COMPLETED
+    stats = (
+        {
+            "walltime": wall_time,
+            "cputime": cpu_time,
+            "nodecount": node_count,
+            "error": str(error) if error else None,
+        },
+    )
+
     await AgentGraphExecution.prisma().update(
         where={"id": graph_exec_id},
-        data={"executionStatus": ExecutionStatus.COMPLETED, "stats": json.dumps(stats)},
+        data={
+            "executionStatus": status,
+            "stats": json.dumps(stats),
+        },
     )
 
 


### PR DESCRIPTION
### Background

Current graph execution is always in the completed status, the notion of failing only happens in the node execution.
But there is a possibility the graph executor has a buggy code and the graph execution is failed.

### Changes 🏗️

Add execution failure and exception on graph execution persisted to the DB.


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
