### PR TITLE
refactor(frontend): Update buttons to edit agents in Monitor

### DIFF
--- a/autogpt_platform/frontend/src/components/monitor/FlowInfo.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/FlowInfo.tsx
@@ -105,10 +105,11 @@ export const FlowInfo: React.FC<
             </DropdownMenu>
           )}
           <Link
-            className={buttonVariants({ variant: "outline" })}
+            className={buttonVariants({ variant: "default" })}
             href={`/build?flowID=${flow.id}`}
           >
-            <Pencil2Icon />
+            <Pencil2Icon className="mr-2" />
+            Open in Builder
           </Link>
           <Button
             variant="outline"
@@ -126,7 +127,7 @@ export const FlowInfo: React.FC<
               )
             }
           >
-            <ExitIcon />
+            <ExitIcon className="mr-2" /> Export
           </Button>
           <Button variant="outline" onClick={() => setIsDeleteModalOpen(true)}>
             <Trash2Icon className="h-full" />

--- a/autogpt_platform/frontend/src/components/monitor/FlowRunInfo.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/FlowRunInfo.tsx
@@ -47,10 +47,10 @@ export const FlowRunInfo: React.FC<
             </Button>
           )}
           <Link
-            className={buttonVariants({ variant: "outline" })}
+            className={buttonVariants({ variant: "default" })}
             href={`/build?flowID=${flow.id}`}
           >
-            <Pencil2Icon className="mr-2" /> Edit Agent
+            <Pencil2Icon className="mr-2" /> Open in Builder
           </Link>
         </div>
       </CardHeader>


### PR DESCRIPTION
Edit button in Monitor is currently just an icon of a pencil.

### Changes 🏗️

- Make edit buttons for both agent and particular run in a `default` style with `Open in Builder` text
- Add `Export` text to json export button

<img width="349" alt="Screenshot 2024-11-18 at 8 21 40 PM" src="https://github.com/user-attachments/assets/c5d16367-2a9e-4ca4-811f-b18e5f71bef1">
