### PR TITLE
feat(backend): Minimize the non caught error logic between graph exec creation and queueing

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -657,6 +657,10 @@ class Executor:
         try:
             queue = ExecutionQueue[NodeExecutionEntry]()
             for node_exec in graph_exec.start_node_execs:
+                exec_update = cls.db_client.update_execution_status(
+                    node_exec.node_exec_id, ExecutionStatus.QUEUED, node_exec.data
+                )
+                cls.db_client.send_execution_update(exec_update)
                 queue.add(node_exec)
 
             running_executions: dict[str, AsyncResult] = {}
@@ -853,10 +857,6 @@ class ExecutionManager(AppService):
                     data=node_exec.input_data,
                 )
             )
-            exec_update = self.db_client.update_execution_status(
-                node_exec.node_exec_id, ExecutionStatus.QUEUED, node_exec.input_data
-            )
-            self.db_client.send_execution_update(exec_update)
 
         graph_exec = GraphExecutionEntry(
             user_id=user_id,


### PR DESCRIPTION
There should be no possibly failing code between graph exec creation and the actual queueing.
It could risk the graph execution being stuck on the QUEUED status.

### Changes 🏗️

Moved the node exec creation and status update to be inside the graph execution logic.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
