### PR TITLE
fix(backend): Make URL pinning work with `extra_url_validator`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,9 +32,9 @@
       "type": "debugpy",
       "request": "launch",
       "module": "backend.app",
-      // "env": {
-      //   "ENV": "dev"
-      // },
+      "env": {
+        "OBJC_DISABLE_INITIALIZE_FORK_SAFETY": "YES"
+      },
       "envFile": "${workspaceFolder}/backend/.env",
       "justMyCode": false,
       "cwd": "${workspaceFolder}/autogpt_platform/backend"

--- a/autogpt_platform/backend/backend/util/request.py
+++ b/autogpt_platform/backend/backend/util/request.py
@@ -237,10 +237,10 @@ class Requests:
             headers.update(self.extra_headers)
 
         # Force the Host header to the original hostname
-        if urlparse(pinned_url).hostname not in self.trusted_origins:
+        if (pinned_hostname := urlparse(pinned_url).hostname) not in self.trusted_origins:
             headers["Host"] = original_hostname
         else:
-            headers["Host"] = urlparse(pinned_url).hostname
+            headers["Host"] = pinned_hostname
 
         # Create a fresh session & mount our HostSSLAdapter if pinned to IP
         session = req.Session()

--- a/autogpt_platform/backend/backend/util/request.py
+++ b/autogpt_platform/backend/backend/util/request.py
@@ -237,7 +237,10 @@ class Requests:
             headers.update(self.extra_headers)
 
         # Force the Host header to the original hostname
-        headers["Host"] = original_hostname
+        if urlparse(pinned_url).hostname not in self.trusted_origins:
+            headers["Host"] = original_hostname
+        else:
+            headers["Host"] = urlparse(pinned_url).hostname
 
         # Create a fresh session & mount our HostSSLAdapter if pinned to IP
         session = req.Session()


### PR DESCRIPTION
Github Blocks use an URL transformer passed to `Requests` to convert web URLs to the API URLs. This doesn't always work with the anti-SSRF URL pinning mechanism that was implemented in #8531.

### Changes 🏗️
In `Requests.request(..)`:
- Apply `validate_url` *after* `extra_url_validator`, to prevent mismatch between `pinned_url` and `original_hostname`
- Simplify logic & add clarifying comments

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Tested the github blocks that had the issue
