### PR TITLE
feat(frontend): fix admin add dollars

### DIFF
--- a/autogpt_platform/frontend/src/components/admin/spending/add-money-button.tsx
+++ b/autogpt_platform/frontend/src/components/admin/spending/add-money-button.tsx
@@ -85,7 +85,7 @@ export function AdminAddMoneyButton({
             <input
               type="hidden"
               name="amount"
-              value={formatCredits(Number(dollarAmount))}
+              value={Math.round(parseFloat(dollarAmount) * 100)}
             />
 
             <div className="grid gap-4 py-4">


### PR DESCRIPTION
Fixes the admin add dollars, in the ``add-money-button.tsx`` file, in the handleApproveSubmit action it was trying to use formatCredits for the value which is wrong, this fix changes it

```diff
 <form action={handleApproveSubmit}>
   <input type="hidden" name="id" value={userId} />
   <input
     type="hidden"
     name="amount"
-    value={formatCredits(Number(dollarAmount))}
+    value={Math.round(parseFloat(dollarAmount) * 100)}
   />
```
i was able to add $1, $0.10 and $0.01
![image](https://github.com/user-attachments/assets/3a3126c2-5f17-4c9b-8657-4372332a0ea3)
