### PR TITLE
fix(frontend): Fix unreliable websocket connection for node execution update

### DIFF
--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -114,10 +114,19 @@ export default function useAgentGraph(
     });
 
     if (flowID && flowVersion) {
-      api.subscribeToExecution(flowID, flowVersion);
-      console.debug(
-        `Subscribed to execution events for ${flowID} v.${flowVersion}`,
-      );
+      api
+        .subscribeToExecution(flowID, flowVersion)
+        .then(() =>
+          console.debug(
+            `Subscribed to execution events for ${flowID} v.${flowVersion}`,
+          ),
+        )
+        .catch((error) =>
+          console.error(
+            `Failed to subscribe to execution events for ${flowID} v.${flowVersion}:`,
+            error,
+          ),
+        );
     }
   }, [api, flowID, flowVersion, flowExecutionID]);
 


### PR DESCRIPTION
The current execution update is unreliable, once you lose WebSocket connection, you will receive no updates.

### Changes 🏗️

Fix web socket re-connection logic.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the app and execute an agent, then restart the API server, and re-execute the app without refreshing the page.