### PR TITLE
fix(frontend): Re-subscribe on WebSocket re-connect

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
@@ -140,6 +140,7 @@ export default function AgentRunsPage(): React.ReactElement {
     }
   }, [api, agentID, getGraphVersion, graph, selectedView, isFirstLoad, agent]);
 
+  // Initial load
   useEffect(() => {
     fetchAgents();
   }, []);
@@ -148,9 +149,13 @@ export default function AgentRunsPage(): React.ReactElement {
   useEffect(() => {
     if (!agent) return;
 
-    // Subscribe to all executions for this agent
-    api.subscribeToGraphExecutions(agent.graph_id);
-  }, [api, agent]);
+    return api.onWebSocketConnect(() => {
+      fetchAgents(); // Sync up on (re)connect
+
+      // Subscribe to all executions for this agent
+      api.subscribeToGraphExecutions(agent.graph_id);
+    });
+  }, [api, agent, fetchAgents]);
 
   // Handle execution updates
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
@@ -197,17 +197,21 @@ export default function AgentRunsPage(): React.ReactElement {
     };
   }, [api, agent?.graph_id, selectedView.id]);
 
-  // Load selectedRun based on selectedView; refresh on agent refresh
+  // Pre-load selectedRun based on selectedView
   useEffect(() => {
-    if (selectedView.type != "run" || !selectedView.id || !agent) return;
+    if (selectedView.type != "run" || !selectedView.id) return;
 
     const newSelectedRun = agentRuns.find((run) => run.id == selectedView.id);
     if (selectedView.id !== selectedRun?.id) {
       // Pull partial data from "cache" while waiting for the rest to load
       setSelectedRun(newSelectedRun ?? null);
     }
+  }, [api, selectedView, agentRuns, selectedRun?.id]);
 
-    // Load/refresh the view, even if selected view doesn't change
+  // Load selectedRun based on selectedView; refresh on agent refresh
+  useEffect(() => {
+    if (selectedView.type != "run" || !selectedView.id || !agent) return;
+
     api
       .getGraphExecutionInfo(agent.graph_id, selectedView.id)
       .then(async (run) => {
@@ -215,7 +219,7 @@ export default function AgentRunsPage(): React.ReactElement {
         await getGraphVersion(run.graph_id, run.graph_version);
         setSelectedRun(run);
       });
-  }, [api, selectedView, agent, agentRuns, selectedRun?.id, getGraphVersion]);
+  }, [api, selectedView, agent, getGraphVersion]);
 
   const fetchSchedules = useCallback(async () => {
     if (!agent) return;

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
@@ -160,7 +160,7 @@ export default function AgentRunsPage(): React.ReactElement {
 
   // Subscribe to WebSocket updates for agent runs
   useEffect(() => {
-    if (!agent) return;
+    if (!agent?.graph_id) return;
 
     return api.onWebSocketConnect(() => {
       refreshPageData(); // Sync up on (re)connect
@@ -168,7 +168,7 @@ export default function AgentRunsPage(): React.ReactElement {
       // Subscribe to all executions for this agent
       api.subscribeToGraphExecutions(agent.graph_id);
     });
-  }, [api, agent, refreshPageData]);
+  }, [api, agent?.graph_id, refreshPageData]);
 
   // Handle execution updates
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
@@ -1,5 +1,11 @@
 "use client";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useParams, useRouter } from "next/navigation";
 
 import { exportAsJSONFile } from "@/lib/utils";
@@ -41,7 +47,7 @@ export default function AgentRunsPage(): React.ReactElement {
 
   // ============================ STATE =============================
 
-  const [graph, setGraph] = useState<Graph | null>(null);
+  const [graph, setGraph] = useState<Graph | null>(null); // Graph version corresponding to LibraryAgent
   const [agent, setAgent] = useState<LibraryAgent | null>(null);
   const [agentRuns, setAgentRuns] = useState<GraphExecutionMeta[]>([]);
   const [schedules, setSchedules] = useState<Schedule[]>([]);
@@ -60,7 +66,8 @@ export default function AgentRunsPage(): React.ReactElement {
     useState<boolean>(false);
   const [confirmingDeleteAgentRun, setConfirmingDeleteAgentRun] =
     useState<GraphExecutionMeta | null>(null);
-  const { state, updateState } = useOnboarding();
+  const { state: onboardingState, updateState: updateOnboardingState } =
+    useOnboarding();
   const [copyAgentDialogOpen, setCopyAgentDialogOpen] = useState(false);
   const { toast } = useToast();
 
@@ -77,34 +84,43 @@ export default function AgentRunsPage(): React.ReactElement {
     setSelectedSchedule(schedule);
   }, []);
 
-  const [graphVersions, setGraphVersions] = useState<Record<number, Graph>>({});
+  const graphVersions = useRef<Record<number, Graph>>({});
+  const loadingGraphVersions = useRef<Record<number, Promise<Graph>>>({});
   const getGraphVersion = useCallback(
     async (graphID: GraphID, version: number) => {
-      if (graphVersions[version]) return graphVersions[version];
+      if (version in graphVersions.current)
+        return graphVersions.current[version];
+      if (version in loadingGraphVersions.current)
+        return loadingGraphVersions.current[version];
 
-      const graphVersion = await api.getGraph(graphID, version);
-      setGraphVersions((prev) => ({
-        ...prev,
-        [version]: graphVersion,
-      }));
-      return graphVersion;
+      const pendingGraph = api.getGraph(graphID, version).then((graph) => {
+        graphVersions.current[version] = graph;
+        return graph;
+      });
+      // Cache promise as well to avoid duplicate requests
+      loadingGraphVersions.current[version] = pendingGraph;
+      return pendingGraph;
     },
-    [api, graphVersions],
+    [api, graphVersions, loadingGraphVersions],
   );
 
   // Reward user for viewing results of their onboarding agent
   useEffect(() => {
-    if (!state || !selectedRun || state.completedSteps.includes("GET_RESULTS"))
+    if (
+      !onboardingState ||
+      !selectedRun ||
+      onboardingState.completedSteps.includes("GET_RESULTS")
+    )
       return;
 
-    if (selectedRun.id === state.onboardingAgentExecutionId) {
-      updateState({
-        completedSteps: [...state.completedSteps, "GET_RESULTS"],
+    if (selectedRun.id === onboardingState.onboardingAgentExecutionId) {
+      updateOnboardingState({
+        completedSteps: [...onboardingState.completedSteps, "GET_RESULTS"],
       });
     }
-  }, [selectedRun, state]);
+  }, [selectedRun, onboardingState, updateOnboardingState]);
 
-  const fetchAgents = useCallback(() => {
+  const refreshPageData = useCallback(() => {
     api.getLibraryAgent(agentID).then((agent) => {
       setAgent(agent);
 
@@ -119,43 +135,40 @@ export default function AgentRunsPage(): React.ReactElement {
         new Set(agentRuns.map((run) => run.graph_version)).forEach((version) =>
           getGraphVersion(agent.graph_id, version),
         );
-
-        if (!selectedView.id && isFirstLoad && agentRuns.length > 0) {
-          // only for first load or first execution
-          setIsFirstLoad(false);
-
-          const latestRun = agentRuns.reduce((latest, current) => {
-            if (latest.started_at && !current.started_at) return current;
-            else if (!latest.started_at) return latest;
-            return latest.started_at > current.started_at ? latest : current;
-          }, agentRuns[0]);
-          selectView({ type: "run", id: latestRun.id });
-        }
       });
     });
-    if (selectedView.type == "run" && selectedView.id && agent) {
-      api
-        .getGraphExecutionInfo(agent.graph_id, selectedView.id)
-        .then(setSelectedRun);
-    }
-  }, [api, agentID, getGraphVersion, graph, selectedView, isFirstLoad, agent]);
+  }, [api, agentID, getGraphVersion, graph]);
+
+  // On first load: select the latest run
+  useEffect(() => {
+    // Only for first load or first execution
+    if (selectedView.id || !isFirstLoad || agentRuns.length == 0) return;
+    setIsFirstLoad(false);
+
+    const latestRun = agentRuns.reduce((latest, current) => {
+      if (latest.started_at && !current.started_at) return current;
+      else if (!latest.started_at) return latest;
+      return latest.started_at > current.started_at ? latest : current;
+    }, agentRuns[0]);
+    selectView({ type: "run", id: latestRun.id });
+  }, [agentRuns, isFirstLoad, selectedView.id, selectView]);
 
   // Initial load
   useEffect(() => {
-    fetchAgents();
+    refreshPageData();
   }, []);
 
-  // Subscribe to websocket updates for agent runs
+  // Subscribe to WebSocket updates for agent runs
   useEffect(() => {
     if (!agent) return;
 
     return api.onWebSocketConnect(() => {
-      fetchAgents(); // Sync up on (re)connect
+      refreshPageData(); // Sync up on (re)connect
 
       // Subscribe to all executions for this agent
       api.subscribeToGraphExecutions(agent.graph_id);
     });
-  }, [api, agent, fetchAgents]);
+  }, [api, agent, refreshPageData]);
 
   // Handle execution updates
   useEffect(() => {
@@ -184,7 +197,7 @@ export default function AgentRunsPage(): React.ReactElement {
     };
   }, [api, agent?.graph_id, selectedView.id]);
 
-  // load selectedRun based on selectedView
+  // Load selectedRun based on selectedView; refresh on agent refresh
   useEffect(() => {
     if (selectedView.type != "run" || !selectedView.id || !agent) return;
 
@@ -192,15 +205,16 @@ export default function AgentRunsPage(): React.ReactElement {
     if (selectedView.id !== selectedRun?.id) {
       // Pull partial data from "cache" while waiting for the rest to load
       setSelectedRun(newSelectedRun ?? null);
-
-      // Ensure corresponding graph version is available before rendering I/O
-      api
-        .getGraphExecutionInfo(agent.graph_id, selectedView.id)
-        .then(async (run) => {
-          await getGraphVersion(run.graph_id, run.graph_version);
-          setSelectedRun(run);
-        });
     }
+
+    // Load/refresh the view, even if selected view doesn't change
+    api
+      .getGraphExecutionInfo(agent.graph_id, selectedView.id)
+      .then(async (run) => {
+        // Ensure corresponding graph version is available before rendering I/O
+        await getGraphVersion(run.graph_id, run.graph_version);
+        setSelectedRun(run);
+      });
   }, [api, selectedView, agent, agentRuns, selectedRun?.id, getGraphVersion]);
 
   const fetchSchedules = useCallback(async () => {
@@ -333,7 +347,7 @@ export default function AgentRunsPage(): React.ReactElement {
           selectedRun && (
             <AgentRunDetailsView
               agent={agent}
-              graph={graphVersions[selectedRun.graph_version] ?? graph}
+              graph={graphVersions.current[selectedRun.graph_version] ?? graph}
               run={selectedRun}
               agentActions={agentActions}
               onRun={(runID) => selectRun(runID)}

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -932,6 +932,7 @@ export default class BackendAPI {
   onWebSocketConnect(handler: () => void): () => void {
     this.wsOnConnectHandlers.add(handler);
 
+    this.connectWebSocket();
     if (this.webSocket?.readyState == WebSocket.OPEN) handler();
 
     // Return detacher
@@ -968,7 +969,7 @@ export default class BackendAPI {
           reject(error);
         };
 
-        this.webSocket.addEventListener("message", this._handleWSMessage);
+        this.webSocket.onmessage = (event) => this._handleWSMessage(event);
       } catch (error) {
         console.error("Error connecting to WebSocket:", error);
         reject(error);


### PR DESCRIPTION
- Resolves #9929

### Changes 🏗️

- Implement `BackendAPI.onWebSocketConnect(..)`

- Improve reliability and reactivity of `/library/agents/[id]`:
  - Refresh page data and (re)subscribe and on WebSocket (re)connect
  - Break up multi-action hooks into smaller parts to reduce unnecessary re-renders and requests
  - Reduce duplicate requests

- Use `onWebSocketConnect` in `useAgentGraph` as well

- Tidy up `autogpt-server-api/client.ts` a bit

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Go to `/library/agents/[id]`
  - Run the agent
    - [x] -> UI should update normally with execution updates
  - Suspend your computer, or restart the backend (or WS server) to break the connection
    - DO NOT REFRESH THE TAB ITSELF
    - [x] -> On reconnect, page data should be refreshed (check in network tab of dev tools)
  - Run the agent again
    - [x] -> UI should update normally with execution updates
