### PR TITLE
fix(frontend): use `NEXT_PUBLIC_AGPT_SERVER_URL` on proxy route

### DIFF
--- a/autogpt_platform/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/autogpt_platform/frontend/src/app/api/proxy/[...path]/route.ts
@@ -1,15 +1,20 @@
-import { NextRequest, NextResponse } from "next/server";
 import {
-  makeAuthenticatedRequest,
   makeAuthenticatedFileUpload,
+  makeAuthenticatedRequest,
 } from "@/lib/autogpt-server-api/helpers";
+import { NextRequest, NextResponse } from "next/server";
 
-const BACKEND_BASE_URL =
-  process.env.NEXT_PUBLIC_AGPT_SERVER_BASE_URL || "http://localhost:8006";
+function getBackendBaseUrl() {
+  if (process.env.NEXT_PUBLIC_AGPT_SERVER_URL) {
+    return process.env.NEXT_PUBLIC_AGPT_SERVER_URL.replace("/api", "");
+  }
+
+  return "http://localhost:8006";
+}
 
 function buildBackendUrl(path: string[], queryString: string): string {
   const backendPath = path.join("/");
-  return `${BACKEND_BASE_URL}/${backendPath}${queryString}`;
+  return `${getBackendBaseUrl()}/${backendPath}${queryString}`;
 }
 
 async function handleJsonRequest(
@@ -145,9 +150,9 @@ async function handler(
 }
 
 export {
+  handler as DELETE,
   handler as GET,
+  handler as PATCH,
   handler as POST,
   handler as PUT,
-  handler as PATCH,
-  handler as DELETE,
 };


### PR DESCRIPTION
### Changes 🏗️

A new undocumented env var, `NEXT_PUBLIC_AGPT_SERVER_BASE_URL`, was added to the proxy route for it to work with the new `react-query` mutator. 

I removed it and used the existing `NEXT_PUBLIC_AGPT_SERVER_URL`, so we have fewer environment variables to manage ( _and this one is already added to all environments_ ).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the server locally
  - [x] All pages ( library, marketplace, builder, settings ) work

