### PR TITLE
fix(platform): Remove blind try-except for yielding error on block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/__init__.py
+++ b/autogpt_platform/backend/backend/blocks/__init__.py
@@ -53,13 +53,20 @@ for cls in all_subclasses(Block):
     if block.id in AVAILABLE_BLOCKS:
         raise ValueError(f"Block ID {block.name} error: {block.id} is already in use")
 
+    input_schema = block.input_schema.model_fields
+    output_schema = block.output_schema.model_fields
+
     # Prevent duplicate field name in input_schema and output_schema
-    duplicate_field_names = set(block.input_schema.model_fields.keys()) & set(
-        block.output_schema.model_fields.keys()
-    )
+    duplicate_field_names = set(input_schema.keys()) & set(output_schema.keys())
     if duplicate_field_names:
         raise ValueError(
             f"{block.name} has duplicate field names in input_schema and output_schema: {duplicate_field_names}"
+        )
+
+    # Make sure `error` field is a string in the output schema
+    if "error" in output_schema and output_schema["error"].annotation is not str:
+        raise ValueError(
+            f"{block.name} `error` field in output_schema must be a string"
         )
 
     for field in block.input_schema.model_fields.values():

--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -330,20 +330,17 @@ class AddToDictionaryBlock(Block):
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        try:
-            # If no dictionary is provided, create a new one
-            if input_data.dictionary is None:
-                updated_dict = {}
-            else:
-                # Create a copy of the input dictionary to avoid modifying the original
-                updated_dict = input_data.dictionary.copy()
+        # If no dictionary is provided, create a new one
+        if input_data.dictionary is None:
+            updated_dict = {}
+        else:
+            # Create a copy of the input dictionary to avoid modifying the original
+            updated_dict = input_data.dictionary.copy()
 
-            # Add the new key-value pair
-            updated_dict[input_data.key] = input_data.value
+        # Add the new key-value pair
+        updated_dict[input_data.key] = input_data.value
 
-            yield "updated_dictionary", updated_dict
-        except Exception as e:
-            yield "error", f"Failed to add entry to dictionary: {str(e)}"
+        yield "updated_dictionary", updated_dict
 
 
 class AddToListBlock(Block):
@@ -401,23 +398,20 @@ class AddToListBlock(Block):
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        try:
-            # If no list is provided, create a new one
-            if input_data.list is None:
-                updated_list = []
-            else:
-                # Create a copy of the input list to avoid modifying the original
-                updated_list = input_data.list.copy()
+        # If no list is provided, create a new one
+        if input_data.list is None:
+            updated_list = []
+        else:
+            # Create a copy of the input list to avoid modifying the original
+            updated_list = input_data.list.copy()
 
-            # Add the new entry
-            if input_data.position is None:
-                updated_list.append(input_data.entry)
-            else:
-                updated_list.insert(input_data.position, input_data.entry)
+        # Add the new entry
+        if input_data.position is None:
+            updated_list.append(input_data.entry)
+        else:
+            updated_list.insert(input_data.position, input_data.entry)
 
-            yield "updated_list", updated_list
-        except Exception as e:
-            yield "error", f"Failed to add entry to list: {str(e)}"
+        yield "updated_list", updated_list
 
 
 class NoteBlock(Block):

--- a/autogpt_platform/backend/backend/blocks/block.py
+++ b/autogpt_platform/backend/backend/blocks/block.py
@@ -37,14 +37,12 @@ class BlockInstallationBlock(Block):
         if search := re.search(r"class (\w+)\(Block\):", code):
             class_name = search.group(1)
         else:
-            yield "error", "No class found in the code."
-            return
+            raise RuntimeError("No class found in the code.")
 
         if search := re.search(r"id=\"(\w+-\w+-\w+-\w+-\w+)\"", code):
             file_name = search.group(1)
         else:
-            yield "error", "No UUID found in the code."
-            return
+            raise RuntimeError("No UUID found in the code.")
 
         block_dir = os.path.dirname(__file__)
         file_path = f"{block_dir}/{file_name}.py"
@@ -63,4 +61,4 @@ class BlockInstallationBlock(Block):
             yield "success", "Block installed successfully."
         except Exception as e:
             os.remove(file_path)
-            yield "error", f"[Code]\n{code}\n\n[Error]\n{str(e)}"
+            raise RuntimeError(f"[Code]\n{code}\n\n[Error]\n{str(e)}")

--- a/autogpt_platform/backend/backend/blocks/decoder_block.py
+++ b/autogpt_platform/backend/backend/blocks/decoder_block.py
@@ -35,8 +35,5 @@ This is a "quoted" string.""",
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        try:
-            decoded_text = codecs.decode(input_data.text, "unicode_escape")
-            yield "decoded_text", decoded_text
-        except Exception as e:
-            yield "error", f"Error decoding text: {str(e)}"
+        decoded_text = codecs.decode(input_data.text, "unicode_escape")
+        yield "decoded_text", decoded_text

--- a/autogpt_platform/backend/backend/blocks/email_block.py
+++ b/autogpt_platform/backend/backend/blocks/email_block.py
@@ -67,35 +67,28 @@ class SendEmailBlock(Block):
     def send_email(
         creds: EmailCredentials, to_email: str, subject: str, body: str
     ) -> str:
-        try:
-            smtp_server = creds.smtp_server
-            smtp_port = creds.smtp_port
-            smtp_username = creds.smtp_username.get_secret_value()
-            smtp_password = creds.smtp_password.get_secret_value()
+        smtp_server = creds.smtp_server
+        smtp_port = creds.smtp_port
+        smtp_username = creds.smtp_username.get_secret_value()
+        smtp_password = creds.smtp_password.get_secret_value()
 
-            msg = MIMEMultipart()
-            msg["From"] = smtp_username
-            msg["To"] = to_email
-            msg["Subject"] = subject
-            msg.attach(MIMEText(body, "plain"))
+        msg = MIMEMultipart()
+        msg["From"] = smtp_username
+        msg["To"] = to_email
+        msg["Subject"] = subject
+        msg.attach(MIMEText(body, "plain"))
 
-            with smtplib.SMTP(smtp_server, smtp_port) as server:
-                server.starttls()
-                server.login(smtp_username, smtp_password)
-                server.sendmail(smtp_username, to_email, msg.as_string())
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            server.starttls()
+            server.login(smtp_username, smtp_password)
+            server.sendmail(smtp_username, to_email, msg.as_string())
 
-            return "Email sent successfully"
-        except Exception as e:
-            return f"Failed to send email: {str(e)}"
+        return "Email sent successfully"
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        status = self.send_email(
+        yield "status", self.send_email(
             input_data.creds,
             input_data.to_email,
             input_data.subject,
             input_data.body,
         )
-        if "successfully" in status:
-            yield "status", status
-        else:
-            yield "error", status

--- a/autogpt_platform/backend/backend/blocks/github/issues.py
+++ b/autogpt_platform/backend/backend/blocks/github/issues.py
@@ -93,16 +93,13 @@ class GithubCommentBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            id, url = self.post_comment(
-                credentials,
-                input_data.issue_url,
-                input_data.comment,
-            )
-            yield "id", id
-            yield "url", url
-        except Exception as e:
-            yield "error", f"Failed to post comment: {str(e)}"
+        id, url = self.post_comment(
+            credentials,
+            input_data.issue_url,
+            input_data.comment,
+        )
+        yield "id", id
+        yield "url", url
 
 
 # --8<-- [end:GithubCommentBlockExample]
@@ -179,17 +176,14 @@ class GithubMakeIssueBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            number, url = self.create_issue(
-                credentials,
-                input_data.repo_url,
-                input_data.title,
-                input_data.body,
-            )
-            yield "number", number
-            yield "url", url
-        except Exception as e:
-            yield "error", f"Failed to create issue: {str(e)}"
+        number, url = self.create_issue(
+            credentials,
+            input_data.repo_url,
+            input_data.title,
+            input_data.body,
+        )
+        yield "number", number
+        yield "url", url
 
 
 class GithubReadIssueBlock(Block):
@@ -262,16 +256,13 @@ class GithubReadIssueBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            title, body, user = self.read_issue(
-                credentials,
-                input_data.issue_url,
-            )
-            yield "title", title
-            yield "body", body
-            yield "user", user
-        except Exception as e:
-            yield "error", f"Failed to read issue: {str(e)}"
+        title, body, user = self.read_issue(
+            credentials,
+            input_data.issue_url,
+        )
+        yield "title", title
+        yield "body", body
+        yield "user", user
 
 
 class GithubListIssuesBlock(Block):
@@ -350,14 +341,11 @@ class GithubListIssuesBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            issues = self.list_issues(
-                credentials,
-                input_data.repo_url,
-            )
-            yield from (("issue", issue) for issue in issues)
-        except Exception as e:
-            yield "error", f"Failed to list issues: {str(e)}"
+        issues = self.list_issues(
+            credentials,
+            input_data.repo_url,
+        )
+        yield from (("issue", issue) for issue in issues)
 
 
 class GithubAddLabelBlock(Block):
@@ -428,15 +416,12 @@ class GithubAddLabelBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            status = self.add_label(
-                credentials,
-                input_data.issue_url,
-                input_data.label,
-            )
-            yield "status", status
-        except Exception as e:
-            yield "error", f"Failed to add label: {str(e)}"
+        status = self.add_label(
+            credentials,
+            input_data.issue_url,
+            input_data.label,
+        )
+        yield "status", status
 
 
 class GithubRemoveLabelBlock(Block):
@@ -512,15 +497,12 @@ class GithubRemoveLabelBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            status = self.remove_label(
-                credentials,
-                input_data.issue_url,
-                input_data.label,
-            )
-            yield "status", status
-        except Exception as e:
-            yield "error", f"Failed to remove label: {str(e)}"
+        status = self.remove_label(
+            credentials,
+            input_data.issue_url,
+            input_data.label,
+        )
+        yield "status", status
 
 
 class GithubAssignIssueBlock(Block):
@@ -594,15 +576,12 @@ class GithubAssignIssueBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            status = self.assign_issue(
-                credentials,
-                input_data.issue_url,
-                input_data.assignee,
-            )
-            yield "status", status
-        except Exception as e:
-            yield "error", f"Failed to assign issue: {str(e)}"
+        status = self.assign_issue(
+            credentials,
+            input_data.issue_url,
+            input_data.assignee,
+        )
+        yield "status", status
 
 
 class GithubUnassignIssueBlock(Block):
@@ -676,12 +655,9 @@ class GithubUnassignIssueBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            status = self.unassign_issue(
-                credentials,
-                input_data.issue_url,
-                input_data.assignee,
-            )
-            yield "status", status
-        except Exception as e:
-            yield "error", f"Failed to unassign issue: {str(e)}"
+        status = self.unassign_issue(
+            credentials,
+            input_data.issue_url,
+            input_data.assignee,
+        )
+        yield "status", status

--- a/autogpt_platform/backend/backend/blocks/github/repo.py
+++ b/autogpt_platform/backend/backend/blocks/github/repo.py
@@ -96,14 +96,11 @@ class GithubListTagsBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            tags = self.list_tags(
-                credentials,
-                input_data.repo_url,
-            )
-            yield from (("tag", tag) for tag in tags)
-        except Exception as e:
-            yield "error", f"Failed to list tags: {str(e)}"
+        tags = self.list_tags(
+            credentials,
+            input_data.repo_url,
+        )
+        yield from (("tag", tag) for tag in tags)
 
 
 class GithubListBranchesBlock(Block):
@@ -183,14 +180,11 @@ class GithubListBranchesBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            branches = self.list_branches(
-                credentials,
-                input_data.repo_url,
-            )
-            yield from (("branch", branch) for branch in branches)
-        except Exception as e:
-            yield "error", f"Failed to list branches: {str(e)}"
+        branches = self.list_branches(
+            credentials,
+            input_data.repo_url,
+        )
+        yield from (("branch", branch) for branch in branches)
 
 
 class GithubListDiscussionsBlock(Block):
@@ -294,13 +288,10 @@ class GithubListDiscussionsBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            discussions = self.list_discussions(
-                credentials, input_data.repo_url, input_data.num_discussions
-            )
-            yield from (("discussion", discussion) for discussion in discussions)
-        except Exception as e:
-            yield "error", f"Failed to list discussions: {str(e)}"
+        discussions = self.list_discussions(
+            credentials, input_data.repo_url, input_data.num_discussions
+        )
+        yield from (("discussion", discussion) for discussion in discussions)
 
 
 class GithubListReleasesBlock(Block):
@@ -381,14 +372,11 @@ class GithubListReleasesBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            releases = self.list_releases(
-                credentials,
-                input_data.repo_url,
-            )
-            yield from (("release", release) for release in releases)
-        except Exception as e:
-            yield "error", f"Failed to list releases: {str(e)}"
+        releases = self.list_releases(
+            credentials,
+            input_data.repo_url,
+        )
+        yield from (("release", release) for release in releases)
 
 
 class GithubReadFileBlock(Block):
@@ -474,18 +462,15 @@ class GithubReadFileBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            raw_content, size = self.read_file(
-                credentials,
-                input_data.repo_url,
-                input_data.file_path.lstrip("/"),
-                input_data.branch,
-            )
-            yield "raw_content", raw_content
-            yield "text_content", base64.b64decode(raw_content).decode("utf-8")
-            yield "size", size
-        except Exception as e:
-            yield "error", f"Failed to read file: {str(e)}"
+        raw_content, size = self.read_file(
+            credentials,
+            input_data.repo_url,
+            input_data.file_path.lstrip("/"),
+            input_data.branch,
+        )
+        yield "raw_content", raw_content
+        yield "text_content", base64.b64decode(raw_content).decode("utf-8")
+        yield "size", size
 
 
 class GithubReadFolderBlock(Block):
@@ -612,17 +597,14 @@ class GithubReadFolderBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            files, dirs = self.read_folder(
-                credentials,
-                input_data.repo_url,
-                input_data.folder_path.lstrip("/"),
-                input_data.branch,
-            )
-            yield from (("file", file) for file in files)
-            yield from (("dir", dir) for dir in dirs)
-        except Exception as e:
-            yield "error", f"Failed to read folder: {str(e)}"
+        files, dirs = self.read_folder(
+            credentials,
+            input_data.repo_url,
+            input_data.folder_path.lstrip("/"),
+            input_data.branch,
+        )
+        yield from (("file", file) for file in files)
+        yield from (("dir", dir) for dir in dirs)
 
 
 class GithubMakeBranchBlock(Block):
@@ -703,16 +685,13 @@ class GithubMakeBranchBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            status = self.create_branch(
-                credentials,
-                input_data.repo_url,
-                input_data.new_branch,
-                input_data.source_branch,
-            )
-            yield "status", status
-        except Exception as e:
-            yield "error", f"Failed to create branch: {str(e)}"
+        status = self.create_branch(
+            credentials,
+            input_data.repo_url,
+            input_data.new_branch,
+            input_data.source_branch,
+        )
+        yield "status", status
 
 
 class GithubDeleteBranchBlock(Block):
@@ -775,12 +754,9 @@ class GithubDeleteBranchBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        try:
-            status = self.delete_branch(
-                credentials,
-                input_data.repo_url,
-                input_data.branch,
-            )
-            yield "status", status
-        except Exception as e:
-            yield "error", f"Failed to delete branch: {str(e)}"
+        status = self.delete_branch(
+            credentials,
+            input_data.repo_url,
+            input_data.branch,
+        )
+        yield "status", status

--- a/autogpt_platform/backend/backend/blocks/google/gmail.py
+++ b/autogpt_platform/backend/backend/blocks/google/gmail.py
@@ -104,16 +104,11 @@ class GmailReadBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = self._build_service(credentials, **kwargs)
-            messages = self._read_emails(
-                service, input_data.query, input_data.max_results
-            )
-            for email in messages:
-                yield "email", email
-            yield "emails", messages
-        except Exception as e:
-            yield "error", str(e)
+        service = self._build_service(credentials, **kwargs)
+        messages = self._read_emails(service, input_data.query, input_data.max_results)
+        for email in messages:
+            yield "email", email
+        yield "emails", messages
 
     @staticmethod
     def _build_service(credentials: GoogleCredentials, **kwargs):
@@ -267,14 +262,11 @@ class GmailSendBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = GmailReadBlock._build_service(credentials, **kwargs)
-            send_result = self._send_email(
-                service, input_data.to, input_data.subject, input_data.body
-            )
-            yield "result", send_result
-        except Exception as e:
-            yield "error", str(e)
+        service = GmailReadBlock._build_service(credentials, **kwargs)
+        send_result = self._send_email(
+            service, input_data.to, input_data.subject, input_data.body
+        )
+        yield "result", send_result
 
     def _send_email(self, service, to: str, subject: str, body: str) -> dict:
         if not to or not subject or not body:
@@ -342,12 +334,9 @@ class GmailListLabelsBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = GmailReadBlock._build_service(credentials, **kwargs)
-            labels = self._list_labels(service)
-            yield "result", labels
-        except Exception as e:
-            yield "error", str(e)
+        service = GmailReadBlock._build_service(credentials, **kwargs)
+        labels = self._list_labels(service)
+        yield "result", labels
 
     def _list_labels(self, service) -> list[dict]:
         results = service.users().labels().list(userId="me").execute()
@@ -406,14 +395,9 @@ class GmailAddLabelBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = GmailReadBlock._build_service(credentials, **kwargs)
-            result = self._add_label(
-                service, input_data.message_id, input_data.label_name
-            )
-            yield "result", result
-        except Exception as e:
-            yield "error", str(e)
+        service = GmailReadBlock._build_service(credentials, **kwargs)
+        result = self._add_label(service, input_data.message_id, input_data.label_name)
+        yield "result", result
 
     def _add_label(self, service, message_id: str, label_name: str) -> dict:
         label_id = self._get_or_create_label(service, label_name)
@@ -494,14 +478,11 @@ class GmailRemoveLabelBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = GmailReadBlock._build_service(credentials, **kwargs)
-            result = self._remove_label(
-                service, input_data.message_id, input_data.label_name
-            )
-            yield "result", result
-        except Exception as e:
-            yield "error", str(e)
+        service = GmailReadBlock._build_service(credentials, **kwargs)
+        result = self._remove_label(
+            service, input_data.message_id, input_data.label_name
+        )
+        yield "result", result
 
     def _remove_label(self, service, message_id: str, label_name: str) -> dict:
         label_id = self._get_label_id(service, label_name)

--- a/autogpt_platform/backend/backend/blocks/google/sheets.py
+++ b/autogpt_platform/backend/backend/blocks/google/sheets.py
@@ -68,14 +68,9 @@ class GoogleSheetsReadBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = self._build_service(credentials, **kwargs)
-            data = self._read_sheet(
-                service, input_data.spreadsheet_id, input_data.range
-            )
-            yield "result", data
-        except Exception as e:
-            yield "error", str(e)
+        service = self._build_service(credentials, **kwargs)
+        data = self._read_sheet(service, input_data.spreadsheet_id, input_data.range)
+        yield "result", data
 
     @staticmethod
     def _build_service(credentials: GoogleCredentials, **kwargs):
@@ -162,17 +157,14 @@ class GoogleSheetsWriteBlock(Block):
     def run(
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
-        try:
-            service = GoogleSheetsReadBlock._build_service(credentials, **kwargs)
-            result = self._write_sheet(
-                service,
-                input_data.spreadsheet_id,
-                input_data.range,
-                input_data.values,
-            )
-            yield "result", result
-        except Exception as e:
-            yield "error", str(e)
+        service = GoogleSheetsReadBlock._build_service(credentials, **kwargs)
+        result = self._write_sheet(
+            service,
+            input_data.spreadsheet_id,
+            input_data.range,
+            input_data.values,
+        )
+        yield "result", result
 
     def _write_sheet(
         self, service, spreadsheet_id: str, range: str, values: list[list[str]]

--- a/autogpt_platform/backend/backend/blocks/google_maps.py
+++ b/autogpt_platform/backend/backend/blocks/google_maps.py
@@ -82,17 +82,14 @@ class GoogleMapsSearchBlock(Block):
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        try:
-            places = self.search_places(
-                input_data.api_key.get_secret_value(),
-                input_data.query,
-                input_data.radius,
-                input_data.max_results,
-            )
-            for place in places:
-                yield "place", place
-        except Exception as e:
-            yield "error", str(e)
+        places = self.search_places(
+            input_data.api_key.get_secret_value(),
+            input_data.query,
+            input_data.radius,
+            input_data.max_results,
+        )
+        for place in places:
+            yield "place", place
 
     def search_places(self, api_key, query, radius, max_results):
         client = googlemaps.Client(key=api_key)

--- a/autogpt_platform/backend/backend/blocks/replicate_flux_advanced.py
+++ b/autogpt_platform/backend/backend/blocks/replicate_flux_advanced.py
@@ -139,24 +139,21 @@ class ReplicateFluxAdvancedModelBlock(Block):
         if seed is None:
             seed = int.from_bytes(os.urandom(4), "big")
 
-        try:
-            # Run the model using the provided inputs
-            result = self.run_model(
-                api_key=input_data.api_key.get_secret_value(),
-                model_name=input_data.replicate_model_name.api_name,
-                prompt=input_data.prompt,
-                seed=seed,
-                steps=input_data.steps,
-                guidance=input_data.guidance,
-                interval=input_data.interval,
-                aspect_ratio=input_data.aspect_ratio,
-                output_format=input_data.output_format,
-                output_quality=input_data.output_quality,
-                safety_tolerance=input_data.safety_tolerance,
-            )
-            yield "result", result
-        except Exception as e:
-            yield "error", str(e)
+        # Run the model using the provided inputs
+        result = self.run_model(
+            api_key=input_data.api_key.get_secret_value(),
+            model_name=input_data.replicate_model_name.api_name,
+            prompt=input_data.prompt,
+            seed=seed,
+            steps=input_data.steps,
+            guidance=input_data.guidance,
+            interval=input_data.interval,
+            aspect_ratio=input_data.aspect_ratio,
+            output_format=input_data.output_format,
+            output_quality=input_data.output_quality,
+            safety_tolerance=input_data.safety_tolerance,
+        )
+        yield "result", result
 
     def run_model(
         self,

--- a/autogpt_platform/backend/backend/blocks/text_to_speech_block.py
+++ b/autogpt_platform/backend/backend/blocks/text_to_speech_block.py
@@ -68,12 +68,9 @@ class UnrealTextToSpeechBlock(Block):
         return response.json()
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        try:
-            api_response = self.call_unreal_speech_api(
-                input_data.api_key.get_secret_value(),
-                input_data.text,
-                input_data.voice_id,
-            )
-            yield "mp3_url", api_response["OutputUri"]
-        except Exception as e:
-            yield "error", str(e)
+        api_response = self.call_unreal_speech_api(
+            input_data.api_key.get_secret_value(),
+            input_data.text,
+            input_data.voice_id,
+        )
+        yield "mp3_url", api_response["OutputUri"]

--- a/autogpt_platform/backend/backend/blocks/youtube.py
+++ b/autogpt_platform/backend/backend/blocks/youtube.py
@@ -64,14 +64,11 @@ class TranscribeYouTubeVideoBlock(Block):
         return YouTubeTranscriptApi.get_transcript(video_id)
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        try:
-            video_id = self.extract_video_id(input_data.youtube_url)
-            yield "video_id", video_id
+        video_id = self.extract_video_id(input_data.youtube_url)
+        yield "video_id", video_id
 
-            transcript = self.get_transcript(video_id)
-            formatter = TextFormatter()
-            transcript_text = formatter.format_transcript(transcript)
+        transcript = self.get_transcript(video_id)
+        formatter = TextFormatter()
+        transcript_text = formatter.format_transcript(transcript)
 
-            yield "transcript", transcript_text
-        except Exception as e:
-            yield "error", str(e)
+        yield "transcript", transcript_text

--- a/autogpt_platform/backend/backend/data/block.py
+++ b/autogpt_platform/backend/backend/data/block.py
@@ -272,6 +272,8 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
         for output_name, output_data in self.run(
             self.input_schema(**input_data), **kwargs
         ):
+            if output_name == "error":
+                raise RuntimeError(output_data)
             if error := self.output_schema.validate_field(output_name, output_data):
                 raise ValueError(f"Block produced an invalid output data: {error}")
             yield output_name, output_data

--- a/autogpt_platform/backend/backend/data/block.py
+++ b/autogpt_platform/backend/backend/data/block.py
@@ -272,8 +272,6 @@ class Block(ABC, Generic[BlockSchemaInputType, BlockSchemaOutputType]):
         for output_name, output_data in self.run(
             self.input_schema(**input_data), **kwargs
         ):
-            if "error" in output_name:
-                raise ValueError(output_data)
             if error := self.output_schema.validate_field(output_name, output_data):
                 raise ValueError(f"Block produced an invalid output data: {error}")
             yield output_name, output_data

--- a/docs/content/server/new_blocks.md
+++ b/docs/content/server/new_blocks.md
@@ -44,7 +44,7 @@ Follow these steps to create and test a new block:
 
     class Output(BlockSchema):
         summary: str  # The summary of the topic from Wikipedia
-        error: str  # Any error message if the request fails
+        error: str  # Any error message if the request fails, error field needs to be named `error`.
     ```
 
 4. **Implement the `__init__` method, including test data and mocks:**
@@ -95,17 +95,13 @@ Follow these steps to create and test a new block:
            yield "summary", response['extract']
 
        except requests.exceptions.HTTPError as http_err:
-           yield "error", f"HTTP error occurred: {http_err}"
-       except requests.RequestException as e:
-           yield "error", f"Request to Wikipedia failed: {e}"
-       except KeyError as e:
-           yield "error", f"Error parsing Wikipedia response: {e}"
+           raise RuntimeError(f"HTTP error occurred: {http_err}")
    ```
 
    - **Try block**: Contains the main logic to fetch and process the Wikipedia summary.
    - **API request**: Send a GET request to the Wikipedia API.
-   - **Error handling**: Handle various exceptions that might occur during the API request and data processing.
-   - **Yield**: Use `yield` to output the results. Prefer to output one result object at a time. If you are calling a function that returns a list, you can yield each item in the list separately. You can also yield the whole list as well, but do both rather than yielding the list. For example: If you were writing a block that outputs emails, you'd yield each email as a separate result object, but you could also yield the whole list as an additional single result object.
+   - **Error handling**: Handle various exceptions that might occur during the API request and data processing. We don't need to catch all exceptions, only the ones we expect and can handle. The uncaught exceptions will be automatically yielded as `error` in the output. Any block that raises an exception (or yields an `error` output) will be marked as failed. Prefer raising exceptions over yielding `error`, as it will stop the execution immediately.
+   - **Yield**: Use `yield` to output the results. Prefer to output one result object at a time. If you are calling a function that returns a list, you can yield each item in the list separately. You can also yield the whole list as well, but do both rather than yielding the list. For example: If you were writing a block that outputs emails, you'd yield each email as a separate result object, but you could also yield the whole list as an additional single result object. Yielding output named `error` will break the execution right away and mark the block execution as failed.
 
 ### Blocks with authentication
 


### PR DESCRIPTION
### Background

https://github.com/Significant-Gravitas/AutoGPT/pull/8267 revealed the inconsistency of the way we throw an error in the block implementation:
* Yielding `error` and abort
* Yielding `error` without aborting
* Raise an error

Any error happening in the block has already been yielding an `error`. So the simplest approach to produce an error is by simply raising it. This will mark the execution as failed. Manually yielding `error` without using an exception will be interpreted as a fully handled & completed execution.

### Changes 🏗️

* Remove all try-catch yield "error" in block implementation.
* Remove if output == "error": raise error logic on the block implementation.
* Add check to ensure all block `error` pin is a string, this will be used to expose execution error to other nodes, if needed.


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
