### PR TITLE
fix(backend): Fix exception response on RPC error & Missing Graph `Running` Status

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -265,14 +265,18 @@ async def upsert_execution_output(
     )
 
 
-async def update_graph_execution_start_time(graph_exec_id: str):
-    await AgentGraphExecution.prisma().update(
+async def update_graph_execution_start_time(graph_exec_id: str) -> ExecutionResult:
+    res = await AgentGraphExecution.prisma().update(
         where={"id": graph_exec_id},
         data={
             "executionStatus": ExecutionStatus.RUNNING,
             "startedAt": datetime.now(tz=timezone.utc),
         },
     )
+    if not res:
+        raise ValueError(f"Execution {graph_exec_id} not found.")
+
+    return ExecutionResult.from_graph(res)
 
 
 async def update_graph_execution_stats(

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -8,6 +8,7 @@ from backend.data.execution import (
     get_incomplete_executions,
     get_latest_execution,
     update_execution_status,
+    update_graph_execution_start_time,
     update_graph_execution_stats,
     update_node_execution_stats,
     upsert_execution_input,
@@ -52,6 +53,9 @@ class DatabaseManager(AppService):
     get_incomplete_executions = exposed_run_and_wait(get_incomplete_executions)
     get_latest_execution = exposed_run_and_wait(get_latest_execution)
     update_execution_status = exposed_run_and_wait(update_execution_status)
+    update_graph_execution_start_time = exposed_run_and_wait(
+        update_graph_execution_start_time
+    )
     update_graph_execution_stats = exposed_run_and_wait(update_graph_execution_stats)
     update_node_execution_stats = exposed_run_and_wait(update_node_execution_stats)
     upsert_execution_input = exposed_run_and_wait(upsert_execution_input)

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -644,6 +644,7 @@ class Executor:
             node_eid="*",
             block_name="-",
         )
+        cls.db_client.update_graph_execution_start_time(graph_exec.graph_exec_id)
         timing_info, (exec_stats, status, error) = cls._on_graph_execution(
             graph_exec, cancel, log_metadata
         )

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -66,7 +66,7 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         description="Maximum number of workers to use for node execution within a single graph.",
     )
     use_http_based_rpc: bool = Field(
-        default=False,
+        default=True,
         description="Whether to use HTTP-based RPC for communication between services.",
     )
     pyro_host: str = Field(


### PR DESCRIPTION
HttpResponse error introduced by RPC is buggy since we are returning the exception as is instead of the string version of it.
Also `RUNNING` status on the graph execution is missing.

### Changes 🏗️

* Refactored & fixed the exception return handling on RPC failure.
* Add `RUNNING` status update during the graph execution.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
