### PR TITLE
fix(platform): Fix possible db-config permission denied when running two different Supabase versions

### DIFF
--- a/autogpt_platform/db/docker/docker-compose.yml
+++ b/autogpt_platform/db/docker/docker-compose.yml
@@ -405,7 +405,7 @@ services:
       # Changes required for Pooler support
       - ./volumes/db/pooler.sql:/docker-entrypoint-initdb.d/migrations/99-pooler.sql:Z
       # Use named volume to persist pgsodium decryption key between restarts
-      - db-config:/etc/postgresql-custom
+      - supabase-config:/etc/postgresql-custom
     healthcheck:
       test:
         [
@@ -523,4 +523,4 @@ services:
       ]
 
 volumes:
-  db-config:
+  supabase-config:

--- a/autogpt_platform/docker-compose.yml
+++ b/autogpt_platform/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     name: shared-network
 
 volumes:
-  db-config:
+  supabase-config:
 
 x-agpt-services:
   &agpt-services


### PR DESCRIPTION
The change in https://github.com/Significant-Gravitas/AutoGPT/pull/9620 introduces a breaking change in the database volume content; however, the database's volume location does not change, making switching between two versions clash.

### Changes 🏗️

Renamed db-config named volume to supabase-config.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] CI
