### PR TITLE
fix(backend): Resolve Pydantic warning about missing `secrets_dir`

### DIFF
--- a/autogpt_platform/backend/backend/util/data.py
+++ b/autogpt_platform/backend/backend/util/data.py
@@ -3,14 +3,6 @@ import pathlib
 import sys
 
 
-def get_secrets_path() -> pathlib.Path:
-    return get_data_path() / "secrets"
-
-
-def get_config_path() -> pathlib.Path:
-    return get_data_path()
-
-
 def get_frontend_path() -> pathlib.Path:
     if getattr(sys, "frozen", False):
         # The application is frozen

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -11,7 +11,7 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
-from backend.util.data import get_data_path, get_secrets_path
+from backend.util.data import get_data_path
 
 T = TypeVar("T", bound=BaseSettings)
 
@@ -272,7 +272,6 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     # Add more secret fields as needed
 
     model_config = SettingsConfigDict(
-        secrets_dir=get_secrets_path(),
         env_file=".env",
         env_file_encoding="utf-8",
         extra="allow",
@@ -299,11 +298,3 @@ class Settings(BaseModel):
                 with open(config_path, "w") as f:
                     json.dump(config_to_save, f, indent=2)
             self.config.clear_updates()
-
-        # Save updated secrets to individual files
-        secrets_dir = get_secrets_path()
-        for key in self.secrets.updated_fields:
-            secret_file = os.path.join(secrets_dir, key)
-            with open(secret_file, "w") as f:
-                f.write(str(getattr(self.secrets, key)))
-        self.secrets.clear_updates()


### PR DESCRIPTION
- Resolves #8689
- Follow-up to #8521

### Changes 🏗️

- Remove `secrets_dir` and other references to `get_secrets_path()`
- Remove unused `get_config_path()`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Run backend, see if warnings appear

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

