### PR TITLE
fix(infra): Update backend server health check endpoint

### DIFF
--- a/autogpt_platform/infra/helm/autogpt-server/values.dev.yaml
+++ b/autogpt_platform/infra/helm/autogpt-server/values.dev.yaml
@@ -58,7 +58,7 @@ resources:
 
 livenessProbe:
   httpGet:
-    path: /docs
+    path: /heath
     port: 8006
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -66,7 +66,7 @@ livenessProbe:
   failureThreshold: 6
 readinessProbe:
   httpGet:
-    path: /docs
+    path: /health
     port: 8006
   initialDelaySeconds: 30
   periodSeconds: 10

--- a/autogpt_platform/infra/helm/autogpt-server/values.prod.yaml
+++ b/autogpt_platform/infra/helm/autogpt-server/values.prod.yaml
@@ -72,7 +72,7 @@ cors:
 
 livenessProbe:
   httpGet:
-    path: /docs
+    path: /heath
     port: 8006
   initialDelaySeconds: 30
   periodSeconds: 10
@@ -80,7 +80,7 @@ livenessProbe:
   failureThreshold: 6
 readinessProbe:
   httpGet:
-    path: /docs
+    path: /heath
     port: 8006
   initialDelaySeconds: 30
   periodSeconds: 10


### PR DESCRIPTION
### Background

Removed docs endpoint. Should now use health endpoint

### Changes 🏗️

Changed /docs > /health in values.dev and values.prod for server


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
