### PR TITLE
fix(frontend): Monitor Page got all the request doubled on each page refresh

### DIFF
--- a/autogpt_platform/frontend/src/components/SupabaseProvider.tsx
+++ b/autogpt_platform/frontend/src/components/SupabaseProvider.tsx
@@ -37,7 +37,9 @@ export default function SupabaseProvider({
           if (event === "SIGNED_IN") {
             api.createUser();
           }
-          router.refresh();
+          if (event === "SIGNED_OUT") {
+            router.refresh();
+          }
         });
 
         return () => {


### PR DESCRIPTION
All requests executed by the monitor page on the first load were always doubled, this made the page load the data twice.

This was caused by the explicit page refresh on each Supabase auth state change: https://github.com/Significant-Gravitas/AutoGPT/pull/7655/files#diff-f0d8e7150741c7f5a883b2b37e86155e03d04807c5d8971d5b7e5c9817cc4b98R35

### Changes 🏗️

Avoid refreshing the page on each auth state change event, only refresh on the `SIGNED_OUT` event.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
