### PR TITLE
feat(backend): Mark starting nodes as QUEUED instead of INCOMPLETE during the initial execution

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -157,7 +157,7 @@ async def create_graph_execution(
                 "create": [  # type: ignore
                     {
                         "agentNodeId": node_id,
-                        "executionStatus": ExecutionStatus.INCOMPLETE,
+                        "executionStatus": ExecutionStatus.QUEUED,
                         "Input": {
                             "create": [
                                 {"name": name, "data": Json(data)}

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -167,6 +167,7 @@ async def create_graph_execution(
                     {
                         "agentNodeId": node_id,
                         "executionStatus": ExecutionStatus.QUEUED,
+                        "queuedTime": datetime.now(tz=timezone.utc),
                         "Input": {
                             "create": [
                                 {"name": name, "data": Json(data)}

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -679,10 +679,6 @@ class Executor:
         try:
             queue = ExecutionQueue[NodeExecutionEntry]()
             for node_exec in graph_exec.start_node_execs:
-                exec_update = cls.db_client.update_execution_status(
-                    node_exec.node_exec_id, ExecutionStatus.QUEUED, node_exec.data
-                )
-                cls.db_client.send_execution_update(exec_update)
                 queue.add(node_exec)
 
             running_executions: dict[str, AsyncResult] = {}


### PR DESCRIPTION
Having the starting nodes of the execution marked as incomplete misled the users.

### Changes 🏗️

Mark the starting nodes during the executions as QUEUED instead of INCOMPLETE. 

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Executed the graph, the incomplete initial starting node is no more.
