### PR TITLE
fix(backend): Increase block request security; Prevent DNS rebinding & open redirect attack

### DIFF
--- a/autogpt_platform/backend/backend/util/request.py
+++ b/autogpt_platform/backend/backend/util/request.py
@@ -65,8 +65,7 @@ def _remove_insecure_headers(headers: dict, old_url: str, new_url: str) -> dict:
 class SNIHostAdapter(HTTPAdapter):
     """
     A custom adapter that connects to an IP address but still
-    sets the TLS SNI to the original domain name so the cert
-    can match. Also sets assert_hostname for proper validation.
+    sets the TLS SNI to the original host name so the cert can match.
     """
 
     def __init__(self, ssl_hostname, *args, **kwargs):
@@ -160,6 +159,7 @@ def validate_url(
             )
 
     # Pin to the first valid IP (for SSRF defense).
+    # More reliable but slower alternative: iterate the IPs and pick the one that works.
     pinned_ip = ip_addresses[0]
 
     # If it's IPv6, bracket it

--- a/autogpt_platform/backend/test/util/test_request.py
+++ b/autogpt_platform/backend/test/util/test_request.py
@@ -77,3 +77,44 @@ def test_validate_url():
 
     # Non-ASCII Characters in Query/Fragment
     assert validate_url("example.com?param=äöü", []) == "http://example.com?param=äöü"
+
+
+@pytest.mark.parametrize(
+    "hostname, resolved_ips, expect_error, expected_ip",
+    [
+        # Multiple public IPs, none blocked
+        ("public-example.com", ["8.8.8.8", "9.9.9.9"], False, "8.8.8.8"),
+        # Includes a blocked IP (e.g. link-local 169.254.x.x) => should raise
+        ("rebinding.com", ["1.2.3.4", "169.254.169.254"], True, None),
+        # Single public IP
+        ("single-public.com", ["8.8.8.8"], False, "8.8.8.8"),
+        # Single blocked IP
+        ("blocked.com", ["127.0.0.1"], True, None),
+    ],
+)
+def test_dns_rebinding_fix(
+    monkeypatch, hostname, resolved_ips, expect_error, expected_ip
+):
+    """
+    Tests that validate_url pins the first valid public IP address, and rejects
+    the domain if any of the resolved IPs are blocked (i.e., DNS Rebinding scenario).
+    """
+
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        # Simulate multiple IPs returned for the given hostname
+        return [(None, None, None, None, (ip, port)) for ip in resolved_ips]
+
+    # Patch socket.getaddrinfo so we control the DNS resolution in the test
+    monkeypatch.setattr("socket.getaddrinfo", mock_getaddrinfo)
+
+    if expect_error:
+        # If any IP is blocked, we expect a ValueError
+        with pytest.raises(ValueError):
+            validate_url(hostname, [])
+    else:
+        pinned_url, ascii_hostname = validate_url(hostname, [])
+        # The pinned_url should contain the first valid IP
+        assert pinned_url.startswith("http://") or pinned_url.startswith("https://")
+        assert expected_ip in pinned_url
+        # The ascii_hostname should match our original hostname after IDNA encoding
+        assert ascii_hostname == hostname

--- a/autogpt_platform/backend/test/util/test_request.py
+++ b/autogpt_platform/backend/test/util/test_request.py
@@ -3,80 +3,66 @@ import pytest
 from backend.util.request import validate_url
 
 
-def test_validate_url():
-    # Rejected IP ranges
-    with pytest.raises(ValueError):
-        validate_url("localhost", [])
-
-    with pytest.raises(ValueError):
-        validate_url("192.168.1.1", [])
-
-    with pytest.raises(ValueError):
-        validate_url("127.0.0.1", [])
-
-    with pytest.raises(ValueError):
-        validate_url("0.0.0.0", [])
-
-    # Normal URLs
-    assert validate_url("google.com/a?b=c", []) == "http://google.com/a?b=c"
-    assert validate_url("github.com?key=!@!@", []) == "http://github.com?key=!@!@"
-
-    # Scheme Enforcement
-    with pytest.raises(ValueError):
-        validate_url("ftp://example.com", [])
-    with pytest.raises(ValueError):
-        validate_url("file://example.com", [])
-
-    # International domain that converts to punycode - should be allowed if public
-    assert validate_url("http://xn--exmple-cua.com", []) == "http://xn--exmple-cua.com"
-    # If the domain fails IDNA encoding or is invalid, it should raise an error
-    with pytest.raises(ValueError):
-        validate_url("http://exa◌mple.com", [])
-
-    # IPv6 Addresses
-    with pytest.raises(ValueError):
-        validate_url("::1", [])  # IPv6 loopback should be blocked
-    with pytest.raises(ValueError):
-        validate_url("http://[::1]", [])  # IPv6 loopback in URL form
-
-    # Suspicious Characters in Hostname
-    with pytest.raises(ValueError):
-        validate_url("http://example_underscore.com", [])
-    with pytest.raises(ValueError):
-        validate_url("http://exa mple.com", [])  # Space in hostname
-
-    # Malformed URLs
-    with pytest.raises(ValueError):
-        validate_url("http://", [])  # No hostname
-    with pytest.raises(ValueError):
-        validate_url("://missing-scheme", [])  # Missing proper scheme
-
-    # Trusted Origins
-    trusted = ["internal-api.company.com", "10.0.0.5"]
-    assert (
-        validate_url("internal-api.company.com", trusted)
-        == "http://internal-api.company.com"
-    )
-    assert validate_url("10.0.0.5", ["10.0.0.5"]) == "http://10.0.0.5"
-
-    # Special Characters in Path or Query
-    assert (
-        validate_url("example.com/path%20with%20spaces", [])
-        == "http://example.com/path%20with%20spaces"
-    )
-
-    # Backslashes should be replaced with forward slashes
-    assert (
-        validate_url("http://example.com\\backslash", [])
-        == "http://example.com/backslash"
-    )
-
-    # Check defaulting scheme behavior for valid domains
-    assert validate_url("example.com", []) == "http://example.com"
-    assert validate_url("https://secure.com", []) == "https://secure.com"
-
-    # Non-ASCII Characters in Query/Fragment
-    assert validate_url("example.com?param=äöü", []) == "http://example.com?param=äöü"
+@pytest.mark.parametrize(
+    "url, trusted_origins, expected_value, should_raise",
+    [
+        # Rejected IP ranges
+        ("localhost", [], None, True),
+        ("192.168.1.1", [], None, True),
+        ("127.0.0.1", [], None, True),
+        ("0.0.0.0", [], None, True),
+        # Normal URLs (should default to http:// if no scheme provided)
+        ("google.com/a?b=c", [], "http://google.com/a?b=c", False),
+        ("github.com?key=!@!@", [], "http://github.com?key=!@!@", False),
+        # Scheme Enforcement
+        ("ftp://example.com", [], None, True),
+        ("file://example.com", [], None, True),
+        # International domain converting to punycode (allowed if public)
+        ("http://xn--exmple-cua.com", [], "http://xn--exmple-cua.com", False),
+        # Invalid domain (IDNA failure)
+        ("http://exa◌mple.com", [], None, True),
+        # IPv6 addresses (loopback/blocked)
+        ("::1", [], None, True),
+        ("http://[::1]", [], None, True),
+        # Suspicious Characters in Hostname
+        ("http://example_underscore.com", [], None, True),
+        ("http://exa mple.com", [], None, True),
+        # Malformed URLs
+        ("http://", [], None, True),  # No hostname
+        ("://missing-scheme", [], None, True),  # Missing proper scheme
+        # Trusted Origins
+        (
+            "internal-api.company.com",
+            ["internal-api.company.com", "10.0.0.5"],
+            "http://internal-api.company.com",
+            False,
+        ),
+        ("10.0.0.5", ["10.0.0.5"], "http://10.0.0.5", False),
+        # Special Characters in Path
+        (
+            "example.com/path%20with%20spaces",
+            [],
+            "http://example.com/path%20with%20spaces",
+            False,
+        ),
+        # Backslashes should be replaced with forward slashes
+        ("http://example.com\\backslash", [], "http://example.com/backslash", False),
+        # Check default-scheme behavior for valid domains
+        ("example.com", [], "http://example.com", False),
+        ("https://secure.com", [], "https://secure.com", False),
+        # Non-ASCII Characters in Query/Fragment
+        ("example.com?param=äöü", [], "http://example.com?param=äöü", False),
+    ],
+)
+def test_validate_url_no_dns_rebinding(
+    url, trusted_origins, expected_value, should_raise
+):
+    if should_raise:
+        with pytest.raises(ValueError):
+            validate_url(url, trusted_origins, enable_dns_rebinding=False)
+    else:
+        url, host = validate_url(url, trusted_origins, enable_dns_rebinding=False)
+        assert url == expected_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The current block web requests utility has a logic to avoid the system firing into blocklisted IPs.
However, the current logic is still prone to a few security issues:

* DNS rebinding attack: due to the lack of guarantee on the used IP not being changed during the IP checking and firing step.
* Open redirect: due to the request sensitive request headers are still being propagated throughout the web redirect.

### Changes 🏗️

* Uses IP pinning to request the web.
* Strip `Authorization`, `Proxy-Authorization`,  `Cookie` upon web redirects.


### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Test the web request block, add more tests with different validation scenarios.

