### PR TITLE
chore(platform):Refactor GraphExecution naming clash and remove unused Graph Execution functions

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -9,7 +9,6 @@ from prisma.models import (
     AgentNodeExecution,
     AgentNodeExecutionInputOutput,
 )
-from prisma.types import AgentGraphExecutionWhereInput
 from pydantic import BaseModel
 
 from backend.data.block import BlockData, BlockInput, CompletedBlockOutput
@@ -19,14 +18,14 @@ from backend.util import json, mock
 from backend.util.settings import Config
 
 
-class GraphExecution(BaseModel):
+class GraphExecutionEntry(BaseModel):
     user_id: str
     graph_exec_id: str
     graph_id: str
-    start_node_execs: list["NodeExecution"]
+    start_node_execs: list["NodeExecutionEntry"]
 
 
-class NodeExecution(BaseModel):
+class NodeExecutionEntry(BaseModel):
     user_id: str
     graph_exec_id: str
     graph_id: str
@@ -323,34 +322,6 @@ async def update_execution_status(
         raise ValueError(f"Execution {node_exec_id} not found.")
 
     return ExecutionResult.from_db(res)
-
-
-async def get_graph_execution(
-    graph_exec_id: str, user_id: str
-) -> AgentGraphExecution | None:
-    """
-    Retrieve a specific graph execution by its ID.
-
-    Args:
-        graph_exec_id (str): The ID of the graph execution to retrieve.
-        user_id (str): The ID of the user to whom the graph (execution) belongs.
-
-    Returns:
-        AgentGraphExecution | None: The graph execution if found, None otherwise.
-    """
-    execution = await AgentGraphExecution.prisma().find_first(
-        where={"id": graph_exec_id, "userId": user_id},
-        include=GRAPH_EXECUTION_INCLUDE,
-    )
-    return execution
-
-
-async def list_executions(graph_id: str, graph_version: int | None = None) -> list[str]:
-    where: AgentGraphExecutionWhereInput = {"agentGraphId": graph_id}
-    if graph_version is not None:
-        where["agentGraphVersion"] = graph_version
-    executions = await AgentGraphExecution.prisma().find_many(where=where)
-    return [execution.id for execution in executions]
 
 
 async def get_execution_results(graph_exec_id: str) -> list[ExecutionResult]:

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -25,8 +25,8 @@ from backend.data.execution import (
     ExecutionQueue,
     ExecutionResult,
     ExecutionStatus,
-    GraphExecution,
-    NodeExecution,
+    GraphExecutionEntry,
+    NodeExecutionEntry,
     merge_execution_input,
     parse_execution_output,
 )
@@ -96,13 +96,13 @@ class LogMetadata:
 
 
 T = TypeVar("T")
-ExecutionStream = Generator[NodeExecution, None, None]
+ExecutionStream = Generator[NodeExecutionEntry, None, None]
 
 
 def execute_node(
     db_client: "DatabaseManager",
     creds_manager: IntegrationCredentialsManager,
-    data: NodeExecution,
+    data: NodeExecutionEntry,
     execution_stats: dict[str, Any] | None = None,
 ) -> ExecutionStream:
     """
@@ -252,15 +252,15 @@ def _enqueue_next_nodes(
     graph_exec_id: str,
     graph_id: str,
     log_metadata: LogMetadata,
-) -> list[NodeExecution]:
+) -> list[NodeExecutionEntry]:
     def add_enqueued_execution(
         node_exec_id: str, node_id: str, data: BlockInput
-    ) -> NodeExecution:
+    ) -> NodeExecutionEntry:
         exec_update = db_client.update_execution_status(
             node_exec_id, ExecutionStatus.QUEUED, data
         )
         db_client.send_execution_update(exec_update)
-        return NodeExecution(
+        return NodeExecutionEntry(
             user_id=user_id,
             graph_exec_id=graph_exec_id,
             graph_id=graph_id,
@@ -269,7 +269,7 @@ def _enqueue_next_nodes(
             data=data,
         )
 
-    def register_next_executions(node_link: Link) -> list[NodeExecution]:
+    def register_next_executions(node_link: Link) -> list[NodeExecutionEntry]:
         enqueued_executions = []
         next_output_name = node_link.source_name
         next_input_name = node_link.sink_name
@@ -501,8 +501,8 @@ class Executor:
     @error_logged
     def on_node_execution(
         cls,
-        q: ExecutionQueue[NodeExecution],
-        node_exec: NodeExecution,
+        q: ExecutionQueue[NodeExecutionEntry],
+        node_exec: NodeExecutionEntry,
     ) -> dict[str, Any]:
         log_metadata = LogMetadata(
             user_id=node_exec.user_id,
@@ -529,8 +529,8 @@ class Executor:
     @time_measured
     def _on_node_execution(
         cls,
-        q: ExecutionQueue[NodeExecution],
-        node_exec: NodeExecution,
+        q: ExecutionQueue[NodeExecutionEntry],
+        node_exec: NodeExecutionEntry,
         log_metadata: LogMetadata,
         stats: dict[str, Any] | None = None,
     ):
@@ -580,7 +580,9 @@ class Executor:
 
     @classmethod
     @error_logged
-    def on_graph_execution(cls, graph_exec: GraphExecution, cancel: threading.Event):
+    def on_graph_execution(
+        cls, graph_exec: GraphExecutionEntry, cancel: threading.Event
+    ):
         log_metadata = LogMetadata(
             user_id=graph_exec.user_id,
             graph_eid=graph_exec.graph_exec_id,
@@ -605,7 +607,7 @@ class Executor:
     @time_measured
     def _on_graph_execution(
         cls,
-        graph_exec: GraphExecution,
+        graph_exec: GraphExecutionEntry,
         cancel: threading.Event,
         log_metadata: LogMetadata,
     ) -> tuple[dict[str, Any], Exception | None]:
@@ -636,13 +638,13 @@ class Executor:
         cancel_thread.start()
 
         try:
-            queue = ExecutionQueue[NodeExecution]()
+            queue = ExecutionQueue[NodeExecutionEntry]()
             for node_exec in graph_exec.start_node_execs:
                 queue.add(node_exec)
 
             running_executions: dict[str, AsyncResult] = {}
 
-            def make_exec_callback(exec_data: NodeExecution):
+            def make_exec_callback(exec_data: NodeExecutionEntry):
                 node_id = exec_data.node_id
 
                 def callback(result: object):
@@ -717,7 +719,7 @@ class ExecutionManager(AppService):
         self.use_redis = True
         self.use_supabase = True
         self.pool_size = settings.config.num_graph_workers
-        self.queue = ExecutionQueue[GraphExecution]()
+        self.queue = ExecutionQueue[GraphExecutionEntry]()
         self.active_graph_runs: dict[str, tuple[Future, threading.Event]] = {}
 
     @classmethod
@@ -768,7 +770,7 @@ class ExecutionManager(AppService):
         data: BlockInput,
         user_id: str,
         graph_version: int | None = None,
-    ) -> GraphExecution:
+    ) -> GraphExecutionEntry:
         graph: GraphModel | None = self.db_client.get_graph(
             graph_id=graph_id, user_id=user_id, version=graph_version
         )
@@ -818,7 +820,7 @@ class ExecutionManager(AppService):
         starting_node_execs = []
         for node_exec in node_execs:
             starting_node_execs.append(
-                NodeExecution(
+                NodeExecutionEntry(
                     user_id=user_id,
                     graph_exec_id=node_exec.graph_exec_id,
                     graph_id=node_exec.graph_id,
@@ -832,7 +834,7 @@ class ExecutionManager(AppService):
             )
             self.db_client.send_execution_update(exec_update)
 
-        graph_exec = GraphExecution(
+        graph_exec = GraphExecutionEntry(
             user_id=user_id,
             graph_id=graph_id,
             graph_exec_id=graph_exec_id,

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -117,17 +117,17 @@ class AgentServer(backend.util.service.AppProcess):
     async def test_create_graph(
         create_graph: backend.server.routers.v1.CreateGraph,
         user_id: str,
-        is_template=False,
     ):
         return await backend.server.routers.v1.create_new_graph(create_graph, user_id)
 
     @staticmethod
-    async def test_get_graph_run_status(
-        graph_id: str, graph_exec_id: str, user_id: str
-    ):
-        return await backend.server.routers.v1.__test__get_graph_run_status(
-            graph_id, graph_exec_id, user_id
+    async def test_get_graph_run_status(graph_exec_id: str, user_id: str):
+        execution = await backend.data.graph.get_execution(
+            user_id=user_id, execution_id=graph_exec_id
         )
+        if not execution:
+            raise ValueError(f"Execution {graph_exec_id} not found")
+        return execution.status
 
     @staticmethod
     async def test_get_graph_run_node_execution_results(

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -125,7 +125,7 @@ class AgentServer(backend.util.service.AppProcess):
     async def test_get_graph_run_status(
         graph_id: str, graph_exec_id: str, user_id: str
     ):
-        return await backend.server.routers.v1.get_graph_run_status(
+        return await backend.server.routers.v1.__test__get_graph_run_status(
             graph_id, graph_exec_id, user_id
         )
 

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -422,26 +422,6 @@ async def get_graph_run_node_execution_results(
     return await execution_db.get_execution_results(graph_exec_id)
 
 
-async def __test__get_graph_run_status(
-    graph_id: str,
-    graph_exec_id: str,
-    user_id: Annotated[str, Depends(get_user_id)],
-) -> execution_db.ExecutionStatus:
-    graph = await graph_db.get_graph(graph_id, user_id=user_id)
-    if not graph:
-        raise HTTPException(status_code=404, detail=f"Graph #{graph_id} not found.")
-
-    execution = await graph_db.get_execution(
-        user_id=user_id, execution_id=graph_exec_id
-    )
-    if not execution:
-        raise HTTPException(
-            status_code=404, detail=f"Execution #{graph_exec_id} not found."
-        )
-
-    return execution.status
-
-
 ########################################################
 ##################### Templates ########################
 ########################################################

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -149,12 +149,9 @@ class DeleteGraphResponse(TypedDict):
 
 @v1_router.get(path="/graphs", tags=["graphs"], dependencies=[Depends(auth_middleware)])
 async def get_graphs(
-    user_id: Annotated[str, Depends(get_user_id)],
-    with_runs: bool = False,
+    user_id: Annotated[str, Depends(get_user_id)]
 ) -> Sequence[graph_db.Graph]:
-    return await graph_db.get_graphs(
-        include_executions=with_runs, filter_by="active", user_id=user_id
-    )
+    return await graph_db.get_graphs(filter_by="active", user_id=user_id)
 
 
 @v1_router.get(
@@ -386,7 +383,7 @@ def execute_graph(
 async def stop_graph_run(
     graph_exec_id: str, user_id: Annotated[str, Depends(get_user_id)]
 ) -> Sequence[execution_db.ExecutionResult]:
-    if not await execution_db.get_graph_execution(graph_exec_id, user_id):
+    if not await graph_db.get_execution(user_id=user_id, execution_id=graph_exec_id):
         raise HTTPException(404, detail=f"Agent execution #{graph_exec_id} not found")
 
     await asyncio.to_thread(
@@ -409,26 +406,6 @@ async def get_executions(
 
 
 @v1_router.get(
-    path="/graphs/{graph_id}/executions",
-    tags=["graphs"],
-    dependencies=[Depends(auth_middleware)],
-)
-async def list_graph_runs(
-    graph_id: str,
-    user_id: Annotated[str, Depends(get_user_id)],
-    graph_version: int | None = None,
-) -> Sequence[str]:
-    graph = await graph_db.get_graph(graph_id, graph_version, user_id=user_id)
-    if not graph:
-        rev = "" if graph_version is None else f" v{graph_version}"
-        raise HTTPException(
-            status_code=404, detail=f"Agent #{graph_id}{rev} not found."
-        )
-
-    return await execution_db.list_executions(graph_id, graph_version)
-
-
-@v1_router.get(
     path="/graphs/{graph_id}/executions/{graph_exec_id}",
     tags=["graphs"],
     dependencies=[Depends(auth_middleware)],
@@ -445,8 +422,7 @@ async def get_graph_run_node_execution_results(
     return await execution_db.get_execution_results(graph_exec_id)
 
 
-# NOTE: This is used for testing
-async def get_graph_run_status(
+async def __test__get_graph_run_status(
     graph_id: str,
     graph_exec_id: str,
     user_id: Annotated[str, Depends(get_user_id)],
@@ -455,13 +431,15 @@ async def get_graph_run_status(
     if not graph:
         raise HTTPException(status_code=404, detail=f"Graph #{graph_id} not found.")
 
-    execution = await execution_db.get_graph_execution(graph_exec_id, user_id)
+    execution = await graph_db.get_execution(
+        user_id=user_id, execution_id=graph_exec_id
+    )
     if not execution:
         raise HTTPException(
             status_code=404, detail=f"Execution #{graph_exec_id} not found."
         )
 
-    return execution.executionStatus
+    return execution.status
 
 
 ########################################################

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -60,9 +60,7 @@ async def wait_execution(
     timeout: int = 20,
 ) -> Sequence[ExecutionResult]:
     async def is_execution_completed():
-        status = await AgentServer().test_get_graph_run_status(
-            graph_id, graph_exec_id, user_id
-        )
+        status = await AgentServer().test_get_graph_run_status(graph_exec_id, user_id)
         log.info(f"Execution status: {status}")
         if status == ExecutionStatus.FAILED:
             log.info("Execution failed")

--- a/autogpt_platform/backend/test/executor/test_scheduler.py
+++ b/autogpt_platform/backend/test/executor/test_scheduler.py
@@ -14,7 +14,6 @@ async def test_agent_schedule(server: SpinTestServer):
     test_user = await create_test_user()
     test_graph = await server.agent_server.test_create_graph(
         create_graph=CreateGraph(graph=create_test_graph()),
-        is_template=False,
         user_id=test_user.id,
     )
 

--- a/autogpt_platform/frontend/src/app/page.tsx
+++ b/autogpt_platform/frontend/src/app/page.tsx
@@ -87,9 +87,7 @@ const Monitor = () => {
         selectedFlow={selectedFlow}
         onSelectFlow={(f) => {
           setSelectedRun(null);
-          setSelectedFlow(
-            f.id == selectedFlow?.id ? null : (f as GraphMetaWithRuns),
-          );
+          setSelectedFlow(f.id == selectedFlow?.id ? null : (f as GraphMeta));
         }}
       />
       <FlowRunsList

--- a/autogpt_platform/frontend/src/components/feature-flag/with-feature-flag.tsx
+++ b/autogpt_platform/frontend/src/components/feature-flag/with-feature-flag.tsx
@@ -18,13 +18,13 @@ export function withFeatureFlag<P extends object>(
       if (flags && flagKey in flags) {
         setHasFlagLoaded(true);
       }
-    }, [flags, flagKey]);
+    }, [flags]);
 
     useEffect(() => {
       if (hasFlagLoaded && !flags[flagKey]) {
         router.push("/404");
       }
-    }, [hasFlagLoaded, flags, flagKey, router]);
+    }, [hasFlagLoaded, flags, router]);
 
     // Show loading state until flags loaded
     if (!hasFlagLoaded) {

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/baseClient.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/baseClient.ts
@@ -12,7 +12,6 @@ import {
   GraphCreatable,
   GraphExecuteResponse,
   GraphMeta,
-  GraphMetaWithRuns,
   GraphUpdateable,
   NodeExecutionResult,
   OAuth2Credentials,
@@ -67,11 +66,6 @@ export default class BaseAutoGPTServerAPI {
 
   listGraphs(): Promise<GraphMeta[]> {
     return this._get(`/graphs`);
-  }
-
-  async listGraphsWithRuns(): Promise<GraphMetaWithRuns[]> {
-    let graphs = await this._get(`/graphs?with_runs=true`);
-    return graphs.map(parseGraphMetaWithRuns);
   }
 
   getExecutions(): Promise<GraphExecution[]> {
@@ -161,12 +155,6 @@ export default class BaseAutoGPTServerAPI {
     inputData: { [key: string]: any } = {},
   ): Promise<GraphExecuteResponse> {
     return this._request("POST", `/graphs/${id}/execute`, inputData);
-  }
-
-  listGraphRunIDs(graphID: string, graphVersion?: number): Promise<string[]> {
-    const query =
-      graphVersion !== undefined ? `?graph_version=${graphVersion}` : "";
-    return this._get(`/graphs/${graphID}/executions` + query);
   }
 
   async getGraphExecutionInfo(
@@ -519,22 +507,5 @@ function parseNodeExecutionResultTimestamps(result: any): NodeExecutionResult {
     queue_time: result.queue_time ? new Date(result.queue_time) : undefined,
     start_time: result.start_time ? new Date(result.start_time) : undefined,
     end_time: result.end_time ? new Date(result.end_time) : undefined,
-  };
-}
-
-function parseGraphMetaWithRuns(result: any): GraphMetaWithRuns {
-  return {
-    ...result,
-    executions: result.executions
-      ? result.executions.map(parseExecutionMetaTimestamps)
-      : [],
-  };
-}
-
-function parseExecutionMetaTimestamps(result: any): GraphExecution {
-  return {
-    ...result,
-    started_at: new Date(result.started_at).getTime(),
-    ended_at: result.ended_at ? new Date(result.ended_at).getTime() : undefined,
   };
 }

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -211,6 +211,7 @@ export type GraphMeta = {
   output_schema: BlockIOObjectSubSchema;
 };
 
+/* Mirror of backend/data/graph.py:Graph */
 export type Graph = GraphMeta & {
   nodes: Array<Node>;
   links: Array<Link>;

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -200,7 +200,6 @@ export type GraphExecution = {
   graph_version: number;
 };
 
-/* backend/data/graph.py:Graph = GraphMeta & Graph */
 export type GraphMeta = {
   id: string;
   version: number;

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -200,7 +200,7 @@ export type GraphExecution = {
   graph_version: number;
 };
 
-/* backend/data/graph.py:Graph = GraphMeta & GraphMetaWithRuns & Graph */
+/* backend/data/graph.py:Graph = GraphMeta & Graph */
 export type GraphMeta = {
   id: string;
   version: number;
@@ -210,10 +210,6 @@ export type GraphMeta = {
   description: string;
   input_schema: BlockIOObjectSubSchema;
   output_schema: BlockIOObjectSubSchema;
-};
-
-export type GraphMetaWithRuns = GraphMeta & {
-  executions: GraphExecution[];
 };
 
 export type Graph = GraphMeta & {


### PR DESCRIPTION
This is a follow-up of https://github.com/Significant-Gravitas/AutoGPT/pull/8752

There are several APIs and functions related to graph execution that are unused now.
There is also confusion about the name of `GraphExecution` that exists in graph.py & execution.py.

### Changes 🏗️

* Renamed `GraphExecution` in `execution.py` to `GraphExecutionEntry`, this is only used as a queue entry for execution.
* Removed unused `get_graph_execution` & `list_executions` in `execution.py`.
* Removed `with_run` option on `get_graph` function in `graph.py`.
* Removed `GraphMetaWithRuns`
* Removed exposed functions only for testing.
* Removed `executions` fields in Graph model.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
