### PR TITLE
fix(frontend): avoid displaying long description text for block

### DIFF
--- a/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
@@ -205,7 +205,10 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
                         {beautifyString(block.name).replace(/ Block$/, "")}
                       </span>
                       <span className="block break-words text-xs font-normal text-gray-500">
-                        {block.description}
+                        {/* Cap description at 100 characters max */}
+                        {block.description?.length > 100
+                          ? block.description.slice(0, 100) + "..."
+                          : block.description}
                       </span>
                     </div>
                     <div


### PR DESCRIPTION
<img width="624" alt="image" src="https://github.com/user-attachments/assets/74574c21-f3cc-4afe-b128-79aa17f2355e">


### Changes 🏗️

Avoid displaying long description text for block

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
