### PR TITLE
feat(backend): schema updates, migration, queries for Email Notification Service

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -364,6 +364,26 @@ async def get_execution_results(graph_exec_id: str) -> list[ExecutionResult]:
     return res
 
 
+async def get_executions_in_timerange(
+    user_id: str, start_time: str, end_time: str
+) -> list[ExecutionResult]:
+    executions = await AgentGraphExecution.prisma().find_many(
+        where={
+            "AND": [
+                {
+                    "startedAt": {
+                        "gte": datetime.fromisoformat(start_time),
+                        "lte": datetime.fromisoformat(end_time),
+                    }
+                },
+                {"userId": user_id},
+            ]
+        },
+        include=GRAPH_EXECUTION_INCLUDE,
+    )
+    return [ExecutionResult.from_graph(execution) for execution in executions]
+
+
 LIST_SPLIT = "_$_"
 DICT_SPLIT = "_#_"
 OBJC_SPLIT = "_@_"

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import logging
 from datetime import datetime
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -22,6 +23,7 @@ from prisma.enums import CreditTransactionType
 from pydantic import (
     BaseModel,
     ConfigDict,
+    EmailStr,
     Field,
     GetCoreSchemaHandler,
     SecretStr,
@@ -389,3 +391,23 @@ class UserTransaction(BaseModel):
 class TransactionHistory(BaseModel):
     transactions: list[UserTransaction]
     next_transaction_time: datetime | None
+
+
+class NotificationPreference(BaseModel):
+    user_id: str
+    email: EmailStr
+    preferences: dict[NotificationType, bool] = {}  # Which notifications they want
+    daily_limit: int = 10  # Max emails per day
+    emails_sent_today: int = 0
+    last_reset_date: datetime = datetime.now()
+
+
+class NotificationType(str, Enum):
+    AGENT_RUN = "agent_run"
+    ZERO_BALANCE = "zero_balance"
+    LOW_BALANCE = "low_balance"
+    BLOCK_EXECUTION_FAILED = "block_execution_failed"
+    CONTINUOUS_AGENT_ERROR = "continuous_agent_error"
+    DAILY_SUMMARY = "daily_summary"
+    WEEKLY_SUMMARY = "weekly_summary"
+    MONTHLY_SUMMARY = "monthly_summary"

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -8,6 +8,7 @@ from backend.data.execution import (
     RedisExecutionEventBus,
     create_graph_execution,
     get_execution_results,
+    get_executions_in_timerange,
     get_incomplete_executions,
     get_latest_execution,
     update_execution_status,
@@ -18,8 +19,11 @@ from backend.data.execution import (
 )
 from backend.data.graph import get_graph, get_node
 from backend.data.user import (
+    get_active_user_ids_in_timerange,
+    get_user_by_id,
     get_user_integrations,
     get_user_metadata,
+    get_user_notification_preference,
     update_user_integrations,
     update_user_metadata,
 )
@@ -72,6 +76,7 @@ class DatabaseManager(AppService):
     update_node_execution_stats = exposed_run_and_wait(update_node_execution_stats)
     upsert_execution_input = exposed_run_and_wait(upsert_execution_input)
     upsert_execution_output = exposed_run_and_wait(upsert_execution_output)
+    get_executions_in_timerange = exposed_run_and_wait(get_executions_in_timerange)
 
     # Graphs
     get_node = exposed_run_and_wait(get_node)
@@ -84,8 +89,15 @@ class DatabaseManager(AppService):
         exposed_run_and_wait(user_credit_model.spend_credits),
     )
 
-    # User + User Metadata + User Integrations
+    # User + User Metadata + User Integrations + User Notification Preferences
     get_user_metadata = exposed_run_and_wait(get_user_metadata)
     update_user_metadata = exposed_run_and_wait(update_user_metadata)
     get_user_integrations = exposed_run_and_wait(get_user_integrations)
     update_user_integrations = exposed_run_and_wait(update_user_integrations)
+    get_active_user_ids_in_timerange = exposed_run_and_wait(
+        get_active_user_ids_in_timerange
+    )
+    get_user_by_id = exposed_run_and_wait(get_user_by_id)
+    get_user_notification_preference = exposed_run_and_wait(
+        get_user_notification_preference
+    )

--- a/autogpt_platform/backend/migrations/20250207203559_add_user_notification_preferences/migration.sql
+++ b/autogpt_platform/backend/migrations/20250207203559_add_user_notification_preferences/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "UserNotificationPreference" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+    "preferences" JSONB NOT NULL DEFAULT '{}',
+
+    CONSTRAINT "UserNotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "UserNotificationPreference" ADD CONSTRAINT "UserNotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -33,12 +33,13 @@ model User {
   AgentPreset AgentPreset[]
   UserAgent   UserAgent[]
 
-  Profile                Profile[]
-  StoreListing           StoreListing[]
-  StoreListingReview     StoreListingReview[]
-  StoreListingSubmission StoreListingSubmission[]
-  APIKeys                APIKey[]
-  IntegrationWebhooks    IntegrationWebhook[]
+  Profile                    Profile[]
+  StoreListing               StoreListing[]
+  StoreListingReview         StoreListingReview[]
+  StoreListingSubmission     StoreListingSubmission[]
+  APIKeys                    APIKey[]
+  IntegrationWebhooks        IntegrationWebhook[]
+  UserNotificationPreference UserNotificationPreference[]
 
   @@index([id])
   @@index([email])
@@ -108,6 +109,17 @@ model AgentPreset {
   AgentExecution AgentGraphExecution[]
 
   @@index([userId])
+}
+
+model UserNotificationPreference {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  preferences Json @default("{}")
 }
 
 // For the library page


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

The email service has requirements to
- Email users when some activity has happened on their account on some scheduled basis -> We need a way to get active users and the executions that happened while they were active
- Allow users to configure what emails they get -> Need a user preference
- Get User email by Id so that we can email them -> Pretty self-explanatory

We need to add a few new backend queries + db models for the notification to start handling these details. This is the first set of those changes based on experience building the app service

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
- Adds a new DB Model, `UserNotificationPreferences,` with related migration
- Adds queries to get users and executions by `datetime` ranges as `ISO` strings
- Adds new queries to the `DatabaseManager` and exposes them to the other `AppService`s
- Exposes all new queries plus an existing one `get_user_by_id`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] I extracted these changes from a working implementation of the service, and tested they don't bring down the service by being uncalled
