### PR TITLE
fix(frontend): Update Schedule Task's default value to "daily"

### DIFF
--- a/autogpt_platform/frontend/src/components/cronScheduler.tsx
+++ b/autogpt_platform/frontend/src/components/cronScheduler.tsx
@@ -26,9 +26,9 @@ export function CronScheduler({
 }: CronSchedulerProps) {
   const [frequency, setFrequency] = useState<
     "minute" | "hour" | "daily" | "weekly" | "monthly" | "yearly" | "custom"
-  >("minute");
+  >("daily");
   const [selectedDays, setSelectedDays] = useState<number[]>([]);
-  const [selectedTime, setSelectedTime] = useState<string>("00:00");
+  const [selectedTime, setSelectedTime] = useState<string>("09:00");
   const [showCustomDays, setShowCustomDays] = useState<boolean>(false);
   const [selectedMinute, setSelectedMinute] = useState<string>("0");
   const [customInterval, setCustomInterval] = useState<{
@@ -77,7 +77,7 @@ export function CronScheduler({
 
             <Select
               onValueChange={(value: any) => setFrequency(value)}
-              defaultValue="minute"
+              defaultValue="daily"
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select frequency" />


### PR DESCRIPTION
### Changes 🏗️

Fixes: [Make the default scheduler frequency to daily instead of every minute #9985](https://github.com/Significant-Gravitas/AutoGPT/issues/9985)

This simply updates the Schedule Task's default from minute to daily at 09:00 as default time

![image](https://github.com/user-attachments/assets/673f5e75-a970-41d9-a7b6-531bce4a6d7b)


### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Open the Schedule Task UI and see the default is now daily at 09:00
