### PR TITLE
fix(blocks): improve handling of plain text in send web request block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/http.py
+++ b/autogpt_platform/backend/backend/blocks/http.py
@@ -56,15 +56,24 @@ class SendWebRequestBlock(Block):
         )
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
-        if isinstance(input_data.body, str):
-            input_data.body = json.loads(input_data.body)
-
+        body = input_data.body
+        
+        if input_data.json_format:
+            if isinstance(body, str):
+                try:
+                    # Try to parse as JSON first
+                    body = json.loads(body)
+                except json.JSONDecodeError:
+                    # If it's not valid JSON and just plain text,
+                    # we should send it as plain text instead
+                    input_data.json_format = False
+        
         response = requests.request(
             input_data.method.value,
             input_data.url,
             headers=input_data.headers,
-            json=input_data.body if input_data.json_format else None,
-            data=input_data.body if not input_data.json_format else None,
+            json=body if input_data.json_format else None,
+            data=body if not input_data.json_format else None,
         )
         result = response.json() if input_data.json_format else response.text
 

--- a/autogpt_platform/backend/backend/blocks/http.py
+++ b/autogpt_platform/backend/backend/blocks/http.py
@@ -57,7 +57,7 @@ class SendWebRequestBlock(Block):
 
     def run(self, input_data: Input, **kwargs) -> BlockOutput:
         body = input_data.body
-        
+
         if input_data.json_format:
             if isinstance(body, str):
                 try:
@@ -67,7 +67,7 @@ class SendWebRequestBlock(Block):
                     # If it's not valid JSON and just plain text,
                     # we should send it as plain text instead
                     input_data.json_format = False
-        
+
         response = requests.request(
             input_data.method.value,
             input_data.url,


### PR DESCRIPTION
### Changes 🏗️
This is to improve how we deal with plain text in the send web request block.

-	Plain text stays as plain text (regardless of JSON toggle)
-	Valid JSON with JSON toggle enabled sends as JSON
-	JSON-like data with JSON toggle disabled sends as form data

