### PR TITLE
Fix Exa search block results

### DIFF
--- a/autogpt_platform/backend/backend/blocks/exa/helpers.py
+++ b/autogpt_platform/backend/backend/blocks/exa/helpers.py
@@ -1,8 +1,28 @@
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
 from backend.data.model import SchemaField
+
+
+def _to_camel_case(value: str) -> str:
+    parts = value.split("_")
+    return parts[0] + "".join(part.capitalize() for part in parts[1:])
+
+
+def to_camel_case_dict(data: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, val in data.items():
+        camel_key = _to_camel_case(key)
+        if isinstance(val, dict):
+            result[camel_key] = to_camel_case_dict(val)
+        elif isinstance(val, list):
+            result[camel_key] = [
+                to_camel_case_dict(v) if isinstance(v, dict) else v for v in val
+            ]
+        else:
+            result[camel_key] = val
+    return result
 
 
 class TextSettings(BaseModel):

--- a/autogpt_platform/backend/backend/blocks/exa/search.py
+++ b/autogpt_platform/backend/backend/blocks/exa/search.py
@@ -6,7 +6,7 @@ from backend.blocks.exa._auth import (
     ExaCredentialsField,
     ExaCredentialsInput,
 )
-from backend.blocks.exa.helpers import ContentSettings
+from backend.blocks.exa.helpers import ContentSettings, to_camel_case_dict
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import SchemaField
 from backend.util.request import requests
@@ -101,7 +101,7 @@ class ExaSearchBlock(Block):
             "query": input_data.query,
             "useAutoprompt": input_data.use_auto_prompt,
             "numResults": input_data.number_of_results,
-            "contents": input_data.contents.dict(),
+            "contents": to_camel_case_dict(input_data.contents.dict()),
         }
 
         date_field_mapping = {

--- a/autogpt_platform/backend/backend/blocks/exa/similar.py
+++ b/autogpt_platform/backend/backend/blocks/exa/similar.py
@@ -10,7 +10,7 @@ from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import SchemaField
 from backend.util.request import requests
 
-from .helpers import ContentSettings
+from .helpers import ContentSettings, to_camel_case_dict
 
 
 class ExaFindSimilarBlock(Block):
@@ -89,7 +89,7 @@ class ExaFindSimilarBlock(Block):
         payload = {
             "url": input_data.url,
             "numResults": input_data.number_of_results,
-            "contents": input_data.contents.dict(),
+            "contents": to_camel_case_dict(input_data.contents.dict()),
         }
 
         optional_field_mapping = {


### PR DESCRIPTION
## Summary
- ensure Exa search payload uses camelCase names
- convert Exa similar payload to use camelCase
- add util helper to convert settings to camelCase

## Testing
- `black autogpt_platform/backend/backend/blocks/exa/helpers.py autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py --line-length 88`
- `ruff check autogpt_platform/backend/backend/blocks/exa/helpers.py autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py`
- `poetry -C autogpt_platform/backend run pyright backend/blocks/exa/helpers.py backend/blocks/exa/search.py backend/blocks/exa/similar.py`