### PR TITLE
fix(frontend): Typing in the NodeKeyValueInput field causes the field to un-focus

### DIFF
--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -404,7 +404,7 @@ const NodeKeyValueInput: FC<{
     >
       <div>
         {keyValuePairs.map(({ key, value }, index) => (
-          <div key={getEntryKey(key)}>
+          <div key={index}>
             <NodeHandle
               keyName={getEntryKey(key)}
               schema={{ type: "string" }}

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -404,6 +404,10 @@ const NodeKeyValueInput: FC<{
     >
       <div>
         {keyValuePairs.map(({ key, value }, index) => (
+          /* 
+          `index` is used as a DOM key instead of the actual `key`,
+          because the `key` changes on each input making the input lose focus.
+          */
           <div key={index}>
             <NodeHandle
               keyName={getEntryKey(key)}

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -405,8 +405,8 @@ const NodeKeyValueInput: FC<{
       <div>
         {keyValuePairs.map(({ key, value }, index) => (
           /* 
-          `index` is used as a DOM key instead of the actual `key`,
-          because the `key` changes on each input making the input lose focus.
+          The `index` is used as a DOM key instead of the actual `key`
+          because the `key` can change with each input, causing the input to lose focus.
           */
           <div key={index}>
             <NodeHandle


### PR DESCRIPTION
https://github.com/Significant-Gravitas/AutoGPT/pull/8657 introduces state change on each input `onChange` event.  This causes the NodeKeyValueInput to get re-rendered on each value change making the input unfocussed.

### Changes 🏗️

Use a numbered index as the DOM key instead of an actual input key to avoid React's dirty check and re-render the component as a different DOM, which causes the input to un-focus.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
