### PR TITLE
fix(frontend): init LD on the client

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.tsx
@@ -63,7 +63,10 @@ export function AccountMenu({
             <div className="max-w-[10.5rem] truncate font-sans text-base font-semibold leading-none text-white dark:text-neutral-200">
               {userName}
             </div>
-            <div className="max-w-[10.5rem] truncate font-sans text-base font-normal leading-none text-white dark:text-neutral-400">
+            <div
+              data-testid="account-menu-user-email"
+              className="max-w-[10.5rem] truncate font-sans text-base font-normal leading-none text-white dark:text-neutral-400"
+            >
               {userEmail}
             </div>
           </div>

--- a/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
+++ b/autogpt_platform/frontend/src/services/feature-flags/feature-flag-provider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { LDProvider } from "launchdarkly-react-client-sdk";
 import { ReactNode } from "react";
 import { useSupabase } from "@/lib/supabase/hooks/useSupabase";

--- a/autogpt_platform/frontend/src/tests/signin.spec.ts
+++ b/autogpt_platform/frontend/src/tests/signin.spec.ts
@@ -46,7 +46,9 @@ test("user can login successfully", async ({ page }) => {
 
   const accountMenuUserEmail = getId("account-menu-user-email");
   await isVisible(accountMenuUserEmail);
-  await test.expect(accountMenuUserEmail).toHaveText(testUser.email);
+  await test
+    .expect(accountMenuUserEmail)
+    .toHaveText(testUser.email.split("@")[0].toLowerCase());
 
   const logoutBtn = getButton("Log out");
   await isVisible(logoutBtn);

--- a/autogpt_platform/frontend/src/tests/signin.spec.ts
+++ b/autogpt_platform/frontend/src/tests/signin.spec.ts
@@ -31,7 +31,7 @@ test("check the navigation when logged out", async ({ page }) => {
 test("user can login successfully", async ({ page }) => {
   const testUser = await getTestUser();
   const loginPage = new LoginPage(page);
-  const { getId, getButton, getText, getRole } = getSelectors(page);
+  const { getId, getButton, getRole } = getSelectors(page);
 
   await loginPage.login(testUser.email, testUser.password);
   await hasUrl(page, "/marketplace");
@@ -44,8 +44,9 @@ test("user can login successfully", async ({ page }) => {
   const accountMenuPopover = getRole("dialog");
   await isVisible(accountMenuPopover);
 
-  const username = testUser.email.split("@")[0];
-  await isVisible(getText(username));
+  const accountMenuUserEmail = getId("account-menu-user-email");
+  await isVisible(accountMenuUserEmail);
+  await test.expect(accountMenuUserEmail).toHaveText(testUser.email);
 
   const logoutBtn = getButton("Log out");
   await isVisible(logoutBtn);


### PR DESCRIPTION
## Changes 🏗️

Launch Darkly is not being initialised in production, despite on paper all env variables being well set 🧐 

I tried doing production builds locally, and I noticed this provider needs to be initialised on the client because Launch Darkly flags are designed to work on the client side, where they can access user context and browser environment.

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Did production build locally and run it
  - [x] See LD initialised on the console after the `use client` directive was added  


### For configuration changes:

None
