### PR TITLE
feat(backend/executor): Avoid executor premature termination on inflight agent execution

### DIFF
--- a/autogpt_platform/backend/backend/blocks/agent.py
+++ b/autogpt_platform/backend/backend/blocks/agent.py
@@ -199,5 +199,5 @@ class AgentExecutorBlock(Block):
                 wait_timeout=3600,
             )
             logger.info(f"Execution {log_id} stopped successfully.")
-        except Exception as e:
-            logger.error(f"Failed to stop execution {log_id}: {e}")
+        except TimeoutError as e:
+            logger.error(f"Execution {log_id} stop timed out: {e}")

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -2,13 +2,12 @@ import asyncio
 import logging
 import multiprocessing
 import os
-import sys
 import threading
 import time
 from collections import defaultdict
 from concurrent.futures import Future, ProcessPoolExecutor
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast, override
 
 from pika.adapters.blocking_connection import BlockingChannel
 from pika.spec import Basic, BasicProperties
@@ -57,6 +56,7 @@ from backend.data.execution import (
 )
 from backend.data.graph import Link, Node
 from backend.executor.utils import (
+    GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS,
     GRAPH_EXECUTION_CANCEL_QUEUE_NAME,
     GRAPH_EXECUTION_QUEUE_NAME,
     CancelExecutionEvent,
@@ -66,7 +66,6 @@ from backend.executor.utils import (
     execution_usage_cost,
     get_async_execution_event_bus,
     get_execution_event_bus,
-    get_execution_queue,
     parse_execution_output,
     validate_exec,
 )
@@ -522,7 +521,7 @@ class Executor:
             else:
                 # CancelledError or SystemExit
                 log_metadata.warning(
-                    f"Interuption error on node execution {node_exec.node_exec_id}: {type(e).__name__}"
+                    f"Interruption error on node execution {node_exec.node_exec_id}: {type(e).__name__}"
                 )
                 status = ExecutionStatus.TERMINATED
 
@@ -714,6 +713,13 @@ class Executor:
         log_metadata: LogMetadata,
         execution_stats: GraphExecutionStats,
     ) -> ExecutionStatus:
+
+        # Agent execution is uninterrupted.
+        import signal
+
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
         """
         Returns:
             dict: The execution statistics of the graph execution.
@@ -892,11 +898,11 @@ class Executor:
 
             return execution_status
 
-        except BaseException as exc:
+        except BaseException as e:
             error = (
-                exc
-                if isinstance(exc, Exception)
-                else Exception(f"{exc.__class__.__name__}: {exc}")
+                e
+                if isinstance(e, Exception)
+                else Exception(f"{e.__class__.__name__}: {e}")
             )
 
             known_errors = (InsufficientBalanceError,)
@@ -1081,36 +1087,50 @@ class ExecutionManager(AppProcess):
     def __init__(self):
         super().__init__()
         self.pool_size = settings.config.num_graph_workers
-        self.running = True
         self.active_graph_runs: dict[str, tuple[Future, threading.Event]] = {}
+        self._stop_consuming = None
+        self._executor = None
+
+    @property
+    def stop_consuming(self) -> threading.Event:
+        if self._stop_consuming is None:
+            self._stop_consuming = threading.Event()
+        return self._stop_consuming
+
+    @property
+    def executor(self) -> ProcessPoolExecutor:
+        if self._executor is None:
+            self._executor = ProcessPoolExecutor(
+                max_workers=self.pool_size,
+                initializer=Executor.on_graph_executor_start,
+            )
+        return self._executor
 
     def run(self):
+        logger.info(f"[{self.service_name}] ⏳ Spawn max-{self.pool_size} workers...")
+
         pool_size_gauge.set(self.pool_size)
         active_runs_gauge.set(0)
         utilization_gauge.set(0)
-
-        self.metrics_server = threading.Thread(
-            target=start_http_server,
-            args=(settings.config.execution_manager_port,),
-            daemon=True,
-        )
-        self.metrics_server.start()
-        logger.info(f"[{self.service_name}] Starting execution manager...")
-        self._run()
-
-    def _run(self):
-        logger.info(f"[{self.service_name}] ⏳ Spawn max-{self.pool_size} workers...")
-        self.executor = ProcessPoolExecutor(
-            max_workers=self.pool_size,
-            initializer=Executor.on_graph_executor_start,
-        )
 
         threading.Thread(
             target=lambda: self._consume_execution_cancel(),
             daemon=True,
         ).start()
 
-        self._consume_execution_run()
+        threading.Thread(
+            target=lambda: self._consume_execution_run(),
+            daemon=True,
+        ).start()
+
+        threading.Thread(
+            target=start_http_server,
+            args=(settings.config.execution_manager_port,),
+            daemon=True,
+        ).start()
+
+        while True:
+            time.sleep(1e5)
 
     @continuous_retry()
     def _consume_execution_cancel(self):
@@ -1128,11 +1148,15 @@ class ExecutionManager(AppProcess):
 
     @continuous_retry()
     def _consume_execution_run(self):
-
         # Long-running executions are handled by:
         # 1. Long consumer timeout (x-consumer-timeout) allows long running agent
         # 2. Enhanced connection settings (5 retries, 1s delay) for quick reconnection
         # 3. Process monitoring ensures failed executors release messages back to queue
+        if self.stop_consuming.is_set():
+            logger.info(
+                f"[{self.service_name}] Stop reconnecting execution consumer since the service is cleaned up."
+            )
+            return
 
         run_client = SyncRabbitMQ(create_execution_queue_config())
         run_client.connect()
@@ -1150,15 +1174,27 @@ class ExecutionManager(AppProcess):
         run_channel.confirm_delivery()
 
         logger.info(f"[{self.service_name}] ⏳ Starting to consume run messages...")
-        run_channel.start_consuming()
-        raise RuntimeError(f"❌ run message consumer is stopped: {run_channel}")
+
+        # Continue consuming messages until stop flag is set
+        # This keeps the connection alive but rejects new messages in _handle_run_message
+        while not self.stop_consuming.is_set():
+            try:
+                run_channel.connection.process_data_events(time_limit=1)
+            except Exception as e:
+                if self.stop_consuming.is_set():
+                    # Expected during shutdown
+                    break
+                logger.error(f"[{self.service_name}] Error processing events: {e}")
+                raise
+
+        logger.info(f"[{self.service_name}] ✅ Run message consumer stopped gracefully")
 
     @error_logged(swallow=True)
     def _handle_cancel_message(
         self,
-        channel: BlockingChannel,
-        method: Basic.Deliver,
-        properties: BasicProperties,
+        _channel: BlockingChannel,
+        _method: Basic.Deliver,
+        _properties: BasicProperties,
         body: bytes,
     ):
         """
@@ -1191,10 +1227,18 @@ class ExecutionManager(AppProcess):
         self,
         channel: BlockingChannel,
         method: Basic.Deliver,
-        properties: BasicProperties,
+        _properties: BasicProperties,
         body: bytes,
     ):
         delivery_tag = method.delivery_tag
+
+        # Check if we're shutting down - reject new messages but keep connection alive
+        if self.stop_consuming.is_set():
+            logger.info(
+                f"[{self.service_name}] Rejecting new execution during shutdown"
+            )
+            channel.basic_nack(delivery_tag, requeue=True)
+            return
 
         # Check if we can accept more runs
         self._cleanup_completed_runs()
@@ -1281,30 +1325,57 @@ class ExecutionManager(AppProcess):
 
         return completed_runs
 
+    @override
     def cleanup(self):
-        super().cleanup()
-        self._on_cleanup()
-
-    def _on_cleanup(self, log=logger.info):
+        """Override cleanup to implement graceful shutdown with active execution waiting."""
         prefix = f"[{self.service_name}][on_graph_executor_stop {os.getpid()}]"
-        log(f"{prefix} ⏳ Shutting down service loop...")
-        self.running = False
+        logger.info(f"{prefix} 🧹 Starting graceful shutdown...")
 
-        log(f"{prefix} ⏳ Shutting down RabbitMQ channel...")
-        get_execution_queue().get_channel().stop_consuming()
+        # Signal the consumer thread to stop (thread-safe)
+        self.stop_consuming.set()
+        logger.info(f"{prefix} ✅ Signaled execution message consumer to stop")
 
-        if hasattr(self, "executor"):
-            log(f"{prefix} ⏳ Shutting down GraphExec pool...")
-            self.executor.shutdown(cancel_futures=True, wait=False)
+        # Wait for active executions to complete
+        if self.active_graph_runs:
+            logger.info(
+                f"{prefix} ⏳ Waiting for {len(self.active_graph_runs)} active executions to complete..."
+            )
 
-        log(f"{prefix} ⏳ Cleaning up active graph runs...")
-        self._cleanup_completed_runs(log=log)
+            max_wait = GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+            wait_interval = 5
+            waited = 0
 
-        log(f"{prefix} ⏳ Disconnecting Redis...")
-        redis.disconnect()
+            while waited < max_wait:
+                self._cleanup_completed_runs()
+                if not self.active_graph_runs:
+                    logger.info(f"{prefix} ✅ All active executions completed")
+                    break
+                else:
+                    logger.info(
+                        f"{prefix} ⏳ Still waiting for {len(self.active_graph_runs)} executions..."
+                    )
 
-        log(f"{prefix} ✅ Finished GraphExec cleanup")
-        sys.exit(0)
+                time.sleep(wait_interval)
+                waited += wait_interval
+
+            if self.active_graph_runs:
+                logger.error(
+                    f"{prefix} ⚠️ {len(self.active_graph_runs)} executions still running after {max_wait}s"
+                )
+            else:
+                logger.info(f"{prefix} ✅ All executions completed gracefully")
+
+        # NOW shutdown executor pool after all executions are complete
+        if self._executor:
+            logger.info(f"{prefix} ⏳ Shutting down GraphExec pool...")
+            try:
+                # All active executions are done, safe to shutdown workers
+                self._executor.shutdown(cancel_futures=True, wait=False)
+                logger.info(f"{prefix} ✅ Executor shutdown completed")
+            except Exception as e:
+                logger.error(f"{prefix} ⚠️ Error during executor shutdown: {e}")
+
+        logger.info(f"{prefix} ✅ Finished GraphExec cleanup")
 
 
 # ------- UTILITIES ------- #
@@ -1429,11 +1500,3 @@ def increment_execution_count(user_id: str) -> int:
     if counter == 1:
         r.expire(k, settings.config.execution_counter_expiration_time)
     return counter
-
-
-def llprint(message: str):
-    """
-    Low-level print/log helper function for use in signal handlers.
-    Regular log/print statements are not allowed in signal handlers.
-    """
-    os.write(sys.stdout.fileno(), (message + "\n").encode())

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -259,8 +259,8 @@ class Scheduler(AppService):
 
     def cleanup(self):
         super().cleanup()
-        logger.info("⏳ Shutting down scheduler...")
         if self.scheduler:
+            logger.info("⏳ Shutting down scheduler...")
             self.scheduler.shutdown(wait=False)
 
     @expose

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -655,6 +655,11 @@ GRAPH_EXECUTION_CANCEL_EXCHANGE = Exchange(
 )
 GRAPH_EXECUTION_CANCEL_QUEUE_NAME = "graph_execution_cancel_queue"
 
+# Graceful shutdown timeout constants
+# Agent executions can run for up to 1 day, so we need a graceful shutdown period
+# that allows long-running executions to complete naturally
+GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS = 24 * 60 * 60  # 1 day to complete active executions
+
 
 def create_execution_queue_config() -> RabbitMQConfig:
     """
@@ -675,7 +680,8 @@ def create_execution_queue_config() -> RabbitMQConfig:
             # Solution: Disable consumer timeout entirely - let graphs run indefinitely
             # Safety: Heartbeat mechanism now handles dead consumer detection instead
             # Use case: Graph executions that take hours to complete (AI model training, etc.)
-            "x-consumer-timeout": (7 * 24 * 60 * 60 * 1000),  # 7 days in milliseconds
+            "x-consumer-timeout": GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+            * 1000,
         },
     )
     cancel_queue = Queue(

--- a/autogpt_platform/backend/backend/util/process.py
+++ b/autogpt_platform/backend/backend/util/process.py
@@ -73,19 +73,30 @@ class AppProcess(ABC):
             set_service_name(self.service_name)
             logger.info(f"[{self.service_name}] Starting...")
             self.run()
-        except (KeyboardInterrupt, SystemExit) as e:
-            logger.warning(f"[{self.service_name}] Terminated: {e}; quitting...")
+        except BaseException as e:
+            logger.warning(
+                f"[{self.service_name}] Termination request: {type(e).__name__}; executing cleanup."
+            )
         finally:
-            if not self.cleaned_up:
-                self.cleanup()
-                self.cleaned_up = True
+            self.cleanup()
             logger.info(f"[{self.service_name}] Terminated.")
+
+    @staticmethod
+    def llprint(message: str):
+        """
+        Low-level print/log helper function for use in signal handlers.
+        Regular log/print statements are not allowed in signal handlers.
+        """
+        os.write(sys.stdout.fileno(), (message + "\n").encode())
 
     def _self_terminate(self, signum: int, frame):
         if not self.cleaned_up:
-            self.cleanup()
             self.cleaned_up = True
-        sys.exit(0)
+            sys.exit(0)
+        else:
+            self.llprint(
+                f"[{self.service_name}] Received exit signal {signum}, but cleanup is already underway."
+            )
 
     # Methods that are executed OUTSIDE the process #
 


### PR DESCRIPTION
There is no 100% accurate way of retrying an agent that has been terminated. And the safest way to avoid executing an agent wrong is minimizing the chance of an agent execution being terminated. A whole set of mechanism to make sure the agent is retried on failure is still in place and improved, this is used as our best-effort reliability mechanism.

### Changes 🏗️

* Cap SIGINT & SIGTERM to be raised at most once, so the executor can gracefully handle the stopping.
* SIGINT & SIGTERM will stop the execution request message consumption, but not agent execution.
* Executor process will only stop if all the in-flight agent executions are completed or terminated.
* Avoid retrying the agent stop command on AgentExecutorBlock on timeout.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run agent, send SIGTERM to the executor pod, execution should not be interrupted.
  - [x] Run agent, send SIGKILL to the executor pod, execution should be transferred to another pod.

