### PR TITLE
hotfix(backend): Fix doubly reported produced output

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -210,16 +210,16 @@ def execute_node(
             ):
                 yield execution
 
-            # Update execution status and spend credits
-            res = update_execution(ExecutionStatus.COMPLETED)
-            s = input_size + output_size
-            t = (
-                (res.end_time - res.start_time).total_seconds()
-                if res.end_time and res.start_time
-                else 0
-            )
-            data.data = input_data
-            db_client.spend_credits(data, s, t)
+        # Update execution status and spend credits
+        res = update_execution(ExecutionStatus.COMPLETED)
+        s = input_size + output_size
+        t = (
+            (res.end_time - res.start_time).total_seconds()
+            if res.end_time and res.start_time
+            else 0
+        )
+        data.data = input_data
+        db_client.spend_credits(data, s, t)
 
     except Exception as e:
         error_msg = str(e)

--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -809,7 +809,7 @@ async def get_agent(
     try:
         store_listing_version = (
             await prisma.models.StoreListingVersion.prisma().find_unique(
-                where={"id": store_listing_version_id}
+                where={"id": store_listing_version_id}, include={"Agent": True}
             )
         )
 


### PR DESCRIPTION
https://github.com/Significant-Gravitas/AutoGPT/pull/9340/files#diff-1b278ebf10a9da0fb5030010222b3a6df2b05a5463cad428cd6c38a1541b0f73R210-R219 introduced a bug where the spend_credit and update_execution is called inside the loop instead of by the end of the execution.

### Changes 🏗️

Untabbed the `spend_credit` and `update_execution` code outside the loop.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
