### PR TITLE
fix(frontend): Fix Input value mixup on Library page 

### DIFF
--- a/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
@@ -258,11 +258,7 @@ export default function AgentRunDetailsView({
               Object.entries(agentRunInputs).map(([key, { title, value }]) => (
                 <div key={key} className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">{title || key}</label>
-                  <Input
-                    defaultValue={value}
-                    className="rounded-full"
-                    disabled
-                  />
+                  <Input value={value} className="rounded-full" disabled />
                 </div>
               ))
             ) : (

--- a/autogpt_platform/frontend/src/components/agents/agent-schedule-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-schedule-details-view.tsx
@@ -109,11 +109,7 @@ export default function AgentScheduleDetailsView({
               Object.entries(agentRunInputs).map(([key, { title, value }]) => (
                 <div key={key} className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium">{title || key}</label>
-                  <Input
-                    defaultValue={value}
-                    className="rounded-full"
-                    disabled
-                  />
+                  <Input value={value} className="rounded-full" disabled />
                 </div>
               ))
             ) : (


### PR DESCRIPTION
### Changes 🏗️

Fix this broken behaviors:
Input data mix-up caused by running two different executions of the same agent with the same input.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run agent with old user
  - [x] Running two different executions of the same agent with the same input. 

