### PR TITLE
feat(blocks): Add new openrouter models

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -117,6 +117,14 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     PERPLEXITY_LLAMA_3_1_SONAR_LARGE_128K_ONLINE = (
         "perplexity/llama-3.1-sonar-large-128k-online"
     )
+    QWEN_QWQ_32B_PREVIEW = "qwen/qwq-32b-preview"
+    NOUSRESEARCH_HERMES_3_LLAMA_3_1_405B = "nousresearch/hermes-3-llama-3.1-405b"
+    NOUSRESEARCH_HERMES_3_LLAMA_3_1_70B = "nousresearch/hermes-3-llama-3.1-70b"
+    AMAZON_NOVA_LITE_V1 = "amazon/nova-lite-v1"
+    AMAZON_NOVA_MICRO_V1 = "amazon/nova-micro-v1"
+    AMAZON_NOVA_PRO_V1 = "amazon/nova-pro-v1"
+    MICROSOFT_WIZARDLM_2_8X22B = "microsoft/wizardlm-2-8x22b"
+    GRYPHE_MYTHOMAX_L2_13B = "gryphe/mythomax-l2-13b"
 
     @property
     def metadata(self) -> ModelMetadata:
@@ -162,6 +170,14 @@ MODEL_METADATA = {
     LlmModel.PERPLEXITY_LLAMA_3_1_SONAR_LARGE_128K_ONLINE: ModelMetadata(
         "open_router", 8192
     ),
+    LlmModel.QWEN_QWQ_32B_PREVIEW: ModelMetadata("open_router", 4000),
+    LlmModel.NOUSRESEARCH_HERMES_3_LLAMA_3_1_405B: ModelMetadata("open_router", 4000),
+    LlmModel.NOUSRESEARCH_HERMES_3_LLAMA_3_1_70B: ModelMetadata("open_router", 4000),
+    LlmModel.AMAZON_NOVA_LITE_V1: ModelMetadata("open_router", 4000),
+    LlmModel.AMAZON_NOVA_MICRO_V1: ModelMetadata("open_router", 4000),
+    LlmModel.AMAZON_NOVA_PRO_V1: ModelMetadata("open_router", 4000),
+    LlmModel.MICROSOFT_WIZARDLM_2_8X22B: ModelMetadata("open_router", 4000),
+    LlmModel.GRYPHE_MYTHOMAX_L2_13B: ModelMetadata("open_router", 4000),
 }
 
 for model in LlmModel:

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -107,7 +107,6 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     OLLAMA_LLAMA3_405B = "llama3.1:405b"
     # OpenRouter models
     GEMINI_FLASH_1_5_8B = "google/gemini-flash-1.5"
-    GEMINI_FLASH_1_5_EXP = "google/gemini-flash-1.5-exp"
     GROK_BETA = "x-ai/grok-beta"
     MISTRAL_NEMO = "mistralai/mistral-nemo"
     COHERE_COMMAND_R_08_2024 = "cohere/command-r-08-2024"
@@ -160,7 +159,6 @@ MODEL_METADATA = {
     LlmModel.OLLAMA_LLAMA3_8B: ModelMetadata("ollama", 8192),
     LlmModel.OLLAMA_LLAMA3_405B: ModelMetadata("ollama", 8192),
     LlmModel.GEMINI_FLASH_1_5_8B: ModelMetadata("open_router", 8192),
-    LlmModel.GEMINI_FLASH_1_5_EXP: ModelMetadata("open_router", 8192),
     LlmModel.GROK_BETA: ModelMetadata("open_router", 8192),
     LlmModel.MISTRAL_NEMO: ModelMetadata("open_router", 4000),
     LlmModel.COHERE_COMMAND_R_08_2024: ModelMetadata("open_router", 4000),

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -54,7 +54,6 @@ MODEL_COST: dict[LlmModel, int] = {
     LlmModel.OLLAMA_LLAMA3_8B: 1,
     LlmModel.OLLAMA_LLAMA3_405B: 1,
     LlmModel.GEMINI_FLASH_1_5_8B: 1,
-    LlmModel.GEMINI_FLASH_1_5_EXP: 1,
     LlmModel.GROK_BETA: 5,
     LlmModel.MISTRAL_NEMO: 1,
     LlmModel.COHERE_COMMAND_R_08_2024: 1,

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -62,6 +62,14 @@ MODEL_COST: dict[LlmModel, int] = {
     LlmModel.EVA_QWEN_2_5_32B: 1,
     LlmModel.DEEPSEEK_CHAT: 2,
     LlmModel.PERPLEXITY_LLAMA_3_1_SONAR_LARGE_128K_ONLINE: 1,
+    LlmModel.QWEN_QWQ_32B_PREVIEW: 2,
+    LlmModel.NOUSRESEARCH_HERMES_3_LLAMA_3_1_405B: 1,
+    LlmModel.NOUSRESEARCH_HERMES_3_LLAMA_3_1_70B: 1,
+    LlmModel.AMAZON_NOVA_LITE_V1: 1,
+    LlmModel.AMAZON_NOVA_MICRO_V1: 1,
+    LlmModel.AMAZON_NOVA_PRO_V1: 1,
+    LlmModel.MICROSOFT_WIZARDLM_2_8X22B: 1,
+    LlmModel.GRYPHE_MYTHOMAX_L2_13B: 1,
 }
 
 for model in LlmModel:


### PR DESCRIPTION
**Summary:**
This PR removes the `GEMINI_FLASH_1_5_EXP` model (due to inference on OpenRouter not working) and introduces several new models to the `LlmModel` enum. Corresponding updates have been made to the metadata configurations and block cost settings to reflect the changes.

**Key Changes:**
1. **Removed Models:**
   - `GEMINI_FLASH_1_5_EXP`

2. **Added New Models:**
   - `QWEN_QWQ_32B_PREVIEW`
   - `NOUSRESEARCH_HERMES_3_LLAMA_3_1_405B`
   - `NOUSRESEARCH_HERMES_3_LLAMA_3_1_70B`
   - `AMAZON_NOVA_LITE_V1`
   - `AMAZON_NOVA_MICRO_V1`
   - `AMAZON_NOVA_PRO_V1`
   - `MICROSOFT_WIZARDLM_2_8X22B`
   - `GRYPHE_MYTHOMAX_L2_13B`

3. **Metadata Updates:**
   - Added metadata entries for the new models with a max output tokens of 4,000 tokens.

4. **Cost Configuration Updates:**
   - Defined block costs for the newly added models:
     - `QWEN_QWQ_32B_PREVIEW`: 2 credits
     - All other new models: 1 credit

**Testing:**
- Verified that all models can be called without errors with the AI Text generator block