### PR TITLE
fix(store): "Publish an Agent" flow has a missing default image

### DIFF
--- a/autogpt_platform/frontend/src/components/agptui/PublishAgentSelectInfo.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/PublishAgentSelectInfo.tsx
@@ -62,13 +62,7 @@ export const PublishAgentInfo: React.FC<PublishAgentInfoProps> = ({
 
   React.useEffect(() => {
     if (initialData) {
-      setImages(
-        initialData.additionalImages
-          ? [initialData.thumbnailSrc, ...initialData.additionalImages]
-          : initialData.thumbnailSrc
-            ? [initialData.thumbnailSrc]
-            : [],
-      );
+      setImages(initialData.additionalImages || []);
       setSelectedImage(initialData.thumbnailSrc || null);
       setTitle(initialData.title);
       setSubheader(initialData.subheader);


### PR DESCRIPTION
Introduced when making sure initialData was inferred from the agent object. This has been fixed now
