### PR TITLE
fix(dockercompose): Fix db manager connection

### DIFF
--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -103,6 +103,7 @@ services:
       - ENABLE_AUTH=true
       - PYRO_HOST=0.0.0.0
       - AGENTSERVER_HOST=rest_server
+      - DATABASEMANAGER_HOST=0.0.0.0
     ports:
       - "8002:8000"
     networks:


### PR DESCRIPTION
### Background
DB manager was added https://github.com/Significant-Gravitas/AutoGPT/commit/6f07d24e9303ec496f12fc281f1d45d32f2f3c0d#diff-9f50c422480771c499000baff849597248109048f6277e0381fe973e494a30eb

and the db manager runs on 0.0.0.0 and we were trying to connect on localhost

### Changes 🏗️

Added DATABASEMANAGER_HOST=0.0.0.0


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
