### PR TITLE
Fix Provider name enum being used instead of value

### DIFF
--- a/autogpt_platform/backend/backend/integrations/webhooks/utils.py
+++ b/autogpt_platform/backend/backend/integrations/webhooks/utils.py
@@ -7,6 +7,6 @@ app_config = Config()
 # TODO: add test to assert this matches the actual API route
 def webhook_ingress_url(provider_name: ProviderName, webhook_id: str) -> str:
     return (
-        f"{app_config.platform_base_url}/api/integrations/{provider_name}"
+        f"{app_config.platform_base_url}/api/integrations/{provider_name.value}"
         f"/webhooks/{webhook_id}/ingress"
     )


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

Webhooks are broken

### Changes 🏗️
Swaps the way we fill webhooks into strings
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manually test creating a webhook with Github and Compass