### PR TITLE
feat(backend): Register agent subgraphs as library entries during agent import

### DIFF
--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -621,13 +621,11 @@ async def create_new_graph(
     graph.reassign_ids(user_id=user_id, reassign_graph_id=True)
     graph.validate_graph(for_run=False)
 
-    graph = await graph_db.create_graph(graph, user_id=user_id)
-
-    # Create a library agents for the new graph
-    await library_db.create_library_agent(graph, user_id)
-
-    graph = await on_graph_activate(graph, user_id=user_id)
-    return graph
+    # The return value of the create graph & library function is intentionally not used here,
+    # as the graph already valid and no sub-graphs are returned back.
+    await graph_db.create_graph(graph, user_id=user_id)
+    await library_db.create_library_agent(graph, user_id=user_id)
+    return await on_graph_activate(graph, user_id=user_id)
 
 
 @v1_router.delete(

--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -623,11 +623,8 @@ async def create_new_graph(
 
     graph = await graph_db.create_graph(graph, user_id=user_id)
 
-    # Create a library agent for the new graph
-    library_agent = await library_db.create_library_agent(graph, user_id)
-    _ = asyncio.create_task(
-        library_db.add_generated_agent_image(graph, library_agent.id)
-    )
+    # Create a library agents for the new graph
+    await library_db.create_library_agent(graph, user_id)
 
     graph = await on_graph_activate(graph, user_id=user_id)
     return graph

--- a/autogpt_platform/backend/backend/server/v2/library/db.py
+++ b/autogpt_platform/backend/backend/server/v2/library/db.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Literal, Optional
 
@@ -246,13 +247,13 @@ async def get_library_agent_by_graph_id(
 
 
 async def add_generated_agent_image(
-    graph: graph_db.GraphModel,
+    graph: graph_db.BaseGraph,
+    user_id: str,
     library_agent_id: str,
 ) -> Optional[prisma.models.LibraryAgent]:
     """
     Generates an image for the specified LibraryAgent and updates its record.
     """
-    user_id = graph.user_id
     graph_id = graph.id
 
     # Use .jpeg here since we are generating JPEG images
@@ -281,7 +282,8 @@ async def add_generated_agent_image(
 async def create_library_agent(
     graph: graph_db.GraphModel,
     user_id: str,
-) -> library_model.LibraryAgent:
+    create_library_for_sub_graphs: bool = True,
+) -> list[library_model.LibraryAgent]:
     """
     Adds an agent to the user's library (LibraryAgent table).
 
@@ -290,7 +292,8 @@ async def create_library_agent(
         user_id: The user to whom the agent will be added.
 
     Returns:
-        The newly created LibraryAgent record.
+        The newly created LibraryAgent records.
+        If the graph has sub-graphs, the parent graph will always be the first entry in the list.
 
     Raises:
         AgentNotFoundError: If the specified agent does not exist.
@@ -300,26 +303,39 @@ async def create_library_agent(
         f"Creating library agent for graph #{graph.id} v{graph.version}; "
         f"user #{user_id}"
     )
+    graph_entries = (
+        [graph, *graph.sub_graphs] if create_library_for_sub_graphs else [graph]
+    )
 
-    try:
-        agent = await prisma.models.LibraryAgent.prisma().create(
-            data=prisma.types.LibraryAgentCreateInput(
-                isCreatedByUser=(user_id == graph.user_id),
-                useGraphIsActiveVersion=True,
-                User={"connect": {"id": user_id}},
-                # Creator={"connect": {"id": graph.user_id}},
-                AgentGraph={
-                    "connect": {
-                        "graphVersionId": {"id": graph.id, "version": graph.version}
-                    }
-                },
-            ),
-            include={"AgentGraph": True},
+    async with transaction() as tx:
+        library_agents = await asyncio.gather(
+            *(
+                prisma.models.LibraryAgent.prisma(tx).create(
+                    data=prisma.types.LibraryAgentCreateInput(
+                        isCreatedByUser=(user_id == user_id),
+                        useGraphIsActiveVersion=True,
+                        User={"connect": {"id": user_id}},
+                        # Creator={"connect": {"id": user_id}},
+                        AgentGraph={
+                            "connect": {
+                                "graphVersionId": {
+                                    "id": graph_entry.id,
+                                    "version": graph_entry.version,
+                                }
+                            }
+                        },
+                    ),
+                    include=library_agent_include(user_id),
+                )
+                for graph_entry in graph_entries
+            )
         )
-        return library_model.LibraryAgent.from_db(agent)
-    except prisma.errors.PrismaError as e:
-        logger.error(f"Database error creating agent in library: {e}")
-        raise store_exceptions.DatabaseError("Failed to create agent in library") from e
+
+    # Generate images for the main graph and sub-graphs
+    for agent, graph in zip(library_agents, graph_entries):
+        asyncio.create_task(add_generated_agent_image(graph, user_id, agent.id))
+
+    return [library_model.LibraryAgent.from_db(agent) for agent in library_agents]
 
 
 async def update_agent_version_in_library(
@@ -872,7 +888,9 @@ async def delete_preset(user_id: str, preset_id: str) -> None:
         raise store_exceptions.DatabaseError("Failed to delete preset") from e
 
 
-async def fork_library_agent(library_agent_id: str, user_id: str):
+async def fork_library_agent(
+    library_agent_id: str, user_id: str
+) -> library_model.LibraryAgent:
     """
     Clones a library agent and its underyling graph and nodes (with new ids) for the given user.
 
@@ -881,7 +899,7 @@ async def fork_library_agent(library_agent_id: str, user_id: str):
         user_id: The ID of the user who owns the library agent.
 
     Returns:
-        The forked LibraryAgent.
+        The forked parent (if it has sub-graphs) LibraryAgent.
 
     Raises:
         DatabaseError: If there's an error during the forking process.
@@ -907,7 +925,7 @@ async def fork_library_agent(library_agent_id: str, user_id: str):
             new_graph = await on_graph_activate(new_graph, user_id=user_id)
 
             # Create a library agent for the new graph
-            return await create_library_agent(new_graph, user_id)
+            return (await create_library_agent(new_graph, user_id))[0]
     except prisma.errors.PrismaError as e:
         logger.error(f"Database error cloning library agent: {e}")
         raise store_exceptions.DatabaseError("Failed to fork library agent") from e

--- a/autogpt_platform/backend/backend/server/v2/library/db.py
+++ b/autogpt_platform/backend/backend/server/v2/library/db.py
@@ -282,7 +282,7 @@ async def add_generated_agent_image(
 async def create_library_agent(
     graph: graph_db.GraphModel,
     user_id: str,
-    create_library_for_sub_graphs: bool = True,
+    create_library_agents_for_sub_graphs: bool = True,
 ) -> list[library_model.LibraryAgent]:
     """
     Adds an agent to the user's library (LibraryAgent table).
@@ -290,6 +290,7 @@ async def create_library_agent(
     Args:
         agent: The agent/Graph to add to the library.
         user_id: The user to whom the agent will be added.
+        create_library_agents_for_sub_graphs: If True, creates LibraryAgent records for sub-graphs as well.
 
     Returns:
         The newly created LibraryAgent records.
@@ -304,7 +305,7 @@ async def create_library_agent(
         f"user #{user_id}"
     )
     graph_entries = (
-        [graph, *graph.sub_graphs] if create_library_for_sub_graphs else [graph]
+        [graph, *graph.sub_graphs] if create_library_agents_for_sub_graphs else [graph]
     )
 
     async with transaction() as tx:

--- a/autogpt_platform/backend/backend/server/v2/store/image_gen.py
+++ b/autogpt_platform/backend/backend/server/v2/store/image_gen.py
@@ -16,7 +16,7 @@ from backend.blocks.ideogram import (
     StyleType,
     UpscaleOption,
 )
-from backend.data.graph import Graph
+from backend.data.graph import BaseGraph
 from backend.data.model import CredentialsMetaInput, ProviderName
 from backend.integrations.credentials_store import ideogram_credentials
 from backend.util.request import Requests
@@ -34,14 +34,14 @@ class ImageStyle(str, Enum):
     DIGITAL_ART = "digital art"
 
 
-async def generate_agent_image(agent: Graph | AgentGraph) -> io.BytesIO:
+async def generate_agent_image(agent: BaseGraph | AgentGraph) -> io.BytesIO:
     if settings.config.use_agent_image_generation_v2:
         return await generate_agent_image_v2(graph=agent)
     else:
         return await generate_agent_image_v1(agent=agent)
 
 
-async def generate_agent_image_v2(graph: Graph | AgentGraph) -> io.BytesIO:
+async def generate_agent_image_v2(graph: BaseGraph | AgentGraph) -> io.BytesIO:
     """
     Generate an image for an agent using Ideogram model.
     Returns:
@@ -99,7 +99,7 @@ async def generate_agent_image_v2(graph: Graph | AgentGraph) -> io.BytesIO:
     return io.BytesIO(response.content)
 
 
-async def generate_agent_image_v1(agent: Graph | AgentGraph) -> io.BytesIO:
+async def generate_agent_image_v1(agent: BaseGraph | AgentGraph) -> io.BytesIO:
     """
     Generate an image for an agent using Flux model via Replicate API.
 

--- a/autogpt_platform/backend/test/e2e_test_data.py
+++ b/autogpt_platform/backend/test/e2e_test_data.py
@@ -386,8 +386,10 @@ class TestDataCreator:
                     )
                     if graph:
                         # Use the API function to create library agent
-                        library_agent = await create_library_agent(graph, user["id"])
-                        library_agents.append(library_agent.model_dump())
+                        library_agents.extend(
+                            v.model_dump()
+                            for v in await create_library_agent(graph, user["id"])
+                        )
                 except Exception as e:
                     print(f"Error creating library agent: {e}")
                     continue


### PR DESCRIPTION
Currently, we only create a library entry of the top-most graph when importing the graph from an exported file.
This can cause some complications, as there is no way to remove the library entry of it.

### Changes 🏗️

Create the library entry for all the subgraphs during the import process.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Export an agent with subgraphs and import it back.
