### PR TITLE
fix(classic): update docs for security deprecation 

### DIFF
--- a/classic/README.md
+++ b/classic/README.md
@@ -54,7 +54,7 @@ This project segment is licensed under the MIT License - see the [LICENSE](LICEN
 
 ## Documentation
 
-Please refer to the [documentation] (https://docs.agpt.co) for more detailed information about the project's architecture and concepts.
+Please refer to the [documentation](https://docs.agpt.co) for more detailed information about the project's architecture and concepts.
 You can browse at the same point in time as this commit so the docs don't change.
 
 ## Historical Impact

--- a/classic/README.md
+++ b/classic/README.md
@@ -1,6 +1,6 @@
-# AutoGPT
+# AutoGPT Classic
 
-AutoGPT is an experimental project that demonstrates autonomous GPT-4 operation. It was designed to make GPT-4 independently operate and chain together tasks to achieve more complex goals.
+AutoGPT Classic was an experimental project to demonstrate autonomous GPT-4 operation. It was designed to make GPT-4 independently operate and chain together tasks to achieve more complex goals.
 
 ## Project Status
 
@@ -10,7 +10,7 @@ For those interested in autonomous AI agents, we recommend exploring more active
 
 ## Overview
 
-AutoGPT was one of the first implementations of autonomous AI agents - AI systems that can independently:
+AutoGPT Classic was one of the first implementations of autonomous AI agents - AI systems that can independently:
 - Break down complex goals into smaller tasks
 - Execute those tasks using available tools and APIs
 - Learn from the results and adjust its approach
@@ -59,7 +59,7 @@ You can browse at the same point in time as this commit so the docs don't change
 
 ## Historical Impact
 
-AutoGPT played a significant role in advancing the field of autonomous AI agents:
+AutoGPT Classic played a significant role in advancing the field of autonomous AI agents:
 - Demonstrated practical implementation of AI autonomy
 - Inspired numerous derivative projects and research
 - Contributed to the development of AI agent architectures

--- a/classic/README.md
+++ b/classic/README.md
@@ -1,0 +1,81 @@
+# AutoGPT
+
+AutoGPT is an experimental project that demonstrates autonomous GPT-4 operation. It was designed to make GPT-4 independently operate and chain together tasks to achieve more complex goals.
+
+## Project Status
+
+⚠️ **This project is unsupported, and dependencies will not be updated. It was an experiment that has concluded its initial research phase. If you want to use AutoGPT, you should use the [AutoGPT Platform](/autogpt_platform)**
+
+For those interested in autonomous AI agents, we recommend exploring more actively maintained alternatives or referring to this codebase for educational purposes only.
+
+## Overview
+
+AutoGPT was one of the first implementations of autonomous AI agents - AI systems that can independently:
+- Break down complex goals into smaller tasks
+- Execute those tasks using available tools and APIs
+- Learn from the results and adjust its approach
+- Chain multiple actions together to achieve an objective
+
+## Key Features
+
+- 🔄 Autonomous task chaining
+- 🛠 Tool and API integration capabilities
+- 💾 Memory management for context retention
+- 🔍 Web browsing and information gathering
+- 📝 File operations and content creation
+- 🔄 Self-prompting and task breakdown
+
+## Structure
+
+The project is organized into several key components:
+- `/benchmark` - Performance testing tools
+- `/forge` - Core autonomous agent framework
+- `/frontend` - User interface components
+- `/original_autogpt` - Original implementation
+
+## Getting Started
+
+While this project is no longer actively maintained, you can still explore the codebase:
+
+1. Clone the repository:
+```bash
+git clone https://github.com/Significant-Gravitas/AutoGPT.git
+cd classic
+```
+
+2. Review the documentation:
+- For reference, see the [documentation](https://docs.agpt.co). You can browse at the same point in time as this commit so the docs don't change.
+- Check `CLI-USAGE.md` for command-line interface details
+- Refer to `TROUBLESHOOTING.md` for common issues
+
+## License
+
+This project segment is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Documentation
+
+Please refer to the [documentation] (https://docs.agpt.co) for more detailed information about the project's architecture and concepts.
+You can browse at the same point in time as this commit so the docs don't change.
+
+## Historical Impact
+
+AutoGPT played a significant role in advancing the field of autonomous AI agents:
+- Demonstrated practical implementation of AI autonomy
+- Inspired numerous derivative projects and research
+- Contributed to the development of AI agent architectures
+- Helped identify key challenges in AI autonomy
+
+## Security Notice
+
+If you're studying this codebase, please understand this has KNOWN vulnerabilities and issues with its dependencies. It will not be updated to new dependencies.
+
+## Community & Support
+
+While active development has concluded:
+- The codebase remains available for study and reference
+- Historical discussions can be found in project issues
+- Related research and developments continue in the broader AI agent community
+
+## Acknowledgments
+
+Thanks to all contributors who participated in this experimental project and helped advance the field of autonomous AI agents.

--- a/docs/content/classic/index.md
+++ b/docs/content/classic/index.md
@@ -57,7 +57,7 @@ We continue to develop this project with the goal of providing access to AI assi
 
 - 🚀 **Build with us** - We welcome any input, whether it's code or ideas for new features or improvements! Join us on [Discord](https://discord.gg/autogpt) and find out how you can join in on the action.
 
-If you'd like to see what's next, check out the [AutoGPT Platform](/index.md).
+If you'd like to see what's next, check out the [AutoGPT Platform](/).
 
 <small>* it isn't quite there yet, but that is the ultimate goal that we are still pursuing</small>
 

--- a/docs/content/classic/index.md
+++ b/docs/content/classic/index.md
@@ -8,38 +8,33 @@
 
 **Location:** `classic/original_autogpt/` in the GitHub repo
 
-**Maintance Notice:** Classic AutogGPT is not supported from a security perspective. 
+**Maintance Notice:** AutoGPT Classic is not supported from a security perspective. 
 Dependencies will not be updated, nor will issues be fixed. If someone wishes to
 contribute to novel development, we will give best effort merging to the changes that
 pass the existing CI.
 
-AutoGPT was conceived when OpenAI published their GPT-4 model accompanied by a paper
+AutoGPT Classic was conceived when OpenAI published their GPT-4 model accompanied by a paper
 outlining the advanced reasoning and task-solving abilities of the model. The concept
 was (and still is) fairly simple: let an LLM decide what to do over and over, while
 feeding the results of its actions back into the prompt. This allows the program to
 iteratively and incrementally work towards its objective.
 
 The fact that this program is able to execute actions on behalf of its user makes
-it an **agent**. In the case of AutoGPT, the user still has to authorize every action,
+it an **agent**. In the case of AutoGPT Classic, the user still has to authorize every action,
 but as the project progresses we'll be able to give the agent more autonomy and only
 require consent for select actions.
 
-AutoGPT is a **generalist agent**, meaning it is not designed with a specific task in
+AutoGPT Classic is a **generalist agent**, meaning it is not designed with a specific task in
 mind. Instead, it is designed to be able to execute a wide range of tasks across many
 disciplines, as long as it can be done on a computer.
-
-## Coming soon
-* How does AutoGPT work?
-* What can I use AutoGPT for?
-* What does the future of AutoGPT look like?
 
 # AutoGPT Classic Documentation
 
 Welcome to the AutoGPT Classic Documentation.
 
-The AutoGPT project consists of four main components:
+The AutoGPT Classic project consists of four main components:
 
-- The [Agent](#agent) &ndash; also known as just "AutoGPT"
+- The [Agent](#agent) &ndash; also known as just "AutoGPT Classic"
 - The [Benchmark](#benchmark) &ndash; AKA `agbenchmark`
 - The [Forge](#forge)
 - The [Frontend](#frontend)
@@ -48,19 +43,21 @@ To tie these together, we also have a [CLI] at the root of the project.
 
 ## 🤖 Agent
 
-**[📖 About AutoGPT](#autogpt-agent)**
+**[📖 About AutoGPT Classic](#autogpt-agent)**
 &ensp;|&ensp;
 **[🔧 Setup](setup/index.md)**
 &ensp;|&ensp;
 **[💻 Usage](./usage.md)**
 
-The heart of AutoGPT, and the project that kicked it all off: a semi-autonomous agent powered by LLMs to execute any task for you*.
+The former heart of AutoGPT, and the project that kicked it all off: a semi-autonomous agent powered by LLMs to execute any task for you*.
 
 We continue to develop this project with the goal of providing access to AI assistance to the masses, and building the future transparently and together.
 
 - 💡 **Explore** - See what AI can do and be inspired by a glimpse of the future.
 
 - 🚀 **Build with us** - We welcome any input, whether it's code or ideas for new features or improvements! Join us on [Discord](https://discord.gg/autogpt) and find out how you can join in on the action.
+
+If you'd like to see what's next, check out the [AutoGPT Platform](/index.md).
 
 <small>* it isn't quite there yet, but that is the ultimate goal that we are still pursuing</small>
 
@@ -70,13 +67,13 @@ We continue to develop this project with the goal of providing access to AI assi
 
 **[🗒️ Readme](https://github.com/Significant-Gravitas/AutoGPT/blob/master/classic/benchmark/README.md)**
 
-Measure your agent's performance! The `agbenchmark` can be used with any agent that supports the agent protocol, and the integration with the project's [CLI] makes it even easier to use with AutoGPT and forge-based agents. The benchmark offers a stringent testing environment. Our framework allows for autonomous, objective performance evaluations, ensuring your agents are primed for real-world action.
+Measure your agent's performance! The `agbenchmark` can be used with any agent that supports the agent protocol, and the integration with the project's [CLI] makes it even easier to use with AutoGPT Classic and forge-based agents. The benchmark offers a stringent testing environment. Our framework allows for autonomous, objective performance evaluations, ensuring your agents are primed for real-world action.
 
 <!-- TODO: insert visual demonstrating the benchmark -->
 
 - 📦 [**`agbenchmark`**](https://pypi.org/project/agbenchmark/) on Pypi
 
-- 🔌 **Agent Protocol Standardization** - AutoGPT uses the agent protocol from the AI Engineer Foundation to ensure compatibility with many agents, both from within and outside the project.
+- 🔌 **Agent Protocol Standardization** - AutoGPT Classic uses the agent protocol from the AI Engineer Foundation to ensure compatibility with many agents, both from within and outside the project.
 
 ---
 
@@ -109,7 +106,7 @@ An easy-to-use and open source frontend for any Agent Protocol-compliant agent.
 ## 🔧 CLI
 [CLI]: #cli
 
-The project CLI makes it easy to use all of the components in the repo, separately or
+The project CLI makes it easy to use all of the components of AutoGPT Classic in the repo, separately or
 together. To install its dependencies, simply run `./run setup`, and you're ready to go!
 
 ```shell
@@ -127,7 +124,7 @@ Commands:
 
 Common commands:
 
-* `./run agent start autogpt` &ndash; [runs](./usage.md#serve-agent-protocol-mode-with-ui) the AutoGPT agent
+* `./run agent start autogpt` &ndash; [runs](./usage.md#serve-agent-protocol-mode-with-ui) the AutoGPT Classic agent
 * `./run agent create <name>` &ndash; creates a new Forge-based agent project at `agents/<name>`
 * `./run benchmark start <agent>` &ndash; benchmarks the specified agent
 

--- a/docs/content/classic/index.md
+++ b/docs/content/classic/index.md
@@ -8,6 +8,11 @@
 
 **Location:** `classic/original_autogpt/` in the GitHub repo
 
+**Maintance Notice:** Classic AutogGPT is not supported from a security perspective. 
+Dependencies will not be updated, nor will issues be fixed. If someone wishes to
+contribute to novel development, we will give best effort merging to the changes that
+pass the existing CI.
+
 AutoGPT was conceived when OpenAI published their GPT-4 model accompanied by a paper
 outlining the advanced reasoning and task-solving abilities of the model. The concept
 was (and still is) fairly simple: let an LLM decide what to do over and over, while


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

We need to clearly state that the classic AutoGPT is unsupported for security reasons.

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

Adds a readme for classic autogpt to show that we won't update



### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] Test Plan

<details>
  <summary>Test Plan</summary>
  
  - [ ] Open the classic readme and make sure it renders
  - [ ] Test the links
  - [ ] Check the docs page for classic has the warning
</details>
