### PR TITLE
fix(backend): correctly check if email service is set up

### DIFF
--- a/autogpt_platform/backend/backend/notifications/email.py
+++ b/autogpt_platform/backend/backend/notifications/email.py
@@ -41,6 +41,7 @@ class EmailSender:
             logger.warning(
                 "Postmark server API token not found, email sending disabled"
             )
+            self.postmark = None
         self.formatter = TextFormatter()
 
     def send_templated(
@@ -90,6 +91,9 @@ class EmailSender:
         )
 
     def _send_email(self, user_email: str, subject: str, body: str):
+        if not self.postmark:
+            logger.warning("Email tried to send without postmark configured")
+            return
         logger.debug(f"Sending email to {user_email} with subject {subject}")
         self.postmark.emails.send(
             From=settings.config.postmark_sender_email,


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
I made a mistake in how we check if postmark exists

### Changes 🏗️
- adds a more explicit setting of postmark to none and extra checking to prevent its use if it isn’t set

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] I have no plan, it’s a simple logic bug so if it passes CI it’s good
