### PR TITLE
dx: Fix dependabot PR/commit titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(libs/deps)"
+      prefix-development: "chore(libs/deps-dev)"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -26,6 +29,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(backend/deps)"
+      prefix-development: "chore(backend/deps-dev)"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -37,7 +43,6 @@ updates:
         update-types:
         - "minor"
         - "patch"
-
 
   # frontend (Next.js project)
   - package-ecosystem: "npm"
@@ -46,6 +51,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(frontend/deps)"
+      prefix-development: "chore(frontend/deps-dev)"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -57,7 +65,6 @@ updates:
         update-types:
         - "minor"
         - "patch"
-
 
   # infra (Terraform)
   - package-ecosystem: "terraform"
@@ -66,6 +73,10 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(infra/deps)"
+      prefix-development: "chore(infra/deps-dev)"
+
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -78,7 +89,6 @@ updates:
         - "minor"
         - "patch"
 
-
   # market (Poetry project)
   - package-ecosystem: "pip"
     directory: "autogpt_platform/market"
@@ -86,6 +96,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(market/deps)"
+      prefix-development: "chore(market/deps-dev)"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -146,6 +159,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(platform/deps)"
+      prefix-development: "chore(platform/deps-dev)"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -166,6 +182,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 1
     target-branch: "dev"
+    commit-message:
+      prefix: "chore(docs/deps)"
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
Dependabot's commit messages are bulky and don't use our commit message scopes. Although not fully customizable, this partially fixes it.

### Changes 🏗️

- Fix dependabot commit message scopes