### PR TITLE
fix(frontend/library): Prevent execution updates mixing between library agents

### DIFF
--- a/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/library/agents/[id]/page.tsx
@@ -145,6 +145,8 @@ export default function AgentRunsPage(): React.ReactElement {
     const detachExecUpdateHandler = api.onWebSocketMessage(
       "graph_execution_event",
       (data) => {
+        if (data.graph_id != agent?.graph_id) return;
+
         setAgentRuns((prev) => {
           const index = prev.findIndex((run) => run.id === data.id);
           if (index === -1) {
@@ -163,7 +165,7 @@ export default function AgentRunsPage(): React.ReactElement {
     return () => {
       detachExecUpdateHandler();
     };
-  }, [api, selectedView.id]);
+  }, [api, agent?.graph_id, selectedView.id]);
 
   // load selectedRun based on selectedView
   useEffect(() => {


### PR DESCRIPTION
If the websocket doesn't disconnect when the user switches to viewing a different agent, they aren't unsubscribed. If execution updates *from a different agent* are adopted into the page state, that can cause crashes.

### Changes 🏗️

- Filter incoming execution updates by `graph_id`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - Go to an agent and initiate a run that will take a while (long enough to navigate to a different agent)
  - Navigate: Library -> [another agent]
  - [ ] Runs from the first agent don't show up in the runs list of the other agent
