### PR TITLE
fix(marketplace): Add 58px bottom padding to creator page agents section on large screens

### DIFF
--- a/autogpt_platform/frontend/src/app/marketplace/creator/[creator]/page.tsx
+++ b/autogpt_platform/frontend/src/app/marketplace/creator/[creator]/page.tsx
@@ -77,7 +77,7 @@ export default async function Page({
               <CreatorLinks links={creator.links} />
             </div>
           </div>
-          <div className="mt-8 sm:mt-12 md:mt-16">
+          <div className="mt-8 sm:mt-12 md:mt-16 lg:pb-[58px]">
             <hr className="w-full bg-neutral-700" />
             <AgentsSection
               agents={creatorAgents.agents}


### PR DESCRIPTION
- fix #9000 

Currently, we have a 32px bottom padding on the Creator’s page on larger screen. I have added an extra 58px to make it 90px.