### PR TITLE
fix(frontend): Catch exception on agent listing page

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { AgentsSection } from "@/components/agptui/composite/AgentsSection";
 import { BecomeACreator } from "@/components/agptui/BecomeACreator";
 import { Separator } from "@/components/ui/separator";
 import { Metadata } from "next";
-import getServerSupabase from "@/lib/supabase/getServerSupabase";
+import getServerUser from "@/lib/supabase/getServerUser";
 
 export async function generateMetadata({
   params,
@@ -44,9 +44,7 @@ export default async function Page({
     // We are using slug as we know its has been sanitized and is not null
     search_query: agent.slug.replace(/-/g, " "),
   });
-  const {
-    data: { user },
-  } = await getServerSupabase().auth.getUser();
+  const { user } = await getServerUser();
   const libraryAgent = user
     ? await api.getLibraryAgentByStoreListingVersionID(
         agent.store_listing_version_id,

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
@@ -37,6 +37,7 @@ export default async function Page({
   params: { creator: string; slug: string };
 }) {
   const creator_lower = params.creator.toLowerCase();
+  const { user } = await getServerUser();
   const api = new BackendAPI();
   const agent = await api.getStoreAgent(creator_lower, params.slug);
   const otherAgents = await api.getStoreAgents({ creator: creator_lower });
@@ -44,7 +45,6 @@ export default async function Page({
     // We are using slug as we know its has been sanitized and is not null
     search_query: agent.slug.replace(/-/g, " "),
   });
-  const { user } = await getServerUser();
   const libraryAgent = user
     ? await api.getLibraryAgentByStoreListingVersionID(
         agent.store_listing_version_id,

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
@@ -46,9 +46,12 @@ export default async function Page({
     search_query: agent.slug.replace(/-/g, " "),
   });
   const libraryAgent = user
-    ? await api.getLibraryAgentByStoreListingVersionID(
-        agent.store_listing_version_id,
-      )
+    ? await api
+        .getLibraryAgentByStoreListingVersionID(agent.store_listing_version_id)
+        .catch((error) => {
+          console.error("Failed to fetch library agent:", error);
+          return null;
+        })
     : null;
 
   const breadcrumbs = [


### PR DESCRIPTION
Listing page throws exception on deployment because of supabase auth issue.

### Changes 🏗️

Catch the exception when getting library agent. This reverts the behavior of listing page and it'll always show "Add to Library" when user is logged in.

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] ...

