### PR TITLE
fix(frontend): Make pins smaller and fix hover area and highlight for input pins

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomEdge.tsx
+++ b/autogpt_platform/frontend/src/components/CustomEdge.tsx
@@ -49,7 +49,7 @@ export function CustomEdge({
   const { svgPath, length, getPointForT, getTForDistance } = useBezierPath(
     sourceX - 5,
     sourceY - 5,
-    targetX - 9,
+    targetX + 3,
     targetY - 5,
   );
   const { deleteElements } = useReactFlow<Node, CustomEdge>();

--- a/autogpt_platform/frontend/src/components/NodeHandle.tsx
+++ b/autogpt_platform/frontend/src/components/NodeHandle.tsx
@@ -51,7 +51,7 @@ const NodeHandle: FC<HandleProps> = ({
       : "border-gray-300";
     return (
       <div
-        className={`${className} ${color} m-1 h-6 w-6 rounded-full border-2 bg-white transition-colors duration-100 group-hover:bg-gray-300`}
+        className={`${className} ${color} m-1 h-4 w-4 rounded-full border-2 bg-white transition-colors duration-100 group-hover:bg-gray-300`}
       />
     );
   };
@@ -64,7 +64,7 @@ const NodeHandle: FC<HandleProps> = ({
           data-testid={`input-handle-${keyName}`}
           position={Position.Left}
           id={keyName}
-          className="-ml-[26px]"
+          className="group -ml-[26px]"
         >
           <div className="pointer-events-none flex items-center">
             <Dot className={`-ml-2 mr-2`} />

--- a/autogpt_platform/frontend/src/components/NodeHandle.tsx
+++ b/autogpt_platform/frontend/src/components/NodeHandle.tsx
@@ -45,13 +45,13 @@ const NodeHandle: FC<HandleProps> = ({
     </div>
   );
 
-  const Dot = ({ className = "" }) => {
+  const Dot = () => {
     const color = isConnected
       ? getTypeBgColor(schema.type || "any")
       : "border-gray-300";
     return (
       <div
-        className={`${className} ${color} m-1 h-4 w-4 rounded-full border-2 bg-white transition-colors duration-100 group-hover:bg-gray-300`}
+        className={`${color} m-1 h-4 w-4 rounded-full border-2 bg-white transition-colors duration-100 group-hover:bg-gray-300`}
       />
     );
   };
@@ -64,10 +64,10 @@ const NodeHandle: FC<HandleProps> = ({
           data-testid={`input-handle-${keyName}`}
           position={Position.Left}
           id={keyName}
-          className="group -ml-[26px]"
+          className="group -ml-[38px]"
         >
           <div className="pointer-events-none flex items-center">
-            <Dot className={`-ml-2 mr-2`} />
+            <Dot />
             {label}
           </div>
         </Handle>


### PR DESCRIPTION
Recently pins were made slightly bigger and misaligned needlessly. The problem in the linked issue was to fix connection area, not make them bigger.
- https://github.com/Significant-Gravitas/AutoGPT/issues/8913

### Changes 🏗️

- Revert pins size to smaller
- Fix hover area and highlight for input pins

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Connect, reconnect, remove connection
  - [x] Tutorial works

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
