### PR TITLE
fix(backend): Avoid swallowing exception on graph execution failure

### DIFF
--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -588,11 +588,11 @@ async def update_graph_execution_start_time(
 
 async def update_graph_execution_stats(
     graph_exec_id: str,
-    status: ExecutionStatus,
+    status: ExecutionStatus | None = None,
     stats: GraphExecutionStats | None = None,
 ) -> GraphExecution | None:
     update_data: AgentGraphExecutionUpdateManyMutationInput = {
-        "executionStatus": status
+        "updatedAt": datetime.now(tz=timezone.utc),
     }
 
     if stats:
@@ -600,6 +600,9 @@ async def update_graph_execution_stats(
         if isinstance(stats_dict.get("error"), Exception):
             stats_dict["error"] = str(stats_dict["error"])
         update_data["stats"] = Json(stats_dict)
+
+    if status:
+        update_data["executionStatus"] = status
 
     updated_count = await AgentGraphExecution.prisma().update_many(
         where={

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -421,7 +421,7 @@ class Executor:
     """
 
     @classmethod
-    @async_error_logged
+    @async_error_logged(swallow=True)
     async def on_node_execution(
         cls,
         node_exec: NodeExecutionEntry,
@@ -529,7 +529,7 @@ class Executor:
         logger.info(f"[GraphExecutor] {cls.pid} started")
 
     @classmethod
-    @error_logged
+    @error_logged(swallow=False)
     def on_graph_execution(
         cls, graph_exec: GraphExecutionEntry, cancel: threading.Event
     ):
@@ -684,7 +684,6 @@ class Executor:
 
             if _graph_exec := db_client.update_graph_execution_stats(
                 graph_exec_id=graph_exec.graph_exec_id,
-                status=execution_status,
                 stats=execution_stats,
             ):
                 send_execution_update(_graph_exec)

--- a/autogpt_platform/backend/backend/util/decorator_test.py
+++ b/autogpt_platform/backend/backend/util/decorator_test.py
@@ -1,6 +1,8 @@
 import time
 
-from backend.util.decorator import error_logged, time_measured
+import pytest
+
+from backend.util.decorator import async_error_logged, error_logged, time_measured
 
 
 @time_measured
@@ -9,18 +11,64 @@ def example_function(a: int, b: int, c: int) -> int:
     return a + b + c
 
 
-@error_logged
-def example_function_with_error(a: int, b: int, c: int) -> int:
-    raise ValueError("This is a test error")
+@error_logged(swallow=True)
+def example_function_with_error_swallowed(a: int, b: int, c: int) -> int:
+    raise ValueError("This error should be swallowed")
+
+
+@error_logged(swallow=False)
+def example_function_with_error_not_swallowed(a: int, b: int, c: int) -> int:
+    raise ValueError("This error should NOT be swallowed")
+
+
+@async_error_logged(swallow=True)
+async def async_function_with_error_swallowed() -> int:
+    raise ValueError("This async error should be swallowed")
+
+
+@async_error_logged(swallow=False)
+async def async_function_with_error_not_swallowed() -> int:
+    raise ValueError("This async error should NOT be swallowed")
 
 
 def test_timer_decorator():
+    """Test that the time_measured decorator correctly measures execution time."""
     info, res = example_function(1, 2, 3)
     assert info.cpu_time >= 0
     assert info.wall_time >= 0.4
     assert res == 6
 
 
-def test_error_decorator():
-    res = example_function_with_error(1, 2, 3)
+def test_error_decorator_swallow_true():
+    """Test that error_logged(swallow=True) logs and swallows errors."""
+    res = example_function_with_error_swallowed(1, 2, 3)
     assert res is None
+
+
+def test_error_decorator_swallow_false():
+    """Test that error_logged(swallow=False) logs errors but re-raises them."""
+    with pytest.raises(ValueError, match="This error should NOT be swallowed"):
+        example_function_with_error_not_swallowed(1, 2, 3)
+
+
+def test_async_error_decorator_swallow_true():
+    """Test that async_error_logged(swallow=True) logs and swallows errors."""
+    import asyncio
+
+    async def run_test():
+        res = await async_function_with_error_swallowed()
+        return res
+
+    res = asyncio.run(run_test())
+    assert res is None
+
+
+def test_async_error_decorator_swallow_false():
+    """Test that async_error_logged(swallow=False) logs errors but re-raises them."""
+    import asyncio
+
+    async def run_test():
+        await async_function_with_error_not_swallowed()
+
+    with pytest.raises(ValueError, match="This async error should NOT be swallowed"):
+        asyncio.run(run_test())

--- a/autogpt_platform/backend/backend/util/service_test.py
+++ b/autogpt_platform/backend/backend/util/service_test.py
@@ -51,7 +51,7 @@ class ServiceTestClient(AppServiceClient):
     subtract_async = endpoint_to_async(ServiceTest.subtract)
 
 
-@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.asyncio
 async def test_service_creation(server):
     with ServiceTest():
         client = get_service_client(ServiceTestClient)


### PR DESCRIPTION
Graph execution that fails due to interruption or unknown error should be enqueued back to the queue. However, swallowing the error ends up not marking the execution as a failure. 

### Changes 🏗️

* Avoid keep updating the graph execution status on each node execution step.
* Added a guard rail to avoid completing graph execution on non-completed execution status.
* Avoid acknowledging messages from the queue if the graph execution is not yet completed.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run graph execution, kill the process, re-run the process
