### PR TITLE
fix(marketplace/library): Removing white borders from Avatar

### DIFF
--- a/autogpt_platform/frontend/src/components/agptui/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/StoreCard.tsx
@@ -57,14 +57,14 @@ export const StoreCard: React.FC<StoreCardProps> = ({
         )}
         {!hideAvatar && (
           <div className="absolute bottom-4 left-4">
-            <Avatar className="h-16 w-16 border-2 border-white dark:border-gray-800">
+            <Avatar className="h-20 w-20">
               {avatarSrc && (
                 <AvatarImage
                   src={avatarSrc}
                   alt={`${creatorName || agentName} creator avatar`}
                 />
               )}
-              <AvatarFallback>
+              <AvatarFallback size={80}>
                 {(creatorName || agentName).charAt(0)}
               </AvatarFallback>
             </Avatar>

--- a/autogpt_platform/frontend/src/components/agptui/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/StoreCard.tsx
@@ -57,14 +57,14 @@ export const StoreCard: React.FC<StoreCardProps> = ({
         )}
         {!hideAvatar && (
           <div className="absolute bottom-4 left-4">
-            <Avatar className="h-20 w-20">
+            <Avatar className="h-16 w-16">
               {avatarSrc && (
                 <AvatarImage
                   src={avatarSrc}
                   alt={`${creatorName || agentName} creator avatar`}
                 />
               )}
-              <AvatarFallback size={80}>
+              <AvatarFallback size={64}>
                 {(creatorName || agentName).charAt(0)}
               </AvatarFallback>
             </Avatar>

--- a/autogpt_platform/frontend/src/components/library/library-agent-card.tsx
+++ b/autogpt_platform/frontend/src/components/library/library-agent-card.tsx
@@ -48,7 +48,7 @@ export default function LibraryAgentCard({
           />
         )}
         <div className="absolute bottom-4 left-4">
-          <Avatar className="h-16 w-16 border-2 border-white dark:border-gray-800">
+          <Avatar className="h-16 w-16">
             <AvatarImage
               src={
                 creator_image_url
@@ -57,7 +57,7 @@ export default function LibraryAgentCard({
               }
               alt={`${name} creator avatar`}
             />
-            <AvatarFallback>{name.charAt(0)}</AvatarFallback>
+            <AvatarFallback size={64}>{name.charAt(0)}</AvatarFallback>
           </Avatar>
         </div>
       </Link>


### PR DESCRIPTION
There are some white borders around the avatar in the store card, but they are not present in the design, so I'm removing them.

![Screenshot 2025-04-15 at 3 58 05 PM](https://github.com/user-attachments/assets/f8c98076-9cc3-46f1-b4f3-41d4e48f6127)
