### PR TITLE
fix(backend): Change library agents fetch sort from version to updatedAt

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -967,7 +967,7 @@ async def get_my_agents(
 
         library_agents = await prisma.models.LibraryAgent.prisma().find_many(
             where=search_filter,
-            order=[{"agentGraphVersion": "desc"}],
+            order=[{"updatedAt": "desc"}],
             skip=(page - 1) * page_size,
             take=page_size,
             include={"AgentGraph": True},


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

### Changes 🏗️
This pull request includes a small change to the `get_my_agents` function in `autogpt_platform/backend/backend/server/v2/store/db.py`. The change updates the sorting order for retrieving library agents to use the `updatedAt` field instead of `agentGraphVersion`.

This aligns with the later sorting that is applied to the fetched page in the frontend.

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [ ] ...

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
