### PR TITLE
fix(frontend): do not swallow errors on the proxy

### DIFF
--- a/autogpt_platform/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/autogpt_platform/frontend/src/app/api/proxy/[...path]/route.ts
@@ -1,4 +1,5 @@
 import {
+  ApiError,
   makeAuthenticatedFileUpload,
   makeAuthenticatedRequest,
 } from "@/lib/autogpt-server-api/helpers";
@@ -97,6 +98,16 @@ function createResponse(
 
 function createErrorResponse(error: unknown): NextResponse {
   console.error("API proxy error:", error);
+
+  // If it's our custom ApiError, preserve the original status and response
+  if (error instanceof ApiError) {
+    return NextResponse.json(
+      error.response || { error: error.message, detail: error.message },
+      { status: error.status },
+    );
+  }
+
+  // For other errors, use generic response
   const detail =
     error instanceof Error ? error.message : "An unknown error occurred";
   return NextResponse.json(


### PR DESCRIPTION
## Changes 🏗️

Requests to the Backend happen now on the server, given we moved to server-side cookies 🍪 ... however the client proxy is not exposing the API errors to the client correctly. This aim to fix that.

## Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Login to the platform
  - [x] Run agents until you encounter an error
  - [x] The error is shown on the toast   
