### PR TITLE
fix(frontend): advanced-toggle-default

### DIFF
--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -110,7 +110,7 @@ def SchemaField(
     title: Optional[str] = None,
     description: Optional[str] = None,
     placeholder: Optional[str] = None,
-    advanced: Optional[bool] = None,
+    advanced: Optional[bool] = False,
     secret: bool = False,
     exclude: bool = False,
     hidden: Optional[bool] = None,


### PR DESCRIPTION
- resolve #8739

I don't think so that this is a frontend issue [might be wrong] , because if we are not classifying that a particular input is `advanced = true/false`. Then we automatically get `advanced = True`.

<img width="1142" alt="Screenshot 2024-11-27 at 10 36 59 AM" src="https://github.com/user-attachments/assets/e8d9c037-5b8b-45b2-b40b-8390bc63de99">
