### PR TITLE
fix(frontend): Consolidate Application Buttons to ShadcN Base Button Component

### DIFF
--- a/autogpt_platform/frontend/src/app/error.tsx
+++ b/autogpt_platform/frontend/src/app/error.tsx
@@ -30,7 +30,7 @@ export default function Error({
           again later or contact support if the issue persists.
         </p>
         <div className="mt-6 flex flex-row justify-center gap-4">
-          <Button onClick={reset} variant="outline">
+          <Button onClick={reset} variant="secondary">
             Retry
           </Button>
           <Button>

--- a/autogpt_platform/frontend/src/app/globals.css
+++ b/autogpt_platform/frontend/src/app/globals.css
@@ -4,26 +4,26 @@
 
 @layer base {
   :root {
-    --background: 0 0% 99.6%; /* #FEFEFE */
-    --foreground: 240 10% 3.9%;
+    --background: 220 14.29% 95.88%;
+    --foreground: 240 3.7% 15.88%;
     --card: 0 0% 100%;
-    --card-foreground: 240 10% 3.9%;
+    --card-foreground: 222.2 47.4% 11.2%;
     --popover: 0 0% 100%;
-    --popover-foreground: 240 10% 3.9%;
-    --primary: 240 5.9% 10%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 240 4.8% 95.9%;
-    --secondary-foreground: 240 5.9% 10%;
-    --muted: 240 4.8% 95.9%;
-    --muted-foreground: 240 3.8% 46.1%;
-    --accent: 262 83% 58%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 240 5.9% 90%;
-    --input: 240 5.9% 85%;
-    --ring: 240 5.9% 10%;
-    --radius: 0.5rem;
+    --popover-foreground: 240 3.7% 15.88%;
+    --primary: 240 3.7% 15.88%;
+    --primary-foreground: 0 0% 98.04%;
+    --secondary: 240 5.88% 90%;
+    --secondary-foreground: 240 3.7% 15.88%;
+    --muted: 240 5.88% 90%;
+    --muted-foreground: 240 5.2% 33.92%;
+    --accent: 220 13.04% 90.98%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.24% 60.2%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 240 5.88% 90%;
+    --input: 240 4.88% 83.92%;
+    --ring: 216.92 22.29% 65.69%;
+    --radius: 1rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;

--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -837,11 +837,7 @@ export const CustomNode = React.memo(
                     data={data.executionResults!.at(-1)?.data || {}}
                   />
                   <div className="flex justify-end">
-                    <Button
-                      variant="ghost"
-                      onClick={handleOutputClick}
-
-                    >
+                    <Button variant="ghost" onClick={handleOutputClick}>
                       View More
                     </Button>
                   </div>

--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -840,7 +840,7 @@ export const CustomNode = React.memo(
                     <Button
                       variant="ghost"
                       onClick={handleOutputClick}
-                      className="border border-gray-300"
+
                     >
                       View More
                     </Button>

--- a/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
+++ b/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Clock, LogOut, ChevronLeft } from "lucide-react";
+import React from "react";
+import { Clock, LogOut } from "lucide-react";
 import { IconPlay, IconSquare } from "@/components/ui/icons";
 import {
   Tooltip,
@@ -41,10 +41,7 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
       <div className={`flex gap-1 md:gap-4`}>
         <Tooltip key="ViewOutputs" delayDuration={500}>
           <TooltipTrigger asChild>
-            <Button
-              onClick={onClickAgentOutputs}
-              variant="outline"
-            >
+            <Button onClick={onClickAgentOutputs} variant="outline">
               <LogOut className="hidden h-5 w-5 md:flex" />
               <span className="text-sm font-medium md:text-lg">
                 Agent Outputs{" "}

--- a/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
+++ b/autogpt_platform/frontend/src/components/PrimaryActionButton.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Button } from "./ui/button";
 import { Clock, LogOut, ChevronLeft } from "lucide-react";
 import { IconPlay, IconSquare } from "@/components/ui/icons";
 import {
@@ -8,6 +7,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { FaSpinner } from "react-icons/fa";
+import { Button } from "@/components/ui/button";
 
 interface PrimaryActionBarProps {
   onClickAgentOutputs: () => void;
@@ -42,9 +42,7 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
         <Tooltip key="ViewOutputs" delayDuration={500}>
           <TooltipTrigger asChild>
             <Button
-              className="flex items-center gap-2"
               onClick={onClickAgentOutputs}
-              size="primary"
               variant="outline"
             >
               <LogOut className="hidden h-5 w-5 md:flex" />
@@ -60,9 +58,7 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
         <Tooltip key="RunAgent" delayDuration={500}>
           <TooltipTrigger asChild>
             <Button
-              className="flex items-center gap-2"
               onClick={runButtonOnClick}
-              size="primary"
               style={{
                 background: isRunning ? "#DF4444" : "#7544DF",
                 opacity: isDisabled ? 0.5 : 1,
@@ -82,9 +78,7 @@ const PrimaryActionBar: React.FC<PrimaryActionBarProps> = ({
         <Tooltip key="ScheduleAgent" delayDuration={500}>
           <TooltipTrigger asChild>
             <Button
-              className="flex items-center gap-2"
               onClick={onClickScheduleButton}
-              size="primary"
               disabled={isScheduling}
               variant="outline"
               data-id="primary-action-schedule-agent"

--- a/autogpt_platform/frontend/src/components/TallyPopup.tsx
+++ b/autogpt_platform/frontend/src/components/TallyPopup.tsx
@@ -57,20 +57,14 @@ const TallyPopupSimple = () => {
 
   return (
     <div className="fixed bottom-1 right-6 z-50 hidden select-none items-center gap-4 p-3 transition-all duration-300 ease-in-out md:flex">
-      {show_tutorial && (
-        <Button
-          onClick={resetTutorial}
-        >
-          Tutorial
-        </Button>
-      )}
+      {show_tutorial && <Button onClick={resetTutorial}>Tutorial</Button>}
       <Button
         size="icon"
         data-tally-open="3yx2L0"
         data-tally-emoji-text="👋"
         data-tally-emoji-animation="wave"
       >
-        <QuestionMarkCircledIcon  />
+        <QuestionMarkCircledIcon />
         <span className="sr-only">Reach Out</span>
       </Button>
     </div>

--- a/autogpt_platform/frontend/src/components/TallyPopup.tsx
+++ b/autogpt_platform/frontend/src/components/TallyPopup.tsx
@@ -59,21 +59,18 @@ const TallyPopupSimple = () => {
     <div className="fixed bottom-1 right-6 z-50 hidden select-none items-center gap-4 p-3 transition-all duration-300 ease-in-out md:flex">
       {show_tutorial && (
         <Button
-          variant="default"
           onClick={resetTutorial}
-          className="mb-0 h-14 w-28 rounded-2xl bg-[rgba(65,65,64,1)] text-left font-inter text-lg font-medium leading-6"
         >
           Tutorial
         </Button>
       )}
       <Button
-        className="h-14 w-14 rounded-full bg-[rgba(65,65,64,1)]"
-        variant="default"
+        size="icon"
         data-tally-open="3yx2L0"
         data-tally-emoji-text="👋"
         data-tally-emoji-animation="wave"
       >
-        <QuestionMarkCircledIcon className="h-14 w-14" />
+        <QuestionMarkCircledIcon  />
         <span className="sr-only">Reach Out</span>
       </Button>
     </div>

--- a/autogpt_platform/frontend/src/components/agptui/BecomeACreator.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/BecomeACreator.tsx
@@ -47,13 +47,7 @@ export const BecomeACreator: React.FC<BecomeACreatorProps> = ({
         </p>
 
         <PublishAgentPopout
-          trigger={
-            <Button
-              onClick={handleButtonClick}
-            >
-              {buttonText}
-            </Button>
-          }
+          trigger={<Button onClick={handleButtonClick}>{buttonText}</Button>}
         />
       </div>
     </div>

--- a/autogpt_platform/frontend/src/components/agptui/BecomeACreator.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/BecomeACreator.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { PublishAgentPopout } from "./composite/PublishAgentPopout";
+import { Button } from "@/components/ui/button";
 interface BecomeACreatorProps {
   title?: string;
   description?: string;
@@ -47,14 +48,11 @@ export const BecomeACreator: React.FC<BecomeACreatorProps> = ({
 
         <PublishAgentPopout
           trigger={
-            <button
+            <Button
               onClick={handleButtonClick}
-              className="inline-flex h-[48px] cursor-pointer items-center justify-center rounded-[38px] bg-neutral-800 px-8 py-3 transition-colors hover:bg-neutral-700 dark:bg-neutral-700 dark:hover:bg-neutral-600 md:h-[56px] md:px-10 md:py-4 lg:h-[68px] lg:px-12 lg:py-5"
             >
-              <span className="whitespace-nowrap font-poppins text-base font-medium leading-normal text-neutral-50 md:text-lg md:leading-relaxed lg:text-xl lg:leading-7">
-                {buttonText}
-              </span>
-            </button>
+              {buttonText}
+            </Button>
           }
         />
       </div>

--- a/autogpt_platform/frontend/src/components/agptui/ProfileInfoForm.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/ProfileInfoForm.tsx
@@ -5,12 +5,12 @@ import { useState } from "react";
 
 import Image from "next/image";
 
-import { Button } from "./Button";
 import { IconPersonFill } from "@/components/ui/icons";
 import { CreatorDetails, ProfileDetails } from "@/lib/autogpt-server-api/types";
 import { Separator } from "@/components/ui/separator";
 import useSupabase from "@/hooks/useSupabase";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+import { Button } from "@/components/ui/button";
 
 export const ProfileInfoForm = ({ profile }: { profile: CreatorDetails }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -245,9 +245,7 @@ export const ProfileInfoForm = ({ profile }: { profile: CreatorDetails }) => {
 
           <div className="flex h-[50px] items-center justify-end gap-3 py-8">
             <Button
-              type="button"
               variant="secondary"
-              className="font-circular h-[50px] rounded-[35px] bg-neutral-200 px-6 py-3 text-base font-medium text-neutral-800 transition-colors hover:bg-neutral-300 dark:border-neutral-700 dark:bg-neutral-700 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:bg-neutral-600"
               onClick={() => {
                 setProfileData(profile);
               }}
@@ -257,7 +255,6 @@ export const ProfileInfoForm = ({ profile }: { profile: CreatorDetails }) => {
             <Button
               type="submit"
               disabled={isSubmitting}
-              className="font-circular h-[50px] rounded-[35px] bg-neutral-800 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-neutral-900 dark:bg-neutral-200 dark:text-neutral-900 dark:hover:bg-neutral-100"
               onClick={submitForm}
             >
               {isSubmitting ? "Saving..." : "Save changes"}

--- a/autogpt_platform/frontend/src/components/agptui/ProfileInfoForm.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/ProfileInfoForm.tsx
@@ -252,11 +252,7 @@ export const ProfileInfoForm = ({ profile }: { profile: CreatorDetails }) => {
             >
               Cancel
             </Button>
-            <Button
-              type="submit"
-              disabled={isSubmitting}
-              onClick={submitForm}
-            >
+            <Button type="submit" disabled={isSubmitting} onClick={submitForm}>
               {isSubmitting ? "Saving..." : "Save changes"}
             </Button>
           </div>

--- a/autogpt_platform/frontend/src/components/auth/AuthButton.tsx
+++ b/autogpt_platform/frontend/src/components/auth/AuthButton.tsx
@@ -19,7 +19,7 @@ export default function AuthButton({
 }: Props) {
   return (
     <Button
-      className="mt-2 w-full self-stretch rounded-md bg-slate-900 px-4 py-2"
+      className="w-full"
       type={type}
       disabled={isLoading || disabled}
       onClick={onClick}

--- a/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/BlocksControl.tsx
@@ -155,7 +155,6 @@ export const BlocksControl: React.FC<BlocksControlProps> = ({
               data-id="blocks-control-popover-trigger"
               data-testid="blocks-control-blocks-button"
               name="Blocks"
-              className="dark:hover:bg-slate-800"
             >
               <IconToyBrick />
             </Button>

--- a/autogpt_platform/frontend/src/components/edit/control/ControlPanel.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/ControlPanel.tsx
@@ -61,7 +61,6 @@ export const ControlPanel = ({
                     data-id={`control-button-${index}`}
                     data-testid={`blocks-control-${control.label.toLowerCase()}-button`}
                     disabled={control.disabled || false}
-                    className="dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
                   >
                     {control.icon}
                     <span className="sr-only">{control.label}</span>

--- a/autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx
+++ b/autogpt_platform/frontend/src/components/edit/control/SaveControl.tsx
@@ -93,7 +93,7 @@ export const SaveControl = ({
               data-testid="blocks-control-save-button"
               name="Save"
             >
-              <IconSave className="dark:text-gray-300" />
+              <IconSave />
             </Button>
           </PopoverTrigger>
         </TooltipTrigger>
@@ -153,7 +153,6 @@ export const SaveControl = ({
           </CardContent>
           <CardFooter className="flex flex-col items-stretch gap-2">
             <Button
-              className="w-full dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-800"
               onClick={handleSave}
               data-id="save-control-save-agent"
               data-testid="save-control-save-agent-button"

--- a/autogpt_platform/frontend/src/components/profile/settings/SettingsForm.tsx
+++ b/autogpt_platform/frontend/src/components/profile/settings/SettingsForm.tsx
@@ -382,7 +382,7 @@ export default function SettingsForm({ user, preferences }: SettingsFormProps) {
         {/* Form Actions */}
         <div className="flex justify-end gap-4">
           <Button
-            variant="outline"
+            variant="secondary"
             type="button"
             onClick={onCancel}
             disabled={form.formState.isSubmitting}

--- a/autogpt_platform/frontend/src/components/ui/button.stories.tsx
+++ b/autogpt_platform/frontend/src/components/ui/button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Button } from "./button";
+import { Button } from "@/components/ui/button";
 import { userEvent, within, expect } from "@storybook/test";
 
 const meta = {
@@ -23,7 +23,8 @@ const meta = {
     },
     size: {
       control: "select",
-      options: ["default", "sm", "lg", "primary", "icon"],
+      options: ["default", "sm", "lg", "icon"],
+      description: "Button size variants. The 'primary' size is deprecated."
     },
     disabled: {
       control: "boolean",
@@ -45,6 +46,32 @@ export const Default: Story = {
   args: {
     children: "Button",
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button", { name: /Button/i });
+
+    // Test default styling
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("rounded-full")
+    );
+
+    // Test SVG styling is present
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:size-4")
+    );
+
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:shrink-0")
+    );
+
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:pointer-events-none")
+    );
+  },
 };
 
 export const Interactive: Story = {
@@ -57,14 +84,33 @@ export const Interactive: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /Interactive Button/i });
+
+    // Test interaction
     await userEvent.click(button);
     await expect(button).toHaveFocus();
+
+    // Test styling matches the updated component
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("rounded-full")
+    );
+
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("gap-2")
+    );
+
+    // Test other key button styles
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("inline-flex items-center justify-center")
+    );
   },
 };
 
 export const Variants: Story = {
   render: (args) => (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-4">
       <Button {...args} variant="default">
         Default
       </Button>
@@ -89,6 +135,8 @@ export const Variants: Story = {
     const canvas = within(canvasElement);
     const buttons = canvas.getAllByRole("button");
     await expect(buttons).toHaveLength(6);
+
+    // Test hover states
     for (const button of buttons) {
       await userEvent.hover(button);
       await expect(button).toHaveAttribute(
@@ -96,47 +144,78 @@ export const Variants: Story = {
         expect.stringContaining("hover:"),
       );
     }
+
+    // Test rounded-full styling on appropriate variants
+    const roundedVariants = ["default", "destructive", "outline", "secondary", "ghost"];
+    for (let i = 0; i < 5; i++) {
+      await expect(buttons[i]).toHaveAttribute(
+        "class",
+        expect.stringContaining("rounded-full")
+      );
+    }
+
+    // Link variant should not have rounded-full
+    await expect(buttons[5]).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("rounded-full")
+    );
   },
 };
 
 export const Sizes: Story = {
   render: (args) => (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-4">
+      <Button {...args} size="icon">
+        🚀
+      </Button>
       <Button {...args} size="sm">
         Small
       </Button>
-      <Button {...args} size="default">
+      <Button {...args} >
         Default
       </Button>
       <Button {...args} size="lg">
         Large
       </Button>
-      <Button {...args} size="primary">
-        Primary
-      </Button>
-      <Button {...args} size="icon">
-        🚀
-      </Button>
+      <div className="flex flex-col items-start gap-2 border p-4 rounded">
+        <p className="text-xs text-muted-foreground mb-2">Deprecated Size:</p>
+        <Button {...args} size="primary">
+          Primary (deprecated)
+        </Button>
+      </div>
+
     </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const buttons = canvas.getAllByRole("button");
     await expect(buttons).toHaveLength(5);
-    const sizes = ["sm", "default", "lg", "primary", "icon"];
-    const sizeClasses = [
-      "h-8 rounded-md px-3 text-xs",
-      "h-9 px-4 py-2",
-      "h-10 rounded-md px-8",
-      "md:h-14 md:w-44 rounded-2xl h-10 w-28",
-      "h-9 w-9",
-    ];
-    buttons.forEach(async (button, index) => {
-      await expect(button).toHaveAttribute(
-        "class",
-        expect.stringContaining(sizeClasses[index]),
-      );
-    });
+
+    // Test icon size
+    const iconButton = canvas.getByRole("button", { name: /🚀/i });
+    await expect(iconButton).toHaveAttribute(
+      "class",
+      expect.stringContaining("h-9 w-9")
+    );
+
+    // Test specific size classes
+    const smallButton = canvas.getByRole("button", { name: /Small/i });
+    await expect(smallButton).toHaveAttribute(
+      "class",
+      expect.stringContaining("h-8")
+    );
+
+    const defaultButton = canvas.getByRole("button", { name: /Default/i });
+    await expect(defaultButton).toHaveAttribute(
+      "class",
+      expect.stringContaining("h-9")
+    );
+
+    const largeButton = canvas.getByRole("button", { name: /Large/i });
+    await expect(largeButton).toHaveAttribute(
+      "class",
+      expect.stringContaining("h-10")
+    );
   },
 };
 
@@ -149,39 +228,99 @@ export const Disabled: Story = {
     const canvas = within(canvasElement);
     const button = canvas.getByRole("button", { name: /Disabled Button/i });
     await expect(button).toBeDisabled();
-    await expect(button).toHaveStyle("pointer-events: none");
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("disabled:pointer-events-none")
+    );
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("disabled:opacity-50")
+    );
     await expect(button).not.toHaveFocus();
   },
 };
 
 export const WithIcon: Story = {
-  args: {
-    children: (
-      <>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="mr-2 h-4 w-4"
-        >
-          <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
-        </svg>
-        Button with Icon
-      </>
-    ),
-  },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-4">
+        <Button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+          </svg>
+          Icon Left
+        </Button>
+        <Button>
+          Icon Right
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+          </svg>
+        </Button>
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground mb-2">Icon with automatic gap spacing:</p>
+        <Button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+          </svg>
+          Button with Icon
+        </Button>
+      </div>
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const button = canvas.getByRole("button", { name: /Button with Icon/i });
-    const icon = button.querySelector("svg");
-    await expect(icon).toBeInTheDocument();
-    await expect(button).toHaveTextContent("Button with Icon");
+    const buttons = canvas.getAllByRole("button");
+    const icons = canvasElement.querySelectorAll("svg");
+
+    // Test that SVGs are present
+    await expect(icons.length).toBeGreaterThan(0);
+
+    // Test for gap-2 class for spacing
+    await expect(buttons[0]).toHaveAttribute(
+      "class",
+      expect.stringContaining("gap-2")
+    );
+
+    // Test SVG styling from buttonVariants
+    await expect(buttons[0]).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:size-4")
+    );
+
+    await expect(buttons[0]).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:shrink-0")
+    );
+
+    await expect(buttons[0]).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:pointer-events-none")
+    );
   },
 };
 
@@ -193,10 +332,8 @@ export const LoadingState: Story = {
   render: (args) => (
     <Button {...args}>
       <svg
-        className="mr-2 h-4 w-4 animate-spin"
+        className="animate-spin"
         xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"
@@ -215,5 +352,52 @@ export const LoadingState: Story = {
     await expect(button).toBeDisabled();
     const spinner = button.querySelector("svg");
     await expect(spinner).toHaveClass("animate-spin");
+
+    // Test SVG styling from buttonVariants
+    await expect(button).toHaveAttribute(
+      "class",
+      expect.stringContaining("[&_svg]:size-4")
+    );
+  },
+};
+
+export const RoundedStyles: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="text-sm text-muted-foreground mb-2">Default variants have rounded-full style:</p>
+        <div className="flex gap-4">
+          <Button variant="default">Default</Button>
+          <Button variant="destructive">Destructive</Button>
+          <Button variant="outline">Outline</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="ghost">Ghost</Button>
+        </div>
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground mb-2">Link variant maintains its original style:</p>
+        <div className="flex gap-4">
+          <Button variant="link">Link</Button>
+        </div>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const buttons = canvas.getAllByRole("button");
+
+    // Test rounded-full on first 5 buttons
+    for (let i = 0; i < 5; i++) {
+      await expect(buttons[i]).toHaveAttribute(
+        "class",
+        expect.stringContaining("rounded-full")
+      );
+    }
+
+    // Test that link variant doesn't have rounded-full
+    await expect(buttons[5]).not.toHaveAttribute(
+      "class",
+      expect.stringContaining("rounded-full")
+    );
   },
 };

--- a/autogpt_platform/frontend/src/components/ui/button.stories.tsx
+++ b/autogpt_platform/frontend/src/components/ui/button.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
     size: {
       control: "select",
       options: ["default", "sm", "lg", "icon"],
-      description: "Button size variants. The 'primary' size is deprecated."
+      description: "Button size variants. The 'primary' size is deprecated.",
     },
     disabled: {
       control: "boolean",
@@ -53,23 +53,23 @@ export const Default: Story = {
     // Test default styling
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("rounded-full")
+      expect.stringContaining("rounded-full"),
     );
 
     // Test SVG styling is present
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:size-4")
+      expect.stringContaining("[&_svg]:size-4"),
     );
 
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:shrink-0")
+      expect.stringContaining("[&_svg]:shrink-0"),
     );
 
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:pointer-events-none")
+      expect.stringContaining("[&_svg]:pointer-events-none"),
     );
   },
 };
@@ -92,18 +92,18 @@ export const Interactive: Story = {
     // Test styling matches the updated component
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("rounded-full")
+      expect.stringContaining("rounded-full"),
     );
 
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("gap-2")
+      expect.stringContaining("gap-2"),
     );
 
     // Test other key button styles
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("inline-flex items-center justify-center")
+      expect.stringContaining("inline-flex items-center justify-center"),
     );
   },
 };
@@ -146,18 +146,24 @@ export const Variants: Story = {
     }
 
     // Test rounded-full styling on appropriate variants
-    const roundedVariants = ["default", "destructive", "outline", "secondary", "ghost"];
+    const roundedVariants = [
+      "default",
+      "destructive",
+      "outline",
+      "secondary",
+      "ghost",
+    ];
     for (let i = 0; i < 5; i++) {
       await expect(buttons[i]).toHaveAttribute(
         "class",
-        expect.stringContaining("rounded-full")
+        expect.stringContaining("rounded-full"),
       );
     }
 
     // Link variant should not have rounded-full
     await expect(buttons[5]).not.toHaveAttribute(
       "class",
-      expect.stringContaining("rounded-full")
+      expect.stringContaining("rounded-full"),
     );
   },
 };
@@ -171,19 +177,16 @@ export const Sizes: Story = {
       <Button {...args} size="sm">
         Small
       </Button>
-      <Button {...args} >
-        Default
-      </Button>
+      <Button {...args}>Default</Button>
       <Button {...args} size="lg">
         Large
       </Button>
-      <div className="flex flex-col items-start gap-2 border p-4 rounded">
-        <p className="text-xs text-muted-foreground mb-2">Deprecated Size:</p>
+      <div className="flex flex-col items-start gap-2 rounded border p-4">
+        <p className="mb-2 text-xs text-muted-foreground">Deprecated Size:</p>
         <Button {...args} size="primary">
           Primary (deprecated)
         </Button>
       </div>
-
     </div>
   ),
   play: async ({ canvasElement }) => {
@@ -195,26 +198,26 @@ export const Sizes: Story = {
     const iconButton = canvas.getByRole("button", { name: /🚀/i });
     await expect(iconButton).toHaveAttribute(
       "class",
-      expect.stringContaining("h-9 w-9")
+      expect.stringContaining("h-9 w-9"),
     );
 
     // Test specific size classes
     const smallButton = canvas.getByRole("button", { name: /Small/i });
     await expect(smallButton).toHaveAttribute(
       "class",
-      expect.stringContaining("h-8")
+      expect.stringContaining("h-8"),
     );
 
     const defaultButton = canvas.getByRole("button", { name: /Default/i });
     await expect(defaultButton).toHaveAttribute(
       "class",
-      expect.stringContaining("h-9")
+      expect.stringContaining("h-9"),
     );
 
     const largeButton = canvas.getByRole("button", { name: /Large/i });
     await expect(largeButton).toHaveAttribute(
       "class",
-      expect.stringContaining("h-10")
+      expect.stringContaining("h-10"),
     );
   },
 };
@@ -230,11 +233,11 @@ export const Disabled: Story = {
     await expect(button).toBeDisabled();
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("disabled:pointer-events-none")
+      expect.stringContaining("disabled:pointer-events-none"),
     );
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("disabled:opacity-50")
+      expect.stringContaining("disabled:opacity-50"),
     );
     await expect(button).not.toHaveFocus();
   },
@@ -274,7 +277,9 @@ export const WithIcon: Story = {
         </Button>
       </div>
       <div>
-        <p className="text-sm text-muted-foreground mb-2">Icon with automatic gap spacing:</p>
+        <p className="mb-2 text-sm text-muted-foreground">
+          Icon with automatic gap spacing:
+        </p>
         <Button>
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -303,23 +308,23 @@ export const WithIcon: Story = {
     // Test for gap-2 class for spacing
     await expect(buttons[0]).toHaveAttribute(
       "class",
-      expect.stringContaining("gap-2")
+      expect.stringContaining("gap-2"),
     );
 
     // Test SVG styling from buttonVariants
     await expect(buttons[0]).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:size-4")
+      expect.stringContaining("[&_svg]:size-4"),
     );
 
     await expect(buttons[0]).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:shrink-0")
+      expect.stringContaining("[&_svg]:shrink-0"),
     );
 
     await expect(buttons[0]).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:pointer-events-none")
+      expect.stringContaining("[&_svg]:pointer-events-none"),
     );
   },
 };
@@ -356,7 +361,7 @@ export const LoadingState: Story = {
     // Test SVG styling from buttonVariants
     await expect(button).toHaveAttribute(
       "class",
-      expect.stringContaining("[&_svg]:size-4")
+      expect.stringContaining("[&_svg]:size-4"),
     );
   },
 };
@@ -365,7 +370,9 @@ export const RoundedStyles: Story = {
   render: () => (
     <div className="flex flex-col gap-6">
       <div>
-        <p className="text-sm text-muted-foreground mb-2">Default variants have rounded-full style:</p>
+        <p className="mb-2 text-sm text-muted-foreground">
+          Default variants have rounded-full style:
+        </p>
         <div className="flex gap-4">
           <Button variant="default">Default</Button>
           <Button variant="destructive">Destructive</Button>
@@ -375,7 +382,9 @@ export const RoundedStyles: Story = {
         </div>
       </div>
       <div>
-        <p className="text-sm text-muted-foreground mb-2">Link variant maintains its original style:</p>
+        <p className="mb-2 text-sm text-muted-foreground">
+          Link variant maintains its original style:
+        </p>
         <div className="flex gap-4">
           <Button variant="link">Link</Button>
         </div>
@@ -390,14 +399,14 @@ export const RoundedStyles: Story = {
     for (let i = 0; i < 5; i++) {
       await expect(buttons[i]).toHaveAttribute(
         "class",
-        expect.stringContaining("rounded-full")
+        expect.stringContaining("rounded-full"),
       );
     }
 
     // Test that link variant doesn't have rounded-full
     await expect(buttons[5]).not.toHaveAttribute(
       "class",
-      expect.stringContaining("rounded-full")
+      expect.stringContaining("rounded-full"),
     );
   },
 };

--- a/autogpt_platform/frontend/src/components/ui/button.tsx
+++ b/autogpt_platform/frontend/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -33,27 +33,27 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Button.displayName = "Button"
+    );
+  },
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/autogpt_platform/frontend/src/components/ui/button.tsx
+++ b/autogpt_platform/frontend/src/components/ui/button.tsx
@@ -1,59 +1,59 @@
-import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-950 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-neutral-300",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-neutral-900 text-neutral-50 shadow hover:bg-neutral-900/90 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-50/90",
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90 rounded-full",
         destructive:
-          "bg-red-500 text-neutral-50 shadow-sm hover:bg-red-500/90 dark:bg-red-900 dark:text-neutral-50 dark:hover:bg-red-900/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 rounded-full",
         outline:
-          "border border-neutral-200 bg-white shadow-sm hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground rounded-full",
         secondary:
-          "bg-neutral-100 text-neutral-900 shadow-sm hover:bg-neutral-100/80 dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-800/80",
-        ghost:
-          "hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
-        link: "text-neutral-900 underline-offset-4 hover:underline dark:text-neutral-50",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 rounded-full",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
-        primary: "md:h-14 md:w-44 rounded-2xl h-10 w-28",
         icon: "h-9 w-9",
+        /** @deprecated Use default size with custom classes instead */
+        primary: "md:h-14 md:w-44 rounded-2xl h-10 w-28",
       },
     },
     defaultVariants: {
       variant: "default",
       size: "default",
     },
-  },
-);
+  }
+)
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  asChild?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
+    const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    );
-  },
-);
-Button.displayName = "Button";
+    )
+  }
+)
+Button.displayName = "Button"
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/autogpt_platform/frontend/src/components/ui/button.tsx
+++ b/autogpt_platform/frontend/src/components/ui/button.tsx
@@ -10,14 +10,14 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90 rounded-full",
+          "bg-primary/90 text-primary-foreground shadow hover:bg-primary rounded-full",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 rounded-full",
+          "bg-destructive/90 text-destructive-foreground shadow-sm hover:bg-destructive rounded-full",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground rounded-full",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 rounded-full",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary/90 text-secondary-foreground shadow-sm hover:bg-secondary rounded-full",
+        ghost: "hover:bg-accent hover:text-accent-foreground rounded-full",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
Our application currently uses multiple inconsistent button implementations across the codebase. 
This PR standardizes buttons to use our base Button component that leverages ShadcN, improving UI consistency, maintainability, and accessibility.

Resolves: #9567 

### Changes 🏗️

- Replaced custom button implementations in various components with our base Button component and greatly reduced redundant overlapping styles. 
- Paired with our designer to streamline our `globals.css` to match the desired approach.  
- Added button variant documentation in Storybook
- Deprecated the obsolete 'primary' class  and marked it.

### Screenshots 📷

#### Variants  
<img width="466" alt="image" src="https://github.com/user-attachments/assets/9e4f6360-57ec-4f28-b702-e57252d67def" />

<img width="418" alt="image" src="https://github.com/user-attachments/assets/a9af17dc-e8bc-429d-a9ac-8380e34b9089" />

<img width="129" alt="image" src="https://github.com/user-attachments/assets/2df5d184-bb49-4640-bfb4-879360ca35e6" />

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:

<details>
  <summary>Button Consolidation Test Plan</summary>
 Visual Verification

- [ ]  Verify all button variants (default, destructive, outline, secondary, ghost, link) render correctly
- [ ]  Confirm button styling is consistent across all themes (light, dark, etc.)
- [ ]  Validate that the rounded-full style is applied to appropriate variants

 Functional Testing

- [ ]  Test click handlers continue to work on all migrated buttons
- [ ]  Verify hover, focus, and active states display correctly on all buttons
- [ ]  Confirm disabled states are working properly
- [ ]  Test loading state animations and behavior

 Responsive Testing

- [ ]  Verify button layouts on mobile devices (< 640px)
- [ ]  Confirm button layouts on tablet devices (640px - 1024px)
- [ ]  Test button layouts on desktop screens (> 1024px)
</details>