### PR TITLE
fix(store): Marketplace - "Integrations" link in Settings is a 404

### DIFF
--- a/autogpt_platform/frontend/src/app/store/(user)/layout.tsx
+++ b/autogpt_platform/frontend/src/app/store/(user)/layout.tsx
@@ -7,7 +7,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       links: [
         { text: "Creator Dashboard", href: "/store/dashboard" },
         { text: "Agent dashboard", href: "/store/agent-dashboard" },
-        { text: "Integrations", href: "/store/integrations" },
+        { text: "Integrations", href: "/profile" },
         { text: "Profile", href: "/store/profile" },
         { text: "Settings", href: "/store/settings" },
       ],

--- a/autogpt_platform/frontend/src/components/agptui/Sidebar.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/Sidebar.tsx
@@ -94,7 +94,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ linkGroups }) => {
               </div>
             </Link>
             <Link
-              href="/integrations"
+              href="/profile"
               className="inline-flex w-full items-center gap-2.5 rounded-xl px-3 py-3 text-neutral-800 hover:bg-neutral-800 hover:text-white dark:text-neutral-200 dark:hover:bg-neutral-700 dark:hover:text-white"
             >
               <IconIntegrations className="h-6 w-6" />


### PR DESCRIPTION
closes #9070 

### Changes 🏗️

- redirect users to the old "profile" page to show integrations.

⚠️ This PR does not introduce a newly styled integrations page