### PR TITLE
feat(platform/frontend) Remove dotenv

### DIFF
--- a/autogpt_platform/frontend/next.config.mjs
+++ b/autogpt_platform/frontend/next.config.mjs
@@ -1,16 +1,7 @@
 import { withSentryConfig } from "@sentry/nextjs";
-import dotenv from "dotenv";
-
-// Load environment variables
-dotenv.config();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  env: {
-    NEXT_PUBLIC_AGPT_SERVER_URL: process.env.NEXT_PUBLIC_AGPT_SERVER_URL,
-    NEXT_PUBLIC_AGPT_MARKETPLACE_URL:
-      process.env.NEXT_PUBLIC_AGPT_MARKETPLACE_URL,
-  },
   images: {
     domains: ["images.unsplash.com"],
   },


### PR DESCRIPTION
### Background

dontenv loads environment variables only from environment variable files and it's messing with docker and k8s environments when not adding these files dynamically

### Changes 🏗️

Remove dotenv and let nextjs handle environment variabels. This still loads from .env* files locally and in different environments but also from system environment when needed. You can read here: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly

### Configuration Changes 📝
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

If you're making configuration or infrastructure changes, please remember to check you've updated the related infrastructure code in the autogpt_platform/infra folder.

Examples of such changes might include: 

- Changing ports
- Adding new services that need to communicate with each other
- Secrets or environment variable changes
- New or infrastructure changes such as databases
