### PR TITLE
fix(frontend): Add support to optional multiselect

### DIFF
--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -429,9 +429,9 @@ export const NodeGenericInputField: FC<{
             // If you want to build an object of booleans from `selection`
             // (like your old code), do it here. Otherwise adapt to your actual UI.
             // Example:
-            const allKeys = schema.properties
-              ? Object.keys(schema.properties)
-              : [];
+            const subSchema =
+              schema.properties || (schema as any).anyOf[0].properties;
+            const allKeys = subSchema ? Object.keys(subSchema) : [];
             handleInputChange(
               key,
               Object.fromEntries(
@@ -1025,7 +1025,8 @@ const NodeMultiSelectInput: FC<{
   displayName,
   handleInputChange,
 }) => {
-  const options = Object.keys(schema.properties);
+  const optionSchema = schema.properties || (schema as any).anyOf[0].properties;
+  const options = Object.keys(optionSchema);
 
   return (
     <div className={cn("flex flex-col", className)}>
@@ -1044,7 +1045,7 @@ const NodeMultiSelectInput: FC<{
         <MultiSelectorContent className="nowheel">
           <MultiSelectorList>
             {options
-              .map((key) => ({ ...schema.properties[key], key }))
+              .map((key) => ({ ...optionSchema[key], key }))
               .map(({ key, title, description }) => (
                 <MultiSelectorItem key={key} value={key} title={description}>
                   {title ?? key}

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -1027,7 +1027,9 @@ const NodeMultiSelectInput: FC<{
 }) => {
   const optionSchema =
     schema.properties ||
-    ((schema as any).anyOf?.length > 0 ? (schema as any).anyOf[0].properties : {});
+    ((schema as any).anyOf?.length > 0
+      ? (schema as any).anyOf[0].properties
+      : {});
   const options = Object.keys(optionSchema);
 
   return (

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -1025,7 +1025,9 @@ const NodeMultiSelectInput: FC<{
   displayName,
   handleInputChange,
 }) => {
-  const optionSchema = schema.properties || (schema as any).anyOf[0].properties;
+  const optionSchema =
+    schema.properties ||
+    ((schema as any).anyOf?.length > 0 ? (schema as any).anyOf[0].properties : {});
   const options = Object.keys(optionSchema);
 
   return (


### PR DESCRIPTION
- fix #9882 

we’re currently using optional multi select, and it’s working great. We’re able to correctly determine the data type for it. However, there’s a small issue. We’re not using the correct subSchema that is inside anyOf on the multi select input. This is why we’re getting the problem on the Twitter block. It’s the only one that’s using this type of input, so it’s the only one that’s affected. 

![Screenshot 2025-04-26 at 5 39 51 PM](https://github.com/user-attachments/assets/834d64d8-84dc-4dbd-a03a-df03172ecee5)
