### PR TITLE
fix(frontend): Hide Google Maps Key ID filter

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/integrations/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/integrations/page.tsx
@@ -116,6 +116,7 @@ export default function PrivatePage() {
       "544c62b5-1d0f-4156-8fb4-9525f11656eb", // Apollo
       "3bcdbda3-84a3-46af-8fdb-bfd2472298b8", // SmartLead
       "63a6e279-2dc2-448e-bf57-85776f7176dc", // ZeroBounce
+      "9aa1bde0-4947-4a70-a20c-84daa3850d52", // Google Maps
     ],
     [],
   );


### PR DESCRIPTION
### Changes 🏗️

![image](https://github.com/user-attachments/assets/d6b9f971-d914-4ff1-9319-a903707a2c72)

Hide Google Maps system id key on the frontend UI.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan