### PR TITLE
fix: check if linear is enabled before showing blocks

### DIFF
--- a/autogpt_platform/backend/backend/blocks/linear/comment.py
+++ b/autogpt_platform/backend/backend/blocks/linear/comment.py
@@ -1,5 +1,6 @@
 from backend.blocks.linear._api import LinearAPIException, LinearClient
 from backend.blocks.linear._auth import (
+    LINEAR_OAUTH_IS_CONFIGURED,
     TEST_CREDENTIALS_INPUT_OAUTH,
     TEST_CREDENTIALS_OAUTH,
     LinearCredentials,
@@ -41,6 +42,7 @@ class LinearCreateCommentBlock(Block):
                 "comment": "Test comment",
                 "credentials": TEST_CREDENTIALS_INPUT_OAUTH,
             },
+            disabled=not LINEAR_OAUTH_IS_CONFIGURED,
             test_credentials=TEST_CREDENTIALS_OAUTH,
             test_output=[("comment_id", "abc123"), ("comment_body", "Test comment")],
             test_mock={

--- a/autogpt_platform/backend/backend/blocks/linear/issues.py
+++ b/autogpt_platform/backend/backend/blocks/linear/issues.py
@@ -1,5 +1,6 @@
 from backend.blocks.linear._api import LinearAPIException, LinearClient
 from backend.blocks.linear._auth import (
+    LINEAR_OAUTH_IS_CONFIGURED,
     TEST_CREDENTIALS_INPUT_OAUTH,
     TEST_CREDENTIALS_OAUTH,
     LinearCredentials,
@@ -44,6 +45,7 @@ class LinearCreateIssueBlock(Block):
         super().__init__(
             id="f9c68f55-dcca-40a8-8771-abf9601680aa",
             description="Creates a new issue on Linear",
+            disabled=not LINEAR_OAUTH_IS_CONFIGURED,
             input_schema=self.Input,
             output_schema=self.Output,
             categories={BlockCategory.PRODUCTIVITY, BlockCategory.ISSUE_TRACKING},
@@ -132,6 +134,7 @@ class LinearSearchIssuesBlock(Block):
             description="Searches for issues on Linear",
             input_schema=self.Input,
             output_schema=self.Output,
+            disabled=not LINEAR_OAUTH_IS_CONFIGURED,
             test_input={
                 "term": "Test issue",
                 "credentials": TEST_CREDENTIALS_INPUT_OAUTH,

--- a/autogpt_platform/backend/backend/blocks/linear/projects.py
+++ b/autogpt_platform/backend/backend/blocks/linear/projects.py
@@ -1,5 +1,6 @@
 from backend.blocks.linear._api import LinearAPIException, LinearClient
 from backend.blocks.linear._auth import (
+    LINEAR_OAUTH_IS_CONFIGURED,
     TEST_CREDENTIALS_INPUT_OAUTH,
     TEST_CREDENTIALS_OAUTH,
     LinearCredentials,
@@ -36,6 +37,7 @@ class LinearSearchProjectsBlock(Block):
                 "term": "Test project",
                 "credentials": TEST_CREDENTIALS_INPUT_OAUTH,
             },
+            disabled=not LINEAR_OAUTH_IS_CONFIGURED,
             test_credentials=TEST_CREDENTIALS_OAUTH,
             test_output=[
                 (


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
Linear blocks show up even if oauth isn't configured

### Changes 🏗️
disables the linear blocks if oauth isn't configured

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] checked block list with and without oauth configured
