### PR TITLE
ci: Enforce `dev` as base branch for development

### DIFF
--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -13,3 +13,5 @@ jobs:
         run: |
           gh pr comment ${{ github.event.number }} --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
           gh pr edit ${{ github.event.number }} --base dev
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -1,9 +1,9 @@
 name: Repo - Enforce dev as base branch
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
-    types: [ opened, synchronize ]
-# test
+    types: [ opened ]
+
 jobs:
   check_pr_target:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Check if PR is from dev or hotfix
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
         run: |
-          gh pr comment ${{ github.event.number }} --body "This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`."
+          gh pr comment ${{ github.event.number }} --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
           gh pr edit ${{ github.event.number }} --base dev

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check if PR is from dev or hotfix
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
         run: |
-          gh repo set-default ${{ github.repository.full_name }}
+          gh repo set-default ${{ github.repository }}
           gh pr comment ${{ github.event.number }} --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
           gh pr edit ${{ github.event.number }} --base dev
         env:

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -1,16 +1,19 @@
 name: Repo - Enforce dev as base branch
 on:
-  pull_request:
+  pull_request_target:
     branches: [ master ]
     types: [ opened, synchronize ]
 
 jobs:
   check_pr_target:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check if PR is from dev or hotfix
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
         run: |
+          gh repo set-default ${{ github.repository.full_name }}
           gh pr comment ${{ github.event.number }} --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
           gh pr edit ${{ github.event.number }} --base dev
         env:

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -1,0 +1,15 @@
+name: Repo - Enforce dev as base branch
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened ]
+
+jobs:
+  check_pr_target:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from dev or hotfix
+        if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
+        run: |
+          gh pr comment ${{ github.event.number }} --body "This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`."
+          gh pr edit ${{ github.event.number }} --base dev

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -1,6 +1,6 @@
 name: Repo - Enforce dev as base branch
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
     types: [ opened, synchronize ]
 

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize ]
-# test
+
 jobs:
   check_pr_target:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
         run: |
           gh pr comment ${{ github.event.number }} --repo "$REPO" \
-            --body "This PR targets the \`master\` branch but does not come from \`dev\` or a \`hotfix/*\` branch.\n\nAutomatically setting the base branch to \`dev\`."
+            --body $'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
           gh pr edit ${{ github.event.number }} --base dev --repo "$REPO"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -2,7 +2,7 @@ name: Repo - Enforce dev as base branch
 on:
   pull_request:
     branches: [ master ]
-    types: [ opened ]
+    types: [ opened, synchronize ]
 
 jobs:
   check_pr_target:

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -13,8 +13,9 @@ jobs:
       - name: Check if PR is from dev or hotfix
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
         run: |
-          gh repo set-default ${{ github.repository }}
-          gh pr comment ${{ github.event.number }} --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
-          gh pr edit ${{ github.event.number }} --base dev
+          gh pr comment ${{ github.event.number }} --repo "$REPO" \
+            --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
+          gh pr edit ${{ github.event.number }} --base dev --repo "$REPO"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -14,7 +14,7 @@ jobs:
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}
         run: |
           gh pr comment ${{ github.event.number }} --repo "$REPO" \
-            --body 'This PR targets the `master` branch but does not come from `dev` or a `hotfix/*` branch.\n\nAutomatically setting the base branch to `dev`.'
+            --body "This PR targets the \`master\` branch but does not come from \`dev\` or a \`hotfix/*\` branch.\n\nAutomatically setting the base branch to \`dev\`."
           gh pr edit ${{ github.event.number }} --base dev --repo "$REPO"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -8,7 +8,7 @@ jobs:
   check_pr_target:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       - name: Check if PR is from dev or hotfix
         if: ${{ !(startsWith(github.event.pull_request.head.ref, 'hotfix/') || github.event.pull_request.head.ref == 'dev') }}

--- a/.github/workflows/repo-pr-enforce-base-branch.yml
+++ b/.github/workflows/repo-pr-enforce-base-branch.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize ]
-
+# test
 jobs:
   check_pr_target:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to keep `master` as the default branch for easy and safe cloning, but `dev` as the target for all pull requests.

### Changes 🏗️

- ci: Add a workflow that automatically changes PRs' target branch from `master` to `dev` unless the head branch is `dev` or `hotfix/*`