### PR TITLE
feat(builder): Use configmap for builder

### DIFF
--- a/autogpt_platform/infra/helm/autogpt-builder/templates/deployment.yaml
+++ b/autogpt_platform/infra/helm/autogpt-builder/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "autogpt-builder.fullname" . }}-config
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
### Background

We were using .env.local previously. this won't work in ci and we shouldn't be using it anyways. 

### Changes 🏗️

Added configmap to deployment


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
