### PR TITLE
fix(frontend): Use `FRONTEND_BASE_URL` to make password reset link

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/reset_password/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/reset_password/actions.ts
@@ -2,7 +2,6 @@
 import getServerSupabase from "@/lib/supabase/getServerSupabase";
 import { redirect } from "next/navigation";
 import * as Sentry from "@sentry/nextjs";
-import { headers } from "next/headers";
 import { verifyTurnstileToken } from "@/lib/turnstile";
 
 export async function sendResetEmail(email: string, turnstileToken: string) {
@@ -11,8 +10,7 @@ export async function sendResetEmail(email: string, turnstileToken: string) {
     {},
     async () => {
       const supabase = getServerSupabase();
-      const headersList = await headers();
-      const host = headersList.get("host");
+      const host = process.env.FRONTEND_BASE_URL ?? "localhost:3000";
       const protocol =
         process.env.NODE_ENV === "development" ? "http" : "https";
       const origin = `${protocol}://${host}`;


### PR DESCRIPTION
- Fixes #9215
- ⚠️ Merge first: https://github.com/Significant-Gravitas/AutoGPT_cloud_infrastructure/pull/93

### Changes 🏗️

- Use `FRONTEND_BASE_URL` instead of Host header to make password reset redirect link

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Resetting password gives an e-mail with a link that points to the correct URL

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
