### PR TITLE
fix(platform): Fixs to allow formatting and tests to work from sub command

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -188,6 +188,8 @@ SMARTLEAD_API_KEY=
 # ZeroBounce
 ZEROBOUNCE_API_KEY=
 
+## ===== OPTIONAL API KEYS END ===== ##
+
 # Logging Configuration
 LOG_LEVEL=INFO
 ENABLE_CLOUD_LOGGING=false

--- a/autogpt_platform/backend/docker-compose.test.yaml
+++ b/autogpt_platform/backend/docker-compose.test.yaml
@@ -26,6 +26,21 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  rabbitmq-test:
+    image: rabbitmq:management
+    container_name: rabbitmq-test
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+    environment:
+      - RABBITMQ_DEFAULT_USER=rabbitmq_user_default
+      - RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7 # CHANGE THIS TO A RANDOM PASSWORD IN PRODUCTION -- everywhere lol
+    ports:
+      - "5672:5672"
+      - "15672:15672"
 
 networks:
      app-network-test:

--- a/autogpt_platform/backend/linter.py
+++ b/autogpt_platform/backend/linter.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -10,7 +11,16 @@ TARGET_DIRS = [BACKEND_DIR, LIBS_DIR]
 
 def run(*command: str) -> None:
     print(f">>>>> Running poetry run {' '.join(command)}")
-    subprocess.run(["poetry", "run"] + list(command), cwd=directory, check=True)
+    try:
+        subprocess.run(
+            ["poetry", "run"] + list(command),
+            cwd=directory,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as e:
+        print(e.output.decode("utf-8"), file=sys.stderr)
 
 
 def lint():

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -108,7 +108,7 @@ ignore_patterns = []
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "session"
 
 [tool.ruff]
 target-version = "py310"

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -108,7 +108,6 @@ ignore_patterns = []
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
 
 [tool.ruff]
 target-version = "py310"

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -108,6 +108,7 @@ ignore_patterns = []
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 target-version = "py310"

--- a/autogpt_platform/backend/run_tests.py
+++ b/autogpt_platform/backend/run_tests.py
@@ -52,7 +52,6 @@ def test():
             "docker-compose.test.yaml",
             "up",
             "-d",
-            "postgres-test",
         ]
     )
 


### PR DESCRIPTION
This pull request includes several changes to improve the backend functionality and configuration of the `autogpt_platform`. The most important changes involve adding a RabbitMQ service for testing, enhancing logging configuration, updating the linter script to handle errors gracefully, and modifying test configurations.

Backend configuration improvements:

* [`autogpt_platform/backend/docker-compose.test.yaml`](diffhunk://#diff-f6a211ff1c6d96d19adb5641ee287258a6af8d72a99e33dafb4a334094205a43R29-R43): Added RabbitMQ service configuration for testing, including health checks and environment variables.
* [`autogpt_platform/backend/.env.example`](diffhunk://#diff-62020caf1b9a15e0e3b9b3b1b69d5f6464bf7643f62354cbbaabf755d57b6064R191-R192): Added a section delimiter for optional API keys for use in finding the optional keys end when auto generating integrations.

Error handling and logging enhancements:

* [`autogpt_platform/backend/linter.py`](diffhunk://#diff-0787e3ef718ac9963df64d9ab1d8e7a3b35dc4ab0cb874c65da6c2901e1e4991R3): Updated the `run` function to handle `subprocess.CalledProcessError` exceptions and print error output to `stderr` and prevent raising a stack trace when it should not.  [[1]](diffhunk://#diff-0787e3ef718ac9963df64d9ab1d8e7a3b35dc4ab0cb874c65da6c2901e1e4991R3) [[2]](diffhunk://#diff-0787e3ef718ac9963df64d9ab1d8e7a3b35dc4ab0cb874c65da6c2901e1e4991L13-R23)

Testing configuration updates:

* [`autogpt_platform/backend/pyproject.toml`](diffhunk://#diff-26ebebd91da791c6484f07d9d91484a66f52836708f5294b24365603438b880cR111): Added `asyncio_default_fixture_loop_scope` to pytest configuration for better control over asyncio fixtures.
* [`autogpt_platform/backend/run_tests.py`](diffhunk://#diff-f09930577243a4ef5213bf6191a3c500a4b8d3dcfee2d4b452cf7ce66b3c494fL55): Removed the `postgres-test` service from the test setup script as we need all of docker services up for the tests to run.