### PR TITLE
fix(backend): Add graph_id path parameter to fix automatic client generation from OpenAPI spec 

### DIFF
--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -590,7 +590,7 @@ async def execute_graph(
     dependencies=[Depends(auth_middleware)],
 )
 async def stop_graph_run(
-   graph_id:str, graph_exec_id: str, user_id: Annotated[str, Depends(get_user_id)]
+    graph_id: str, graph_exec_id: str, user_id: Annotated[str, Depends(get_user_id)]
 ) -> execution_db.GraphExecution:
     if not await execution_db.get_graph_execution_meta(
         user_id=user_id, execution_id=graph_exec_id

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -590,7 +590,7 @@ async def execute_graph(
     dependencies=[Depends(auth_middleware)],
 )
 async def stop_graph_run(
-    graph_exec_id: str, user_id: Annotated[str, Depends(get_user_id)]
+   graph_id:str, graph_exec_id: str, user_id: Annotated[str, Depends(get_user_id)]
 ) -> execution_db.GraphExecution:
     if not await execution_db.get_graph_execution_meta(
         user_id=user_id, execution_id=graph_exec_id


### PR DESCRIPTION
## Description
Added the `graph_id` parameter to the stop execution endpoint path (`/graphs/{graph_id}/executions/{graph_exec_id}/stop`) to fix client generation from Openapi spec error.

## Problem
The client generation was failing due to missing path parameter definition for `graph_id` in the stop execution endpoint.

<img width="1412" alt="Screenshot 2025-06-19 at 9 20 17 AM" src="https://github.com/user-attachments/assets/aa1667d3-05be-48c6-975b-84473830ac03" />


## Solution
Added `graph_id` as a path parameter while maintaining the existing functionality.

## Testing
- [x] Verified OpenAPI client generation works without errors
- [x] Confirmed endpoint functionality remains unchanged
- [x] Tested API calls maintain backward compatibility