### PR TITLE
feat(frontend): add block connecting test

### DIFF
--- a/autogpt_platform/frontend/src/tests/pages/build.page.ts
+++ b/autogpt_platform/frontend/src/tests/pages/build.page.ts
@@ -172,7 +172,25 @@ export class BuildPage extends BasePage {
     blockInputId: string,
     blockInputName: string,
   ): Promise<void> {
-    throw new Error("Not implemented");
+    try {
+      // Locate the output element
+      const outputElement = await this.page.locator(`[data-id="${blockOutputId}"]`);
+      // Locate the input element
+      const inputElement = await this.page.locator(`[data-id="${blockInputId}"]`);
+
+      // Drag from the output to the input
+      const outputBox = await outputElement.boundingBox();
+      const inputBox = await inputElement.boundingBox();
+
+      if (outputBox && inputBox) {
+        await this.page.mouse.move(outputBox.x + outputBox.width / 2, outputBox.y + outputBox.height / 2);
+        await this.page.mouse.down();
+        await this.page.mouse.move(inputBox.x + inputBox.width / 2, inputBox.y + inputBox.height / 2);
+        await this.page.mouse.up();
+      }
+    } catch (error) {
+      console.error("Error connecting block output to input:", error);
+    }
   }
 
   async isLoaded(): Promise<boolean> {


### PR DESCRIPTION
### This is for https://github.com/Significant-Gravitas/AutoGPT/pull/8804

In the block tests we didn't have ``connectBlockOutputToBlockInput`` implemented, this PR adds it and adds a test to add two blocks, connect them, saves the graph then runs it to make sure it all works

### Changes 🏗️

implements ``connectBlockOutputToBlockInput`` and adds test 

### Showing the full testing being run
https://github.com/user-attachments/assets/4aed4f5d-8d52-47bc-bd62-9e45e0782c0f

