### PR TITLE
feat(blocks): add veo3 to ai video generator

### DIFF
--- a/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
+++ b/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
@@ -104,7 +104,7 @@ class AIVideoGeneratorBlock(Block):
         submit_url = f"{base_url}/{input_data.model.value}"
         submit_data = {"prompt": input_data.prompt}
         if input_data.model == FalModel.VEO3:
-            submit_data["generate_audio"] = True
+            submit_data["generate_audio"] = True # type: ignore
 
         seen_logs = set()
 

--- a/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
+++ b/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
@@ -104,7 +104,7 @@ class AIVideoGeneratorBlock(Block):
         submit_url = f"{base_url}/{input_data.model.value}"
         submit_data = {"prompt": input_data.prompt}
         if input_data.model == FalModel.VEO3:
-            submit_data["generate_audio"] = True # type: ignore
+            submit_data["generate_audio"] = True  # type: ignore
 
         seen_logs = set()
 

--- a/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
+++ b/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 class FalModel(str, Enum):
     MOCHI = "fal-ai/mochi-v1"
     LUMA = "fal-ai/luma-dream-machine"
+    VEO3 = "fal-ai/veo3"
 
 
 class AIVideoGeneratorBlock(Block):

--- a/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
+++ b/autogpt_platform/backend/backend/blocks/fal/ai_video_generator.py
@@ -103,6 +103,8 @@ class AIVideoGeneratorBlock(Block):
         # Submit generation request
         submit_url = f"{base_url}/{input_data.model.value}"
         submit_data = {"prompt": input_data.prompt}
+        if input_data.model == FalModel.VEO3:
+            submit_data["generate_audio"] = True
 
         seen_logs = set()
 


### PR DESCRIPTION
### Changes 🏗️

This simply adds "fal-ai/veo3" to the ``FalModel`` in the ``ai_video_generator.py`` file
Oh i also set it so veo3 also always generates videos with audio so ``generate_audio=True`` is set to true if veo3 is selected

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Test the veo3 model via Fal.ai and it should work.