### PR TITLE
fix(backend): Use Pyro for RPC by default

### DIFF
--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -66,7 +66,7 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         description="Maximum number of workers to use for node execution within a single graph.",
     )
     use_http_based_rpc: bool = Field(
-        default=True,
+        default=False,
         description="Whether to use HTTP-based RPC for communication between services.",
     )
     pyro_host: str = Field(


### PR DESCRIPTION
- Follow-up to #9508 

HTTP-based RPC has not been fully tested and should be disabled by default.

### Changes 🏗️

- Disable HTTP-based RPC and use Pyro by default