### PR TITLE
feat(frontend): Make `Save to Templates` Marketplace button create and redirect to a new agent

### DIFF
--- a/autogpt_platform/frontend/src/components/marketplace/AgentDetailContent.tsx
+++ b/autogpt_platform/frontend/src/components/marketplace/AgentDetailContent.tsx
@@ -10,76 +10,93 @@ import MarketplaceAPI from "@/lib/marketplace-api";
 import AutoGPTServerAPI, { GraphCreatable } from "@/lib/autogpt-server-api";
 import "@xyflow/react/dist/style.css";
 import { makeAnalyticsEvent } from "./actions";
-
-async function downloadAgent(id: string): Promise<void> {
-  const api = new MarketplaceAPI();
-  try {
-    const file = await api.downloadAgentFile(id);
-    console.debug(`Agent file downloaded:`, file);
-
-    // Create a Blob from the file content
-    const blob = new Blob([file], { type: "application/json" });
-
-    // Create a temporary URL for the Blob
-    const url = window.URL.createObjectURL(blob);
-
-    // Create a temporary anchor element
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `agent_${id}.json`; // Set the filename
-
-    // Append the anchor to the body, click it, and remove it
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-
-    // Revoke the temporary URL
-    window.URL.revokeObjectURL(url);
-  } catch (error) {
-    console.error(`Error downloading agent:`, error);
-    throw error;
-  }
-}
-
-async function installGraph(id: string): Promise<void> {
-  const apiUrl =
-    process.env.NEXT_PUBLIC_AGPT_MARKETPLACE_URL ||
-    "http://localhost:8015/api/v1/market";
-  const api = new MarketplaceAPI(apiUrl);
-
-  const serverAPIUrl = process.env.NEXT_PUBLIC_AGPT_SERVER_API_URL;
-  const serverAPI = new AutoGPTServerAPI(serverAPIUrl);
-  try {
-    console.debug(`Installing agent with id: ${id}`);
-    let agent = await api.downloadAgent(id);
-    console.debug(`Agent downloaded:`, agent);
-    const data: GraphCreatable = {
-      id: agent.id,
-      version: agent.version,
-      is_active: true,
-      is_template: false,
-      name: agent.name,
-      description: agent.description,
-      nodes: agent.graph.nodes,
-      links: agent.graph.links,
-    };
-    const result = await serverAPI.createTemplate(data);
-    makeAnalyticsEvent({
-      event_name: "agent_installed_from_marketplace",
-      event_data: {
-        marketplace_agent_id: id,
-        installed_agent_id: result.id,
-        installation_location: InstallationLocation.CLOUD,
-      },
-    });
-    console.debug(`Agent installed successfully`, result);
-  } catch (error) {
-    console.error(`Error installing agent:`, error);
-    throw error;
-  }
-}
+import { useToast } from "../ui/use-toast";
 
 function AgentDetailContent({ agent }: { agent: AgentDetailResponse }) {
+  const { toast } = useToast();
+
+  const downloadAgent = async (id: string): Promise<void> => {
+    const api = new MarketplaceAPI();
+    try {
+      const file = await api.downloadAgentFile(id);
+      console.debug(`Agent file downloaded:`, file);
+  
+      // Create a Blob from the file content
+      const blob = new Blob([file], { type: "application/json" });
+  
+      // Create a temporary URL for the Blob
+      const url = window.URL.createObjectURL(blob);
+  
+      // Create a temporary anchor element
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `agent_${id}.json`; // Set the filename
+  
+      // Append the anchor to the body, click it, and remove it
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+  
+      // Revoke the temporary URL
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error(`Error downloading agent:`, error);
+      throw error;
+    }
+  }
+  
+  const installGraph = async (id: string): Promise<void> => {
+    toast({
+      title: "Saving and opening a new agent...",
+      duration: 2000,
+    })
+    const apiUrl =
+      process.env.NEXT_PUBLIC_AGPT_MARKETPLACE_URL ||
+      "http://localhost:8015/api/v1/market";
+    const api = new MarketplaceAPI(apiUrl);
+  
+    const serverAPIUrl = process.env.NEXT_PUBLIC_AGPT_SERVER_API_URL;
+    const serverAPI = new AutoGPTServerAPI(serverAPIUrl);
+    try {
+      console.debug(`Installing agent with id: ${id}`);
+      let agent = await api.downloadAgent(id);
+      console.debug(`Agent downloaded:`, agent);
+      const data: GraphCreatable = {
+        id: agent.id,
+        version: agent.version,
+        is_active: true,
+        is_template: false,
+        name: agent.name,
+        description: agent.description,
+        nodes: agent.graph.nodes,
+        links: agent.graph.links,
+      };
+      const result = await serverAPI.createTemplate(data);
+      makeAnalyticsEvent({
+        event_name: "agent_installed_from_marketplace",
+        event_data: {
+          marketplace_agent_id: id,
+          installed_agent_id: result.id,
+          installation_location: InstallationLocation.CLOUD,
+        },
+      });
+      console.debug(`Agent installed successfully`, result);
+      serverAPI
+        .createGraph(agent.id, agent.version)
+        .then((newGraph) => {
+          window.location.href = `/build?flowID=${newGraph.id}`;
+        });
+    } catch (error) {
+      console.error(`Error installing agent:`, error);
+      toast({
+        title: "Error saving template",
+        variant: "destructive",
+        duration: 2000,
+      })
+      throw error;
+    }
+  }
+  
   return (
     <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
       <div className="mb-4 flex items-center justify-between">

--- a/autogpt_platform/frontend/src/components/marketplace/AgentDetailContent.tsx
+++ b/autogpt_platform/frontend/src/components/marketplace/AgentDetailContent.tsx
@@ -81,7 +81,7 @@ function AgentDetailContent({ agent }: { agent: AgentDetailResponse }) {
         },
       });
       console.debug(`Agent installed successfully`, result);
-      serverAPI.createGraph(agent.id, agent.version).then((newGraph) => {
+      serverAPI.createGraph(result.id, agent.version).then((newGraph) => {
         window.location.href = `/build?flowID=${newGraph.id}`;
       });
     } catch (error) {

--- a/autogpt_platform/frontend/src/components/marketplace/AgentDetailContent.tsx
+++ b/autogpt_platform/frontend/src/components/marketplace/AgentDetailContent.tsx
@@ -20,41 +20,41 @@ function AgentDetailContent({ agent }: { agent: AgentDetailResponse }) {
     try {
       const file = await api.downloadAgentFile(id);
       console.debug(`Agent file downloaded:`, file);
-  
+
       // Create a Blob from the file content
       const blob = new Blob([file], { type: "application/json" });
-  
+
       // Create a temporary URL for the Blob
       const url = window.URL.createObjectURL(blob);
-  
+
       // Create a temporary anchor element
       const a = document.createElement("a");
       a.href = url;
       a.download = `agent_${id}.json`; // Set the filename
-  
+
       // Append the anchor to the body, click it, and remove it
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
-  
+
       // Revoke the temporary URL
       window.URL.revokeObjectURL(url);
     } catch (error) {
       console.error(`Error downloading agent:`, error);
       throw error;
     }
-  }
-  
+  };
+
   const installGraph = async (id: string): Promise<void> => {
     toast({
       title: "Saving and opening a new agent...",
       duration: 2000,
-    })
+    });
     const apiUrl =
       process.env.NEXT_PUBLIC_AGPT_MARKETPLACE_URL ||
       "http://localhost:8015/api/v1/market";
     const api = new MarketplaceAPI(apiUrl);
-  
+
     const serverAPIUrl = process.env.NEXT_PUBLIC_AGPT_SERVER_API_URL;
     const serverAPI = new AutoGPTServerAPI(serverAPIUrl);
     try {
@@ -81,22 +81,20 @@ function AgentDetailContent({ agent }: { agent: AgentDetailResponse }) {
         },
       });
       console.debug(`Agent installed successfully`, result);
-      serverAPI
-        .createGraph(agent.id, agent.version)
-        .then((newGraph) => {
-          window.location.href = `/build?flowID=${newGraph.id}`;
-        });
+      serverAPI.createGraph(agent.id, agent.version).then((newGraph) => {
+        window.location.href = `/build?flowID=${newGraph.id}`;
+      });
     } catch (error) {
       console.error(`Error installing agent:`, error);
       toast({
         title: "Error saving template",
         variant: "destructive",
         duration: 2000,
-      })
+      });
       throw error;
     }
-  }
-  
+  };
+
   return (
     <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
       <div className="mb-4 flex items-center justify-between">


### PR DESCRIPTION
### Background

Currently clicking "Save to Templates" on a template page provides no visual feedback and doesn't do anything.

### Changes 🏗️

- Create and redirect to a new agent instance when clicking on the `Save to Templates` button
- Show toast as a visual feedback when clicking button and on error


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly

### Configuration Changes 📝
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

If you're making configuration or infrastructure changes, please remember to check you've updated the related infrastructure code in the autogpt_platform/infra folder.

Examples of such changes might include: 

- Changing ports
- Adding new services that need to communicate with each other
- Secrets or environment variable changes
- New or infrastructure changes such as databases
