### PR TITLE
feat(executor;frontend): Move output processing step from node executor to graph executor & simplify input beads calculation

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from multiprocessing import Manager
+from queue import Empty
 from typing import (
     Annotated,
     Any,
@@ -793,6 +794,12 @@ class ExecutionQueue(Generic[T]):
 
     def empty(self) -> bool:
         return self.queue.empty()
+
+    def get_or_none(self) -> T | None:
+        try:
+            return self.queue.get_nowait()
+        except Empty:
+            return None
 
 
 # --------------------- Event Bus --------------------- #

--- a/autogpt_platform/frontend/src/components/CustomEdge.tsx
+++ b/autogpt_platform/frontend/src/components/CustomEdge.tsx
@@ -12,6 +12,7 @@ import "./customedge.css";
 import { X } from "lucide-react";
 import { useBezierPath } from "@/hooks/useBezierPath";
 import { FlowContext } from "./Flow";
+import { NodeExecutionResult } from "@/lib/autogpt-server-api";
 
 export type CustomEdgeData = {
   edgeColor: string;
@@ -19,7 +20,7 @@ export type CustomEdgeData = {
   isStatic?: boolean;
   beadUp?: number;
   beadDown?: number;
-  beadData?: any[];
+  beadData?: Map<string, NodeExecutionResult["status"]>;
 };
 
 type Bead = {

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -241,7 +241,6 @@ export default function useAgentGraph(
                 isStatic: link.is_static,
                 beadUp: 0,
                 beadDown: 0,
-                beadData: [],
               },
               markerEnd: {
                 type: MarkerType.ArrowClosed,
@@ -304,64 +303,57 @@ export default function useAgentGraph(
 
   const updateEdgeBeads = useCallback(
     (executionData: NodeExecutionResult) => {
+      const { node_id, status, node_exec_id } = executionData;
+
       setEdges((edges) => {
         return edges.map((e) => {
           const edge = { ...e, data: { ...e.data } } as CustomEdge;
 
-          if (executionData.status === "COMPLETED") {
-            // Produce output beads
-            for (let key in executionData.output_data) {
-              if (
-                edge.source !== getFrontendId(executionData.node_id, nodes) ||
-                edge.sourceHandle !== cleanupSourceName(key) ||
-                (isToolSourceName(key) &&
-                  getToolArgName(key) !== edge.targetHandle)
-              ) {
-                console.log(
-                  key,
-                  cleanupSourceName(key),
-                  edge.targetHandle,
-                  " are not equal ",
-                  getToolArgName(key),
-                  edge.sourceHandle,
-                );
-                continue;
-              }
-              const count = executionData.output_data[key].length;
-              edge.data!.beadUp = (edge.data!.beadUp ?? 0) + count;
-              // For static edges beadDown is always one less than beadUp
-              // Because there's no queueing and one bead is always at the connection point
-              if (edge.data?.isStatic) {
-                edge.data!.beadDown = (edge.data!.beadUp ?? 0) - 1;
-                edge.data!.beadData = edge.data!.beadData!.slice(0, -1);
-                continue;
-              }
-              edge.data!.beadData = [
-                ...executionData.output_data[key].toReversed(),
-                ...edge.data!.beadData!,
-              ];
-            }
-          } else if (executionData.status === "RUNNING") {
-            // Consume input beads
-            for (let key in executionData.input_data) {
-              if (
-                edge.target !== getFrontendId(executionData.node_id, nodes) ||
-                edge.targetHandle !== key
-              ) {
-                continue;
-              }
-              // Skip decreasing bead count if edge doesn't match or if it's static
-              if (
-                edge.data!.beadData![edge.data!.beadData!.length - 1] !==
-                  executionData.input_data[key] ||
-                edge.data?.isStatic
-              ) {
-                continue;
-              }
-              edge.data!.beadDown = (edge.data!.beadDown ?? 0) + 1;
-              edge.data!.beadData = edge.data!.beadData!.slice(0, -1);
-            }
+          // Initialize execution tracking if not exists
+          if (!edge.data?.beadData) {
+            edge.data!.beadData = new Map<
+              string,
+              NodeExecutionResult["status"]
+            >();
           }
+          const execStatus = edge.data!.beadData!;
+
+          // Update execution status for input edges
+          for (let key in executionData.input_data) {
+            if (
+              edge.target !== getFrontendId(executionData.node_id, nodes) ||
+              edge.targetHandle !== key
+            ) {
+              continue;
+            }
+
+            // Store only the execution status
+            execStatus.set(executionData.node_exec_id, executionData.status);
+          }
+
+          // Calculate bead counts based on execution status
+          let beadUp = 0;
+          let beadDown = 0;
+
+          execStatus.forEach((status) => {
+            beadUp++;
+            if (status !== "INCOMPLETE") {
+              // Count any non-incomplete execution as consumed
+              beadDown++;
+            }
+          });
+
+          // For static edges, ensure beadUp is always beadDown + 1
+          // This is because static edges represent reusable inputs that are never fully consumed
+          // The +1 represents the input that's still available for reuse
+          if (edge.data?.isStatic && beadUp > 0) {
+            beadUp = beadDown + 1;
+          }
+
+          // Update edge data
+          edge.data!.beadUp = beadUp;
+          edge.data!.beadDown = beadDown;
+
           return edge;
         });
       });
@@ -397,7 +389,11 @@ export default function useAgentGraph(
                   executionResults:
                     Object.keys(executionData.output_data).length > 0
                       ? [
-                          ...(node.data.executionResults || []),
+                          // Execution updates are not cumulative, so we need to filter out the old ones.
+                          ...(node.data.executionResults?.filter(
+                            (result) =>
+                              result.execId !== executionData.node_exec_id,
+                          ) || []),
                           {
                             execId: executionData.node_exec_id,
                             data: {
@@ -434,14 +430,11 @@ export default function useAgentGraph(
     }
     setUpdateQueue((prev) => {
       prev.forEach((data) => {
-        // Skip already processed updates by checking
-        // if the data is in the processedUpdates array by reference
-        // This is not to process twice in react dev mode
-        // because it'll add double the beads
-        if (processedUpdates.current.includes(data)) {
-          return;
-        }
         updateNodesWithExecutionData(data);
+        // Execution updates are not cumulative, so we need to filter out the old ones.
+        processedUpdates.current = processedUpdates.current.filter(
+          (update) => update.node_exec_id !== data.node_exec_id,
+        );
         processedUpdates.current.push(data);
       });
       return [];
@@ -997,7 +990,6 @@ export default function useAgentGraph(
           edgeColor: edge.data?.edgeColor!,
           beadUp: 0,
           beadDown: 0,
-          beadData: [],
         },
       }));
     });


### PR DESCRIPTION
**Goal**
Allow parallel runs within a single node. Currently, we prevent this to avoid unexpected ordering of the execution.

### Changes 🏗️

#### Executor changes

We decoupled the node execution output processing, which is responsible for deciding the next executions from the node executor code.

Currently, `execute_node` does two big things:
* Runs the block’s execute(...) (which yields outputs).
* immediately enqueues the next nodes based on those outputs.

This PR makes:
* execute_node(node_exec) -> stream of (output_name, data). That purely runs the block and yields each output as soon as it’s available.
* Move _enqueue_next_nodes into the graph executor. So the next execution is handled serially by the graph executor to avoid concurrency issues.

#### UI changes

The change on the executor also fixes the behavior of the execution update to the UI We will report the execution output to the UI as soon as it is available, not when the node execution is fully completed. This, however, broke the bread calculation logic that assumes each execution update will never overlap. So the change in this PR makes the bead calculation take the overlap / duplicated execution update into account, and simplify the overall calculation logic.


### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Execute this agent and observe its concurrency ordering
  
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/0fe8259f-9091-4ecc-b824-ce8e8819c2d2" />

