### PR TITLE
fix(backend): allow more than one arg on the tuple

### DIFF
--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -242,7 +242,7 @@ class BaseAppService(AppProcess, ABC):
 
 class RemoteCallError(BaseModel):
     type: str = "RemoteCallError"
-    args: Optional[Tuple[Any]] = None
+    args: Optional[Tuple[Any, ...]] = None
 
 
 EXCEPTION_MAPPING = {


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
We allow tuples to be returned from exceptions, but pydantic restricts their size to 1 b/c the typehint. This fixes that

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
- Adds `, ...` to the tuple type hint

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Extracted from other pr where it was tested as part of an exception
