### PR TITLE
feat(backend): add getting user profile, drafts, update send email to use mulitple to, cc, bcc

### DIFF
--- a/autogpt_platform/backend/backend/blocks/google/gmail.py
+++ b/autogpt_platform/backend/backend/blocks/google/gmail.py
@@ -563,7 +563,9 @@ class GmailCreateDraftBlock(Block):
             test_output=[
                 (
                     "result",
-                    {"id": "draft1", "message_id": "msg1", "status": "draft_created"},
+                    GmailDraftResult(
+                        id="draft1", message_id="msg1", status="draft_created"
+                    ),
                 ),
             ],
             test_mock={
@@ -1141,6 +1143,24 @@ class GmailReplyBlock(Block):
                 ("messageId", "m2"),
                 ("threadId", "t1"),
                 ("message", {"id": "m2", "threadId": "t1"}),
+                (
+                    "email",
+                    Email(
+                        threadId="t1",
+                        labelIds=[],
+                        id="m2",
+                        subject="",
+                        snippet="",
+                        from_="",
+                        to=[],
+                        cc=[],
+                        bcc=[],
+                        date="",
+                        body="Thanks",
+                        sizeEstimate=0,
+                        attachments=[],
+                    ),
+                ),
             ],
             test_mock={
                 "_reply": lambda *args, **kwargs: {


### PR DESCRIPTION
Need: The Gmail integration had several parsing issues that were causing data loss and
  workflow incompatibilities:
  1. Email recipient parsing only captured the first recipient, losing CC/BCC and multiple TO
   recipients
  2. Email body parsing was inconsistent between blocks, sometimes showing "This email does
  not contain a readable body" for valid emails
  3. Type mismatches between blocks caused serialization issues when connecting them in
  workflows (lists being converted to string representations like "[\"email@example.com\"]")

  # Changes 🏗️

  1. Enhanced Email Model:
    - Added cc and bcc fields to capture all recipients
    - Changed to field from string to list for consistency
    - Now captures all recipients instead of just the first one
  2. Improved Email Parsing:
    - Updated GmailReadBlock and GmailGetThreadBlock to parse all recipients using
  getaddresses()
    - Unified email body parsing logic across blocks with robust multipart handling
    - Added support for HTML to plain text conversion
    - Fixed handling of emails with attachments as body content
  3. Fixed Block Compatibility:
    - Updated GmailSendBlock and GmailCreateDraftBlock to accept lists for recipient fields
    - Added validation to ensure at least one recipient is provided
    - All blocks now consistently use lists for recipient fields, preventing serialization
  issues
  4. Updated Test Data:
    - Modified all test inputs/outputs to use the new list format for recipients
    - Ensures tests reflect the new data structure

  # Checklist 📋

  For code changes:

  - I have clearly listed my changes in the PR description
  - I have made a test plan
  - I have tested my changes according to the test plan:
    - Run existing Gmail block unit tests with poetry run test
    - Create a workflow that reads emails with multiple recipients and verify all TO, CC, BCC
   recipients are captured
    - Test email body parsing with plain text, HTML, and multipart emails
    - Connect GmailReadBlock → GmailSendBlock in a workflow and verify recipient data flows
  correctly
    - Connect GmailReplyBlock → GmailSendBlock and verify no serialization errors occur
    - Test sending emails with multiple recipients via GmailSendBlock
    - Test creating drafts with multiple recipients via GmailCreateDraftBlock
    - Verify backwards compatibility by testing with single recipient strings (should now
  require lists)

  - Create from scratch and execute an agent with at least 3 blocks
  - Import an agent from file upload, and confirm it executes correctly
  - Upload agent to marketplace
  - Import an agent from marketplace and confirm it executes correctly
  - Edit an agent from monitor, and confirm it executes correctly

# Breaking Change Note: The to field in GmailSendBlock and GmailCreateDraftBlock now requires
   a list instead of accepting both string and list. Existing workflows using strings will
  need to be updated to use lists (e.g., ["email@example.com"] instead of
  "email@example.com").