### PR TITLE
fix(frontend): handle JSON requests without payload

### DIFF
--- a/autogpt_platform/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/autogpt_platform/frontend/src/app/api/proxy/[...path]/route.ts
@@ -23,7 +23,16 @@ async function handleJsonRequest(
   method: string,
   backendUrl: string,
 ): Promise<any> {
-  const payload = await req.json();
+  let payload;
+
+  try {
+    payload = await req.json();
+  } catch (error) {
+    // Handle cases where request body is empty, invalid JSON, or already consumed
+    console.warn("Failed to parse JSON from request body:", error);
+    payload = null;
+  }
+
   return await makeAuthenticatedRequest(
     method,
     backendUrl,


### PR DESCRIPTION
## Changes 🏗️

We created a proxy route ( `/api/proxy/...` ) to handle API calls made in the browser from the legacy `BackendAPI`, ensuring security and compatibility with server cookies 💆🏽 🍪 

However, the code on the proxy was written optimistically, expecting the payload to be present in the JSON requests... even though many requests, such as `POST` or `PATCH`, can sometimes be fired without a body.

This fixed the issue we saw when stopping a running agent wasn't working, because to stop it, fires a `PATCH` without a payload.

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Checkout and run this locally
  - [x] Login
  - [x] Go to Library
  - [x] Run agent
  - [x] Stop it
  - [x] It works without errors       

