### PR TITLE
Fix Exa blocks handling of empty results

### DIFF
--- a/autogpt_platform/backend/backend/blocks/exa/contents.py
+++ b/autogpt_platform/backend/backend/blocks/exa/contents.py
@@ -82,7 +82,10 @@ class ExaContentsBlock(Block):
             response = requests.post(url, headers=headers, json=payload)
             response.raise_for_status()
             data = response.json()
-            yield "results", data.get("results", [])
+            results = data.get("results", [])
+            if not results:
+                yield "error", "results are empty"
+            else:
+                yield "results", results
         except Exception as e:
             yield "error", str(e)
-            yield "results", []

--- a/autogpt_platform/backend/backend/blocks/exa/search.py
+++ b/autogpt_platform/backend/backend/blocks/exa/search.py
@@ -136,8 +136,10 @@ class ExaSearchBlock(Block):
             response = requests.post(url, headers=headers, json=payload)
             response.raise_for_status()
             data = response.json()
-            # Extract just the results array from the response
-            yield "results", data.get("results", [])
+            results = data.get("results", [])
+            if not results:
+                yield "error", "results are empty"
+            else:
+                yield "results", results
         except Exception as e:
             yield "error", str(e)
-            yield "results", []

--- a/autogpt_platform/backend/backend/blocks/exa/similar.py
+++ b/autogpt_platform/backend/backend/blocks/exa/similar.py
@@ -122,7 +122,10 @@ class ExaFindSimilarBlock(Block):
             response = requests.post(url, headers=headers, json=payload)
             response.raise_for_status()
             data = response.json()
-            yield "results", data.get("results", [])
+            results = data.get("results", [])
+            if not results:
+                yield "error", "results are empty"
+            else:
+                yield "results", results
         except Exception as e:
             yield "error", str(e)
-            yield "results", []


### PR DESCRIPTION
## Summary
- ensure Exa search/contents/similar blocks return an error when API results are empty

## Testing
- `ruff check --fix autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py autogpt_platform/backend/backend/blocks/exa/contents.py`
- `black autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py autogpt_platform/backend/backend/blocks/exa/contents.py`
- `isort autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/similar.py autogpt_platform/backend/backend/blocks/exa/contents.py`
