### PR TITLE
fix(platform): Fields with default value are not set to advanced by default

### DIFF
--- a/autogpt_platform/backend/backend/data/block.py
+++ b/autogpt_platform/backend/backend/data/block.py
@@ -97,11 +97,6 @@ class BlockSchema(BaseModel):
 
         cls.cached_jsonschema = cast(dict[str, Any], ref_to_dict(model))
 
-        # Set default properties values
-        for field in cls.cached_jsonschema.get("properties", {}).values():
-            if isinstance(field, dict) and "advanced" not in field:
-                field["advanced"] = True
-
         return cls.cached_jsonschema
 
     @classmethod

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -193,7 +193,8 @@ class Graph(BaseDbModel):
             "properties": {
                 p.name: {
                     "secret": p.secret,
-                    "advanced": p.advanced,
+                    # Default value has to be set for advanced fields.
+                    "advanced": p.advanced and p.value is not None,
                     "title": p.title or p.name,
                     **({"description": p.description} if p.description else {}),
                     **({"default": p.value} if p.value is not None else {}),

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -142,8 +142,6 @@ def SchemaField(
     **kwargs,
 ) -> T:
     if default is PydanticUndefined and default_factory is None:
-        if advanced:
-            raise ValueError("Advanced fields must have a default value.")
         advanced = False
     elif advanced is None:
         advanced = True

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -134,13 +134,20 @@ def SchemaField(
     title: Optional[str] = None,
     description: Optional[str] = None,
     placeholder: Optional[str] = None,
-    advanced: Optional[bool] = False,
+    advanced: Optional[bool] = None,
     secret: bool = False,
     exclude: bool = False,
     hidden: Optional[bool] = None,
     depends_on: list[str] | None = None,
     **kwargs,
 ) -> T:
+    if default is PydanticUndefined and default_factory is None:
+        if advanced:
+            raise ValueError("Advanced fields must have a default value.")
+        advanced = False
+    elif advanced is None:
+        advanced = True
+
     json_extra = {
         k: v
         for k, v in {

--- a/autogpt_platform/backend/test/data/test_graph.py
+++ b/autogpt_platform/backend/test/data/test_graph.py
@@ -90,7 +90,12 @@ async def test_get_input_schema(server: SpinTestServer):
             Node(
                 id="node_0_a",
                 block_id=input_block,
-                input_default={"name": "in_key_a", "title": "Key A", "value": "A"},
+                input_default={
+                    "name": "in_key_a",
+                    "title": "Key A",
+                    "value": "A",
+                    "advanced": True,
+                },
                 metadata={"id": "node_0_a"},
             ),
             Node(
@@ -138,8 +143,10 @@ async def test_get_input_schema(server: SpinTestServer):
     )
 
     class ExpectedInputSchema(BlockSchema):
-        in_key_a: Any = SchemaField(title="Key A", default="A", advanced=False)
-        in_key_b: Any = SchemaField(title="in_key_b", advanced=True)
+        in_key_a: Any = SchemaField(title="Key A", default="A", advanced=True)
+        in_key_b: Any = SchemaField(
+            title="in_key_b", advanced=False
+        )  # no default value
 
     class ExpectedOutputSchema(BlockSchema):
         out_key: Any = SchemaField(

--- a/autogpt_platform/backend/test/data/test_graph.py
+++ b/autogpt_platform/backend/test/data/test_graph.py
@@ -144,9 +144,7 @@ async def test_get_input_schema(server: SpinTestServer):
 
     class ExpectedInputSchema(BlockSchema):
         in_key_a: Any = SchemaField(title="Key A", default="A", advanced=True)
-        in_key_b: Any = SchemaField(
-            title="in_key_b", advanced=False
-        )  # no default value
+        in_key_b: Any = SchemaField(title="in_key_b", advanced=False)
 
     class ExpectedOutputSchema(BlockSchema):
         out_key: Any = SchemaField(
@@ -157,6 +155,8 @@ async def test_get_input_schema(server: SpinTestServer):
 
     input_schema = created_graph.input_schema
     input_schema["title"] = "ExpectedInputSchema"
+    print(">>>> input_schema", input_schema)
+    print(">>>> ExpectedInputSchema", ExpectedInputSchema.jsonschema())
     assert input_schema == ExpectedInputSchema.jsonschema()
 
     output_schema = created_graph.output_schema

--- a/autogpt_platform/backend/test/data/test_graph.py
+++ b/autogpt_platform/backend/test/data/test_graph.py
@@ -155,8 +155,6 @@ async def test_get_input_schema(server: SpinTestServer):
 
     input_schema = created_graph.input_schema
     input_schema["title"] = "ExpectedInputSchema"
-    print(">>>> input_schema", input_schema)
-    print(">>>> ExpectedInputSchema", ExpectedInputSchema.jsonschema())
     assert input_schema == ExpectedInputSchema.jsonschema()
 
     output_schema = created_graph.output_schema


### PR DESCRIPTION
https://github.com/Significant-Gravitas/AutoGPT/issues/8739 causes input fields that are supposed to be an advanced field end up being a mandatory field:

![image](https://github.com/user-attachments/assets/1cb41a79-fe85-4012-91b8-861bd5f9a0ca)

*See the retry count field here.

### Changes 🏗️

Set the `advanced` field on each input field, and set the default value using this logic:
* If it has a default value, set it to True.
* otherwise, False.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
