### PR TITLE
fix(platform): Expose DB Manager Port

### DIFF
--- a/autogpt_platform/infra/helm/autogpt-server/templates/deployment-executor.yaml
+++ b/autogpt_platform/infra/helm/autogpt-server/templates/deployment-executor.yaml
@@ -46,6 +46,9 @@ spec:
             - name: http
               containerPort: {{ .Values.serviceExecutor.port }}
               protocol: TCP
+            - name: db-http
+              containerPort: {{ .Values.serviceDBManager.port }}
+              protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/autogpt_platform/infra/helm/autogpt-server/templates/service-executor.yaml
+++ b/autogpt_platform/infra/helm/autogpt-server/templates/service-executor.yaml
@@ -15,5 +15,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.serviceDBManager.port }}
+      targetPort: db-http
+      protocol: TCP
+      name: db-http
   selector:
     app.kubernetes.io/component: executor

--- a/autogpt_platform/infra/helm/autogpt-server/values.dev.yaml
+++ b/autogpt_platform/infra/helm/autogpt-server/values.dev.yaml
@@ -25,6 +25,13 @@ serviceExecutor:
   annotations:
     beta.cloud.google.com/backend-config: '{"default": "autogpt-server-backend-config"}'
 
+serviceDBManager:
+  type: ClusterIP
+  port: 8005
+  targetPort: 8005
+  annotations:
+    beta.cloud.google.com/backend-config: '{"default": "autogpt-server-backend-config"}'
+
 ingress:
   enabled: true
   className: "gce"

--- a/autogpt_platform/infra/helm/autogpt-server/values.prod.yaml
+++ b/autogpt_platform/infra/helm/autogpt-server/values.prod.yaml
@@ -25,6 +25,13 @@ serviceExecutor:
   annotations:
     beta.cloud.google.com/backend-config: '{"default": "autogpt-server-backend-config"}'
 
+serviceDBManager:
+  type: ClusterIP
+  port: 8005
+  targetPort: 8005
+  annotations:
+    beta.cloud.google.com/backend-config: '{"default": "autogpt-server-backend-config"}'
+
 ingress:
   enabled: true
   className: "gce"


### PR DESCRIPTION
### Background

A change was made so that the rest server now uses the DB Manager inside of executor. So we have to expose that port for use

### Changes 🏗️

Expose port 8005 on the deployment and service


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly
