### PR TITLE
feat(blocks): add plural outputs where blocks yield singular values in loops

### DIFF
--- a/autogpt_platform/backend/backend/blocks/github/issues.py
+++ b/autogpt_platform/backend/backend/blocks/github/issues.py
@@ -517,13 +517,6 @@ class GithubListIssuesBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "issue",
-                    {
-                        "title": "Issue 1",
-                        "url": "https://github.com/owner/repo/issues/1",
-                    },
-                ),
-                (
                     "issues",
                     [
                         {
@@ -531,6 +524,13 @@ class GithubListIssuesBlock(Block):
                             "url": "https://github.com/owner/repo/issues/1",
                         }
                     ],
+                ),
+                (
+                    "issue",
+                    {
+                        "title": "Issue 1",
+                        "url": "https://github.com/owner/repo/issues/1",
+                    },
                 ),
             ],
             test_mock={

--- a/autogpt_platform/backend/backend/blocks/github/issues.py
+++ b/autogpt_platform/backend/backend/blocks/github/issues.py
@@ -498,6 +498,9 @@ class GithubListIssuesBlock(Block):
         issue: IssueItem = SchemaField(
             title="Issue", description="Issues with their title and URL"
         )
+        issues: list[IssueItem] = SchemaField(
+            description="List of issues with their title and URL"
+        )
         error: str = SchemaField(description="Error message if listing issues failed")
 
     def __init__(self):
@@ -519,7 +522,16 @@ class GithubListIssuesBlock(Block):
                         "title": "Issue 1",
                         "url": "https://github.com/owner/repo/issues/1",
                     },
-                )
+                ),
+                (
+                    "issues",
+                    [
+                        {
+                            "title": "Issue 1",
+                            "url": "https://github.com/owner/repo/issues/1",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_issues": lambda *args, **kwargs: [
@@ -551,10 +563,12 @@ class GithubListIssuesBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        for issue in await self.list_issues(
+        issues = await self.list_issues(
             credentials,
             input_data.repo_url,
-        ):
+        )
+        yield "issues", issues
+        for issue in issues:
             yield "issue", issue
 
 

--- a/autogpt_platform/backend/backend/blocks/github/pull_requests.py
+++ b/autogpt_platform/backend/backend/blocks/github/pull_requests.py
@@ -34,7 +34,7 @@ class GithubListPullRequestsBlock(Block):
         pull_requests: list[PRItem] = SchemaField(
             description="List of pull requests with their title and URL"
         )
-        error: str = SchemaField(description="Error message if listing issues failed")
+        error: str = SchemaField(description="Error message if listing pull requests failed")
 
     def __init__(self):
         super().__init__(

--- a/autogpt_platform/backend/backend/blocks/github/pull_requests.py
+++ b/autogpt_platform/backend/backend/blocks/github/pull_requests.py
@@ -34,7 +34,9 @@ class GithubListPullRequestsBlock(Block):
         pull_requests: list[PRItem] = SchemaField(
             description="List of pull requests with their title and URL"
         )
-        error: str = SchemaField(description="Error message if listing pull requests failed")
+        error: str = SchemaField(
+            description="Error message if listing pull requests failed"
+        )
 
     def __init__(self):
         super().__init__(
@@ -50,13 +52,6 @@ class GithubListPullRequestsBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "pull_request",
-                    {
-                        "title": "Pull request 1",
-                        "url": "https://github.com/owner/repo/pull/1",
-                    },
-                ),
-                (
                     "pull_requests",
                     [
                         {
@@ -64,6 +59,13 @@ class GithubListPullRequestsBlock(Block):
                             "url": "https://github.com/owner/repo/pull/1",
                         }
                     ],
+                ),
+                (
+                    "pull_request",
+                    {
+                        "title": "Pull request 1",
+                        "url": "https://github.com/owner/repo/pull/1",
+                    },
                 ),
             ],
             test_mock={
@@ -494,13 +496,6 @@ class GithubListPRReviewersBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "reviewer",
-                    {
-                        "username": "reviewer1",
-                        "url": "https://github.com/reviewer1",
-                    },
-                ),
-                (
                     "reviewers",
                     [
                         {
@@ -508,6 +503,13 @@ class GithubListPRReviewersBlock(Block):
                             "url": "https://github.com/reviewer1",
                         }
                     ],
+                ),
+                (
+                    "reviewer",
+                    {
+                        "username": "reviewer1",
+                        "url": "https://github.com/reviewer1",
+                    },
                 ),
             ],
             test_mock={

--- a/autogpt_platform/backend/backend/blocks/github/pull_requests.py
+++ b/autogpt_platform/backend/backend/blocks/github/pull_requests.py
@@ -31,6 +31,9 @@ class GithubListPullRequestsBlock(Block):
         pull_request: PRItem = SchemaField(
             title="Pull Request", description="PRs with their title and URL"
         )
+        pull_requests: list[PRItem] = SchemaField(
+            description="List of pull requests with their title and URL"
+        )
         error: str = SchemaField(description="Error message if listing issues failed")
 
     def __init__(self):
@@ -52,7 +55,16 @@ class GithubListPullRequestsBlock(Block):
                         "title": "Pull request 1",
                         "url": "https://github.com/owner/repo/pull/1",
                     },
-                )
+                ),
+                (
+                    "pull_requests",
+                    [
+                        {
+                            "title": "Pull request 1",
+                            "url": "https://github.com/owner/repo/pull/1",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_prs": lambda *args, **kwargs: [
@@ -88,6 +100,7 @@ class GithubListPullRequestsBlock(Block):
             credentials,
             input_data.repo_url,
         )
+        yield "pull_requests", pull_requests
         for pr in pull_requests:
             yield "pull_request", pr
 
@@ -460,6 +473,9 @@ class GithubListPRReviewersBlock(Block):
             title="Reviewer",
             description="Reviewers with their username and profile URL",
         )
+        reviewers: list[ReviewerItem] = SchemaField(
+            description="List of reviewers with their username and profile URL"
+        )
         error: str = SchemaField(
             description="Error message if listing reviewers failed"
         )
@@ -483,7 +499,16 @@ class GithubListPRReviewersBlock(Block):
                         "username": "reviewer1",
                         "url": "https://github.com/reviewer1",
                     },
-                )
+                ),
+                (
+                    "reviewers",
+                    [
+                        {
+                            "username": "reviewer1",
+                            "url": "https://github.com/reviewer1",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_reviewers": lambda *args, **kwargs: [
@@ -516,10 +541,12 @@ class GithubListPRReviewersBlock(Block):
         credentials: GithubCredentials,
         **kwargs,
     ) -> BlockOutput:
-        for reviewer in await self.list_reviewers(
+        reviewers = await self.list_reviewers(
             credentials,
             input_data.pr_url,
-        ):
+        )
+        yield "reviewers", reviewers
+        for reviewer in reviewers:
             yield "reviewer", reviewer
 
 

--- a/autogpt_platform/backend/backend/blocks/github/repo.py
+++ b/autogpt_platform/backend/backend/blocks/github/repo.py
@@ -50,13 +50,6 @@ class GithubListTagsBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "tag",
-                    {
-                        "name": "v1.0.0",
-                        "url": "https://github.com/owner/repo/tree/v1.0.0",
-                    },
-                ),
-                (
                     "tags",
                     [
                         {
@@ -64,6 +57,13 @@ class GithubListTagsBlock(Block):
                             "url": "https://github.com/owner/repo/tree/v1.0.0",
                         }
                     ],
+                ),
+                (
+                    "tag",
+                    {
+                        "name": "v1.0.0",
+                        "url": "https://github.com/owner/repo/tree/v1.0.0",
+                    },
                 ),
             ],
             test_mock={
@@ -146,13 +146,6 @@ class GithubListBranchesBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "branch",
-                    {
-                        "name": "main",
-                        "url": "https://github.com/owner/repo/tree/main",
-                    },
-                ),
-                (
                     "branches",
                     [
                         {
@@ -160,6 +153,13 @@ class GithubListBranchesBlock(Block):
                             "url": "https://github.com/owner/repo/tree/main",
                         }
                     ],
+                ),
+                (
+                    "branch",
+                    {
+                        "name": "main",
+                        "url": "https://github.com/owner/repo/tree/main",
+                    },
                 ),
             ],
             test_mock={
@@ -247,13 +247,6 @@ class GithubListDiscussionsBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "discussion",
-                    {
-                        "title": "Discussion 1",
-                        "url": "https://github.com/owner/repo/discussions/1",
-                    },
-                ),
-                (
                     "discussions",
                     [
                         {
@@ -261,6 +254,13 @@ class GithubListDiscussionsBlock(Block):
                             "url": "https://github.com/owner/repo/discussions/1",
                         }
                     ],
+                ),
+                (
+                    "discussion",
+                    {
+                        "title": "Discussion 1",
+                        "url": "https://github.com/owner/repo/discussions/1",
+                    },
                 ),
             ],
             test_mock={
@@ -358,13 +358,6 @@ class GithubListReleasesBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "release",
-                    {
-                        "name": "v1.0.0",
-                        "url": "https://github.com/owner/repo/releases/tag/v1.0.0",
-                    },
-                ),
-                (
                     "releases",
                     [
                         {
@@ -372,6 +365,13 @@ class GithubListReleasesBlock(Block):
                             "url": "https://github.com/owner/repo/releases/tag/v1.0.0",
                         }
                     ],
+                ),
+                (
+                    "release",
+                    {
+                        "name": "v1.0.0",
+                        "url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+                    },
                 ),
             ],
             test_mock={
@@ -1114,13 +1114,6 @@ class GithubListStargazersBlock(Block):
             test_credentials=TEST_CREDENTIALS,
             test_output=[
                 (
-                    "stargazer",
-                    {
-                        "username": "octocat",
-                        "url": "https://github.com/octocat",
-                    },
-                ),
-                (
                     "stargazers",
                     [
                         {
@@ -1128,6 +1121,13 @@ class GithubListStargazersBlock(Block):
                             "url": "https://github.com/octocat",
                         }
                     ],
+                ),
+                (
+                    "stargazer",
+                    {
+                        "username": "octocat",
+                        "url": "https://github.com/octocat",
+                    },
                 ),
             ],
             test_mock={

--- a/autogpt_platform/backend/backend/blocks/github/repo.py
+++ b/autogpt_platform/backend/backend/blocks/github/repo.py
@@ -31,6 +31,9 @@ class GithubListTagsBlock(Block):
         tag: TagItem = SchemaField(
             title="Tag", description="Tags with their name and file tree browser URL"
         )
+        tags: list[TagItem] = SchemaField(
+            description="List of tags with their name and file tree browser URL"
+        )
         error: str = SchemaField(description="Error message if listing tags failed")
 
     def __init__(self):
@@ -52,7 +55,16 @@ class GithubListTagsBlock(Block):
                         "name": "v1.0.0",
                         "url": "https://github.com/owner/repo/tree/v1.0.0",
                     },
-                )
+                ),
+                (
+                    "tags",
+                    [
+                        {
+                            "name": "v1.0.0",
+                            "url": "https://github.com/owner/repo/tree/v1.0.0",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_tags": lambda *args, **kwargs: [
@@ -93,6 +105,7 @@ class GithubListTagsBlock(Block):
             credentials,
             input_data.repo_url,
         )
+        yield "tags", tags
         for tag in tags:
             yield "tag", tag
 
@@ -113,6 +126,9 @@ class GithubListBranchesBlock(Block):
         branch: BranchItem = SchemaField(
             title="Branch",
             description="Branches with their name and file tree browser URL",
+        )
+        branches: list[BranchItem] = SchemaField(
+            description="List of branches with their name and file tree browser URL"
         )
         error: str = SchemaField(description="Error message if listing branches failed")
 
@@ -135,7 +151,16 @@ class GithubListBranchesBlock(Block):
                         "name": "main",
                         "url": "https://github.com/owner/repo/tree/main",
                     },
-                )
+                ),
+                (
+                    "branches",
+                    [
+                        {
+                            "name": "main",
+                            "url": "https://github.com/owner/repo/tree/main",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_branches": lambda *args, **kwargs: [
@@ -176,6 +201,7 @@ class GithubListBranchesBlock(Block):
             credentials,
             input_data.repo_url,
         )
+        yield "branches", branches
         for branch in branches:
             yield "branch", branch
 
@@ -198,6 +224,9 @@ class GithubListDiscussionsBlock(Block):
 
         discussion: DiscussionItem = SchemaField(
             title="Discussion", description="Discussions with their title and URL"
+        )
+        discussions: list[DiscussionItem] = SchemaField(
+            description="List of discussions with their title and URL"
         )
         error: str = SchemaField(
             description="Error message if listing discussions failed"
@@ -223,7 +252,16 @@ class GithubListDiscussionsBlock(Block):
                         "title": "Discussion 1",
                         "url": "https://github.com/owner/repo/discussions/1",
                     },
-                )
+                ),
+                (
+                    "discussions",
+                    [
+                        {
+                            "title": "Discussion 1",
+                            "url": "https://github.com/owner/repo/discussions/1",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_discussions": lambda *args, **kwargs: [
@@ -279,6 +317,7 @@ class GithubListDiscussionsBlock(Block):
             input_data.repo_url,
             input_data.num_discussions,
         )
+        yield "discussions", discussions
         for discussion in discussions:
             yield "discussion", discussion
 
@@ -299,6 +338,9 @@ class GithubListReleasesBlock(Block):
         release: ReleaseItem = SchemaField(
             title="Release",
             description="Releases with their name and file tree browser URL",
+        )
+        releases: list[ReleaseItem] = SchemaField(
+            description="List of releases with their name and file tree browser URL"
         )
         error: str = SchemaField(description="Error message if listing releases failed")
 
@@ -321,7 +363,16 @@ class GithubListReleasesBlock(Block):
                         "name": "v1.0.0",
                         "url": "https://github.com/owner/repo/releases/tag/v1.0.0",
                     },
-                )
+                ),
+                (
+                    "releases",
+                    [
+                        {
+                            "name": "v1.0.0",
+                            "url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_releases": lambda *args, **kwargs: [
@@ -357,6 +408,7 @@ class GithubListReleasesBlock(Block):
             credentials,
             input_data.repo_url,
         )
+        yield "releases", releases
         for release in releases:
             yield "release", release
 
@@ -1041,6 +1093,9 @@ class GithubListStargazersBlock(Block):
             title="Stargazer",
             description="Stargazers with their username and profile URL",
         )
+        stargazers: list[StargazerItem] = SchemaField(
+            description="List of stargazers with their username and profile URL"
+        )
         error: str = SchemaField(
             description="Error message if listing stargazers failed"
         )
@@ -1064,7 +1119,16 @@ class GithubListStargazersBlock(Block):
                         "username": "octocat",
                         "url": "https://github.com/octocat",
                     },
-                )
+                ),
+                (
+                    "stargazers",
+                    [
+                        {
+                            "username": "octocat",
+                            "url": "https://github.com/octocat",
+                        }
+                    ],
+                ),
             ],
             test_mock={
                 "list_stargazers": lambda *args, **kwargs: [
@@ -1104,5 +1168,6 @@ class GithubListStargazersBlock(Block):
             credentials,
             input_data.repo_url,
         )
+        yield "stargazers", stargazers
         for stargazer in stargazers:
             yield "stargazer", stargazer

--- a/autogpt_platform/backend/backend/blocks/mem0.py
+++ b/autogpt_platform/backend/backend/blocks/mem0.py
@@ -77,6 +77,9 @@ class AddMemoryBlock(Block, Mem0Base):
     class Output(BlockSchema):
         action: str = SchemaField(description="Action of the operation")
         memory: str = SchemaField(description="Memory created")
+        results: list[dict[str, str]] = SchemaField(
+            description="List of all results from the operation"
+        )
         error: str = SchemaField(description="Error message if operation fails")
 
     def __init__(self):
@@ -104,8 +107,10 @@ class AddMemoryBlock(Block, Mem0Base):
                 },
             ],
             test_output=[
+                ("results", [{"event": "CREATED", "memory": "test memory"}]),
                 ("action", "CREATED"),
                 ("memory", "test memory"),
+                ("results", [{"event": "CREATED", "memory": "test memory"}]),
                 ("action", "CREATED"),
                 ("memory", "test memory"),
             ],
@@ -150,8 +155,11 @@ class AddMemoryBlock(Block, Mem0Base):
                 **params,
             )
 
-            if len(result.get("results", [])) > 0:
-                for result in result.get("results", []):
+            results = result.get("results", [])
+            yield "results", results
+
+            if len(results) > 0:
+                for result in results:
                     yield "action", result["event"]
                     yield "memory", result["memory"]
             else:

--- a/autogpt_platform/backend/backend/blocks/reddit.py
+++ b/autogpt_platform/backend/backend/blocks/reddit.py
@@ -96,6 +96,7 @@ class GetRedditPostsBlock(Block):
 
     class Output(BlockSchema):
         post: RedditPost = SchemaField(description="Reddit post")
+        posts: list[RedditPost] = SchemaField(description="List of all Reddit posts")
 
     def __init__(self):
         super().__init__(
@@ -116,6 +117,23 @@ class GetRedditPostsBlock(Block):
                 "post_limit": 2,
             },
             test_output=[
+                (
+                    "posts",
+                    [
+                        RedditPost(
+                            id="id1",
+                            subreddit="subreddit",
+                            title="title1",
+                            body="body1",
+                        ),
+                        RedditPost(
+                            id="id2",
+                            subreddit="subreddit",
+                            title="title2",
+                            body="body2",
+                        ),
+                    ],
+                ),
                 (
                     "post",
                     RedditPost(
@@ -150,6 +168,7 @@ class GetRedditPostsBlock(Block):
         self, input_data: Input, *, credentials: RedditCredentials, **kwargs
     ) -> BlockOutput:
         current_time = datetime.now(tz=timezone.utc)
+        all_posts = []
         for post in self.get_posts(input_data=input_data, credentials=credentials):
             if input_data.last_minutes:
                 post_datetime = datetime.fromtimestamp(
@@ -162,12 +181,16 @@ class GetRedditPostsBlock(Block):
             if input_data.last_post and post.id == input_data.last_post:
                 break
 
-            yield "post", RedditPost(
+            reddit_post = RedditPost(
                 id=post.id,
                 subreddit=input_data.subreddit,
                 title=post.title,
                 body=post.selftext,
             )
+            all_posts.append(reddit_post)
+            yield "post", reddit_post
+
+        yield "posts", all_posts
 
 
 class PostRedditCommentBlock(Block):

--- a/autogpt_platform/backend/backend/blocks/reddit.py
+++ b/autogpt_platform/backend/backend/blocks/reddit.py
@@ -118,6 +118,18 @@ class GetRedditPostsBlock(Block):
             },
             test_output=[
                 (
+                    "post",
+                    RedditPost(
+                        id="id1", subreddit="subreddit", title="title1", body="body1"
+                    ),
+                ),
+                (
+                    "post",
+                    RedditPost(
+                        id="id2", subreddit="subreddit", title="title2", body="body2"
+                    ),
+                ),
+                (
                     "posts",
                     [
                         RedditPost(
@@ -133,18 +145,6 @@ class GetRedditPostsBlock(Block):
                             body="body2",
                         ),
                     ],
-                ),
-                (
-                    "post",
-                    RedditPost(
-                        id="id1", subreddit="subreddit", title="title1", body="body1"
-                    ),
-                ),
-                (
-                    "post",
-                    RedditPost(
-                        id="id2", subreddit="subreddit", title="title2", body="body2"
-                    ),
                 ),
             ],
             test_mock={

--- a/autogpt_platform/backend/backend/blocks/rss.py
+++ b/autogpt_platform/backend/backend/blocks/rss.py
@@ -57,6 +57,17 @@ class ReadRSSFeedBlock(Block):
             },
             test_output=[
                 (
+                    "entry",
+                    RSSEntry(
+                        title="Example RSS Item",
+                        link="https://example.com/article",
+                        description="This is an example RSS item description.",
+                        pub_date=datetime(2023, 6, 23, 12, 30, 0, tzinfo=timezone.utc),
+                        author="John Doe",
+                        categories=["Technology", "News"],
+                    ),
+                ),
+                (
                     "entries",
                     [
                         RSSEntry(
@@ -70,17 +81,6 @@ class ReadRSSFeedBlock(Block):
                             categories=["Technology", "News"],
                         ),
                     ],
-                ),
-                (
-                    "entry",
-                    RSSEntry(
-                        title="Example RSS Item",
-                        link="https://example.com/article",
-                        description="This is an example RSS item description.",
-                        pub_date=datetime(2023, 6, 23, 12, 30, 0, tzinfo=timezone.utc),
-                        author="John Doe",
-                        categories=["Technology", "News"],
-                    ),
                 ),
             ],
             test_mock={

--- a/autogpt_platform/backend/backend/blocks/rss.py
+++ b/autogpt_platform/backend/backend/blocks/rss.py
@@ -40,6 +40,7 @@ class ReadRSSFeedBlock(Block):
 
     class Output(BlockSchema):
         entry: RSSEntry = SchemaField(description="The RSS item")
+        entries: list[RSSEntry] = SchemaField(description="List of all RSS entries")
 
     def __init__(self):
         super().__init__(
@@ -55,6 +56,21 @@ class ReadRSSFeedBlock(Block):
                 "run_continuously": False,
             },
             test_output=[
+                (
+                    "entries",
+                    [
+                        RSSEntry(
+                            title="Example RSS Item",
+                            link="https://example.com/article",
+                            description="This is an example RSS item description.",
+                            pub_date=datetime(
+                                2023, 6, 23, 12, 30, 0, tzinfo=timezone.utc
+                            ),
+                            author="John Doe",
+                            categories=["Technology", "News"],
+                        ),
+                    ],
+                ),
                 (
                     "entry",
                     RSSEntry(
@@ -96,21 +112,22 @@ class ReadRSSFeedBlock(Block):
             keep_going = input_data.run_continuously
 
             feed = self.parse_feed(input_data.rss_url)
+            all_entries = []
 
             for entry in feed["entries"]:
                 pub_date = datetime(*entry["published_parsed"][:6], tzinfo=timezone.utc)
 
                 if pub_date > start_time:
-                    yield (
-                        "entry",
-                        RSSEntry(
-                            title=entry["title"],
-                            link=entry["link"],
-                            description=entry.get("summary", ""),
-                            pub_date=pub_date,
-                            author=entry.get("author", ""),
-                            categories=[tag["term"] for tag in entry.get("tags", [])],
-                        ),
+                    rss_entry = RSSEntry(
+                        title=entry["title"],
+                        link=entry["link"],
+                        description=entry.get("summary", ""),
+                        pub_date=pub_date,
+                        author=entry.get("author", ""),
+                        categories=[tag["term"] for tag in entry.get("tags", [])],
                     )
+                    all_entries.append(rss_entry)
+                    yield "entry", rss_entry
 
+            yield "entries", all_entries
             await asyncio.sleep(input_data.polling_rate)


### PR DESCRIPTION
## Summary

This PR adds missing plural output versions to blocks that yield individual items in loops but don't provide the complete collection, enabling both individual item access (for iteration) and complete collection access (for aggregate operations).

## Changes

### GitHub Blocks (existing)
- **GithubListPullRequestsBlock**: Added `pull_requests` output alongside existing `pull_request` 
- **GithubListPRReviewersBlock**: Added `reviewers` output alongside existing `reviewer`

### Additional Blocks (added in this PR)
- **GetRedditPostsBlock**: Added `posts` output for complete list of Reddit posts
- **ReadRSSFeedBlock**: Added `entries` output for complete list of RSS entries  
- **AddMemoryBlock**: Added `results` output for complete list of memory operation results

## Pattern Applied

The pattern ensures blocks provide both:
```python
# Complete collection first
yield "plural_output", all_items

# Then individual items for iteration
for item in all_items:
    yield "singular_output", item
```

## Testing
- Updated test outputs to include plural versions
- All blocks maintain backward compatibility with existing singular outputs
- `poetry run format` - ✅ Passed
- `poetry run test` - ✅ Blocks validated

## Benefits
- **Iteration**: Users can still iterate over individual items as before
- **Aggregation**: Users can now access complete collections for operations like counting, filtering, or batch processing
- **Compatibility**: Existing workflows continue to work unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)