### PR TITLE
fix(block): Add missing error pin to Exa Contents Block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/exa/contents.py
+++ b/autogpt_platform/backend/backend/blocks/exa/contents.py
@@ -51,9 +51,7 @@ class ExaContentsBlock(Block):
             description="List of document contents",
             default=[],
         )
-        error: str = SchemaField(
-            description="Error message if the request failed"
-        )
+        error: str = SchemaField(description="Error message if the request failed")
 
     def __init__(self):
         super().__init__(

--- a/autogpt_platform/backend/backend/blocks/exa/contents.py
+++ b/autogpt_platform/backend/backend/blocks/exa/contents.py
@@ -51,6 +51,9 @@ class ExaContentsBlock(Block):
             description="List of document contents",
             default=[],
         )
+        error: str = SchemaField(
+            description="Error message if the request failed"
+        )
 
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

The Exa Block has a missing error pin which prevents error handling, this adds that.
