### PR TITLE
feat(backend): Reduce number of services on the local mode

### DIFF
--- a/autogpt_platform/docker-compose.yml
+++ b/autogpt_platform/docker-compose.yml
@@ -150,15 +150,8 @@ services:
     image: busybox
     command: /bin/true
     depends_on:
-      - studio
       - kong
       - auth
-      - rest
-      - realtime
-      - storage
-      - imgproxy
-      - meta
-      - functions
       - analytics
       - db
       - vector


### PR DESCRIPTION
### Background

This PR adopted https://github.com/Significant-Gravitas/AutoGPT/pull/8561 changes for the local mode to reduce the number of services being run for local development.

### Changes 🏗️

Removed these supabase services on local app out-of-docker mode:
     - studio
      - rest
      - realtime
      - storage
      - imgproxy
      - meta
      - functions


### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly

### Configuration Changes 📝
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

If you're making configuration or infrastructure changes, please remember to check you've updated the related infrastructure code in the autogpt_platform/infra folder.

Examples of such changes might include: 

- Changing ports
- Adding new services that need to communicate with each other
- Secrets or environment variable changes
- New or infrastructure changes such as databases
