### PR TITLE
fix(backend): Avoid broken process pool by not failing process initializer

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -1097,14 +1097,16 @@ class ExecutionManager(AppProcess):
 def get_db_client() -> "DatabaseManagerClient":
     from backend.executor import DatabaseManagerClient
 
-    return get_service_client(DatabaseManagerClient)
+    # Disable health check for the DB client to avoid breaking process initializer.
+    return get_service_client(DatabaseManagerClient, health_check=False)
 
 
 @thread_cached
 def get_notification_service() -> "NotificationManagerClient":
     from backend.notifications import NotificationManagerClient
 
-    return get_service_client(NotificationManagerClient)
+    # Disable health check for the DB client to avoid breaking process initializer.
+    return get_service_client(NotificationManagerClient, health_check=False)
 
 
 def send_execution_update(entry: GraphExecution | NodeExecutionResult | None):

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -247,6 +247,7 @@ ASC = TypeVar("ASC", bound=AppServiceClient)
 def get_service_client(
     service_client_type: Type[ASC],
     call_timeout: int | None = api_call_timeout,
+    health_check: bool = True,
 ) -> ASC:
     class DynamicClient:
         def __init__(self):
@@ -351,7 +352,8 @@ def get_service_client(
                 return sync_method
 
     client = cast(ASC, DynamicClient())
-    client.health_check()
+    if health_check:
+        client.health_check()
 
     return client
 


### PR DESCRIPTION
Process initializer on the process pool should never fail, but we do network-related stuff there.
This cause the pool to be in a broken state.

### Changes 🏗️

Remove the health check step on process initializer.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Existing CI test
