### PR TITLE
fix(frontend): Unbreak save button after save error

### DIFF
--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.ts
@@ -862,6 +862,7 @@ export default function useAgentGraph(
         title: "Error saving agent",
         description: errorMessage,
       });
+      setSaveRunRequest({ request: "save", state: "error" });
     }
   }, [_saveAgent, toast]);
 


### PR DESCRIPTION
- Resolves #9253

### Changes 🏗️

- Update state when an error occurs on save, to re-enable the save button

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Try to save an agent with missing required fields -> should give an error
  - Fill out the required fields and try saving again -> should work
