### PR TITLE
fix(frontend/builder): Fix key-value pair input for any non-string types

### DIFF
--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -772,24 +772,16 @@ const NodeKeyValueInput: FC<{
     );
   }
 
+  const isNumberType =
+    schema.additionalProperties &&
+    ["number", "integer"].includes(schema.additionalProperties.type);
+
   function convertValueType(value: string): string | number | null {
-    if (
-      schema.additionalProperties &&
-      ["number", "integer"].includes(schema.additionalProperties.type)
-    ) {
+    if (isNumberType) {
       const numValue = Number(value);
-      return !isNaN(numValue) ? numValue : value;
+      return !isNaN(numValue) ? numValue : null;
     }
-
-    if (
-      !!value ||
-      !schema.additionalProperties ||
-      schema.additionalProperties.type == "string"
-    ) {
-      return value;
-    }
-
-    return null;
+    return value;
   }
 
   function getEntryKey(key: string): string {
@@ -835,7 +827,7 @@ const NodeKeyValueInput: FC<{
                   }
                 />
                 <LocalValuedInput
-                  type="text"
+                  type={isNumberType ? "number" : "text"}
                   placeholder="Value"
                   value={value ?? ""}
                   onChange={(e) =>

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -774,12 +774,22 @@ const NodeKeyValueInput: FC<{
 
   function convertValueType(value: string): string | number | null {
     if (
+      schema.additionalProperties &&
+      ["number", "integer"].includes(schema.additionalProperties.type)
+    ) {
+      const numValue = Number(value);
+      return !isNaN(numValue) ? numValue : value;
+    }
+
+    if (
+      !!value ||
       !schema.additionalProperties ||
       schema.additionalProperties.type == "string"
-    )
+    ) {
       return value;
-    if (!value) return null;
-    return Number(value);
+    }
+
+    return null;
   }
 
   function getEntryKey(key: string): string {


### PR DESCRIPTION
- Resolves #9823 

The key-value pairs input, like those used in CreateDictionaryBlock, are assumed to be either a numeric or a string type.
When it has `any` type, it was randomly assumed to be a numeric type. 

### Changes 🏗️

Only convert to number when it's explicitly defined to do so on key-value pair input.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Tried two different key-value pair input: AiTextGenerator & CreateDictionary

