### PR TITLE
feat(platform): Schedule specific agent version

### DIFF
--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -609,6 +609,7 @@ class ScheduleCreationRequest(pydantic.BaseModel):
     cron: str
     input_data: dict[Any, Any]
     graph_id: str
+    graph_version: int
 
 
 @v1_router.post(
@@ -620,10 +621,13 @@ async def create_schedule(
     user_id: Annotated[str, Depends(get_user_id)],
     schedule: ScheduleCreationRequest,
 ) -> scheduler.JobInfo:
-    graph = await graph_db.get_graph(schedule.graph_id, user_id=user_id)
+    graph = await graph_db.get_graph(
+        schedule.graph_id, schedule.graph_version, user_id=user_id
+    )
     if not graph:
         raise HTTPException(
-            status_code=404, detail=f"Graph #{schedule.graph_id} not found."
+            status_code=404,
+            detail=f"Graph #{schedule.graph_id} v.{schedule.graph_version} not found.",
         )
 
     return await asyncio.to_thread(

--- a/autogpt_platform/frontend/src/app/monitoring/page.tsx
+++ b/autogpt_platform/frontend/src/app/monitoring/page.tsx
@@ -37,8 +37,8 @@ const Monitor = () => {
   );
 
   const fetchAgents = useCallback(() => {
-    api.listLibraryAgents().then((agent) => {
-      setFlows(agent);
+    api.listLibraryAgents().then((agents) => {
+      setFlows(agents);
     });
     api.getExecutions().then((executions) => {
       setExecutions(executions);

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -963,6 +963,8 @@ export default function useAgentGraph(
         if (flowID) {
           await api.createSchedule({
             graph_id: flowID,
+            // flowVersion is always defined here because scheduling is opened for a specific version
+            graph_version: flowVersion!,
             cron: cronExpression,
             input_data: inputs.reduce(
               (acc, input) => ({

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -512,6 +512,7 @@ export type Schedule = {
 export type ScheduleCreatable = {
   cron: string;
   graph_id: string;
+  graph_version: number;
   input_data: { [key: string]: any };
 };
 


### PR DESCRIPTION
Scheduling always takes the newest version of an agent.

### Changes 🏗️

This PR allows to schedule any graph version by adding number input to schedule popup. Number is automatically set to the newest version when agent is chosen.

<img width="533" alt="Screenshot 2025-02-07 at 5 05 56 PM" src="https://github.com/user-attachments/assets/357b8810-6f02-4066-b7a3-824d9bfd62af" />

- Update API, so it accepts graph version
- Update schedule pop up, so it lets user input version number
- Open and schedule correct agent
- Add `Version` column to the schedules table

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Can schedule version between 1 and max version
  - [x] Reject incorrect version
  - [x] Table shows proper version
  - [x] Removing schedule works

