### PR TITLE
feat(backend): Avoid executor over-consuming messages when it's fully occupied

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -193,8 +193,7 @@ async def execute_node(
             yield output_name, output_data
 
     except Exception as e:
-        error_msg = str(e)
-        yield "error", error_msg
+        yield "error", str(e) or type(e).__name__
         raise e
 
     finally:

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -668,6 +668,15 @@ def create_execution_queue_config() -> RabbitMQConfig:
         routing_key=GRAPH_EXECUTION_ROUTING_KEY,
         durable=True,
         auto_delete=False,
+        arguments={
+            # x-consumer-timeout (0 = disabled)
+            # Problem: Default 30-minute consumer timeout kills long-running graph executions
+            # Original error: "Consumer acknowledgement timed out after 1800000 ms (30 minutes)"
+            # Solution: Disable consumer timeout entirely - let graphs run indefinitely
+            # Safety: Heartbeat mechanism now handles dead consumer detection instead
+            # Use case: Graph executions that take hours to complete (AI model training, etc.)
+            "x-consumer-timeout": 0,
+        },
     )
     cancel_queue = Queue(
         name=GRAPH_EXECUTION_CANCEL_QUEUE_NAME,


### PR DESCRIPTION
When we run multiple instances of the executor, some of the executors can oversubscribe the messages and end up queuing the agent execution request instead of letting another executor handle the job. This change solves the problem.

### Changes 🏗️

* Reject execution request when the executor is full.
* Improve `active_graph_runs` tracking for better horizontal scaling heuristics.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual graph execution & CI
