### PR TITLE
fix(backend): Remove hardcoded auto-top-up config definition on set_auto_top_up

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -517,10 +517,10 @@ async def get_stripe_customer_id(user_id: str) -> str:
     return customer.id
 
 
-async def set_auto_top_up(user_id: str, threshold: int, amount: int):
+async def set_auto_top_up(user_id: str, config: AutoTopUpConfig):
     await User.prisma().update(
         where={"id": user_id},
-        data={"topUpConfig": Json({"threshold": threshold, "amount": amount})},
+        data={"topUpConfig": Json(config.model_dump())},
     )
 
 

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -183,7 +183,9 @@ async def configure_user_auto_top_up(
     else:
         await _user_credit_model.top_up_credits(user_id, 0)
 
-    await set_auto_top_up(user_id, threshold=request.threshold, amount=request.amount)
+    await set_auto_top_up(
+        user_id, AutoTopUpConfig(threshold=request.threshold, amount=request.amount)
+    )
     return "Auto top-up settings updated"
 
 


### PR DESCRIPTION
### Changes 🏗️

Make set_auto_top_up accepts AutoTopUpConfig & eliminate hardcoding of json value.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
