### PR TITLE
dx(backend): Fix `pre-commit` `isort` step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
       - id: isort
         name: Lint (isort) - AutoGPT Platform - Backend
         alias: isort-platform-backend
-        entry: poetry -C autogpt_platform/backend run isort
+        entry: poetry -C autogpt_platform/backend run isort -p backend
         files: ^autogpt_platform/backend/
         types: [file, python]
         language: system
@@ -113,7 +113,7 @@ repos:
       - id: isort
         name: Lint (isort) - Classic - AutoGPT
         alias: isort-classic-autogpt
-        entry: poetry -C classic/original_autogpt run isort
+        entry: poetry -C classic/original_autogpt run isort -p autogpt
         files: ^classic/original_autogpt/
         types: [file, python]
         language: system
@@ -121,7 +121,7 @@ repos:
       - id: isort
         name: Lint (isort) - Classic - Forge
         alias: isort-classic-forge
-        entry: poetry -C classic/forge run isort
+        entry: poetry -C classic/forge run isort -p forge
         files: ^classic/forge/
         types: [file, python]
         language: system
@@ -129,7 +129,7 @@ repos:
       - id: isort
         name: Lint (isort) - Classic - Benchmark
         alias: isort-classic-benchmark
-        entry: poetry -C classic/benchmark run isort
+        entry: poetry -C classic/benchmark run isort -p agbenchmark
         files: ^classic/benchmark/
         types: [file, python]
         language: system

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -74,6 +74,9 @@ format = "linter:format"
 lint = "linter:lint"
 test = "run_tests:test"
 
+[tool.isort]
+profile = "black"
+
 [tool.pytest-watcher]
 now = false
 clear = true


### PR DESCRIPTION
Extracted from #8358 because of https://github.com/Significant-Gravitas/AutoGPT/pull/8358#discussion_r1848785855

`isort` doesn't detect first-party packages correctly and applies its own styling which is incompatible with `black`.

## Changes 🏗️
- Set `tool.isort.profile = "black"`
- Explicitly pass the first-party package name in the `isort` jobs in the `pre-commit` config
