### PR TITLE
fix(backend): resolve unclosed HTTP client session errors

### DIFF
--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -75,6 +75,15 @@ async def lifespan_context(app: fastapi.FastAPI):
     await backend.data.graph.migrate_llm_models(LlmModel.GPT4O)
     with launch_darkly_context():
         yield
+
+    # Cleanup cloud storage handler to prevent unclosed client sessions
+    from backend.util.cloud_storage import shutdown_cloud_storage_handler
+
+    try:
+        await shutdown_cloud_storage_handler()
+    except Exception as e:
+        logger.warning(f"Error shutting down cloud storage handler: {e}")
+
     await backend.data.db.disconnect()
 
 

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -40,6 +40,7 @@ from backend.integrations.providers import ProviderName
 from backend.server.external.api import external_app
 from backend.server.middleware.security import SecurityHeadersMiddleware
 from backend.util import json
+from backend.util.cloud_storage import shutdown_cloud_storage_handler
 
 settings = backend.util.settings.Settings()
 logger = logging.getLogger(__name__)
@@ -75,9 +76,6 @@ async def lifespan_context(app: fastapi.FastAPI):
     await backend.data.graph.migrate_llm_models(LlmModel.GPT4O)
     with launch_darkly_context():
         yield
-
-    # Cleanup cloud storage handler to prevent unclosed client sessions
-    from backend.util.cloud_storage import shutdown_cloud_storage_handler
 
     try:
         await shutdown_cloud_storage_handler()

--- a/autogpt_platform/backend/backend/server/v2/store/media_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/media_test.py
@@ -26,6 +26,10 @@ def mock_storage_client(mocker):
     mock_client = AsyncMock()
     mock_client.upload = AsyncMock()
 
+    # Mock context manager methods
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
     # Mock the constructor to return our mock client
     mocker.patch(
         "backend.server.v2.store.media.async_storage.Storage", return_value=mock_client


### PR DESCRIPTION
## Summary

This PR resolves unclosed HTTP client session errors that were occurring in the backend, particularly during file uploads and service-to-service communication.

### Key Changes

- **Fixed GCS storage operations**: Convert `gcloud.aio.storage.Storage()` to use async context managers in `media.py` and `cloud_storage.py`
- **Enhanced service client cleanup**: Added proper cleanup methods to `DynamicClient` class in `service.py` with `__del__` fallback and context manager support
- **Application shutdown cleanup**: Added cloud storage handler cleanup to FastAPI application lifespan
- **Updated test mocks**: Fixed test fixtures to properly mock async context manager behavior

### Root Cause Analysis

The "Unclosed client session" and "Unclosed connector" errors were caused by:

1. **GCS storage clients** not using context managers (agent image uploads)
2. **Service HTTP clients** (`httpx.Client`/`AsyncClient`) not being properly cleaned up in the `DynamicClient` class

### Technical Details

- All `gcloud.aio.storage.Storage()` instances now use `async with` context managers
- `DynamicClient` class now has proper cleanup methods and context manager support
- Application shutdown hook ensures cloud storage handlers are properly closed
- Test fixtures updated to mock async context manager protocol

### Testing

- ✅ All media upload tests pass
- ✅ Service client tests pass
- ✅ Linting and formatting pass

## Test plan

- [ ] Deploy to staging environment
- [ ] Monitor logs for "Unclosed client session" errors (should be eliminated)
- [ ] Verify file upload functionality works correctly
- [ ] Check service-to-service communication operates normally

🤖 Generated with [Claude Code](https://claude.ai/code)