### PR TITLE
feat(backend): Use forkserver on process creation if possible

### DIFF
--- a/autogpt_platform/backend/backend/util/process.py
+++ b/autogpt_platform/backend/backend/util/process.py
@@ -3,7 +3,7 @@ import os
 import signal
 import sys
 from abc import ABC, abstractmethod
-from multiprocessing import Process, set_start_method
+from multiprocessing import Process, get_all_start_methods, set_start_method
 from typing import Optional
 
 from backend.util.logging import configure_logging
@@ -30,7 +30,12 @@ class AppProcess(ABC):
     process: Optional[Process] = None
     cleaned_up = False
 
-    set_start_method("spawn", force=True)
+    if "forkserver" in get_all_start_methods():
+        set_start_method("forkserver", force=True)
+    else:
+        logger.warning("Forkserver start method is not available. Using spawn instead.")
+        set_start_method("spawn", force=True)
+
     configure_logging()
     sentry_init()
 


### PR DESCRIPTION
### Changes 🏗️

Set process starting mode to forkserver instead of spawn, if possible, for performance benefits.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Existing tests
