### PR TITLE
fix: Resolve `logger.warn(..)` deprecration warnings

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/middleware.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/middleware.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 async def auth_middleware(request: Request):
     if not settings.ENABLE_AUTH:
         # If authentication is disabled, allow the request to proceed
-        logger.warn("Auth disabled")
+        logger.warning("Auth disabled")
         return {}
 
     security = HTTPBearer()

--- a/classic/benchmark/agbenchmark/challenges/webarena.py
+++ b/classic/benchmark/agbenchmark/challenges/webarena.py
@@ -410,7 +410,7 @@ class WebArenaChallenge(BaseChallenge):
                 config, timeout, mock=bool(request.config.getoption("--mock"))
             ):
                 if not step.output:
-                    logger.warn(f"Step has no output: {step}")
+                    logger.warning(f"Step has no output: {step}")
                     continue
 
                 n_steps += 1


### PR DESCRIPTION
This small PR resolves the deprecation warnings of the `logger` library:
```
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] CI