### PR TITLE
feat(store): Auto-populate the agent submission form

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -757,6 +757,7 @@ async def get_my_agents(
                 agent_version=agent.version,
                 agent_name=agent.name or "",
                 last_edited=agent.updatedAt or agent.createdAt,
+                description=agent.description or "",
             )
             for agent in agents
         ]

--- a/autogpt_platform/backend/backend/server/v2/store/model.py
+++ b/autogpt_platform/backend/backend/server/v2/store/model.py
@@ -24,6 +24,7 @@ class MyAgent(pydantic.BaseModel):
     agent_id: str
     agent_version: int
     agent_name: str
+    description: str
     last_edited: datetime.datetime
 
 

--- a/autogpt_platform/frontend/src/components/agptui/PublishAgentSelectInfo.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/PublishAgentSelectInfo.tsx
@@ -60,6 +60,25 @@ export const PublishAgentInfo: React.FC<PublishAgentInfoProps> = ({
   const [slug, setSlug] = React.useState(initialData?.slug || "");
   const thumbnailsContainerRef = React.useRef<HTMLDivElement | null>(null);
 
+  React.useEffect(() => {
+    if (initialData) {
+      setImages(
+        initialData.additionalImages
+          ? [initialData.thumbnailSrc, ...initialData.additionalImages]
+          : initialData.thumbnailSrc
+            ? [initialData.thumbnailSrc]
+            : [],
+      );
+      setSelectedImage(initialData.thumbnailSrc || null);
+      setTitle(initialData.title);
+      setSubheader(initialData.subheader);
+      setYoutubeLink(initialData.youtubeLink);
+      setCategory(initialData.category);
+      setDescription(initialData.description);
+      setSlug(initialData.slug);
+    }
+  }, [initialData]);
+
   const handleRemoveImage = (indexToRemove: number) => {
     const newImages = [...images];
     newImages.splice(indexToRemove, 1);

--- a/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx
@@ -44,6 +44,16 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
   );
   const [myAgents, setMyAgents] = React.useState<MyAgentsResponse | null>(null);
   const [selectedAgent, setSelectedAgent] = React.useState<string | null>(null);
+  const [initialData, setInitialData] = React.useState<{
+    title: string;
+    subheader: string;
+    slug: string;
+    thumbnailSrc: string;
+    youtubeLink: string;
+    category: string;
+    description: string;
+    additionalImages?: string[];
+  } | null>(null);
   const [publishData, setPublishData] =
     React.useState<StoreSubmissionRequest>(submissionData);
   const [selectedAgentId, setSelectedAgentId] = React.useState<string | null>(
@@ -102,6 +112,23 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
   };
 
   const handleNextFromSelect = (agentId: string, agentVersion: number) => {
+    const selectedAgentData = myAgents?.agents.find(
+      (agent) => agent.agent_id === agentId,
+    );
+
+    const name = selectedAgentData?.agent_name || "";
+    const description = selectedAgentData?.description || "";
+    setInitialData({
+      title: name,
+      subheader: "",
+      description: description,
+      thumbnailSrc: "",
+      youtubeLink: "",
+      category: "",
+      slug: name.replace(/ /g, "-"),
+      additionalImages: [],
+    });
+
     setStep("info");
     setSelectedAgentId(agentId);
     setSelectedAgentVersion(agentVersion);
@@ -203,6 +230,7 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
                   onBack={handleBack}
                   onSubmit={handleNextFromInfo}
                   onClose={handleClose}
+                  initialData={initialData}
                 />
               </div>
             </div>

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -488,6 +488,7 @@ export type MyAgent = {
   agent_version: number;
   agent_name: string;
   last_edited: string;
+  description: string;
 };
 
 export type MyAgentsResponse = {


### PR DESCRIPTION

### Changes 🏗️

- added description to my agents response
- auto populate the publish agent info form

https://github.com/user-attachments/assets/68cd5d33-0f67-4875-80e9-5a7115b847e7

