### PR TITLE
fix(frontend): Fill defaults from schema to `hardcodedValues` at node creation

### DIFF
--- a/autogpt_platform/frontend/src/hooks/useCredentials.ts
+++ b/autogpt_platform/frontend/src/hooks/useCredentials.ts
@@ -43,17 +43,12 @@ export default function useCredentials(
     inputFieldName
   ] as BlockIOCredentialsSubSchema;
 
-  const fieldValue =
-    credentialsSchema.discriminator &&
-    (getValue(credentialsSchema.discriminator, data.hardcodedValues) ||
-      (
-        data.inputSchema.properties[
-          credentialsSchema.discriminator
-        ] as BlockIOCredentialsSubSchema
-      ).default);
-
   const discriminatorValue: CredentialsProviderName | null =
-    credentialsSchema.discriminator_mapping![fieldValue] || null;
+    (credentialsSchema.discriminator &&
+      credentialsSchema.discriminator_mapping![
+        getValue(credentialsSchema.discriminator, data.hardcodedValues)
+      ]) ||
+    null;
 
   let providerName: CredentialsProviderName;
   if (credentialsSchema.credentials_provider.length > 1) {

--- a/autogpt_platform/frontend/src/hooks/useCredentials.ts
+++ b/autogpt_platform/frontend/src/hooks/useCredentials.ts
@@ -43,12 +43,17 @@ export default function useCredentials(
     inputFieldName
   ] as BlockIOCredentialsSubSchema;
 
+  const fieldValue =
+    credentialsSchema.discriminator &&
+    (getValue(credentialsSchema.discriminator, data.hardcodedValues) ||
+      (
+        data.inputSchema.properties[
+          credentialsSchema.discriminator
+        ] as BlockIOCredentialsSubSchema
+      ).default);
+
   const discriminatorValue: CredentialsProviderName | null =
-    (credentialsSchema.discriminator &&
-      credentialsSchema.discriminator_mapping![
-        getValue(credentialsSchema.discriminator, data.hardcodedValues)
-      ]) ||
-    null;
+    credentialsSchema.discriminator_mapping![fieldValue] || null;
 
   let providerName: CredentialsProviderName;
   if (credentialsSchema.credentials_provider.length > 1) {


### PR DESCRIPTION
Defaults need to be handled as special cases every time there's no `hardcodedValues` in node data. This causes multiple issues such as `useCredentials` not taking into account default model and requiring user to manually switch model back and forth.

### Changes 🏗️

- Set default values from `inputSchema` to `hardcodedValues` when new node is placed.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Newly placed node has defaults set as `hardcodedValues`
  - [x] AI Blocks: Model is recognised, node shows price and credentials work correctly without the need to switch