### PR TITLE
Implement custom save shortcut in SaveControl component

### DIFF
--- a/autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 import {
   Popover,
   PopoverContent,
@@ -15,6 +15,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useToast } from "@/components/ui/use-toast";
 
 interface SaveControlProps {
   agentMeta: GraphMeta | null;
@@ -52,13 +53,34 @@ export const SaveControl = ({
 
   // Determines if we're saving a template or an agent
   let isTemplate = agentMeta?.is_template ? true : undefined;
-  const handleSave = () => {
+  const handleSave = useCallback(() => {
     onSave(isTemplate);
-  };
+  }, [onSave, isTemplate]);
 
   const getType = () => {
     return agentMeta?.is_template ? "template" : "agent";
   };
+
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+        event.preventDefault(); // Stop the browser default action
+        handleSave(); // Call your save function
+        toast({
+          duration: 2000,
+          title: "All changes saved successfully..!!",
+        });
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleSave]);
 
   return (
     <Popover open={pinSavePopover ? true : undefined}>

--- a/autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx
@@ -70,7 +70,7 @@ export const SaveControl = ({
         handleSave(); // Call your save function
         toast({
           duration: 2000,
-          title: "All changes saved successfully..!!",
+          title: "All changes saved successfully!",
         });
       }
     };


### PR DESCRIPTION
### Enhance #8329 

This update stops the browser from showing its usual save page pop-up when you press Ctrl/Cmd + S. Instead, it now saves your work in the application, making it easier and quicker to use.

### Changes 🏗️

1. Now,pressing Ctrl/Cmd + S saves changes directly in the app instead of triggering the browser’s save page dialog.

2. A toast notification confirms successful saves,