### PR TITLE
fix(library/run): Replace credits to cents

### DIFF
--- a/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
@@ -23,6 +23,7 @@ import {
   AgentRunStatus,
   agentRunStatusMap,
 } from "@/components/agents/agent-run-status-chip";
+import useCredits from "@/hooks/useCredits";
 
 export default function AgentRunDetailsView({
   agent,
@@ -40,6 +41,7 @@ export default function AgentRunDetailsView({
   deleteRun: () => void;
 }): React.ReactNode {
   const api = useBackendAPI();
+  const { formatCredits } = useCredits();
 
   const runStatus: AgentRunStatus = useMemo(
     () => agentRunStatusMap[run.status],
@@ -66,11 +68,11 @@ export default function AgentRunDetailsView({
               value: moment.duration(run.stats.duration, "seconds").humanize(),
             },
             { label: "Steps", value: run.stats.node_exec_count },
-            { label: "Cost", value: `$ ${run.stats.cost / 100}` },
+            { label: "Cost", value: formatCredits(run.stats.cost) },
           ]
         : []),
     ];
-  }, [run, runStatus]);
+  }, [run, runStatus, formatCredits]);
 
   const agentRunInputs:
     | Record<

--- a/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-details-view.tsx
@@ -66,7 +66,7 @@ export default function AgentRunDetailsView({
               value: moment.duration(run.stats.duration, "seconds").humanize(),
             },
             { label: "Steps", value: run.stats.node_exec_count },
-            { label: "Cost", value: `${run.stats.cost} credits` },
+            { label: "Cost", value: `$ ${run.stats.cost / 100}` },
           ]
         : []),
     ];


### PR DESCRIPTION
Replacing credits with cents (100 credits = 1$).

I haven’t touched anything internally, just changed the UI.

Everything is working great.

On the frontend, there’s no other place where we use credits instead of dollars. 

![Screenshot 2025-04-19 at 11 36 00 AM](https://github.com/user-attachments/assets/de799b5c-094e-4c96-a7da-273ce60b2125)
<img width="1503" alt="Screenshot 2025-04-19 at 11 33 24 AM" src="https://github.com/user-attachments/assets/87d7e218-f8f5-4e2e-92ef-70c81735db6b" />
