### PR TITLE
ux(builder): Remove title from input and output blocks

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -148,9 +148,6 @@ class AgentInputBlock(Block):
             description="The value to be passed as input.",
             default=None,
         )
-        title: str | None = SchemaField(
-            description="The title of the input.", default=None, advanced=True
-        )
         description: str | None = SchemaField(
             description="The description of the input.",
             default=None,
@@ -232,11 +229,6 @@ class AgentOutputBlock(Block):
             advanced=False,
         )
         name: str = SchemaField(description="The name of the output.")
-        title: str | None = SchemaField(
-            description="The title of the output.",
-            default=None,
-            advanced=True,
-        )
         description: str | None = SchemaField(
             description="The description of the output.",
             default=None,


### PR DESCRIPTION
There's no functional difference between Name and Title. It's just an aditional field with the same meaning.

### Changes 🏗️

Removed title from input and output blocks

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
