### PR TITLE
fix(blocks/backend): update Gmail block tests

### DIFF
--- a/autogpt_platform/backend/backend/blocks/google/gmail.py
+++ b/autogpt_platform/backend/backend/blocks/google/gmail.py
@@ -577,7 +577,9 @@ class GmailGetThreadBlock(Block):
             test_input={"threadId": "t1", "credentials": TEST_CREDENTIALS_INPUT},
             test_credentials=TEST_CREDENTIALS,
             test_output=[("thread", {"id": "t1", "messages": []})],
-            test_mock={"_get_thread": lambda *args, **kwargs: {"id": "t1"}},
+            test_mock={
+                "_get_thread": lambda *args, **kwargs: {"id": "t1", "messages": []}
+            },
         )
 
     def run(
@@ -706,6 +708,7 @@ class GmailReplyBlock(Block):
             test_output=[
                 ("messageId", "m2"),
                 ("threadId", "t1"),
+                ("message", {"id": "m2", "threadId": "t1"}),
             ],
             test_mock={
                 "_reply": lambda *args, **kwargs: {


### PR DESCRIPTION
## Changes
- adjust GmailGetThreadBlock mocked output
- expect message output from GmailReplyBlock

## Testing
- `poetry run format`
- `yarn format`
- `poetry run lint`
- `yarn lint`
- `poetry run test` *(fails: FileNotFoundError: 'docker')*
- `yarn test` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_683ef5498ddc832eb1fd5477971c1067