### PR TITLE
fix(backend/blocks): Fix Exa search block not returning results

### DIFF
--- a/autogpt_platform/backend/backend/blocks/exa/helpers.py
+++ b/autogpt_platform/backend/backend/blocks/exa/helpers.py
@@ -10,12 +10,17 @@ class TextSettings(BaseModel):
         default=1000,
         description="Maximum number of characters to return",
         placeholder="1000",
+        alias="maxCharacters",
     )
     include_html_tags: bool = SchemaField(
         default=False,
         description="Whether to include HTML tags in the text",
         placeholder="False",
+        alias="includeHtmlTags",
     )
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class HighlightSettings(BaseModel):
@@ -23,12 +28,17 @@ class HighlightSettings(BaseModel):
         default=3,
         description="Number of sentences per highlight",
         placeholder="3",
+        alias="numSentences",
     )
     highlights_per_url: int = SchemaField(
         default=3,
         description="Number of highlights per URL",
         placeholder="3",
+        alias="highlightsPerUrl",
     )
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class SummarySettings(BaseModel):
@@ -37,6 +47,9 @@ class SummarySettings(BaseModel):
         description="Query string for summarization",
         placeholder="Enter query",
     )
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class ContentSettings(BaseModel):
@@ -52,3 +65,6 @@ class ContentSettings(BaseModel):
         default=SummarySettings(),
         description="Summary settings",
     )
+
+    class Config:
+        allow_population_by_field_name = True

--- a/autogpt_platform/backend/backend/blocks/exa/search.py
+++ b/autogpt_platform/backend/backend/blocks/exa/search.py
@@ -101,7 +101,7 @@ class ExaSearchBlock(Block):
             "query": input_data.query,
             "useAutoprompt": input_data.use_auto_prompt,
             "numResults": input_data.number_of_results,
-            "contents": input_data.contents.dict(),
+            "contents": input_data.contents.dict(by_alias=True),
         }
 
         date_field_mapping = {

--- a/autogpt_platform/backend/backend/blocks/exa/similar.py
+++ b/autogpt_platform/backend/backend/blocks/exa/similar.py
@@ -89,7 +89,7 @@ class ExaFindSimilarBlock(Block):
         payload = {
             "url": input_data.url,
             "numResults": input_data.number_of_results,
-            "contents": input_data.contents.dict(),
+            "contents": input_data.contents.dict(by_alias=True),
         }
 
         optional_field_mapping = {


### PR DESCRIPTION
## Summary
- ensure Exa search payload uses camelCase names
- convert Exa similar payload to use camelCase
- allow camelCase aliases for Exa content settings

## Testing
- `black autogpt_platform/backend/backend/blocks/exa/helpers.py autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py`
- `ruff check autogpt_platform/backend/backend/blocks/exa/helpers.py autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py`
