### PR TITLE
feat(platform): Move NotificationManager service from rest-api pod to scheduler pod

### DIFF
--- a/autogpt_platform/backend/backend/rest.py
+++ b/autogpt_platform/backend/backend/rest.py
@@ -1,6 +1,5 @@
 from backend.app import run_processes
 from backend.executor import DatabaseManager
-from backend.notifications.notifications import NotificationManager
 from backend.server.rest_api import AgentServer
 
 
@@ -9,7 +8,6 @@ def main():
     Run all the processes required for the AutoGPT-server REST API.
     """
     run_processes(
-        NotificationManager(),
         DatabaseManager(),
         AgentServer(),
     )

--- a/autogpt_platform/backend/backend/scheduler.py
+++ b/autogpt_platform/backend/backend/scheduler.py
@@ -1,12 +1,16 @@
 from backend.app import run_processes
 from backend.executor.scheduler import Scheduler
+from backend.notifications.notifications import NotificationManager
 
 
 def main():
     """
     Run all the processes required for the AutoGPT-server Scheduling System.
     """
-    run_processes(Scheduler())
+    run_processes(
+        NotificationManager(),
+        Scheduler(),
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rest-Api service is a vital service where we should minimize the amount of external resources impacting it.
And the NotificationManager service is running as a singleton in nature (similar to the scheduler service), so it makes sense to put it in a single pod.

### Changes 🏗️

Move the NotificationManager service from rest-api pod to the scheduler pod

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual test
