### PR TITLE
feat(backend): Add request retry on block execution and RPC

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -85,7 +85,8 @@ from backend.util.retry import continuous_retry, func_retry
 from backend.util.service import get_service_client
 from backend.util.settings import Settings
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
+logger = TruncatedLogger(_logger, prefix="[GraphExecutor]")
 settings = Settings()
 
 active_runs_gauge = Gauge(
@@ -122,7 +123,7 @@ class LogMetadata(TruncatedLogger):
         }
         prefix = f"[ExecutionManager|uid:{user_id}|gid:{graph_id}|nid:{node_id}]|geid:{graph_eid}|neid:{node_eid}|{block_name}]"
         super().__init__(
-            logger,
+            _logger,
             max_length=max_length,
             prefix=prefix,
             metadata=metadata,
@@ -1214,7 +1215,9 @@ def get_db_client() -> "DatabaseManagerClient":
     from backend.executor import DatabaseManagerClient
 
     # Disable health check for the service client to avoid breaking process initializer.
-    return get_service_client(DatabaseManagerClient, health_check=False)
+    return get_service_client(
+        DatabaseManagerClient, health_check=False, request_retry=True
+    )
 
 
 @thread_cached
@@ -1222,7 +1225,9 @@ def get_db_async_client() -> "DatabaseManagerAsyncClient":
     from backend.executor import DatabaseManagerAsyncClient
 
     # Disable health check for the service client to avoid breaking process initializer.
-    return get_service_client(DatabaseManagerAsyncClient, health_check=False)
+    return get_service_client(
+        DatabaseManagerAsyncClient, health_check=False, request_retry=True
+    )
 
 
 async def send_async_execution_update(

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -39,6 +39,7 @@ from backend.data.rabbitmq import (
     SyncRabbitMQ,
 )
 from backend.util.exceptions import NotFoundError
+from backend.util.logging import TruncatedLogger
 from backend.util.mock import MockObject
 from backend.util.service import get_service_client
 from backend.util.settings import Config
@@ -49,7 +50,7 @@ if TYPE_CHECKING:
     from backend.integrations.credentials_store import IntegrationCredentialsStore
 
 config = Config()
-logger = logging.getLogger(__name__)
+logger = TruncatedLogger(logging.getLogger(__name__), prefix="[GraphExecutorUtil]")
 
 # ============ Resource Helpers ============ #
 


### PR DESCRIPTION
Request on block execution can be throttled, and requests between services can sometimes break. The scope of this PR is to add an appropriate retry on those.

### Changes 🏗️

* Block request retry: Retry on throttled status code only (504, 429, etc).
* RPC request retry: Retry connection issues (ConnectError, Timeout, etc).
* Truncate logging on executor/utils.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual graph execution