### PR TITLE
fix(frontend) update PublishAgentAwaitingReview router push path

### DIFF
--- a/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx
@@ -263,7 +263,7 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
                   onClose={handleClose}
                   onDone={handleClose}
                   onViewProgress={() => {
-                    router.push("/marketplace/dashboard");
+                    router.push("/profile/dashboard");
                     handleClose();
                   }}
                 />


### PR DESCRIPTION
Updates the PublishAgentAwaitingReview router.push path, it was going to ``/marketplace/dashboard`` it should be ``/profile/dashboard``

### Changes 🏗️

https://github.com/Significant-Gravitas/AutoGPT/blob/8181ee8cd1f71bd351a3e0ad66356a0313877db2/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx#L265-L267

to be

```tsx
		onViewProgress={() => {
		  router.push("/profile/dashboard");
		  handleClose();
		}}
```