### PR TITLE
fix(backend/library): Include subgraphs in `get_library_agent`

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/library/db.py
+++ b/autogpt_platform/backend/backend/server/v2/library/db.py
@@ -170,7 +170,14 @@ async def get_library_agent(id: str, user_id: str) -> library_model.LibraryAgent
         if not library_agent:
             raise NotFoundError(f"Library agent #{id} not found")
 
-        return library_model.LibraryAgent.from_db(library_agent)
+        return library_model.LibraryAgent.from_db(
+            library_agent,
+            sub_graphs=(
+                await graph_db.get_sub_graphs(library_agent.AgentGraph)
+                if library_agent.AgentGraph
+                else None
+            ),
+        )
 
     except prisma.errors.PrismaError as e:
         logger.error(f"Database error fetching library agent: {e}")

--- a/autogpt_platform/backend/backend/server/v2/library/model.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model.py
@@ -51,7 +51,7 @@ class LibraryAgent(pydantic.BaseModel):
     description: str
 
     input_schema: dict[str, Any]  # Should be BlockIOObjectSubSchema in frontend
-    credentials_input_schema: dict[str, Any] = pydantic.Field(
+    credentials_input_schema: dict[str, Any] | None = pydantic.Field(
         description="Input schema for credentials required by the agent",
     )
 
@@ -70,7 +70,10 @@ class LibraryAgent(pydantic.BaseModel):
     is_latest_version: bool
 
     @staticmethod
-    def from_db(agent: prisma.models.LibraryAgent) -> "LibraryAgent":
+    def from_db(
+        agent: prisma.models.LibraryAgent,
+        sub_graphs: Optional[list[prisma.models.AgentGraph]] = None,
+    ) -> "LibraryAgent":
         """
         Factory method that constructs a LibraryAgent from a Prisma LibraryAgent
         model instance.
@@ -78,7 +81,7 @@ class LibraryAgent(pydantic.BaseModel):
         if not agent.AgentGraph:
             raise ValueError("Associated Agent record is required.")
 
-        graph = graph_model.GraphModel.from_db(agent.AgentGraph)
+        graph = graph_model.GraphModel.from_db(agent.AgentGraph, sub_graphs=sub_graphs)
 
         agent_updated_at = agent.AgentGraph.updatedAt
         lib_agent_updated_at = agent.updatedAt
@@ -123,7 +126,9 @@ class LibraryAgent(pydantic.BaseModel):
             name=graph.name,
             description=graph.description,
             input_schema=graph.input_schema,
-            credentials_input_schema=graph.credentials_input_schema,
+            credentials_input_schema=(
+                graph.credentials_input_schema if sub_graphs else None
+            ),
             has_external_trigger=graph.has_webhook_trigger,
             trigger_setup_info=(
                 LibraryAgentTriggerInfo(


### PR DESCRIPTION
- Resolves #10300
- Follow-up fix to #10167

### Changes 🏗️

- Include sub-graphs in `get_library_agent` endpoint

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Executing agent with sub-graphs that require credentials works
