### PR TITLE
feat(platform): Tweaks to Search page 

### DIFF
--- a/autogpt_platform/frontend/src/app/[lang]/store/search/page.tsx
+++ b/autogpt_platform/frontend/src/app/[lang]/store/search/page.tsx
@@ -32,8 +32,8 @@ export default async function Page({
   return (
     <div className="w-full bg-white">
       <div className="px-10 max-w-[1440px] mx-auto">
-        <div className="flex items-center justify-between mt-8">
-          <div className="flex flex-col">
+        <div className="flex items-center mt-8">
+          <div className="w-[910px]">
             <h2 className="font-['Geist'] text-base font-medium text-neutral-800">
               Results for:
             </h2>
@@ -41,31 +41,44 @@ export default async function Page({
               {search_term}
             </h1>
           </div>
-          <div>
+          <div className="ml-auto">
             <SearchBar width="w-[439px]" />
           </div>
         </div>
 
-        <div className="mt-8 flex justify-between items-center">
-          <SearchFilterChips 
-            totalCount={totalCount}
-            agentsCount={agentsCount}
-            creatorsCount={creatorsCount}
-          />
-          <SortDropdown />
-        </div>
+        {totalCount > 0 ? (
+          <>
+            <div className="mt-8 flex justify-between items-center">
+              <SearchFilterChips 
+                totalCount={totalCount}
+                agentsCount={agentsCount}
+                creatorsCount={creatorsCount}
+              />
+              <SortDropdown />
+            </div>
 
-        <div className="mt-6">
-          <h2 className="text-neutral-800 text-lg font-semibold font-['Poppins'] mb-4">Agents</h2>
-          <AgentsSection agents={agents} sectionTitle="Search Results" />
-        </div>
-        
-        <Separator className="my-6" />
-        
-        <div className="mb-8">
-          <h2 className="text-neutral-800 text-lg font-semibold font-['Poppins'] mb-4">Creators</h2>
-          <FeaturedCreators featuredCreators={creators} />
-        </div>
+            {agentsCount > 0 && (
+              <div className="mt-6">
+                <h2 className="text-neutral-800 text-lg font-semibold font-['Poppins'] mb-4">Agents</h2>
+                <AgentsSection agents={agents} sectionTitle="Search Results" />
+              </div>
+            )}
+            
+            {agentsCount > 0 && creatorsCount > 0 && <Separator className="my-6" />}
+            
+            {creatorsCount > 0 && (
+              <div className="mb-8">
+                <h2 className="text-neutral-800 text-lg font-semibold font-['Poppins'] mb-4">Creators</h2>
+                <FeaturedCreators featuredCreators={creators} />
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="flex flex-col items-center justify-center mt-20">
+            <h3 className="text-xl font-medium text-neutral-600 mb-2">No results found</h3>
+            <p className="text-neutral-500">Try adjusting your search terms or filters</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/autogpt_platform/frontend/src/app/[lang]/store/search/page.tsx
+++ b/autogpt_platform/frontend/src/app/[lang]/store/search/page.tsx
@@ -58,7 +58,7 @@ export default async function Page({
             </div>
 
             {agentsCount > 0 && (
-              <div className="mt-6">
+              <div className="mt-8">
                 <h2 className="text-neutral-800 text-lg font-semibold font-['Poppins'] mb-4">Agents</h2>
                 <AgentsSection agents={agents} sectionTitle="Search Results" />
               </div>
@@ -67,7 +67,7 @@ export default async function Page({
             {agentsCount > 0 && creatorsCount > 0 && <Separator className="my-6" />}
             
             {creatorsCount > 0 && (
-              <div className="mb-8">
+              <div className="mt-8">
                 <h2 className="text-neutral-800 text-lg font-semibold font-['Poppins'] mb-4">Creators</h2>
                 <FeaturedCreators featuredCreators={creators} />
               </div>

--- a/autogpt_platform/frontend/src/app/[lang]/store/search/page.tsx
+++ b/autogpt_platform/frontend/src/app/[lang]/store/search/page.tsx
@@ -33,7 +33,7 @@ export default async function Page({
     <div className="w-full bg-white">
       <div className="px-10 max-w-[1440px] mx-auto">
         <div className="flex items-center mt-8">
-          <div className="w-[910px]">
+          <div className="flex-1 min-w-[910px]">
             <h2 className="font-['Geist'] text-base font-medium text-neutral-800">
               Results for:
             </h2>
@@ -41,7 +41,7 @@ export default async function Page({
               {search_term}
             </h1>
           </div>
-          <div className="ml-auto">
+          <div className="flex-none ml-auto">
             <SearchBar width="w-[439px]" />
           </div>
         </div>
@@ -50,6 +50,7 @@ export default async function Page({
           <>
             <div className="mt-8 flex justify-between items-center">
               <SearchFilterChips 
+              
                 totalCount={totalCount}
                 agentsCount={agentsCount}
                 creatorsCount={creatorsCount}


### PR DESCRIPTION
This make it so the search page can deal with no results / showing only agents and only creators depending on what the search results 

### Changes 🏗️

### Shows everything
![image](https://github.com/user-attachments/assets/e4312108-dff0-4852-b49c-8f9e11db1d53)
### Shows nothing
![image](https://github.com/user-attachments/assets/2cf02a73-eea0-4cf5-a338-bfbd514c614f)
### Shows only agents
![image](https://github.com/user-attachments/assets/26c3e0a9-9eb6-4b00-b55a-1894d4167bc6)
### Shows only creators
![image](https://github.com/user-attachments/assets/49b44968-054a-4976-b1db-6b3cace65322)
