### PR TITLE
feat(platform/library): Real-time execution updates

### DIFF
--- a/autogpt_platform/backend/backend/blocks/agent.py
+++ b/autogpt_platform/backend/backend/blocks/agent.py
@@ -90,7 +90,9 @@ class AgentExecutorBlock(Block):
         logger.info(f"Starting execution of {log_id}")
 
         for event in event_bus.listen(
-            graph_id=graph_exec.graph_id, graph_exec_id=graph_exec.graph_exec_id
+            user_id=graph_exec.user_id,
+            graph_id=graph_exec.graph_id,
+            graph_exec_id=graph_exec.graph_exec_id,
         ):
             if event.event_type == ExecutionEventType.GRAPH_EXEC_UPDATE:
                 if event.status in [

--- a/autogpt_platform/backend/backend/blocks/io.py
+++ b/autogpt_platform/backend/backend/blocks/io.py
@@ -550,3 +550,17 @@ class AgentToggleInputBlock(AgentInputBlock):
                 ("result", False),
             ],
         )
+
+
+IO_BLOCK_IDs = [
+    AgentInputBlock().id,
+    AgentOutputBlock().id,
+    AgentShortTextInputBlock().id,
+    AgentLongTextInputBlock().id,
+    AgentNumberInputBlock().id,
+    AgentDateInputBlock().id,
+    AgentTimeInputBlock().id,
+    AgentFileInputBlock().id,
+    AgentDropdownInputBlock().id,
+    AgentToggleInputBlock().id,
+]

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -292,8 +292,16 @@ async def get_graph_execution(
 async def get_graph_execution(
     user_id: str,
     execution_id: str,
-    include_node_executions: bool = False,
+    include_node_executions: Literal[False] = False,
 ) -> GraphExecution | None: ...
+
+
+@overload
+async def get_graph_execution(
+    user_id: str,
+    execution_id: str,
+    include_node_executions: bool = False,
+) -> GraphExecution | GraphExecutionWithNodes | None: ...
 
 
 async def get_graph_execution(

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -264,7 +264,7 @@ async def create_graph_execution(
     nodes_input: list[tuple[str, BlockInput]],
     user_id: str,
     preset_id: str | None = None,
-) -> tuple[str, list[NodeExecutionResult]]:
+) -> GraphExecution:
     """
     Create a new AgentGraphExecution record.
     Returns:
@@ -297,10 +297,7 @@ async def create_graph_execution(
         include=GRAPH_EXECUTION_INCLUDE,
     )
 
-    return result.id, [
-        NodeExecutionResult.from_db(execution, result.userId)
-        for execution in result.AgentNodeExecutions or []
-    ]
+    return GraphExecution.from_db(result)
 
 
 async def upsert_execution_input(

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     Optional,
     TypeVar,
+    overload,
 )
 
 from prisma import Json
@@ -277,6 +278,22 @@ async def get_graph_execution_meta(
         where={"id": execution_id, "isDeleted": False, "userId": user_id}
     )
     return GraphExecutionMeta.from_db(execution) if execution else None
+
+
+@overload
+async def get_graph_execution(
+    user_id: str,
+    execution_id: str,
+    include_node_executions: Literal[True],
+) -> GraphExecutionWithNodes | None: ...
+
+
+@overload
+async def get_graph_execution(
+    user_id: str,
+    execution_id: str,
+    include_node_executions: bool = False,
+) -> GraphExecution | None: ...
 
 
 async def get_graph_execution(

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -603,7 +603,7 @@ async def get_node_execution_results(
 
 async def get_graph_executions_in_timerange(
     user_id: str, start_time: str, end_time: str
-) -> list[GraphExecutionWithNodes]:
+) -> list[GraphExecution]:
     try:
         executions = await AgentGraphExecution.prisma().find_many(
             where={
@@ -614,9 +614,9 @@ async def get_graph_executions_in_timerange(
                 "userId": user_id,
                 "isDeleted": False,
             },
-            include=GRAPH_EXECUTION_INCLUDE_WITH_NODES,
+            include=GRAPH_EXECUTION_INCLUDE,
         )
-        return [GraphExecutionWithNodes.from_db(execution) for execution in executions]
+        return [GraphExecution.from_db(execution) for execution in executions]
     except Exception as e:
         raise DatabaseError(
             f"Failed to get executions in timerange {start_time} to {end_time} for user {user_id}: {e}"

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -317,12 +317,13 @@ async def get_graph_execution(
             else GRAPH_EXECUTION_INCLUDE
         ),
     )
+    if not execution:
+        return None
+
     return (
-        (
-            GraphExecutionWithNodes if include_node_executions else GraphExecution
-        ).from_db(execution)
-        if execution
-        else None
+        GraphExecutionWithNodes.from_db(execution)
+        if include_node_executions
+        else GraphExecution.from_db(execution)
     )
 
 

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -808,16 +808,16 @@ class RedisExecutionEventBus(RedisEventBus[ExecutionEvent]):
 
     def publish_node_exec_update(self, res: NodeExecutionResult):
         event = NodeExecutionEvent.model_validate(res.model_dump())
-        self.publish_event(event, f"{res.graph_id}/{res.graph_exec_id}")
+        self.publish_event(event, f"{res.user_id}/{res.graph_id}/{res.graph_exec_id}")
 
     def publish_graph_exec_update(self, res: GraphExecutionMeta):
         event = GraphExecutionEvent.model_validate(res.model_dump())
-        self.publish_event(event, f"{res.graph_id}/{res.id}")
+        self.publish_event(event, f"{res.user_id}/{res.graph_id}/{res.id}")
 
     def listen(
-        self, graph_id: str = "*", graph_exec_id: str = "*"
+        self, user_id: str, graph_id: str = "*", graph_exec_id: str = "*"
     ) -> Generator[ExecutionEvent, None, None]:
-        for event in self.listen_events(f"{graph_id}/{graph_exec_id}"):
+        for event in self.listen_events(f"{user_id}/{graph_id}/{graph_exec_id}"):
             yield event
 
 
@@ -836,14 +836,16 @@ class AsyncRedisExecutionEventBus(AsyncRedisEventBus[ExecutionEvent]):
 
     async def publish_node_exec_update(self, res: NodeExecutionResult):
         event = NodeExecutionEvent.model_validate(res.model_dump())
-        await self.publish_event(event, f"{res.graph_id}/{res.graph_exec_id}")
+        await self.publish_event(
+            event, f"{res.user_id}/{res.graph_id}/{res.graph_exec_id}"
+        )
 
     async def publish_graph_exec_update(self, res: GraphExecutionMeta):
         event = GraphExecutionEvent.model_validate(res.model_dump())
-        await self.publish_event(event, f"{res.graph_id}/{res.id}")
+        await self.publish_event(event, f"{res.user_id}/{res.graph_id}/{res.id}")
 
     async def listen(
-        self, graph_id: str = "*", graph_exec_id: str = "*"
+        self, user_id: str, graph_id: str = "*", graph_exec_id: str = "*"
     ) -> AsyncGenerator[ExecutionEvent, None]:
-        async for event in self.listen_events(f"{graph_id}/{graph_exec_id}"):
+        async for event in self.listen_events(f"{user_id}/{graph_id}/{graph_exec_id}"):
             yield event

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -538,7 +538,6 @@ async def get_graph_metadata(graph_id: str, version: int | None = None) -> Graph
 
     graph = await AgentGraph.prisma().find_first(
         where=where_clause,
-        include=AGENT_GRAPH_INCLUDE,
         order={"version": "desc"},
     )
 

--- a/autogpt_platform/backend/backend/data/includes.py
+++ b/autogpt_platform/backend/backend/data/includes.py
@@ -22,7 +22,7 @@ EXECUTION_RESULT_INCLUDE: prisma.types.AgentNodeExecutionInclude = {
 
 MAX_NODE_EXECUTIONS_FETCH = 1000
 
-GRAPH_EXECUTION_INCLUDE_ALL: prisma.types.AgentGraphExecutionInclude = {
+GRAPH_EXECUTION_INCLUDE_WITH_NODES: prisma.types.AgentGraphExecutionInclude = {
     "AgentNodeExecutions": {
         "include": {
             "Input": True,
@@ -39,9 +39,9 @@ GRAPH_EXECUTION_INCLUDE_ALL: prisma.types.AgentGraphExecutionInclude = {
     }
 }
 
-GRAPH_EXECUTION_INCLUDE_IO_ONLY: prisma.types.AgentGraphExecutionInclude = {
+GRAPH_EXECUTION_INCLUDE: prisma.types.AgentGraphExecutionInclude = {
     "AgentNodeExecutions": {
-        **GRAPH_EXECUTION_INCLUDE_ALL["AgentNodeExecutions"],  # type: ignore
+        **GRAPH_EXECUTION_INCLUDE_WITH_NODES["AgentNodeExecutions"],  # type: ignore
         "where": {
             "AgentNode": {
                 "AgentBlock": {"id": {"in": IO_BLOCK_IDs}},  # type: ignore

--- a/autogpt_platform/backend/backend/data/includes.py
+++ b/autogpt_platform/backend/backend/data/includes.py
@@ -1,5 +1,7 @@
 import prisma
 
+from backend.blocks.io import IO_BLOCK_IDs
+
 AGENT_NODE_INCLUDE: prisma.types.AgentNodeInclude = {
     "Input": True,
     "Output": True,
@@ -20,7 +22,7 @@ EXECUTION_RESULT_INCLUDE: prisma.types.AgentNodeExecutionInclude = {
 
 MAX_NODE_EXECUTIONS_FETCH = 1000
 
-GRAPH_EXECUTION_INCLUDE: prisma.types.AgentGraphExecutionInclude = {
+GRAPH_EXECUTION_INCLUDE_ALL: prisma.types.AgentGraphExecutionInclude = {
     "AgentNodeExecutions": {
         "include": {
             "Input": True,
@@ -34,6 +36,17 @@ GRAPH_EXECUTION_INCLUDE: prisma.types.AgentGraphExecutionInclude = {
             {"addedTime": "desc"},
         ],
         "take": MAX_NODE_EXECUTIONS_FETCH,  # Avoid loading excessive node executions.
+    }
+}
+
+GRAPH_EXECUTION_INCLUDE_IO_ONLY: prisma.types.AgentGraphExecutionInclude = {
+    "AgentNodeExecutions": {
+        **GRAPH_EXECUTION_INCLUDE_ALL["AgentNodeExecutions"],  # type: ignore
+        "where": {
+            "AgentNode": {
+                "AgentBlock": {"id": {"in": IO_BLOCK_IDs}},  # type: ignore
+            },
+        },
     }
 }
 

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -107,6 +107,7 @@ class DatabaseManager(AppService):
             )
         )
 
+        # Automatically push execution updates for all agent I/O
         if node_exec_id in IO_BLOCK_IDs:
             graph_exec = self.run_and_wait(
                 get_graph_execution(user_id=user_id, execution_id=graph_exec_id)

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -1,6 +1,6 @@
 from backend.data.credit import UsageTransactionMetadata, get_user_credit_model
 from backend.data.execution import (
-    GraphExecutionMeta,
+    GraphExecution,
     NodeExecutionResult,
     RedisExecutionEventBus,
     create_graph_execution,
@@ -64,7 +64,7 @@ class DatabaseManager(AppService):
 
     @expose
     def send_execution_update(
-        self, execution_result: GraphExecutionMeta | NodeExecutionResult
+        self, execution_result: GraphExecution | NodeExecutionResult
     ):
         self.execution_event_bus.publish(execution_result)
 

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -1,6 +1,3 @@
-from typing import Any
-
-from backend.blocks.io import IO_BLOCK_IDs
 from backend.data.credit import UsageTransactionMetadata, get_user_credit_model
 from backend.data.execution import (
     GraphExecution,
@@ -17,8 +14,8 @@ from backend.data.execution import (
     update_node_execution_status,
     update_node_execution_status_batch,
     upsert_execution_input,
+    upsert_execution_output,
 )
-from backend.data.execution import upsert_execution_output as _upsert_execution_output
 from backend.data.graph import (
     get_connected_output_nodes,
     get_graph,
@@ -73,6 +70,7 @@ class DatabaseManager(AppService):
         self.execution_event_bus.publish(execution_result)
 
     # Executions
+    get_graph_execution = exposed_run_and_wait(get_graph_execution)
     create_graph_execution = exposed_run_and_wait(create_graph_execution)
     get_node_execution_results = exposed_run_and_wait(get_node_execution_results)
     get_incomplete_node_executions = exposed_run_and_wait(
@@ -89,34 +87,7 @@ class DatabaseManager(AppService):
     update_graph_execution_stats = exposed_run_and_wait(update_graph_execution_stats)
     update_node_execution_stats = exposed_run_and_wait(update_node_execution_stats)
     upsert_execution_input = exposed_run_and_wait(upsert_execution_input)
-
-    @expose
-    def upsert_execution_output(
-        self,
-        user_id: str,
-        graph_exec_id: str,
-        node_exec_id: str,
-        output_name: str,
-        output_data: Any,
-    ):
-        self.run_and_wait(
-            _upsert_execution_output(
-                node_exec_id=node_exec_id,
-                output_name=output_name,
-                output_data=output_data,
-            )
-        )
-
-        # Automatically push execution updates for all agent I/O
-        if node_exec_id in IO_BLOCK_IDs:
-            graph_exec = self.run_and_wait(
-                get_graph_execution(user_id=user_id, execution_id=graph_exec_id)
-            )
-            if not graph_exec:
-                raise ValueError(
-                    f"Graph execution #{graph_exec_id} for user #{user_id} not found"
-                )
-            self.send_execution_update(graph_exec)
+    upsert_execution_output = exposed_run_and_wait(upsert_execution_output)
 
     # Graphs
     get_node = exposed_run_and_wait(get_node)

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -180,6 +180,7 @@ def execute_node(
             user_id=user_id,
             graph_exec_id=graph_exec_id,
             node_exec_id=node_exec_id,
+            block_id=node_block.id,
             output_name="error",
             output_data=error,
         )
@@ -232,6 +233,7 @@ def execute_node(
                 user_id=user_id,
                 graph_exec_id=graph_exec_id,
                 node_exec_id=node_exec_id,
+                block_id=node_block.id,
                 output_name=output_name,
                 output_data=output_data,
             )
@@ -257,6 +259,7 @@ def execute_node(
             user_id=user_id,
             graph_exec_id=graph_exec_id,
             node_exec_id=node_exec_id,
+            block_id=node_block.id,
             output_name="error",
             output_data=error_msg,
         )
@@ -296,6 +299,7 @@ def _register_node_execution_output(
     user_id: str,
     graph_exec_id: str,
     node_exec_id: str,
+    block_id: str,
     output_name: str,
     output_data: Any,
 ):
@@ -308,7 +312,7 @@ def _register_node_execution_output(
     )
 
     # Automatically push execution updates for all agent I/O
-    if node_exec_id in IO_BLOCK_IDs:
+    if block_id in IO_BLOCK_IDs:
         graph_exec = db_client.get_graph_execution(
             user_id=user_id, execution_id=graph_exec_id
         )
@@ -831,6 +835,7 @@ class Executor:
                         user_id=graph_exec.user_id,
                         graph_exec_id=graph_exec.graph_exec_id,
                         node_exec_id=node_exec_id,
+                        block_id=exec_data.block_id,
                         output_name="error",
                         output_data=str(error),
                     )

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -244,7 +244,6 @@ def execute_node(
             ):
                 yield execution
 
-        # Update execution status and spend credits
         update_execution_status(ExecutionStatus.COMPLETED)
 
     except Exception as e:

--- a/autogpt_platform/backend/backend/server/model.py
+++ b/autogpt_platform/backend/backend/server/model.py
@@ -9,6 +9,7 @@ from backend.data.graph import Graph
 
 class WSMethod(enum.Enum):
     SUBSCRIBE_GRAPH_EXEC = "subscribe_graph_execution"
+    SUBSCRIBE_GRAPH_EXECS = "subscribe_graph_executions"
     UNSUBSCRIBE = "unsubscribe"
     GRAPH_EXECUTION_EVENT = "graph_execution_event"
     NODE_EXECUTION_EVENT = "node_execution_event"
@@ -26,6 +27,10 @@ class WSMessage(pydantic.BaseModel):
 
 class WSSubscribeGraphExecutionRequest(pydantic.BaseModel):
     graph_exec_id: str
+
+
+class WSSubscribeGraphExecutionsRequest(pydantic.BaseModel):
+    graph_id: str
 
 
 class ExecuteGraphResponse(pydantic.BaseModel):

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -187,14 +187,6 @@ class AgentServer(backend.util.service.AppProcess):
         return execution.status
 
     @staticmethod
-    async def test_get_graph_run_results(
-        graph_id: str, graph_exec_id: str, user_id: str
-    ):
-        return await backend.server.routers.v1.get_graph_execution(
-            graph_id, graph_exec_id, user_id
-        )
-
-    @staticmethod
     async def test_delete_graph(graph_id: str, user_id: str):
         await backend.server.v2.library.db.delete_library_agent_by_graph_id(
             graph_id=graph_id, user_id=user_id

--- a/autogpt_platform/backend/backend/server/ws_api.py
+++ b/autogpt_platform/backend/backend/server/ws_api.py
@@ -57,7 +57,7 @@ async def event_broadcaster(manager: ConnectionManager):
     try:
         redis.connect()
         event_queue = AsyncRedisExecutionEventBus()
-        async for event in event_queue.listen():
+        async for event in event_queue.listen("*"):
             await manager.send_execution_update(event)
     except Exception as e:
         logger.exception(f"Event broadcaster error: {e}")

--- a/autogpt_platform/backend/backend/usecases/block_autogen.py
+++ b/autogpt_platform/backend/backend/usecases/block_autogen.py
@@ -259,7 +259,6 @@ async def block_autogen_agent():
         )
         print(response)
         result = await wait_execution(
-            graph_id=test_graph.id,
             graph_exec_id=response.graph_exec_id,
             timeout=1200,
             user_id=test_user.id,

--- a/autogpt_platform/backend/backend/usecases/reddit_marketing.py
+++ b/autogpt_platform/backend/backend/usecases/reddit_marketing.py
@@ -162,9 +162,7 @@ async def reddit_marketing_agent():
             node_input=input_data,
         )
         print(response)
-        result = await wait_execution(
-            test_user.id, test_graph.id, response.graph_exec_id, 120
-        )
+        result = await wait_execution(test_user.id, response.graph_exec_id, 120)
         print(result)
 
 

--- a/autogpt_platform/backend/backend/usecases/sample.py
+++ b/autogpt_platform/backend/backend/usecases/sample.py
@@ -94,7 +94,7 @@ async def sample_agent():
             user_id=test_user.id,
             node_input=input_data,
         )
-        await wait_execution(test_user.id, test_graph.id, response.graph_exec_id, 10)
+        await wait_execution(test_user.id, response.graph_exec_id, 10)
 
 
 if __name__ == "__main__":

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -81,7 +81,7 @@ async def wait_execution(
             graph_exec = await AgentServer().test_get_graph_run_results(
                 graph_id, graph_exec_id, user_id
             )
-            return graph_exec.node_executions
+            return graph_exec.node_executions  # type: ignore
         time.sleep(1)
 
     assert False, "Execution did not complete in time."

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -5,7 +5,11 @@ from typing import Sequence, cast
 
 from backend.data import db
 from backend.data.block import Block, BlockSchema, initialize_blocks
-from backend.data.execution import ExecutionStatus, NodeExecutionResult
+from backend.data.execution import (
+    ExecutionStatus,
+    NodeExecutionResult,
+    get_graph_execution,
+)
 from backend.data.model import _BaseCredentials
 from backend.data.user import create_default_user
 from backend.executor import DatabaseManager, ExecutionManager, Scheduler
@@ -60,7 +64,6 @@ class SpinTestServer:
 
 async def wait_execution(
     user_id: str,
-    graph_id: str,
     graph_exec_id: str,
     timeout: int = 30,
 ) -> Sequence[NodeExecutionResult]:
@@ -78,13 +81,13 @@ async def wait_execution(
     # Wait for the executions to complete
     for i in range(timeout):
         if await is_execution_completed():
-            graph_exec = await AgentServer().test_get_graph_run_results(
-                graph_id, graph_exec_id, user_id
+            graph_exec = await get_graph_execution(
+                user_id=user_id,
+                execution_id=graph_exec_id,
+                include_node_executions=True,
             )
-            # `graph_exec.node_executions` is not set
-            # if `graph_exec.user_id` != `graph.user_id`.
-            # This isn't relevant for any (current) test case though so we can ignore:
-            return graph_exec.node_executions  # type: ignore
+            assert graph_exec, f"Graph execution #{graph_exec_id} not found"
+            return graph_exec.node_executions
         time.sleep(1)
 
     assert False, "Execution did not complete in time."

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -81,6 +81,9 @@ async def wait_execution(
             graph_exec = await AgentServer().test_get_graph_run_results(
                 graph_id, graph_exec_id, user_id
             )
+            # `graph_exec.node_executions` is not set
+            # if `graph_exec.user_id` != `graph.user_id`.
+            # This isn't relevant for any (current) test case though so we can ignore:
             return graph_exec.node_executions  # type: ignore
         time.sleep(1)
 

--- a/autogpt_platform/backend/test/executor/test_manager.py
+++ b/autogpt_platform/backend/test/executor/test_manager.py
@@ -46,23 +46,20 @@ async def execute_graph(
 
     # Execution queue should be empty
     logger.info("Waiting for execution to complete...")
-    result = await wait_execution(test_user.id, test_graph.id, graph_exec_id, 30)
+    result = await wait_execution(test_user.id, graph_exec_id, 30)
     logger.info(f"Execution completed with {len(result)} results")
     assert len(result) == num_execs
     return graph_exec_id
 
 
 async def assert_sample_graph_executions(
-    agent_server: AgentServer,
     test_graph: graph.Graph,
     test_user: User,
     graph_exec_id: str,
 ):
     logger.info(f"Checking execution results for graph {test_graph.id}")
-    graph_run = await agent_server.test_get_graph_run_results(
-        test_graph.id,
-        graph_exec_id,
-        test_user.id,
+    graph_run = await execution.get_graph_execution(
+        test_user.id, graph_exec_id, include_node_executions=True
     )
     assert isinstance(graph_run, execution.GraphExecutionWithNodes)
 
@@ -143,9 +140,7 @@ async def test_agent_execution(server: SpinTestServer):
         data,
         4,
     )
-    await assert_sample_graph_executions(
-        server.agent_server, test_graph, test_user, graph_exec_id
-    )
+    await assert_sample_graph_executions(test_graph, test_user, graph_exec_id)
     logger.info("Completed test_agent_execution")
 
 
@@ -204,8 +199,8 @@ async def test_input_pin_always_waited(server: SpinTestServer):
     )
 
     logger.info("Checking execution results")
-    graph_exec = await server.agent_server.test_get_graph_run_results(
-        test_graph.id, graph_exec_id, test_user.id
+    graph_exec = await execution.get_graph_execution(
+        test_user.id, graph_exec_id, include_node_executions=True
     )
     assert isinstance(graph_exec, execution.GraphExecutionWithNodes)
     assert len(graph_exec.node_executions) == 3
@@ -288,8 +283,8 @@ async def test_static_input_link_on_graph(server: SpinTestServer):
         server.agent_server, test_graph, test_user, {}, 8
     )
     logger.info("Checking execution results")
-    graph_exec = await server.agent_server.test_get_graph_run_results(
-        test_graph.id, graph_exec_id, test_user.id
+    graph_exec = await execution.get_graph_execution(
+        test_user.id, graph_exec_id, include_node_executions=True
     )
     assert isinstance(graph_exec, execution.GraphExecutionWithNodes)
     assert len(graph_exec.node_executions) == 8
@@ -388,7 +383,7 @@ async def test_execute_preset(server: SpinTestServer):
     graph_exec_id = result["id"]
 
     # Wait for execution to complete
-    executions = await wait_execution(test_user.id, test_graph.id, graph_exec_id)
+    executions = await wait_execution(test_user.id, graph_exec_id)
     assert len(executions) == 4
 
     # FindInDictionaryBlock should wait for the input pin to be provided,
@@ -478,7 +473,7 @@ async def test_execute_preset_with_clash(server: SpinTestServer):
     graph_exec_id = result["id"]
 
     # Wait for execution to complete
-    executions = await wait_execution(test_user.id, test_graph.id, graph_exec_id)
+    executions = await wait_execution(test_user.id, graph_exec_id)
     assert len(executions) == 4
 
     # FindInDictionaryBlock should wait for the input pin to be provided,
@@ -545,7 +540,5 @@ async def test_store_listing_graph(server: SpinTestServer):
         4,
     )
 
-    await assert_sample_graph_executions(
-        server.agent_server, test_graph, alt_test_user, graph_exec_id
-    )
+    await assert_sample_graph_executions(test_graph, alt_test_user, graph_exec_id)
     logger.info("Completed test_agent_execution")

--- a/autogpt_platform/backend/test/executor/test_manager.py
+++ b/autogpt_platform/backend/test/executor/test_manager.py
@@ -64,6 +64,7 @@ async def assert_sample_graph_executions(
         graph_exec_id,
         test_user.id,
     )
+    assert isinstance(graph_run, execution.GraphExecutionWithNodes)
 
     output_list = [{"result": ["Hello"]}, {"result": ["World"]}]
     input_list = [
@@ -206,6 +207,7 @@ async def test_input_pin_always_waited(server: SpinTestServer):
     graph_exec = await server.agent_server.test_get_graph_run_results(
         test_graph.id, graph_exec_id, test_user.id
     )
+    assert isinstance(graph_exec, execution.GraphExecutionWithNodes)
     assert len(graph_exec.node_executions) == 3
     # FindInDictionaryBlock should wait for the input pin to be provided,
     # Hence executing extraction of "key" from {"key1": "value1", "key2": "value2"}
@@ -289,6 +291,7 @@ async def test_static_input_link_on_graph(server: SpinTestServer):
     graph_exec = await server.agent_server.test_get_graph_run_results(
         test_graph.id, graph_exec_id, test_user.id
     )
+    assert isinstance(graph_exec, execution.GraphExecutionWithNodes)
     assert len(graph_exec.node_executions) == 8
     # The last 3 executions will be a+b=4+5=9
     for i, exec_data in enumerate(graph_exec.node_executions[-3:]):

--- a/autogpt_platform/backend/test/executor/test_tool_use.py
+++ b/autogpt_platform/backend/test/executor/test_tool_use.py
@@ -55,7 +55,7 @@ async def execute_graph(
 
     # Execution queue should be empty
     logger.info("Waiting for execution to complete...")
-    result = await wait_execution(test_user.id, test_graph.id, graph_exec_id, 30)
+    result = await wait_execution(test_user.id, graph_exec_id, 30)
     logger.info("Execution completed with %d results", len(result))
     return graph_exec_id
 

--- a/autogpt_platform/backend/test/server/test_con_manager.py
+++ b/autogpt_platform/backend/test/server/test_con_manager.py
@@ -68,7 +68,7 @@ async def test_unsubscribe(
     channel_key = "user-1|graph_exec#graph-exec-1"
     connection_manager.subscriptions[channel_key] = {mock_websocket}
 
-    await connection_manager.unsubscribe(
+    await connection_manager.unsubscribe_graph_exec(
         user_id="user-1",
         graph_exec_id="graph-exec-1",
         websocket=mock_websocket,

--- a/autogpt_platform/backend/test/server/test_con_manager.py
+++ b/autogpt_platform/backend/test/server/test_con_manager.py
@@ -94,6 +94,14 @@ async def test_send_graph_execution_result(
         total_run_time=0.5,
         started_at=datetime.now(tz=timezone.utc),
         ended_at=datetime.now(tz=timezone.utc),
+        inputs={
+            "input_1": "some input value :)",
+            "input_2": "some *other* input value",
+        },
+        outputs={
+            "the_output": ["some output value"],
+            "other_output": ["sike there was another output"],
+        },
     )
 
     await connection_manager.send_execution_update(result)

--- a/autogpt_platform/backend/test/server/test_ws_api.py
+++ b/autogpt_platform/backend/test/server/test_ws_api.py
@@ -70,7 +70,7 @@ async def test_websocket_router_unsubscribe(
         ).model_dump_json(),
         WebSocketDisconnect(),
     ]
-    mock_manager.unsubscribe.return_value = (
+    mock_manager.unsubscribe_graph_exec.return_value = (
         f"{DEFAULT_USER_ID}|graph_exec#test-graph-exec-1"
     )
 
@@ -79,7 +79,7 @@ async def test_websocket_router_unsubscribe(
     )
 
     mock_manager.connect_socket.assert_called_once_with(mock_websocket)
-    mock_manager.unsubscribe.assert_called_once_with(
+    mock_manager.unsubscribe_graph_exec.assert_called_once_with(
         user_id=DEFAULT_USER_ID,
         graph_exec_id="test-graph-exec-1",
         websocket=mock_websocket,
@@ -168,7 +168,9 @@ async def test_handle_unsubscribe_success(
     message = WSMessage(
         method=WSMethod.UNSUBSCRIBE, data={"graph_exec_id": "test-graph-exec-id"}
     )
-    mock_manager.unsubscribe.return_value = "user-1|graph_exec#test-graph-exec-id"
+    mock_manager.unsubscribe_graph_exec.return_value = (
+        "user-1|graph_exec#test-graph-exec-id"
+    )
 
     await handle_unsubscribe(
         connection_manager=cast(ConnectionManager, mock_manager),
@@ -177,7 +179,7 @@ async def test_handle_unsubscribe_success(
         message=message,
     )
 
-    mock_manager.unsubscribe.assert_called_once_with(
+    mock_manager.unsubscribe_graph_exec.assert_called_once_with(
         user_id="user-1",
         graph_exec_id="test-graph-exec-id",
         websocket=mock_websocket,
@@ -200,7 +202,7 @@ async def test_handle_unsubscribe_missing_data(
         message=message,
     )
 
-    mock_manager.unsubscribe.assert_not_called()
+    mock_manager._unsubscribe.assert_not_called()
     mock_websocket.send_text.assert_called_once()
     assert '"method":"error"' in mock_websocket.send_text.call_args[0][0]
     assert '"success":false' in mock_websocket.send_text.call_args[0][0]

--- a/autogpt_platform/backend/test/server/test_ws_api.py
+++ b/autogpt_platform/backend/test/server/test_ws_api.py
@@ -9,7 +9,7 @@ from backend.server.conn_manager import ConnectionManager
 from backend.server.ws_api import (
     WSMessage,
     WSMethod,
-    handle_subscribe,
+    handle_subscribe_graph_exec,
     handle_unsubscribe,
     websocket_router,
 )
@@ -122,7 +122,7 @@ async def test_handle_subscribe_success(
         "user-1|graph_exec#test-graph-exec-id"
     )
 
-    await handle_subscribe(
+    await handle_subscribe_graph_exec(
         connection_manager=cast(ConnectionManager, mock_manager),
         websocket=cast(WebSocket, mock_websocket),
         user_id="user-1",
@@ -148,7 +148,7 @@ async def test_handle_subscribe_missing_data(
 ) -> None:
     message = WSMessage(method=WSMethod.SUBSCRIBE_GRAPH_EXEC)
 
-    await handle_subscribe(
+    await handle_subscribe_graph_exec(
         connection_manager=cast(ConnectionManager, mock_manager),
         websocket=cast(WebSocket, mock_websocket),
         user_id="user-1",

--- a/autogpt_platform/backend/test/server/test_ws_api.py
+++ b/autogpt_platform/backend/test/server/test_ws_api.py
@@ -9,7 +9,7 @@ from backend.server.conn_manager import ConnectionManager
 from backend.server.ws_api import (
     WSMessage,
     WSMethod,
-    handle_subscribe_graph_exec,
+    handle_subscribe,
     handle_unsubscribe,
     websocket_router,
 )
@@ -122,7 +122,7 @@ async def test_handle_subscribe_success(
         "user-1|graph_exec#test-graph-exec-id"
     )
 
-    await handle_subscribe_graph_exec(
+    await handle_subscribe(
         connection_manager=cast(ConnectionManager, mock_manager),
         websocket=cast(WebSocket, mock_websocket),
         user_id="user-1",
@@ -148,7 +148,7 @@ async def test_handle_subscribe_missing_data(
 ) -> None:
     message = WSMessage(method=WSMethod.SUBSCRIBE_GRAPH_EXEC)
 
-    await handle_subscribe_graph_exec(
+    await handle_subscribe(
         connection_manager=cast(ConnectionManager, mock_manager),
         websocket=cast(WebSocket, mock_websocket),
         user_id="user-1",

--- a/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
@@ -137,16 +137,19 @@ export default function AgentRunsPage(): React.ReactElement {
             return [...prev, data];
           }
           const newRuns = [...prev];
-          newRuns[index] = data;
+          newRuns[index] = { ...newRuns[index], ...data };
           return newRuns;
         });
+        if (data.id === selectedView.id) {
+          setSelectedRun((prev) => ({ ...prev, ...data }));
+        }
       },
     );
 
     return () => {
       detachExecUpdateHandler();
     };
-  }, [api, agent]);
+  }, [api, agent, selectedView.id]);
 
   // Subscribe to websocket updates for selected run
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
@@ -164,7 +164,8 @@ export default function AgentRunsPage(): React.ReactElement {
       (data) => {
         if (data.graph_exec_id === selectedView.id) {
           setSelectedRun((prev) => {
-            if (!prev || !("node_executions" in prev)) return prev;
+            if (!prev || !("node_executions" in prev) || !prev.node_executions)
+              return prev;
             const index = prev.node_executions.findIndex(
               (node) => node.node_exec_id === data.node_exec_id,
             );

--- a/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
@@ -126,8 +126,10 @@ export default function AgentRunsPage(): React.ReactElement {
 
     // Subscribe to all executions for this agent
     api.subscribeToGraphExecutions(agent.agent_id);
+  }, [api, agent]);
 
-    // Handle execution updates
+  // Handle execution updates
+  useEffect(() => {
     const detachExecUpdateHandler = api.onWebSocketMessage(
       "graph_execution_event",
       (data) => {
@@ -149,42 +151,7 @@ export default function AgentRunsPage(): React.ReactElement {
     return () => {
       detachExecUpdateHandler();
     };
-  }, [api, agent, selectedView.id]);
-
-  // Subscribe to websocket updates for selected run
-  useEffect(() => {
-    if (!selectedView.id || selectedView.type !== "run") return;
-
-    // Subscribe to specific execution updates
-    api.subscribeToGraphExecution(selectedView.id);
-
-    // Handle node execution updates
-    const detachNodeExecUpdateHandler = api.onWebSocketMessage(
-      "node_execution_event",
-      (data) => {
-        if (data.graph_exec_id === selectedView.id) {
-          setSelectedRun((prev) => {
-            if (!prev || !("node_executions" in prev) || !prev.node_executions)
-              return prev;
-            const index = prev.node_executions.findIndex(
-              (node) => node.node_exec_id === data.node_exec_id,
-            );
-            const newNodeExecutions = [...prev.node_executions];
-            if (index === -1) {
-              newNodeExecutions.push(data);
-            } else {
-              newNodeExecutions[index] = data;
-            }
-            return { ...prev, node_executions: newNodeExecutions };
-          });
-        }
-      },
-    );
-
-    return () => {
-      detachNodeExecUpdateHandler();
-    };
-  }, [api, selectedView]);
+  }, [api, selectedView.id]);
 
   // load selectedRun based on selectedView
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/monitoring/page.tsx
+++ b/autogpt_platform/frontend/src/app/monitoring/page.tsx
@@ -100,7 +100,7 @@ const Monitor = () => {
           ...(selectedFlow
             ? executions.filter((v) => v.graph_id == selectedFlow.agent_id)
             : executions),
-        ].sort((a, b) => Number(b.started_at) - Number(a.started_at))}
+        ].sort((a, b) => b.started_at.getTime() - a.started_at.getTime())}
         selectedRun={selectedRun}
         onSelectRun={(r) => setSelectedRun(r.id == selectedRun?.id ? null : r)}
       />

--- a/autogpt_platform/frontend/src/app/monitoring/page.tsx
+++ b/autogpt_platform/frontend/src/app/monitoring/page.tsx
@@ -106,7 +106,7 @@ const Monitor = () => {
       />
       {(selectedRun && (
         <FlowRunInfo
-          flow={
+          agent={
             selectedFlow ||
             flows.find((f) => f.agent_id == selectedRun.graph_id)!
           }

--- a/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
+++ b/autogpt_platform/frontend/src/components/RunnerUIWrapper.tsx
@@ -4,8 +4,8 @@ import React, {
   forwardRef,
   useImperativeHandle,
 } from "react";
+import RunnerOutputUI, { BlockOutput } from "./runner-ui/RunnerOutputUI";
 import RunnerInputUI from "./runner-ui/RunnerInputUI";
-import RunnerOutputUI from "./runner-ui/RunnerOutputUI";
 import { Node } from "@xyflow/react";
 import { filterBlocksByType } from "@/lib/utils";
 import { BlockIORootSchema, BlockUIType } from "@/lib/autogpt-server-api/types";
@@ -60,7 +60,11 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
     const [isRunnerOutputOpen, setIsRunnerOutputOpen] = useState(false);
     const [scheduledInput, setScheduledInput] = useState(false);
     const [cronExpression, setCronExpression] = useState("");
-    const getBlockInputsAndOutputs = useCallback(() => {
+
+    const getBlockInputsAndOutputs = useCallback((): {
+      inputs: InputItem[];
+      outputs: BlockOutput[];
+    } => {
       const inputBlocks = filterBlocksByType(
         nodes,
         (node) => node.data.uiType === BlockUIType.INPUT,
@@ -71,34 +75,37 @@ const RunnerUIWrapper = forwardRef<RunnerUIWrapperRef, RunnerUIWrapperProps>(
         (node) => node.data.uiType === BlockUIType.OUTPUT,
       );
 
-      const inputs = inputBlocks.map((node) => ({
-        id: node.id,
-        type: "input" as const,
-        inputSchema: node.data.inputSchema as BlockIORootSchema,
-        hardcodedValues: {
-          name: (node.data.hardcodedValues as any).name || "",
-          description: (node.data.hardcodedValues as any).description || "",
-          value: (node.data.hardcodedValues as any).value,
-          placeholder_values:
-            (node.data.hardcodedValues as any).placeholder_values || [],
-          limit_to_placeholder_values:
-            (node.data.hardcodedValues as any).limit_to_placeholder_values ||
-            false,
-        },
-      }));
+      const inputs = inputBlocks.map(
+        (node) =>
+          ({
+            id: node.id,
+            type: "input" as const,
+            inputSchema: node.data.inputSchema as BlockIORootSchema,
+            hardcodedValues: {
+              name: (node.data.hardcodedValues as any).name || "",
+              description: (node.data.hardcodedValues as any).description || "",
+              value: (node.data.hardcodedValues as any).value,
+              placeholder_values:
+                (node.data.hardcodedValues as any).placeholder_values || [],
+              limit_to_placeholder_values:
+                (node.data.hardcodedValues as any)
+                  .limit_to_placeholder_values || false,
+            },
+          }) satisfies InputItem,
+      );
 
-      const outputs = outputBlocks.map((node) => ({
-        id: node.id,
-        type: "output" as const,
-        hardcodedValues: {
-          name: (node.data.hardcodedValues as any).name || "Output",
-          description:
-            (node.data.hardcodedValues as any).description ||
-            "Output from the agent",
-          value: (node.data.hardcodedValues as any).value,
-        },
-        result: (node.data.executionResults as any)?.at(-1)?.data?.output,
-      }));
+      const outputs = outputBlocks.map(
+        (node) =>
+          ({
+            metadata: {
+              name: (node.data.hardcodedValues as any).name || "Output",
+              description:
+                (node.data.hardcodedValues as any).description ||
+                "Output from the agent",
+            },
+            result: (node.data.executionResults as any)?.at(-1)?.data?.output,
+          }) satisfies BlockOutput,
+      );
 
       return { inputs, outputs };
     }, [nodes]);

--- a/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
@@ -5,6 +5,7 @@ import moment from "moment";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 import {
   GraphExecution,
+  GraphExecutionID,
   GraphExecutionMeta,
   GraphMeta,
 } from "@/lib/autogpt-server-api";
@@ -24,11 +25,13 @@ export default function AgentRunDetailsView({
   graph,
   run,
   agentActions,
+  onRun,
   deleteRun,
 }: {
   graph: GraphMeta;
   run: GraphExecution | GraphExecutionMeta;
   agentActions: ButtonAction[];
+  onRun: (runID: GraphExecutionID) => void;
   deleteRun: () => void;
 }): React.ReactNode {
   const api = useBackendAPI();
@@ -79,14 +82,16 @@ export default function AgentRunDetailsView({
   const runAgain = useCallback(
     () =>
       agentRunInputs &&
-      api.executeGraph(
-        graph.id,
-        graph.version,
-        Object.fromEntries(
-          Object.entries(agentRunInputs).map(([k, v]) => [k, v.value]),
-        ),
-      ),
-    [api, graph, agentRunInputs],
+      api
+        .executeGraph(
+          graph.id,
+          graph.version,
+          Object.fromEntries(
+            Object.entries(agentRunInputs).map(([k, v]) => [k, v.value]),
+          ),
+        )
+        .then(({ graph_exec_id }) => onRun(graph_exec_id)),
+    [api, graph, agentRunInputs, onRun],
   );
 
   const stopRun = useCallback(

--- a/autogpt_platform/frontend/src/components/agents/agent-runs-selector-list.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-runs-selector-list.tsx
@@ -105,11 +105,13 @@ export default function AgentRunsSelectorList({
 
           {activeListTab === "runs"
             ? agentRuns
-                .toSorted((a, b) => Number(b.started_at) - Number(a.started_at))
-                .map((run, i) => (
+                .toSorted(
+                  (a, b) => b.started_at.getTime() - a.started_at.getTime(),
+                )
+                .map((run) => (
                   <AgentRunSummaryCard
                     className="h-28 w-72 lg:h-32 xl:w-80"
-                    key={i}
+                    key={run.id}
                     status={agentRunStatusMap[run.status]}
                     title={agent.name}
                     timestamp={run.started_at}
@@ -120,10 +122,10 @@ export default function AgentRunsSelectorList({
                 ))
             : schedules
                 .filter((schedule) => schedule.graph_id === agent.agent_id)
-                .map((schedule, i) => (
+                .map((schedule) => (
                   <AgentRunSummaryCard
                     className="h-28 w-72 lg:h-32 xl:w-80"
-                    key={i}
+                    key={schedule.id}
                     status="scheduled"
                     title={schedule.name}
                     timestamp={schedule.next_run_time}

--- a/autogpt_platform/frontend/src/components/agents/agent-runs-selector-list.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-runs-selector-list.tsx
@@ -104,18 +104,20 @@ export default function AgentRunsSelectorList({
           </Button>
 
           {activeListTab === "runs"
-            ? agentRuns.map((run, i) => (
-                <AgentRunSummaryCard
-                  className="h-28 w-72 lg:h-32 xl:w-80"
-                  key={i}
-                  status={agentRunStatusMap[run.status]}
-                  title={agent.name}
-                  timestamp={run.started_at}
-                  selected={selectedView.id === run.id}
-                  onClick={() => onSelectRun(run.id)}
-                  onDelete={() => onDeleteRun(run)}
-                />
-              ))
+            ? agentRuns
+                .toSorted((a, b) => Number(b.started_at) - Number(a.started_at))
+                .map((run, i) => (
+                  <AgentRunSummaryCard
+                    className="h-28 w-72 lg:h-32 xl:w-80"
+                    key={i}
+                    status={agentRunStatusMap[run.status]}
+                    title={agent.name}
+                    timestamp={run.started_at}
+                    selected={selectedView.id === run.id}
+                    onClick={() => onSelectRun(run.id)}
+                    onDelete={() => onDeleteRun(run)}
+                  />
+                ))
             : schedules
                 .filter((schedule) => schedule.graph_id === agent.agent_id)
                 .map((schedule, i) => (

--- a/autogpt_platform/frontend/src/components/monitor/AgentFlowList.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/AgentFlowList.tsx
@@ -126,7 +126,8 @@ export const AgentFlowList = ({
                 if (!a.lastRun) return 1;
                 if (!b.lastRun) return -1;
                 return (
-                  Number(b.lastRun.started_at) - Number(a.lastRun.started_at)
+                  b.lastRun.started_at.getTime() -
+                  a.lastRun.started_at.getTime()
                 );
               })
               .map(({ flow, runCount, lastRun }) => (

--- a/autogpt_platform/frontend/src/components/monitor/FlowRunInfo.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/FlowRunInfo.tsx
@@ -17,59 +17,39 @@ import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 
 export const FlowRunInfo: React.FC<
   React.HTMLAttributes<HTMLDivElement> & {
-    flow: LibraryAgent;
+    agent: LibraryAgent;
     execution: GraphExecutionMeta;
   }
-> = ({ flow, execution, ...props }) => {
+> = ({ agent, execution, ...props }) => {
   const [isOutputOpen, setIsOutputOpen] = useState(false);
   const [blockOutputs, setBlockOutputs] = useState<BlockOutput[]>([]);
   const api = useBackendAPI();
 
   const fetchBlockResults = useCallback(async () => {
-    const executionResults = (
-      await api.getGraphExecutionInfo(flow.agent_id, execution.id)
-    ).node_executions;
-
-    // Create a map of the latest COMPLETED execution results of output nodes by node_id
-    const latestCompletedResults = executionResults
-      .filter(
-        (result) =>
-          result.status === "COMPLETED" &&
-          result.block_id === SpecialBlockID.OUTPUT,
-      )
-      .reduce((acc, result) => {
-        const existing = acc.get(result.node_id);
-
-        // Compare dates if there's an existing result
-        if (existing) {
-          const existingDate = existing.end_time || existing.add_time;
-          const currentDate = result.end_time || result.add_time;
-
-          if (currentDate > existingDate) {
-            acc.set(result.node_id, result);
-          }
-        } else {
-          acc.set(result.node_id, result);
-        }
-
-        return acc;
-      }, new Map<string, NodeExecutionResult>());
+    const graph = await api.getGraph(agent.agent_id, agent.agent_version);
+    const graphExecution = await api.getGraphExecutionInfo(
+      agent.agent_id,
+      execution.id,
+    );
 
     // Transform results to BlockOutput format
     setBlockOutputs(
-      Array.from(latestCompletedResults.values()).map((result) => ({
-        id: result.node_id,
-        type: "output" as const,
-        hardcodedValues: {
-          name: result.input_data.name || "Output",
-          description: result.input_data.description || "Output from the agent",
-          value: result.input_data.value,
-        },
-        // Change this line to extract the array directly
-        result: result.output_data?.output || undefined,
-      })),
+      Object.entries(graphExecution.outputs).flatMap(([key, values]) =>
+        values.map(
+          (value) =>
+            ({
+              metadata: {
+                name: graph.output_schema.properties[key].title || "Output",
+                description:
+                  graph.output_schema.properties[key].description ||
+                  "Output from the agent",
+              },
+              result: value,
+            }) satisfies BlockOutput,
+        ),
+      ),
     );
-  }, [api, flow.agent_id, execution.id]);
+  }, [api, agent.agent_id, agent.agent_version, execution.id]);
 
   // Fetch graph and execution data
   useEffect(() => {
@@ -77,15 +57,15 @@ export const FlowRunInfo: React.FC<
     fetchBlockResults();
   }, [isOutputOpen, fetchBlockResults]);
 
-  if (execution.graph_id != flow.agent_id) {
+  if (execution.graph_id != agent.agent_id) {
     throw new Error(
       `FlowRunInfo can't be used with non-matching execution.graph_id and flow.id`,
     );
   }
 
   const handleStopRun = useCallback(() => {
-    api.stopGraphExecution(flow.agent_id, execution.id);
-  }, [api, flow.agent_id, execution.id]);
+    api.stopGraphExecution(agent.agent_id, execution.id);
+  }, [api, agent.agent_id, execution.id]);
 
   return (
     <>
@@ -93,7 +73,7 @@ export const FlowRunInfo: React.FC<
         <CardHeader className="flex-row items-center justify-between space-x-3 space-y-0">
           <div>
             <CardTitle>
-              {flow.name}{" "}
+              {agent.name}{" "}
               <span className="font-light">v{execution.graph_version}</span>
             </CardTitle>
           </div>
@@ -106,7 +86,7 @@ export const FlowRunInfo: React.FC<
             <Button onClick={() => setIsOutputOpen(true)} variant="outline">
               <ExitIcon className="mr-2" /> View Outputs
             </Button>
-            {flow.can_access_graph && (
+            {agent.can_access_graph && (
               <Link
                 className={buttonVariants({ variant: "default" })}
                 href={`/build?flowID=${execution.graph_id}&flowVersion=${execution.graph_version}&flowExecutionID=${execution.id}`}
@@ -118,7 +98,7 @@ export const FlowRunInfo: React.FC<
         </CardHeader>
         <CardContent>
           <p className="hidden">
-            <strong>Agent ID:</strong> <code>{flow.agent_id}</code>
+            <strong>Agent ID:</strong> <code>{agent.agent_id}</code>
           </p>
           <p className="hidden">
             <strong>Run ID:</strong> <code>{execution.id}</code>

--- a/autogpt_platform/frontend/src/components/monitor/FlowRunsStatus.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/FlowRunsStatus.tsx
@@ -29,7 +29,7 @@ export const FlowRunsStatus: React.FC<{
         : statsSince;
   const filteredFlowRuns =
     statsSinceTimestamp != null
-      ? executions.filter((fr) => Number(fr.started_at) > statsSinceTimestamp)
+      ? executions.filter((fr) => fr.started_at.getTime() > statsSinceTimestamp)
       : executions;
 
   return (

--- a/autogpt_platform/frontend/src/components/monitor/FlowRunsTimeline.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/FlowRunsTimeline.tsx
@@ -99,7 +99,7 @@ export const FlowRunsTimeline = ({
             .filter((e) => e.graph_id == flow.agent_id)
             .map((e) => ({
               ...e,
-              time: Number(e.started_at) + e.total_run_time * 1000,
+              time: e.started_at.getTime() + e.total_run_time * 1000,
               _duration: e.total_run_time,
             }))}
           name={flow.name}
@@ -112,10 +112,14 @@ export const FlowRunsTimeline = ({
           type="linear"
           dataKey="_duration"
           data={[
-            { ...execution, time: Number(execution.started_at), _duration: 0 },
             {
               ...execution,
-              time: Number(execution.ended_at),
+              time: execution.started_at.getTime(),
+              _duration: 0,
+            },
+            {
+              ...execution,
+              time: execution.ended_at.getTime(),
               _duration: execution.total_run_time,
             },
           ]}

--- a/autogpt_platform/frontend/src/components/runner-ui/RunnerOutputUI.tsx
+++ b/autogpt_platform/frontend/src/components/runner-ui/RunnerOutputUI.tsx
@@ -7,21 +7,19 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { BlockIORootSchema } from "@/lib/autogpt-server-api/types";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Clipboard } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 
-export interface BlockOutput {
-  id: string;
-  hardcodedValues: {
+export type BlockOutput = {
+  metadata: {
     name: string;
     description: string;
   };
   result?: any;
-}
+};
 
 interface OutputModalProps {
   isOpen: boolean;
@@ -87,15 +85,15 @@ export function RunnerOutputUI({
           <ScrollArea className="h-full overflow-auto pr-4">
             <div className="space-y-4">
               {blockOutputs && blockOutputs.length > 0 ? (
-                blockOutputs.map((block) => (
-                  <div key={block.id} className="space-y-1">
+                blockOutputs.map((block, i) => (
+                  <div key={i} className="space-y-1">
                     <Label className="text-base font-semibold">
-                      {block.hardcodedValues.name || "Unnamed Output"}
+                      {block.metadata.name || "Unnamed Output"}
                     </Label>
 
-                    {block.hardcodedValues.description && (
+                    {block.metadata.description && (
                       <Label className="block text-sm text-gray-600">
-                        {block.hardcodedValues.description}
+                        {block.metadata.description}
                       </Label>
                     )}
 
@@ -106,7 +104,7 @@ export function RunnerOutputUI({
                         size="icon"
                         onClick={() =>
                           copyOutput(
-                            block.hardcodedValues.name || "Unnamed Output",
+                            block.metadata.name || "Unnamed Output",
                             block.result,
                           )
                         }

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -631,7 +631,10 @@ export default function useAgentGraph(
           activeExecutionID: flowExecutionID,
         });
       }
-      setUpdateQueue((prev) => [...prev, ...execution.node_executions]);
+      setUpdateQueue((prev) => {
+        if (!execution.node_executions) return prev;
+        return [...prev, ...execution.node_executions];
+      });
 
       // Track execution until completed
       const pendingNodeExecutions: Set<string> = new Set();

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -978,7 +978,7 @@ type GraphCreateRequestBody = {
 type WebsocketMessageTypeMap = {
   subscribe_graph_execution: { graph_exec_id: GraphExecutionID };
   subscribe_graph_executions: { graph_id: GraphID };
-  graph_execution_event: GraphExecutionMeta;
+  graph_execution_event: GraphExecution;
   node_execution_event: NodeExecutionResult;
   heartbeat: "ping" | "pong";
 };
@@ -1003,7 +1003,7 @@ function parseGraphExecutionTimestamps<
   T extends GraphExecutionMeta | GraphExecution,
 >(result: any): T {
   const fixed = _parseObjectTimestamps<T>(result, ["started_at", "ended_at"]);
-  if ("node_executions" in fixed) {
+  if ("node_executions" in fixed && fixed.node_executions) {
     fixed.node_executions = fixed.node_executions.map(
       parseNodeExecutionResultTimestamps,
     );

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -828,6 +828,12 @@ export default class BackendAPI {
     });
   }
 
+  subscribeToGraphExecutions(graphID: GraphID): Promise<void> {
+    return this.sendWebSocketMessage("subscribe_graph_executions", {
+      graph_id: graphID,
+    });
+  }
+
   async sendWebSocketMessage<M extends keyof WebsocketMessageTypeMap>(
     method: M,
     data: WebsocketMessageTypeMap[M],
@@ -973,6 +979,7 @@ type GraphCreateRequestBody = {
 
 type WebsocketMessageTypeMap = {
   subscribe_graph_execution: { graph_exec_id: GraphExecutionID };
+  subscribe_graph_executions: { graph_id: GraphID };
   graph_execution_event: GraphExecutionMeta;
   node_execution_event: NodeExecutionResult;
   heartbeat: "ping" | "pong";

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -228,7 +228,7 @@ export type LinkCreatable = Omit<Link, "id" | "is_static"> & {
   id?: string;
 };
 
-/* Mirror of backend/data/graph.py:GraphExecutionMeta */
+/* Mirror of backend/data/execution.py:GraphExecutionMeta */
 export type GraphExecutionMeta = {
   id: GraphExecutionID;
   started_at: Date;
@@ -244,11 +244,11 @@ export type GraphExecutionMeta = {
 
 export type GraphExecutionID = Brand<string, "GraphExecutionID">;
 
-/* Mirror of backend/data/graph.py:GraphExecution */
+/* Mirror of backend/data/execution.py:GraphExecution */
 export type GraphExecution = GraphExecutionMeta & {
   inputs: Record<string, any>;
   outputs: Record<string, Array<any>>;
-  node_executions: NodeExecutionResult[];
+  node_executions?: NodeExecutionResult[];
 };
 
 export type GraphMeta = {
@@ -297,7 +297,7 @@ export type GraphUpdateable = Omit<
 
 export type GraphCreatable = Omit<GraphUpdateable, "id"> & { id?: string };
 
-/* Mirror of backend/data/execution.py:ExecutionResult */
+/* Mirror of backend/data/execution.py:NodeExecutionResult */
 export type NodeExecutionResult = {
   graph_id: GraphID;
   graph_version: number;


### PR DESCRIPTION
- Resolves #8782

### Changes 🏗️

- feat(frontend/library): Use WS subscription to get real-time execution updates
  - feat(backend/ws_api): Send `GraphExecutionUpdate` on all new agent I/O
    - Include agent I/O in `GraphExecutionUpdate` (by subclassing `GraphExecution`)
    - Add `IO_BLOCK_IDs` to `.blocks.io`
  - feat(backend/ws_api): Add `subscribe_graph_executions` method to WebSocket API

- feat(backend): Withhold `GraphExecution.node_executions` from requests by non-graph-owners
  - Split `GraphExecutionWithNodes` off of `GraphExecution`
    - Use `GraphExecution` as much as possible, as it's a much cheaper query than `GraphExecutionWithNodes`
  - refactor(frontend): Make `GraphExecution.node_executions` optional

- fix(frontend): Parse dates in responses of `/executions` and `/graphs/{graph_id}/executions`

- refactor(frontend/library): Move sorting logic for agent runs list from `AgentRunsPage` to `AgentRunsSelectorList`

- refactor(backend/ws_api): Clean up message handler implementations

- refactor(backend/tests): Use `.data.execution.get_graph_execution(..)` directly instead of `AgentServer.test_get_graph_run_results(..)`

Out-of-scope changes:
- refactor(backend): Remove unnecessary query include from `.data.graph.get_graph_metadata(..)`

Demo:

https://github.com/user-attachments/assets/8ea6225d-7334-49cb-a522-83f153d840da

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Go to `/library/agents/[id]` for an agent with inputs and outputs
    - Draft and run a new run
      - [x] -> should appear in the list of runs at the top
      - [x] -> should be selected as soon as the request finishes
      - [x] -> new I/O should appear as it is generated
      - [x] -> status should be updated in real-time (both in list and in adjacent details view)
    - Click "Run again"
      - [x] -> should appear in the list of runs at the top
      - [x] -> should be selected as soon as the request finishes
      - [x] -> new I/O should appear as it is generated
      - [x] -> status should be updated in real-time (both in list and in adjacent details view)
    - Click "Open in builder" under "Agent actions"; run the agent from the builder
      - [x] -> should work the same as before
        - [x] -> node I/O should appear in real-time
        - [x] -> node execution statuses should update in real-time