### PR TITLE
fix(backend): Add default credentials for Fal, Exa, E2B

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -121,6 +121,15 @@ REPLICATE_API_KEY=
 # Ideogram
 IDEOGRAM_API_KEY=
 
+# Fal
+FAL_API_KEY=
+
+# Exa
+EXA_API_KEY=
+
+# E2B
+E2B_API_KEY=
+
 # Logging Configuration
 LOG_LEVEL=INFO
 ENABLE_CLOUD_LOGGING=false

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -93,6 +93,27 @@ open_router_credentials = APIKeyCredentials(
     title="Use Credits for Open Router",
     expires_at=None,
 )
+fal_credentials = APIKeyCredentials(
+    id="6c0f5bd0-9008-4638-9d79-4b40b631803e",
+    provider="fal",
+    api_key=SecretStr(settings.secrets.fal_api_key),
+    title="Use Credits for FAL",
+    expires_at=None,
+)
+exa_credentials = APIKeyCredentials(
+    id="96153e04-9c6c-4486-895f-5bb683b1ecec",
+    provider="exa",
+    api_key=SecretStr(settings.secrets.exa_api_key),
+    title="Use Credits for Exa search",
+    expires_at=None,
+)
+e2b_credentials = APIKeyCredentials(
+    id="78d19fd7-4d59-4a16-8277-3ce310acf2b7",
+    provider="e2b",
+    api_key=SecretStr(settings.secrets.e2b_api_key),
+    title="Use Credits for E2B",
+    expires_at=None,
+)
 
 
 DEFAULT_CREDENTIALS = [
@@ -106,6 +127,9 @@ DEFAULT_CREDENTIALS = [
     jina_credentials,
     unreal_credentials,
     open_router_credentials,
+    fal_credentials,
+    exa_credentials,
+    e2b_credentials,
 ]
 
 
@@ -157,6 +181,12 @@ class IntegrationCredentialsStore:
             all_credentials.append(unreal_credentials)
         if settings.secrets.open_router_api_key:
             all_credentials.append(open_router_credentials)
+        if settings.secrets.fal_api_key:
+            all_credentials.append(fal_credentials)
+        if settings.secrets.exa_api_key:
+            all_credentials.append(exa_credentials)
+        if settings.secrets.e2b_api_key:
+            all_credentials.append(e2b_credentials)
         return all_credentials
 
     def get_creds_by_id(self, user_id: str, credentials_id: str) -> Credentials | None:

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -304,7 +304,9 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     jina_api_key: str = Field(default="", description="Jina API Key")
     unreal_speech_api_key: str = Field(default="", description="Unreal Speech API Key")
 
-    fal_key: str = Field(default="", description="FAL API key")
+    fal_api_key: str = Field(default="", description="FAL API key")
+    exa_api_key: str = Field(default="", description="Exa API key")
+    e2b_api_key: str = Field(default="", description="E2B API key")
 
     # Add more secret fields as needed
 


### PR DESCRIPTION
We want to provide certain providers by default on our platform. These three were not added previously, so fixing that.

### Changes 🏗️

If api keys for Fal Exa or E2B exist in environment variables, load them by default as credentials that are usable by our users. 

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
