### PR TITLE
refactor(frontend/login): Hide sign in with Google/GitHub/Discord for now

### DIFF
--- a/autogpt_platform/frontend/src/app/login/page.tsx
+++ b/autogpt_platform/frontend/src/app/login/page.tsx
@@ -114,7 +114,7 @@ export default function LoginPage() {
   return (
     <div className="flex h-[80vh] items-center justify-center">
       <div className="w-full max-w-md space-y-6 rounded-lg p-8 shadow-md">
-        <div className="mb-6 space-y-2">
+        {/* <div className="mb-6 space-y-2">
           <Button
             className="w-full"
             onClick={() => handleSignInWithProvider("google")}
@@ -145,7 +145,7 @@ export default function LoginPage() {
             <FaDiscord className="mr-2 h-4 w-4" />
             Sign in with Discord
           </Button>
-        </div>
+        </div> */}
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onLogin)}>
             <FormField


### PR DESCRIPTION
### Background

This simply comments out the buttons for logging in with Google/GitHub/Discord for now
![image](https://github.com/user-attachments/assets/dd98c7a2-9e4d-4521-aafe-cc23b14160b8)

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
