### PR TITLE
feat(frontend): Add toast on agent execution request failure on library page

### DIFF
--- a/autogpt_platform/frontend/src/app/profile/(user)/credits/page.tsx
+++ b/autogpt_platform/frontend/src/app/profile/(user)/credits/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import useCredits from "@/hooks/useCredits";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 import { useSearchParams, useRouter } from "next/navigation";
-import { useToast } from "@/components/ui/use-toast";
+import { useToast, useToastOnFail } from "@/components/ui/use-toast";
 
 import { RefundModal } from "./RefundModal";
 import { CreditTransaction } from "@/lib/autogpt-server-api";
@@ -38,20 +38,7 @@ export default function CreditsPage() {
   const searchParams = useSearchParams();
   const topupStatus = searchParams.get("topup") as "success" | "cancel" | null;
   const { toast } = useToast();
-
-  const toastOnFail = useCallback(
-    (action: string, fn: () => Promise<any>) => {
-      return fn().catch((e) => {
-        toast({
-          title: `Unable to ${action}`,
-          description: e.message,
-          variant: "destructive",
-          duration: 10000,
-        });
-      });
-    },
-    [toast],
-  );
+  const toastOnFail = useToastOnFail();
 
   const [isRefundModalOpen, setIsRefundModalOpen] = useState(false);
   const [topUpTransactions, setTopUpTransactions] = useState<

--- a/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { IconRefresh, IconSquare } from "@/components/ui/icons";
 import { Button } from "@/components/agptui/Button";
 import { Input } from "@/components/ui/input";
+import { useToastOnFail } from "@/components/ui/use-toast";
 
 import {
   AgentRunStatus,
@@ -37,6 +38,8 @@ export default function AgentRunDetailsView({
     () => agentRunStatusMap[run.status],
     [run],
   );
+
+  const toastOnFail = useToastOnFail();
 
   const infoStats: { label: string; value: React.ReactNode }[] = useMemo(() => {
     if (!run) return [];
@@ -79,14 +82,16 @@ export default function AgentRunDetailsView({
   const runAgain = useCallback(
     () =>
       agentRunInputs &&
-      api.executeGraph(
-        graph.id,
-        graph.version,
-        Object.fromEntries(
-          Object.entries(agentRunInputs).map(([k, v]) => [k, v.value]),
+      toastOnFail("execute agent", () =>
+        api.executeGraph(
+          graph.id,
+          graph.version,
+          Object.fromEntries(
+            Object.entries(agentRunInputs).map(([k, v]) => [k, v.value]),
+          ),
         ),
       ),
-    [api, graph, agentRunInputs],
+    [api, graph, agentRunInputs, toastOnFail],
   );
 
   const stopRun = useCallback(

--- a/autogpt_platform/frontend/src/components/agents/agent-run-draft-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-draft-view.tsx
@@ -17,6 +17,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useToastOnFail } from "@/components/ui/use-toast";
 
 export default function AgentRunDraftView({
   graph,
@@ -28,6 +29,7 @@ export default function AgentRunDraftView({
   agentActions: ButtonAction[];
 }): React.ReactNode {
   const api = useBackendAPI();
+  const toastOnFail = useToastOnFail();
 
   const agentInputs = graph.input_schema.properties;
   const [inputValues, setInputValues] = useState<Record<string, any>>({});
@@ -55,10 +57,12 @@ export default function AgentRunDraftView({
 
   const doRun = useCallback(
     () =>
-      api
-        .executeGraph(graph.id, graph.version, inputValues)
-        .then((newRun) => onRun(newRun.graph_exec_id)),
-    [api, graph, inputValues, onRun],
+      toastOnFail("execute agent", () =>
+        api
+          .executeGraph(graph.id, graph.version, inputValues)
+          .then((newRun) => onRun(newRun.graph_exec_id)),
+      ),
+    [api, graph, inputValues, onRun, toastOnFail],
   );
 
   const runActions: ButtonAction[] = useMemo(

--- a/autogpt_platform/frontend/src/components/agents/agent-schedule-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-schedule-details-view.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AgentRunStatus } from "@/components/agents/agent-run-status-chip";
 import { Button } from "@/components/agptui/Button";
 import { Input } from "@/components/ui/input";
+import { useToastOnFail } from "@/components/ui/use-toast";
 
 export default function AgentScheduleDetailsView({
   graph,
@@ -28,6 +29,8 @@ export default function AgentScheduleDetailsView({
   const api = useBackendAPI();
 
   const selectedRunStatus: AgentRunStatus = "scheduled";
+
+  const toastOnFail = useToastOnFail();
 
   const infoStats: { label: string; value: React.ReactNode }[] = useMemo(() => {
     return [
@@ -65,10 +68,12 @@ export default function AgentScheduleDetailsView({
 
   const runNow = useCallback(
     () =>
-      api
-        .executeGraph(graph.id, graph.version, schedule.input_data)
-        .then((run) => onForcedRun(run.graph_exec_id)),
-    [api, graph, schedule, onForcedRun],
+      toastOnFail("execute agent", () =>
+        api
+          .executeGraph(graph.id, graph.version, schedule.input_data)
+          .then((run) => onForcedRun(run.graph_exec_id)),
+      ),
+    [api, graph, schedule, onForcedRun, toastOnFail],
   );
 
   const runActions: { label: string; callback: () => void }[] = useMemo(

--- a/autogpt_platform/frontend/src/components/ui/use-toast.tsx
+++ b/autogpt_platform/frontend/src/components/ui/use-toast.tsx
@@ -188,4 +188,17 @@ function useToast() {
   };
 }
 
-export { useToast, toast };
+function useToastOnFail() {
+  return React.useCallback((action: string, fn: () => Promise<unknown>) => {
+    return fn().catch((e) => {
+      toast({
+        title: `Unable to ${action}`,
+        description: e?.message ?? "Something went wrong",
+        variant: "destructive",
+        duration: 10000,
+      });
+    });
+  }, []);
+}
+
+export { useToast, toast, useToastOnFail };


### PR DESCRIPTION
Currently, when an agent execution fails to be executed, the front-end does not display any feedback to the user.
The scope of this change is providing that.

### Changes 🏗️

* Extracted `useToastOnFail` from `credits` page into a unified helper method.
* Uses `useToastOnFail` on agent execution requests on library pages.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/2daa0597-eb93-457d-8887-0f00c4db89ac" />
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/1a541c98-fb95-424f-8ffe-972332b3ce01" />


### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run agent with invalid input 

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
