### PR TITLE
fix(backend;frontend): Add auto-type convertion support for optional types

### DIFF
--- a/autogpt_platform/backend/backend/util/type_test.py
+++ b/autogpt_platform/backend/backend/util/type_test.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from backend.util.type import convert
 
 
@@ -5,6 +7,8 @@ def test_type_conversion():
     assert convert(5.5, int) == 5
     assert convert("5.5", int) == 5
     assert convert([1, 2, 3], int) == 3
+    assert convert("7", Optional[int]) == 7
+    assert convert("7", int | None) == 7
 
     assert convert("5.5", float) == 5.5
     assert convert(5, float) == 5.0
@@ -24,8 +28,6 @@ def test_type_conversion():
     assert convert('{"a": 1, "b": 2}', dict) == {"a": 1, "b": 2}
     assert convert([1, 2, 3], dict) == {0: 1, 1: 2, 2: 3}
     assert convert((1, 2, 3), dict) == {0: 1, 1: 2, 2: 3}
-
-    from typing import List
 
     assert convert("5", List[int]) == [5]
     assert convert("[5,4,2]", List[int]) == [5, 4, 2]

--- a/autogpt_platform/frontend/src/components/agents/agent-run-draft-view.tsx
+++ b/autogpt_platform/frontend/src/components/agents/agent-run-draft-view.tsx
@@ -90,14 +90,14 @@ export default function AgentRunDraftView({
   const agentInputFields = useMemo(
     () =>
       Object.fromEntries(
-        Object.entries(agentInputSchema.properties).filter(
+        Object.entries(agentInputSchema?.properties || {}).filter(
           ([_, subSchema]) => !subSchema.hidden,
         ),
       ),
     [agentInputSchema],
   );
   const agentCredentialsInputFields = useMemo(
-    () => agent.credentials_input_schema?.properties,
+    () => agent.credentials_input_schema?.properties || {},
     [agent],
   );
 


### PR DESCRIPTION
Auto type conversion doesn't work on optional type.

To reproduce:
<img width="981" alt="image" src="https://github.com/user-attachments/assets/92198d32-bce9-44fd-a9b0-b7b431aec3ba" />

Use the AgentNumberInput block and try to pass a string value to the sub-agent that uses it.


### Changes 🏗️

Added optional type auto conversation support.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Try to convert string to optional[int] 
