### PR TITLE
feat(backend): Add new llama 4 maverick & scout models

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -135,6 +135,8 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     AMAZON_NOVA_PRO_V1 = "amazon/nova-pro-v1"
     MICROSOFT_WIZARDLM_2_8X22B = "microsoft/wizardlm-2-8x22b"
     GRYPHE_MYTHOMAX_L2_13B = "gryphe/mythomax-l2-13b"
+    META_LLAMA_4_SCOUT = "meta-llama/llama-4-scout"
+    META_LLAMA_4_MAVERICK = "meta-llama/llama-4-maverick"
 
     @property
     def metadata(self) -> ModelMetadata:
@@ -216,6 +218,8 @@ MODEL_METADATA = {
     LlmModel.AMAZON_NOVA_PRO_V1: ModelMetadata("open_router", 300000, 5120),
     LlmModel.MICROSOFT_WIZARDLM_2_8X22B: ModelMetadata("open_router", 65536, 4096),
     LlmModel.GRYPHE_MYTHOMAX_L2_13B: ModelMetadata("open_router", 4096, 4096),
+    LlmModel.META_LLAMA_4_SCOUT: ModelMetadata("open_router", 131072, 131072),
+    LlmModel.META_LLAMA_4_MAVERICK: ModelMetadata("open_router", 1048576, 1000000),
 }
 
 for model in LlmModel:

--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -75,6 +75,8 @@ MODEL_COST: dict[LlmModel, int] = {
     LlmModel.AMAZON_NOVA_PRO_V1: 1,
     LlmModel.MICROSOFT_WIZARDLM_2_8X22B: 1,
     LlmModel.GRYPHE_MYTHOMAX_L2_13B: 1,
+    LlmModel.META_LLAMA_4_SCOUT: 1,
+    LlmModel.META_LLAMA_4_MAVERICK: 1,
 }
 
 for model in LlmModel:


### PR DESCRIPTION
This PR is to add the new [Meta: Llama 4 Maverick](https://openrouter.ai/meta-llama/llama-4-maverick) and [Meta: Llama 4 Scout](https://openrouter.ai/meta-llama/llama-4-scout) models via [OpenRouter](https://openrouter.ai/)


### Changes 🏗️

Added the model names to ``llm.py``
```
    META_LLAMA_4_SCOUT = "meta-llama/llama-4-scout"
    META_LLAMA_4_MAVERICK = "meta-llama/llama-4-maverick"
```
and the modela metadata
```
    LlmModel.META_LLAMA_4_SCOUT: ModelMetadata("open_router", 131072, 131072),
    LlmModel.META_LLAMA_4_MAVERICK: ModelMetadata("open_router", 1048576, 1000000),
```

and i have added the model price to ``block_cost_config.py``
```
    LlmModel.META_LLAMA_4_SCOUT: 1,
    LlmModel.META_LLAMA_4_MAVERICK: 1,
```

### Checklist 📋

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Open the build page and place a ai text block, open the model select and scroll to the bottom and select either of the 2 models
  - [x] test them with a prompt and wait for a reply!
