### PR TITLE
feat(platform): Add Support for Managing Agent Presets with Pagination and Soft Delete

### DIFF
--- a/autogpt_platform/backend/backend/server/model.py
+++ b/autogpt_platform/backend/backend/server/model.py
@@ -56,3 +56,18 @@ class SetGraphActiveVersion(pydantic.BaseModel):
 
 class UpdatePermissionsRequest(pydantic.BaseModel):
     permissions: List[APIKeyPermission]
+
+
+class Pagination(pydantic.BaseModel):
+    total_items: int = pydantic.Field(
+        description="Total number of items.", examples=[42]
+    )
+    total_pages: int = pydantic.Field(
+        description="Total number of pages.", examples=[97]
+    )
+    current_page: int = pydantic.Field(
+        description="Current_page page number.", examples=[1]
+    )
+    page_size: int = pydantic.Field(
+        description="Number of items per page.", examples=[25]
+    )

--- a/autogpt_platform/backend/backend/server/v2/library/model.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model.py
@@ -1,6 +1,12 @@
+import datetime
+import json
 import typing
 
+import prisma.models
 import pydantic
+
+import backend.data.block
+import backend.server.model
 
 
 class LibraryAgent(pydantic.BaseModel):
@@ -14,3 +20,49 @@ class LibraryAgent(pydantic.BaseModel):
     # Made input_schema and output_schema match GraphMeta's type
     input_schema: dict[str, typing.Any]  # Should be BlockIOObjectSubSchema in frontend
     output_schema: dict[str, typing.Any]  # Should be BlockIOObjectSubSchema in frontend
+
+
+class LibraryAgentPreset(pydantic.BaseModel):
+    id: str
+    updated_at: datetime.datetime
+
+    agent_id: str
+    agent_version: int
+
+    name: str
+    description: str
+
+    is_active: bool
+    inputs: dict[str, backend.data.block.BlockInput]
+
+    @staticmethod
+    def from_db(preset: prisma.models.AgentPreset):
+        input_data = {}
+
+        for data in preset.InputPresets or []:
+            input_data[data.name] = json.loads(data.data)
+
+        return LibraryAgentPreset(
+            id=preset.id,
+            updated_at=preset.updatedAt,
+            agent_id=preset.agentId,
+            agent_version=preset.agentVersion,
+            name=preset.name,
+            description=preset.description,
+            is_active=preset.isActive,
+            inputs=input_data,
+        )
+
+
+class LibraryAgentPresetResponse(pydantic.BaseModel):
+    presets: list[LibraryAgentPreset]
+    pagination: backend.server.model.Pagination
+
+
+class CreateLibraryAgentPresetRequest(pydantic.BaseModel):
+    name: str
+    description: str
+    inputs: dict[str, backend.data.block.BlockInput]
+    agent_id: str
+    agent_version: int
+    is_active: bool

--- a/autogpt_platform/backend/backend/server/v2/library/model_test.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model_test.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+import backend.data.block
+import backend.server.model
 import backend.server.v2.library.model
 
 
@@ -41,3 +45,84 @@ def test_library_agent_with_user_created():
     assert agent.isCreatedByUser is True
     assert agent.input_schema == {"type": "object", "properties": {}}
     assert agent.output_schema == {"type": "object", "properties": {}}
+
+
+def test_library_agent_preset():
+    preset = backend.server.v2.library.model.LibraryAgentPreset(
+        id="preset-123",
+        name="Test Preset",
+        description="Test preset description",
+        agent_id="test-agent-123",
+        agent_version=1,
+        is_active=True,
+        inputs={
+            "input1": backend.data.block.BlockInput(
+                name="input1",
+                data={"type": "string", "value": "test value"},
+            )
+        },
+        updated_at=datetime.now(),
+    )
+    assert preset.id == "preset-123"
+    assert preset.name == "Test Preset"
+    assert preset.description == "Test preset description"
+    assert preset.agent_id == "test-agent-123"
+    assert preset.agent_version == 1
+    assert preset.is_active is True
+    assert preset.inputs == {"input1": "test value"}
+
+
+def test_library_agent_preset_response():
+    preset = backend.server.v2.library.model.LibraryAgentPreset(
+        id="preset-123",
+        name="Test Preset",
+        description="Test preset description",
+        agent_id="test-agent-123",
+        agent_version=1,
+        is_active=True,
+        inputs={
+            "input1": backend.data.block.BlockInput(
+                name="input1",
+                data={"type": "string", "value": "test value"},
+            )
+        },
+        updated_at=datetime.now(),
+    )
+
+    pagination = backend.server.model.Pagination(
+        total_items=1, total_pages=1, current_page=1, page_size=10
+    )
+
+    response = backend.server.v2.library.model.LibraryAgentPresetResponse(
+        presets=[preset], pagination=pagination
+    )
+
+    assert len(response.presets) == 1
+    assert response.presets[0].id == "preset-123"
+    assert response.pagination.total_items == 1
+    assert response.pagination.total_pages == 1
+    assert response.pagination.current_page == 1
+    assert response.pagination.page_size == 10
+
+
+def test_create_library_agent_preset_request():
+    request = backend.server.v2.library.model.CreateLibraryAgentPresetRequest(
+        name="New Preset",
+        description="New preset description",
+        agent_id="agent-123",
+        agent_version=1,
+        is_active=True,
+        inputs={
+            "input1": backend.data.block.BlockInput(
+                name="input1",
+                data={"type": "string", "value": "test value"},
+            )
+        },
+    )
+
+    assert request.name == "New Preset"
+    assert request.description == "New preset description"
+    assert request.agent_id == "agent-123"
+    assert request.agent_version == 1
+    assert request.is_active is True
+    assert request.inputs == {"input1": "test value"}

--- a/autogpt_platform/backend/migrations/20250107095812_preset_soft_delete/migration.sql
+++ b/autogpt_platform/backend/migrations/20250107095812_preset_soft_delete/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AgentPreset" ADD COLUMN     "isDeleted" BOOLEAN NOT NULL DEFAULT false;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -106,6 +106,8 @@ model AgentPreset {
   UserAgents             UserAgent[]
   AgentExecution         AgentGraphExecution[]
 
+  isDeleted Boolean @default(false)
+
   @@index([userId])
 }
 


### PR DESCRIPTION
#### Summary
- **New Models**: Added `LibraryAgentPreset`, `LibraryAgentPresetResponse`, `Pagination`, and `CreateLibraryAgentPresetRequest`.
- **Database Changes**:
  - Added `isDeleted` column in `AgentPreset` for soft delete.
  - CRUD operations for `AgentPreset`:
    - `get_presets` with pagination.
    - `get_preset` by ID.
    - `create_or_update_preset` for upsert.
    - `delete_preset` to soft delete.
- **API Routes**:
  - `GET /presets`: Fetch paginated presets.
  - `GET /presets/{preset_id}`: Fetch a single preset.
  - `POST /presets`: Create a preset.
  - `PUT /presets/{preset_id}`: Update a preset.
  - `DELETE /presets/{preset_id}`: Soft delete a preset.
- **Tests**:
  - Coverage for models, CRUD operations, and pagination.
- **Migration**:
  - Added `isDeleted` field to support soft delete.

#### Review Notes
- Validate migration scripts and test coverage.
- Ensure API aligns with project standards.