### PR TITLE
feat(frontend): Add marketplace creator page tests

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/page.tsx
@@ -72,6 +72,7 @@ export default async function Page({
                 About
               </p>
               <div
+                data-testid="creator-description"
                 className="text-[48px] font-normal leading-[59px] text-neutral-900 dark:text-zinc-50"
                 style={{ whiteSpace: "pre-line" }}
               >

--- a/autogpt_platform/frontend/src/components/agptui/CreatorInfoCard.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/CreatorInfoCard.tsx
@@ -40,8 +40,12 @@ export const CreatorInfoCard: React.FC<CreatorInfoCardProps> = ({
             {username.charAt(0)}
           </AvatarFallback>
         </Avatar>
-        <div className="flex w-full flex-col items-start justify-start gap-1.5">
-          <div className="w-full font-poppins text-[35px] font-medium leading-10 text-neutral-900 dark:text-neutral-100 sm:text-[35px] sm:leading-10">
+        <div
+          className="flex w-full flex-col items-start justify-start gap-1.5"
+        >
+          <div
+          data-testid="creator-title"
+          className="w-full font-poppins text-[35px] font-medium leading-10 text-neutral-900 dark:text-neutral-100 sm:text-[35px] sm:leading-10">
             {username}
           </div>
           <div className="w-full text-lg font-normal leading-6 text-neutral-800 dark:text-neutral-200 sm:text-xl sm:leading-7">

--- a/autogpt_platform/frontend/src/tests/marketplace-creator.spec.ts
+++ b/autogpt_platform/frontend/src/tests/marketplace-creator.spec.ts
@@ -1,0 +1,74 @@
+import { test } from "@playwright/test";
+import { MarketplacePage } from "./pages/marketplace.page";
+import { LoginPage } from "./pages/login.page";
+import { isVisible, hasUrl, matchesUrl } from "./utils/assertion";
+import { TEST_CREDENTIALS } from "./credentials";
+import { getSelectors } from "./utils/selectors";
+
+test.describe("Marketplace Creator Page – Basic Functionality", () => {
+  test("User can access creator's page when logged out", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+
+    await marketplacePage.goto();
+    await hasUrl(page, "/marketplace");
+
+    const firstCreatorProfile = await marketplacePage.getFirstCreatorProfile();
+    await firstCreatorProfile.click();
+
+    await page.waitForURL("**/marketplace/creator/**");
+    await matchesUrl(page, /\/marketplace\/creator\/.+/);
+  });
+
+  test("User can access creator's page when logged in", async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    const marketplacePage = new MarketplacePage(page);
+
+    await loginPage.goto();
+    await loginPage.login(TEST_CREDENTIALS.email, TEST_CREDENTIALS.password);
+    await hasUrl(page, "/marketplace");
+
+    await marketplacePage.goto();
+    await hasUrl(page, "/marketplace");
+
+    const firstCreatorProfile = await marketplacePage.getFirstCreatorProfile();
+    await firstCreatorProfile.click();
+
+    await page.waitForURL("**/marketplace/creator/**");
+    await matchesUrl(page, /\/marketplace\/creator\/.+/);
+  });
+
+  test("Creator page details are visible", async ({ page }) => {
+    const { getId } = getSelectors(page);
+    const marketplacePage = new MarketplacePage(page);
+
+    await marketplacePage.goto();
+    await hasUrl(page, "/marketplace");
+
+    const firstCreatorProfile = await marketplacePage.getFirstCreatorProfile();
+    await firstCreatorProfile.click();
+    await page.waitForURL("**/marketplace/creator/**");
+
+    const creatorTitle = getId("creator-title");
+    await isVisible(creatorTitle);
+
+    const creatorDescription = getId("creator-description")
+    await isVisible(creatorDescription);
+  });
+
+  test("Agents in agent by sections navigation works", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+
+    await marketplacePage.goto();
+    await hasUrl(page, "/marketplace");
+
+    const firstCreatorProfile = await marketplacePage.getFirstCreatorProfile();
+    await firstCreatorProfile.click();
+    await page.waitForURL("**/marketplace/creator/**");
+    const firstAgent = page.locator('[data-testid="store-card"]:visible').first();
+    
+    await firstAgent.click();
+    await page.waitForURL("**/marketplace/agent/**");
+    await matchesUrl(page, /\/marketplace\/agent\/.+/);
+    
+  });
+});

--- a/autogpt_platform/frontend/src/tests/marketplace.spec.ts
+++ b/autogpt_platform/frontend/src/tests/marketplace.spec.ts
@@ -5,7 +5,7 @@ import { isVisible, hasUrl, hasMinCount, matchesUrl, hasTextContent } from "./ut
 import { TEST_CREDENTIALS } from "./credentials";
 
 test.describe("Marketplace – Basic Functionality", () => {
-  test("user can access marketplace page when logged out", async ({ page }) => {
+  test("User can access marketplace page when logged out", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     
     await marketplacePage.goto();
@@ -15,7 +15,7 @@ test.describe("Marketplace – Basic Functionality", () => {
     await isVisible(marketplaceTitle);
   });
 
-  test("user can access marketplace page when logged in", async ({ page }) => {
+  test("User can access marketplace page when logged in", async ({ page }) => {
     const loginPage = new LoginPage(page);
     const marketplacePage = new MarketplacePage(page);
     
@@ -30,7 +30,7 @@ test.describe("Marketplace – Basic Functionality", () => {
     await isVisible(marketplaceTitle);
   });
 
-  test("featured agents, top agents, and featured creators are visible", async ({ page }) => {
+  test("Featured agents, top agents, and featured creators are visible", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
     
@@ -50,7 +50,7 @@ test.describe("Marketplace – Basic Functionality", () => {
     await hasMinCount(creatorProfiles, 1);
   });
 
-  test("can navigate and interact with marketplace elements", async ({ page }) => {
+  test("Can navigate and interact with marketplace elements", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
     
@@ -73,7 +73,7 @@ test.describe("Marketplace – Basic Functionality", () => {
     await matchesUrl(page, /\/marketplace\/creator\/.+/);
   });
   
-  test("complete search flow works correctly", async ({ page }) => {
+  test("Complete search flow works correctly", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
   
@@ -98,7 +98,7 @@ test.describe("Marketplace – Basic Functionality", () => {
 });
 
 test.describe("Marketplace – Edge Cases", () => {
-  test("search for non-existent item shows no results", async ({ page }) => {
+  test("Search for non-existent item shows no results", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
   

--- a/autogpt_platform/frontend/src/tests/marketplace.spec.ts
+++ b/autogpt_platform/frontend/src/tests/marketplace.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "@playwright/test";
+import { MarketplacePage } from "./pages/marketplace.page";
+import { LoginPage } from "./pages/login.page";
+import { isVisible, hasUrl, hasMinCount, matchesUrl, hasTextContent } from "./utils/assertion";
+import { TEST_CREDENTIALS } from "./credentials";
+
+test.describe("Marketplace – Basic Functionality", () => {
+  test("user can access marketplace page when logged out", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+    
+    await marketplacePage.goto();
+    await hasUrl(page, "/marketplace");
+    
+    const marketplaceTitle = await marketplacePage.getMarketplaceTitle();
+    await isVisible(marketplaceTitle);
+  });
+
+  test("user can access marketplace page when logged in", async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    const marketplacePage = new MarketplacePage(page);
+    
+    await loginPage.goto();
+    await loginPage.login(TEST_CREDENTIALS.email, TEST_CREDENTIALS.password);
+    await hasUrl(page, "/marketplace");
+    
+    await marketplacePage.goto();
+    await hasUrl(page, "/marketplace");
+    
+    const marketplaceTitle = await marketplacePage.getMarketplaceTitle();
+    await isVisible(marketplaceTitle);
+  });
+
+  test("featured agents, top agents, and featured creators are visible", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+    await marketplacePage.goto();
+    
+    const featuredAgentsSection = await marketplacePage.getFeaturedAgentsSection();
+    await isVisible(featuredAgentsSection);
+    const featuredAgentCards = await marketplacePage.getFeaturedAgentCards();
+    await hasMinCount(featuredAgentCards, 1);
+
+    const topAgentsSection = await marketplacePage.getTopAgentsSection();
+    await isVisible(topAgentsSection);    
+    const topAgentCards = await marketplacePage.getTopAgentCards();
+    await hasMinCount(topAgentCards, 1);
+
+    const featuredCreatorsSection = await marketplacePage.getFeaturedCreatorsSection();
+    await isVisible(featuredCreatorsSection);
+    const creatorProfiles = await marketplacePage.getCreatorProfiles();
+    await hasMinCount(creatorProfiles, 1);
+  });
+
+  test("can navigate and interact with marketplace elements", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+    await marketplacePage.goto();
+    
+    const firstFeaturedAgent = await marketplacePage.getFirstFeaturedAgent();
+    await firstFeaturedAgent.waitFor({ state: 'visible' });
+    await firstFeaturedAgent.click();
+    await page.waitForURL('**/marketplace/agent/**');
+    await matchesUrl(page, /\/marketplace\/agent\/.+/);
+    await marketplacePage.goto();
+
+    const firstTopAgent = await marketplacePage.getFirstTopAgent();
+    await firstTopAgent.click();
+    await page.waitForURL('**/marketplace/agent/**');
+    await matchesUrl(page, /\/marketplace\/agent\/.+/);
+    await marketplacePage.goto();
+    
+    const firstCreatorProfile = await marketplacePage.getFirstCreatorProfile();
+    await firstCreatorProfile.click()
+    await page.waitForURL('**/marketplace/creator/**');
+    await matchesUrl(page, /\/marketplace\/creator\/.+/);
+  });
+  
+  test("complete search flow works correctly", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+    await marketplacePage.goto();
+  
+    await marketplacePage.searchAndNavigate("DummyInput");
+
+    await marketplacePage.waitForSearchResults();
+    
+    await matchesUrl(page, /\/marketplace\/search\?searchTerm=/);
+    
+    const resultsHeading = page.getByText("Results for:");
+    await isVisible(resultsHeading);
+    
+    const searchTerm = page.getByText("DummyInput").first();
+    await isVisible(searchTerm);
+    
+    const results = await marketplacePage.getSearchResultsCount();
+    expect(results).toBeGreaterThan(1);
+  });
+
+  // We need to add a test search with filters, but the current business logic for filters doesn't work as expected. We'll add it once we modify that.
+
+});
+
+test.describe("Marketplace – Edge Cases", () => {
+  test("search for non-existent item shows no results", async ({ page }) => {
+    const marketplacePage = new MarketplacePage(page);
+    await marketplacePage.goto();
+  
+    await marketplacePage.searchAndNavigate("xyznonexistentitemxyz123");
+
+    await marketplacePage.waitForSearchResults();
+    
+    await matchesUrl(page, /\/marketplace\/search\?searchTerm=/);
+    
+    const resultsHeading = page.getByText("Results for:");
+    await isVisible(resultsHeading);
+    
+    const searchTerm = page.getByText("xyznonexistentitemxyz123");
+    await isVisible(searchTerm);
+    
+    const results = await marketplacePage.getSearchResultsCount();
+    expect(results).toBe(0);
+  });
+});

--- a/autogpt_platform/frontend/src/tests/marketplace.spec.ts
+++ b/autogpt_platform/frontend/src/tests/marketplace.spec.ts
@@ -1,16 +1,21 @@
 import { test, expect } from "@playwright/test";
 import { MarketplacePage } from "./pages/marketplace.page";
 import { LoginPage } from "./pages/login.page";
-import { isVisible, hasUrl, hasMinCount, matchesUrl, hasTextContent } from "./utils/assertion";
+import {
+  isVisible,
+  hasUrl,
+  hasMinCount,
+  matchesUrl,
+} from "./utils/assertion";
 import { TEST_CREDENTIALS } from "./credentials";
 
 test.describe("Marketplace – Basic Functionality", () => {
   test("User can access marketplace page when logged out", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
-    
+
     await marketplacePage.goto();
     await hasUrl(page, "/marketplace");
-    
+
     const marketplaceTitle = await marketplacePage.getMarketplaceTitle();
     await isVisible(marketplaceTitle);
   });
@@ -18,102 +23,107 @@ test.describe("Marketplace – Basic Functionality", () => {
   test("User can access marketplace page when logged in", async ({ page }) => {
     const loginPage = new LoginPage(page);
     const marketplacePage = new MarketplacePage(page);
-    
+
     await loginPage.goto();
     await loginPage.login(TEST_CREDENTIALS.email, TEST_CREDENTIALS.password);
     await hasUrl(page, "/marketplace");
-    
+
     await marketplacePage.goto();
     await hasUrl(page, "/marketplace");
-    
+
     const marketplaceTitle = await marketplacePage.getMarketplaceTitle();
     await isVisible(marketplaceTitle);
   });
 
-  test("Featured agents, top agents, and featured creators are visible", async ({ page }) => {
+  test("Featured agents, top agents, and featured creators are visible", async ({
+    page,
+  }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
-    
-    const featuredAgentsSection = await marketplacePage.getFeaturedAgentsSection();
+
+    const featuredAgentsSection =
+    await marketplacePage.getFeaturedAgentsSection();
     await isVisible(featuredAgentsSection);
     const featuredAgentCards = await marketplacePage.getFeaturedAgentCards();
     await hasMinCount(featuredAgentCards, 1);
 
     const topAgentsSection = await marketplacePage.getTopAgentsSection();
-    await isVisible(topAgentsSection);    
+    await isVisible(topAgentsSection);
     const topAgentCards = await marketplacePage.getTopAgentCards();
     await hasMinCount(topAgentCards, 1);
 
-    const featuredCreatorsSection = await marketplacePage.getFeaturedCreatorsSection();
+    const featuredCreatorsSection =
+      await marketplacePage.getFeaturedCreatorsSection();
     await isVisible(featuredCreatorsSection);
     const creatorProfiles = await marketplacePage.getCreatorProfiles();
     await hasMinCount(creatorProfiles, 1);
   });
 
-  test("Can navigate and interact with marketplace elements", async ({ page }) => {
+  test("Can navigate and interact with marketplace elements", async ({
+    page,
+  }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
-    
+
     const firstFeaturedAgent = await marketplacePage.getFirstFeaturedAgent();
-    await firstFeaturedAgent.waitFor({ state: 'visible' });
+    await firstFeaturedAgent.waitFor({ state: "visible" });
     await firstFeaturedAgent.click();
-    await page.waitForURL('**/marketplace/agent/**');
+    await page.waitForURL("**/marketplace/agent/**");
     await matchesUrl(page, /\/marketplace\/agent\/.+/);
     await marketplacePage.goto();
 
     const firstTopAgent = await marketplacePage.getFirstTopAgent();
     await firstTopAgent.click();
-    await page.waitForURL('**/marketplace/agent/**');
+    await page.waitForURL("**/marketplace/agent/**");
     await matchesUrl(page, /\/marketplace\/agent\/.+/);
     await marketplacePage.goto();
-    
+
     const firstCreatorProfile = await marketplacePage.getFirstCreatorProfile();
-    await firstCreatorProfile.click()
-    await page.waitForURL('**/marketplace/creator/**');
+    await firstCreatorProfile.click();
+    await page.waitForURL("**/marketplace/creator/**");
     await matchesUrl(page, /\/marketplace\/creator\/.+/);
   });
-  
+
   test("Complete search flow works correctly", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
-  
+
     await marketplacePage.searchAndNavigate("DummyInput");
 
     await marketplacePage.waitForSearchResults();
-    
+
     await matchesUrl(page, /\/marketplace\/search\?searchTerm=/);
-    
+
     const resultsHeading = page.getByText("Results for:");
     await isVisible(resultsHeading);
-    
+
     const searchTerm = page.getByText("DummyInput").first();
     await isVisible(searchTerm);
-    
+
     const results = await marketplacePage.getSearchResultsCount();
     expect(results).toBeGreaterThan(1);
   });
 
   // We need to add a test search with filters, but the current business logic for filters doesn't work as expected. We'll add it once we modify that.
-
 });
 
 test.describe("Marketplace – Edge Cases", () => {
   test("Search for non-existent item shows no results", async ({ page }) => {
     const marketplacePage = new MarketplacePage(page);
     await marketplacePage.goto();
-  
+
     await marketplacePage.searchAndNavigate("xyznonexistentitemxyz123");
 
     await marketplacePage.waitForSearchResults();
-    
+
     await matchesUrl(page, /\/marketplace\/search\?searchTerm=/);
-    
+
     const resultsHeading = page.getByText("Results for:");
     await isVisible(resultsHeading);
-    
+
     const searchTerm = page.getByText("xyznonexistentitemxyz123");
     await isVisible(searchTerm);
-    
+
     const results = await marketplacePage.getSearchResultsCount();
     expect(results).toBe(0);
   });

--- a/autogpt_platform/frontend/src/tests/pages/login.page.ts
+++ b/autogpt_platform/frontend/src/tests/pages/login.page.ts
@@ -3,6 +3,10 @@ import { Page } from "@playwright/test";
 export class LoginPage {
   constructor(private page: Page) {}
 
+  async goto() {
+    await this.page.goto("/login");
+  }
+
   async login(email: string, password: string) {
     console.log(`ℹ️ Attempting login on ${this.page.url()} with`, {
       email,

--- a/autogpt_platform/frontend/src/tests/pages/marketplace.page.ts
+++ b/autogpt_platform/frontend/src/tests/pages/marketplace.page.ts
@@ -101,7 +101,7 @@ export class MarketplacePage extends BasePage {
   }
 
   async waitForSearchResults() {
-    await this.page.waitForURL('**/marketplace/search**');
+    await this.page.waitForURL("**/marketplace/search**");
   }
 
   async getFirstFeaturedAgent() {

--- a/autogpt_platform/frontend/src/tests/pages/marketplace.page.ts
+++ b/autogpt_platform/frontend/src/tests/pages/marketplace.page.ts
@@ -1,0 +1,123 @@
+import { Page } from "@playwright/test";
+import { BasePage } from "./base.page";
+import { getSelectors } from "../utils/selectors";
+
+export class MarketplacePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto() {
+    await this.page.goto("/marketplace");
+  }
+
+  async getMarketplaceTitle() {
+    const { getText } = getSelectors(this.page);
+    return getText("Explore AI agents", { exact: false });
+  }
+
+  async getCreatorsSection() {
+    const { getId, getText } = getSelectors(this.page);
+    return getId("creators-section") || getText("Creators", { exact: false });
+  }
+
+  async getAgentsSection() {
+    const { getId, getText } = getSelectors(this.page);
+    return getId("agents-section") || getText("Agents", { exact: false });
+  }
+
+  async getCreatorsLink() {
+    const { getLink } = getSelectors(this.page);
+    return getLink(/creators/i);
+  }
+
+  async getAgentsLink() {
+    const { getLink } = getSelectors(this.page);
+    return getLink(/agents/i);
+  }
+
+  async getSearchInput() {
+    const { getField, getId } = getSelectors(this.page);
+    return getId("store-search-input") || getField(/search/i);
+  }
+
+  async getFilterDropdown() {
+    const { getId, getButton } = getSelectors(this.page);
+    return getId("filter-dropdown") || getButton(/filter/i);
+  }
+
+  async searchFor(query: string) {
+    const searchInput = await this.getSearchInput();
+    await searchInput.fill(query);
+    await searchInput.press("Enter");
+  }
+
+  async clickCreators() {
+    const creatorsLink = await this.getCreatorsLink();
+    await creatorsLink.click();
+  }
+
+  async clickAgents() {
+    const agentsLink = await this.getAgentsLink();
+    await agentsLink.click();
+  }
+
+  async openFilter() {
+    const filterDropdown = await this.getFilterDropdown();
+    await filterDropdown.click();
+  }
+
+  async getFeaturedAgentsSection() {
+    const { getText } = getSelectors(this.page);
+    return getText("Featured agents");
+  }
+
+  async getTopAgentsSection() {
+    const { getText } = getSelectors(this.page);
+    return getText("Top Agents");
+  }
+
+  async getFeaturedCreatorsSection() {
+    const { getText } = getSelectors(this.page);
+    return getText("Featured Creators");
+  }
+
+  async getFeaturedAgentCards() {
+    return this.page.locator('[data-testid="featured-store-card"]');
+  }
+
+  async getTopAgentCards() {
+    return this.page.locator('[data-testid="store-card"]');
+  }
+
+  async getCreatorProfiles() {
+    return this.page.locator('[data-testid="creator-card"]');
+  }
+
+  async searchAndNavigate(query: string) {
+    const searchInput = await this.getSearchInput();
+    await searchInput.fill(query);
+    await searchInput.press("Enter");
+  }
+
+  async waitForSearchResults() {
+    await this.page.waitForURL('**/marketplace/search**');
+  }
+
+  async getFirstFeaturedAgent() {
+    return this.page.locator('[data-testid="featured-store-card"]').first();
+  }
+
+  async getFirstTopAgent() {
+    return this.page.locator('[data-testid="store-card"]:visible').first();
+  }
+
+  async getFirstCreatorProfile() {
+    return this.page.locator('[data-testid="creator-card"]').first();
+  }
+
+  async getSearchResultsCount() {
+    const storeCards = this.page.locator('[data-testid="store-card"]');
+    return await storeCards.count();
+  }
+}

--- a/autogpt_platform/frontend/src/tests/utils/assertion.ts
+++ b/autogpt_platform/frontend/src/tests/utils/assertion.ts
@@ -12,7 +12,7 @@ export async function hasAttribute(
   await expect(el).toHaveAttribute(label, val);
 }
 
-export async function hasTextContent(el: Locator, text: string) {
+export async function hasTextContent(el: Locator, text: string | RegExp) {
   await expect(el).toContainText(text);
 }
 
@@ -42,4 +42,13 @@ export async function isDisabled(el: Locator) {
 
 export async function isEnabled(el: Locator) {
   await expect(el).toBeEnabled();
+}
+
+export async function hasMinCount(el: Locator, minCount: number) {
+  const count = await el.count();
+  expect(count).toBeGreaterThanOrEqual(minCount);
+}
+
+export async function matchesUrl(page: Page, pattern: RegExp) {
+  expect(page.url()).toMatch(pattern);
 }


### PR DESCRIPTION
- Resolves - https://github.com/Significant-Gravitas/AutoGPT/issues/10428
- Depends on - https://github.com/Significant-Gravitas/AutoGPT/pull/10427
- Need to review this pr, once this issue is fixed - https://github.com/Significant-Gravitas/AutoGPT/issues/10404

I’ve created additional tests for the creators marketplace page

Tests that I have added
- User can access creator's page when logged out.
- User can access creator's page when logged in.
- Creator page details are visible.
- Agents in agent by sections navigation works.

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] I have done all the tests and they are working perfectly

