### PR TITLE
feat(blocks/exa): Fix Exa Search block error reporting

### DIFF
--- a/autogpt_platform/backend/backend/blocks/exa/search.py
+++ b/autogpt_platform/backend/backend/blocks/exa/search.py
@@ -78,6 +78,7 @@ class ExaSearchBlock(Block):
             description="List of search results",
             default_factory=list,
         )
+        error: str = SchemaField(description="Error message if the request failed")
 
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
## Summary
- return error messages from the `ExaSearchBlock`
- remove advanced flag and default value from the error output

## Testing
- `ruff check autogpt_platform/backend/backend/blocks/exa/search.py --fix`
- `black autogpt_platform/backend/backend/blocks/exa/search.py`
- `isort autogpt_platform/backend/backend/blocks/exa/search.py`
- `pre-commit run --files autogpt_platform/backend/backend/blocks/exa/search.py` *(fails: couldn't connect to server)*