### PR TITLE
fix(frontend): fix form upload

### DIFF
--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -840,7 +840,7 @@ export default class BackendAPI {
       throw handleFetchError(response, errorData);
     }
 
-    return await response.text();
+    return await response.json();
   }
 
   private async _makeServerFileUpload(

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/helpers.ts
@@ -302,5 +302,5 @@ export async function makeAuthenticatedFileUpload(
     throw new ApiError(errorMessage, response.status, responseData);
   }
 
-  return await response.text();
+  return await response.json();
 }


### PR DESCRIPTION
## Changes 🏗️

### The Issue

- Backend returns: `"https://storage.googleapis.com/..."`  (valid JSON string)
- Frontend was calling `response.text()` which gave: `"\"https://storage.googleapis.com/...\""`
- This resulted in a URL with extra quotes that couldn't be loaded

### The Fix
I changed both file upload methods to use `response.json()` instead of `response.text()`:

1. **Client-side uploads** (`_makeClientFileUpload`): Changed `return await response.text();` to `return await response.json();`
2. **Server-side uploads** (`makeAuthenticatedFileUpload`): Changed `return await response.text();` to `return await response.json();`

Now when the backend returns a JSON string like `"https://example.com/file.png"`, the frontend will properly parse it as JSON and extract just the URL without the quotes.

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Login
  - [x] Upload an image on your profile
  - [x] It works  


### For configuration changes:

No configuration changes