### PR TITLE
feat(frontend): Show CAPTCHA only in cloud environments

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/login/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/login/page.tsx
@@ -85,7 +85,7 @@ export default function LoginPage() {
             />
 
             {/* Turnstile CAPTCHA Component */}
-            {!turnstile.verified ? (
+            {isCloudEnv && !turnstile.verified ? (
               <Turnstile
                 key={captchaKey}
                 siteKey={turnstile.siteKey}

--- a/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/login/useLoginPage.ts
@@ -48,7 +48,7 @@ export function useLoginPage() {
   async function handleProviderLogin(provider: LoginProvider) {
     setIsGoogleLoading(true);
 
-    if (!turnstile.verified && !isVercelPreview) {
+    if (isCloudEnv && !turnstile.verified && !isVercelPreview) {
       toast({
         title: "Please complete the CAPTCHA challenge.",
         variant: "info",
@@ -77,7 +77,7 @@ export function useLoginPage() {
 
   async function handleLogin(data: z.infer<typeof loginFormSchema>) {
     setIsLoading(true);
-    if (!turnstile.verified && !isVercelPreview) {
+    if (isCloudEnv && !turnstile.verified && !isVercelPreview) {
       toast({
         title: "Please complete the CAPTCHA challenge.",
         variant: "info",

--- a/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
@@ -163,7 +163,7 @@ export default function SignupPage() {
             />
 
             {/* Turnstile CAPTCHA Component */}
-            {!turnstile.verified ? (
+            {isCloudEnv && !turnstile.verified ? (
               <Turnstile
                 key={captchaKey}
                 siteKey={turnstile.siteKey}

--- a/autogpt_platform/frontend/src/app/(platform)/signup/useSignupPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/useSignupPage.ts
@@ -52,7 +52,7 @@ export function useSignupPage() {
   async function handleProviderSignup(provider: LoginProvider) {
     setIsGoogleLoading(true);
 
-    if (!turnstile.verified && !isVercelPreview) {
+    if (isCloudEnv && !turnstile.verified && !isVercelPreview) {
       toast({
         title: "Please complete the CAPTCHA challenge.",
         variant: "default",
@@ -78,7 +78,7 @@ export function useSignupPage() {
   async function handleSignup(data: z.infer<typeof signupFormSchema>) {
     setIsLoading(true);
 
-    if (!turnstile.verified && !isVercelPreview) {
+    if (isCloudEnv && !turnstile.verified && !isVercelPreview) {
       toast({
         title: "Please complete the CAPTCHA challenge.",
         variant: "default",


### PR DESCRIPTION
Updated login and signup pages to display the Turnstile CAPTCHA and require verification only when running in a cloud environment. This prevents unnecessary CAPTCHA prompts in local or non-cloud deployments.

### Changes 🏗️

Locally when you try to login with the wrong password, and you update and login again, you get a warning about captcha which is wrong, so this fix makes it so the captcha will only when running in a cloud 

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Try to login with the wrong password, get "Invalid login credentials" and try to login again, you should keep getting "Invalid login credentials" and it should not mention captcha

