### PR TITLE
feat(infra): add rabbitmq to docker compose

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -31,6 +31,10 @@ SUPABASE_URL=http://localhost:8000
 SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
 SUPABASE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
 
+# RabbitMQ credentials -- Used for communication between services
+RABBITMQ_DEFAULT_USER=rabbitmq_user_default
+RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
+
 ## For local development, you may need to set FRONTEND_BASE_URL for the OAuth flow
 ## for integrations to work. Defaults to the value of PLATFORM_BASE_URL if not set.
 # FRONTEND_BASE_URL=http://localhost:3000

--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -32,6 +32,8 @@ SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZ
 SUPABASE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
 
 # RabbitMQ credentials -- Used for communication between services
+RABBITMQ_HOST=localhost
+RABBITMQ_PORT=5672
 RABBITMQ_DEFAULT_USER=rabbitmq_user_default
 RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
 

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -71,6 +71,8 @@ services:
       - DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_PORT=5672
       - RABBITMQ_USER=rabbitmq_user_default
       - RABBITMQ_PASSWORD=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
       - REDIS_PASSWORD=password

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -39,6 +39,12 @@ services:
   rabbitmq:
     image: rabbitmq:management
     container_name: rabbitmq
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
     environment:
       - RABBITMQ_DEFAULT_USER=rabbitmq_user_default
       - RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7 # CHANGE THIS TO A RANDOM PASSWORD IN PRODUCTION -- everywhere lol

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -36,6 +36,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  rabbitmq:
+    image: rabbitmq:management
+    container_name: rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_USER=rabbitmq_user_default
+      - RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7 # CHANGE THIS TO A RANDOM PASSWORD IN PRODUCTION -- everywhere lol
+    ports:
+      - "5672:5672"
+      - "15672:15672"
 
   rest_server:
     build:
@@ -62,6 +71,8 @@ services:
       - DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - RABBITMQ_USER=rabbitmq_user_default
+      - RABBITMQ_PASSWORD=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
       - REDIS_PASSWORD=password
       - ENABLE_AUTH=true
       - PYRO_HOST=0.0.0.0
@@ -69,7 +80,7 @@ services:
       - EXECUTIONMANAGER_HOST=executor
       - FRONTEND_BASE_URL=http://localhost:3000
       - BACKEND_CORS_ALLOW_ORIGINS=["http://localhost:3000"]
-      - ENCRYPTION_KEY=dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw=  # DO NOT USE IN PRODUCTION!!
+      - ENCRYPTION_KEY=dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw= # DO NOT USE IN PRODUCTION!!
     ports:
       - "8006:8006"
       - "8003:8003" # execution scheduler
@@ -102,10 +113,14 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=password
+      - RABBITMQ_HOST=rabbitmq
+      - RABBITMQ_PORT=5672
+      - RABBITMQ_USER=rabbitmq_user_default
+      - RABBITMQ_PASSWORD=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
       - ENABLE_AUTH=true
       - PYRO_HOST=0.0.0.0
       - AGENTSERVER_HOST=rest_server
-      - ENCRYPTION_KEY=dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw=  # DO NOT USE IN PRODUCTION!!
+      - ENCRYPTION_KEY=dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw= # DO NOT USE IN PRODUCTION!!
     ports:
       - "8002:8000"
     networks:
@@ -135,6 +150,10 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=password
+      # - RABBITMQ_HOST=rabbitmq # TODO: Uncomment this when we have a need for it in websocket (like nofifying when stuff went down)
+      # - RABBITMQ_PORT=5672
+      # - RABBITMQ_USER=rabbitmq_user_default
+      # - RABBITMQ_PASSWORD=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
       - ENABLE_AUTH=true
       - PYRO_HOST=0.0.0.0
       - BACKEND_CORS_ALLOW_ORIGINS=["http://localhost:3000"]

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -64,6 +64,8 @@ services:
         condition: service_healthy
       migrate:
         condition: service_completed_successfully
+      rabbitmq:
+        condition: service_healthy
     environment:
       - SUPABASE_URL=http://kong:8000
       - SUPABASE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
@@ -102,6 +104,8 @@ services:
           action: rebuild
     depends_on:
       redis:
+        condition: service_healthy
+      rabbitmq:
         condition: service_healthy
       db:
         condition: service_healthy
@@ -144,8 +148,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      # rabbitmq:
+      #   condition: service_healthy
       migrate:
-        condition: service_completed_successfully
+        condition: service_completed_successfully 
     environment:
       - SUPABASE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
       - DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform

--- a/autogpt_platform/docker-compose.yml
+++ b/autogpt_platform/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       file: ./docker-compose.platform.yml
       service: redis
 
+  rabbitmq:
+    <<: *agpt-services
+    extends:
+      file: ./docker-compose.platform.yml
+      service: rabbitmq
+
   rest_server:
     <<: *agpt-services
     extends:
@@ -146,3 +152,4 @@ services:
       - db
       - vector
       - redis
+      - rabbitmq


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
We want to use RabbitMQ for email (and executor in the future) to ensure message delivery -- something we currently lack with Redis. This PR is adding RabbitMQ to the docker-compose and setup details with defaults so that when we start bringing services up, they have the backing to do so.

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
- Adds rabbitmq container (with exposed API and mgmt ports)
- Adds .env.example config for the backend
- Adds dockercompose config for the backend, and passes the variables around as needed

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Start the container using docker compose deps subset

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)