### PR TITLE
fix(backend): Increase logging level threshold of RPC service to WARNING

### DIFF
--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -326,7 +326,12 @@ class FastApiAppService(BaseAppService, ABC):
             f"[{self.service_name}] Starting RPC server at http://{api_host}:{self.get_port()}"
         )
         server = uvicorn.Server(
-            uvicorn.Config(self.fastapi_app, host=api_host, port=self.get_port())
+            uvicorn.Config(
+                self.fastapi_app,
+                host=api_host,
+                port=self.get_port(),
+                log_level="debug",
+            )
         )
         self.shared_event_loop.run_until_complete(server.serve())
 

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -330,7 +330,7 @@ class FastApiAppService(BaseAppService, ABC):
                 self.fastapi_app,
                 host=api_host,
                 port=self.get_port(),
-                log_level="debug",
+                log_level="warning",
             )
         )
         self.shared_event_loop.run_until_complete(server.serve())


### PR DESCRIPTION
Increase the logging threshold to WARNING to avoid chatty RPC service request logs.

Before:
![RPC calls show up in backend log](https://github.com/user-attachments/assets/70791f87-12ef-4a12-8343-4b8641302faa)