### PR TITLE
fix(blocks): Error messages from SendWebRequestBlock use the requested translated IP instead of the orignal URL

### DIFF
--- a/autogpt_platform/backend/backend/util/request.py
+++ b/autogpt_platform/backend/backend/util/request.py
@@ -247,6 +247,7 @@ class Requests:
 
         # Pin the URL if untrusted
         hostname = url.hostname
+        original_url = url.geturl()
         if not is_trusted:
             url = pin_url(url, ip_addresses)
 
@@ -276,6 +277,12 @@ class Requests:
             *args,
             **kwargs,
         )
+
+        # Replace response URLs with the original host for clearer error messages
+        if url.hostname != hostname:
+            response.url = original_url
+            if response.request is not None:
+                response.request.url = original_url
 
         if self.raise_for_status:
             response.raise_for_status()


### PR DESCRIPTION
### Changes 🏗️

Keep the original URL when an HTTP error occurs in `SendWebRequestBlock`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Test sending POST request on a web that doesn't support POST request using `SendWebRequestBlock`.
