### PR TITLE
feat(backend): Support sub-agent on export/import agent feature

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -796,7 +796,11 @@ async def _get_sub_graphs(graph: AgentGraph) -> list[AgentGraph]:
         graphs = await AgentGraph.prisma().find_many(
             where={
                 "OR": [
-                    {"id": graph_id, "version": graph_version}
+                    {
+                        "id": graph_id,
+                        "version": graph_version,
+                        "userId": graph.userId,  # Ensure the sub-graph is owned by the same user
+                    }
                     for graph_id, graph_version in sub_graph_ids
                 ]  # type: ignore
             },

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -769,6 +769,11 @@ async def get_graph(
 
 
 async def _get_sub_graphs(graph: AgentGraph) -> list[AgentGraph]:
+    """
+    Iteratively fetches all sub-graphs of a given graph, and flattens them into a list.
+    This call involves a DB fetch in batch, breadth-first, per-level of graph depth.
+    On each DB fetch we will only fetch the sub-graphs that are not already in the list.
+    """
     sub_graphs = {graph.id: graph}
     search_graphs = [graph]
     agent_block_id = AgentExecutorBlock().id

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -122,6 +122,12 @@ class NodeModel(Node):
                 stripped_node.input_default, self.block.input_schema.jsonschema()
             )
 
+        if (
+            stripped_node.block.block_type == BlockType.INPUT
+            and "value" in stripped_node.input_default
+        ):
+            stripped_node.input_default["value"] = ""
+
         # Remove webhook info
         stripped_node.webhook_id = None
         stripped_node.webhook = None
@@ -538,7 +544,7 @@ class GraphModel(Graph):
     ):
         return GraphModel(
             id=graph.id,
-            user_id=graph.userId,
+            user_id=graph.userId if not for_export else "",
             version=graph.version,
             is_active=graph.isActive,
             name=graph.name or "",
@@ -558,26 +564,6 @@ class GraphModel(Graph):
                 for sub_graph in sub_graphs or []
             ],
         )
-
-    def clean_graph(self):
-        blocks = [block() for block in get_blocks().values()]
-
-        input_blocks = [
-            node
-            for node in self.nodes
-            if next(
-                (
-                    b
-                    for b in blocks
-                    if b.id == node.block_id and b.block_type == BlockType.INPUT
-                ),
-                None,
-            )
-        ]
-
-        for node in self.nodes:
-            if any(input_block.id == node.id for input_block in input_blocks):
-                node.input_default["value"] = ""
 
 
 # --------------------- CRUD functions --------------------- #

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -154,9 +154,10 @@ class AgentServer(backend.util.service.AppProcess):
         graph_id: str,
         graph_version: int,
         user_id: str,
+        for_export: bool = False,
     ):
         return await backend.server.routers.v1.get_graph(
-            graph_id, user_id, graph_version
+            graph_id, user_id, graph_version, for_export
         )
 
     @staticmethod

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -396,10 +396,10 @@ async def get_graph(
     graph_id: str,
     user_id: Annotated[str, Depends(get_user_id)],
     version: int | None = None,
-    hide_credentials: bool = False,
+    for_export: bool = False,
 ) -> graph_db.GraphModel:
     graph = await graph_db.get_graph(
-        graph_id, version, user_id=user_id, for_export=hide_credentials
+        graph_id, version, user_id=user_id, for_export=for_export
     )
     if not graph:
         raise HTTPException(status_code=404, detail=f"Graph #{graph_id} not found.")
@@ -429,6 +429,7 @@ async def create_new_graph(
 ) -> graph_db.GraphModel:
     graph = graph_db.make_graph_model(create_graph.graph, user_id)
     graph.reassign_ids(user_id=user_id, reassign_graph_id=True)
+    graph.validate_graph(for_run=False)
 
     graph = await graph_db.create_graph(graph, user_id=user_id)
 
@@ -480,17 +481,10 @@ async def update_graph(
     latest_version_number = max(g.version for g in existing_versions)
     graph.version = latest_version_number + 1
 
-    latest_version_graph = next(
-        v for v in existing_versions if v.version == latest_version_number
-    )
     current_active_version = next((v for v in existing_versions if v.is_active), None)
-    if latest_version_graph.is_template != graph.is_template:
-        raise HTTPException(
-            400, detail="Changing is_template on an existing graph is forbidden"
-        )
-    graph.is_active = not graph.is_template
     graph = graph_db.make_graph_model(graph, user_id)
-    graph.reassign_ids(user_id=user_id)
+    graph.reassign_ids(user_id=user_id, reassign_graph_id=False)
+    graph.validate_graph(for_run=False)
 
     new_graph_version = await graph_db.create_graph(graph, user_id=user_id)
 

--- a/autogpt_platform/backend/backend/server/v2/library/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/library/db_test.py
@@ -3,20 +3,11 @@ from datetime import datetime
 import prisma.errors
 import prisma.models
 import pytest
-from prisma import Prisma
 
 import backend.server.v2.library.db as db
 import backend.server.v2.store.exceptions
-
-
-@pytest.fixture(autouse=True)
-async def setup_prisma():
-    # Don't register client if already registered
-    try:
-        Prisma()
-    except prisma.errors.ClientAlreadyRegisteredError:
-        pass
-    yield
+from backend.data.db import connect
+from backend.data.includes import library_agent_include
 
 
 @pytest.mark.asyncio
@@ -89,10 +80,11 @@ async def test_get_library_agents(mocker):
     assert result.pagination.page_size == 50
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_add_agent_to_library(mocker):
+    await connect()
     # Mock data
-    mock_store_listing = prisma.models.StoreListingVersion(
+    mock_store_listing_data = prisma.models.StoreListingVersion(
         id="version123",
         version=1,
         createdAt=datetime.now(),
@@ -120,17 +112,34 @@ async def test_add_agent_to_library(mocker):
         ),
     )
 
+    mock_library_agent_data = prisma.models.LibraryAgent(
+        id="ua1",
+        userId="test-user",
+        agentId=mock_store_listing_data.agentId,
+        agentVersion=1,
+        isCreatedByUser=False,
+        isDeleted=False,
+        isArchived=False,
+        createdAt=datetime.now(),
+        updatedAt=datetime.now(),
+        isFavorite=False,
+        useGraphIsActiveVersion=True,
+        Agent=mock_store_listing_data.Agent,
+    )
+
     # Mock prisma calls
     mock_store_listing_version = mocker.patch(
         "prisma.models.StoreListingVersion.prisma"
     )
     mock_store_listing_version.return_value.find_unique = mocker.AsyncMock(
-        return_value=mock_store_listing
+        return_value=mock_store_listing_data
     )
 
     mock_library_agent = mocker.patch("prisma.models.LibraryAgent.prisma")
     mock_library_agent.return_value.find_first = mocker.AsyncMock(return_value=None)
-    mock_library_agent.return_value.create = mocker.AsyncMock()
+    mock_library_agent.return_value.create = mocker.AsyncMock(
+        return_value=mock_library_agent_data
+    )
 
     # Call function
     await db.add_store_agent_to_library("version123", "test-user")
@@ -144,17 +153,20 @@ async def test_add_agent_to_library(mocker):
             "userId": "test-user",
             "agentId": "agent1",
             "agentVersion": 1,
-        }
+        },
+        include=library_agent_include("test-user"),
     )
     mock_library_agent.return_value.create.assert_called_once_with(
         data=prisma.types.LibraryAgentCreateInput(
             userId="test-user", agentId="agent1", agentVersion=1, isCreatedByUser=False
-        )
+        ),
+        include=library_agent_include("test-user"),
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="session")
 async def test_add_agent_to_library_not_found(mocker):
+    await connect()
     # Mock prisma calls
     mock_store_listing_version = mocker.patch(
         "prisma.models.StoreListingVersion.prisma"

--- a/autogpt_platform/backend/backend/server/v2/library/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/library/db_test.py
@@ -31,7 +31,6 @@ async def test_get_library_agents(mocker):
             userId="test-user",
             isActive=True,
             createdAt=datetime.now(),
-            isTemplate=False,
         )
     ]
 
@@ -56,7 +55,6 @@ async def test_get_library_agents(mocker):
                 userId="other-user",
                 isActive=True,
                 createdAt=datetime.now(),
-                isTemplate=False,
             ),
         )
     ]
@@ -119,7 +117,6 @@ async def test_add_agent_to_library(mocker):
             userId="creator",
             isActive=True,
             createdAt=datetime.now(),
-            isTemplate=False,
         ),
     )
 

--- a/autogpt_platform/backend/backend/server/v2/library/model_test.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model_test.py
@@ -2,11 +2,14 @@ import datetime
 
 import prisma.fields
 import prisma.models
+import pytest
 
 import backend.server.v2.library.model as library_model
+from backend.util import json
 
 
-def test_agent_preset_from_db():
+@pytest.mark.asyncio
+async def test_agent_preset_from_db():
     # Create mock DB agent
     db_agent = prisma.models.AgentPreset(
         id="test-agent-123",
@@ -24,7 +27,7 @@ def test_agent_preset_from_db():
                 id="input-123",
                 time=datetime.datetime.now(),
                 name="input1",
-                data=prisma.fields.Json({"type": "string", "value": "test value"}),
+                data=json.dumps({"type": "string", "value": "test value"}),  # type: ignore
             )
         ],
     )

--- a/autogpt_platform/backend/backend/server/v2/library/routes_test.py
+++ b/autogpt_platform/backend/backend/server/v2/library/routes_test.py
@@ -1,7 +1,6 @@
 import datetime
 
 import autogpt_libs.auth as autogpt_auth_lib
-import fastapi
 import fastapi.testclient
 import pytest
 import pytest_mock
@@ -30,49 +29,48 @@ app.dependency_overrides[autogpt_auth_lib.auth_middleware] = override_auth_middl
 app.dependency_overrides[autogpt_auth_lib.depends.get_user_id] = override_get_user_id
 
 
-def test_get_library_agents_success(mocker: pytest_mock.MockFixture):
-    mocked_value = [
-        library_model.LibraryAgentResponse(
-            agents=[
-                library_model.LibraryAgent(
-                    id="test-agent-1",
-                    agent_id="test-agent-1",
-                    agent_version=1,
-                    name="Test Agent 1",
-                    description="Test Description 1",
-                    image_url=None,
-                    creator_name="Test Creator",
-                    creator_image_url="",
-                    input_schema={"type": "object", "properties": {}},
-                    status=library_model.LibraryAgentStatus.COMPLETED,
-                    new_output=False,
-                    can_access_graph=True,
-                    is_latest_version=True,
-                    updated_at=datetime.datetime(2023, 1, 1, 0, 0, 0),
-                ),
-                library_model.LibraryAgent(
-                    id="test-agent-2",
-                    agent_id="test-agent-2",
-                    agent_version=1,
-                    name="Test Agent 2",
-                    description="Test Description 2",
-                    image_url=None,
-                    creator_name="Test Creator",
-                    creator_image_url="",
-                    input_schema={"type": "object", "properties": {}},
-                    status=library_model.LibraryAgentStatus.COMPLETED,
-                    new_output=False,
-                    can_access_graph=False,
-                    is_latest_version=True,
-                    updated_at=datetime.datetime(2023, 1, 1, 0, 0, 0),
-                ),
-            ],
-            pagination=server_model.Pagination(
-                total_items=2, total_pages=1, current_page=1, page_size=50
+@pytest.mark.asyncio
+async def test_get_library_agents_success(mocker: pytest_mock.MockFixture):
+    mocked_value = library_model.LibraryAgentResponse(
+        agents=[
+            library_model.LibraryAgent(
+                id="test-agent-1",
+                agent_id="test-agent-1",
+                agent_version=1,
+                name="Test Agent 1",
+                description="Test Description 1",
+                image_url=None,
+                creator_name="Test Creator",
+                creator_image_url="",
+                input_schema={"type": "object", "properties": {}},
+                status=library_model.LibraryAgentStatus.COMPLETED,
+                new_output=False,
+                can_access_graph=True,
+                is_latest_version=True,
+                updated_at=datetime.datetime(2023, 1, 1, 0, 0, 0),
             ),
+            library_model.LibraryAgent(
+                id="test-agent-2",
+                agent_id="test-agent-2",
+                agent_version=1,
+                name="Test Agent 2",
+                description="Test Description 2",
+                image_url=None,
+                creator_name="Test Creator",
+                creator_image_url="",
+                input_schema={"type": "object", "properties": {}},
+                status=library_model.LibraryAgentStatus.COMPLETED,
+                new_output=False,
+                can_access_graph=False,
+                is_latest_version=True,
+                updated_at=datetime.datetime(2023, 1, 1, 0, 0, 0),
+            ),
+        ],
+        pagination=server_model.Pagination(
+            total_items=2, total_pages=1, current_page=1, page_size=50
         ),
-    ]
-    mock_db_call = mocker.patch("backend.server.v2.library.db.get_library_agents")
+    )
+    mock_db_call = mocker.patch("backend.server.v2.library.db.list_library_agents")
     mock_db_call.return_value = mocked_value
 
     response = client.get("/agents?search_term=test")
@@ -94,7 +92,7 @@ def test_get_library_agents_success(mocker: pytest_mock.MockFixture):
 
 
 def test_get_library_agents_error(mocker: pytest_mock.MockFixture):
-    mock_db_call = mocker.patch("backend.server.v2.library.db.get_library_agents")
+    mock_db_call = mocker.patch("backend.server.v2.library.db.list_library_agents")
     mock_db_call.side_effect = Exception("Test error")
 
     response = client.get("/agents?search_term=test")

--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from typing import Optional
 
 import fastapi
 import prisma.enums
@@ -754,46 +753,31 @@ async def get_my_agents(
 
 
 async def get_agent(
-    store_listing_version_id: str, version_id: Optional[int]
+    user_id: str,
+    store_listing_version_id: str,
 ) -> GraphModel:
     """Get agent using the version ID and store listing version ID."""
-    try:
-        store_listing_version = (
-            await prisma.models.StoreListingVersion.prisma().find_unique(
-                where={"id": store_listing_version_id}, include={"Agent": True}
-            )
+    store_listing_version = (
+        await prisma.models.StoreListingVersion.prisma().find_unique(
+            where={"id": store_listing_version_id}
+        )
+    )
+
+    if not store_listing_version:
+        raise ValueError(f"Store listing version {store_listing_version_id} not found")
+
+    graph = await backend.data.graph.get_graph(
+        user_id=user_id,
+        graph_id=store_listing_version.agentId,
+        version=store_listing_version.agentVersion,
+        for_export=True,
+    )
+    if not graph:
+        raise ValueError(
+            f"Agent {store_listing_version.agentId} v{store_listing_version.agentVersion} not found"
         )
 
-        if not store_listing_version or not store_listing_version.Agent:
-            raise fastapi.HTTPException(
-                status_code=404,
-                detail=f"Store listing version {store_listing_version_id} not found",
-            )
-
-        graph_id = store_listing_version.agentId
-        graph_version = store_listing_version.agentVersion
-        graph = await backend.data.graph.get_graph(graph_id, graph_version)
-
-        if not graph:
-            raise fastapi.HTTPException(
-                status_code=404,
-                detail=(
-                    f"Agent #{graph_id} not found "
-                    f"for store listing version #{store_listing_version_id}"
-                ),
-            )
-
-        graph.version = 1
-        graph.is_active = True
-        delattr(graph, "user_id")
-
-        return graph
-
-    except Exception as e:
-        logger.error(f"Error getting agent: {e}")
-        raise backend.server.v2.store.exceptions.DatabaseError(
-            "Failed to fetch agent"
-        ) from e
+    return graph
 
 
 async def review_store_submission(

--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -784,7 +784,6 @@ async def get_agent(
             )
 
         graph.version = 1
-        graph.is_template = False
         graph.is_active = True
         delattr(graph, "user_id")
 

--- a/autogpt_platform/backend/backend/server/v2/store/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db_test.py
@@ -146,7 +146,6 @@ async def test_create_store_submission(mocker):
         userId="user-id",
         createdAt=datetime.now(),
         isActive=True,
-        isTemplate=False,
     )
 
     mock_listing = prisma.models.StoreListing(

--- a/autogpt_platform/backend/migrations/20250316095525_remove_graph_template/migration.sql
+++ b/autogpt_platform/backend/migrations/20250316095525_remove_graph_template/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isTemplate` on the `AgentGraph` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "AgentGraph" DROP COLUMN "isTemplate";

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -87,7 +87,6 @@ model AgentGraph {
   description String?
 
   isActive    Boolean @default(true)
-  isTemplate  Boolean @default(false)
 
   // Link to User model
   userId String

--- a/autogpt_platform/backend/test/data/test_graph.py
+++ b/autogpt_platform/backend/test/data/test_graph.py
@@ -199,7 +199,9 @@ async def test_clean_graph(server: SpinTestServer):
     )
 
     # Clean the graph
-    created_graph.clean_graph()
+    created_graph = await server.agent_server.test_get_graph(
+        created_graph.id, created_graph.version, DEFAULT_USER_ID, for_export=True
+    )
 
     # # Verify input block value is cleared
     input_node = next(

--- a/autogpt_platform/backend/test/test_data_creator.py
+++ b/autogpt_platform/backend/test/test_data_creator.py
@@ -91,7 +91,6 @@ async def main():
                     "description": faker.text(max_nb_chars=200),
                     "userId": user.id,
                     "isActive": True,
-                    "isTemplate": False,
                 }
             )
             agent_graphs.append(graph)

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -197,14 +197,14 @@ export default class BackendAPI {
   getGraph(
     id: GraphID,
     version?: number,
-    hide_credentials?: boolean,
+    for_export?: boolean,
   ): Promise<Graph> {
     let query: Record<string, any> = {};
     if (version !== undefined) {
       query["version"] = version;
     }
-    if (hide_credentials !== undefined) {
-      query["hide_credentials"] = hide_credentials;
+    if (for_export !== undefined) {
+      query["for_export"] = for_export;
     }
     return this._get(`/graphs/${id}`, query);
   }


### PR DESCRIPTION
Agents using Agent blocks should be seamlessly downloaded from the marketplace to a file and imported from a file.

Requirements:
* A recursive export process that exports all the required agents to a single file, no matter how many layers deep (taking care of potential loops).
* An import process that expects and extracts several agents from a single file into your library at once.

Considerations:
We need to ensure the reference IDs in the Agent Blocks match/are updated to match the imported sub-agent ids to prevent broken references.

### Changes 🏗️

* Add sub_graphs field on Graph model 
* Improve graph creation query to support inserting graph + subgraphs in batch
* Deprecate graph template & remove its column
* Update on marketplace download agent (unified the used method, with more secure cleanup & proper ownership check).
* Fix failing test cases

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Export graph with sub agents.
  - [x] Import the exported graph with sub agents.
