### PR TITLE
fix(frontend): Fix typing for `dict`/`dict[Any, Any]` `SchemaField`

### DIFF
--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -662,6 +662,20 @@ export const NodeGenericInputField: FC<{
           handleInputClick={handleInputClick}
         />
       );
+    case "object":
+      return (
+        <NodeKeyValueInput
+          nodeId={nodeId}
+          selfKey={propKey}
+          schema={propSchema}
+          entries={currentValue}
+          errors={errors}
+          className={className}
+          displayName={displayName}
+          connections={connections}
+          handleInputChange={handleInputChange}
+        />
+      );
     default:
       console.warn(
         `Schema for '${propKey}' specifies unknown type:`,

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -70,7 +70,7 @@ export type BlockIOObjectSubSchema = BlockIOSubSchemaMeta & {
 
 export type BlockIOKVSubSchema = BlockIOSubSchemaMeta & {
   type: "object";
-  additionalProperties: { type: "string" | "number" | "integer" };
+  additionalProperties?: { type: "string" | "number" | "integer" };
   default?: { [key: string]: string | number };
   secret?: boolean;
 };


### PR DESCRIPTION
Type system complains about this entry as impossible but this code path is possible and without it some blocks are broken (e.g. `Step Through Items`)

### Changes 🏗️

- Restore `case "object"` in `NodeGenericInputField` 
- Update `BlockIOKVSubSchema` type, so ts type checking doesn't complain

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
