### PR TITLE
fix(platform/backend): skip invalid graphs when listing

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -655,7 +655,10 @@ async def get_graphs(
     graph_models = []
     for graph in graphs:
         try:
-            graph_models.append(GraphModel.from_db(graph))
+            graph_model = GraphModel.from_db(graph)
+            # Trigger serialization to validate that the graph is well formed.
+            graph_model.model_dump()
+            graph_models.append(graph_model)
         except Exception as e:
             logger.error(f"Error processing graph {graph.id}: {e}")
             continue


### PR DESCRIPTION
## Summary
- skip serialization errors when listing graphs so an invalid graph doesn't block the entire response

## Testing
- `poetry run format`
- `poetry run test` *(fails: FileNotFoundError: 'docker')*


------
https://chatgpt.com/codex/tasks/task_b_684c49adef68832e9da3339805295046