### PR TITLE
tweak(docs): Further clarify licencing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Also check out our [🚀 Roadmap][roadmap] for information about our priorities 
 [kanban board]: https://github.com/orgs/Significant-Gravitas/projects/1
 
 ## Contributing to the AutoGPT Platform Folder
-All contributions to [the autogpt_platform folder](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform) will be under our [Contribution License Agreement](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/Contributor%20License%20Agreement%20(CLA).md). By making a pull request contributing to this folder, you agree to the terms of our CLA for your contribution.
+All contributions to the autogpt_platform folder will be under our Contribution License Agreement. By making a pull request contributing to this folder, you agree to the terms of our CLA for your contribution. All contributions to other folders will be under the MIT license.
 
 ## In short
 1. Avoid duplicate work, issues, PRs etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Also check out our [🚀 Roadmap][roadmap] for information about our priorities 
 [kanban board]: https://github.com/orgs/Significant-Gravitas/projects/1
 
 ## Contributing to the AutoGPT Platform Folder
-All contributions to the autogpt_platform folder will be under our Contribution License Agreement. By making a pull request contributing to this folder, you agree to the terms of our CLA for your contribution. All contributions to other folders will be under the MIT license.
+All contributions to [the autogpt_platform folder](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform) will be under our [Contribution License Agreement](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/Contributor%20License%20Agreement%20(CLA).md). By making a pull request contributing to this folder, you agree to the terms of our CLA for your contribution. All contributions to other folders will be under the MIT license.
 
 ## In short
 1. Avoid duplicate work, issues, PRs etc.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,12 @@
+﻿All portions of this repository are under one of two licenses. The majority of the AutoGPT repository is under the MIT License below. The autogpt_platform folder is under the
+Polyform Shield License. 
+
+
 MIT License
 
+
 Copyright (c) 2023 Toran Bruce Richards
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,8 +15,10 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
+
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Here are two examples of what you can do with AutoGPT:
 These examples show just a glimpse of what you can achieve with AutoGPT! You can create customized workflows to build agents for any use case.
 
 ---
+### Mission and Licencing
 Our mission is to provide the tools, so that you can focus on what matters:
 
 - 🏗️ **Building** - Lay the foundation for something amazing.
@@ -77,6 +78,13 @@ Be part of the revolution! **AutoGPT** is here to stay, at the forefront of AI i
 &ensp;|&ensp;
 **🚀 [Contributing](CONTRIBUTING.md)**
 
+**Licensing:**
+
+MIT License: The majority of the AutoGPT repository is under the MIT License.
+
+Polyform Shield License: This license applies to the autogpt_platform folder. 
+
+For more information, see https://agpt.co/blog/introducing-the-autogpt-platform
 
 ---
 ## 🤖 AutoGPT Classic


### PR DESCRIPTION
This pull request includes clarifications to the licensing information and documentation for the AutoGPT repository. The changes clarify the licensing terms for different parts of the repository and update related documentation files.

### Licensing Updates:
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7R1-R22): Added a section specifying that the majority of the AutoGPT repository is under the MIT License, while the `autogpt_platform` folder is under the Polyform Shield License.

### Documentation Updates:
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L14-R14): Updated the contribution guidelines to specify that contributions to folders other than `autogpt_platform` will be under the MIT license.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68): Added sections to clarify the mission and licensing terms, including details about the MIT License and Polyform Shield License. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R87)