### PR TITLE
fix: use subheading for agent info not description

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function Page({
             <AgentInfo
               name={agent.agent_name}
               creator={agent.creator}
-              shortDescription={agent.description}
+              shortDescription={agent.sub_heading}
               longDescription={agent.description}
               rating={agent.rating}
               runs={agent.runs}


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
we oopsed and used the wrong attribute for short desc
### Changes 🏗️
Uses sub heading instead now
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] check the expected text shows
