### PR TITLE
fix(frontend): Show feedback if user exists on sign up

### DIFF
--- a/autogpt_platform/frontend/src/app/signup/actions.ts
+++ b/autogpt_platform/frontend/src/app/signup/actions.ts
@@ -25,10 +25,10 @@ export async function signup(values: z.infer<typeof signupFormSchema>) {
         console.error("Error signing up", error);
         // FIXME: supabase doesn't return the correct error message for this case
         if (error.message.includes("P0001")) {
-          return "Please join our waitlist for your turn: https://agpt.co/waitlist";
+          return "not_allowed";
         }
-        if (error.code?.includes("user_already_exists")) {
-          redirect("/login");
+        if (error.code === "user_already_exists") {
+          return "user_already_exists";
         }
         return error.message;
       }

--- a/autogpt_platform/frontend/src/app/signup/page.tsx
+++ b/autogpt_platform/frontend/src/app/signup/page.tsx
@@ -34,6 +34,7 @@ export default function SignupPage() {
   const [feedback, setFeedback] = useState<string | null>(null);
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  //TODO: Remove after closed beta
   const [showWaitlistPrompt, setShowWaitlistPrompt] = useState(false);
 
   const form = useForm<z.infer<typeof signupFormSchema>>({
@@ -58,10 +59,16 @@ export default function SignupPage() {
       const error = await signup(data);
       setIsLoading(false);
       if (error) {
-        setShowWaitlistPrompt(true);
+        if (error === "user_already_exists") {
+          setFeedback("User with this email already exists");
+          return;
+        } else {
+          setShowWaitlistPrompt(true);
+        }
         return;
       }
       setFeedback(null);
+      setShowWaitlistPrompt(false);
     },
     [form],
   );


### PR DESCRIPTION
Currently if user tries to sign in with an email that is already associated with a user they are redirected to login without any feedback.

### Changes 🏗️

- Show feedback: "User with this email already exists" on signup when user already registered
- Beta user waitlist message is shown otherwise as previously

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
