### PR TITLE
fix(frontend): missed a password prompt

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/reset_password/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/reset_password/page.tsx
@@ -175,7 +175,7 @@ export default function ResetPasswordPage() {
                       <PasswordInput {...field} />
                     </FormControl>
                     <FormDescription className="text-sm font-normal leading-tight text-slate-500">
-                      Password needs to be at least 6 characters long
+                      Password needs to be at least 12 characters long
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
@@ -151,7 +151,7 @@ export default function SignupPage() {
                   <PasswordInput {...field} autoComplete="new-password" />
                 </FormControl>
                 <FormDescription className="text-sm font-normal leading-tight text-slate-500">
-                  Password needs to be at least 6 characters long
+                  Password needs to be at least 12 characters long
                 </FormDescription>
                 <FormMessage />
               </FormItem>


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->
CASA requires a length of 12 passwords, which we did update. When testing in dev, I realized I missed a few.

### Changes 🏗️

<!-- Concisely describe all of the changes made in this pull request: -->
updates a missed prompt

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Test manually, and read all the prompts carefully

