### PR TITLE
fix(frontend): Remove double title on credentials input

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -218,14 +218,14 @@ export function CustomNode({
                     side="left"
                   />
                 ) : (
-                  <span
-                    className="text-m green mb-0 text-gray-900"
-                    title={propSchema.description}
-                  >
-                    {propKey == "credentials"
-                      ? "Credentials"
-                      : propSchema.title || beautifyString(propKey)}
-                  </span>
+                  propKey != "credentials" && (
+                    <span
+                      className="text-m green mb-0 text-gray-900"
+                      title={propSchema.description}
+                    >
+                      {propSchema.title || beautifyString(propKey)}
+                    </span>
+                  )
                 )}
                 {!isConnected && (
                   <NodeGenericInputField

--- a/autogpt_platform/frontend/src/components/integrations/credentials-input.tsx
+++ b/autogpt_platform/frontend/src/components/integrations/credentials-input.tsx
@@ -234,7 +234,12 @@ export const CredentialsInput: FC<{
   if (savedApiKeys.length === 0 && savedOAuthCredentials.length === 0) {
     return (
       <>
-        <span className="text-m green mb-0 text-gray-900">Credentials</span>
+        <span
+          className="text-m green mb-0 text-gray-900"
+          title={schema.description}
+        >
+          Credentials
+        </span>
         <div className={cn("flex flex-row space-x-2", className)}>
           {supportsOAuth2 && (
             <Button onClick={handleOAuthLogin}>


### PR DESCRIPTION
- Follow-up on #8524
- Resolves #8637

### Changes 🏗️

- Add back condition to hide `credentials` input title in `CustomNode:generateInputHandles`
- Add `title={schema.description}` to `<CredentialsInput>` title element

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
