### PR TITLE
fix(backend): Fix graph fetching of non-owned marketplace agent

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -731,9 +731,6 @@ async def get_graph(
         ):
             return None
 
-    if graph is None or (graph.userId != user_id and not ()):
-        return None
-
     if include_subgraphs or for_export:
         sub_graphs = await get_sub_graphs(graph)
         return GraphModel.from_db(


### PR DESCRIPTION
Currently, the get_graph function, with no graph version specifier will try to fetch the latest version, and when the graph is not owned and the latest version is not available for listing, it will return `None` instead of picking the latest graph version available on the store.

### Changes 🏗️

Instead of using the latest graph.version to fetch the store listing, don't provide any version filter at all and pick up whatever available version in the store.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] CI, existing tests