### PR TITLE
hotfix(backend): Avoid executing any agent with zero balance

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -945,7 +945,7 @@ class BetaUserCredit(UserCredit):
 
 class DisabledUserCredit(UserCreditBase):
     async def get_credits(self, *args, **kwargs) -> int:
-        return 0
+        return 100
 
     async def get_transaction_history(self, *args, **kwargs) -> TransactionHistory:
         return TransactionHistory(transactions=[], next_transaction_time=None)

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -53,6 +53,10 @@ async def _spend_credits(
     return await _user_credit_model.spend_credits(user_id, cost, metadata)
 
 
+async def _get_credits(user_id: str) -> int:
+    return await _user_credit_model.get_credits(user_id)
+
+
 class DatabaseManager(AppService):
 
     def run_service(self) -> None:
@@ -97,6 +101,7 @@ class DatabaseManager(AppService):
 
     # Credits
     spend_credits = exposed_run_and_wait(_spend_credits)
+    get_credits = exposed_run_and_wait(_get_credits)
 
     # User + User Metadata + User Integrations
     get_user_metadata = exposed_run_and_wait(get_user_metadata)

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -104,19 +104,21 @@ class UsageTransactionMetadata(BaseModel):
 
 def execution_usage_cost(execution_count: int) -> tuple[int, int]:
     """
-    Calculate the cost of executing a graph based on the number of executions.
+    Calculate the cost of executing a graph based on the current number of node executions.
 
     Args:
-        execution_count: Number of executions
+        execution_count: Number of node executions
 
     Returns:
-        Tuple of cost amount and remaining execution count
+        Tuple of cost amount and the number of execution count that is included in the cost.
     """
     return (
-        execution_count
-        // config.execution_cost_count_threshold
-        * config.execution_cost_per_threshold,
-        execution_count % config.execution_cost_count_threshold,
+        (
+            config.execution_cost_per_threshold
+            if execution_count % config.execution_cost_count_threshold == 0
+            else 0
+        ),
+        config.execution_cost_count_threshold,
     )
 
 

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -117,6 +117,10 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         default=1,
         description="Cost per execution in cents after each threshold.",
     )
+    execution_counter_expiration_time: int = Field(
+        default=60 * 60 * 24,
+        description="Time in seconds after which the execution counter is reset.",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",


### PR DESCRIPTION
### Changes 🏗️

* Avoid executing any agent with a zero balance.
* Make node execution count global across agents for a single user.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run agents by tweaking the `execution_cost_count_threshold` & `execution_cost_per_threshold` values.
