### PR TITLE
fix(backend): serialize the pydantic objects correctly for github checks and statuses

### DIFF
--- a/autogpt_platform/backend/backend/blocks/github/checks.py
+++ b/autogpt_platform/backend/backend/blocks/github/checks.py
@@ -172,7 +172,9 @@ class GithubCreateCheckRunBlock(Block):
             data.output = output_data
 
         check_runs_url = f"{repo_url}/check-runs"
-        response = api.post(check_runs_url, data=data.model_dump_json(exclude_none=True))
+        response = api.post(
+            check_runs_url, data=data.model_dump_json(exclude_none=True)
+        )
         result = response.json()
 
         return {
@@ -323,7 +325,9 @@ class GithubUpdateCheckRunBlock(Block):
             data.output = output_data
 
         check_run_url = f"{repo_url}/check-runs/{check_run_id}"
-        response = api.patch(check_run_url, data=data.model_dump_json(exclude_none=True))
+        response = api.patch(
+            check_run_url, data=data.model_dump_json(exclude_none=True)
+        )
         result = response.json()
 
         return {

--- a/autogpt_platform/backend/backend/blocks/github/checks.py
+++ b/autogpt_platform/backend/backend/blocks/github/checks.py
@@ -172,7 +172,7 @@ class GithubCreateCheckRunBlock(Block):
             data.output = output_data
 
         check_runs_url = f"{repo_url}/check-runs"
-        response = api.post(check_runs_url)
+        response = api.post(check_runs_url, data=data.model_dump_json(exclude_none=True))
         result = response.json()
 
         return {
@@ -323,7 +323,7 @@ class GithubUpdateCheckRunBlock(Block):
             data.output = output_data
 
         check_run_url = f"{repo_url}/check-runs/{check_run_id}"
-        response = api.patch(check_run_url)
+        response = api.patch(check_run_url, data=data.model_dump_json(exclude_none=True))
         result = response.json()
 
         return {

--- a/autogpt_platform/backend/backend/blocks/github/statuses.py
+++ b/autogpt_platform/backend/backend/blocks/github/statuses.py
@@ -144,7 +144,7 @@ class GithubCreateStatusBlock(Block):
             data.description = description
 
         status_url = f"{repo_url}/statuses/{sha}"
-        response = api.post(status_url, json=data)
+        response = api.post(status_url, data=data.model_dump_json(exclude_none=True))
         result = response.json()
 
         return {


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
Trying to run the GitHub Status blocks results in a serialization error

### Changes 🏗️
- Serializes the checks and blocks data objects correctly
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] make a one block agent, test it and make sure it works
