### PR TITLE
fix(backend): Cleanup service on service closure

### DIFF
--- a/autogpt_platform/backend/backend/util/process.py
+++ b/autogpt_platform/backend/backend/util/process.py
@@ -73,6 +73,9 @@ class AppProcess(ABC):
             self.run()
         except (KeyboardInterrupt, SystemExit) as e:
             logger.warning(f"[{self.service_name}] Terminated: {e}; quitting...")
+        finally:
+            self.cleanup()
+            logger.info(f"[{self.service_name}] Terminated.")
 
     def _self_terminate(self, signum: int, frame):
         self.cleanup()


### PR DESCRIPTION
The cleanup command was only called on SIGTERM, making it possible for the service to close without being cleaned. Risking the connection not being proactively closed when the service is unused.

### Changes 🏗️

Call the cleanup command on the service finally block.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the service, stop it, see the log is printed (locally)

