### PR TITLE
feat(backend): Continue instead of retrying aborted/broken agent execution

### DIFF
--- a/autogpt_platform/backend/backend/app.py
+++ b/autogpt_platform/backend/backend/app.py
@@ -32,14 +32,14 @@ def main(**kwargs):
     Run all the processes required for the AutoGPT-server (REST and WebSocket APIs).
     """
 
-    from backend.executor import DatabaseManager, ExecutionManager, Scheduler
+    from backend.executor import DatabaseManager, Scheduler
     from backend.notifications import NotificationManager
     from backend.server.rest_api import AgentServer
     from backend.server.ws_api import WebsocketServer
 
     run_processes(
         DatabaseManager(),
-        ExecutionManager(),
+        # ExecutionManager(),
         Scheduler(),
         NotificationManager(),
         WebsocketServer(),

--- a/autogpt_platform/backend/backend/app.py
+++ b/autogpt_platform/backend/backend/app.py
@@ -32,14 +32,14 @@ def main(**kwargs):
     Run all the processes required for the AutoGPT-server (REST and WebSocket APIs).
     """
 
-    from backend.executor import DatabaseManager, Scheduler
+    from backend.executor import DatabaseManager, ExecutionManager, Scheduler
     from backend.notifications import NotificationManager
     from backend.server.rest_api import AgentServer
     from backend.server.ws_api import WebsocketServer
 
     run_processes(
         DatabaseManager(),
-        # ExecutionManager(),
+        ExecutionManager(),
         Scheduler(),
         NotificationManager(),
         WebsocketServer(),

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -6,9 +6,9 @@ from backend.data.credit import UsageTransactionMetadata, get_user_credit_model
 from backend.data.execution import (
     create_graph_execution,
     get_graph_execution,
-    get_incomplete_node_executions,
+    get_graph_execution_meta,
     get_latest_node_execution,
-    get_node_execution_results,
+    get_node_executions,
     update_graph_execution_start_time,
     update_graph_execution_stats,
     update_node_execution_stats,
@@ -78,9 +78,9 @@ class DatabaseManager(AppService):
 
     # Executions
     get_graph_execution = _(get_graph_execution)
+    get_graph_execution_meta = _(get_graph_execution_meta)
     create_graph_execution = _(create_graph_execution)
-    get_node_execution_results = _(get_node_execution_results)
-    get_incomplete_node_executions = _(get_incomplete_node_executions)
+    get_node_executions = _(get_node_executions)
     get_latest_node_execution = _(get_latest_node_execution)
     update_node_execution_status = _(update_node_execution_status)
     update_node_execution_status_batch = _(update_node_execution_status_batch)
@@ -133,9 +133,9 @@ class DatabaseManagerClient(AppServiceClient):
 
     # Executions
     get_graph_execution = _(d.get_graph_execution)
+    get_graph_execution_meta = _(d.get_graph_execution_meta)
     create_graph_execution = _(d.create_graph_execution)
-    get_node_execution_results = _(d.get_node_execution_results)
-    get_incomplete_node_executions = _(d.get_incomplete_node_executions)
+    get_node_executions = _(d.get_node_executions)
     get_latest_node_execution = _(d.get_latest_node_execution)
     update_node_execution_status = _(d.update_node_execution_status)
     update_node_execution_status_batch = _(d.update_node_execution_status_batch)

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -373,8 +373,10 @@ def _enqueue_next_nodes(
 
             # If link is static, there could be some incomplete executions waiting for it.
             # Load and complete the input missing input data, and try to re-enqueue them.
-            for iexec in db_client.get_incomplete_node_executions(
-                next_node_id, graph_exec_id
+            for iexec in db_client.get_node_executions(
+                node_id=next_node_id,
+                graph_exec_id=graph_exec_id,
+                statuses=[ExecutionStatus.INCOMPLETE],
             ):
                 idata = iexec.input_data
                 ineid = iexec.node_exec_id
@@ -566,16 +568,35 @@ class Executor:
             node_eid="*",
             block_name="-",
         )
-        exec_meta = cls.db_client.update_graph_execution_start_time(
-            graph_exec.graph_exec_id
+
+        exec_meta = cls.db_client.get_graph_execution_meta(
+            user_id=graph_exec.user_id,
+            execution_id=graph_exec.graph_exec_id,
         )
         if exec_meta is None:
-            logger.warning(
+            log_metadata.warning(
                 f"Skipped graph execution {graph_exec.graph_exec_id}, the graph execution is not found."
             )
             return
 
-        send_execution_update(exec_meta)
+        if exec_meta.status == ExecutionStatus.QUEUED:
+            log_metadata.info(f"⚙️ Starting graph execution {graph_exec.graph_exec_id}")
+            exec_meta.status = ExecutionStatus.RUNNING
+            send_execution_update(
+                cls.db_client.update_graph_execution_start_time(
+                    graph_exec.graph_exec_id
+                )
+            )
+        elif exec_meta.status == ExecutionStatus.RUNNING:
+            log_metadata.info(
+                f"⚙️ Graph execution {graph_exec.graph_exec_id} is already running, continuing where it left off."
+            )
+        else:
+            log_metadata.warning(
+                f"Skipped graph execution {graph_exec.graph_exec_id}, the graph execution status is `{exec_meta.status}`."
+            )
+            return
+
         timing_info, (exec_stats, status, error) = cls._on_graph_execution(
             graph_exec, cancel, log_metadata
         )
@@ -655,7 +676,6 @@ class Executor:
             ExecutionStatus: The final status of the graph execution.
             Exception | None: The error that occurred during the execution, if any.
         """
-        log_metadata.info(f"Start graph execution {graph_exec.graph_exec_id}")
         execution_stats = GraphExecutionStats()
         execution_status = ExecutionStatus.RUNNING
         error = None
@@ -678,8 +698,11 @@ class Executor:
 
         try:
             queue = ExecutionQueue[NodeExecutionEntry]()
-            for node_exec in graph_exec.start_node_execs:
-                queue.add(node_exec)
+            for node_exec in cls.db_client.get_node_executions(
+                graph_exec.graph_exec_id,
+                statuses=[ExecutionStatus.RUNNING, ExecutionStatus.QUEUED],
+            ):
+                queue.add(node_exec.to_node_execution_entry())
 
             exec_cost_counter = 0
             running_executions: dict[str, AsyncResult] = {}
@@ -800,24 +823,21 @@ class Executor:
                         execution.wait(3)
 
             log_metadata.info(f"Finished graph execution {graph_exec.graph_exec_id}")
+            execution_status = ExecutionStatus.COMPLETED
 
         except Exception as e:
             error = e
-        finally:
-            if error:
-                log_metadata.error(
-                    f"Failed graph execution {graph_exec.graph_exec_id}: {error}"
-                )
-                execution_status = ExecutionStatus.FAILED
-            else:
-                execution_status = ExecutionStatus.COMPLETED
+            log_metadata.error(
+                f"Failed graph execution {graph_exec.graph_exec_id}: {error}"
+            )
+            execution_status = ExecutionStatus.FAILED
 
+        finally:
             if not cancel.is_set():
                 finished = True
                 cancel.set()
             cancel_thread.join()
             clean_exec_files(graph_exec.graph_exec_id)
-
             return execution_stats, execution_status, error
 
     @classmethod
@@ -829,7 +849,7 @@ class Executor:
         metadata = cls.db_client.get_graph_metadata(
             graph_exec.graph_id, graph_exec.graph_version
         )
-        outputs = cls.db_client.get_node_execution_results(
+        outputs = cls.db_client.get_node_executions(
             graph_exec.graph_exec_id,
             block_ids=[AgentOutputBlock().id],
         )
@@ -1057,7 +1077,7 @@ class ExecutionManager(AppProcess):
 
         if hasattr(self, "executor"):
             log(f"{prefix} ⏳ Shutting down GraphExec pool...")
-            self.executor.shutdown(cancel_futures=True, wait=True)
+            self.executor.shutdown(cancel_futures=False, wait=True)
 
         log(f"{prefix} ⏳ Disconnecting Redis...")
         redis.disconnect()
@@ -1082,7 +1102,9 @@ def get_notification_service() -> "NotificationManagerClient":
     return get_service_client(NotificationManagerClient)
 
 
-def send_execution_update(entry: GraphExecution | NodeExecutionResult):
+def send_execution_update(entry: GraphExecution | NodeExecutionResult | None):
+    if entry is None:
+        return
     return get_execution_event_bus().publish(entry)
 
 

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -575,12 +575,12 @@ class Executor:
         )
         if exec_meta is None:
             log_metadata.warning(
-                f"Skipped graph execution {graph_exec.graph_exec_id}, the graph execution is not found."
+                f"Skipped graph execution #{graph_exec.graph_exec_id}, the graph execution is not found."
             )
             return
 
         if exec_meta.status == ExecutionStatus.QUEUED:
-            log_metadata.info(f"⚙️ Starting graph execution {graph_exec.graph_exec_id}")
+            log_metadata.info(f"⚙️ Starting graph execution #{graph_exec.graph_exec_id}")
             exec_meta.status = ExecutionStatus.RUNNING
             send_execution_update(
                 cls.db_client.update_graph_execution_start_time(
@@ -589,7 +589,7 @@ class Executor:
             )
         elif exec_meta.status == ExecutionStatus.RUNNING:
             log_metadata.info(
-                f"⚙️ Graph execution {graph_exec.graph_exec_id} is already running, continuing where it left off."
+                f"⚙️ Graph execution #{graph_exec.graph_exec_id} is already running, continuing where it left off."
             )
         else:
             log_metadata.warning(

--- a/autogpt_platform/backend/backend/server/external/routes/v1.py
+++ b/autogpt_platform/backend/backend/server/external/routes/v1.py
@@ -122,7 +122,7 @@ async def get_graph_execution_results(
     if not graph:
         raise HTTPException(status_code=404, detail=f"Graph #{graph_id} not found.")
 
-    results = await execution_db.get_node_execution_results(graph_exec_id)
+    results = await execution_db.get_node_executions(graph_exec_id)
     last_result = results[-1] if results else None
     execution_status = (
         last_result.status if last_result else AgentExecutionStatus.INCOMPLETE

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -663,7 +663,7 @@ async def _cancel_execution(graph_exec_id: str):
     )
     node_execs = [
         node_exec.model_copy(update={"status": execution_db.ExecutionStatus.TERMINATED})
-        for node_exec in await execution_db.get_node_execution_results(
+        for node_exec in await execution_db.get_node_executions(
             graph_exec_id=graph_exec_id,
             statuses=[
                 execution_db.ExecutionStatus.QUEUED,


### PR DESCRIPTION
Currently, the agent/graph execution engine is consuming the execution queue and acknowledges the message after fully completing its execution or failing it. 

However, in the case of the agent executor failing due to a hardware/resource issue, or the executor did not manage to acknowledge the execution message. Another agent executor will pick it up and start the execution again from the beginning. 

The scope of this PR is to make the next executor pick up the next work to continue the pre-existing execution instead of starting it all over from the beginning. 

### Changes 🏗️

* Removed `start_node_execs` from `GraphExecutionEntry`
* Populate the starting graph node from the DB query instead (fetching Running & Queued node executions).
* Removed `get_incomplete_node_executions` from DB manager.
* Use get_node_executions with a status filter instead.
* Allow graph execution to end in non-FAILED/COMPLETED status, e.g, when the executor is interrupted, it should be stuck in the running status, and let other executors continue the task.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run an agent, stop the executor midway, re-reun the executor, the execution should be continued instead of restarted.
