### PR TITLE
fix(backend): Deny public direct access to marketplace-listed graphs

### DIFF
--- a/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
+++ b/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
@@ -79,7 +79,6 @@ class SmartDecisionMakerBlock(Block):
         )
 
     class Output(BlockSchema):
-
         prompt: str = SchemaField(description="The prompt sent to the language model.")
         error: str = SchemaField(description="Error message if the API call failed.")
         function_signatures: list[dict[str, Any]] = SchemaField(
@@ -351,7 +350,11 @@ class SmartDecisionMakerBlock(Block):
         db_client = get_database_manager_client()
 
         # Retrieve the current graph and node details
-        graph = db_client.get_graph(graph_id=graph_id, user_id=user_id)
+        graph = db_client.get_graph(
+            graph_id=graph_id,
+            user_id=user_id,
+            ignore_ownership_if_listed_in_marketplace=True,
+        )
 
         if not graph:
             raise ValueError(
@@ -388,7 +391,6 @@ class SmartDecisionMakerBlock(Block):
         )
 
         if not response.tool_calls:
-
             yield "finished", f"No Decision Made finishing task: {response.response}"
 
         if response.tool_calls:

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -667,6 +667,7 @@ async def get_graph(
     template: bool = False,  # note: currently not in use; TODO: remove from DB entirely
     user_id: str | None = None,
     for_export: bool = False,
+    ignore_ownership_if_listed_in_marketplace: bool = False,
 ) -> GraphModel | None:
     """
     Retrieves a graph from the DB.
@@ -694,7 +695,8 @@ async def get_graph(
     if graph is None or (
         graph.userId != user_id
         and not (
-            await StoreListingVersion.prisma().find_first(
+            ignore_ownership_if_listed_in_marketplace
+            and await StoreListingVersion.prisma().find_first(
                 where={
                     "agentId": graph_id,
                     "agentVersion": version or graph.version,

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -868,7 +868,10 @@ class ExecutionManager(AppService):
         preset_id: str | None = None,
     ) -> GraphExecutionEntry:
         graph: GraphModel | None = self.db_client.get_graph(
-            graph_id=graph_id, user_id=user_id, version=graph_version
+            graph_id=graph_id,
+            version=graph_version,
+            user_id=user_id,
+            ignore_ownership_if_listed_in_marketplace=True,
         )
         if not graph:
             raise ValueError(f"Graph #{graph_id} not found.")

--- a/autogpt_platform/backend/backend/server/external/routes/v1.py
+++ b/autogpt_platform/backend/backend/server/external/routes/v1.py
@@ -126,7 +126,11 @@ async def get_graph_execution_results(
     graph_exec_id: str,
     api_key: APIKey = Depends(require_permission(APIKeyPermission.READ_GRAPH)),
 ) -> GraphExecutionResult:
-    graph = await graph_db.get_graph(graph_id, user_id=api_key.user_id)
+    graph = await graph_db.get_graph(
+        graph_id,
+        user_id=api_key.user_id,
+        ignore_ownership_if_listed_in_marketplace=True,
+    )
     if not graph:
         raise HTTPException(status_code=404, detail=f"Graph #{graph_id} not found.")
 

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -10,6 +10,7 @@ from autogpt_libs.auth.middleware import auth_middleware
 from autogpt_libs.feature_flag.client import feature_flag
 from autogpt_libs.utils.cache import thread_cached
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response
+from starlette.status import HTTP_403_FORBIDDEN
 from typing_extensions import Optional, TypedDict
 
 import backend.data.block
@@ -372,6 +373,11 @@ async def get_graph(
     )
     if not graph:
         raise HTTPException(status_code=404, detail=f"Graph #{graph_id} not found.")
+    if graph.user_id != user_id:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail=f"Graph #{graph_id} is not publicly accessible",
+        )
     return graph
 
 

--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -772,7 +772,9 @@ async def get_agent(
 
         graph_id = store_listing_version.agentId
         graph_version = store_listing_version.agentVersion
-        graph = await backend.data.graph.get_graph(graph_id, graph_version)
+        graph = await backend.data.graph.get_graph(
+            graph_id, graph_version, ignore_ownership_if_listed_in_marketplace=True
+        )
 
         if not graph:
             raise fastapi.HTTPException(

--- a/autogpt_platform/backend/test/data/test_graph.py
+++ b/autogpt_platform/backend/test/data/test_graph.py
@@ -290,8 +290,16 @@ async def test_access_store_listing_graph(server: SpinTestServer):
         ),
     )
 
-    # Now we check the graph can be accessed by a user that does not own the graph
+    # Now we check the graph still can't be accessed by a user other than the owner
     got_graph = await server.agent_server.test_get_graph(
-        created_graph.id, created_graph.version, "3e53486c-cf57-477e-ba2a-cb02dc828e1b"
+        created_graph.id, created_graph.version, DEFAULT_USER_ID
     )
     assert got_graph is not None
+
+    with pytest.raises(fastapi.exceptions.HTTPException) as exc_info:
+        await server.agent_server.test_get_graph(
+            created_graph.id,
+            created_graph.version,
+            "3e53486c-cf57-477e-ba2a-cb02dc828e1b",
+        )
+    assert exc_info.value.status_code == 404


### PR DESCRIPTION
> [!WARNING]
> - Blocked by #9549

In the future, agent creators will be able to specify whether the the graph of their marketplace-listed agent should be publicly accessible (open-source).
Pending this functionality, we want to prevent users from directly accessing graphs that don't belong to them, even if they have a corresponding marketplace listing.

This only prohibits direct read access, not *usage* of the graph such as running it.

### Changes 🏗️

- Make access control to marketplace-listed graphs "default deny" in `backend.data.graph.get_graph(..)`
  - Add `ignore_ownership_if_listed_in_marketplace=True` to `get_graph` calls where necessary

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>
