### PR TITLE
feat(blocks): fix output divider bar being in the wrong place

### DIFF
--- a/autogpt_platform/frontend/src/components/NodeOutputs.tsx
+++ b/autogpt_platform/frontend/src/components/NodeOutputs.tsx
@@ -23,7 +23,6 @@ export default function NodeOutputs({
             <strong className="mr-2">Pin:</strong>
             <span>{beautifyString(pin)}</span>
           </div>
-          <Separator.Root className="my-4 h-[1px] bg-gray-300" />
           <div className="mt-2">
             <strong className="mr-2">Data:</strong>
             <div className="mt-1">
@@ -37,6 +36,7 @@ export default function NodeOutputs({
                 </React.Fragment>
               ))}
             </div>
+            <Separator.Root className="my-4 h-[1px] bg-gray-300" />
           </div>
         </div>
       ))}


### PR DESCRIPTION
### Background

This just fixes the output as before it looked like this where the divider bar is in the wrong place
![image](https://github.com/user-attachments/assets/75b35712-1fe7-48dc-aa38-febd0d6722b3)

this simply fixes it so it now looks like
![image](https://github.com/user-attachments/assets/b33a036e-7a29-4908-8146-0543c8b6c5bb)