### PR TITLE
fix(platform): Always filter on user id

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -585,7 +585,9 @@ TEMPLATES_DIR = Path(__file__).parent.parent.parent / "graph_templates"
 
 
 async def import_packaged_templates() -> None:
-    templates_in_db = await get_graphs_meta(filter_by="template")
+    templates_in_db = await get_graphs_meta(
+        user_id=DEFAULT_USER_ID, filter_by="template"
+    )
 
     logging.info("Loading templates...")
     for template_file in TEMPLATES_DIR.glob("*.json"):

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -382,9 +382,9 @@ async def get_node(node_id: str) -> Node:
 
 
 async def get_graphs_meta(
+    user_id: str,
     include_executions: bool = False,
     filter_by: Literal["active", "template"] | None = "active",
-    user_id: str,
 ) -> list[GraphMeta]:
     """
     Retrieves graph metadata objects.

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -384,7 +384,7 @@ async def get_node(node_id: str) -> Node:
 async def get_graphs_meta(
     include_executions: bool = False,
     filter_by: Literal["active", "template"] | None = "active",
-    user_id: str | None = None,
+    user_id: str,
 ) -> list[GraphMeta]:
     """
     Retrieves graph metadata objects.
@@ -393,6 +393,7 @@ async def get_graphs_meta(
     Args:
         include_executions: Whether to include executions in the graph metadata.
         filter_by: An optional filter to either select templates or active graphs.
+        user_id: The ID of the user that owns the graph.
 
     Returns:
         list[GraphMeta]: A list of objects representing the retrieved graph metadata.

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -404,8 +404,7 @@ async def get_graphs_meta(
     elif filter_by == "template":
         where_clause["isTemplate"] = True
 
-    if user_id and filter_by != "template":
-        where_clause["userId"] = user_id
+    where_clause["userId"] = user_id
 
     graphs = await AgentGraph.prisma().find_many(
         where=where_clause,


### PR DESCRIPTION
### Background

We don't want to show templates downloaded from the marketplace to all users. Only to the user who downloaded it.

### Changes 🏗️

Updated the get_graphs_meta function to always filter by user_id.
Made user_id not optional


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
