### PR TITLE
feat(frontend): Disallow webhook+input or webhook+webhook in the same graph

### DIFF
--- a/autogpt_platform/frontend/src/components/Flow.tsx
+++ b/autogpt_platform/frontend/src/components/Flow.tsx
@@ -673,6 +673,7 @@ const FlowEditor: React.FC<{
                 blocks={availableNodes}
                 addBlock={addNode}
                 flows={availableFlows}
+                nodes={nodes}
               />
             }
             botChildren={

--- a/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
@@ -54,8 +54,12 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
-  const graphHasWebhookNodes = nodes.some((n) => n.data.uiType == BlockUIType.WEBHOOK);
-  const graphHasInputNodes = nodes.some((n) => n.data.uiType == BlockUIType.INPUT);
+  const graphHasWebhookNodes = nodes.some(
+    (n) => n.data.uiType == BlockUIType.WEBHOOK,
+  );
+  const graphHasInputNodes = nodes.some(
+    (n) => n.data.uiType == BlockUIType.INPUT,
+  );
 
   const filteredAvailableBlocks = useMemo(() => {
     const blockList = blocks

--- a/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useMemo } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TextRenderer } from "@/components/ui/render";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { CustomNode } from "@/components/CustomNode";
 import { beautifyString } from "@/lib/utils";
 import {
   Popover,
@@ -31,6 +32,7 @@ interface BlocksControlProps {
   ) => void;
   pinBlocksPopover: boolean;
   flows: GraphMeta[];
+  nodes: CustomNode[];
 }
 
 /**
@@ -47,15 +49,19 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
   addBlock,
   pinBlocksPopover,
   flows,
+  nodes,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
-  const getFilteredBlockList = (): Block[] => {
+  const graphHasWebhookNodes = nodes.some((n) => n.data.uiType == BlockUIType.WEBHOOK);
+  const graphHasInputNodes = nodes.some((n) => n.data.uiType == BlockUIType.INPUT);
+
+  const filteredAvailableBlocks = useMemo(() => {
     const blockList = blocks
       .filter((b) => b.uiType !== BlockUIType.AGENT)
       .sort((a, b) => a.name.localeCompare(b.name));
-    const agentList = flows.map(
+    const agentBlockList = flows.map(
       (flow) =>
         ({
           id: SpecialBlockID.AGENT,
@@ -80,7 +86,7 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
     );
 
     return blockList
-      .concat(agentList)
+      .concat(agentBlockList)
       .filter(
         (block: Block) =>
           (block.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -92,8 +98,29 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
               .includes(searchQuery.toLowerCase())) &&
           (!selectedCategory ||
             block.categories.some((cat) => cat.category === selectedCategory)),
-      );
-  };
+      )
+      .map((block) => ({
+        ...block,
+        notAvailable:
+          (block.uiType == BlockUIType.WEBHOOK &&
+            graphHasWebhookNodes &&
+            "Agents can only have one webhook-triggered block") ||
+          (block.uiType == BlockUIType.WEBHOOK &&
+            graphHasInputNodes &&
+            "Webhook-triggered blocks can't be used together with input blocks") ||
+          (block.uiType == BlockUIType.INPUT &&
+            graphHasWebhookNodes &&
+            "Input blocks can't be used together with a webhook-triggered block") ||
+          null,
+      }));
+  }, [
+    blocks,
+    flows,
+    searchQuery,
+    selectedCategory,
+    graphHasInputNodes,
+    graphHasWebhookNodes,
+  ]);
 
   const resetFilters = React.useCallback(() => {
     setSearchQuery("");
@@ -187,14 +214,20 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
               className="h-[60vh]"
               data-id="blocks-control-scroll-area"
             >
-              {getFilteredBlockList().map((block) => (
+              {filteredAvailableBlocks.map((block) => (
                 <Card
                   key={block.uiKey || block.id}
-                  className="m-2 my-4 flex h-20 cursor-pointer shadow-none hover:shadow-lg"
+                  className={`m-2 my-4 flex h-20 shadow-none ${
+                    block.notAvailable
+                      ? "cursor-not-allowed opacity-50"
+                      : "cursor-pointer hover:shadow-lg"
+                  }`}
                   data-id={`block-card-${block.id}`}
                   onClick={() =>
+                    !block.notAvailable &&
                     addBlock(block.id, block.name, block?.hardcodedValues || {})
                   }
+                  title={block.notAvailable ?? undefined}
                 >
                   <div
                     className={`-ml-px h-full w-3 rounded-l-xl ${getPrimaryCategoryColor(block.categories)}`}


### PR DESCRIPTION
- **feat(frontend): Disallow combining webhook+webhook or webhook+input blocks in the same graph**
- **format**

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
