### PR TITLE
feat(backend): add the capibility to disable llm models in the cloud env

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -12,7 +12,10 @@ REDIS_PORT=6379
 REDIS_PASSWORD=password
 
 ENABLE_CREDIT=false
-APP_ENV="local"
+# What environment things should be logged under: local dev or prod
+APP_ENV=local
+# What environment to behave as: "local" or "cloud"
+BEHAVE_AS=local
 PYRO_HOST=localhost
 SENTRY_DSN=
 
@@ -98,5 +101,3 @@ ENABLE_CLOUD_LOGGING=false
 ENABLE_FILE_LOGGING=false
 # Use to manually set the log directory
 # LOG_DIR=./logs
-
-APP_ENV=local

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -1,9 +1,12 @@
 import ast
 import logging
-from enum import Enum, EnumMeta, _EnumMemberT
+from enum import Enum, EnumMeta
 from json import JSONDecodeError
 from types import MappingProxyType
-from typing import Any, List, NamedTuple
+from typing import TYPE_CHECKING, Any, List, NamedTuple
+
+if TYPE_CHECKING:
+    from enum import _EnumMemberT
 
 import anthropic
 import ollama
@@ -34,8 +37,8 @@ class ModelMetadata(NamedTuple):
 class LlmModelMeta(EnumMeta):
     @property
     def __members__(
-        self: type[_EnumMemberT],
-    ) -> MappingProxyType[str, _EnumMemberT]:
+        self: type["_EnumMemberT"],
+    ) -> MappingProxyType[str, "_EnumMemberT"]:
         if Settings().config.behave_as == BehaveAs.LOCAL:
             members = super().__members__
             return members

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -12,6 +12,7 @@ from groq import Groq
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import BlockSecret, SchemaField, SecretField
 from backend.util import json
+from backend.util.settings import Settings, BehaveAs
 
 logger = logging.getLogger(__name__)
 
@@ -32,20 +33,15 @@ class ModelMetadata(NamedTuple):
 class LlmModelMeta(EnumMeta):
     @property
     def __members__(cls):
-        return {
-            name: member
-            for name, member in super().__members__.items()
-            if name != "O1_PREVIEW"
-            and name != "O1_MINI"
-            and name != "GPT4O_MINI"
-            and name != "GPT4O"
-            and name != "GPT4_TURBO"
-            and name != "GPT3_5_TURBO"
-            and name != "CLAUDE_3_5_SONNET"
-            and name != "CLAUDE_3_HAIKU"
-            and name != "LLAMA3_8B"
-            and name != "LLAMA3_70B"
-        }
+        if Settings().config.behave_as == BehaveAs.LOCAL:
+            return super().__members__
+        else:
+            removed_providers = ["ollama"]
+            return {
+                name: member
+                for name, member in super().__members__.items()
+                if LlmModel[name].provider not in removed_providers
+            }
 
 
 class LlmModel(str, Enum, metaclass=LlmModelMeta):

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -12,7 +12,7 @@ from groq import Groq
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import BlockSecret, SchemaField, SecretField
 from backend.util import json
-from backend.util.settings import Settings, BehaveAs
+from backend.util.settings import BehaveAs, Settings
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class ModelMetadata(NamedTuple):
 
 class LlmModelMeta(EnumMeta):
     @property
-    def __members__(cls):
+    def __members__(cls):  # type: ignore
         if Settings().config.behave_as == BehaveAs.LOCAL:
             return super().__members__
         else:

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -1,6 +1,6 @@
 import ast
 import logging
-from enum import Enum
+from enum import Enum, EnumMeta
 from json import JSONDecodeError
 from typing import Any, List, NamedTuple
 
@@ -29,7 +29,26 @@ class ModelMetadata(NamedTuple):
     cost_factor: int
 
 
-class LlmModel(str, Enum):
+class LlmModelMeta(EnumMeta):
+    @property
+    def __members__(cls):
+        return {
+            name: member
+            for name, member in super().__members__.items()
+            if name != "O1_PREVIEW"
+            and name != "O1_MINI"
+            and name != "GPT4O_MINI"
+            and name != "GPT4O"
+            and name != "GPT4_TURBO"
+            and name != "GPT3_5_TURBO"
+            and name != "CLAUDE_3_5_SONNET"
+            and name != "CLAUDE_3_HAIKU"
+            and name != "LLAMA3_8B"
+            and name != "LLAMA3_70B"
+        }
+
+
+class LlmModel(str, Enum, metaclass=LlmModelMeta):
     # OpenAI models
     O1_PREVIEW = "o1-preview"
     O1_MINI = "o1-mini"
@@ -57,6 +76,18 @@ class LlmModel(str, Enum):
     @property
     def metadata(self) -> ModelMetadata:
         return MODEL_METADATA[self]
+
+    @property
+    def provider(self) -> str:
+        return self.metadata.provider
+
+    @property
+    def context_window(self) -> int:
+        return self.metadata.context_window
+
+    @property
+    def cost_factor(self) -> int:
+        return self.metadata.cost_factor
 
 
 MODEL_METADATA = {

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -23,7 +23,7 @@ from backend.data.user import get_or_create_user
 from backend.executor import ExecutionManager, ExecutionScheduler
 from backend.server.model import CreateGraph, SetGraphActiveVersion
 from backend.util.service import AppService, expose, get_service_client
-from backend.util.settings import Config, Settings
+from backend.util.settings import AppEnvironment, Config, Settings
 
 from .utils import get_user_id
 
@@ -52,7 +52,7 @@ class AgentServer(AppService):
         await db.disconnect()
 
     def run_service(self):
-        docs_url = "/docs" if settings.config.app_env == "local" else None
+        docs_url = "/docs" if settings.config.app_env == AppEnvironment.LOCAL else None
         app = FastAPI(
             title="AutoGPT Agent Server",
             description=(

--- a/autogpt_platform/backend/backend/server/ws_api.py
+++ b/autogpt_platform/backend/backend/server/ws_api.py
@@ -12,7 +12,7 @@ from backend.data.user import DEFAULT_USER_ID
 from backend.server.conn_manager import ConnectionManager
 from backend.server.model import ExecutionSubscription, Methods, WsMessage
 from backend.util.service import AppProcess
-from backend.util.settings import Config, Settings
+from backend.util.settings import AppEnvironment, Config, Settings
 
 logger = logging.getLogger(__name__)
 settings = Settings()
@@ -28,7 +28,7 @@ async def lifespan(app: FastAPI):
     event_queue.close()
 
 
-docs_url = "/docs" if settings.config.app_env == "local" else None
+docs_url = "/docs" if settings.config.app_env == AppEnvironment.LOCAL else None
 app = FastAPI(lifespan=lifespan)
 event_queue = RedisEventQueue()
 _connection_manager = None

--- a/autogpt_platform/backend/backend/util/logging.py
+++ b/autogpt_platform/backend/backend/util/logging.py
@@ -1,4 +1,6 @@
-import os
+from backend.util.settings import AppEnvironment, BehaveAs, Settings
+
+settings = Settings()
 
 
 def configure_logging():
@@ -6,7 +8,10 @@ def configure_logging():
 
     import autogpt_libs.logging.config
 
-    if os.getenv("APP_ENV") != "cloud":
+    if (
+        settings.config.behave_as == BehaveAs.LOCAL
+        or settings.config.app_env == AppEnvironment.LOCAL
+    ):
         autogpt_libs.logging.config.configure_logging(force_cloud_logging=False)
     else:
         autogpt_libs.logging.config.configure_logging(force_cloud_logging=True)

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -22,6 +22,11 @@ class AppEnvironment(str, Enum):
     PRODUCTION = "prod"
 
 
+class BehaveAs(str, Enum):
+    LOCAL = "local"
+    CLOUD = "cloud"
+
+
 class UpdateTrackingModel(BaseModel, Generic[T]):
     _updated_fields: Set[str] = PrivateAttr(default_factory=set)
 
@@ -130,7 +135,12 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
 
     app_env: AppEnvironment = Field(
         default=AppEnvironment.LOCAL,
-        description="The name of the app environment.",
+        description="The name of the app environment: local or dev or prod",
+    )
+
+    behave_as: BehaveAs = Field(
+        default=BehaveAs.LOCAL,
+        description="What environment to behave as: local or cloud",
     )
 
     backend_cors_allow_origins: List[str] = Field(default_factory=list)


### PR DESCRIPTION
### Background

<!-- Clearly explain the need for these changes: -->

We dont offer ollama instance so we need to remove it from the LLM options. 
We can use ~~one of the cloud flags we have now~~ *these didn't actually do what we thought* to turn it on and off

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

Adds 
- BehaveAs as an environment variable
- Adds a metaclass to the LLM Model
- Updates various issues with how AppEnv was used 
- Updates Logging to correctly follow cloud pathway in cloud


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
