### PR TITLE
tweak(platform): Remove importing templates from local dir

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -585,7 +585,9 @@ TEMPLATES_DIR = Path(__file__).parent.parent.parent / "graph_templates"
 
 
 async def import_packaged_templates() -> None:
-    templates_in_db = await get_graphs_meta(filter_by="template")
+    templates_in_db = await get_graphs_meta(
+        user_id=DEFAULT_USER_ID, filter_by="template"
+    )
 
     logging.info("Loading templates...")
     for template_file in TEMPLATES_DIR.glob("*.json"):

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -382,9 +382,9 @@ async def get_node(node_id: str) -> Node:
 
 
 async def get_graphs_meta(
+    user_id: str,
     include_executions: bool = False,
     filter_by: Literal["active", "template"] | None = "active",
-    user_id: str,
 ) -> list[GraphMeta]:
     """
     Retrieves graph metadata objects.

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Literal
 
 import prisma.types
@@ -15,7 +14,6 @@ from backend.blocks.basic import AgentInputBlock, AgentOutputBlock
 from backend.data.block import BlockInput, get_block, get_blocks
 from backend.data.db import BaseDbModel, transaction
 from backend.data.execution import ExecutionStatus
-from backend.data.user import DEFAULT_USER_ID
 from backend.util import json
 
 logger = logging.getLogger(__name__)
@@ -576,32 +574,3 @@ async def __create_graph(tx, graph: Graph, user_id: str):
             for link in graph.links
         ]
     )
-
-
-# --------------------- Helper functions --------------------- #
-
-
-TEMPLATES_DIR = Path(__file__).parent.parent.parent / "graph_templates"
-
-
-async def import_packaged_templates() -> None:
-    templates_in_db = await get_graphs_meta(
-        user_id=DEFAULT_USER_ID, filter_by="template"
-    )
-
-    logging.info("Loading templates...")
-    for template_file in TEMPLATES_DIR.glob("*.json"):
-        template_data = json.loads(template_file.read_bytes())
-
-        template = Graph.model_validate(template_data)
-        if not template.is_template:
-            logging.warning(
-                f"pre-packaged graph file {template_file} is not a template"
-            )
-            continue
-        if (
-            exists := next((t for t in templates_in_db if t.id == template.id), None)
-        ) and exists.version >= template.version:
-            continue
-        await create_graph(template, DEFAULT_USER_ID)
-        logging.info(f"Loaded template '{template.name}' ({template.id})")

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -384,7 +384,7 @@ async def get_node(node_id: str) -> Node:
 async def get_graphs_meta(
     include_executions: bool = False,
     filter_by: Literal["active", "template"] | None = "active",
-    user_id: str | None = None,
+    user_id: str,
 ) -> list[GraphMeta]:
     """
     Retrieves graph metadata objects.
@@ -393,6 +393,7 @@ async def get_graphs_meta(
     Args:
         include_executions: Whether to include executions in the graph metadata.
         filter_by: An optional filter to either select templates or active graphs.
+        user_id: The ID of the user that owns the graph.
 
     Returns:
         list[GraphMeta]: A list of objects representing the retrieved graph metadata.

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -404,8 +404,7 @@ async def get_graphs_meta(
     elif filter_by == "template":
         where_clause["isTemplate"] = True
 
-    if user_id and filter_by != "template":
-        where_clause["userId"] = user_id
+    where_clause["userId"] = user_id
 
     graphs = await AgentGraph.prisma().find_many(
         where=where_clause,

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -14,7 +14,6 @@ from fastapi.responses import JSONResponse
 from backend.data import block, db
 from backend.data import execution as execution_db
 from backend.data import graph as graph_db
-from backend.data import user as user_db
 from backend.data.block import BlockInput, CompletedBlockOutput
 from backend.data.credit import get_block_costs, get_user_credit_model
 from backend.data.queue import RedisEventQueue
@@ -44,8 +43,6 @@ class AgentServer(AppService):
         await db.connect()
         self.event_queue.connect()
         await block.initialize_blocks()
-        if await user_db.create_default_user(settings.config.enable_auth):
-            await graph_db.import_packaged_templates()
         yield
         self.event_queue.close()
         await db.disconnect()


### PR DESCRIPTION
### Background

This was designed for local use/installs. We don't support this anymore and all users are exepcted to have a user and download agents from the marketplace

### Changes 🏗️

Removed the import_packaged_templates function and references


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
