### PR TITLE
feat(backend): Introduce late execution check scheduled job

### DIFF
--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -7,6 +7,7 @@ from backend.data.execution import (
     create_graph_execution,
     get_graph_execution,
     get_graph_execution_meta,
+    get_graph_executions,
     get_latest_node_execution,
     get_node_executions,
     update_graph_execution_start_time,
@@ -86,6 +87,7 @@ class DatabaseManager(AppService):
 
     # Executions
     get_graph_execution = _(get_graph_execution)
+    get_graph_executions = _(get_graph_executions)
     get_graph_execution_meta = _(get_graph_execution_meta)
     create_graph_execution = _(create_graph_execution)
     get_node_executions = _(get_node_executions)
@@ -142,6 +144,7 @@ class DatabaseManagerClient(AppServiceClient):
 
     # Executions
     get_graph_execution = _(d.get_graph_execution)
+    get_graph_executions = _(d.get_graph_executions)
     get_graph_execution_meta = _(d.get_graph_execution_meta)
     create_graph_execution = _(d.create_graph_execution)
     get_node_executions = _(d.get_node_executions)

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -89,7 +89,7 @@ class LateExecutionException(Exception):
     pass
 
 
-def report_late_executions():
+def report_late_executions() -> str:
     late_executions = execution_utils.get_db_client().get_graph_executions(
         statuses=[ExecutionStatus.QUEUED],
         created_time_gte=datetime.now(timezone.utc)
@@ -100,11 +100,7 @@ def report_late_executions():
     )
 
     if not late_executions:
-        logger.info(
-            ">>>>>>>>>>>> No late executions detected. "
-            f"Last check was {config.execution_late_notification_checkrange_secs} seconds ago."
-        )
-        return
+        return "No late executions detected."
 
     num_late_executions = len(late_executions)
     num_users = len(set([r.user_id for r in late_executions]))
@@ -116,6 +112,7 @@ def report_late_executions():
     )
     logger.error(error)
     sentry_alert(error)
+    return str(error)
 
 
 def process_existing_batches(**kwargs):
@@ -337,7 +334,7 @@ class Scheduler(AppService):
 
     @expose
     def execute_report_late_executions(self):
-        report_late_executions()
+        return report_late_executions()
 
 
 class SchedulerClient(AppServiceClient):

--- a/autogpt_platform/backend/backend/notifications/notifications.py
+++ b/autogpt_platform/backend/backend/notifications/notifications.py
@@ -113,13 +113,6 @@ def create_notification_config() -> RabbitMQConfig:
 
 
 @thread_cached
-def get_scheduler():
-    from backend.executor.scheduler import SchedulerClient
-
-    return get_service_client(SchedulerClient)
-
-
-@thread_cached
 def get_db():
     from backend.executor.database import DatabaseManagerClient
 
@@ -714,22 +707,6 @@ class NotificationManager(AppService):
         self.run_and_wait(self.rabbitmq_service.connect())
 
         logger.info(f"[{self.service_name}] Started notification service")
-
-        # Set up scheduler for batch processing of all notification types
-        # this can be changed later to spawn different cleanups on different schedules
-        try:
-            get_scheduler().add_batched_notification_schedule(
-                notification_types=list(NotificationType),
-                data={},
-                cron="0 * * * *",
-            )
-            # get_scheduler().add_weekly_notification_schedule(
-            #     # weekly on Friday at 12pm
-            #     cron="0 12 * * 5",
-            # )
-            logger.info("Scheduled notification cleanup")
-        except Exception as e:
-            logger.error(f"Error scheduling notification cleanup: {e}")
 
         # Set up queue consumers
         channel = self.run_and_wait(self.rabbit.get_channel())

--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -22,3 +22,8 @@ def sentry_init():
             ),
         ],
     )
+
+
+def sentry_alert(error: Exception):
+    sentry_sdk.capture_exception(error)
+    sentry_sdk.flush()

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -121,6 +121,14 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         default=60 * 60 * 24,
         description="Time in seconds after which the execution counter is reset.",
     )
+    execution_late_notification_threshold_secs: int = Field(
+        default=5 * 60,
+        description="Time in seconds after which the execution stuck on QUEUED status is considered late.",
+    )
+    execution_late_notification_checkrange_secs: int = Field(
+        default=60 * 60,
+        description="Time in seconds for how far back to check for the late executions.",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -25,7 +25,7 @@ class SpinTestServer:
         self.db_api = DatabaseManager()
         self.exec_manager = ExecutionManager()
         self.agent_server = AgentServer()
-        self.scheduler = Scheduler()
+        self.scheduler = Scheduler(register_system_tasks=False)
         self.notif_manager = NotificationManager()
 
     @staticmethod

--- a/autogpt_platform/backend/migrations/20250507025350_execution_created_at_index/migration.sql
+++ b/autogpt_platform/backend/migrations/20250507025350_execution_created_at_index/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "AgentGraphExecution_createdAt_idx" ON "AgentGraphExecution"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentNodeExecution_addedTime_idx" ON "AgentNodeExecution"("addedTime");

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -352,6 +352,7 @@ model AgentGraphExecution {
 
   @@index([agentGraphId, agentGraphVersion])
   @@index([userId])
+  @@index([createdAt])
 }
 
 // This model describes the execution of an AgentNode.
@@ -378,6 +379,7 @@ model AgentNodeExecution {
 
   @@index([agentGraphExecutionId])
   @@index([agentNodeId])
+  @@index([addedTime])
 }
 
 // This model describes the output of an AgentNodeExecution.


### PR DESCRIPTION
Introduce a late execution check scheduled job. The late threshold duration is configurable.
This initial version only reports the error to Sentry.

### Changes 🏗️

* Added late execution check scheduled job
* Move the registration weekly notification processing job out of API call and calling it directly from the scheduler service.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual firing of scheduled job through an exposed API
