### PR TITLE
fix(platform): Fix Google Maps API Key setting through env

### DIFF
--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -161,6 +161,14 @@ smartlead_credentials = APIKeyCredentials(
     expires_at=None,
 )
 
+google_maps_credentials = APIKeyCredentials(
+    id="9aa1bde0-4947-4a70-a20c-84daa3850d52",
+    provider="google_maps",
+    api_key=SecretStr(settings.secrets.google_maps_api_key),
+    title="Use Credits for Google Maps",
+    expires_at=None,
+)
+
 zerobounce_credentials = APIKeyCredentials(
     id="63a6e279-2dc2-448e-bf57-85776f7176dc",
     provider="zerobounce",
@@ -190,6 +198,7 @@ DEFAULT_CREDENTIALS = [
     apollo_credentials,
     smartlead_credentials,
     zerobounce_credentials,
+    google_maps_credentials,
 ]
 
 
@@ -263,6 +272,8 @@ class IntegrationCredentialsStore:
             all_credentials.append(smartlead_credentials)
         if settings.secrets.zerobounce_api_key:
             all_credentials.append(zerobounce_credentials)
+        if settings.secrets.google_maps_api_key:
+            all_credentials.append(google_maps_credentials)
         return all_credentials
 
     def get_creds_by_id(self, user_id: str, credentials_id: str) -> Credentials | None:


### PR DESCRIPTION
Setting the Google Maps API through the API has never worked on the platform.

### Changes 🏗️

Set the default api key from the environment variable.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Test GoogleMapsBlock
