### PR TITLE
fix(marketplace): Render newline in marketplace description text

### DIFF
--- a/autogpt_platform/frontend/src/components/agptui/AgentInfo.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/AgentInfo.tsx
@@ -170,10 +170,10 @@ export const AgentInfo: React.FC<AgentInfoProps> = ({
 
       {/* Description Section */}
       <div className="mb-4 w-full lg:mb-[36px]">
-        <div className="font-geist decoration-skip-ink-none mb-1.5 text-base font-medium leading-6 text-neutral-800 dark:text-neutral-200 sm:mb-2">
+        <div className="mb-1.5 font-sans text-base font-medium leading-6 text-neutral-800 dark:text-neutral-200 sm:mb-2">
           Description
         </div>
-        <div className="font-geist decoration-skip-ink-none text-base font-normal leading-6 text-neutral-600 underline-offset-[from-font] dark:text-neutral-400">
+        <div className="whitespace-pre-line font-sans text-base font-normal leading-6 text-neutral-600 dark:text-neutral-400">
           {longDescription}
         </div>
       </div>


### PR DESCRIPTION
- fix #9177 

Add `whitespace-pre-line` tailwind property to allow newline rendering in marketplace description text

### Before

![Screenshot 2025-04-11 at 10 32 23 AM](https://github.com/user-attachments/assets/b07f58b6-218e-4b33-a018-93757e59cd8d)

### After

![Screenshot 2025-04-11 at 10 32 59 AM](https://github.com/user-attachments/assets/f1086ee4-aef3-491a-ba81-cf681086f67b)
