### PR TITLE
fix(frontend): migrate to `NEXT_PUBLIC_FRONTEND_BASE_URL`

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -55,9 +55,9 @@ RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
 ## GCS bucket is required for marketplace and library functionality
 MEDIA_GCS_BUCKET_NAME=
 
-## For local development, you may need to set FRONTEND_BASE_URL for the OAuth flow
+## For local development, you may need to set NEXT_PUBLIC_FRONTEND_BASE_URL for the OAuth flow
 ## for integrations to work. Defaults to the value of PLATFORM_BASE_URL if not set.
-# FRONTEND_BASE_URL=http://localhost:3000
+# NEXT_PUBLIC_FRONTEND_BASE_URL=http://localhost:3000
 
 ## PLATFORM_BASE_URL must be set to a *publicly accessible* URL pointing to your backend
 ## to use the platform's webhook-related functionality.

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -93,7 +93,7 @@ services:
       - SCHEDULER_HOST=scheduler_server
       - EXECUTIONMANAGER_HOST=executor
       - NOTIFICATIONMANAGER_HOST=rest_server
-      - FRONTEND_BASE_URL=http://localhost:3000
+      - NEXT_PUBLIC_FRONTEND_BASE_URL=http://localhost:3000
       - BACKEND_CORS_ALLOW_ORIGINS=["http://localhost:3000"]
       - ENCRYPTION_KEY=dvziYgz0KSK8FENhju0ZYi8-fRTfAdlz6YLhdB_jhNw= # DO NOT USE IN PRODUCTION!!
       - UNSUBSCRIBE_SECRET_KEY=HlP8ivStJjmbf6NKi78m_3FnOogut0t5ckzjsIqeaio= # DO NOT USE IN PRODUCTION!!

--- a/autogpt_platform/frontend/.env.example
+++ b/autogpt_platform/frontend/.env.example
@@ -1,4 +1,3 @@
-FRONTEND_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_FRONTEND_BASE_URL=http://localhost:3000
 
 NEXT_PUBLIC_AUTH_CALLBACK_URL=http://localhost:8006/auth/callback
@@ -24,7 +23,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAic
 ## OAuth Callback URL
 ## This should be {domain}/auth/callback
 ## Only used if you're using Supabase and OAuth
-AUTH_CALLBACK_URL="${FRONTEND_BASE_URL}/auth/callback"
+AUTH_CALLBACK_URL="${NEXT_PUBLIC_FRONTEND_BASE_URL}/auth/callback"
 GA_MEASUREMENT_ID=G-FH2XK2W4GN
 
 # When running locally, set NEXT_PUBLIC_BEHAVE_AS=CLOUD to use the a locally hosted marketplace (as is typical in development, and the cloud deployment), otherwise set it to LOCAL to have the marketplace open in a new tab

--- a/autogpt_platform/frontend/src/app/(platform)/reset-password/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/reset-password/actions.ts
@@ -10,7 +10,8 @@ export async function sendResetEmail(email: string, turnstileToken: string) {
     {},
     async () => {
       const supabase = await getServerSupabase();
-      const origin = process.env.FRONTEND_BASE_URL || "http://localhost:3000";
+      const origin =
+        process.env.NEXT_PUBLIC_FRONTEND_BASE_URL || "http://localhost:3000";
 
       if (!supabase) {
         redirect("/error");


### PR DESCRIPTION
## Changes 🏗️

We need to `FRONTEND_BASE_URL` to → `NEXT_PUBLIC_FRONTEND_BASE_URL` given is needed on the new API client on the Front-end to make requests. The `NEXT_PUBLIC` prefix is important so that it is available on the client.

## Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the app locally
  - [x] The library and other pages work
