### PR TITLE
fix(backend): Define executionmanager hostname for local docker-mode

### DIFF
--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -107,6 +107,7 @@ services:
       - PYRO_HOST=0.0.0.0
       - AGENTSERVER_HOST=rest_server
       - DATABASEMANAGER_HOST=0.0.0.0 
+      - EXECUTIONMANAGER_HOST=0.0.0.0
       - ENCRYPTION_KEY=dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw=  # DO NOT USE IN PRODUCTION!!
     ports:
       - "8002:8000"


### PR DESCRIPTION
When running in local docker-mode, the executor is unable to access the pyro server of the execution manager with this error:
`Node execution failed with error cannot connect to ('localhost', 8002): [Errno 111] Connection refused`.

### Changes 🏗️

Define executionmanager hostname for local docker-mode

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
