### PR TITLE
chore(backend): Tell Dependabot not to update Poetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     commit-message:
       prefix: "chore(libs/deps)"
       prefix-development: "chore(libs/deps-dev)"
+    ignore:
+      - dependency-name: "poetry"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -32,6 +34,8 @@ updates:
     commit-message:
       prefix: "chore(backend/deps)"
       prefix-development: "chore(backend/deps-dev)"
+    ignore:
+      - dependency-name: "poetry"
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
- Fixes #10098

### Changes 🏗️
Tells dependabot to ignore poetry

### Checklist 📋
N/A