### PR TITLE
fix(backend): Fix executor running RabbitMQ operations on closed/closing connection

### DIFF
--- a/autogpt_platform/backend/backend/data/rabbitmq.py
+++ b/autogpt_platform/backend/backend/data/rabbitmq.py
@@ -140,6 +140,7 @@ class SyncRabbitMQ(RabbitMQBase):
             socket_timeout=SOCKET_TIMEOUT,
             connection_attempts=CONNECTION_ATTEMPTS,
             retry_delay=RETRY_DELAY,
+            heartbeat=300,  # 5 minute timeout (heartbeats sent every 2.5 min)
         )
 
         self._connection = pika.BlockingConnection(parameters)
@@ -244,6 +245,7 @@ class AsyncRabbitMQ(RabbitMQBase):
             password=self.password,
             virtualhost=self.config.vhost.lstrip("/"),
             blocked_connection_timeout=BLOCKED_CONNECTION_TIMEOUT,
+            heartbeat=300,  # 5 minute timeout (heartbeats sent every 2.5 min)
         )
         self._channel = await self._connection.channel()
         await self._channel.set_qos(prefetch_count=1)


### PR DESCRIPTION
The RabbitMQ connection is unreliable (fixing it is a separate issue) and sometimes get restarted. The scope of this PR is to avoid the operation break due to executing on a stale, broken connection.

### Changes 🏗️

Fix executor running RabbitMQ operations on closed/closing connection

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manually kill rabbitmq and see how it goes while executing an agent
