### PR TITLE
Fix AddMemoryBlock JSON serialization error

### DIFF
--- a/autogpt_platform/backend/backend/blocks/mem0.py
+++ b/autogpt_platform/backend/backend/blocks/mem0.py
@@ -124,8 +124,10 @@ class AddMemoryBlock(Block, Mem0Base):
 
             if isinstance(input_data.content, Conversation):
                 messages = input_data.content.messages
+            elif isinstance(input_data.content, Content):
+                messages = [{"role": "user", "content": input_data.content.content}]
             else:
-                messages = [{"role": "user", "content": input_data.content}]
+                messages = [{"role": "user", "content": str(input_data.content)}]
 
             params = {
                 "user_id": user_id,
@@ -152,7 +154,7 @@ class AddMemoryBlock(Block, Mem0Base):
                 yield "action", "NO_CHANGE"
 
         except Exception as e:
-            yield "error", str(object=e)
+            yield "error", str(e)
 
 
 class SearchMemoryBlock(Block, Mem0Base):


### PR DESCRIPTION
This pull request refines the handling of `input_data.content` and improves error message formatting in the `run` method of `mem0.py`. The changes enhance robustness and clarity in the code.

### Handling `input_data.content`:

* Updated the `run` method to handle `Content` objects explicitly, ensuring proper formatting of messages when `input_data.content` is of type `Content`. Additionally, non-standard types are now converted to strings for consistent handling. (`[autogpt_platform/backend/backend/blocks/mem0.pyR127-R130](diffhunk://#diff-d7abf8c3299388129480b6a9be78438fe7e0fbe239da630ebb486ad99c80dd24R127-R130)`)

### Error message formatting:

* Simplified the error message formatting by removing the unnecessary `object=` keyword in the `str()` conversion of exceptions. (`[autogpt_platform/backend/backend/blocks/mem0.pyL155-R157](diffhunk://#diff-d7abf8c3299388129480b6a9be78438fe7e0fbe239da630ebb486ad99c80dd24L155-R157)`)

## Summary
- fix AddMemoryBlock so `Content` input uses the underlying string
- improve error handling in Mem0 AddMemoryBlock

## Testing
- `ruff check autogpt_platform/backend/backend/blocks/mem0.py`
- `pre-commit run --files autogpt_platform/backend/backend/blocks/mem0.py` *(fails: unable to fetch remote hooks)*
- `poetry run pytest -k AddMemoryBlock -q` *(fails: Error 111 connecting to localhost:6379)*

Checklist 📋
For code changes:
 I have clearly listed my changes in the PR description
 I have made a test plan
 I have tested my changes according to the test plan:
 Payload for webhook-triggered runs is shown on /library/agents/[id]