### PR TITLE
fix(backend): Fix failing test_block_credit_reset when it's executed at the end of 31-days month

### DIFF
--- a/autogpt_platform/backend/test/data/test_credit.py
+++ b/autogpt_platform/backend/test/data/test_credit.py
@@ -92,17 +92,23 @@ async def test_block_credit_reset(server: SpinTestServer):
     month2 = 2
 
     # set the calendar to month 2 but use current time from now
-    user_credit.time_now = lambda: datetime.now(timezone.utc).replace(month=month2)
+    user_credit.time_now = lambda: datetime.now(timezone.utc).replace(
+        month=month2, day=1
+    )
     month2credit = await user_credit.get_credits(DEFAULT_USER_ID)
 
     # Month 1 result should only affect month 1
-    user_credit.time_now = lambda: datetime.now(timezone.utc).replace(month=month1)
+    user_credit.time_now = lambda: datetime.now(timezone.utc).replace(
+        month=month1, day=1
+    )
     month1credit = await user_credit.get_credits(DEFAULT_USER_ID)
     await top_up(100)
     assert await user_credit.get_credits(DEFAULT_USER_ID) == month1credit + 100
 
     # Month 2 balance is unaffected
-    user_credit.time_now = lambda: datetime.now(timezone.utc).replace(month=month2)
+    user_credit.time_now = lambda: datetime.now(timezone.utc).replace(
+        month=month2, day=1
+    )
     assert await user_credit.get_credits(DEFAULT_USER_ID) == month2credit
 
 


### PR DESCRIPTION
Currently, the test is failing on Jan 29 because 29th Feb does not exist.

### Changes 🏗️

Force use the first day of the month for getting the current time.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
