### PR TITLE
fix(backend): Fix Agent Input with empty string default value not being rendered

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -212,9 +212,9 @@ class BaseGraph(BaseDbModel):
         schema_fields: list[AgentInputBlock.Input | AgentOutputBlock.Input] = []
         for type_class, input_default in props:
             try:
-                schema_fields.append(type_class(**input_default))
+                schema_fields.append(type_class.model_construct(**input_default))
             except Exception as e:
-                logger.warning(f"Invalid {type_class}: {input_default}, {e}")
+                logger.error(f"Invalid {type_class}: {input_default}, {e}")
 
         return {
             "type": "object",


### PR DESCRIPTION
Some AgentInput can store empty string as the default value, this will cause error on non string input.

Error:
```
2025-07-22 23:14:10,424 WARNING  Invalid <class 'backend.blocks.io.AgentToggleInputBlock.Input'>: {'name': 'Enriched info (including email), will double the search cost', 'value': '', 'advanced': False, 'placeholder_values': []}, 1 validation error for Input
value
  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/bool_parsing
2025-07-22 23:14:10,424 WARNING  Invalid <class 'backend.blocks.io.AgentNumberInputBlock.Input'>: {'name': 'Expected New Leads Count', 'value': '', 'advanced': False, 'placeholder_values': []}, 1 validation error for Input
value
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing
```

### Changes 🏗️

Ignosre invalid field when constructing agent input schema.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Use AgentNumberInput and AgenToggleInput with empty string value.