### PR TITLE
fix(backend): Skip updating status of already terminated graph

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -406,7 +406,7 @@ async def update_graph_execution_stats(
     graph_exec_id: str,
     status: ExecutionStatus,
     stats: GraphExecutionStats | None = None,
-) -> GraphExecutionMeta:
+) -> GraphExecutionMeta | None:
     data = stats.model_dump() if stats else {}
     if isinstance(data.get("error"), Exception):
         data["error"] = str(data["error"])
@@ -423,10 +423,8 @@ async def update_graph_execution_stats(
             "stats": Json(data),
         },
     )
-    if not res:
-        raise ValueError(f"Graph execution #{graph_exec_id} not found")
 
-    return GraphExecutionMeta.from_db(res)
+    return GraphExecutionMeta.from_db(res) if res else None
 
 
 async def update_node_execution_stats(node_exec_id: str, stats: NodeExecutionStats):

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -633,16 +633,14 @@ class Executor:
         )
         exec_stats.walltime = timing_info.wall_time
         exec_stats.cputime = timing_info.cpu_time
-        exec_stats.error = error
+        exec_stats.error = str(error)
 
-        if isinstance(exec_stats.error, Exception):
-            exec_stats.error = str(exec_stats.error)
-        result = cls.db_client.update_graph_execution_stats(
+        if result := cls.db_client.update_graph_execution_stats(
             graph_exec_id=graph_exec.graph_exec_id,
             status=status,
             stats=exec_stats,
-        )
-        cls.db_client.send_execution_update(result)
+        ):
+            cls.db_client.send_execution_update(result)
 
         cls._handle_agent_run_notif(graph_exec, exec_stats)
 


### PR DESCRIPTION
When we are cancelling a running graph execution, it's possible that the graph is already terminated.
We need to allow this process to proceed and update the rest of its node execution to terminate.

### Changes 🏗️

Instead of erroring out the graph execution status update, we proceed on updating the node execution status.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Stop an already terminated graph
