### PR TITLE
fix(frontend): Newly typed text in Input fields vanishes on scroll

### DIFF
--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
-import { Input } from "./ui/input";
+import { LocalValuedInput } from "./ui/input";
 import NodeHandle from "./NodeHandle";
 import { ConnectionData } from "./CustomNode";
 import { CredentialsInput } from "./integrations/credentials-input";
@@ -413,11 +413,11 @@ const NodeKeyValueInput: FC<{
             />
             {!isConnected(key) && (
               <div className="nodrag mb-2 flex items-center space-x-2">
-                <Input
+                <LocalValuedInput
                   type="text"
                   placeholder="Key"
-                  ref={InputRef(key ?? "")}
-                  onBlur={(e) =>
+                  value={key ?? ""}
+                  onChange={(e) =>
                     updateKeyValuePairs(
                       keyValuePairs.toSpliced(index, 1, {
                         key: e.target.value,
@@ -426,11 +426,11 @@ const NodeKeyValueInput: FC<{
                     )
                   }
                 />
-                <Input
+                <LocalValuedInput
                   type="text"
                   placeholder="Value"
-                  ref={InputRef(value ?? "")}
-                  onBlur={(e) =>
+                  value={value ?? ""}
+                  onChange={(e) =>
                     updateKeyValuePairs(
                       keyValuePairs.toSpliced(index, 1, {
                         key: key,
@@ -640,17 +640,15 @@ const NodeStringInput: FC<{
           className="nodrag relative"
           onClick={schema.secret ? () => handleInputClick(selfKey) : undefined}
         >
-          <Input
+          <LocalValuedInput
             type="text"
             id={selfKey}
-            ref={InputRef(
-              schema.secret && value ? "*".repeat(value.length) : value,
-            )}
+            value={schema.secret && value ? "*".repeat(value.length) : value}
+            onChange={(e) => handleInputChange(selfKey, e.target.value)}
             readOnly={schema.secret}
             placeholder={
               schema?.placeholder || `Enter ${beautifyString(displayName)}`
             }
-            onBlur={(e) => handleInputChange(selfKey, e.target.value)}
             className="pr-8 read-only:cursor-pointer read-only:text-gray-500"
           />
           <Button
@@ -737,11 +735,13 @@ const NodeNumberInput: FC<{
   return (
     <div className={className}>
       <div className="nodrag flex items-center justify-between space-x-3">
-        <Input
+        <LocalValuedInput
           type="number"
           id={selfKey}
-          ref={InputRef(value)}
-          onBlur={(e) => handleInputChange(selfKey, parseFloat(e.target.value))}
+          value={value}
+          onChange={(e) =>
+            handleInputChange(selfKey, parseFloat(e.target.value))
+          }
           placeholder={
             schema.placeholder || `Enter ${beautifyString(displayName)}`
           }

--- a/autogpt_platform/frontend/src/components/ui/input.tsx
+++ b/autogpt_platform/frontend/src/components/ui/input.tsx
@@ -23,4 +23,35 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = "Input";
 
-export { Input };
+const LocalValuedInput: React.FC<InputProps> = ({
+  value,
+  onChange,
+  ...props
+}) => {
+  /**
+   * Input component that manages its own value state.
+   * This component is useful when you want to control the value of the input
+   * from the parent component, but also want to allow the user to change the value.
+   */
+  const [inputValue, setInputValue] = React.useState(value ?? "");
+
+  React.useEffect(() => {
+    if (value !== undefined && value !== inputValue) {
+      setInputValue(value);
+    }
+    // Note:
+    // It's intended that the `inputValue` not being added to the dependency array,
+    // `inputValue` should only be updated from the outside only when `value` changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    if (onChange) onChange(e);
+  };
+
+  return <Input {...props} value={inputValue} onChange={handleChange} />;
+};
+LocalValuedInput.displayName = "LocalValuedInput";
+
+export { Input, LocalValuedInput };


### PR DESCRIPTION
This fixes https://github.com/Significant-Gravitas/AutoGPT/issues/8625

Due to the input values are globally managed and asynchronous, the `onBlur` event was used instead of `onChange` to avoid the [jumping caret problem](https://dev.to/kwirke/solving-caret-jumping-in-react-inputs-36ic).

However, this causes issues when there could be some re-render events that still keep the input box focused, making the `onBlur` not triggered, but the input was reset. One such scenario is the scrolling (zoom-in & zoom-out of the node editor).

### Changes 🏗️

Introduce & use `LocalValuedInput`. Instead of using onBlur as a trigger, the component maintains its local state value to be displayed on the input box, but also calls the `onChange` update on the globally managed value state, while syncing its value from the outside.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
