### PR TITLE
feat(blocks/jina): Add default credentials for Jina

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/supabase_integration_credentials_store/store.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/supabase_integration_credentials_store/store.py
@@ -72,6 +72,14 @@ did_credentials = APIKeyCredentials(
     title="Use Credits for D-ID",
     expires_at=None,
 )
+jina_credentials = APIKeyCredentials(
+    id="7f26de70-ba0d-494e-ba76-238e65e7b45f",
+    provider="jina",
+    api_key=SecretStr(settings.secrets.jina_api_key),
+    title="Use Credits for Jina",
+    expires_at=None,
+)
+
 
 DEFAULT_CREDENTIALS = [
     revid_credentials,
@@ -81,6 +89,7 @@ DEFAULT_CREDENTIALS = [
     anthropic_credentials,
     groq_credentials,
     did_credentials,
+    jina_credentials,
 ]
 
 
@@ -124,6 +133,8 @@ class SupabaseIntegrationCredentialsStore:
             all_credentials.append(anthropic_credentials)
         if settings.secrets.did_api_key:
             all_credentials.append(did_credentials)
+        if settings.secrets.jina_api_key:
+            all_credentials.append(jina_credentials)
         return all_credentials
 
     def get_creds_by_id(self, user_id: str, credentials_id: str) -> Credentials | None:

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -9,6 +9,7 @@ from autogpt_libs.supabase_integration_credentials_store.store import (
     did_credentials,
     groq_credentials,
     ideogram_credentials,
+    jina_credentials,
     openai_credentials,
     replicate_credentials,
     revid_credentials,
@@ -144,7 +145,18 @@ BLOCK_COSTS: dict[Type[Block], list[BlockCost]] = {
             },
         )
     ],
-    SearchTheWebBlock: [BlockCost(cost_amount=1)],
+    SearchTheWebBlock: [
+        BlockCost(
+            cost_amount=1,
+            cost_filter={
+                "credentials": {
+                    "id": jina_credentials.id,
+                    "provider": jina_credentials.provider,
+                    "type": jina_credentials.type,
+                }
+            },
+        )
+    ],
     ExtractWebsiteContentBlock: [
         BlockCost(cost_amount=1, cost_filter={"raw_content": False})
     ],

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -266,6 +266,7 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     replicate_api_key: str = Field(default="", description="Replicate API Key")
     unreal_speech_api_key: str = Field(default="", description="Unreal Speech API Key")
     ideogram_api_key: str = Field(default="", description="Ideogram API Key")
+    jina_api_key: str = Field(default="", description="Jina API Key")
 
     # Add more secret fields as needed
 


### PR DESCRIPTION
We want to provide jina by default on our platform

### Changes 🏗️

Added Jina credentials to all the default settings in store.py. 
Added a jina cost filter in credit.py

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
