### PR TITLE
fix(frontend): Fix builder UI glitch

### DIFF
--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -579,7 +579,7 @@ async def execute_graph(
     if current_balance <= 0:
         raise HTTPException(
             status_code=402,
-            detail="Insufficient credits to execute the graph. Please top up your credits.",
+            detail="Insufficient balance to execute the agent. Please top up your account.",
         )
 
     graph_exec = await execution_utils.add_graph_execution_async(

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -575,6 +575,13 @@ async def execute_graph(
     graph_version: Optional[int] = None,
     preset_id: Optional[str] = None,
 ) -> ExecuteGraphResponse:
+    current_balance = await _user_credit_model.get_credits(user_id)
+    if current_balance <= 0:
+        raise HTTPException(
+            status_code=402,
+            detail="Insufficient credits to execute the graph. Please top up your credits.",
+        )
+
     graph_exec = await execution_utils.add_graph_execution_async(
         graph_id=graph_id,
         user_id=user_id,

--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -82,6 +82,7 @@ export type CustomNodeData = {
   executionResults?: {
     execId: string;
     data: NodeExecutionResult["output_data"];
+    status: NodeExecutionResult["status"];
   }[];
   block_id: string;
   backend_id?: string;

--- a/autogpt_platform/frontend/src/components/customnode.css
+++ b/autogpt_platform/frontend/src/components/customnode.css
@@ -9,19 +9,6 @@
   margin-bottom: 1rem;
 }
 
-.custom-node input:not([type="checkbox"]):not([type="file"]),
-.custom-node textarea,
-.custom-node select,
-.custom-node [data-id^="date-picker"],
-.custom-node [data-list-container],
-.custom-node [data-add-item],
-.custom-node [data-content-settings] .array-item-container {
-  display: flex;
-  align-items: center;
-  min-width: calc(100% - 2.5rem);
-  max-width: 100%;
-}
-
 .custom-node .custom-switch {
   padding: 0.5rem 1.25rem;
   display: flex;

--- a/autogpt_platform/frontend/src/components/node-input-components.tsx
+++ b/autogpt_platform/frontend/src/components/node-input-components.tsx
@@ -229,7 +229,6 @@ const NodeFileInput: FC<{
   const handleFileChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
-      console.log(">>> file", file);
       if (!file) return;
 
       const reader = new FileReader();

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -379,12 +379,12 @@ export default function useAgentGraph(
       ];
 
       const statusRank = {
-        TERMINATED: 0,
+        RUNNING: 0,
         QUEUED: 1,
-        RUNNING: 2,
-        COMPLETED: 3,
-        FAILED: 4,
-        INCOMPLETE: 5,
+        INCOMPLETE: 2,
+        TERMINATED: 3,
+        COMPLETED: 4,
+        FAILED: 5,
       };
       const status = executionResults
         .map((v) => v.status)

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -281,6 +281,7 @@ export type GraphExecutionMeta = {
   started_at: Date;
   ended_at: Date;
   stats?: {
+    error?: string;
     cost: number;
     duration: number;
     duration_cpu_only: number;


### PR DESCRIPTION
There are a few UI bugs on the builder that this PR addresses.

<img width="554" alt="image" src="https://github.com/user-attachments/assets/1be70197-de7e-40fe-ab11-405c145e763d" />

### Changes 🏗️

Fix these UI issues:
* (screenshot attached above) Key-value input width was unintentionally maxed out due to a stale CSS rule.
* When multiple executions within the same node are running, we pick the latest status, making one running and one completed execution displayed as completed.
* No balance errors were executed, only displayed while at least one node execution was triggered, while this can be done directly when the execution request is triggered.
* Run & Stop button glitch: it's still showing as stopped when the graph is still running, this is due to way the UI code tracks execution in the node-level, instead of graph level.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual tests on the described behaviours.
