### PR TITLE
feat(backend): Add conversation history as Smart Decision Block output

### DIFF
--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -14,7 +14,12 @@ from backend.data.execution import (
     upsert_execution_input,
     upsert_execution_output,
 )
-from backend.data.graph import get_graph, get_graph_metadata, get_node
+from backend.data.graph import (
+    get_connected_output_nodes,
+    get_graph,
+    get_graph_metadata,
+    get_node,
+)
 from backend.data.user import (
     get_user_integrations,
     get_user_metadata,
@@ -64,6 +69,7 @@ class DatabaseManager(AppService):
     # Graphs
     get_node = exposed_run_and_wait(get_node)
     get_graph = exposed_run_and_wait(get_graph)
+    get_connected_output_nodes = exposed_run_and_wait(get_connected_output_nodes)
     get_graph_metadata = exposed_run_and_wait(get_graph_metadata)
 
     # Credits

--- a/autogpt_platform/backend/test/executor/test_tool_use.py
+++ b/autogpt_platform/backend/test/executor/test_tool_use.py
@@ -230,7 +230,7 @@ async def test_smart_decision_maker_function_signature(server: SpinTestServer):
     test_graph = await create_graph(server, test_graph, test_user)
 
     tool_functions = SmartDecisionMakerBlock._create_function_signature(
-        test_graph.nodes[0].id, test_graph, [test_tool_graph]
+        test_graph.nodes[0].id
     )
     assert tool_functions is not None, "Tool functions should not be None"
 

--- a/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
@@ -219,7 +219,7 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
           </CardHeader>
           <CardContent className="overflow-scroll border-t border-t-gray-200 p-0 dark:border-t-slate-700">
             <ScrollArea
-              className="h-[60vh] w-fit"
+              className="h-[60vh] w-full"
               data-id="blocks-control-scroll-area"
             >
               {filteredAvailableBlocks.map((block) => (


### PR DESCRIPTION
Now that the MVP for Smar Decision Block is available, we need to add this info in the block output:

Messages (list) - The messages list sent to the LLM plus its generated response as the latest assistant entry. This is a single list of dictionaries in standard LLM API format).

### Changes 🏗️

* Add `conversations` output pin that populates the update `conversation_history` input pin with the assistant response.
* Refactored `Smart Decision Block` to avoid downloading the whole graph on each execution, remove code duplication, declutter data fetching.
* Minor UI issue on the smart decision block entry in the search bar. 

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
