### PR TITLE
ci(frontend): Speed up test jobs

### DIFF
--- a/.github/workflows/platform-frontend-ci.yml
+++ b/.github/workflows/platform-frontend-ci.yml
@@ -38,23 +38,22 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
 
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
-          tool-cache: false
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
-          android: false
-          dotnet: false
-          haskell: false
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+      # - name: Free Disk Space (Ubuntu)
+      #   uses: jlumbroso/free-disk-space@main
+      #   with:
+      #     tool-cache: false
+      #     android: false
+      #     dotnet: false
+      #     haskell: false
+      #     large-packages: true
+      #     docker-images: true
+      #     swap-storage: true
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -86,16 +85,16 @@ jobs:
         run: |
           cp .env.example .env
 
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps
+      - name: Install Playwright Browser
+        run: yarn playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run tests
         run: |
-          yarn test
+          yarn test --project=${{ matrix.browser }}
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: playwright-report/
           retention-days: 30

--- a/.github/workflows/platform-frontend-ci.yml
+++ b/.github/workflows/platform-frontend-ci.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -44,17 +45,6 @@ jobs:
         browser: [chromium, firefox, webkit]
 
     steps:
-      # - name: Free Disk Space (Ubuntu)
-      #   uses: jlumbroso/free-disk-space@main
-      #   with:
-      #     tool-cache: false
-      #     android: false
-      #     dotnet: false
-      #     haskell: false
-      #     large-packages: true
-      #     docker-images: true
-      #     swap-storage: true
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -64,6 +54,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "21"
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
 
       - name: Copy default supabase .env
         run: |
@@ -85,7 +80,7 @@ jobs:
         run: |
           cp .env.example .env
 
-      - name: Install Playwright Browser
+      - name: Install Browser '${{ matrix.browser }}'
         run: yarn playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run tests

--- a/.github/workflows/platform-frontend-ci.yml
+++ b/.github/workflows/platform-frontend-ci.yml
@@ -58,7 +58,8 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: true
+          large-packages: false  # slow
+          docker-images: false  # limited benefit
 
       - name: Copy default supabase .env
         run: |


### PR DESCRIPTION
- Resolves #8948

### Changes 🏗️

- Parallelize frontend test job into a per-browser matrix
- Speed up "Free Disk Space" step by disabling removal of large system packages