### PR TITLE
feat(blocks): Enabling auto type conversion on block input schema mismatch for nested input

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -497,12 +497,9 @@ class CreateListBlock(Block):
 
     async def run(self, input_data: Input, **kwargs) -> BlockOutput:
         try:
-            # The values are already validated by Pydantic schema
-            if input_data.max_size is not None:
-                for i in range(0, len(input_data.values), input_data.max_size):
-                    yield "list", input_data.values[i : i + input_data.max_size]
-            else:
-                yield "list", input_data.values
+            max_size = input_data.max_size or len(input_data.values)
+            for i in range(0, len(input_data.values), max_size):
+                yield "list", input_data.values[i : i + max_size]
         except Exception as e:
             yield "error", f"Failed to create list: {str(e)}"
 

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -348,10 +348,10 @@ async def llm_call(
     # Calculate available tokens based on context window and input length
     estimated_input_tokens = estimate_token_count(prompt)
     context_window = llm_model.context_window
-    model_max_output = llm_model.max_output_tokens or 4096
+    model_max_output = llm_model.max_output_tokens or int(2**15)
     user_max = max_tokens or model_max_output
     available_tokens = max(context_window - estimated_input_tokens, 0)
-    max_tokens = max(min(available_tokens, model_max_output, user_max), 0)
+    max_tokens = max(min(available_tokens, model_max_output, user_max), 1)
 
     if provider == "openai":
         tools_param = tools if tools else openai.NOT_GIVEN

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -402,12 +402,6 @@ def validate_exec(
         return None, f"Block for {node.block_id} not found."
     schema = node_block.input_schema
 
-    # Convert non-matching data types to the expected input schema.
-    for name, data_type in schema.__annotations__.items():
-        value = data.get(name)
-        if (value is not None) and (type(value) is not data_type):
-            data[name] = convert(value, data_type)
-
     # Input data (without default values) should contain all required fields.
     error_prefix = f"Input data missing or mismatch for `{node_block.name}`:"
     if missing_links := schema.get_missing_links(data, node.input_links):
@@ -418,6 +412,12 @@ def validate_exec(
     data = {**input_default, **data}
     if resolve_input:
         data = merge_execution_input(data)
+
+    # Convert non-matching data types to the expected input schema.
+    for name, data_type in schema.__annotations__.items():
+        value = data.get(name)
+        if (value is not None) and (type(value) is not data_type):
+            data[name] = convert(value, data_type)
 
     # Input data post-merge should contain all required fields from the schema.
     if missing_input := schema.get_missing_input(data):


### PR DESCRIPTION
Since auto conversion is applied before merging nested input in the block, it breaks the auto conversion break.

### Changes 🏗️

* Enabling auto-type conversion on block input schema mismatch for nested input
* Add batching feature for `CreateListBlock`
* Increase default max_token size for LLM call

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run `AIStructuredResponseGeneratorBlock` with non-string prompt value (should be auto-converted).
