### PR TITLE
fix(builder): Make edge delete button render above nodes

### DIFF
--- a/autogpt_platform/frontend/src/components/customedge.css
+++ b/autogpt_platform/frontend/src/components/customedge.css
@@ -42,3 +42,7 @@
 .react-flow__edges > svg:has(> g.selected) {
   z-index: 10 !important;
 }
+
+.react-flow__edgelabel-renderer {
+  z-index: 11 !important;
+}


### PR DESCRIPTION
### Background

`x` button to delete edges was rendered below nodes, even when edge was selected and shown above nodes. This was because edge button element was a sibling of edge, not its descendant.

### Changes 🏗️

- Modify `customedge.css` to make edge label render above nodes


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
