### PR TITLE
feat(backend): avoid using DatabaseManager when direct query is possible from the API layer

### DIFF
--- a/autogpt_platform/backend/backend/blocks/agent.py
+++ b/autogpt_platform/backend/backend/blocks/agent.py
@@ -74,7 +74,6 @@ class AgentExecutorBlock(Block):
             user_id=input_data.user_id,
             inputs=input_data.inputs,
             nodes_input_masks=input_data.nodes_input_masks,
-            use_db_query=False,
         )
 
         logger = execution_utils.LogMetadata(
@@ -198,7 +197,6 @@ class AgentExecutorBlock(Block):
             await execution_utils.stop_graph_execution(
                 graph_exec_id=graph_exec_id,
                 user_id=user_id,
-                use_db_query=False,
             )
             logger.info(f"Execution {log_id} stopped successfully.")
         except Exception as e:

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -88,7 +88,6 @@ async def _execute_graph(**kwargs):
             graph_version=args.graph_version,
             inputs=args.input_data,
             graph_credentials_inputs=args.input_credentials,
-            use_db_query=False,
         )
         logger.info(
             f"Graph execution started with ID {graph_exec.id} for graph {args.graph_id}"

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -2,18 +2,13 @@ import base64
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Optional
-
-from pydantic import SecretStr
-
-from backend.data.redis_client import get_redis_async
-
-if TYPE_CHECKING:
-    from backend.executor.database import DatabaseManagerAsyncClient
+from typing import Optional
 
 from autogpt_libs.utils.cache import thread_cached
 from autogpt_libs.utils.synchronize import AsyncRedisKeyedMutex
+from pydantic import SecretStr
 
+from backend.data.db import prisma
 from backend.data.model import (
     APIKeyCredentials,
     Credentials,
@@ -21,6 +16,7 @@ from backend.data.model import (
     OAuthState,
     UserIntegrations,
 )
+from backend.data.redis_client import get_redis_async
 from backend.util.settings import Settings
 
 settings = Settings()
@@ -233,11 +229,16 @@ class IntegrationCredentialsStore:
 
     @property
     @thread_cached
-    def db_manager(self) -> "DatabaseManagerAsyncClient":
-        from backend.executor.database import DatabaseManagerAsyncClient
-        from backend.util.service import get_service_client
+    def db_manager(self):
+        if prisma.is_connected():
+            from backend.data import user
 
-        return get_service_client(DatabaseManagerAsyncClient)
+            return user
+        else:
+            from backend.executor.database import DatabaseManagerAsyncClient
+            from backend.util.service import get_service_client
+
+            return get_service_client(DatabaseManagerAsyncClient)
 
     async def add_creds(self, user_id: str, credentials: Credentials) -> None:
         async with await self.locked_user_integrations(user_id):


### PR DESCRIPTION
This PR reduces the dependency of the API layer on the database manager service by avoiding using DatabaseManager for credentials fetch when a direct query is possible from the API layer

### Changes 🏗️

* If Prisma is available, use the direct query.
* Otherwise, utilize the database manager.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run blocks with credentials like AiTextGeneratorBlock
