### PR TITLE
fix(turnstile): Disable turnstile by default and rename its env

### DIFF
--- a/autogpt_platform/frontend/.env.example
+++ b/autogpt_platform/frontend/.env.example
@@ -32,4 +32,4 @@ NEXT_PUBLIC_SHOW_BILLING_PAGE=false
 ## Get these from the Cloudflare Turnstile dashboard: https://dash.cloudflare.com/?to=/:account/turnstile
 ## This is the frontend site key
 NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=
-NEXT_PUBLIC_DISABLE_TURNSTILE=false
+NEXT_PUBLIC_TURNSTILE=disabled

--- a/autogpt_platform/frontend/src/hooks/useTurnstile.ts
+++ b/autogpt_platform/frontend/src/hooks/useTurnstile.ts
@@ -47,8 +47,7 @@ export function useTurnstile({
   useEffect(() => {
     const behaveAs = getBehaveAs();
     const hasTurnstileKey = !!TURNSTILE_SITE_KEY;
-    const turnstileDisabled =
-      process.env.NEXT_PUBLIC_TURNSTILE !== "enabled";
+    const turnstileDisabled = process.env.NEXT_PUBLIC_TURNSTILE !== "enabled";
 
     // Only render Turnstile in cloud environment if not explicitly disabled
     setShouldRender(

--- a/autogpt_platform/frontend/src/hooks/useTurnstile.ts
+++ b/autogpt_platform/frontend/src/hooks/useTurnstile.ts
@@ -48,7 +48,7 @@ export function useTurnstile({
     const behaveAs = getBehaveAs();
     const hasTurnstileKey = !!TURNSTILE_SITE_KEY;
     const turnstileDisabled =
-      process.env.NEXT_PUBLIC_DISABLE_TURNSTILE === "true";
+      process.env.NEXT_PUBLIC_TURNSTILE !== "enabled";
 
     // Only render Turnstile in cloud environment if not explicitly disabled
     setShouldRender(

--- a/autogpt_platform/frontend/src/lib/turnstile.ts
+++ b/autogpt_platform/frontend/src/lib/turnstile.ts
@@ -7,8 +7,8 @@ export async function verifyTurnstileToken(
   token: string,
   action?: string,
 ): Promise<boolean> {
-  // Skip verification if explicitly disabled via environment variable
-  if (process.env.NEXT_PUBLIC_DISABLE_TURNSTILE === "true") {
+  // Skip verification unless explicitly enabled via environment variable
+  if (process.env.NEXT_PUBLIC_TURNSTILE !== "enabled") {
     return true;
   }
 


### PR DESCRIPTION
### Changes 🏗️
change ``NEXT_PUBLIC_DISABLE_TURNSTILE`` to ``NEXT_PUBLIC_TURNSTILE``  and set turnstile captcha to be hidden by default 

if ``NEXT_PUBLIC_TURNSTILE=enabled`` is set, captcha will work and show on the frontend login/signup/password reset pages
if ``NEXT_PUBLIC_TURNSTILE=disabled`` is set, captcha will be hidden from the frontend and is not needed to login/signup/password reset
if ``NEXT_PUBLIC_TURNSTILE`` is not set captcha will be hidden from the frontend and is not needed to login/signup/password reset

This means users who setup AutoGPT locally will not need to deal with changing the env to hide captcha

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] start the platform with ``NEXT_PUBLIC_TURNSTILE=enabled`` set to enabled and captcha shows
  - [x] start with ``NEXT_PUBLIC_TURNSTILE=disabled`` and captcha does not show and you dont need it to login ect
  - [x] start with ``NEXT_PUBLIC_TURNSTILE`` not set and the captcha does not show and you dont need it to login ect