### PR TITLE
fix((backend): Fix migrate llm models in existing agents

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -915,7 +915,7 @@ async def migrate_llm_models(migrate_to: LlmModel):
                 llm_model_fields[block.id] = field_name
 
     # Convert enum values to a list of strings for the SQL query
-    enum_values = [v.value for v in LlmModel.__members__.values()]
+    enum_values = [v.value for v in LlmModel]
     escaped_enum_values = repr(tuple(enum_values))  # hack but works
 
     # Update each block

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -914,24 +914,26 @@ async def migrate_llm_models(migrate_to: LlmModel):
             if field.annotation == LlmModel:
                 llm_model_fields[block.id] = field_name
 
+    # Convert enum values to a list of strings for the SQL query
+    enum_values = [v.value for v in LlmModel.__members__.values()]
+    escaped_enum_values = repr(tuple(enum_values))  # hack but works
+
     # Update each block
     for id, path in llm_model_fields.items():
-        # Convert enum values to a list of strings for the SQL query
-        enum_values = [v.value for v in LlmModel.__members__.values()]
+        logger.warning(f"Updating block {id} field {path}")
 
-        escaped_enum_values = repr(tuple(enum_values))  # hack but works
         query = f"""
-            UPDATE "AgentNode"
-            SET "constantInput" = jsonb_set("constantInput", $1, $2, true)
+            UPDATE platform."AgentNode"
+            SET "constantInput" = jsonb_set("constantInput", $1, to_jsonb($2), true)
             WHERE "agentBlockId" = $3
-            AND "constantInput" ? $4
-            AND "constantInput"->>$4 NOT IN {escaped_enum_values}
+            AND "constantInput" ? ($4)::text
+            AND "constantInput"->>($4)::text NOT IN {escaped_enum_values}
             """
 
         await db.execute_raw(
             query,  # type: ignore - is supposed to be LiteralString
-            "{" + path + "}",
-            f'"{migrate_to.value}"',
+            [path],
+            migrate_to.value,
             id,
             path,
         )

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -920,8 +920,6 @@ async def migrate_llm_models(migrate_to: LlmModel):
 
     # Update each block
     for id, path in llm_model_fields.items():
-        logger.warning(f"Updating block {id} field {path}")
-
         query = f"""
             UPDATE platform."AgentNode"
             SET "constantInput" = jsonb_set("constantInput", $1, to_jsonb($2), true)

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -28,6 +28,7 @@ import backend.server.v2.store.model
 import backend.server.v2.store.routes
 import backend.util.service
 import backend.util.settings
+from backend.blocks.llm import LlmModel
 from backend.data.model import Credentials
 from backend.integrations.providers import ProviderName
 from backend.server.external.api import external_app
@@ -56,8 +57,7 @@ async def lifespan_context(app: fastapi.FastAPI):
     await backend.data.block.initialize_blocks()
     await backend.data.user.migrate_and_encrypt_user_integrations()
     await backend.data.graph.fix_llm_provider_credentials()
-    # FIXME ERROR: operator does not exist: text ? unknown
-    # await backend.data.graph.migrate_llm_models(LlmModel.GPT4O)
+    await backend.data.graph.migrate_llm_models(LlmModel.GPT4O)
     with launch_darkly_context():
         yield
     await backend.data.db.disconnect()


### PR DESCRIPTION
https://github.com/Significant-Gravitas/AutoGPT/pull/9452 was throwing `operator does not exist: text ? unknown` on deployed dev and so the function call was commented as a hotfix.
This PR fixes and re-enables the llm model migration function.

### Changes 🏗️

- Uncomment and fix `migrate_llm_models` function

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Migrate nodes with non-existing models
  - [x] Don't migrate nodes without any model or with correct models

