### PR TITLE
fix(frontend): Add fallback for `NEXT_PUBLIC_FRONTEND_BASE_URL` to API proxy

### DIFF
--- a/autogpt_platform/backend/.env.example
+++ b/autogpt_platform/backend/.env.example
@@ -55,9 +55,9 @@ RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7
 ## GCS bucket is required for marketplace and library functionality
 MEDIA_GCS_BUCKET_NAME=
 
-## For local development, you may need to set NEXT_PUBLIC_FRONTEND_BASE_URL for the OAuth flow
+## For local development, you may need to set FRONTEND_BASE_URL for the OAuth flow
 ## for integrations to work. Defaults to the value of PLATFORM_BASE_URL if not set.
-# NEXT_PUBLIC_FRONTEND_BASE_URL=http://localhost:3000
+# FRONTEND_BASE_URL=http://localhost:3000
 
 ## PLATFORM_BASE_URL must be set to a *publicly accessible* URL pointing to your backend
 ## to use the platform's webhook-related functionality.

--- a/autogpt_platform/frontend/src/app/api/mutators/custom-mutator.ts
+++ b/autogpt_platform/frontend/src/app/api/mutators/custom-mutator.ts
@@ -1,4 +1,6 @@
-const BASE_URL = `${process.env.NEXT_PUBLIC_FRONTEND_BASE_URL}/api/proxy`; // Sending request via nextjs Server
+const FRONTEND_BASE_URL =
+  process.env.NEXT_PUBLIC_FRONTEND_BASE_URL || "http://localhost:3000";
+const API_PROXY_BASE_URL = `${FRONTEND_BASE_URL}/api/proxy`; // Sending request via nextjs Server
 
 const getBody = <T>(c: Response | Request): Promise<T> => {
   const contentType = c.headers.get("content-type");
@@ -43,7 +45,7 @@ export const customMutator = async <T = any>(
     ? "?" + new URLSearchParams(params).toString()
     : "";
 
-  const response = await fetch(`${BASE_URL}${url}${queryString}`, {
+  const response = await fetch(`${API_PROXY_BASE_URL}${url}${queryString}`, {
     ...requestOptions,
     method,
     headers,


### PR DESCRIPTION
- Resolves #10298
- Follow-up to #10270

### Changes 🏗️

Amend two changes from #10270:

- Add fallback for `NEXT_PUBLIC_FRONTEND_BASE_URL` in custom-mutator.ts
- Revert rename of `FRONTEND_BASE_URL` to `NEXT_PUBLIC_FRONTEND_BASE_URL` in `backend/.env.example`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - Don't set `NEXT_PUBLIC_FRONTEND_BASE_URL`
  - Run the platform locally
  - [ ] -> `/library` loads normally

#### For configuration changes:
- [x] `.env.example` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
