### PR TITLE
fix(backend): update Unreal Speech API to v8

### DIFF
--- a/autogpt_platform/backend/backend/blocks/text_to_speech_block.py
+++ b/autogpt_platform/backend/backend/blocks/text_to_speech_block.py
@@ -35,8 +35,8 @@ class UnrealTextToSpeechBlock(Block):
         )
         voice_id: str = SchemaField(
             description="The voice ID to use for text-to-speech conversion",
-            placeholder="Scarlett",
-            default="Scarlett",
+            placeholder="Sierra",
+            default="Sierra",
         )
         credentials: CredentialsMetaInput[
             Literal[ProviderName.UNREAL_SPEECH], Literal["api_key"]
@@ -58,7 +58,7 @@ class UnrealTextToSpeechBlock(Block):
             output_schema=UnrealTextToSpeechBlock.Output,
             test_input={
                 "text": "This is a test of the text to speech API.",
-                "voice_id": "Scarlett",
+                "voice_id": "Sierra",
                 "credentials": TEST_CREDENTIALS_INPUT,
             },
             test_output=[("mp3_url", "https://example.com/test.mp3")],
@@ -74,7 +74,7 @@ class UnrealTextToSpeechBlock(Block):
     def call_unreal_speech_api(
         api_key: SecretStr, text: str, voice_id: str
     ) -> dict[str, Any]:
-        url = "https://api.v7.unrealspeech.com/speech"
+        url = "https://api.v8.unrealspeech.com/speech"
         headers = {
             "Authorization": f"Bearer {api_key.get_secret_value()}",
             "Content-Type": "application/json",

--- a/docs/content/platform/blocks/text_to_speech_block.md
+++ b/docs/content/platform/blocks/text_to_speech_block.md
@@ -13,7 +13,7 @@ The block sends the provided text and voice selection to the Unreal Speech API. 
 | Input | Description |
 |-------|-------------|
 | Text | The text you want to convert into speech. This could be a sentence, paragraph, or any written content you'd like to hear spoken aloud. |
-| Voice ID | The identifier for the voice you want to use for the speech. By default, it uses a voice called "Scarlett," but you can change this to other available voices. |
+| Voice ID | The identifier for the voice you want to use for the speech. By default, it uses a voice called "Sierra," but you can change this to other available voices. |
 | API Key | Your personal key to access the Unreal Speech API. This is kept secret and secure. |
 
 ### Outputs


### PR DESCRIPTION
## Summary
- update Unreal Speech TTS block to use API v8
- change default voice to "Sierra" and update docs

## Testing
- `poetry run format`
- `poetry run test` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_b_684c765a8978832ea6d78111ef389808