### PR TITLE
docs(platform): Fix url in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The AutoGPT frontend is where users interact with our powerful AI automation pla
 
    **Monitoring and Analytics:** Keep track of your agents' performance and gain insights to continually improve your automation processes.
 
-[Read this guide](https://docs.agpt.co/server/new_blocks/) to learn how to build your own custom blocks.
+[Read this guide](https://docs.agpt.co/platform/new_blocks/) to learn how to build your own custom blocks.
 
 ### 💽 AutoGPT Server
 


### PR DESCRIPTION
'Read this guide' link uri was 404

### Changes 🏗️

change 'server' to 'platform' in uri
