### PR TITLE
fix(backend): Avoid falling back to default user unless ENABLED_AUTH is set to False

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/depends.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/depends.py
@@ -1,7 +1,8 @@
 import fastapi
 
 from .middleware import auth_middleware
-from .models import User
+from .models import User, DEFAULT_USER_ID, DEFAULT_EMAIL
+from .config import Settings
 
 
 def requires_user(payload: dict = fastapi.Depends(auth_middleware)) -> User:
@@ -16,8 +17,12 @@ def requires_admin_user(
 
 def verify_user(payload: dict | None, admin_only: bool) -> User:
     if not payload:
+        if Settings.ENABLE_AUTH:
+            raise fastapi.HTTPException(
+                status_code=401, detail="Authorization header is missing"
+            )
         # This handles the case when authentication is disabled
-        payload = {"sub": "3e53486c-cf57-477e-ba2a-cb02dc828e1a", "role": "admin"}
+        payload = {"sub": DEFAULT_USER_ID, "role": "admin"}
 
     user_id = payload.get("sub")
 

--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/models.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/models.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 
+DEFAULT_USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
+DEFAULT_EMAIL = "default@example.com"
+
 
 # Using dataclass here to avoid adding dependency on pydantic
 @dataclass(frozen=True)

--- a/autogpt_platform/backend/backend/data/user.py
+++ b/autogpt_platform/backend/backend/data/user.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional, cast
 
+from autogpt_libs.auth.models import DEFAULT_USER_ID
 from autogpt_libs.supabase_integration_credentials_store.types import (
     UserIntegrations,
     UserMetadata,
@@ -14,9 +15,6 @@ from backend.data.db import prisma
 from backend.util.encryption import JSONCryptor
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
-DEFAULT_EMAIL = "default@example.com"
 
 
 async def get_or_create_user(user_data: dict) -> User:

--- a/autogpt_platform/backend/backend/server/utils.py
+++ b/autogpt_platform/backend/backend/server/utils.py
@@ -1,18 +1,11 @@
-from autogpt_libs.auth.middleware import auth_middleware
-from fastapi import Depends, HTTPException
+from autogpt_libs.auth.depends import requires_user
+from autogpt_libs.auth.models import User
+from fastapi import Depends
 
-from backend.data.user import DEFAULT_USER_ID
 from backend.util.settings import Settings
 
 settings = Settings()
 
 
-def get_user_id(payload: dict = Depends(auth_middleware)) -> str:
-    if not payload:
-        # This handles the case when authentication is disabled
-        return DEFAULT_USER_ID
-
-    user_id = payload.get("sub")
-    if not user_id:
-        raise HTTPException(status_code=401, detail="User ID not found in token")
-    return user_id
+def get_user_id(user: User = Depends(requires_user)) -> str:
+    return user.user_id

--- a/autogpt_platform/backend/backend/server/ws_api.py
+++ b/autogpt_platform/backend/backend/server/ws_api.py
@@ -53,24 +53,24 @@ async def event_broadcaster(manager: ConnectionManager):
 
 
 async def authenticate_websocket(websocket: WebSocket) -> str:
-    if settings.config.enable_auth:
-        token = websocket.query_params.get("token")
-        if not token:
-            await websocket.close(code=4001, reason="Missing authentication token")
-            return ""
-
-        try:
-            payload = parse_jwt_token(token)
-            user_id = payload.get("sub")
-            if not user_id:
-                await websocket.close(code=4002, reason="Invalid token")
-                return ""
-            return user_id
-        except ValueError:
-            await websocket.close(code=4003, reason="Invalid token")
-            return ""
-    else:
+    if not settings.config.enable_auth:
         return DEFAULT_USER_ID
+
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=4001, reason="Missing authentication token")
+        return ""
+
+    try:
+        payload = parse_jwt_token(token)
+        user_id = payload.get("sub")
+        if not user_id:
+            await websocket.close(code=4002, reason="Invalid token")
+            return ""
+        return user_id
+    except ValueError:
+        await websocket.close(code=4003, reason="Invalid token")
+        return ""
 
 
 async def handle_subscribe(


### PR DESCRIPTION
https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/autogpt_libs/autogpt_libs/auth/depends.py#L18-L20

This code falls back to the default admin user when the payload is empty, which definite is not intentional.

### Changes 🏗️

Refactor DEFAULT_USER_ID fallback logic into a single location, and add config check for fallback.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
