### PR TITLE
feat(frontend): require passwrods to be min length 12

### DIFF
--- a/autogpt_platform/frontend/src/components/profile/settings/SettingsForm.tsx
+++ b/autogpt_platform/frontend/src/components/profile/settings/SettingsForm.tsx
@@ -33,9 +33,9 @@ const formSchema = z
       .optional()
       .refine((val) => {
         // If password is provided, it must be at least 8 characters
-        if (val) return val.length >= 8;
+        if (val) return val.length >= 12;
         return true;
-      }, "String must contain at least 8 character(s)"),
+      }, "String must contain at least 12 character(s)"),
     confirmPassword: z.string().optional(),
     notifyOnAgentRun: z.boolean(),
     notifyOnZeroBalance: z.boolean(),

--- a/autogpt_platform/frontend/src/types/auth.ts
+++ b/autogpt_platform/frontend/src/types/auth.ts
@@ -23,11 +23,11 @@ export const signupFormSchema = z
       .trim(),
     password: z
       .string()
-      .min(6, "Password must contain at least 6 characters")
+      .min(12, "Password must contain at least 12 characters")
       .max(64, "Password must contain at most 64 characters"),
     confirmPassword: z
       .string()
-      .min(6, "Password must contain at least 6 characters")
+      .min(12, "Password must contain at least 12 characters")
       .max(64, "Password must contain at most 64 characters"),
     agreeToTerms: z.boolean().refine((value) => value === true, {
       message: "You must agree to the Terms of Use and Privacy Policy",
@@ -50,11 +50,11 @@ export const changePasswordFormSchema = z
   .object({
     password: z
       .string()
-      .min(6, "Password must contain at least 6 characters")
+      .min(12, "Password must contain at least 12 characters")
       .max(64, "Password must contain at most 64 characters"),
     confirmPassword: z
       .string()
-      .min(6, "Password must contain at least 6 characters")
+      .min(12, "Password must contain at least 12 characters")
       .max(64, "Password must contain at most 64 characters"),
   })
   .refine((data) => data.password === data.confirmPassword, {


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
We're doing CASA and this is a requirement

### Changes 🏗️
- Requires new passwords to be min length 12
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] test