### PR TITLE
fix(platform/dockercompose): Put removed services back in

### DIFF
--- a/autogpt_platform/docker-compose.yml
+++ b/autogpt_platform/docker-compose.yml
@@ -96,6 +96,37 @@ services:
       file: ./supabase/docker/docker-compose.yml
       service: rest
 
+
+  realtime:
+    <<: *supabase-services
+    extends:
+      file: ./supabase/docker/docker-compose.yml
+      service: realtime
+
+  storage:
+    <<: *supabase-services
+    extends:
+      file: ./supabase/docker/docker-compose.yml
+      service: storage
+
+  imgproxy:
+    <<: *supabase-services
+    extends:
+      file: ./supabase/docker/docker-compose.yml
+      service: imgproxy
+
+  meta:
+    <<: *supabase-services
+    extends:
+      file: ./supabase/docker/docker-compose.yml
+      service: meta
+
+  functions:
+    <<: *supabase-services
+    extends:
+      file: ./supabase/docker/docker-compose.yml
+      service: functions
+
   analytics:
     <<: *supabase-services
     extends:


### PR DESCRIPTION
### Background

We removed a bunch of supabase services https://github.com/Significant-Gravitas/AutoGPT/pull/8178/files?diff=split&w=0#diff-c0568dde0d708d2b1345af548966c8eaa96fec5d35016f1c173944f577af6085

but this seems to break more than fix. 

### Changes 🏗️

Put them all back in


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
