### PR TITLE
fix(backend): Fix execution manager message consuming pattern

### DIFF
--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -137,6 +137,10 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         default=8002,
         description="The port for execution manager daemon to run on",
     )
+    execution_manager_loop_max_retry: int = Field(
+        default=5,
+        description="The maximum number of retries for the execution manager loop",
+    )
 
     execution_scheduler_port: int = Field(
         default=8003,


### PR DESCRIPTION
We have seen instances where the executor gets stuck in a failing message-consuming loop due to the upstream RabbitMQ being down. The current message-consuming pattern is not optimal for handling this.

### Changes 🏗️

* Add a retry limit to the execution loop limit.
* Use `basic_consume` instead of `basic_get` for handling message consumption.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run agents cancel them
