### PR TITLE
Feat/single input validation lock

### DIFF
--- a/autogpt_platform/backend/backend/blocks/test_mutual_exclusive.py
+++ b/autogpt_platform/backend/backend/blocks/test_mutual_exclusive.py
@@ -1,48 +1,49 @@
-from typing import Optional, Literal
-from pydantic import BaseModel
+from typing import Optional
 
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import SchemaField
+
 
 class TestMutualExclusiveBlock(Block):
     class Input(BlockSchema):
         text_input_1: Optional[str] = SchemaField(
             title="Text Input 1",
             description="First mutually exclusive input",
+            mutually_exclusive="group_1",
         )
 
         text_input_2: Optional[str] = SchemaField(
             title="Text Input 2",
             description="Second mutually exclusive input",
+            mutually_exclusive="group_1",
         )
 
         text_input_3: Optional[str] = SchemaField(
             title="Text Input 3",
             description="Third mutually exclusive input",
+            mutually_exclusive="group_1",
         )
 
         number_input_1: Optional[int] = SchemaField(
             title="Number Input 1",
             description="First number input (mutually exclusive)",
-            mutually_exclusive="group2"
+            mutually_exclusive="group2",
         )
 
         number_input_2: Optional[int] = SchemaField(
             title="Number Input 2",
             description="Second number input (mutually exclusive)",
-            mutually_exclusive="group2"
+            mutually_exclusive="group2",
         )
 
         independent_input: str = SchemaField(
             title="Independent Input",
             description="This input is not mutually exclusive with others",
-            default="This can be filled anytime"
+            default="This can be filled anytime",
         )
 
     class Output(BlockSchema):
-        result: str = SchemaField(
-            description="Shows which inputs were filled"
-        )
+        result: str = SchemaField(description="Shows which inputs were filled")
 
     def __init__(self):
         super().__init__(
@@ -51,13 +52,6 @@ class TestMutualExclusiveBlock(Block):
             categories={BlockCategory.BASIC},
             input_schema=TestMutualExclusiveBlock.Input,
             output_schema=TestMutualExclusiveBlock.Output,
-            test_input={
-                "text_input_1": "Test input 1",
-                "independent_input": "Independent test"
-            },
-            test_output=[
-                ("result", "Text Input 1: Test input 1\nIndependent Input: Independent test")
-            ]
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:

--- a/autogpt_platform/backend/backend/blocks/test_mutual_exclusive.py
+++ b/autogpt_platform/backend/backend/blocks/test_mutual_exclusive.py
@@ -1,0 +1,80 @@
+from typing import Optional, Literal
+from pydantic import BaseModel
+
+from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
+from backend.data.model import SchemaField
+
+class TestMutualExclusiveBlock(Block):
+    class Input(BlockSchema):
+        text_input_1: Optional[str] = SchemaField(
+            title="Text Input 1",
+            description="First mutually exclusive input",
+        )
+
+        text_input_2: Optional[str] = SchemaField(
+            title="Text Input 2",
+            description="Second mutually exclusive input",
+        )
+
+        text_input_3: Optional[str] = SchemaField(
+            title="Text Input 3",
+            description="Third mutually exclusive input",
+        )
+
+        number_input_1: Optional[int] = SchemaField(
+            title="Number Input 1",
+            description="First number input (mutually exclusive)",
+            mutually_exclusive="group2"
+        )
+
+        number_input_2: Optional[int] = SchemaField(
+            title="Number Input 2",
+            description="Second number input (mutually exclusive)",
+            mutually_exclusive="group2"
+        )
+
+        independent_input: str = SchemaField(
+            title="Independent Input",
+            description="This input is not mutually exclusive with others",
+            default="This can be filled anytime"
+        )
+
+    class Output(BlockSchema):
+        result: str = SchemaField(
+            description="Shows which inputs were filled"
+        )
+
+    def __init__(self):
+        super().__init__(
+            id="b7faa910-b074-11ef-bee7-477f51db4711",
+            description="A test block to demonstrate mutually exclusive inputs",
+            categories={BlockCategory.BASIC},
+            input_schema=TestMutualExclusiveBlock.Input,
+            output_schema=TestMutualExclusiveBlock.Output,
+            test_input={
+                "text_input_1": "Test input 1",
+                "independent_input": "Independent test"
+            },
+            test_output=[
+                ("result", "Text Input 1: Test input 1\nIndependent Input: Independent test")
+            ]
+        )
+
+    def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        filled_inputs = []
+
+        if input_data.text_input_1:
+            filled_inputs.append(f"Text Input 1: {input_data.text_input_1}")
+        if input_data.text_input_2:
+            filled_inputs.append(f"Text Input 2: {input_data.text_input_2}")
+        if input_data.text_input_3:
+            filled_inputs.append(f"Text Input 3: {input_data.text_input_3}")
+
+        if input_data.number_input_1:
+            filled_inputs.append(f"Number Input 1: {input_data.number_input_1}")
+        if input_data.number_input_2:
+            filled_inputs.append(f"Number Input 2: {input_data.number_input_2}")
+
+        filled_inputs.append(f"Independent Input: {input_data.independent_input}")
+
+        yield "result", "\n".join(filled_inputs)

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -124,6 +124,7 @@ def SchemaField(
     secret: bool = False,
     exclude: bool = False,
     hidden: Optional[bool] = None,
+    mutually_exclusive: Optional[str] = None,
     **kwargs,
 ) -> T:
     json_extra = {
@@ -133,6 +134,7 @@ def SchemaField(
             "secret": secret,
             "advanced": advanced,
             "hidden": hidden,
+            "mutually_exclusive": mutually_exclusive,
         }.items()
         if v is not None
     }

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -57,6 +57,7 @@ export type BlockIOSubSchemaMeta = {
   placeholder?: string;
   advanced?: boolean;
   hidden?: boolean;
+  mutually_exclusive?: string;
 };
 
 export type BlockIOObjectSubSchema = BlockIOSubSchemaMeta & {


### PR DESCRIPTION
- resolve #8731 

### Changes
- Introduced `mutually_exclusive` parameter in `SchemaField` to manage input exclusivity.
- Implemented logic in `NodeGenericInputField` to disable inputs based on mutual exclusivity.
- Updated related components to support the new `disabled` state for inputs.
- Enhanced `BlockIOSubSchemaMeta` to include `mutually_exclusive` property.

> Currently, I’m disabling the input from the same group (I haven’t added any frontend validation to prevent users from bypassing it).

https://github.com/user-attachments/assets/71fb9fe4-943b-4724-8acb-6aed2232ed6b

