### PR TITLE
fix(backend/library): Fix `sub_graphs` check in `LibraryAgent.from_db(..)`

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/library/model.py
+++ b/autogpt_platform/backend/backend/server/v2/library/model.py
@@ -127,7 +127,7 @@ class LibraryAgent(pydantic.BaseModel):
             description=graph.description,
             input_schema=graph.input_schema,
             credentials_input_schema=(
-                graph.credentials_input_schema if sub_graphs else None
+                graph.credentials_input_schema if sub_graphs is not None else None
             ),
             has_external_trigger=graph.has_webhook_trigger,
             trigger_setup_info=(


### PR DESCRIPTION
- Follow-up fix for #10301

The condition that determines whether `LibraryAgent.credentials_input_schema` is set incorrectly handles empty lists of sub-graphs.

### Changes 🏗️

- Check if `sub_graphs is not None` rather than using the boolean interpretation of `sub_graphs`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - Trivial change, no test needed.
