### PR TITLE
fix(frontend): fix my agent count in the library

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/LibraryAgentList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/LibraryAgentList.tsx
@@ -6,6 +6,7 @@ import { useLibraryAgentList } from "./useLibraryAgentList";
 export default function LibraryAgentList() {
   const {
     agentLoading,
+    agentCount,
     allAgents: agents,
     isFetchingNextPage,
     isSearching,
@@ -18,7 +19,7 @@ export default function LibraryAgentList() {
   return (
     <>
       {/* TODO: We need a new endpoint on backend that returns total number of agents */}
-      <LibraryActionSubHeader agentCount={agents.length} />
+      <LibraryActionSubHeader agentCount={agentCount} />
       <div className="px-2">
         {agentLoading ? (
           <div className="flex h-[200px] items-center justify-center">

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/useLibraryAgentList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryAgentList/useLibraryAgentList.ts
@@ -56,11 +56,16 @@ export const useLibraryAgentList = () => {
       return data.agents;
     }) ?? [];
 
+  const agentCount = agents?.pages[0]
+    ? (agents.pages[0].data as LibraryAgentResponse).pagination.total_items
+    : 0;
+
   return {
     allAgents,
     agentLoading,
     isFetchingNextPage,
     hasNextPage,
+    agentCount,
     isSearching: isFetching && !isFetchingNextPage,
   };
 };


### PR DESCRIPTION
Currently, my agents count is showing the initial agent count loads on the library and then adding more agents after pagination.

### Changes 🏗️
- I’ve used `total_items` inside the pagination response and shown the correct result.

### Demo
https://github.com/user-attachments/assets/b9a2cf18-c9fc-42f8-b0d4-3f8a7ad3cbc5


### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Manually test everything, and it works fine.