### PR TITLE
fix(backend): Fix `KeyError` in `LibraryAgent.from_db(..)`

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/library/model.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model.py
@@ -137,7 +137,7 @@ class LibraryAgent(pydantic.BaseModel):
                         },
                         "required": [
                             pn
-                            for pn in json_schema["required"] or []
+                            for pn in json_schema.get("required", [])
                             if not is_credentials_field_name(pn)
                         ],
                     },


### PR DESCRIPTION
- Follow-up fix to #10167
- Resolves #10228

### Changes 🏗️

- Don't assume `block.input_schema.jsonschema()["required"]` exists

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - Create an agent with a Generic Webhook Trigger block; go to it in the Library
  - [ ] -> `/library/agents/[id]` loads normally
