### PR TITLE
Remove Gmail thread includeSpamTrash

### DIFF
--- a/autogpt_platform/backend/backend/blocks/google/gmail.py
+++ b/autogpt_platform/backend/backend/blocks/google/gmail.py
@@ -542,9 +542,6 @@ class GmailGetThreadBlock(Block):
             ["https://www.googleapis.com/auth/gmail.readonly"]
         )
         threadId: str = SchemaField(description="Gmail thread ID")
-        includeSpamTrash: bool = SchemaField(
-            description="Include messages from Spam and Trash", default=False
-        )
 
     class Output(BlockSchema):
         thread: dict = SchemaField(
@@ -570,12 +567,10 @@ class GmailGetThreadBlock(Block):
         self, input_data: Input, *, credentials: GoogleCredentials, **kwargs
     ) -> BlockOutput:
         service = GmailReadBlock._build_service(credentials, **kwargs)
-        thread = self._get_thread(
-            service, input_data.threadId, input_data.includeSpamTrash
-        )
+        thread = self._get_thread(service, input_data.threadId)
         yield "thread", thread
 
-    def _get_thread(self, service, thread_id: str, include_spam_trash: bool) -> dict:
+    def _get_thread(self, service, thread_id: str) -> dict:
         thread = (
             service.users()
             .threads()
@@ -583,7 +578,6 @@ class GmailGetThreadBlock(Block):
                 userId="me",
                 id=thread_id,
                 format="full",
-                includeSpamTrash=include_spam_trash,
             )
             .execute()
         )

--- a/docs/content/platform/blocks/google/gmail.md
+++ b/docs/content/platform/blocks/google/gmail.md
@@ -151,14 +151,13 @@ Automatically removing the "Unread" label from emails after they have been proce
 A block that retrieves an entire Gmail thread.
 
 ### What it does
-Given a `threadId`, this block fetches all messages in that thread and decodes the text bodies. You can optionally include messages in Spam and Trash.
+Given a `threadId`, this block fetches all messages in that thread and decodes the text bodies.
 
 ### Inputs
 | Input | Description |
 |-------|-------------|
 | Credentials | The user's Gmail account credentials for authentication |
 | threadId | The ID of the thread to fetch |
-| includeSpamTrash | Whether to include messages from Spam and Trash |
 
 ### Outputs
 | Output | Description |


### PR DESCRIPTION
## Summary
- drop obsolete includeSpamTrash option from Gmail thread block
- update Gmail block docs

## Testing
- `ruff check autogpt_platform/backend/backend/blocks/google/gmail.py`