### PR TITLE
feat(blocks/exa): Fix Exa blocks error reporting

### DIFF
--- a/autogpt_platform/backend/backend/blocks/exa/contents.py
+++ b/autogpt_platform/backend/backend/blocks/exa/contents.py
@@ -85,4 +85,3 @@ class ExaContentsBlock(Block):
             yield "results", data.get("results", [])
         except Exception as e:
             yield "error", str(e)
-            yield "results", []

--- a/autogpt_platform/backend/backend/blocks/exa/search.py
+++ b/autogpt_platform/backend/backend/blocks/exa/search.py
@@ -78,6 +78,9 @@ class ExaSearchBlock(Block):
             description="List of search results",
             default_factory=list,
         )
+        error: str = SchemaField(
+            description="Error message if the request failed",
+        )
 
     def __init__(self):
         super().__init__(
@@ -140,4 +143,3 @@ class ExaSearchBlock(Block):
             yield "results", data.get("results", [])
         except Exception as e:
             yield "error", str(e)
-            yield "results", []

--- a/autogpt_platform/backend/backend/blocks/exa/similar.py
+++ b/autogpt_platform/backend/backend/blocks/exa/similar.py
@@ -67,6 +67,7 @@ class ExaFindSimilarBlock(Block):
             description="List of similar documents with title, URL, published date, author, and score",
             default_factory=list,
         )
+        error: str = SchemaField(description="Error message if the request failed")
 
     def __init__(self):
         super().__init__(
@@ -125,4 +126,3 @@ class ExaFindSimilarBlock(Block):
             yield "results", data.get("results", [])
         except Exception as e:
             yield "error", str(e)
-            yield "results", []


### PR DESCRIPTION
Exa blocks currently just return an empty list when they fail.

## Changes
- Add `error` output field where missing on Exa blocks
- Don't yield empty results when a request fails

## Testing
- `ruff check autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/contents.py autogpt_platform/backend/backend/blocks/exa/similar.py --fix`
- `black autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/contents.py autogpt_platform/backend/backend/blocks/exa/similar.py`
- `isort autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/contents.py autogpt_platform/backend/backend/blocks/exa/similar.py`
- `pre-commit run --files autogpt_platform/backend/backend/blocks/exa/search.py autogpt_platform/backend/backend/blocks/exa/contents.py autogpt_platform/backend/backend/blocks/exa/similar.py` *(fails: redis connection errors)*