### PR TITLE
feat(backend): Make agent store data to be publicly accessible by non authenticated user

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -1005,7 +1005,7 @@ async def get_my_agents(
 
 
 async def get_agent(
-    user_id: str,
+    user_id: str | None,
     store_listing_version_id: str,
 ) -> GraphModel:
     """Get agent using the version ID and store listing version ID."""


### PR DESCRIPTION
This PR publicly exposes all the agents listed in the store to the internet.

### Changes 🏗️

Remove the auth requirement for an agent to download the agent.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Accessing `http://localhost:8006/api/store/download/agents/{agentId}` without authorization key.
