### PR TITLE
Fix Gmail blocks query error

### DIFF
--- a/docs/content/platform/blocks/google/gmail.md
+++ b/docs/content/platform/blocks/google/gmail.md
@@ -15,7 +15,7 @@ The block connects to the user's Gmail account using their credentials, performs
 | Input | Description |
 |-------|-------------|
 | Credentials | The user's Gmail account credentials for authentication |
-| Query | A search query to filter emails (e.g., "is:unread" for unread emails) |
+| Query | A search query to filter emails (e.g., "is:unread" for unread emails). Ignored if using only the `gmail.metadata` scope. |
 | Max Results | The maximum number of emails to retrieve |
 
 ### Outputs


### PR DESCRIPTION
## Summary
- handle gmail metadata scope in Gmail read
- handle metadata scope in Gmail get thread
- avoid missing payload when scope is metadata
- mention metadata scope limitation in documentation

## Testing
- `poetry run black backend/blocks/google/gmail.py`
- `poetry run isort backend/blocks/google/gmail.py`
- `poetry run ruff format backend/blocks/google/gmail.py`
- `poetry run format` *(fails: pyright errors)*