### PR TITLE
fix(backend): Fix array types in database

### DIFF
--- a/autogpt_platform/backend/migrations/20250416140000_make_arrays_not_null/migration.sql
+++ b/autogpt_platform/backend/migrations/20250416140000_make_arrays_not_null/migration.sql
@@ -1,0 +1,56 @@
+-- Backfill nulls with empty arrays
+UPDATE "UserOnboarding"
+SET "integrations" = ARRAY[]::TEXT[]
+WHERE "integrations" IS NULL;
+
+UPDATE "UserOnboarding"
+SET "completedSteps" = '{}' 
+WHERE "completedSteps" IS NULL;
+
+UPDATE "UserOnboarding"
+SET "notified" = '{}' 
+WHERE "notified" IS NULL;
+
+UPDATE "UserOnboarding"
+SET "rewardedFor" = '{}' 
+WHERE "rewardedFor" IS NULL;
+
+UPDATE "IntegrationWebhook"
+SET "events" = ARRAY[]::TEXT[]
+WHERE "events" IS NULL;
+
+UPDATE "APIKey"
+SET "permissions" = '{}' 
+WHERE "permissions" IS NULL;
+
+UPDATE "Profile"
+SET "links" = ARRAY[]::TEXT[]
+WHERE "links" IS NULL;
+
+UPDATE "StoreListingVersion"
+SET "imageUrls" = ARRAY[]::TEXT[]
+WHERE "imageUrls" IS NULL;
+
+UPDATE "StoreListingVersion"
+SET "categories" = ARRAY[]::TEXT[]
+WHERE "categories" IS NULL;
+
+-- Enforce NOT NULL constraints
+ALTER TABLE "UserOnboarding"
+    ALTER COLUMN "integrations" SET NOT NULL,
+    ALTER COLUMN "completedSteps" SET NOT NULL,
+    ALTER COLUMN "notified" SET NOT NULL,
+    ALTER COLUMN "rewardedFor" SET NOT NULL;
+
+ALTER TABLE "IntegrationWebhook"
+    ALTER COLUMN "events" SET NOT NULL;
+
+ALTER TABLE "APIKey"
+    ALTER COLUMN "permissions" SET NOT NULL;
+
+ALTER TABLE "Profile"
+    ALTER COLUMN "links" SET NOT NULL;
+
+ALTER TABLE "StoreListingVersion"
+    ALTER COLUMN "imageUrls" SET NOT NULL,
+    ALTER COLUMN "categories" SET NOT NULL;


### PR DESCRIPTION
Array fields in `schema.prisma` are non-nullable, but generated migrations don’t add `NOT NULL` constraints. This causes existing rows to get `NULL` values when new array columns are added, breaking schema expectations and leading to bugs.

### Changes 🏗️

- Backfill all `NULL` rows on non-nullable array columns to empty arrays
- Set `NOT NULL` constraint on all array columns

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Existing `NULL` rows are properly backfilled
  - [x] Existing arrays are not set to default empty arrays
  - [x] Affected columns became non-nullable in the db
