### PR TITLE
feat(platform): Move DatabaseManager away from RestAPI as a standalone serice

### DIFF
--- a/autogpt_platform/backend/backend/rest.py
+++ b/autogpt_platform/backend/backend/rest.py
@@ -1,5 +1,4 @@
 from backend.app import run_processes
-from backend.executor import DatabaseManager
 from backend.server.rest_api import AgentServer
 
 
@@ -7,10 +6,7 @@ def main():
     """
     Run all the processes required for the AutoGPT-server REST API.
     """
-    run_processes(
-        DatabaseManager(),
-        AgentServer(),
-    )
+    run_processes(AgentServer())
 
 
 if __name__ == "__main__":

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -14,7 +14,6 @@ from autogpt_libs.feature_flag.client import (
     shutdown_launchdarkly,
 )
 from autogpt_libs.logging.utils import generate_uvicorn_config
-from autogpt_libs.utils.cache import thread_cached
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 
@@ -220,19 +219,8 @@ app.include_router(
 app.mount("/external-api", external_app)
 
 
-@thread_cached
-def get_db_async_client():
-    from backend.executor import DatabaseManagerAsyncClient
-
-    return backend.util.service.get_service_client(
-        DatabaseManagerAsyncClient,
-        health_check=False,
-    )
-
-
 @app.get(path="/health", tags=["health"], dependencies=[])
 async def health():
-    await get_db_async_client().health_check_async()
     return {"status": "healthy"}
 
 


### PR DESCRIPTION
It's hard to debug two processes running in the same pod. We need to decouple the two processes into two services.

### Changes 🏗️

Move DatabaseManager away from RestAPI as a standalone serice

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual test
