### PR TITLE
fix(frontend): Implement infinite scroll for publish agent popout

### DIFF
--- a/autogpt_platform/frontend/src/components/agptui/PublishAgentSelect.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/PublishAgentSelect.tsx
@@ -20,6 +20,7 @@ interface PublishAgentSelectProps {
   onNext: (agentId: string, agentVersion: number) => void;
   onClose: () => void;
   onOpenBuilder: () => void;
+  onListScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
 }
 
 export const PublishAgentSelect: React.FC<PublishAgentSelectProps> = ({
@@ -29,6 +30,7 @@ export const PublishAgentSelect: React.FC<PublishAgentSelectProps> = ({
   onNext,
   onClose,
   onOpenBuilder,
+  onListScroll,
 }) => {
   const [selectedAgentId, setSelectedAgentId] = React.useState<string | null>(
     null,
@@ -93,9 +95,11 @@ export const PublishAgentSelect: React.FC<PublishAgentSelectProps> = ({
           <div className="flex-grow overflow-hidden p-4 sm:p-6">
             <h3 className="sr-only">List of agents</h3>
             <div
-              className="h-[300px] overflow-y-auto pr-2 sm:h-[400px] md:h-[500px]"
+              className="h-[300px] overflow-y-auto overscroll-contain pr-2 sm:h-[400px] md:h-[500px]"
               role="region"
               aria-labelledby="agentListHeading"
+              onScroll={onListScroll}
+              onWheel={(e) => e.stopPropagation()}
             >
               <div id="agentListHeading" className="sr-only">
                 Scrollable list of agents

--- a/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/composite/PublishAgentPopout.tsx
@@ -69,12 +69,43 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
   >(null);
   const [open, setOpen] = React.useState(false);
   const [currentPage, setCurrentPage] = React.useState(1);
-  const [totalPages, setTotalPages] = React.useState(1);
   const [loading, setLoading] = React.useState(false);
+  const [loadingMore, setLoadingMore] = React.useState(false);
+  const [hasMore, setHasMore] = React.useState(true);
+
+  const api = useBackendAPI();
+
+  const fetchMyAgents = React.useCallback(
+    async (page: number, append = false) => {
+      try {
+        append ? setLoadingMore(true) : setLoading(true);
+        const response = await api.getMyAgents({
+          page,
+          page_size: 20,
+        });
+        setCurrentPage(response.pagination.current_page);
+        setHasMore(
+          response.pagination.current_page < response.pagination.total_pages,
+        );
+        setMyAgents((prev) =>
+          append && prev
+            ? {
+                agents: [...prev.agents, ...response.agents],
+                pagination: response.pagination,
+              }
+            : response,
+        );
+      } catch (error) {
+        console.error("Failed to load my agents:", error);
+      } finally {
+        append ? setLoadingMore(false) : setLoading(false);
+      }
+    },
+    [api],
+  );
 
   const popupId = React.useId();
   const router = useRouter();
-  const api = useBackendAPI();
 
   const { toast } = useToast();
 
@@ -87,31 +118,15 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
   React.useEffect(() => {
     if (open) {
       setCurrentPage(1);
+      setHasMore(true);
     }
   }, [open]);
 
   React.useEffect(() => {
     if (open) {
-      const loadMyAgents = async () => {
-        try {
-          setLoading(true);
-          const response = await api.getMyAgents({
-            page: currentPage,
-            page_size: 20,
-          });
-          setMyAgents(response);
-          setCurrentPage(response.pagination.current_page);
-          setTotalPages(response.pagination.total_pages);
-        } catch (error) {
-          console.error("Failed to load my agents:", error);
-        } finally {
-          setLoading(false);
-        }
-      };
-
-      loadMyAgents();
+      fetchMyAgents(1);
     }
-  }, [open, currentPage, api]);
+  }, [open, fetchMyAgents]);
 
   const handleClose = () => {
     setStep("select");
@@ -222,13 +237,27 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
     }
   };
 
+  const handleScroll = React.useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
+      if (
+        hasMore &&
+        !loadingMore &&
+        scrollTop + clientHeight >= scrollHeight - 20
+      ) {
+        fetchMyAgents(currentPage + 1, true);
+      }
+    },
+    [hasMore, loadingMore, currentPage, fetchMyAgents],
+  );
+
   const renderContent = () => {
     switch (step) {
       case "select":
         return (
           <div className="flex min-h-screen items-center justify-center">
             <div className="mx-auto flex w-full max-w-[900px] flex-col rounded-3xl bg-white shadow-lg dark:bg-gray-800">
-              <div className="h-full overflow-y-auto">
+              <div className="h-full overflow-y-hidden">
                 {loading ? (
                   <div className="flex items-center justify-center p-8 text-gray-600">
                     Loading agents...
@@ -258,30 +287,13 @@ export const PublishAgentPopout: React.FC<PublishAgentPopoutProps> = ({
                       onNext={handleNextFromSelect}
                       onClose={handleClose}
                       onOpenBuilder={() => router.push("/build")}
+                      onListScroll={handleScroll}
                     />
-                    <div className="flex items-center justify-between p-4">
-                      <button
-                        onClick={() =>
-                          setCurrentPage((p) => Math.max(1, p - 1))
-                        }
-                        disabled={currentPage === 1}
-                        className="text-sm font-medium text-blue-600 disabled:text-gray-400"
-                      >
-                        ← Previous
-                      </button>
-                      <span className="text-sm text-gray-700">
-                        Page {currentPage} of {totalPages}
-                      </span>
-                      <button
-                        onClick={() =>
-                          setCurrentPage((p) => Math.min(totalPages, p + 1))
-                        }
-                        disabled={currentPage === totalPages}
-                        className="text-sm font-medium text-blue-600 disabled:text-gray-400"
-                      >
-                        Next →
-                      </button>
-                    </div>
+                    {loadingMore && (
+                      <div className="flex items-center justify-center p-4 text-gray-600">
+                        Loading more...
+                      </div>
+                    )}
                   </>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- add scroll handler prop to `PublishAgentSelect` so the publish popout can detect scroll position
- hook up infinite scroll handler in the publish popout and prevent page scrolling

## Testing
- `yarn lint`
- `yarn type-check`
- `yarn test` *(fails: Process from config.webServer exited early)*
### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Test via deployment
  - [ ] test via manual
