### PR TITLE
Fix: Replace broken Discord badge with working Shields.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoGPT: Build, Deploy, and Run AI Agents
 
-[![Discord Follow](https://dcbadge.vercel.app/api/server/autogpt?style=flat)](https://discord.gg/autogpt) &ensp;
+[![Discord](https://img.shields.io/discord/1092243196446249134?label=Join%20Discord&logo=discord&logoColor=white&color=7289DA)](https://discord.gg/autogpt) &ensp;
 [![Twitter Follow](https://img.shields.io/twitter/follow/Auto_GPT?style=social)](https://twitter.com/Auto_GPT) &ensp;
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
This PR replaces the broken Discord badge in `README.md` with a live Shields.io badge to restore proper display and invite functionality.

### Changes 🏗️

* **Updated README badge**

  * Removed the invalid `<img src="…">` for Discord
  * Added a Shields.io Discord badge with server ID `1092243196446249134`
  * Badge shows real-time member count and links to `https://discord.gg/autogpt`


### Checklist 📋

#### For documentation changes:

* [x] I have clearly listed my changes in the PR description
* [x] I have tested that the badge renders correctly in GitHub’s Markdown preview
* [x] I have verified the invite link leads to the Auto-GPT Discord server
* [x] No other files are modified
