### PR TITLE
update(turnstile): Add env to hide turnstile for dev deploy

### DIFF
--- a/autogpt_platform/frontend/.env.example
+++ b/autogpt_platform/frontend/.env.example
@@ -30,3 +30,4 @@ NEXT_PUBLIC_SHOW_BILLING_PAGE=false
 ## Get these from the Cloudflare Turnstile dashboard: https://dash.cloudflare.com/?to=/:account/turnstile
 ## This is the frontend site key
 NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=
+NEXT_PUBLIC_DISABLE_TURNSTILE=false

--- a/autogpt_platform/frontend/src/hooks/useTurnstile.ts
+++ b/autogpt_platform/frontend/src/hooks/useTurnstile.ts
@@ -47,10 +47,13 @@ export function useTurnstile({
   useEffect(() => {
     const behaveAs = getBehaveAs();
     const hasTurnstileKey = !!TURNSTILE_SITE_KEY;
+    const turnstileDisabled = process.env.NEXT_PUBLIC_DISABLE_TURNSTILE === "true";
 
-    setShouldRender(behaveAs === BehaveAs.CLOUD && hasTurnstileKey);
+    // Only render Turnstile in cloud environment if not explicitly disabled
+    setShouldRender(behaveAs === BehaveAs.CLOUD && hasTurnstileKey && !turnstileDisabled);
 
-    if (behaveAs !== BehaveAs.CLOUD || !hasTurnstileKey) {
+    // Skip verification if disabled, in local development, or no key
+    if (turnstileDisabled || behaveAs !== BehaveAs.CLOUD || !hasTurnstileKey) {
       setVerified(true);
     }
   }, []);

--- a/autogpt_platform/frontend/src/lib/turnstile.ts
+++ b/autogpt_platform/frontend/src/lib/turnstile.ts
@@ -7,6 +7,11 @@ export async function verifyTurnstileToken(
   token: string,
   action?: string,
 ): Promise<boolean> {
+  // Skip verification if explicitly disabled via environment variable
+  if (process.env.NEXT_PUBLIC_DISABLE_TURNSTILE === "true") {
+    return true;
+  }
+
   // Skip verification in local development
   const behaveAs = getBehaveAs();
   if (behaveAs !== BehaveAs.CLOUD) {


### PR DESCRIPTION
This simply adds a env to hide turnstile for dev deploys

if this env ``NEXT_PUBLIC_DISABLE_TURNSTILE`` is set to false which it is by default, it will show turnstile, if the env is set to "true" it will hide the turnstile

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Login/register with ``NEXT_PUBLIC_DISABLE_TURNSTILE=false`` and you see the turnstile and that is needed to login/signup
  - [x] Login/register with ``NEXT_PUBLIC_DISABLE_TURNSTILE=true`` and you will see the turnstile is gone, and you can login/signup with out it