### PR TITLE
fix(frontend): update scheduler default

### DIFF
--- a/autogpt_platform/frontend/src/components/cronScheduler.tsx
+++ b/autogpt_platform/frontend/src/components/cronScheduler.tsx
@@ -31,7 +31,7 @@ export function CronScheduler({
 }: CronSchedulerProps) {
   const [frequency, setFrequency] = useState<
     "minute" | "hour" | "daily" | "weekly" | "monthly" | "yearly" | "custom"
-  >("minute");
+  >("daily");
   const [selectedDays, setSelectedDays] = useState<number[]>([]);
   const [selectedTime, setSelectedTime] = useState<string>("00:00");
   const [showCustomDays, setShowCustomDays] = useState<boolean>(false);
@@ -82,7 +82,7 @@ export function CronScheduler({
 
             <Select
               onValueChange={(value: any) => setFrequency(value)}
-              defaultValue="minute"
+              defaultValue="daily"
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select frequency" />
@@ -402,7 +402,7 @@ export function CronScheduler({
                   selectedMinute,
                   customInterval,
                 );
-                setFrequency("minute");
+                setFrequency("daily");
                 setSelectedDays([]);
                 setSelectedTime("00:00");
                 setShowCustomDays(false);


### PR DESCRIPTION
## Changes
- default frequency is now daily for new schedules

## Testing
- `pnpm format`
- `pnpm test`
- `poetry run format`
- `poetry run test` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_b_684c54f163cc832e8a5c0774ee28a801