### PR TITLE
feat(backend): Make agent graph execution retriable

### DIFF
--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -511,7 +511,6 @@ class Executor:
         logger.info(f"[GraphExecutor] {cls.pid} started")
 
     @classmethod
-    @func_retry
     @error_logged(swallow=False)
     def on_graph_execution(
         cls,

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -511,6 +511,7 @@ class Executor:
         logger.info(f"[GraphExecutor] {cls.pid} started")
 
     @classmethod
+    @func_retry
     @error_logged(swallow=False)
     def on_graph_execution(
         cls,
@@ -635,6 +636,7 @@ class Executor:
             execution_stats.cost += cost
 
     @classmethod
+    @func_retry
     @time_measured
     def _on_graph_execution(
         cls,

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -286,7 +286,7 @@ def get_service_client(
         return retry(
             reraise=True,
             stop=stop_after_attempt(api_comm_retry),
-            wait=wait_exponential_jitter(max=4.0),
+            wait=wait_exponential_jitter(max=5.0),
             retry=retry_if_not_exception_type(
                 (
                     # Don't retry these specific exceptions that won't be fixed by retrying

--- a/autogpt_platform/backend/backend/util/service_test.py
+++ b/autogpt_platform/backend/backend/util/service_test.py
@@ -19,6 +19,7 @@ TEST_SERVICE_PORT = 8765
 class ServiceTest(AppService):
     def __init__(self):
         super().__init__()
+        self.fail_count = 0
 
     def cleanup(self):
         pass
@@ -42,6 +43,19 @@ class ServiceTest(AppService):
 
         return self.run_and_wait(add_async(a, b))
 
+    @expose
+    def failing_add(self, a: int, b: int) -> int:
+        """Method that fails 2 times then succeeds - for testing retry logic"""
+        self.fail_count += 1
+        if self.fail_count <= 2:
+            raise RuntimeError("Database connection failed")
+        return a + b
+
+    @expose
+    def always_failing_add(self, a: int, b: int) -> int:
+        """Method that always fails - for testing no retry when disabled"""
+        raise RuntimeError("Database connection failed")
+
 
 class ServiceTestClient(AppServiceClient):
     @classmethod
@@ -51,6 +65,8 @@ class ServiceTestClient(AppServiceClient):
     add = ServiceTest.add
     subtract = ServiceTest.subtract
     fun_with_async = ServiceTest.fun_with_async
+    failing_add = ServiceTest.failing_add
+    always_failing_add = ServiceTest.always_failing_add
 
     add_async = endpoint_to_async(ServiceTest.add)
     subtract_async = endpoint_to_async(ServiceTest.subtract)
@@ -313,3 +329,25 @@ def test_cached_property_behavior():
     resource3 = obj.expensive_resource
     assert creation_count == 2  # New creation
     assert resource1 != resource3
+
+
+def test_service_with_runtime_error_retries(server):
+    """Test a real service method that throws RuntimeError and gets retried"""
+    with ServiceTest():
+        # Get client with retry enabled
+        client = get_service_client(ServiceTestClient, request_retry=True)
+
+        # This should succeed after retries (fails 2 times, succeeds on 3rd try)
+        result = client.failing_add(5, 3)
+        assert result == 8
+
+
+def test_service_no_retry_when_disabled(server):
+    """Test that retry doesn't happen when disabled"""
+    with ServiceTest():
+        # Get client with retry disabled
+        client = get_service_client(ServiceTestClient, request_retry=False)
+
+        # This should fail immediately without retry
+        with pytest.raises(RuntimeError, match="Database connection failed"):
+            client.always_failing_add(5, 3)

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -68,7 +68,7 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         description="The default timeout in seconds, for Pyro client connections.",
     )
     pyro_client_comm_retry: int = Field(
-        default=3,
+        default=5,
         description="The default number of retries for Pyro client connections.",
     )
     rpc_client_call_timeout: int = Field(


### PR DESCRIPTION
Make agent graph execution durable by making it retieable.

### Changes 🏗️

* Make _on_graph_execution retriable
* Increase retry count for failing db-manager RPC
* Add test coverage for RPC failure retry

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Allow graph execution retry
