### PR TITLE
Fix redis config default and logging call

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/middleware.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/middleware.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 async def auth_middleware(request: Request):
     if not settings.ENABLE_AUTH:
         # If authentication is disabled, allow the request to proceed
-        logger.warn("Auth disabled")
+        logger.warning("Auth disabled")
         return {}
 
     security = HTTPBearer()

--- a/autogpt_platform/autogpt_libs/autogpt_libs/rate_limit/config.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/rate_limit/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class RateLimitSettings(BaseSettings):
     redis_host: str = Field(
-        default="redis://localhost:6379",
+        default="localhost",
         description="Redis host",
         validation_alias="REDIS_HOST",
     )


### PR DESCRIPTION
## Summary
- correct redis host default in rate limit settings
- use `logger.warning` in auth middleware instead of deprecated warn

## Testing
- `python -m py_compile autogpt_platform/autogpt_libs/autogpt_libs/auth/middleware.py autogpt_platform/autogpt_libs/autogpt_libs/rate_limit/config.py`