### PR TITLE
Feature/scheduling agent runner

### DIFF
--- a/autogpt_platform/backend/backend/data/schedule.py
+++ b/autogpt_platform/backend/backend/data/schedule.py
@@ -37,7 +37,7 @@ class ExecutionSchedule(BaseDbModel):
 
 async def get_active_schedules(last_fetch_time: datetime) -> list[ExecutionSchedule]:
     query = AgentGraphExecutionSchedule.prisma().find_many(
-        where={"isEnabled": True, "lastUpdated": {"gt": last_fetch_time}},
+        where={"lastUpdated": {"gt": last_fetch_time}},
         order={"lastUpdated": "asc"},
     )
     return [ExecutionSchedule.from_db(schedule) for schedule in await query]
@@ -77,5 +77,5 @@ async def add_schedule(schedule: ExecutionSchedule) -> ExecutionSchedule:
 
 async def update_schedule(schedule_id: str, is_enabled: bool, user_id: str):
     await AgentGraphExecutionSchedule.prisma().update(
-        where={"id": schedule_id}, data={"isEnabled": is_enabled}
+        where={"id": schedule_id}, data={"isEnabled": is_enabled, "lastUpdated": datetime.now()}
     )

--- a/autogpt_platform/frontend/package.json
+++ b/autogpt_platform/frontend/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-icons": "^1.3.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-radio-group": "^1.2.1",
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.0",

--- a/autogpt_platform/frontend/src/app/page.tsx
+++ b/autogpt_platform/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import AutoGPTServerAPI, {
   GraphMetaWithRuns,
   ExecutionMeta,
+  Schedule,
 } from "@/lib/autogpt-server-api";
 
 import { Card } from "@/components/ui/card";
@@ -15,16 +16,63 @@ import {
   FlowRunsList,
   FlowRunsStats,
 } from "@/components/monitor";
+import { SchedulesTable } from "@/components/monitor/scheduleTable";
 
 const Monitor = () => {
   const [flows, setFlows] = useState<GraphMetaWithRuns[]>([]);
   const [flowRuns, setFlowRuns] = useState<FlowRun[]>([]);
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [selectedFlow, setSelectedFlow] = useState<GraphMetaWithRuns | null>(
     null,
   );
   const [selectedRun, setSelectedRun] = useState<FlowRun | null>(null);
+  const [sortColumn, setSortColumn] = useState<keyof Schedule>("agentGraphId");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
   const api = useMemo(() => new AutoGPTServerAPI(), []);
+
+  const fetchSchedules = useCallback(async () => {
+    const schedulesData: Schedule[] = [];
+    for (const flow of flows) {
+      const flowSchedules = await api.getSchedules(flow.id);
+      Object.entries(flowSchedules).forEach(([id, schedule]) => {
+        schedulesData.push({
+          id,
+          schedule,
+          isEnabled: true,
+          graphId: flow.id,
+          lastRun: new Date(
+            Date.now() - Math.random() * 86400000,
+          ).toISOString(),
+          nextRun: new Date(
+            Date.now() + Math.random() * 86400000,
+          ).toISOString(),
+          runCount: Math.floor(Math.random() * 100),
+          status:
+            Math.random() > 0.8
+              ? "error"
+              : Math.random() > 0.5
+                ? "active"
+                : "paused",
+        });
+      });
+    }
+    setSchedules(schedulesData);
+  }, [api, flows]);
+
+  const toggleSchedule = useCallback(
+    async (scheduleId: string, enabled: boolean) => {
+      await api.updateSchedule(scheduleId, { is_enabled: enabled });
+      setSchedules((prevSchedules) =>
+        prevSchedules.map((schedule) =>
+          schedule.id === scheduleId
+            ? { ...schedule, isEnabled: enabled }
+            : schedule,
+        ),
+      );
+    },
+    [api],
+  );
 
   const fetchAgents = useCallback(() => {
     api.listGraphsWithRuns().then((agent) => {
@@ -45,13 +93,26 @@ const Monitor = () => {
   }, [api, fetchAgents]);
 
   useEffect(() => {
+    fetchSchedules();
+  }, [fetchSchedules, flows]);
+
+  useEffect(() => {
     const intervalId = setInterval(() => fetchAgents(), 5000);
     return () => clearInterval(intervalId);
   }, [fetchAgents, flows]);
 
   const column1 = "md:col-span-2 xl:col-span-3 xxl:col-span-2";
-  const column2 = "md:col-span-3 lg:col-span-2 xl:col-span-3 space-y-4";
+  const column2 = "md:col-span-3 lg:col-span-2 xl:col-span-3";
   const column3 = "col-span-full xl:col-span-4 xxl:col-span-5";
+
+  const handleSort = (column: keyof Schedule) => {
+    if (sortColumn === column) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortColumn(column);
+      setSortDirection("asc");
+    }
+  };
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-5 lg:grid-cols-4 xl:grid-cols-10">
@@ -67,17 +128,20 @@ const Monitor = () => {
           );
         }}
       />
-      <FlowRunsList
-        className={column2}
-        flows={flows}
-        runs={[
-          ...(selectedFlow
-            ? flowRuns.filter((v) => v.graphID == selectedFlow.id)
-            : flowRuns),
-        ].sort((a, b) => Number(a.startTime) - Number(b.startTime))}
-        selectedRun={selectedRun}
-        onSelectRun={(r) => setSelectedRun(r.id == selectedRun?.id ? null : r)}
-      />
+      <div className={column2}>
+        <FlowRunsList
+          flows={flows}
+          runs={[
+            ...(selectedFlow
+              ? flowRuns.filter((v) => v.graphID == selectedFlow.id)
+              : flowRuns),
+          ].sort((a, b) => Number(a.startTime) - Number(b.startTime))}
+          selectedRun={selectedRun}
+          onSelectRun={(r) =>
+            setSelectedRun(r.id == selectedRun?.id ? null : r)
+          }
+        />
+      </div>
       {(selectedRun && (
         <FlowRunInfo
           flow={selectedFlow || flows.find((f) => f.id == selectedRun.graphID)!}
@@ -101,6 +165,15 @@ const Monitor = () => {
             <FlowRunsStats flows={flows} flowRuns={flowRuns} />
           </Card>
         )}
+      <div className="col-span-full md:col-span-3 lg:col-span-2 xl:col-span-6">
+        <SchedulesTable
+          schedules={schedules}
+          onToggleSchedule={toggleSchedule}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+        />
+      </div>
     </div>
   );
 };

--- a/autogpt_platform/frontend/src/app/page.tsx
+++ b/autogpt_platform/frontend/src/app/page.tsx
@@ -26,7 +26,7 @@ const Monitor = () => {
     null,
   );
   const [selectedRun, setSelectedRun] = useState<FlowRun | null>(null);
-  const [sortColumn, setSortColumn] = useState<keyof Schedule>("agentGraphId");
+  const [sortColumn, setSortColumn] = useState<keyof Schedule>("id");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
   const api = useMemo(() => new AutoGPTServerAPI(), []);
@@ -39,24 +39,11 @@ const Monitor = () => {
         schedulesData.push({
           id,
           schedule,
-          isEnabled: true,
-          graphId: flow.id,
-          lastRun: new Date(
-            Date.now() - Math.random() * 86400000,
-          ).toISOString(),
-          nextRun: new Date(
-            Date.now() + Math.random() * 86400000,
-          ).toISOString(),
-          runCount: Math.floor(Math.random() * 100),
-          status:
-            Math.random() > 0.8
-              ? "error"
-              : Math.random() > 0.5
-                ? "active"
-                : "paused",
+          graph_id: flow.id,
         });
       });
     }
+
     setSchedules(schedulesData);
   }, [api, flows]);
 
@@ -167,7 +154,8 @@ const Monitor = () => {
         )}
       <div className="col-span-full md:col-span-3 lg:col-span-2 xl:col-span-6">
         <SchedulesTable
-          schedules={schedules}
+          schedules={schedules} // all schedules
+          agents={flows} // for filtering purpose
           onToggleSchedule={toggleSchedule}
           sortColumn={sortColumn}
           sortDirection={sortDirection}

--- a/autogpt_platform/frontend/src/components/Flow.tsx
+++ b/autogpt_platform/frontend/src/components/Flow.tsx
@@ -159,6 +159,12 @@ const FlowEditor: React.FC<{
   ]);
 
   useEffect(() => {
+    if (params.get("open_scheduling") === "true") {
+      setOpenCron(true);
+    }
+  }, [params]);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
       const isUndo =
@@ -593,8 +599,22 @@ const FlowEditor: React.FC<{
     },
   ];
 
+  // This function is called after cron expression is created
+  // So you can collect inputs for scheduling
   const afterCronCreation = (cronExpression: string) => {
     runnerUIRef.current?.collectInputsForScheduling(cronExpression);
+  };
+
+  // This function Opens up form for creating cron expression
+  const handleScheduleButton = () => {
+    if (!savedAgent) {
+      toast({
+        title: `Please save the agent using the button in the left sidebar before running it.`,
+        duration: 2000,
+      });
+      return;
+    }
+    setOpenCron(true);
   };
 
   return (
@@ -658,16 +678,7 @@ const FlowEditor: React.FC<{
                 requestStopRun();
               }
             }}
-            onClickScheduleButton={() => {
-              if (!savedAgent) {
-                toast({
-                  title: `Please save the agent using the button in the left sidebar before running it.`,
-                  duration: 2000,
-                });
-                return;
-              }
-              setOpenCron(true);
-            }}
+            onClickScheduleButton={handleScheduleButton}
             isScheduling={isScheduling}
             isDisabled={!savedAgent}
             isRunning={isRunning}

--- a/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
+++ b/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "./ui/button";
-import { Clock, LogOut } from "lucide-react";
+import { Clock, LogOut, ChevronLeft } from "lucide-react";
 import { IconPlay, IconSquare } from "@/components/ui/icons";
 import {
   Tooltip,

--- a/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
+++ b/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
@@ -1,18 +1,21 @@
 import React from "react";
 import { Button } from "./ui/button";
-import { LogOut } from "lucide-react";
+import { Clock, LogOut } from "lucide-react";
 import { IconPlay, IconSquare } from "@/components/ui/icons";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { FaSpinner } from "react-icons/fa";
 
 interface PrimaryActionBarProps {
   onClickAgentOutputs: () => void;
   onClickRunAgent: () => void;
+  onClickScheduleButton: () => void;
   isRunning: boolean;
   isDisabled: boolean;
+  isScheduling: boolean;
   requestStopRun: () => void;
   runAgentTooltip: string;
 }
@@ -20,8 +23,10 @@ interface PrimaryActionBarProps {
 const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
   onClickAgentOutputs,
   onClickRunAgent,
+  onClickScheduleButton,
   isRunning,
   isDisabled,
+  isScheduling,
   requestStopRun,
   runAgentTooltip,
 }) => {
@@ -72,6 +77,30 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
           </TooltipTrigger>
           <TooltipContent>
             <p>{runAgentTooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip key="ScheduleAgent" delayDuration={500}>
+          <TooltipTrigger asChild>
+            <Button
+              className="flex items-center gap-2"
+              onClick={onClickScheduleButton}
+              size="primary"
+              disabled={isScheduling}
+              variant="outline"
+              data-id="primary-action-schedule-agent"
+            >
+              {isScheduling ? (
+                <FaSpinner className="animate-spin" />
+              ) : (
+                <Clock className="hidden h-5 w-5 md:flex" />
+              )}
+              <span className="text-sm font-medium md:text-lg">
+                Schedule Run
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Schedule this Agent</p>
           </TooltipContent>
         </Tooltip>
       </div>

--- a/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
+++ b/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
@@ -176,6 +176,7 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
               cronExpression,
               getBlockInputsAndOutputs().inputs,
             );
+            setIsScheduling(false);
             setIsRunnerInputOpen(false);
             setScheduledInput(false);
           }}

--- a/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
+++ b/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
@@ -10,24 +10,55 @@ import { Node } from "@xyflow/react";
 import { filterBlocksByType } from "@/lib/utils";
 import { BlockIORootSchema, BlockUIType } from "@/lib/autogpt-server-api/types";
 
+interface HardcodedValues {
+  name: any;
+  description: any;
+  value: any;
+  placeholder_values: any;
+  limit_to_placeholder_values: any;
+}
+
+export interface InputItem {
+  id: string;
+  type: "input";
+  inputSchema: BlockIORootSchema;
+  hardcodedValues: HardcodedValues;
+}
+
 interface RunnerUIWrapperProps {
   nodes: Node[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
+  setIsScheduling: React.Dispatch<React.SetStateAction<boolean>>;
   isRunning: boolean;
+  isScheduling: boolean;
   requestSaveAndRun: () => void;
+  scheduleRunner: (cronExpression: string, input: InputItem[]) => Promise<void>;
 }
 
 export interface RunnerUIWrapperRef {
   openRunnerInput: () => void;
   openRunnerOutput: () => void;
   runOrOpenInput: () => void;
+  collectInputsForScheduling: (cronExpression: string) => void;
 }
 
 const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
-  ({ nodes, setNodes, isRunning, requestSaveAndRun }, ref) => {
+  (
+    {
+      nodes,
+      setIsScheduling,
+      setNodes,
+      isScheduling,
+      isRunning,
+      requestSaveAndRun,
+      scheduleRunner,
+    },
+    ref,
+  ) => {
     const [isRunnerInputOpen, setIsRunnerInputOpen] = useState(false);
     const [isRunnerOutputOpen, setIsRunnerOutputOpen] = useState(false);
-
+    const [scheduledInput, setScheduledInput] = useState(false);
+    const [cronExpression, setCronExpression] = useState("");
     const getBlockInputsAndOutputs = useCallback(() => {
       const inputBlocks = filterBlocksByType(
         nodes,
@@ -107,10 +138,23 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
       }
     };
 
+    const collectInputsForScheduling = (cron_exp: string) => {
+      const { inputs } = getBlockInputsAndOutputs();
+      setCronExpression(cron_exp);
+
+      if (inputs.length > 0) {
+        setScheduledInput(true);
+        setIsRunnerInputOpen(true);
+      } else {
+        scheduleRunner(cron_exp, []);
+      }
+    };
+
     useImperativeHandle(ref, () => ({
       openRunnerInput,
       openRunnerOutput,
       runOrOpenInput,
+      collectInputsForScheduling,
     }));
 
     return (
@@ -123,6 +167,17 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
           onRun={() => {
             setIsRunnerInputOpen(false);
             requestSaveAndRun();
+          }}
+          scheduledInput={scheduledInput}
+          isScheduling={isScheduling}
+          onSchedule={async () => {
+            setIsScheduling(true);
+            await scheduleRunner(
+              cronExpression,
+              getBlockInputsAndOutputs().inputs,
+            );
+            setIsRunnerInputOpen(false);
+            setScheduledInput(false);
           }}
           isRunning={isRunning}
         />

--- a/autogpt_platform/frontend/src/components/cronScheduler.tsx
+++ b/autogpt_platform/frontend/src/components/cronScheduler.tsx
@@ -16,6 +16,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Separator } from "./ui/separator";
+import { CronExpressionManager } from "@/lib/monitor/cronExpressionManager";
 // import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 // import { Calendar } from "@/components/ui/calendar";
 // import {
@@ -78,49 +79,7 @@ export function CronScheduler({
     { label: "Dec", value: "December" },
   ];
 
-  const generateCronExpression = () => {
-    const [hours, minutes] = selectedTime.split(":").map(Number);
-    let expression = "";
-
-    switch (frequency) {
-      case "minute":
-        expression = "* * * * *";
-        break;
-      case "hour":
-        expression = `${selectedMinute} * * * *`;
-        break;
-      case "daily":
-        expression = `${minutes} ${hours} * * *`;
-        break;
-      case "weekly":
-        const days = selectedDays.join(",");
-        expression = `${minutes} ${hours} * * ${days}`;
-        break;
-      case "monthly":
-        const monthDays = selectedDays.sort((a, b) => a - b).join(",");
-        expression = `${minutes} ${hours} ${monthDays} * *`;
-        break;
-      case "yearly":
-        const monthList = selectedDays
-          .map((d) => d + 1)
-          .sort((a, b) => a - b)
-          .join(",");
-        expression = `${minutes} ${hours} 1 ${monthList} *`; // run on day 1 of month every year
-        break;
-      case "custom":
-        if (customInterval.unit === "minutes") {
-          expression = `*/${customInterval.value} * * * *`;
-        } else if (customInterval.unit === "hours") {
-          expression = `0 */${customInterval.value} * * *`;
-        } else {
-          expression = `${minutes} ${hours} */${customInterval.value} * *`;
-        }
-        break;
-      default:
-        expression = "";
-    }
-    return expression;
-  };
+  const cron_manager = new CronExpressionManager();
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -448,7 +407,13 @@ export function CronScheduler({
             </Button>
             <Button
               onClick={() => {
-                const cronExpr = generateCronExpression();
+                const cronExpr = cron_manager.generateCronExpression(
+                  frequency,
+                  selectedTime,
+                  selectedDays,
+                  selectedMinute,
+                  customInterval,
+                );
                 setFrequency("minute");
                 setSelectedDays([]);
                 setSelectedTime("00:00");

--- a/autogpt_platform/frontend/src/components/cronScheduler.tsx
+++ b/autogpt_platform/frontend/src/components/cronScheduler.tsx
@@ -1,0 +1,469 @@
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Separator } from "./ui/separator";
+// import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+// import { Calendar } from "@/components/ui/calendar";
+// import {
+//   Popover,
+//   PopoverContent,
+//   PopoverTrigger,
+// } from "@/components/ui/popover";
+// import { CalendarIcon } from "lucide-react";
+// import { format } from "date-fns";
+
+interface CronSchedulerProps {
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  open: boolean;
+  afterCronCreation: (cronExpression: string) => void;
+}
+
+export function CronScheduler({
+  setOpen,
+  open,
+  afterCronCreation,
+}: CronSchedulerProps) {
+  const [frequency, setFrequency] = useState<
+    "minute" | "hour" | "daily" | "weekly" | "monthly" | "yearly" | "custom"
+  >("minute");
+  const [selectedDays, setSelectedDays] = useState<number[]>([]);
+  const [selectedTime, setSelectedTime] = useState<string>("00:00");
+  const [showCustomDays, setShowCustomDays] = useState<boolean>(false);
+  const [selectedMinute, setSelectedMinute] = useState<string>("0");
+  const [customInterval, setCustomInterval] = useState<{
+    value: number;
+    unit: "minutes" | "hours" | "days";
+  }>({ value: 1, unit: "minutes" });
+
+  // const [endType, setEndType] = useState<"never" | "on" | "after">("never");
+  // const [endDate, setEndDate] = useState<Date | undefined>();
+  // const [occurrences, setOccurrences] = useState<number>(1);
+
+  const weekDays = [
+    { label: "Su", value: 0 },
+    { label: "Mo", value: 1 },
+    { label: "Tu", value: 2 },
+    { label: "We", value: 3 },
+    { label: "Th", value: 4 },
+    { label: "Fr", value: 5 },
+    { label: "Sa", value: 6 },
+  ];
+
+  const months = [
+    { label: "Jan", value: "January" },
+    { label: "Feb", value: "February" },
+    { label: "Mar", value: "March" },
+    { label: "Apr", value: "April" },
+    { label: "May", value: "May" },
+    { label: "Jun", value: "June" },
+    { label: "Jul", value: "July" },
+    { label: "Aug", value: "August" },
+    { label: "Sep", value: "September" },
+    { label: "Oct", value: "October" },
+    { label: "Nov", value: "November" },
+    { label: "Dec", value: "December" },
+  ];
+
+  const generateCronExpression = () => {
+    const [hours, minutes] = selectedTime.split(":").map(Number);
+    let expression = "";
+
+    switch (frequency) {
+      case "minute":
+        expression = "* * * * *";
+        break;
+      case "hour":
+        expression = `${selectedMinute} * * * *`;
+        break;
+      case "daily":
+        expression = `${minutes} ${hours} * * *`;
+        break;
+      case "weekly":
+        const days = selectedDays.join(",");
+        expression = `${minutes} ${hours} * * ${days}`;
+        break;
+      case "monthly":
+        const monthDays = selectedDays.sort((a, b) => a - b).join(",");
+        expression = `${minutes} ${hours} ${monthDays} * *`;
+        break;
+      case "yearly":
+        const monthList = selectedDays
+          .map((d) => d + 1)
+          .sort((a, b) => a - b)
+          .join(",");
+        expression = `${minutes} ${hours} 1 ${monthList} *`; // run on day 1 of month every year
+        break;
+      case "custom":
+        if (customInterval.unit === "minutes") {
+          expression = `*/${customInterval.value} * * * *`;
+        } else if (customInterval.unit === "hours") {
+          expression = `0 */${customInterval.value} * * *`;
+        } else {
+          expression = `${minutes} ${hours} */${customInterval.value} * *`;
+        }
+        break;
+      default:
+        expression = "";
+    }
+    return expression;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">Schedule</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Schedule Task</DialogTitle>
+        <div className="max-w-md space-y-6 p-2">
+          <div className="space-y-4">
+            <Label className="text-base font-medium">Repeat</Label>
+
+            <Select
+              onValueChange={(value: any) => setFrequency(value)}
+              defaultValue="minute"
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select frequency" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="minute">Every Minute</SelectItem>
+                <SelectItem value="hour">Every Hour</SelectItem>
+                <SelectItem value="daily">Daily</SelectItem>
+                <SelectItem value="weekly">Weekly</SelectItem>
+                <SelectItem value="monthly">Monthly</SelectItem>
+                <SelectItem value="yearly">Yearly</SelectItem>
+                <SelectItem value="custom">Custom</SelectItem>
+              </SelectContent>
+            </Select>
+
+            {frequency === "hour" && (
+              <div className="flex items-center gap-2">
+                <Label>At minute</Label>
+                <Select
+                  value={selectedMinute}
+                  onValueChange={setSelectedMinute}
+                >
+                  <SelectTrigger className="w-24">
+                    <SelectValue placeholder="Select minute" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[0, 15, 30, 45].map((min) => (
+                      <SelectItem key={min} value={min.toString()}>
+                        {min}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {frequency === "custom" && (
+              <div className="flex items-center gap-2">
+                <Label>Every</Label>
+                <Input
+                  type="number"
+                  min="1"
+                  className="w-20"
+                  value={customInterval.value}
+                  onChange={(e) =>
+                    setCustomInterval({
+                      ...customInterval,
+                      value: parseInt(e.target.value),
+                    })
+                  }
+                />
+                <Select
+                  value={customInterval.unit}
+                  onValueChange={(value: any) =>
+                    setCustomInterval({ ...customInterval, unit: value })
+                  }
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="minutes">Minutes</SelectItem>
+                    <SelectItem value="hours">Hours</SelectItem>
+                    <SelectItem value="days">Days</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          {frequency === "weekly" && (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Label>On</Label>
+                <Button
+                  variant="outline"
+                  className="h-8 px-2 py-1 text-xs"
+                  onClick={() => {
+                    if (selectedDays.length === weekDays.length) {
+                      setSelectedDays([]);
+                    } else {
+                      setSelectedDays(weekDays.map((day) => day.value));
+                    }
+                  }}
+                >
+                  {selectedDays.length === weekDays.length
+                    ? "Deselect All"
+                    : "Select All"}
+                </Button>
+                <Button
+                  variant="outline"
+                  className="h-8 px-2 py-1 text-xs"
+                  onClick={() => setSelectedDays([1, 2, 3, 4, 5])}
+                >
+                  Weekdays
+                </Button>
+                <Button
+                  variant="outline"
+                  className="h-8 px-2 py-1 text-xs"
+                  onClick={() => setSelectedDays([0, 6])}
+                >
+                  Weekends
+                </Button>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {weekDays.map((day) => (
+                  <Button
+                    key={day.value}
+                    variant={
+                      selectedDays.includes(day.value) ? "default" : "outline"
+                    }
+                    className="h-10 w-10 p-0"
+                    onClick={() => {
+                      setSelectedDays((prev) =>
+                        prev.includes(day.value)
+                          ? prev.filter((d) => d !== day.value)
+                          : [...prev, day.value],
+                      );
+                    }}
+                  >
+                    {day.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+          {frequency === "monthly" && (
+            <div className="space-y-4">
+              <Label>Days of Month</Label>
+              <div className="flex gap-2">
+                <Button
+                  variant={!showCustomDays ? "default" : "outline"}
+                  onClick={() => {
+                    setShowCustomDays(false);
+                    setSelectedDays(
+                      Array.from({ length: 31 }, (_, i) => i + 1),
+                    );
+                  }}
+                >
+                  All Days
+                </Button>
+                <Button
+                  variant={showCustomDays ? "default" : "outline"}
+                  onClick={() => {
+                    setShowCustomDays(true);
+                    setSelectedDays([]);
+                  }}
+                >
+                  Customize
+                </Button>
+                <Button variant="outline" onClick={() => setSelectedDays([15])}>
+                  15th
+                </Button>
+                <Button variant="outline" onClick={() => setSelectedDays([31])}>
+                  Last Day
+                </Button>
+              </div>
+              {showCustomDays && (
+                <div className="flex flex-wrap gap-2">
+                  {Array.from({ length: 31 }, (_, i) => (
+                    <Button
+                      key={i + 1}
+                      variant={
+                        selectedDays.includes(i + 1) ? "default" : "outline"
+                      }
+                      className="h-10 w-10 p-0"
+                      onClick={() => {
+                        setSelectedDays((prev) =>
+                          prev.includes(i + 1)
+                            ? prev.filter((d) => d !== i + 1)
+                            : [...prev, i + 1],
+                        );
+                      }}
+                    >
+                      {i + 1}
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          {frequency === "yearly" && (
+            <div className="space-y-4">
+              <Label>Months</Label>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  className="h-8 px-2 py-1 text-xs"
+                  onClick={() => {
+                    if (selectedDays.length === months.length) {
+                      setSelectedDays([]);
+                    } else {
+                      setSelectedDays(Array.from({ length: 12 }, (_, i) => i));
+                    }
+                  }}
+                >
+                  {selectedDays.length === months.length
+                    ? "Deselect All"
+                    : "Select All"}
+                </Button>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {months.map((month, index) => (
+                  <Button
+                    key={index}
+                    variant={
+                      selectedDays.includes(index) ? "default" : "outline"
+                    }
+                    className="px-2 py-1"
+                    onClick={() => {
+                      setSelectedDays((prev) =>
+                        prev.includes(index)
+                          ? prev.filter((m) => m !== index)
+                          : [...prev, index],
+                      );
+                    }}
+                  >
+                    {month.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {frequency !== "minute" && frequency !== "hour" && (
+            <div className="flex items-center gap-4 space-y-2">
+              <Label className="pt-2">At</Label>
+              <Input
+                type="time"
+                value={selectedTime}
+                onChange={(e) => setSelectedTime(e.target.value)}
+              />
+            </div>
+          )}
+
+          <Separator />
+          {/*
+
+            On the backend, we are using standard cron expressions,
+            which makes it challenging to add an end date or stop execution
+            after a certain time using only cron expressions.
+            (since standard cron expressions have limitations, like the lack of a year field or more...).
+
+            We could also use ranges in cron expression for end dates but It doesm't cover all cases (sometimes break)
+
+            To automatically end the scheduler, we need to store the end date and time occurrence in the database
+            and modify scheduler.add_job. Currently, we can only stop the scheduler manually from the monitor tab.
+
+            */}
+
+          {/* <div className="space-y-6">
+            <Label className="text-lg font-medium">Ends</Label>
+            <RadioGroup
+              value={endType}
+              onValueChange={(value: "never" | "on" | "after") =>
+                setEndType(value)
+              }
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="never" id="never" />
+                <Label htmlFor="never">Never</Label>
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="on" id="on" />
+                <Label htmlFor="on" className="w-[50px]">
+                  On
+                </Label>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-full"
+                      disabled={endType !== "on"}
+                    >
+                      <CalendarIcon className="mr-2 h-4 w-4" />
+                      {endDate ? format(endDate, "PPP") : "Pick a date"}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0">
+                    <Calendar
+                      mode="single"
+                      selected={endDate}
+                      onSelect={setEndDate}
+                      disabled={(date) => date < new Date()}
+                      fromDate={new Date()}
+                    />
+                  </PopoverContent>
+                </Popover>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="after" id="after" />
+                <Label htmlFor="after" className="ml-2 w-[50px]">
+                  After
+                </Label>
+                <Input
+                  type="number"
+                  className="ml-2 w-[100px]"
+                  value={occurrences}
+                  onChange={(e) => setOccurrences(Number(e.target.value))}
+                />
+                <span>times</span>
+              </div>
+            </RadioGroup>
+          </div> */}
+
+          <div className="flex justify-end space-x-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                const cronExpr = generateCronExpression();
+                setFrequency("minute");
+                setSelectedDays([]);
+                setSelectedTime("00:00");
+                setShowCustomDays(false);
+                setSelectedMinute("0");
+                setCustomInterval({ value: 1, unit: "minutes" });
+                setOpen(false);
+                afterCronCreation(cronExpr);
+              }}
+            >
+              Done
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/components/monitor/scheduleTable.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/scheduleTable.tsx
@@ -1,0 +1,146 @@
+import { Schedule } from "@/lib/autogpt-server-api";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  CalendarIcon,
+  ClockIcon,
+  PlayIcon,
+  StopCircleIcon,
+} from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+
+interface SchedulesTableProps {
+  schedules: Schedule[];
+  onToggleSchedule: (scheduleId: string, enabled: boolean) => void;
+  sortColumn: keyof Schedule;
+  sortDirection: "asc" | "desc";
+  onSort: (column: keyof Schedule) => void;
+}
+
+export const SchedulesTable = ({
+  schedules,
+  onToggleSchedule,
+  sortColumn,
+  sortDirection,
+  onSort,
+}: SchedulesTableProps) => {
+  const { toast } = useToast();
+
+  const sortedSchedules = [...schedules].sort((a, b) => {
+    const aValue = a[sortColumn];
+    const bValue = b[sortColumn];
+    if (sortDirection === "asc") {
+      return String(aValue).localeCompare(String(bValue));
+    }
+    return String(bValue).localeCompare(String(aValue));
+  });
+
+  const handleToggleSchedule = (scheduleId: string, enabled: boolean) => {
+    onToggleSchedule(scheduleId, enabled);
+    if (!enabled) {
+      toast({
+        title: "Schedule Disabled",
+        description: "The schedule has been successfully disabled.",
+      });
+    }
+  };
+
+  return (
+    <Card className="h-fit p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Schedules</h3>
+        <Button size="sm" variant="outline">
+          <ClockIcon className="mr-2 h-4 w-4" />
+          New Schedule
+        </Button>
+      </div>
+      <ScrollArea className="max-h-[400px]">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead
+                onClick={() => onSort("agentGraphId")}
+                className="cursor-pointer"
+              >
+                Graph ID
+              </TableHead>
+              <TableHead
+                onClick={() => onSort("schedule")}
+                className="cursor-pointer"
+              >
+                Schedule
+              </TableHead>
+              <TableHead
+                onClick={() => onSort("isEnabled")}
+                className="cursor-pointer"
+              >
+                Status
+              </TableHead>
+              <TableHead
+                onClick={() => onSort("createdAt")}
+                className="cursor-pointer"
+              >
+                Created
+              </TableHead>
+
+              <TableHead>Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedSchedules.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="py-8 text-center text-lg text-gray-400"
+                >
+                  No schedules are available
+                </TableCell>
+              </TableRow>
+            ) : (
+              sortedSchedules.map((schedule) => (
+                <TableRow key={schedule.id}>
+                  <TableCell className="font-medium">
+                    {schedule.agentGraphId}
+                  </TableCell>
+                  <TableCell>{schedule.schedule}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={!schedule.isEnabled ? "destructive" : "default"}
+                    >
+                      {schedule.isEnabled ? "Enabled" : "Disabled"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>{schedule.createdAt}</TableCell>
+
+                  <TableCell>
+                    <div className="flex space-x-2">
+                      <Button
+                        variant={"destructive"}
+                        onClick={() =>
+                          handleToggleSchedule(schedule.id, !schedule.isEnabled)
+                        }
+                      >
+                        Disable
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </ScrollArea>
+    </Card>
+  );
+};

--- a/autogpt_platform/frontend/src/components/runner-ui/RunnerInputUI.tsx
+++ b/autogpt_platform/frontend/src/components/runner-ui/RunnerInputUI.tsx
@@ -29,6 +29,9 @@ interface RunSettingsUiProps {
   blockInputs: BlockInput[];
   onInputChange: (nodeId: string, field: string, value: string) => void;
   onRun: () => void;
+  onSchedule: () => Promise<void>;
+  scheduledInput: boolean;
+  isScheduling: boolean;
   isRunning: boolean;
 }
 
@@ -36,8 +39,11 @@ export function RunnerInputUI({
   isOpen,
   onClose,
   blockInputs,
+  isScheduling,
   onInputChange,
   onRun,
+  onSchedule,
+  scheduledInput,
   isRunning,
 }: RunSettingsUiProps) {
   const handleRun = () => {
@@ -45,11 +51,18 @@ export function RunnerInputUI({
     onClose();
   };
 
+  const handleSchedule = async () => {
+    onClose();
+    await onSchedule();
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="flex max-h-[80vh] flex-col overflow-hidden sm:max-w-[400px] md:max-w-[500px] lg:max-w-[600px]">
         <DialogHeader className="px-4 py-4">
-          <DialogTitle className="text-2xl">Run Settings</DialogTitle>
+          <DialogTitle className="text-2xl">
+            {scheduledInput ? "Schedule Settings" : "Run Settings"}
+          </DialogTitle>
           <DialogDescription className="mt-2 text-sm">
             Configure settings for running your agent.
           </DialogDescription>
@@ -59,11 +72,11 @@ export function RunnerInputUI({
         </div>
         <DialogFooter className="px-6 py-4">
           <Button
-            onClick={handleRun}
+            onClick={scheduledInput ? handleSchedule : handleRun}
             className="px-8 py-2 text-lg"
-            disabled={isRunning}
+            disabled={scheduledInput ? isScheduling : isRunning}
           >
-            {isRunning ? "Running..." : "Run"}
+            {scheduledInput ? "Schedule" : isRunning ? "Running..." : "Run"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/autogpt_platform/frontend/src/components/ui/radio-group.tsx
+++ b/autogpt_platform/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { cn } from "@/lib/utils"
+import { DotFilledIcon } from "@radix-ui/react-icons"
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "aspect-square h-4 w-4 rounded-full border border-neutral-200 border-neutral-900 text-neutral-900 shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-800 dark:border-neutral-50 dark:text-neutral-50 dark:focus-visible:ring-neutral-300",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <DotFilledIcon className="h-3.5 w-3.5 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { RadioGroup, RadioGroupItem }

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
@@ -828,16 +828,37 @@ export default function useAgentGraph(
     cronExpression: string,
     inputs: InputItem[],
   ) => {
-    const agentData = {
-      cronExpression,
-      inputs: inputs,
-    };
-
-    console.log("agent_data : ", agentData);
-
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    setIsScheduling(false);
+    try {
+      const converted = inputs.reduce(
+        (acc, input) => ({
+          ...acc,
+          [input.id]: {
+            type: input.type,
+            inputSchema: input.inputSchema,
+            hardcodedValues: input.hardcodedValues,
+          },
+        }),
+        {},
+      );
+      if (flowID) {
+        await api.createSchedule(flowID, {
+          cron: cronExpression,
+          input_data: converted,
+        });
+        toast({
+          title: "Agent scheduling successful",
+        });
+      } else {
+        return;
+      }
+    } catch (error) {
+      console.log(error);
+      toast({
+        variant: "destructive",
+        title: "Error scheduling agent",
+        description: "Please retry",
+      });
+    }
   };
 
   return {

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
@@ -18,6 +18,7 @@ import Ajv from "ajv";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useToast } from "@/components/ui/use-toast";
+import { InputItem } from "@/components/RunnerUIWrapper";
 
 const ajv = new Ajv({ strict: false, allErrors: true });
 
@@ -32,6 +33,7 @@ export default function useAgentGraph(
     useSearchParams(),
     usePathname(),
   ];
+  const [isScheduling, setIsScheduling] = useState(false);
   const [savedAgent, setSavedAgent] = useState<Graph | null>(null);
   const [agentDescription, setAgentDescription] = useState<string>("");
   const [agentName, setAgentName] = useState<string>("");
@@ -822,6 +824,21 @@ export default function useAgentGraph(
       state: "running",
     }));
   }, [saveRunRequest]);
+  const scheduleRunner = async (
+    cronExpression: string,
+    inputs: InputItem[],
+  ) => {
+    const agentData = {
+      cronExpression,
+      inputs: inputs,
+    };
+
+    console.log("agent_data : ", agentData);
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    setIsScheduling(false);
+  };
 
   return {
     agentName,
@@ -834,9 +851,12 @@ export default function useAgentGraph(
     requestSave,
     requestSaveAndRun,
     requestStopRun,
+    scheduleRunner,
     isSaving: saveRunRequest.state == "saving",
     isRunning: saveRunRequest.state == "running",
     isStopping: saveRunRequest.state == "stopping",
+    isScheduling,
+    setIsScheduling,
     nodes,
     setNodes,
     edges,

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/baseClient.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/baseClient.ts
@@ -16,6 +16,8 @@ import {
   NodeExecutionResult,
   OAuth2Credentials,
   User,
+  ScheduleCreatable,
+  ScheduleUpdateable,
 } from "./types";
 
 export default class BaseAutoGPTServerAPI {
@@ -236,6 +238,31 @@ export default class BaseAutoGPTServerAPI {
 
   private async _get(path: string, query?: Record<string, any>) {
     return this._request("GET", path, query);
+  }
+
+  // Scheduling request
+  async createSchedule(
+    graphId: string,
+    schedule: ScheduleCreatable,
+  ): Promise<{ id: string }> {
+    return this._request(
+      "POST",
+      `/graphs/${graphId}/schedules?cron=${schedule.cron}`,
+      {
+        input_data: schedule.input_data,
+      },
+    );
+  }
+
+  async updateSchedule(
+    scheduleId: string,
+    update: ScheduleUpdateable,
+  ): Promise<{ id: string }> {
+    return this._request("PUT", `/graphs/schedules/${scheduleId}`, update);
+  }
+
+  async getSchedules(graphId: string): Promise<{ [key: string]: string }> {
+    return this._get(`/graphs/${graphId}/schedules`);
   }
 
   private async _request(

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -317,13 +317,11 @@ export type AnalyticsDetails = {
 export type Schedule = {
   id: string;
   createdAt: Date;
-  updatedAt?: Date;
   agentGraphId: string;
   agentGraphVersion: number;
   schedule: string;
   isEnabled: boolean;
   inputData: { [key: string]: any };
-  lastUpdated: Date;
   userId: string;
 };
 

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -312,3 +312,26 @@ export type AnalyticsDetails = {
   data: { [key: string]: any };
   index: string;
 };
+
+// Schedule types
+export type Schedule = {
+  id: string;
+  createdAt: Date;
+  updatedAt?: Date;
+  agentGraphId: string;
+  agentGraphVersion: number;
+  schedule: string;
+  isEnabled: boolean;
+  inputData: { [key: string]: any };
+  lastUpdated: Date;
+  userId: string;
+};
+
+export type ScheduleCreatable = {
+  cron: string;
+  input_data: { [key: string]: any };
+};
+
+export type ScheduleUpdateable = {
+  is_enabled: boolean;
+};

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -315,14 +315,9 @@ export type AnalyticsDetails = {
 
 // Schedule types
 export type Schedule = {
-  id: string;
-  createdAt: Date;
-  agentGraphId: string;
-  agentGraphVersion: number;
-  schedule: string;
-  isEnabled: boolean;
-  inputData: { [key: string]: any };
-  userId: string;
+  id: string; // schedule id
+  schedule: string; //cron expression
+  graph_id: string; // graph id
 };
 
 export type ScheduleCreatable = {

--- a/autogpt_platform/frontend/src/lib/monitor/cronExpressionManager.ts
+++ b/autogpt_platform/frontend/src/lib/monitor/cronExpressionManager.ts
@@ -1,0 +1,239 @@
+export class CronExpressionManager {
+  generateCronExpression(
+    frequency: string,
+    selectedTime: string,
+    selectedDays: number[],
+    selectedMinute: string,
+    customInterval: { unit: string; value: number },
+  ): string {
+    const [hours, minutes] = selectedTime.split(":").map(Number);
+    let expression = "";
+
+    switch (frequency) {
+      case "minute":
+        expression = "* * * * *";
+        break;
+      case "hour":
+        expression = `${selectedMinute} * * * *`;
+        break;
+      case "daily":
+        expression = `${minutes} ${hours} * * *`;
+        break;
+      case "weekly":
+        const days = selectedDays.join(",");
+        expression = `${minutes} ${hours} * * ${days}`;
+        break;
+      case "monthly":
+        const monthDays = selectedDays.sort((a, b) => a - b).join(",");
+        expression = `${minutes} ${hours} ${monthDays} * *`;
+        break;
+      case "yearly":
+        const monthList = selectedDays
+          .map((d) => d + 1)
+          .sort((a, b) => a - b)
+          .join(",");
+        expression = `${minutes} ${hours} 1 ${monthList} *`;
+        break;
+      case "custom":
+        if (customInterval.unit === "minutes") {
+          expression = `*/${customInterval.value} * * * *`;
+        } else if (customInterval.unit === "hours") {
+          expression = `0 */${customInterval.value} * * *`;
+        } else {
+          expression = `${minutes} ${hours} */${customInterval.value} * *`;
+        }
+        break;
+      default:
+        expression = "";
+    }
+    return expression;
+  }
+
+  generateDescription(cronExpression: string): string {
+    const parts = cronExpression.trim().split(/\s+/);
+    if (parts.length !== 5) {
+      throw new Error("Invalid cron expression format.");
+    }
+
+    const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+
+    // Handle every minute
+    if (cronExpression === "* * * * *") {
+      return "Every minute";
+    }
+
+    // Handle minute intervals (e.g., */5 * * * *)
+    if (
+      minute.startsWith("*/") &&
+      hour === "*" &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      const interval = minute.substring(2);
+      return `Every ${interval} minutes`;
+    }
+
+    // Handle hour intervals (e.g., 30 * * * *)
+    if (
+      hour === "*" &&
+      !minute.includes("/") &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      return `Every hour at minute ${minute}`;
+    }
+
+    // Handle every N hours (e.g., 0 */2 * * *)
+    if (
+      hour.startsWith("*/") &&
+      minute === "0" &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      const interval = hour.substring(2);
+      return `Every ${interval} hours`;
+    }
+
+    // Handle daily (e.g., 30 14 * * *)
+    if (
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*" &&
+      !minute.includes("/") &&
+      !hour.includes("/")
+    ) {
+      return `Every day at ${this.formatTime(hour, minute)}`;
+    }
+
+    // Handle weekly (e.g., 30 14 * * 1,3,5)
+    if (
+      dayOfWeek !== "*" &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      !minute.includes("/") &&
+      !hour.includes("/")
+    ) {
+      const days = this.getDayNames(dayOfWeek);
+      return `Every ${days} at ${this.formatTime(hour, minute)}`;
+    }
+
+    // Handle monthly (e.g., 30 14 1,15 * *)
+    if (
+      dayOfMonth !== "*" &&
+      month === "*" &&
+      dayOfWeek === "*" &&
+      !minute.includes("/") &&
+      !hour.includes("/")
+    ) {
+      const days = dayOfMonth.split(",").map(Number);
+      const dayList = days.join(", ");
+      return `On day ${dayList} of every month at ${this.formatTime(hour, minute)}`;
+    }
+
+    // Handle yearly (e.g., 30 14 1 1,6,12 *)
+    if (
+      dayOfMonth !== "*" &&
+      month !== "*" &&
+      dayOfWeek === "*" &&
+      !minute.includes("/") &&
+      !hour.includes("/")
+    ) {
+      const months = this.getMonthNames(month);
+      return `Every year on the 1st day of ${months} at ${this.formatTime(hour, minute)}`;
+    }
+
+    // Handle custom minute intervals with other fields as * (e.g., every N minutes)
+    if (
+      minute.includes("/") &&
+      hour === "*" &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      const interval = minute.split("/")[1];
+      return `Every ${interval} minutes`;
+    }
+
+    // Handle custom hour intervals with other fields as * (e.g., every N hours)
+    if (
+      hour.includes("/") &&
+      minute === "0" &&
+      dayOfMonth === "*" &&
+      month === "*" &&
+      dayOfWeek === "*"
+    ) {
+      const interval = hour.split("/")[1];
+      return `Every ${interval} hours`;
+    }
+
+    // Handle specific days with custom intervals (e.g., every N days)
+    if (
+      dayOfMonth.startsWith("*/") &&
+      month === "*" &&
+      dayOfWeek === "*" &&
+      !minute.includes("/") &&
+      !hour.includes("/")
+    ) {
+      const interval = dayOfMonth.substring(2);
+      return `Every ${interval} days at ${this.formatTime(hour, minute)}`;
+    }
+
+    return `Cron Expression: ${cronExpression}`;
+  }
+
+  private formatTime(hour: string, minute: string): string {
+    const formattedHour = this.padZero(hour);
+    const formattedMinute = this.padZero(minute);
+    return `${formattedHour}:${formattedMinute}`;
+  }
+
+  private padZero(value: string): string {
+    return value.padStart(2, "0");
+  }
+
+  private getDayNames(dayOfWeek: string): string {
+    const days = dayOfWeek.split(",").map(Number);
+    const dayNames = days
+      .map((d) => {
+        const names = [
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+        ];
+        return names[d] || `Unknown(${d})`;
+      })
+      .join(", ");
+    return dayNames;
+  }
+
+  private getMonthNames(month: string): string {
+    const months = month.split(",").map(Number);
+    const monthNames = months
+      .map((m) => {
+        const names = [
+          "January",
+          "February",
+          "March",
+          "April",
+          "May",
+          "June",
+          "July",
+          "August",
+          "September",
+          "October",
+          "November",
+          "December",
+        ];
+        return names[m - 1] || `Unknown(${m})`;
+      })
+      .join(", ");
+    return monthNames;
+  }
+}

--- a/autogpt_platform/frontend/yarn.lock
+++ b/autogpt_platform/frontend/yarn.lock
@@ -2335,6 +2335,22 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
 
+"@radix-ui/react-radio-group@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.2.1.tgz#42b914c85f3a77be3ab766b6e49a9598680f76d1"
+  integrity sha512-kdbv54g4vfRjja9DNWPMxKvXblzqbpEC8kspEkZ6dVP7kQksGCn+iZHkcCz2nb00+lPdRvxrqy4WrvvV1cNqrQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-direction" "1.1.0"
+    "@radix-ui/react-presence" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-roving-focus" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-use-previous" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+
 "@radix-ui/react-roving-focus@1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz"


### PR DESCRIPTION
Feature 

- Created a table on the monitor page to display all schedules.

- This table includes options to filter schedules based on graphs and to create a new schedule.

- Each graph page now has a button to create a schedule.

### Changes 🏗️

- Removed `isEnabled` from `autogpt_platform/backend/backend/data/schedule.py` because it was not fetching the disabled schedules, which prevented them from ending as cron jobs.

- Added a schedule table on the monitor page to display all schedules:
   - Allows filtering of schedules by agent name.
   - Option to create a new schedule.

- Used `cronExpressionManager.ts` to create cron expressions and descriptions for each cron expression.

- Created types and requests for schedule endpoints.

- Reused the run button component to enable rescheduling of graphs. 

## Some Screenshots

<img width="733" alt="Screenshot 2024-11-13 at 5 04 02 PM" src="https://github.com/user-attachments/assets/3e66f250-533d-4c08-a3e3-c236f23580c2">
<img width="728" alt="Screenshot 2024-11-13 at 5 03 36 PM" src="https://github.com/user-attachments/assets/1ff0ac66-c177-4ab2-b401-a590bdb65c9c">
<img width="643" alt="Screenshot 2024-11-13 at 5 04 11 PM" src="https://github.com/user-attachments/assets/4a4d4760-87b8-482a-b806-8f5a096c752d">



## Video 

https://github.com/user-attachments/assets/15ef9591-73ed-4704-8794-99901e9a50c3




