### PR TITLE
fix(frontend): Broken UI caused by lack of error propagation on Run

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -626,10 +626,13 @@ export function CustomNode({
 
         <div className="flex w-full flex-col">
           <div className="flex flex-row items-center justify-between">
-            <div className="font-roboto px-3 text-lg font-semibold">
+            <div className="font-roboto flex items-center px-3 text-lg font-semibold">
               {beautifyString(
                 data.blockType?.replace(/Block$/, "") || data.title,
               )}
+              <div className="px-2 text-xs text-gray-500">
+                #{id.split("-")[0]}
+              </div>
             </div>
           </div>
           {blockCost && (

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -352,9 +352,14 @@ const NodeKeyValueInput: FC<{
     const defaultEntries = new Map(
       Object.entries(entries ?? schema.default ?? {}),
     );
+    const prefix = `${selfKey}_#_`;
+    connections
+      .filter((c) => c.targetHandle.startsWith(prefix) && c.target === nodeId)
+      .map((c) => c.targetHandle.slice(prefix.length))
+      .forEach((k) => !defaultEntries.has(k) && defaultEntries.set(k, ""));
 
     return Array.from(defaultEntries, ([key, value]) => ({ key, value }));
-  }, [entries, schema.default]);
+  }, [entries, schema.default, connections, nodeId, selfKey]);
 
   const [keyValuePairs, setKeyValuePairs] = useState<
     { key: string; value: string | number | null }[]
@@ -497,6 +502,18 @@ const NodeArrayInput: FC<{
   displayName,
 }) => {
   entries ??= schema.default ?? [];
+
+  const prefix = `${selfKey}_$_`;
+  connections
+    .filter((c) => c.targetHandle.startsWith(prefix) && c.target === nodeId)
+    .map((c) => parseInt(c.targetHandle.slice(prefix.length)))
+    .filter((c) => !isNaN(c))
+    .forEach(
+      (c) =>
+        entries.length <= c &&
+        entries.push(...Array(c - entries.length + 1).fill("")),
+    );
+
   const isItemObject = "items" in schema && "properties" in schema.items!;
   const error =
     typeof errors[selfKey] === "string" ? errors[selfKey] : undefined;

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
@@ -487,7 +487,16 @@ export default function useAgentGraph(
               },
             );
           })
-          .catch(() => setSaveRunRequest({ request: "run", state: "error" }));
+          .catch((error) => {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error);
+            toast({
+              variant: "destructive",
+              title: "Error saving agent",
+              description: errorMessage,
+            });
+            setSaveRunRequest({ request: "run", state: "error" });
+          });
 
         processedUpdates.current = processedUpdates.current = [];
       }
@@ -510,6 +519,7 @@ export default function useAgentGraph(
     }
   }, [
     api,
+    toast,
     saveRunRequest,
     savedAgent,
     nodesSyncedWithSavedAgent,
@@ -590,8 +600,7 @@ export default function useAgentGraph(
     [availableNodes],
   );
 
-  const _saveAgent = (
-    () =>
+  const _saveAgent = useCallback(
     async (asTemplate: boolean = false) => {
       //FIXME frontend ids should be resolved better (e.g. returned from the server)
       // currently this relays on block_id and position
@@ -745,8 +754,20 @@ export default function useAgentGraph(
           },
         }));
       });
-    }
-  )();
+    },
+    [
+      api,
+      nodes,
+      edges,
+      pathname,
+      router,
+      searchParams,
+      savedAgent,
+      agentName,
+      agentDescription,
+      prepareNodeInputData,
+    ],
+  );
 
   const saveAgent = useCallback(
     async (asTemplate: boolean = false) => {
@@ -763,18 +784,7 @@ export default function useAgentGraph(
         });
       }
     },
-    [
-      api,
-      nodes,
-      edges,
-      pathname,
-      router,
-      searchParams,
-      savedAgent,
-      agentName,
-      agentDescription,
-      prepareNodeInputData,
-    ],
+    [_saveAgent, toast],
   );
 
   const requestSave = useCallback(


### PR DESCRIPTION
### Background

A few errors are being fixed here:
* https://github.com/Significant-Gravitas/AutoGPT/pull/8252 re-introduced bug on dynamic-pin to not populate links on the field with empty values.
* `Run` execution error is not propagated to the user.
* Agent Output & Agent Input validation is now checked during creation (as opposed to execution), but the input_link validation is buggy on the non-created graph.

### Changes 🏗️

Fixed the above issues (and display a short id on the node): 
![image](https://github.com/user-attachments/assets/8d34a851-8543-4f50-9324-c070736fb044)



### Testing 🔍
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

<!--
Please make sure your changes have been tested and are in good working condition. 
Here is a list of our critical paths, if you need some inspiration on what and how to test:
-->

- Create from scratch and execute an agent with at least 3 blocks
- Import an agent from file upload, and confirm it executes correctly
- Upload agent to marketplace
- Import an agent from marketplace and confirm it executes correctly
- Edit an agent from monitor, and confirm it executes correctly

### Configuration Changes 📝
> [!NOTE] 
Only for the new autogpt platform, currently in autogpt_platform/

If you're making configuration or infrastructure changes, please remember to check you've updated the related infrastructure code in the autogpt_platform/infra folder.

Examples of such changes might include: 

- Changing ports
- Adding new services that need to communicate with each other
- Secrets or environment variable changes
- New or infrastructure changes such as databases
