### PR TITLE
feat(infra,prod): Add prod values builder and ws

### DIFF
--- a/autogpt_platform/infra/helm/autogpt-builder/templates/configmap.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "autogpt-builder.fullname" . }}-config
+  labels:
+    {{- include "autogpt-builder.labels" . | nindent 4 }}
+data:
+  .env.local: |-
+    {{- range $key, $value := .Values.env }}
+    {{ $key }}={{ $value }}
+    {{- end }}

--- a/autogpt_platform/infra/helm/autogpt-builder/templates/frontendconfig.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/templates/frontendconfig.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   redirectToHttps:
     enabled: true
-    responseCodeName: 301
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT

--- a/autogpt_platform/infra/helm/autogpt-builder/templates/managedcert.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/templates/managedcert.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   domains:
     - {{ .Values.domain }}
+    - {{ .Values.wwwDomain }}

--- a/autogpt_platform/infra/helm/autogpt-builder/values.dev.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/values.dev.yaml
@@ -53,13 +53,17 @@ livenessProbe: null
 readinessProbe: null
 
 domain: "dev-builder.agpt.co"
+wwwDomain: "www.dev-builder.agpt.co"
 
 
 env:
   APP_ENV: "dev"
-  NEXT_PUBLIC_AGPT_SERVER_URL: ["http://agpt-server:8000/api"]
+  NEXT_PUBLIC_AGPT_SERVER_URL: ""
   GOOGLE_CLIENT_ID: ""
   GOOGLE_CLIENT_SECRET: ""
   NEXT_PUBLIC_SUPABASE_URL: ""
   NEXT_PUBLIC_SUPABASE_ANON_KEY: ""
-  NEXT_PUBLIC_BEHAVE_AS: "CLOUD"
+  SENTRY_AUTH_TOKEN: ""
+  NEXT_PUBLIC_AUTH_CALLBACK_URL: "https://dev-server.agpt.co/auth/callback"
+  NEXT_PUBLIC_AGPT_WS_SERVER_URL: "wss://dev-ws-server.agpt.co/ws"
+  NEXT_PUBLIC_AGPT_MARKETPLACE_URL: "https://dev-market.agpt.co/api/v1/market"

--- a/autogpt_platform/infra/helm/autogpt-builder/values.prod.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/values.prod.yaml
@@ -1,0 +1,88 @@
+# prod values, overwrite base values as needed.
+
+image:
+  repository: us-east1-docker.pkg.dev/agpt-prod/agpt-frontend-prod/agpt-frontend-prod
+  pullPolicy: Always
+  tag: "latest"
+
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: "prod-agpt-builder-sa@agpt-prod.iam.gserviceaccount.com"
+  name: "prod-agpt-builder-sa"
+
+service:
+  type: ClusterIP
+  port: 8000
+  targetPort: 3000
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+
+ingress:
+  enabled: true
+  className: "gce"
+  annotations:
+    kubernetes.io/ingress.class: gce
+    kubernetes.io/ingress.global-static-ip-name: "agpt-prod-agpt-frontend-ip"
+    networking.gke.io/managed-certificates: "autogpt-builder-cert"
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: "autogpt-builder-frontend-config"
+  hosts:
+    - host: platform.agpt.co
+      paths:
+        - path: /
+          pathType: Prefix
+      backend:
+        service:
+          name: autogpt-builder
+          port: 8000
+    - host: www.platform.agpt.co
+      paths:
+        - path: /
+          pathType: Prefix
+      backend:
+        service:
+          name: autogpt-builder
+          port: 8000
+  defaultBackend:
+    service:
+      name: autogpt-builder
+      port:
+        number: 8000
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+livenessProbe: null
+readinessProbe: null
+
+domain: "platform.agpt.co"
+wwwDomain: "www.platform.agpt.co"
+
+volumes:
+  - name: env-config
+    configMap:
+      name: 'autogpt-builder-config'
+
+volumeMounts:
+  - name: env-config
+    mountPath: /app/.env.local
+    subPath: .env.local
+    readonly: true
+
+
+env:
+  APP_ENV: "prod"
+  NEXT_PUBLIC_AUTH_CALLBACK_URL: "https://backend.agpt.co/auth/callback"
+  NEXT_PUBLIC_AGPT_SERVER_URL: "https://backend.agpt.co/api"
+  NEXT_PUBLIC_AGPT_WS_SERVER_URL: "wss://ws-backend.agpt.co/ws"
+  NEXT_PUBLIC_AGPT_MARKETPLACE_URL: "https://market.agpt.co/api/v1/market"
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ""
+  NEXT_PUBLIC_SUPABASE_URL: "https://bgwpwdsxblryihinutbx.supabase.co"
+  GOOGLE_CLIENT_ID: ""
+  GOOGLE_CLIENT_SECRET: ""
+  SENTRY_AUTH_TOKEN: ""

--- a/autogpt_platform/infra/helm/autogpt-websocket-server/templates/backendconfig.yaml
+++ b/autogpt_platform/infra/helm/autogpt-websocket-server/templates/backendconfig.yaml
@@ -1,0 +1,26 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ include "autogpt-websocket-server.fullname" . }}-backend-config
+spec:
+  customRequestHeaders:
+    headers:
+      - "Access-Control-Allow-Origin:{{ .Values.cors.allowOrigin }}"
+      - "Access-Control-Allow-Methods:{{ .Values.cors.allowMethods | join "," }}"
+      - "Access-Control-Allow-Headers:{{ .Values.cors.allowHeaders | join "," }}"
+      - "Access-Control-Max-Age:{{ .Values.cors.maxAge }}"
+    {{- if .Values.cors.allowCredentials }}
+      - "Access-Control-Allow-Credentials:true"
+    {{- end }}
+  customResponseHeaders:
+    headers:
+      - "Access-Control-Allow-Origin:https://dev-builder.agpt.co"
+      - "Access-Control-Allow-Methods:{{ .Values.cors.allowMethods | join "," }}"
+      - "Access-Control-Allow-Headers:{{ .Values.cors.allowHeaders | join "," }}"
+      - "Access-Control-Max-Age:{{ .Values.cors.maxAge }}"
+    {{- if .Values.cors.allowCredentials }}
+      - "Access-Control-Allow-Credentials:true"
+    {{- end }}
+  timeoutSec: 1800
+  connectionDraining:
+    drainingTimeoutSec: 1800

--- a/autogpt_platform/infra/helm/autogpt-websocket-server/templates/frontendconfig.yaml
+++ b/autogpt_platform/infra/helm/autogpt-websocket-server/templates/frontendconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ include "autogpt-websocket-server.fullname" . }}-frontend-config
+spec:
+  timeoutSec: 1800

--- a/autogpt_platform/infra/helm/autogpt-websocket-server/templates/service.yaml
+++ b/autogpt_platform/infra/helm/autogpt-websocket-server/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "autogpt-websocket-server.fullname" . }}
   labels:
     {{- include "autogpt-websocket-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/autogpt_platform/infra/helm/autogpt-websocket-server/values.prod.yaml
+++ b/autogpt_platform/infra/helm/autogpt-websocket-server/values.prod.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1 # not scaling websocket server for now
 
 image:
-  repository: us-east1-docker.pkg.dev/agpt-dev/agpt-server-dev/agpt-server-dev
+  repository: us-east1-docker.pkg.dev/agpt-prod/agpt-backend-prod/agpt-backend-prod
   tag: latest
   pullPolicy: Always
 
@@ -17,10 +17,10 @@ ingress:
   className: "gce"
   annotations:
     kubernetes.io/ingress.class: gce
-    kubernetes.io/ingress.global-static-ip-name: "agpt-dev-agpt-ws-server-ip"
+    kubernetes.io/ingress.global-static-ip-name: "agpt-prod-agpt-ws-backend-ip"
     networking.gke.io/managed-certificates: "autogpt-websocket-server-cert"
   hosts:
-    - host: dev-ws-server.agpt.co
+    - host: ws-backend.agpt.co
       paths:
         - path: /ws
           pathType: Prefix
@@ -34,7 +34,7 @@ ingress:
       port:
         number: 8001
 
-domain: "dev-ws-server.agpt.co"
+domain: "ws-backend.agpt.co"
 
 resources:
   limits:
@@ -48,7 +48,7 @@ autoscaling:
   enabled: false
 
 cors:
-  allowOrigins: "https://dev-builder.agpt.co"
+  allowOrigins: "https://platform.agpt.co"
   allowMethods:
     - "GET"
     - "POST"
@@ -75,6 +75,7 @@ livenessProbe:
   periodSeconds: 10
 
 env:
-  REDIS_HOST: "redis-dev-master.redis-dev.svc.cluster.local"
+  REDIS_HOST: "redis-prod-master.redis-prod.svc.cluster.local"
   REDIS_PORT: "6379"
-  REDIS_PASSWORD: "password"
+  REDIS_PASSWORD: ""
+  BACKEND_CORS_ALLOW_ORIGINS: '["https://platform.agpt.co"]'


### PR DESCRIPTION
### Background

We have our prod environment now, adding the prod values for builder and ws. 
Doing some small clean ups and removing unused values, adding updated values such as to support www.

### Changes 🏗️

- Added prod values for builder and ws.
- Updated Cors values
- Updated managed cert / ingress to handle www

Has been deployed and fully tested in prod in the past week.


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
