### PR TITLE
fix(frontend): Add extra padding bottom on library agent page

### DIFF
--- a/autogpt_platform/frontend/src/app/library/page.tsx
+++ b/autogpt_platform/frontend/src/app/library/page.tsx
@@ -18,7 +18,7 @@ import LibraryAgentList from "@/components/library/library-agent-list";
 
 export default function LibraryPage() {
   return (
-    <main className="container min-h-screen space-y-4 sm:px-8 md:px-12">
+    <main className="container min-h-screen space-y-4 pb-20 sm:px-8 md:px-12">
       <LibraryPageStateProvider>
         {/* Header section containing notifications, search functionality and upload mechanism */}
         <LibraryActionHeader />


### PR DESCRIPTION
- fix #9705 

Adding extra padding so the banner doesn’t cut below the cards.

![Screenshot 2025-03-28 at 9 30 49 AM](https://github.com/user-attachments/assets/d1990dda-4d16-430b-823c-a6338e57d99c)
