### PR TITLE
fix(backend): Failing test on a new Pydantic version

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/library/model_test.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model_test.py
@@ -22,11 +22,13 @@ async def test_agent_preset_from_db():
         userId="test-user-123",
         isDeleted=False,
         InputPresets=[
-            prisma.models.AgentNodeExecutionInputOutput(
-                id="input-123",
-                time=datetime.datetime.now(),
-                name="input1",
-                data=prisma.Json({"type": "string", "value": "test value"}),
+            prisma.models.AgentNodeExecutionInputOutput.model_validate(
+                {
+                    "id": "input-123",
+                    "time": datetime.datetime.now(),
+                    "name": "input1",
+                    "data": '{"type": "string", "value": "test value"}',
+                }
             )
         ],
     )


### PR DESCRIPTION
```
FAILED test/model_test.py::test_agent_preset_from_db - pydantic_core._pydantic_core.ValidationError: 1 validation error for AgentNodeExecutionInputOutput

E       pydantic_core._pydantic_core.ValidationError: 1 validation error for AgentNodeExecutionInputOutput
E       data
E         JSON input should be string, bytes or bytearray [type=json_type, input_value=Json, input_type=Json]
E           For further information visit https://errors.pydantic.dev/2.11/v/json_type
```

### Changes 🏗️

Manually creating a Prisma model often breaks, and we have such an instance in the test.
This PR fixes the test to make the new Pydantic happy.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] CI
