### PR TITLE
drop price of chatgpt o3 model

### DIFF
--- a/autogpt_platform/backend/backend/data/block_cost_config.py
+++ b/autogpt_platform/backend/backend/data/block_cost_config.py
@@ -38,7 +38,7 @@ from backend.integrations.credentials_store import (
 # =============== Configure the cost for each LLM Model call =============== #
 
 MODEL_COST: dict[LlmModel, int] = {
-    LlmModel.O3: 7,
+    LlmModel.O3: 4,
     LlmModel.O3_MINI: 2,  # $1.10 / $4.40
     LlmModel.O1: 16,  # $15 / $60
     LlmModel.O1_PREVIEW: 16,


### PR DESCRIPTION
### Changes 🏗️

Today openAI dropped the prices of the o3 model so this simply drops the price from 7 to 4

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run the platform with the new price, check the O3 model in the ai text generator block and see its cheaper to use
