### PR TITLE
fix(frontend): password reset with server cookies

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx
@@ -18,24 +18,44 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import LoadingBox from "@/components/ui/loading";
+import { useToast } from "@/components/ui/use-toast";
 import { useTurnstile } from "@/hooks/useTurnstile";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
 import { getBehaveAs } from "@/lib/utils";
 import { changePasswordFormSchema, sendEmailFormSchema } from "@/types/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useCallback, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { changePassword, sendResetEmail } from "./actions";
 
 export default function ResetPasswordPage() {
   const { supabase, user, isUserLoading } = useSupabase();
+  const { toast } = useToast();
+  const searchParams = useSearchParams();
+  const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [isError, setIsError] = useState(false);
   const [disabled, setDisabled] = useState(false);
   const [sendEmailCaptchaKey, setSendEmailCaptchaKey] = useState(0);
   const [changePasswordCaptchaKey, setChangePasswordCaptchaKey] = useState(0);
+
+  useEffect(() => {
+    const error = searchParams.get("error");
+    if (error) {
+      toast({
+        title: "Password Reset Failed",
+        description: error,
+        variant: "destructive",
+      });
+
+      const newUrl = new URL(window.location.href);
+      newUrl.searchParams.delete("error");
+      router.replace(newUrl.pathname + newUrl.search);
+    }
+  }, [searchParams, toast, router]);
 
   const sendEmailTurnstile = useTurnstile({
     action: "reset_password",

--- a/autogpt_platform/frontend/src/lib/supabase/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/supabase/helpers.ts
@@ -98,3 +98,38 @@ export function setupSessionEventListeners(
     },
   };
 }
+
+export interface CodeExchangeResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function exchangePasswordResetCode(
+  supabase: any,
+  code: string,
+): Promise<CodeExchangeResult> {
+  try {
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (error) {
+      return {
+        success: false,
+        error: error.message,
+      };
+    }
+
+    if (!data.session) {
+      return {
+        success: false,
+        error: "Failed to create session",
+      };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/autogpt_platform/frontend/src/lib/supabase/middleware.ts
+++ b/autogpt_platform/frontend/src/lib/supabase/middleware.ts
@@ -1,6 +1,11 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-import { getCookieSettings, isAdminPage, isProtectedPage } from "./helpers";
+import {
+  exchangePasswordResetCode,
+  getCookieSettings,
+  isAdminPage,
+  isProtectedPage,
+} from "./helpers";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -43,17 +48,29 @@ export async function updateSession(request: NextRequest) {
       },
     );
 
+    const userResponse = await supabase.auth.getUser();
+    const user = userResponse.data.user;
+    const userRole = user?.role;
+
+    // RESET PASSWORD CODE EXCHANGE
+    const url = request.nextUrl.clone();
+    const pathname = request.nextUrl.pathname;
+    if (pathname === "/reset-password" && url.searchParams.has("code")) {
+      const code = url.searchParams.get("code");
+      const result = await exchangePasswordResetCode(supabase, code!);
+
+      url.searchParams.delete("code");
+
+      if (!result.success) {
+        url.searchParams.set("error", result.error || "Password reset failed");
+      }
+
+      return NextResponse.redirect(url);
+    }
+
     // IMPORTANT: Avoid writing any logic between createServerClient and
     // supabase.auth.getUser(). A simple mistake could make it very hard to debug
     // issues with users being randomly logged out.
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    const userRole = user?.role;
-    const url = request.nextUrl.clone();
-    const pathname = request.nextUrl.pathname;
 
     // AUTH REDIRECTS
     // 1. Check if user is not authenticated but trying to access protected content


### PR DESCRIPTION
## Changes 🏗️

### Root Cause

With httpOnly cookies, the Supabase client can't automatically exchange password reset codes for sessions client-side because it can't access the secure cookies 🍪 ( _which is a good thing_ ). 

Previously, when users clicked email reset links, the browser would automatically handle the code exchange, but `httpOnly` cookies broke this flow 🥵 

### Solution

Moved password reset code exchange to server-side middleware that can access `httpOnly` cookies and properly create authenticated sessions.

### Code Changes

**`middleware.ts`**
- intercepts `/reset-password` URLs containing `code` parameter
- uses helper function to exchange code for session server-side
- redirects with error parameters if exchange fails
- moved `getUser()` call to avoid middleware timing issues

**`reset-password/page.tsx`**
- added toast notifications for password reset errors
- checks URL parameters for error messages on page load

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Password reset emails send successfully
  - [x] Valid reset codes exchange for sessions server-side
  - [x] Invalid/expired codes show error messages via toast
  - [x] Successfully authenticated users can change passwords
  - [x] URL parameters are cleaned up after error display
  - [x] Middleware doesn't break normal authentication flows