### PR TITLE
feat(backend): improve stop graph execution reliability

### DIFF
--- a/autogpt_platform/backend/backend/blocks/basic.py
+++ b/autogpt_platform/backend/backend/blocks/basic.py
@@ -529,7 +529,7 @@ class CreateListBlock(Block):
                 cur_size, cur_tokens = cur_size + 1, cur_tokens + tokens
 
         # Yield final chunk if any
-        if chunk:
+        if chunk or not input_data.values:
             yield "list", chunk
 
 

--- a/autogpt_platform/backend/backend/data/execution.py
+++ b/autogpt_platform/backend/backend/data/execution.py
@@ -347,6 +347,7 @@ class NodeExecutionResult(BaseModel):
 
 
 async def get_graph_executions(
+    graph_exec_id: str | None = None,
     graph_id: str | None = None,
     user_id: str | None = None,
     statuses: list[ExecutionStatus] | None = None,
@@ -357,6 +358,8 @@ async def get_graph_executions(
     where_filter: AgentGraphExecutionWhereInput = {
         "isDeleted": False,
     }
+    if graph_exec_id:
+        where_filter["id"] = graph_exec_id
     if user_id:
         where_filter["userId"] = user_id
     if graph_id:

--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -204,6 +204,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     create_graph_execution = d.create_graph_execution
     get_latest_node_execution = d.get_latest_node_execution
     get_graph = d.get_graph
+    get_graph_execution_meta = d.get_graph_execution_meta
     get_node = d.get_node
     get_node_execution = d.get_node_execution
     get_node_executions = d.get_node_executions

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -24,7 +24,7 @@ from backend.data.notifications import (
     NotificationType,
 )
 from backend.data.rabbitmq import SyncRabbitMQ
-from backend.executor.utils import create_execution_queue_config
+from backend.executor.utils import LogMetadata, create_execution_queue_config
 from backend.notifications.notifications import queue_notification
 from backend.util.exceptions import InsufficientBalanceError
 
@@ -98,35 +98,6 @@ utilization_gauge = Gauge(
 )
 
 
-class LogMetadata(TruncatedLogger):
-    def __init__(
-        self,
-        user_id: str,
-        graph_eid: str,
-        graph_id: str,
-        node_eid: str,
-        node_id: str,
-        block_name: str,
-        max_length: int = 1000,
-    ):
-        metadata = {
-            "component": "ExecutionManager",
-            "user_id": user_id,
-            "graph_eid": graph_eid,
-            "graph_id": graph_id,
-            "node_eid": node_eid,
-            "node_id": node_id,
-            "block_name": block_name,
-        }
-        prefix = f"[ExecutionManager|uid:{user_id}|gid:{graph_id}|nid:{node_id}]|geid:{graph_eid}|neid:{node_eid}|{block_name}]"
-        super().__init__(
-            _logger,
-            max_length=max_length,
-            prefix=prefix,
-            metadata=metadata,
-        )
-
-
 T = TypeVar("T")
 
 
@@ -158,6 +129,7 @@ async def execute_node(
     node_block = node.block
 
     log_metadata = LogMetadata(
+        logger=_logger,
         user_id=user_id,
         graph_eid=graph_exec_id,
         graph_id=graph_id,
@@ -429,6 +401,7 @@ class Executor:
         nodes_input_masks: Optional[dict[str, dict[str, JsonValue]]] = None,
     ) -> NodeExecutionStats:
         log_metadata = LogMetadata(
+            logger=_logger,
             user_id=node_exec.user_id,
             graph_eid=node_exec.graph_exec_id,
             graph_id=node_exec.graph_id,
@@ -534,6 +507,7 @@ class Executor:
         cls, graph_exec: GraphExecutionEntry, cancel: threading.Event
     ):
         log_metadata = LogMetadata(
+            logger=_logger,
             user_id=graph_exec.user_id,
             graph_eid=graph_exec.graph_exec_id,
             graph_id=graph_exec.graph_id,
@@ -861,6 +835,7 @@ class Executor:
                 f"Failed graph execution {graph_exec.graph_exec_id}: {error}"
             )
         finally:
+            # Cancel and wait for all node executions to complete
             for node_id, inflight_exec in running_node_execution.items():
                 if inflight_exec.is_done():
                     continue
@@ -872,6 +847,28 @@ class Executor:
                     continue
                 log_metadata.info(f"Stopping node evaluation {node_id}")
                 inflight_eval.cancel()
+
+            for node_id, inflight_exec in running_node_execution.items():
+                if inflight_exec.is_done():
+                    continue
+                try:
+                    inflight_exec.wait_for_cancellation(timeout=60.0)
+                except TimeoutError:
+                    log_metadata.exception(
+                        f"Node execution #{node_id} did not stop in time, "
+                        "it may be stuck or taking too long."
+                    )
+
+            for node_id, inflight_eval in running_node_evaluation.items():
+                if inflight_eval.done():
+                    continue
+                try:
+                    inflight_eval.result(timeout=60.0)
+                except TimeoutError:
+                    log_metadata.exception(
+                        f"Node evaluation #{node_id} did not stop in time, "
+                        "it may be stuck or taking too long."
+                    )
 
             if execution_status in [ExecutionStatus.TERMINATED, ExecutionStatus.FAILED]:
                 inflight_executions = db_client.get_node_executions(

--- a/autogpt_platform/frontend/src/components/agents/agent-run-status-chip.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-status-chip.tsx
@@ -57,9 +57,9 @@ export default function AgentRunStatusChip({
   return (
     <Badge
       variant="secondary"
-      className={`text-xs font-medium ${statusStyles[statusData[status].variant]} rounded-[45px] px-[9px] py-[3px]`}
+      className={`text-xs font-medium ${statusStyles[statusData[status]?.variant]} rounded-[45px] px-[9px] py-[3px]`}
     >
-      {statusData[status].label}
+      {statusData[status]?.label}
     </Badge>
   );
 }

--- a/autogpt_platform/frontend/src/components/agents/agent-status-chip.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-status-chip.tsx
@@ -32,7 +32,7 @@ export default function AgentStatusChip({
   return (
     <Badge
       variant="secondary"
-      className={`text-xs font-medium ${statusStyles[statusData[status].variant]} rounded-[45px] px-[9px] py-[3px]`}
+      className={`text-xs font-medium ${statusStyles[statusData[status]?.variant]} rounded-[45px] px-[9px] py-[3px]`}
     >
       {statusData[status].label}
     </Badge>

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -673,14 +673,7 @@ export default function useAgentGraph(
       savedAgent &&
       saveRunRequest.activeExecutionID
     ) {
-      setSaveRunRequest({
-        request: "stop",
-        state: "stopping",
-        activeExecutionID: saveRunRequest.activeExecutionID,
-      });
-      api
-        .stopGraphExecution(savedAgent.id, saveRunRequest.activeExecutionID)
-        .then(() => setSaveRunRequest({ request: "none", state: "none" }));
+      api.stopGraphExecution(savedAgent.id, saveRunRequest.activeExecutionID);
     }
   }, [
     api,


### PR DESCRIPTION
## Summary
- Enhanced graph execution cancellation and cleanup mechanisms
- Improved error handling and logging for graph execution lifecycle
- Added timeout handling for graph termination with proper status updates
- Exposed a new API for stopping graph based on only graph_id or user_id
- Refactored logging metadata structure for better error tracking

## Key Changes
### Backend
- **Graph Execution Management**: Enhanced `stop_graph_execution` with timeout-based waiting and proper status transitions
- **Execution Cleanup**: Added proper cancellation waiting with timeout handling in executor manager
- **Logging Improvements**: Centralized `LogMetadata` class and improved error logging consistency
- **API Enhancements**: Added bulk graph execution stopping functionality
- **Error Handling**: Better exception handling and status management for failed/cancelled executions

### Frontend
- **Status Safety**: Added null safety checks for status chips to prevent runtime errors
- **Execution Control**: Simplified stop execution request handling

## Test Plan
- [x] Verify graph execution can be properly stopped and reaches terminal state
- [x] Test timeout scenarios for stuck executions
- [x] Validate proper cleanup of running node executions when graph is cancelled
- [x] Check frontend status chips handle undefined statuses gracefully
- [x] Test bulk execution stopping functionality

🤖 Generated with [Claude Code](https://claude.ai/code)