### PR TITLE
fix(store): Youtube link not showing video on agent page

### DIFF
--- a/autogpt_platform/frontend/src/app/store/agent/[creator]/[slug]/page.tsx
+++ b/autogpt_platform/frontend/src/app/store/agent/[creator]/[slug]/page.tsx
@@ -68,7 +68,7 @@ export default async function Page({
               storeListingVersionId={agent.store_listing_version_id}
             />
           </div>
-          <AgentImages images={agent.agent_image} />
+          <AgentImages images={[agent.agent_video, ...agent.agent_image]} />
         </div>
         <Separator className="my-6" />
         <AgentsSection


### PR DESCRIPTION
Fixes #9054 

## Changes

- add the video link to the start of the images array