### PR TITLE
update(docs): Remove out dated tutorial video from docs & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@
 > Setting up and hosting the AutoGPT Platform yourself is a technical process. 
 > If you'd rather something that just works, we recommend [joining the waitlist](https://bit.ly/3ZDijAI) for the cloud-hosted beta.
 
-https://github.com/user-attachments/assets/d04273a5-b36a-4a37-818e-f631ce72d603
+### Updated Setup Instructions:
+We’ve moved to a fully maintained and regularly updated documentation site.
+
+👉 [Follow the official self-hosting guide here](https://docs.agpt.co/platform/getting-started/)
+
 
 This tutorial assumes you have Docker, VSCode, git and npm installed.
 

--- a/docs/content/platform/getting-started.md
+++ b/docs/content/platform/getting-started.md
@@ -1,9 +1,5 @@
 # Getting Started with AutoGPT: Self-Hosting Guide
 
-This tutorial will walk you through the process of setting up AutoGPT locally on your machine.
-
-<center><iframe width="560" height="315" src="https://www.youtube.com/embed/4Bycr6_YAMI?si=dXGhFeWrCK2UkKgj" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></center>
-
 ## Introduction
 
 This guide will help you setup the server and builder for the project.


### PR DESCRIPTION
This is to remove the out dated tutorial video from docs & readme and add a direct link to the docs in the readme

### Changes 🏗️

Remove video link from readme.md
Remove video link from https://github.com/Significant-Gravitas/AutoGPT/blob/dev/docs/content/platform/getting-started.md
Add direct link to docs in readme.me
