### PR TITLE
docs: huntr no longer is offering a security bounty so remove it

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ We take the security of our project seriously. If you believe you have found a s
 
 Instead, please report them via:
 - [GitHub Security Advisory](https://github.com/Significant-Gravitas/AutoGPT/security/advisories/new)
-- [Huntr.dev](https://huntr.com/repos/significant-gravitas/autogpt) - where you may be eligible for a bounty
+<!--- [Huntr.dev](https://huntr.com/repos/significant-gravitas/autogpt) - where you may be eligible for a bounty-->
 
 ### Reporting Process
 1. **Submit Report**: Use one of the above channels to submit your report


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

Huntr isn't offering a security bounty for autogpt at the moment so remove it in favor of github security adviosories

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->

comments out huntr line in case they decide to offer it again in the future
