### PR TITLE
Fix Webhook URL overflow

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -804,7 +804,7 @@ export const CustomNode = React.memo(
                     <div className="nodrag mr-5 flex flex-col gap-1">
                       Webhook URL:
                       <div className="flex gap-2 rounded-md bg-gray-50 p-2">
-                        <code className="select-all text-sm">
+                        <code className="select-all break-all text-sm">
                           {data.webhook.url}
                         </code>
                         <Button


### PR DESCRIPTION
## Summary
- wrap webhook URL text to avoid overflow

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: EHOSTUNREACH fonts.googleapis.com)*
