### PR TITLE
fix(blocks): disable Twitter and Todoist blocks if their OAuth is not configured

### DIFF
--- a/autogpt_platform/backend/backend/blocks/todoist/comments.py
+++ b/autogpt_platform/backend/backend/blocks/todoist/comments.py
@@ -7,6 +7,7 @@ from typing_extensions import Optional
 from backend.blocks.todoist._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TODOIST_OAUTH_IS_CONFIGURED,
     TodoistCredentials,
     TodoistCredentialsField,
     TodoistCredentialsInput,
@@ -61,6 +62,7 @@ class TodoistCreateCommentBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistCreateCommentBlock.Input,
             output_schema=TodoistCreateCommentBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "content": "Test comment",
@@ -164,6 +166,8 @@ class TodoistGetCommentsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetCommentsBlock.Input,
             output_schema=TodoistGetCommentsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
+
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "id_type": {"discriminator": "task", "task_id": "2995104339"},
@@ -268,6 +272,7 @@ class TodoistGetCommentBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetCommentBlock.Input,
             output_schema=TodoistGetCommentBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "comment_id": "2992679862",
@@ -346,6 +351,7 @@ class TodoistUpdateCommentBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistUpdateCommentBlock.Input,
             output_schema=TodoistUpdateCommentBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "comment_id": "2992679862",
@@ -404,6 +410,7 @@ class TodoistDeleteCommentBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistDeleteCommentBlock.Input,
             output_schema=TodoistDeleteCommentBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "comment_id": "2992679862",

--- a/autogpt_platform/backend/backend/blocks/todoist/labels.py
+++ b/autogpt_platform/backend/backend/blocks/todoist/labels.py
@@ -4,6 +4,7 @@ from typing_extensions import Optional
 from backend.blocks.todoist._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TODOIST_OAUTH_IS_CONFIGURED,
     TodoistCredentials,
     TodoistCredentialsField,
     TodoistCredentialsInput,
@@ -42,6 +43,7 @@ class TodoistCreateLabelBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistCreateLabelBlock.Input,
             output_schema=TodoistCreateLabelBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "name": "Test Label",
@@ -130,6 +132,7 @@ class TodoistListLabelsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistListLabelsBlock.Input,
             output_schema=TodoistListLabelsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[
@@ -211,6 +214,7 @@ class TodoistGetLabelBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetLabelBlock.Input,
             output_schema=TodoistGetLabelBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "label_id": "2156154810",
@@ -293,6 +297,7 @@ class TodoistUpdateLabelBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistUpdateLabelBlock.Input,
             output_schema=TodoistUpdateLabelBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "label_id": "2156154810",
@@ -364,6 +369,7 @@ class TodoistDeleteLabelBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistDeleteLabelBlock.Input,
             output_schema=TodoistDeleteLabelBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "label_id": "2156154810",
@@ -415,6 +421,7 @@ class TodoistGetSharedLabelsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetSharedLabelsBlock.Input,
             output_schema=TodoistGetSharedLabelsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("labels", ["Label1", "Label2", "Label3"])],
@@ -471,6 +478,7 @@ class TodoistRenameSharedLabelsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistRenameSharedLabelsBlock.Input,
             output_schema=TodoistRenameSharedLabelsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "name": "OldLabel",
@@ -526,6 +534,7 @@ class TodoistRemoveSharedLabelsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistRemoveSharedLabelsBlock.Input,
             output_schema=TodoistRemoveSharedLabelsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "name": "LabelToRemove"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],

--- a/autogpt_platform/backend/backend/blocks/todoist/projects.py
+++ b/autogpt_platform/backend/backend/blocks/todoist/projects.py
@@ -4,6 +4,7 @@ from typing_extensions import Optional
 from backend.blocks.todoist._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TODOIST_OAUTH_IS_CONFIGURED,
     TodoistCredentials,
     TodoistCredentialsField,
     TodoistCredentialsInput,
@@ -35,6 +36,7 @@ class TodoistListProjectsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistListProjectsBlock.Input,
             output_schema=TodoistListProjectsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
             },
@@ -150,6 +152,7 @@ class TodoistCreateProjectBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistCreateProjectBlock.Input,
             output_schema=TodoistCreateProjectBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "name": "Test Project"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],
@@ -230,6 +233,7 @@ class TodoistGetProjectBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetProjectBlock.Input,
             output_schema=TodoistGetProjectBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "project_id": "2203306141",
@@ -332,6 +336,7 @@ class TodoistUpdateProjectBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistUpdateProjectBlock.Input,
             output_schema=TodoistUpdateProjectBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "project_id": "2203306141",
@@ -413,6 +418,7 @@ class TodoistDeleteProjectBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistDeleteProjectBlock.Input,
             output_schema=TodoistDeleteProjectBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "project_id": "2203306141",
@@ -481,6 +487,7 @@ class TodoistListCollaboratorsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistListCollaboratorsBlock.Input,
             output_schema=TodoistListCollaboratorsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "project_id": "2203306141",

--- a/autogpt_platform/backend/backend/blocks/todoist/sections.py
+++ b/autogpt_platform/backend/backend/blocks/todoist/sections.py
@@ -4,6 +4,7 @@ from typing_extensions import Optional
 from backend.blocks.todoist._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TODOIST_OAUTH_IS_CONFIGURED,
     TodoistCredentials,
     TodoistCredentialsField,
     TodoistCredentialsInput,
@@ -36,6 +37,7 @@ class TodoistListSectionsBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistListSectionsBlock.Input,
             output_schema=TodoistListSectionsBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "project_id": "2203306141",
@@ -207,6 +209,7 @@ class TodoistGetSectionBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetSectionBlock.Input,
             output_schema=TodoistGetSectionBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "section_id": "7025"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[
@@ -275,6 +278,7 @@ class TodoistDeleteSectionBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistDeleteSectionBlock.Input,
             output_schema=TodoistDeleteSectionBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "section_id": "7025"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],

--- a/autogpt_platform/backend/backend/blocks/todoist/tasks.py
+++ b/autogpt_platform/backend/backend/blocks/todoist/tasks.py
@@ -7,6 +7,7 @@ from typing_extensions import Optional
 from backend.blocks.todoist._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TODOIST_OAUTH_IS_CONFIGURED,
     TodoistCredentials,
     TodoistCredentialsField,
     TodoistCredentialsInput,
@@ -86,6 +87,7 @@ class TodoistCreateTaskBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistCreateTaskBlock.Input,
             output_schema=TodoistCreateTaskBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "content": "Buy groceries",
@@ -217,6 +219,7 @@ class TodoistGetTasksBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetTasksBlock.Input,
             output_schema=TodoistGetTasksBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "project_id": "2203306141",
@@ -309,6 +312,7 @@ class TodoistGetTaskBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistGetTaskBlock.Input,
             output_schema=TodoistGetTaskBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "task_id": "2995104339"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[
@@ -428,6 +432,7 @@ class TodoistUpdateTaskBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistUpdateTaskBlock.Input,
             output_schema=TodoistUpdateTaskBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "task_id": "2995104339",
@@ -467,32 +472,24 @@ class TodoistUpdateTaskBlock(Block):
             )
 
             task_updates = {}
-            if input_data.content is not None:
-                task_updates["content"] = input_data.content
-            if input_data.description is not None:
-                task_updates["description"] = input_data.description
-            if input_data.project_id is not None:
-                task_updates["project_id"] = input_data.project_id
-            if input_data.section_id is not None:
-                task_updates["section_id"] = input_data.section_id
-            if input_data.parent_id is not None:
-                task_updates["parent_id"] = input_data.parent_id
-            if input_data.order is not None:
-                task_updates["order"] = input_data.order
-            if input_data.labels is not None:
-                task_updates["labels"] = input_data.labels
-            if input_data.priority is not None:
-                task_updates["priority"] = input_data.priority
-            if due_date is not None:
-                task_updates["due_date"] = due_date
-            if deadline_date is not None:
-                task_updates["deadline_date"] = deadline_date
-            if input_data.assignee_id is not None:
-                task_updates["assignee_id"] = input_data.assignee_id
-            if input_data.duration is not None:
-                task_updates["duration"] = input_data.duration
-            if input_data.duration_unit is not None:
-                task_updates["duration_unit"] = input_data.duration_unit
+            update_fields = {
+                "content": input_data.content,
+                "description": input_data.description,
+                "project_id": input_data.project_id,
+                "section_id": input_data.section_id,
+                "parent_id": input_data.parent_id,
+                "order": input_data.order,
+                "labels": input_data.labels,
+                "priority": input_data.priority,
+                "due_date": due_date,
+                "deadline_date": deadline_date,
+                "assignee_id": input_data.assignee_id,
+                "duration": input_data.duration,
+                "duration_unit": input_data.duration_unit,
+            }
+
+            # Filter out None values
+            task_updates = {k: v for k, v in update_fields.items() if v is not None}
 
             self.update_task(
                 credentials,
@@ -526,6 +523,7 @@ class TodoistCloseTaskBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistCloseTaskBlock.Input,
             output_schema=TodoistCloseTaskBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "task_id": "2995104339"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],
@@ -576,6 +574,7 @@ class TodoistReopenTaskBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistReopenTaskBlock.Input,
             output_schema=TodoistReopenTaskBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "task_id": "2995104339"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[
@@ -628,6 +627,7 @@ class TodoistDeleteTaskBlock(Block):
             categories={BlockCategory.PRODUCTIVITY},
             input_schema=TodoistDeleteTaskBlock.Input,
             output_schema=TodoistDeleteTaskBlock.Output,
+            disabled= not TODOIST_OAUTH_IS_CONFIGURED,
             test_input={"credentials": TEST_CREDENTIALS_INPUT, "task_id": "2995104339"},
             test_credentials=TEST_CREDENTIALS,
             test_output=[

--- a/autogpt_platform/backend/backend/blocks/twitter/direct_message/direct_message_lookup.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/direct_message/direct_message_lookup.py
@@ -1,4 +1,4 @@
-# Todo : Add new Type support
+# Todo : Add new Type support, and disable block if it's Oauth is not configured
 
 # from typing import cast
 # import tweepy

--- a/autogpt_platform/backend/backend/blocks/twitter/direct_message/manage_direct_message.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/direct_message/manage_direct_message.py
@@ -1,4 +1,4 @@
-# Todo : Add new Type support
+# Todo : Add new Type support, and disable block if it's Oauth is not configured
 
 # from typing import cast
 

--- a/autogpt_platform/backend/backend/blocks/twitter/lists/list_follows.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/lists/list_follows.py
@@ -4,6 +4,7 @@ import tweepy
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -44,6 +45,7 @@ class TwitterUnfollowListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUnfollowListBlock.Input,
             output_schema=TwitterUnfollowListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={"list_id": "123456789", "credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[
@@ -106,6 +108,7 @@ class TwitterFollowListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterFollowListBlock.Input,
             output_schema=TwitterFollowListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={"list_id": "123456789", "credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[

--- a/autogpt_platform/backend/backend/blocks/twitter/lists/list_lookup.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/lists/list_lookup.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -63,6 +64,7 @@ class TwitterGetListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetListBlock.Input,
             output_schema=TwitterGetListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "list_id": "84839422",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -220,6 +222,7 @@ class TwitterGetOwnedListsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetOwnedListsBlock.Input,
             output_schema=TwitterGetOwnedListsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "user_id": "2244994945",
                 "max_results": 10,

--- a/autogpt_platform/backend/backend/blocks/twitter/lists/list_members.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/lists/list_members.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -65,6 +66,7 @@ class TwitterRemoveListMemberBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterRemoveListMemberBlock.Input,
             output_schema=TwitterRemoveListMemberBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "list_id": "123456789",
                 "user_id": "987654321",
@@ -138,6 +140,7 @@ class TwitterAddListMemberBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterAddListMemberBlock.Input,
             output_schema=TwitterAddListMemberBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "list_id": "123456789",
                 "user_id": "987654321",
@@ -229,6 +232,7 @@ class TwitterGetListMembersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetListMembersBlock.Input,
             output_schema=TwitterGetListMembersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "list_id": "123456789",
                 "max_results": 2,
@@ -405,6 +409,7 @@ class TwitterGetListMembershipsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetListMembershipsBlock.Input,
             output_schema=TwitterGetListMembershipsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "user_id": "123456789",
                 "max_results": 1,

--- a/autogpt_platform/backend/backend/blocks/twitter/lists/list_tweets_lookup.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/lists/list_tweets_lookup.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -81,6 +82,7 @@ class TwitterGetListTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetListTweetsBlock.Input,
             output_schema=TwitterGetListTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "list_id": "84839422",
                 "max_results": 1,

--- a/autogpt_platform/backend/backend/blocks/twitter/lists/manage_lists.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/lists/manage_lists.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -41,6 +42,7 @@ class TwitterDeleteListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterDeleteListBlock.Input,
             output_schema=TwitterDeleteListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={"list_id": "1234567890", "credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],
@@ -118,6 +120,7 @@ class TwitterUpdateListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUpdateListBlock.Input,
             output_schema=TwitterUpdateListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "list_id": "1234567890",
                 "name": "Updated List Name",
@@ -214,6 +217,7 @@ class TwitterCreateListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterCreateListBlock.Input,
             output_schema=TwitterCreateListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "name": "New List Name",
                 "description": "New List Description",

--- a/autogpt_platform/backend/backend/blocks/twitter/lists/pinned_lists.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/lists/pinned_lists.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -52,6 +53,7 @@ class TwitterUnpinListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUnpinListBlock.Input,
             output_schema=TwitterUnpinListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={"list_id": "123456789", "credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],
@@ -115,6 +117,7 @@ class TwitterPinListBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterPinListBlock.Input,
             output_schema=TwitterPinListBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={"list_id": "123456789", "credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("success", True)],
@@ -184,6 +187,7 @@ class TwitterGetPinnedListsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetPinnedListsBlock.Input,
             output_schema=TwitterGetPinnedListsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "expansions": None,
                 "list_fields": None,

--- a/autogpt_platform/backend/backend/blocks/twitter/spaces/search_spaces.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/spaces/search_spaces.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -78,6 +79,7 @@ class TwitterSearchSpacesBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterSearchSpacesBlock.Input,
             output_schema=TwitterSearchSpacesBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "query": "tech",
                 "max_results": 1,

--- a/autogpt_platform/backend/backend/blocks/twitter/spaces/spaces_lookup.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/spaces/spaces_lookup.py
@@ -7,6 +7,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -94,6 +95,7 @@ class TwitterGetSpacesBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetSpacesBlock.Input,
             output_schema=TwitterGetSpacesBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "identifier": {
                     "discriminator": "space_list",
@@ -249,6 +251,7 @@ class TwitterGetSpaceByIdBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetSpaceByIdBlock.Input,
             output_schema=TwitterGetSpaceByIdBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "space_id": "1DXxyRYNejbKM",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -409,6 +412,7 @@ class TwitterGetSpaceBuyersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetSpaceBuyersBlock.Input,
             output_schema=TwitterGetSpaceBuyersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "space_id": "1DXxyRYNejbKM",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -537,6 +541,7 @@ class TwitterGetSpaceTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetSpaceTweetsBlock.Input,
             output_schema=TwitterGetSpaceTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "space_id": "1DXxyRYNejbKM",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/bookmark.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/bookmark.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -55,6 +56,7 @@ class TwitterBookmarkTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterBookmarkTweetBlock.Input,
             output_schema=TwitterBookmarkTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -147,6 +149,7 @@ class TwitterGetBookmarkedTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetBookmarkedTweetsBlock.Input,
             output_schema=TwitterGetBookmarkedTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "max_results": 2,
                 "pagination_token": None,
@@ -330,6 +333,7 @@ class TwitterRemoveBookmarkTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterRemoveBookmarkTweetBlock.Input,
             output_schema=TwitterRemoveBookmarkTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/hide.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/hide.py
@@ -3,6 +3,7 @@ import tweepy
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -38,6 +39,7 @@ class TwitterHideReplyBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterHideReplyBlock.Input,
             output_schema=TwitterHideReplyBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -109,6 +111,7 @@ class TwitterUnhideReplyBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUnhideReplyBlock.Input,
             output_schema=TwitterUnhideReplyBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/like.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/like.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -60,6 +61,7 @@ class TwitterLikeTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterLikeTweetBlock.Input,
             output_schema=TwitterLikeTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -159,6 +161,7 @@ class TwitterGetLikingUsersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetLikingUsersBlock.Input,
             output_schema=TwitterGetLikingUsersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "max_results": 1,
@@ -337,6 +340,7 @@ class TwitterGetLikedTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetLikedTweetsBlock.Input,
             output_schema=TwitterGetLikedTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "user_id": "1234567890",
                 "max_results": 2,
@@ -531,6 +535,7 @@ class TwitterUnlikeTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUnlikeTweetBlock.Input,
             output_schema=TwitterUnlikeTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/manage.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/manage.py
@@ -8,6 +8,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -131,6 +132,7 @@ class TwitterPostTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterPostTweetBlock.Input,
             output_schema=TwitterPostTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_text": "This is a test tweet.",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -263,6 +265,7 @@ class TwitterDeleteTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterDeleteTweetBlock.Input,
             output_schema=TwitterDeleteTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -357,6 +360,7 @@ class TwitterSearchRecentTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterSearchRecentTweetsBlock.Input,
             output_schema=TwitterSearchRecentTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "query": "from:twitterapi #twitterapi",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/quote.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/quote.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -86,6 +87,7 @@ class TwitterGetQuoteTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetQuoteTweetsBlock.Input,
             output_schema=TwitterGetQuoteTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "max_results": 2,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/retweet.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/retweet.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -52,6 +53,7 @@ class TwitterRetweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterRetweetBlock.Input,
             output_schema=TwitterRetweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -128,6 +130,7 @@ class TwitterRemoveRetweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterRemoveRetweetBlock.Input,
             output_schema=TwitterRemoveRetweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -231,6 +234,7 @@ class TwitterGetRetweetersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetRetweetersBlock.Input,
             output_schema=TwitterGetRetweetersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1234567890",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/timeline.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/timeline.py
@@ -7,6 +7,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -91,6 +92,7 @@ class TwitterGetUserMentionsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetUserMentionsBlock.Input,
             output_schema=TwitterGetUserMentionsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "user_id": "12345",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -332,6 +334,7 @@ class TwitterGetHomeTimelineBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetHomeTimelineBlock.Input,
             output_schema=TwitterGetHomeTimelineBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_CREDENTIALS_INPUT,
                 "max_results": 2,
@@ -568,6 +571,7 @@ class TwitterGetUserTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetUserTweetsBlock.Input,
             output_schema=TwitterGetUserTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "user_id": "12345",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/tweets/tweet_lookup.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/tweets/tweet_lookup.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -67,6 +68,7 @@ class TwitterGetTweetBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetTweetBlock.Input,
             output_schema=TwitterGetTweetBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_id": "1460323737035677698",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -229,6 +231,7 @@ class TwitterGetTweetsBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetTweetsBlock.Input,
             output_schema=TwitterGetTweetsBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "tweet_ids": ["1460323737035677698"],
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/users/blocks.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/users/blocks.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -64,6 +65,7 @@ class TwitterGetBlockedUsersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetBlockedUsersBlock.Input,
             output_schema=TwitterGetBlockedUsersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "max_results": 10,
                 "pagination_token": "",

--- a/autogpt_platform/backend/backend/blocks/twitter/users/follows.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/users/follows.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -55,6 +56,7 @@ class TwitterUnfollowUserBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUnfollowUserBlock.Input,
             output_schema=TwitterUnfollowUserBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "target_user_id": "12345",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -126,6 +128,7 @@ class TwitterFollowUserBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterFollowUserBlock.Input,
             output_schema=TwitterFollowUserBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "target_user_id": "12345",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -213,6 +216,7 @@ class TwitterGetFollowersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetFollowersBlock.Input,
             output_schema=TwitterGetFollowersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "target_user_id": "12345",
                 "max_results": 1,
@@ -386,6 +390,7 @@ class TwitterGetFollowingBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetFollowingBlock.Input,
             output_schema=TwitterGetFollowingBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "target_user_id": "12345",
                 "max_results": 1,

--- a/autogpt_platform/backend/backend/blocks/twitter/users/mutes.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/users/mutes.py
@@ -6,6 +6,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -55,6 +56,7 @@ class TwitterUnmuteUserBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterUnmuteUserBlock.Input,
             output_schema=TwitterUnmuteUserBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "target_user_id": "12345",
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -139,6 +141,7 @@ class TwitterGetMutedUsersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetMutedUsersBlock.Input,
             output_schema=TwitterGetMutedUsersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "max_results": 2,
                 "pagination_token": "",
@@ -289,6 +292,7 @@ class TwitterMuteUserBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterMuteUserBlock.Input,
             output_schema=TwitterMuteUserBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "target_user_id": "12345",
                 "credentials": TEST_CREDENTIALS_INPUT,

--- a/autogpt_platform/backend/backend/blocks/twitter/users/user_lookup.py
+++ b/autogpt_platform/backend/backend/blocks/twitter/users/user_lookup.py
@@ -7,6 +7,7 @@ from tweepy.client import Response
 from backend.blocks.twitter._auth import (
     TEST_CREDENTIALS,
     TEST_CREDENTIALS_INPUT,
+    TWITTER_OAUTH_IS_CONFIGURED,
     TwitterCredentials,
     TwitterCredentialsField,
     TwitterCredentialsInput,
@@ -75,6 +76,7 @@ class TwitterGetUserBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetUserBlock.Input,
             output_schema=TwitterGetUserBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "identifier": {"discriminator": "username", "username": "twitter"},
                 "credentials": TEST_CREDENTIALS_INPUT,
@@ -251,6 +253,7 @@ class TwitterGetUsersBlock(Block):
             categories={BlockCategory.SOCIAL},
             input_schema=TwitterGetUsersBlock.Input,
             output_schema=TwitterGetUsersBlock.Output,
+            disabled= not TWITTER_OAUTH_IS_CONFIGURED,
             test_input={
                 "identifier": {
                     "discriminator": "username_list",


### PR DESCRIPTION
I am disabling all the Twitter and Todoist blocks whose OAuth is not configured.

> I have already checked it locally. When OAuth is not set, the blocks do not appear in the block menu