### PR TITLE
fix(frontend): Fix input-field update on empty & default value

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -240,7 +240,10 @@ export function CustomNode({
                     nodeId={id}
                     propKey={getInputPropKey(propKey)}
                     propSchema={propSchema}
-                    currentValue={getValue(getInputPropKey(propKey))}
+                    currentValue={getValue(
+                      getInputPropKey(propKey),
+                      data.hardcodedValues,
+                    )}
                     connections={data.connections}
                     handleInputChange={handleInputChange}
                     handleInputClick={handleInputClick}

--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -22,6 +22,7 @@ import {
   beautifyString,
   cn,
   getValue,
+  hasNonNullNonObjectValue,
   parseKeys,
   setNestedProperty,
 } from "@/lib/utils";
@@ -239,10 +240,7 @@ export function CustomNode({
                     nodeId={id}
                     propKey={getInputPropKey(propKey)}
                     propSchema={propSchema}
-                    currentValue={getValue(
-                      getInputPropKey(propKey),
-                      data.hardcodedValues,
-                    )}
+                    currentValue={getValue(getInputPropKey(propKey))}
                     connections={data.connections}
                     handleInputChange={handleInputChange}
                     handleInputClick={handleInputClick}
@@ -387,9 +385,7 @@ export function CustomNode({
     });
   }, [id, data, height, addNodes, deleteElements, getNode, getNextNodeId]);
 
-  const hasConfigErrors =
-    data.errors &&
-    Object.entries(data.errors).some(([_, value]) => value !== null);
+  const hasConfigErrors = data.errors && hasNonNullNonObjectValue(data.errors);
   const outputData = data.executionResults?.at(-1)?.data;
   const hasOutputError =
     typeof outputData === "object" &&
@@ -399,8 +395,8 @@ export function CustomNode({
   useEffect(() => {
     if (hasConfigErrors) {
       const filteredErrors = Object.fromEntries(
-        Object.entries(data.errors || {}).filter(
-          ([_, value]) => value !== null,
+        Object.entries(data.errors || {}).filter(([, value]) =>
+          hasNonNullNonObjectValue(value),
         ),
       );
       console.error(

--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -239,7 +239,10 @@ export function CustomNode({
                     nodeId={id}
                     propKey={getInputPropKey(propKey)}
                     propSchema={propSchema}
-                    currentValue={getValue(propKey, data.hardcodedValues)}
+                    currentValue={getValue(
+                      getInputPropKey(propKey),
+                      data.hardcodedValues,
+                    )}
                     connections={data.connections}
                     handleInputChange={handleInputChange}
                     handleInputClick={handleInputClick}

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -322,7 +322,7 @@ const NodeCredentialsInput: FC<{
 };
 
 const InputRef = (value: any): ((el: HTMLInputElement | null) => void) => {
-  return (el) => el && value && (el.value = value);
+  return (el) => el && value != null && (el.value = value);
 };
 
 const NodeKeyValueInput: FC<{

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -314,6 +314,14 @@ export function findNewlyAddedBlockCoordinates(
   };
 }
 
+export function hasNonNullNonObjectValue(obj: any): boolean {
+  if (obj !== null && typeof obj === "object") {
+    return Object.values(obj).some((value) => hasNonNullNonObjectValue(value));
+  } else {
+    return obj !== null && typeof obj !== "object";
+  }
+}
+
 type ParsedKey = { key: string; index?: number };
 
 export function parseKeys(key: string): ParsedKey[] {


### PR DESCRIPTION
There are three different issues:
* https://github.com/Significant-Gravitas/AutoGPT/issues/8626 where setting empty string from input box won't visually update the input field.
* https://github.com/Significant-Gravitas/AutoGPT/pull/8524/files#diff-69de95e19acaba021b2e4c08cada30293eb4d8bd451f93aa56cfecb91a5c5f97R235 seems to be a conflict resolving issue which causes the AgentExecutorBlock default value not being populated.
* Setting any nested input field will give a false-negative error UI (which makes the block red) due to the nested field being treated as a non-null error message.

### Changes 🏗️

Fixed the mentioned issues above.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
