### PR TITLE
Fix credential refresh on user switch

### DIFF
--- a/autogpt_platform/frontend/src/components/integrations/credentials-provider.tsx
+++ b/autogpt_platform/frontend/src/components/integrations/credentials-provider.tsx
@@ -8,6 +8,7 @@ import {
   UserPasswordCredentials,
 } from "@/lib/autogpt-server-api";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+import useSupabase from "@/hooks/useSupabase";
 import { createContext, useCallback, useEffect, useState } from "react";
 
 // Get keys from CredentialsProviderName type
@@ -103,6 +104,7 @@ export default function CredentialsProvider({
   const [providers, setProviders] =
     useState<CredentialsProvidersContextType | null>(null);
   const api = useBackendAPI();
+  const { user } = useSupabase();
 
   const addCredentials = useCallback(
     (
@@ -202,6 +204,11 @@ export default function CredentialsProvider({
   );
 
   useEffect(() => {
+    if (!user) {
+      setProviders(null);
+      return;
+    }
+
     api.isAuthenticated().then((isAuthenticated) => {
       if (!isAuthenticated) return;
 
@@ -248,6 +255,7 @@ export default function CredentialsProvider({
     createUserPasswordCredentials,
     deleteCredentials,
     oAuthCallback,
+    user?.id,
   ]);
 
   return (

--- a/autogpt_platform/frontend/src/hooks/useSupabase.ts
+++ b/autogpt_platform/frontend/src/hooks/useSupabase.ts
@@ -40,6 +40,16 @@ export default function useSupabase() {
     };
 
     fetchUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
   }, [supabase]);
 
   return { supabase, user, isUserLoading };


### PR DESCRIPTION
## Summary
- update Supabase hook to listen for auth changes
- refresh credentials whenever the logged in user changes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find modules)*