### PR TITLE
feat(platform): Use a single DB manager across the system

### DIFF
--- a/autogpt_platform/backend/backend/exec.py
+++ b/autogpt_platform/backend/backend/exec.py
@@ -6,10 +6,7 @@ def main():
     """
     Run all the processes required for the AutoGPT-server REST API.
     """
-    run_processes(
-        DatabaseManager(),
-        ExecutionManager(),
-    )
+    run_processes(ExecutionManager())
 
 
 if __name__ == "__main__":

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -121,6 +121,7 @@ services:
       migrate:
         condition: service_completed_successfully
     environment:
+      - DATABASEMANAGER_HOST=rest_server
       - SUPABASE_URL=http://kong:8000
       - SUPABASE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
       - SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
@@ -163,6 +164,7 @@ services:
       migrate:
         condition: service_completed_successfully
     environment:
+      - DATABASEMANAGER_HOST=rest_server
       - SUPABASE_JWT_SECRET=your-super-secret-jwt-token-with-at-least-32-characters-long
       - DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
       - REDIS_HOST=redis


### PR DESCRIPTION
DB Manager uses DB connections, and multiple instances of it hog the very limited Database connection quota. We need this service to be a unified place to control the limited db connection.

### Changes 🏗️

Connect all the database manager usage in a single place, currently running on the rest service.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
