### PR TITLE
fix(backend): Continue stats accounting on aborted or broken executions

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -82,7 +82,7 @@ class GraphExecutionMeta(BaseDbModel):
             default=0,
             description="Seconds from start to end of run",
         )
-        duration_cpu: float = Field(
+        duration_cpu_only: float = Field(
             default=0,
             description="CPU sec of duration",
         )
@@ -90,7 +90,7 @@ class GraphExecutionMeta(BaseDbModel):
             default=0,
             description="Seconds of total node runtime",
         )
-        node_exec_time_cpu: float = Field(
+        node_exec_time_cpu_only: float = Field(
             default=0,
             description="CPU sec of node_exec_time",
         )
@@ -111,9 +111,9 @@ class GraphExecutionMeta(BaseDbModel):
             return GraphExecutionStats(
                 cost=self.cost,
                 walltime=self.duration,
-                cputime=self.duration_cpu,
+                cputime=self.duration_cpu_only,
                 nodes_walltime=self.node_exec_time,
-                nodes_cputime=self.node_exec_time_cpu,
+                nodes_cputime=self.node_exec_time_cpu_only,
                 node_count=self.node_exec_count,
                 node_error_count=self.node_error_count,
                 error=self.error,
@@ -151,9 +151,9 @@ class GraphExecutionMeta(BaseDbModel):
                 GraphExecutionMeta.Stats(
                     cost=stats.cost,
                     duration=stats.walltime,
-                    duration_cpu=stats.cputime,
+                    duration_cpu_only=stats.cputime,
                     node_exec_time=stats.nodes_walltime,
-                    node_exec_time_cpu=stats.nodes_cputime,
+                    node_exec_time_cpu_only=stats.nodes_cputime,
                     node_exec_count=stats.node_count,
                     node_error_count=stats.node_error_count,
                     error=(

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -68,23 +68,6 @@ class GraphExecutionMeta(BaseDbModel):
     started_at: datetime
     ended_at: datetime
 
-    """
-        error: Optional[Exception | str] = None
-        walltime: float = Field(
-            default=0, description="Time between start and end of run (seconds)"
-        )
-        cputime: float = 0
-        nodes_walltime: float = Field(
-            default=0, description="Total node execution time (seconds)"
-        )
-        nodes_cputime: float = 0
-        node_count: int = Field(default=0, description="Total number of node executions")
-        node_error_count: int = Field(
-            default=0, description="Total number of errors generated"
-        )
-        cost: int = Field(default=0, description="Total execution cost (cents)")
-    """
-
     class Stats(BaseModel):
         model_config = ConfigDict(
             extra="allow",

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -634,7 +634,12 @@ class Executor:
             return
 
         timing_info, (exec_stats, status, error) = cls._on_graph_execution(
-            graph_exec, cancel, log_metadata
+            graph_exec=graph_exec,
+            cancel=cancel,
+            log_metadata=log_metadata,
+            execution_stats=(
+                exec_meta.stats.to_db() if exec_meta.stats else GraphExecutionStats()
+            ),
         )
         exec_stats.walltime = timing_info.wall_time
         exec_stats.cputime = timing_info.cpu_time
@@ -705,6 +710,7 @@ class Executor:
         graph_exec: GraphExecutionEntry,
         cancel: threading.Event,
         log_metadata: LogMetadata,
+        execution_stats: GraphExecutionStats,
     ) -> tuple[GraphExecutionStats, ExecutionStatus, Exception | None]:
         """
         Returns:
@@ -712,7 +718,6 @@ class Executor:
             ExecutionStatus: The final status of the graph execution.
             Exception | None: The error that occurred during the execution, if any.
         """
-        execution_stats = GraphExecutionStats()
         execution_status = ExecutionStatus.RUNNING
         error = None
         finished = False

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -259,7 +259,9 @@ export type GraphExecutionMeta = {
   stats?: {
     cost: number;
     duration: number;
+    duration_cpu_only: number;
     node_exec_time: number;
+    node_exec_time_cpu_only: number;
     node_exec_count: number;
   };
 };


### PR DESCRIPTION
This is a follow-up to https://github.com/Significant-Gravitas/AutoGPT/pull/9903

The continued graph execution restarted all the execution stats from zero, making the execution stats misleading.

### Changes 🏗️

Continue the execution stats when continuing the graph execution.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Existing tests, manual graph run with the graph execution aborted midway.