### PR TITLE
refactor(frontend): Clean up graph import & export logic

### DIFF
--- a/autogpt_platform/frontend/src/components/agent-import-form.tsx
+++ b/autogpt_platform/frontend/src/components/agent-import-form.tsx
@@ -12,12 +12,11 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { Graph, GraphCreatable } from "@/lib/autogpt-server-api";
-import { cn, removeCredentials } from "@/lib/utils";
 import { EnterIcon } from "@radix-ui/react-icons";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+import { Graph, GraphCreatable } from "@/lib/autogpt-server-api";
+import { cn, sanitizeImportedGraph } from "@/lib/utils";
 
 // Add this custom schema for File type
 const fileSchema = z.custom<File>((val) => val instanceof File, {
@@ -30,45 +29,6 @@ const formSchema = z.object({
   agentDescription: z.string(),
   importAsTemplate: z.boolean(),
 });
-
-export const updatedBlockIDMap: Record<string, string> = {
-  // https://github.com/Significant-Gravitas/AutoGPT/issues/8223
-  "a1b2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
-    "436c3984-57fd-4b85-8e9a-459b356883bd",
-  "b2g2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
-    "0e50422c-6dee-4145-83d6-3a5a392f65de",
-  "c3d4e5f6-7g8h-9i0j-1k2l-m3n4o5p6q7r8":
-    "a0a69be1-4528-491c-a85a-a4ab6873e3f0",
-  "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8":
-    "32a87eab-381e-4dd4-bdb8-4c47151be35a",
-  "b2c3d4e5-6f7g-8h9i-0j1k-l2m3n4o5p6q7":
-    "87840993-2053-44b7-8da4-187ad4ee518c",
-  "h1i2j3k4-5l6m-7n8o-9p0q-r1s2t3u4v5w6":
-    "d0822ab5-9f8a-44a3-8971-531dd0178b6b",
-  "d3f4g5h6-1i2j-3k4l-5m6n-7o8p9q0r1s2t":
-    "df06086a-d5ac-4abb-9996-2ad0acb2eff7",
-  "h5e7f8g9-1b2c-3d4e-5f6g-7h8i9j0k1l2m":
-    "f5b0f5d0-1862-4d61-94be-3ad0fa772760",
-  "a1234567-89ab-cdef-0123-456789abcdef":
-    "4335878a-394e-4e67-adf2-919877ff49ae",
-  "f8e7d6c5-b4a3-2c1d-0e9f-8g7h6i5j4k3l":
-    "f66a3543-28d3-4ab5-8945-9b336371e2ce",
-  "b29c1b50-5d0e-4d9f-8f9d-1b0e6fcbf0h2":
-    "716a67b3-6760-42e7-86dc-18645c6e00fc",
-  "31d1064e-7446-4693-o7d4-65e5ca9110d1":
-    "cc10ff7b-7753-4ff2-9af6-9399b1a7eddc",
-  "c6731acb-4105-4zp1-bc9b-03d0036h370g":
-    "5ebe6768-8e5d-41e3-9134-1c7bd89a8d52",
-};
-
-function updateBlockIDs(graph: Graph) {
-  graph.nodes
-    .filter((node) => node.block_id in updatedBlockIDMap)
-    .forEach((node) => {
-      node.block_id = updatedBlockIDMap[node.block_id];
-    });
-  return graph;
-}
 
 export const AgentImportForm: React.FC<
   React.FormHTMLAttributes<HTMLFormElement>
@@ -150,12 +110,11 @@ export const AgentImportForm: React.FC<
                                 JSON.stringify(obj, null, 2),
                             );
                           }
-                          const agent = obj as Graph;
-                          removeCredentials(agent);
-                          updateBlockIDs(agent);
-                          setAgentObject(agent);
-                          form.setValue("agentName", agent.name);
-                          form.setValue("agentDescription", agent.description);
+                          const graph = obj as Graph;
+                          sanitizeImportedGraph(graph);
+                          setAgentObject(graph);
+                          form.setValue("agentName", graph.name);
+                          form.setValue("agentDescription", graph.description);
                         } catch (error) {
                           console.error("Error loading agent file:", error);
                         }

--- a/autogpt_platform/frontend/src/components/agent-import-form.tsx
+++ b/autogpt_platform/frontend/src/components/agent-import-form.tsx
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { cn } from "@/lib/utils";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import React, { useState } from "react";
@@ -15,8 +16,11 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { EnterIcon } from "@radix-ui/react-icons";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
-import { Graph, GraphCreatable } from "@/lib/autogpt-server-api";
-import { cn, sanitizeImportedGraph } from "@/lib/utils";
+import {
+  Graph,
+  GraphCreatable,
+  sanitizeImportedGraph,
+} from "@/lib/autogpt-server-api";
 
 // Add this custom schema for File type
 const fileSchema = z.custom<File>((val) => val instanceof File, {

--- a/autogpt_platform/frontend/src/components/library/library-upload-agent-dialog.tsx
+++ b/autogpt_platform/frontend/src/components/library/library-upload-agent-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import { Upload, X } from "lucide-react";
-import { removeCredentials } from "@/lib/utils";
+import { sanitizeImportedGraph } from "@/lib/utils";
 import { Button } from "@/components/agptui/Button";
 import {
   Dialog,
@@ -25,7 +25,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Graph, GraphCreatable } from "@/lib/autogpt-server-api";
-import { updatedBlockIDMap } from "@/components/agent-import-form";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -40,15 +39,6 @@ const formSchema = z.object({
   agentName: z.string().min(1, "Agent name is required"),
   agentDescription: z.string(),
 });
-
-function updateBlockIDs(graph: Graph) {
-  graph.nodes
-    .filter((node) => node.block_id in updatedBlockIDMap)
-    .forEach((node) => {
-      node.block_id = updatedBlockIDMap[node.block_id];
-    });
-  return graph;
-}
 
 export default function LibraryUploadAgentDialog(): React.ReactNode {
   const [isDroped, setisDroped] = useState(false);
@@ -120,8 +110,7 @@ export default function LibraryUploadAgentDialog(): React.ReactNode {
           );
         }
         const agent = obj as Graph;
-        removeCredentials(agent);
-        updateBlockIDs(agent);
+        sanitizeImportedGraph(agent);
         setAgentObject(agent);
         if (!form.getValues("agentName")) {
           form.setValue("agentName", agent.name);

--- a/autogpt_platform/frontend/src/components/library/library-upload-agent-dialog.tsx
+++ b/autogpt_platform/frontend/src/components/library/library-upload-agent-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useState } from "react";
 import { Upload, X } from "lucide-react";
-import { sanitizeImportedGraph } from "@/lib/utils";
 import { Button } from "@/components/agptui/Button";
 import {
   Dialog,
@@ -24,7 +23,11 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Graph, GraphCreatable } from "@/lib/autogpt-server-api";
+import {
+  Graph,
+  GraphCreatable,
+  sanitizeImportedGraph,
+} from "@/lib/autogpt-server-api";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
 import { useToast } from "@/components/ui/use-toast";
 

--- a/autogpt_platform/frontend/src/components/monitor/FlowInfo.tsx
+++ b/autogpt_platform/frontend/src/components/monitor/FlowInfo.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useCallback } from "react";
 import {
   GraphExecutionMeta,
   Graph,
-  safeCopyGraph,
   BlockUIType,
   BlockIORootSchema,
   LibraryAgent,
@@ -242,16 +241,15 @@ export const FlowInfo: React.FC<
               className="px-2.5"
               title="Export to a JSON-file"
               data-testid="export-button"
-              onClick={async () =>
-                exportAsJSONFile(
-                  safeCopyGraph(
-                    flowVersions!.find(
-                      (v) => v.version == selectedFlowVersion!.version,
-                    )!,
-                    await api.getBlocks(),
-                  ),
-                  `${flow.name}_v${selectedFlowVersion!.version}.json`,
-                )
+              onClick={() =>
+                api
+                  .getGraph(flow.agent_id, selectedFlowVersion!.version, true)
+                  .then((graph) =>
+                    exportAsJSONFile(
+                      graph,
+                      `${flow.name}_v${selectedFlowVersion!.version}.json`,
+                    ),
+                  )
               }
             >
               <ExitIcon className="mr-2" /> Export

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -205,7 +205,7 @@ export default class BackendAPI {
     return this._get(`/graphs`);
   }
 
-  getGraph(
+  async getGraph(
     id: GraphID,
     version?: number,
     for_export?: boolean,
@@ -217,7 +217,9 @@ export default class BackendAPI {
     if (for_export !== undefined) {
       query["for_export"] = for_export;
     }
-    return this._get(`/graphs/${id}`, query);
+    const graph = await this._get(`/graphs/${id}`, query);
+    if (for_export) delete graph.user_id;
+    return graph;
   }
 
   getGraphAllVersions(id: GraphID): Promise<Graph[]> {

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -253,6 +253,7 @@ export type GraphExecution = GraphExecutionMeta & {
 
 export type GraphMeta = {
   id: GraphID;
+  user_id: UserID;
   version: number;
   is_active: boolean;
   name: string;
@@ -286,7 +287,12 @@ export type Graph = GraphMeta & {
 
 export type GraphUpdateable = Omit<
   Graph,
-  "version" | "is_active" | "links" | "input_schema" | "output_schema"
+  | "user_id"
+  | "version"
+  | "is_active"
+  | "links"
+  | "input_schema"
+  | "output_schema"
 > & {
   version?: number;
   is_active?: boolean;
@@ -480,7 +486,7 @@ export type NotificationPreferenceDTO = {
 };
 
 export type NotificationPreference = NotificationPreferenceDTO & {
-  user_id: string;
+  user_id: UserID;
   emails_sent_today: number;
   last_reset_date: Date;
 };
@@ -500,9 +506,11 @@ export type Webhook = {
 };
 
 export type User = {
-  id: string;
+  id: UserID;
   email: string;
 };
+
+export type UserID = Brand<string, "UserID">;
 
 export enum BlockUIType {
   STANDARD = "Standard",
@@ -657,7 +665,7 @@ export type Schedule = {
   id: ScheduleID;
   name: string;
   cron: string;
-  user_id: string;
+  user_id: UserID;
   graph_id: GraphID;
   graph_version: number;
   input_data: { [key: string]: any };
@@ -751,7 +759,7 @@ export interface TransactionHistory {
 
 export interface RefundRequest {
   id: string;
-  user_id: string;
+  user_id: UserID;
   transaction_key: string;
   amount: number;
   reason: string;

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/utils.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/utils.ts
@@ -33,3 +33,66 @@ export function formatEdgeID(conn: Link | Connection): string {
     return `${conn.source}_${conn.sourceHandle}_${conn.target}_${conn.targetHandle}`;
   }
 }
+
+/** Sanitizes a graph object in place so it can "safely" be imported into the system.
+ *
+ * **⚠️ Note:** not an actual safety feature, just intended to make the import UX more reliable.
+ */
+export function sanitizeImportedGraph(graph: Graph): void {
+  updateBlockIDs(graph);
+  removeCredentials(graph);
+}
+
+/** Recursively remove (in place) all "credentials" properties from an object */
+function removeCredentials(obj: any): void {
+  if (obj && typeof obj === "object") {
+    if (Array.isArray(obj)) {
+      obj.forEach((item) => removeCredentials(item));
+    } else {
+      delete obj.credentials;
+      Object.values(obj).forEach((value) => removeCredentials(value));
+    }
+  }
+  return obj;
+}
+
+/** ⚠️ Remove after 2025-10-01 (one year after implementation in
+ * [#8229](https://github.com/Significant-Gravitas/AutoGPT/pull/8229))
+ */
+function updateBlockIDs(graph: Graph) {
+  graph.nodes
+    .filter((node) => node.block_id in updatedBlockIDMap)
+    .forEach((node) => {
+      node.block_id = updatedBlockIDMap[node.block_id];
+    });
+}
+
+const updatedBlockIDMap: Record<string, string> = {
+  // https://github.com/Significant-Gravitas/AutoGPT/issues/8223
+  "a1b2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
+    "436c3984-57fd-4b85-8e9a-459b356883bd",
+  "b2g2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
+    "0e50422c-6dee-4145-83d6-3a5a392f65de",
+  "c3d4e5f6-7g8h-9i0j-1k2l-m3n4o5p6q7r8":
+    "a0a69be1-4528-491c-a85a-a4ab6873e3f0",
+  "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8":
+    "32a87eab-381e-4dd4-bdb8-4c47151be35a",
+  "b2c3d4e5-6f7g-8h9i-0j1k-l2m3n4o5p6q7":
+    "87840993-2053-44b7-8da4-187ad4ee518c",
+  "h1i2j3k4-5l6m-7n8o-9p0q-r1s2t3u4v5w6":
+    "d0822ab5-9f8a-44a3-8971-531dd0178b6b",
+  "d3f4g5h6-1i2j-3k4l-5m6n-7o8p9q0r1s2t":
+    "df06086a-d5ac-4abb-9996-2ad0acb2eff7",
+  "h5e7f8g9-1b2c-3d4e-5f6g-7h8i9j0k1l2m":
+    "f5b0f5d0-1862-4d61-94be-3ad0fa772760",
+  "a1234567-89ab-cdef-0123-456789abcdef":
+    "4335878a-394e-4e67-adf2-919877ff49ae",
+  "f8e7d6c5-b4a3-2c1d-0e9f-8g7h6i5j4k3l":
+    "f66a3543-28d3-4ab5-8945-9b336371e2ce",
+  "b29c1b50-5d0e-4d9f-8f9d-1b0e6fcbf0h2":
+    "716a67b3-6760-42e7-86dc-18645c6e00fc",
+  "31d1064e-7446-4693-o7d4-65e5ca9110d1":
+    "cc10ff7b-7753-4ff2-9af6-9399b1a7eddc",
+  "c6731acb-4105-4zp1-bc9b-03d0036h370g":
+    "5ebe6768-8e5d-41e3-9134-1c7bd89a8d52",
+};

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/utils.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/utils.ts
@@ -1,25 +1,5 @@
 import { Connection } from "@xyflow/react";
-import { Graph, Block, Node, BlockUIType, Link } from "./types";
-
-/** Creates a copy of the graph with all secrets removed */
-export function safeCopyGraph(graph: Graph, block_defs: Block[]): Graph {
-  graph = removeAgentInputBlockValues(graph, block_defs);
-  return {
-    ...graph,
-    nodes: graph.nodes.map((node) => {
-      const block = block_defs.find((b) => b.id == node.block_id)!;
-      return {
-        ...node,
-        input_default: Object.keys(node.input_default)
-          .filter((k) => !block.inputSchema.properties[k].secret)
-          .reduce((obj: Node["input_default"], key) => {
-            obj[key] = node.input_default[key];
-            return obj;
-          }, {}),
-      };
-    }),
-  };
-}
+import { Graph, Block, BlockUIType, Link } from "./types";
 
 export function removeAgentInputBlockValues(graph: Graph, blocks: Block[]) {
   const inputBlocks = graph.nodes.filter(

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
-import { Category } from "./autogpt-server-api/types";
+
+import { Category, Graph } from "@/lib/autogpt-server-api/types";
 import { NodeDimension } from "@/components/Flow";
 
 export function cn(...inputs: ClassValue[]) {
@@ -120,28 +121,9 @@ const applyExceptions = (str: string): string => {
   return str;
 };
 
-/** Recursively remove all "credentials" properties from exported JSON files */
-export function removeCredentials(obj: any) {
-  if (obj && typeof obj === "object") {
-    if (Array.isArray(obj)) {
-      obj.forEach((item) => removeCredentials(item));
-    } else {
-      delete obj.credentials;
-      Object.values(obj).forEach((value) => removeCredentials(value));
-    }
-  }
-  return obj;
-}
-
 export function exportAsJSONFile(obj: object, filename: string): void {
-  // Deep clone the object to avoid modifying the original
-  const sanitizedObj = JSON.parse(JSON.stringify(obj));
-
-  // Sanitize the object
-  removeCredentials(sanitizedObj);
-
   // Create downloadable blob
-  const jsonString = JSON.stringify(sanitizedObj, null, 2);
+  const jsonString = JSON.stringify(obj, null, 2);
   const blob = new Blob([jsonString], { type: "application/json" });
   const url = URL.createObjectURL(blob);
 
@@ -156,6 +138,69 @@ export function exportAsJSONFile(obj: object, filename: string): void {
   // Clean up
   URL.revokeObjectURL(url);
 }
+
+/** Sanitizes a graph object in place so it can "safely" be imported into the system.
+ *
+ * **⚠️ Note:** not an actual safety feature, just intended to make the import UX more reliable.
+ */
+export function sanitizeImportedGraph(graph: Graph): void {
+  updateBlockIDs(graph);
+  removeCredentials(graph);
+}
+
+/** Recursively remove (in place) all "credentials" properties from an object */
+function removeCredentials(obj: any): void {
+  if (obj && typeof obj === "object") {
+    if (Array.isArray(obj)) {
+      obj.forEach((item) => removeCredentials(item));
+    } else {
+      delete obj.credentials;
+      Object.values(obj).forEach((value) => removeCredentials(value));
+    }
+  }
+  return obj;
+}
+
+/** ⚠️ Remove after 2025-10-01 (one year after implementation in
+ * [#8229](https://github.com/Significant-Gravitas/AutoGPT/pull/8229))
+ */
+function updateBlockIDs(graph: Graph) {
+  graph.nodes
+    .filter((node) => node.block_id in updatedBlockIDMap)
+    .forEach((node) => {
+      node.block_id = updatedBlockIDMap[node.block_id];
+    });
+}
+
+const updatedBlockIDMap: Record<string, string> = {
+  // https://github.com/Significant-Gravitas/AutoGPT/issues/8223
+  "a1b2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
+    "436c3984-57fd-4b85-8e9a-459b356883bd",
+  "b2g2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
+    "0e50422c-6dee-4145-83d6-3a5a392f65de",
+  "c3d4e5f6-7g8h-9i0j-1k2l-m3n4o5p6q7r8":
+    "a0a69be1-4528-491c-a85a-a4ab6873e3f0",
+  "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8":
+    "32a87eab-381e-4dd4-bdb8-4c47151be35a",
+  "b2c3d4e5-6f7g-8h9i-0j1k-l2m3n4o5p6q7":
+    "87840993-2053-44b7-8da4-187ad4ee518c",
+  "h1i2j3k4-5l6m-7n8o-9p0q-r1s2t3u4v5w6":
+    "d0822ab5-9f8a-44a3-8971-531dd0178b6b",
+  "d3f4g5h6-1i2j-3k4l-5m6n-7o8p9q0r1s2t":
+    "df06086a-d5ac-4abb-9996-2ad0acb2eff7",
+  "h5e7f8g9-1b2c-3d4e-5f6g-7h8i9j0k1l2m":
+    "f5b0f5d0-1862-4d61-94be-3ad0fa772760",
+  "a1234567-89ab-cdef-0123-456789abcdef":
+    "4335878a-394e-4e67-adf2-919877ff49ae",
+  "f8e7d6c5-b4a3-2c1d-0e9f-8g7h6i5j4k3l":
+    "f66a3543-28d3-4ab5-8945-9b336371e2ce",
+  "b29c1b50-5d0e-4d9f-8f9d-1b0e6fcbf0h2":
+    "716a67b3-6760-42e7-86dc-18645c6e00fc",
+  "31d1064e-7446-4693-o7d4-65e5ca9110d1":
+    "cc10ff7b-7753-4ff2-9af6-9399b1a7eddc",
+  "c6731acb-4105-4zp1-bc9b-03d0036h370g":
+    "5ebe6768-8e5d-41e3-9134-1c7bd89a8d52",
+};
 
 export function setNestedProperty(obj: any, path: string, value: any) {
   if (!obj || typeof obj !== "object") {

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -139,69 +139,6 @@ export function exportAsJSONFile(obj: object, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
-/** Sanitizes a graph object in place so it can "safely" be imported into the system.
- *
- * **⚠️ Note:** not an actual safety feature, just intended to make the import UX more reliable.
- */
-export function sanitizeImportedGraph(graph: Graph): void {
-  updateBlockIDs(graph);
-  removeCredentials(graph);
-}
-
-/** Recursively remove (in place) all "credentials" properties from an object */
-function removeCredentials(obj: any): void {
-  if (obj && typeof obj === "object") {
-    if (Array.isArray(obj)) {
-      obj.forEach((item) => removeCredentials(item));
-    } else {
-      delete obj.credentials;
-      Object.values(obj).forEach((value) => removeCredentials(value));
-    }
-  }
-  return obj;
-}
-
-/** ⚠️ Remove after 2025-10-01 (one year after implementation in
- * [#8229](https://github.com/Significant-Gravitas/AutoGPT/pull/8229))
- */
-function updateBlockIDs(graph: Graph) {
-  graph.nodes
-    .filter((node) => node.block_id in updatedBlockIDMap)
-    .forEach((node) => {
-      node.block_id = updatedBlockIDMap[node.block_id];
-    });
-}
-
-const updatedBlockIDMap: Record<string, string> = {
-  // https://github.com/Significant-Gravitas/AutoGPT/issues/8223
-  "a1b2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
-    "436c3984-57fd-4b85-8e9a-459b356883bd",
-  "b2g2c3d4-5e6f-7g8h-9i0j-k1l2m3n4o5p6":
-    "0e50422c-6dee-4145-83d6-3a5a392f65de",
-  "c3d4e5f6-7g8h-9i0j-1k2l-m3n4o5p6q7r8":
-    "a0a69be1-4528-491c-a85a-a4ab6873e3f0",
-  "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8":
-    "32a87eab-381e-4dd4-bdb8-4c47151be35a",
-  "b2c3d4e5-6f7g-8h9i-0j1k-l2m3n4o5p6q7":
-    "87840993-2053-44b7-8da4-187ad4ee518c",
-  "h1i2j3k4-5l6m-7n8o-9p0q-r1s2t3u4v5w6":
-    "d0822ab5-9f8a-44a3-8971-531dd0178b6b",
-  "d3f4g5h6-1i2j-3k4l-5m6n-7o8p9q0r1s2t":
-    "df06086a-d5ac-4abb-9996-2ad0acb2eff7",
-  "h5e7f8g9-1b2c-3d4e-5f6g-7h8i9j0k1l2m":
-    "f5b0f5d0-1862-4d61-94be-3ad0fa772760",
-  "a1234567-89ab-cdef-0123-456789abcdef":
-    "4335878a-394e-4e67-adf2-919877ff49ae",
-  "f8e7d6c5-b4a3-2c1d-0e9f-8g7h6i5j4k3l":
-    "f66a3543-28d3-4ab5-8945-9b336371e2ce",
-  "b29c1b50-5d0e-4d9f-8f9d-1b0e6fcbf0h2":
-    "716a67b3-6760-42e7-86dc-18645c6e00fc",
-  "31d1064e-7446-4693-o7d4-65e5ca9110d1":
-    "cc10ff7b-7753-4ff2-9af6-9399b1a7eddc",
-  "c6731acb-4105-4zp1-bc9b-03d0036h370g":
-    "5ebe6768-8e5d-41e3-9134-1c7bd89a8d52",
-};
-
 export function setNestedProperty(obj: any, path: string, value: any) {
   if (!obj || typeof obj !== "object") {
     throw new Error("Target must be a non-null object");


### PR DESCRIPTION
- Resolves #9716
- Builds on the work done in #9627

### Changes 🏗️

- Remove `safeCopyGraph`; export directly from backend instead
- Explicitly name sanitization functions for *importing* graphs; move to `@/lib/autogpt-server-api/utils`
- Amend `BackendAPI.getGraph(..)` to delete `.user_id` if `for_export == true`

Out-of-scope improvements:
- Add missing `user_id` to frontend `Graph` types
- Add `UserID` branded type for `User.id` + all `user_id` properties

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Create and configure an agent with the Publish To Medium block, a block that uses credentials, and a webhook trigger
  - Go to `/monitoring` and click the agent you just created
    - [x] -> "Export" button should work
      - [x] -> Exported file contains no credentials or secrets
      - [x] -> Exported file contains no user IDs
      - [x] -> Exported file contains no webhook IDs