### PR TITLE
feat(block): Allow undefined self-loop link to `list` input pin on `AddToListBlock`

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -1,13 +1,23 @@
 import enum
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List
 
-from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema, BlockType
+from backend.data.block import (
+    Block,
+    BlockCategory,
+    BlockInput,
+    BlockOutput,
+    BlockSchema,
+    BlockType,
+)
 from backend.data.model import SchemaField
 from backend.util import json
 from backend.util.file import MediaFile, store_media_file
 from backend.util.mock import MockObject
 from backend.util.text import TextFormatter
 from backend.util.type import convert
+
+if TYPE_CHECKING:
+    from backend.data.graph import Link
 
 formatter = TextFormatter()
 
@@ -455,6 +465,17 @@ class AddToListBlock(Block):
             default=None,
             description="The position to insert the new entry. If not provided, the entry will be appended to the end of the list.",
         )
+
+        @classmethod
+        def get_missing_links(cls, data: BlockInput, links: List["Link"]) -> set[str]:
+            return super().get_missing_links(
+                data,
+                [
+                    link
+                    for link in links
+                    if link.sink_name != "list" or link.sink_id != link.source_id
+                ],
+            )
 
     class Output(BlockSchema):
         updated_list: List[Any] = SchemaField(


### PR DESCRIPTION
### Changes 🏗️

Creating a self-loop of the AddToListBlock requires a boilerplate of adding a dummy block to trigger its execution.

![image](https://github.com/user-attachments/assets/329dd1f4-5b3b-4d34-8743-25bd4337d734)

If the only inbound link on an input pin comes from the same block, we don't wait for that pin on the first execution (as it's never going to come).


### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
