### PR TITLE
fix(frontend): navbar profile query not working

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/data.ts
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/data.ts
@@ -1,8 +1,9 @@
-import { getV2GetUserProfile } from "@/app/api/__generated__/endpoints/store/store";
+import BackendAPI from "@/lib/autogpt-server-api";
 import { getServerUser } from "@/lib/supabase/server/getServerUser";
 
 export async function getNavbarAccountData() {
   const { user } = await getServerUser();
+  const api = new BackendAPI();
   const isLoggedIn = Boolean(user);
 
   if (!isLoggedIn) {
@@ -15,8 +16,7 @@ export async function getNavbarAccountData() {
   let profile = null;
 
   try {
-    const profileResponse = await getV2GetUserProfile();
-    profile = profileResponse.data || null;
+    profile = await api.getStoreProfile();
   } catch (error) {
     console.error("Error fetching profile:", error);
     profile = null;

--- a/autogpt_platform/frontend/src/tests/signin.spec.ts
+++ b/autogpt_platform/frontend/src/tests/signin.spec.ts
@@ -6,9 +6,22 @@ test.describe("Authentication", () => {
     await page.goto("/login");
     await loginPage.login(testUser.email, testUser.password);
     await test.expect(page).toHaveURL("/marketplace");
-    await test
-      .expect(page.getByTestId("profile-popout-menu-trigger"))
-      .toBeVisible();
+
+    const accountMenuBtn = page.getByTestId("profile-popout-menu-trigger");
+
+    await test.expect(accountMenuBtn).toBeVisible();
+
+    await accountMenuBtn.click();
+
+    const dialog = page.getByRole("dialog");
+    await test.expect(dialog).toBeVisible();
+
+    const username = testUser.email.split("@")[0];
+    await test.expect(dialog.getByText(username)).toBeVisible();
+
+    const logoutBtn = page.getByRole("button", { name: "Log out" });
+    await test.expect(logoutBtn).toBeVisible();
+    await logoutBtn.click();
   });
 
   test("user can logout successfully", async ({


### PR DESCRIPTION
## Changes 🏗️

<img width="800" height="265" alt="Screenshot 2025-07-16 at 13 10 57" src="https://github.com/user-attachments/assets/01164bde-0523-4284-bf74-d1a735b77d5c" />

When redoing the navigation bar, I moved the profile query to be executed on the server using the new [react-query](https://tanstack.com/query/latest) generated hooks. 

The README [states the new hooks can be called on the server](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/frontend/README.md#server-side-prefetching), but when looking deeply into the implementation of [`custom-mutator.ts`](https://github.com/Significant-Gravitas/AutoGPT/blob/master/autogpt_platform/frontend/src/app/api/mutators/custom-mutator.ts), it turns out they can not ( yet ) as `custom-mutator` calls the proxy API ( _which can't be called from a RSC_ 😅 ).

### Solution

For now, I changed the call to be made through the old `BackendAPI`, which can be called client and server side ✅  ( _I did that as part of the server 🍪 migration_ ) and added an E2E test to catch this ever disappears again.

Next, I will open a separate PR refactoring `custom-mutator` so that it can be called on the server.

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the app
  - [x] Login
  - [x] You see your account name and email when opening the account menu  
