### PR TITLE
docs(backend): Add `--build` to docker command in Getting Started guide

### DIFF
--- a/docs/content/platform/advanced_setup.md
+++ b/docs/content/platform/advanced_setup.md
@@ -55,7 +55,7 @@ This will generate the Prisma client for PostgreSQL. You will also need to run t
 
 ```bash
 cd autogpt_platform/
-docker compose up -d
+docker compose up -d --build
 ```
 
 You can then run the migrations from the `backend` directory.

--- a/docs/content/platform/getting-started.md
+++ b/docs/content/platform/getting-started.md
@@ -90,7 +90,7 @@ To run the backend services, follow these steps:
 
 * Run the backend services:
   ```
-   docker compose up -d
+   docker compose up -d --build
   ```
   This command will start all the necessary backend services defined in the `docker-compose.combined.yml` file in detached mode.
 


### PR DESCRIPTION
User had [issue](https://discord.com/channels/1092243196446249134/1092275629602394184/1310501283400257587) with outdated backend despite updating to the latest version through git.

### Changes 🏗️

- Add `--build` to `docker compose up` instructions