### PR TITLE
fix(block): Updated model_version to prevent conflicts with pydantic naming

### DIFF
--- a/autogpt_platform/backend/backend/blocks/ai_music_generator.py
+++ b/autogpt_platform/backend/backend/blocks/ai_music_generator.py
@@ -63,7 +63,7 @@ class AIMusicGeneratorBlock(Block):
             placeholder="e.g., 'An upbeat electronic dance track with heavy bass'",
             title="Prompt",
         )
-        model_version: MusicGenModelVersion = SchemaField(
+        music_gen_model_version: MusicGenModelVersion = SchemaField(
             description="Model to use for generation",
             default=MusicGenModelVersion.STEREO_LARGE,
             title="Model Version",
@@ -118,7 +118,7 @@ class AIMusicGeneratorBlock(Block):
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "prompt": "An upbeat electronic dance track with heavy bass",
-                "model_version": MusicGenModelVersion.STEREO_LARGE,
+                "music_gen_model_version": MusicGenModelVersion.STEREO_LARGE,
                 "duration": 8,
                 "temperature": 1.0,
                 "top_k": 250,
@@ -134,7 +134,7 @@ class AIMusicGeneratorBlock(Block):
                 ),
             ],
             test_mock={
-                "run_model": lambda api_key, model_version, prompt, duration, temperature, top_k, top_p, classifier_free_guidance, output_format, normalization_strategy: "https://replicate.com/output/generated-audio-url.wav",
+                "run_model": lambda api_key, music_gen_model_version, prompt, duration, temperature, top_k, top_p, classifier_free_guidance, output_format, normalization_strategy: "https://replicate.com/output/generated-audio-url.wav",
             },
             test_credentials=TEST_CREDENTIALS,
         )
@@ -153,7 +153,7 @@ class AIMusicGeneratorBlock(Block):
                 )
                 result = self.run_model(
                     api_key=credentials.api_key,
-                    model_version=input_data.model_version,
+                    music_gen_model_version=input_data.music_gen_model_version,
                     prompt=input_data.prompt,
                     duration=input_data.duration,
                     temperature=input_data.temperature,
@@ -182,7 +182,7 @@ class AIMusicGeneratorBlock(Block):
     def run_model(
         self,
         api_key: SecretStr,
-        model_version: MusicGenModelVersion,
+        music_gen_model_version: MusicGenModelVersion,
         prompt: str,
         duration: int,
         temperature: float,
@@ -200,7 +200,7 @@ class AIMusicGeneratorBlock(Block):
             "meta/musicgen:671ac645ce5e552cc63a54a2bbff63fcf798043055d2dac5fc9e36a837eedcfb",
             input={
                 "prompt": prompt,
-                "model_version": model_version,
+                "music_gen_model_version": music_gen_model_version,
                 "duration": duration,
                 "temperature": temperature,
                 "top_k": top_k,


### PR DESCRIPTION
The field model_version in the ai music generator project conflicted with pydantic internals. This fixes that.

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
This pull request includes several changes to the `autogpt_platform/backend/backend/blocks/ai_music_generator.py` file, focusing on renaming a variable for consistency across the codebase. The variable `model_version` has been renamed to `music_gen_model_version`.

Variable renaming for consistency:

* Renamed `model_version` to `music_gen_model_version` in the `Input` class definition.
* Updated the `__init__` method to use `music_gen_model_version` instead of `model_version` in the test input dictionary.
* Modified the mock function in the `__init__` method to accept `music_gen_model_version` as a parameter.
* Changed the `run` method to use `music_gen_model_version` when calling `run_model`.
* Updated the `run_model` method to replace `model_version` with `music_gen_model_version` in its parameters and input dictionary. [[1]](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L185-R185) [[2]](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L203-R203)
This pull request includes updates to the `autogpt_platform/backend/backend/blocks/ai_music_generator.py` file to rename the `model_version` variable to `music_gen_model_version` for consistency across the codebase. The most important changes include modifications to the `Input` class, the `__init__` method, the `run` method, and the `run_model` method.

Variable renaming for consistency:

* [`autogpt_platform/backend/backend/blocks/ai_music_generator.py`](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L66-R66): Renamed `model_version` to `music_gen_model_version` in the `Input` class.
* [`autogpt_platform/backend/backend/blocks/ai_music_generator.py`](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L121-R121): Updated the `__init__` method to use `music_gen_model_version` instead of `model_version`. [[1]](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L121-R121) [[2]](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L137-R137)
* [`autogpt_platform/backend/backend/blocks/ai_music_generator.py`](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L156-R156): Modified the `run` method to use `music_gen_model_version` in place of `model_version`. [[1]](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L156-R156) [[2]](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L185-R185)
* [`autogpt_platform/backend/backend/blocks/ai_music_generator.py`](diffhunk://#diff-89d6362266448eb6b4fe78472f36e0bd0e6e39ac58e561d08b6e5572cbe8c5b5L203-R203): Adjusted the `run_model` method to accept `music_gen_model_version` instead of `model_version`.