### PR TITLE
fix(backend): Unbreak existing Agent Executor nodes

### DIFF
--- a/autogpt_platform/backend/migrations/20250512104735_rename_agent_executor_node_input/migration.sql
+++ b/autogpt_platform/backend/migrations/20250512104735_rename_agent_executor_node_input/migration.sql
@@ -1,0 +1,9 @@
+-- Rename 'data' input to 'inputs' on all Agent Executor nodes
+UPDATE "AgentNode" AS node
+SET    "constantInput" = jsonb_set(
+         "constantInput",
+         '{inputs}',
+         "constantInput"->'data'
+       ) - 'data'
+WHERE  node."agentBlockId" = 'e189baac-8c20-45a1-94a7-55177ea42565'
+AND    node."constantInput" ? 'data';


### PR DESCRIPTION
- Follow-up fix for #9862

### Changes 🏗️

- Rename the stored `data` input field to `inputs` on all Agent Executor nodes in the DB

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Dry-run the query in Supabase to verify that the data operation works
  - [x] CI
