### PR TITLE
dx(backend): Fix linting & formatting for `autogpt_libs`

### DIFF
--- a/.github/workflows/platform-backend-ci.yml
+++ b/.github/workflows/platform-backend-ci.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - ".github/workflows/platform-backend-ci.yml"
       - "autogpt_platform/backend/**"
+      - "autogpt_platform/autogpt_libs/**"
   pull_request:
     branches: [master, dev, release-*]
     paths:
       - ".github/workflows/platform-backend-ci.yml"
       - "autogpt_platform/backend/**"
+      - "autogpt_platform/autogpt_libs/**"
   merge_group:
 
 concurrency:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,11 @@ repos:
         files: ^autogpt_platform/autogpt_libs/
         args: [--fix]
 
+      - id: ruff-format
+        name: Format (Ruff) - AutoGPT Platform - Libs
+        alias: ruff-lint-platform-libs
+        files: ^autogpt_platform/autogpt_libs/
+
   - repo: local
     # isort needs the context of which packages are installed to function, so we
     # can't use a vendored isort pre-commit hook (which runs in its own isolated venv).
@@ -140,7 +145,7 @@ repos:
     # everything in .gitignore, so it works fine without any config or arguments.
     hooks:
       - id: black
-        name: Lint (Black)
+        name: Format (Black)
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0

--- a/autogpt_platform/autogpt_libs/autogpt_libs/feature_flag/client.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/feature_flag/client.py
@@ -72,7 +72,7 @@ def feature_flag(
     """
 
     def decorator(
-        func: Callable[P, Union[T, Awaitable[T]]]
+        func: Callable[P, Union[T, Awaitable[T]]],
     ) -> Callable[P, Union[T, Awaitable[T]]]:
         @wraps(func)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:

--- a/autogpt_platform/autogpt_libs/autogpt_libs/logging/config.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/logging/config.py
@@ -23,7 +23,6 @@ DEBUG_LOG_FORMAT = (
 
 
 class LoggingConfig(BaseSettings):
-
     level: str = Field(
         default="INFO",
         description="Logging level",

--- a/autogpt_platform/autogpt_libs/autogpt_libs/logging/test_utils.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/logging/test_utils.py
@@ -24,10 +24,10 @@ from .utils import remove_color_codes
         ),
         ("", ""),
         ("hello", "hello"),
-        ("hello\x1B[31m world", "hello world"),
-        ("\x1B[36mHello,\x1B[32m World!", "Hello, World!"),
+        ("hello\x1b[31m world", "hello world"),
+        ("\x1b[36mHello,\x1b[32m World!", "Hello, World!"),
         (
-            "\x1B[1m\x1B[31mError:\x1B[0m\x1B[31m file not found",
+            "\x1b[1m\x1b[31mError:\x1b[0m\x1b[31m file not found",
             "Error: file not found",
         ),
     ],

--- a/autogpt_platform/backend/linter.py
+++ b/autogpt_platform/backend/linter.py
@@ -2,7 +2,10 @@ import os
 import subprocess
 
 directory = os.path.dirname(os.path.realpath(__file__))
-target_dirs = ["../backend", "../autogpt_libs"]
+
+BACKEND_DIR = "."
+LIBS_DIR = "../autogpt_libs"
+TARGET_DIRS = [BACKEND_DIR, LIBS_DIR]
 
 
 def run(*command: str) -> None:
@@ -12,17 +15,19 @@ def run(*command: str) -> None:
 
 def lint():
     try:
-        run("ruff", "check", *target_dirs, "--exit-zero")
-        run("isort", "--diff", "--check", "--profile", "black", ".")
-        run("black", "--diff", "--check", ".")
-        run("pyright", *target_dirs)
+        run("ruff", "check", *TARGET_DIRS, "--exit-zero")
+        run("ruff", "format", "--diff", "--check", LIBS_DIR)
+        run("isort", "--diff", "--check", "--profile", "black", BACKEND_DIR)
+        run("black", "--diff", "--check", BACKEND_DIR)
+        run("pyright", *TARGET_DIRS)
     except subprocess.CalledProcessError as e:
         print("Lint failed, try running `poetry run format` to fix the issues: ", e)
         raise e
 
 
 def format():
-    run("ruff", "check", "--fix", *target_dirs)
-    run("isort", "--profile", "black", ".")
-    run("black", ".")
-    run("pyright", *target_dirs)
+    run("ruff", "check", "--fix", *TARGET_DIRS)
+    run("ruff", "format", LIBS_DIR)
+    run("isort", "--profile", "black", BACKEND_DIR)
+    run("black", BACKEND_DIR)
+    run("pyright", *TARGET_DIRS)


### PR DESCRIPTION
- Resolves #8859
- Follow-up to #8751

### Changes
- Add `autogpt_libs` to the backend CI path filter
- Add `ruff format` step for `autogpt_libs` to `linter.py` and `pre-commit` config
- Run `poetry run format` with the new setup