### PR TITLE
test(frontend): add e2e test for profile form page

### DIFF
--- a/autogpt_platform/frontend/src/components/agptui/ProfileInfoForm.tsx
+++ b/autogpt_platform/frontend/src/components/agptui/ProfileInfoForm.tsx
@@ -56,7 +56,10 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
 
   return (
     <div className="w-full min-w-[800px] px-4 sm:px-8">
-      <h1 className="font-circular mb-6 text-[28px] font-normal text-neutral-900 dark:text-neutral-100 sm:mb-8 sm:text-[35px]">
+      <h1
+        data-testid="profile-info-form-title"
+        className="font-circular mb-6 text-[28px] font-normal text-neutral-900 dark:text-neutral-100 sm:mb-8 sm:text-[35px]"
+      >
         Profile
       </h1>
 
@@ -67,6 +70,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
               <Image
                 src={profileData.avatar_url}
                 alt="Profile"
+                data-testid="profile-info-form-profile-photo"
                 fill
                 className="rounded-full"
               />
@@ -79,6 +83,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
               type="file"
               accept="image/*"
               className="hidden"
+              data-testid="profile-info-form-edit-photo"
               onChange={async (e) => {
                 const file = e.target.files?.[0];
                 if (file) {
@@ -99,6 +104,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
               <input
                 type="text"
                 name="displayName"
+                data-testid="profile-info-form-display-name"
                 defaultValue={profileData.name}
                 placeholder="Enter your display name"
                 className="font-circular w-full border-none bg-transparent text-base font-normal text-neutral-900 placeholder:text-neutral-400 focus:outline-none dark:text-white dark:placeholder:text-neutral-500"
@@ -121,6 +127,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
               <input
                 type="text"
                 name="handle"
+                data-testid="profile-info-form-handle"
                 defaultValue={profileData.username}
                 placeholder="@username"
                 className="font-circular w-full border-none bg-transparent text-base font-normal text-neutral-900 placeholder:text-neutral-400 focus:outline-none dark:text-white dark:placeholder:text-neutral-500"
@@ -142,6 +149,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
             <div className="h-[220px] rounded-2xl border border-slate-200 py-2.5 pl-4 pr-4 dark:border-slate-700 dark:bg-slate-800">
               <textarea
                 name="bio"
+                data-testid="profile-info-form-bio"
                 defaultValue={profileData.description}
                 placeholder="Tell us about yourself..."
                 className="font-circular h-full w-full resize-none border-none bg-transparent text-base font-normal text-neutral-900 placeholder:text-neutral-400 focus:outline-none dark:text-white dark:placeholder:text-neutral-500"
@@ -176,6 +184,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
                       <input
                         type="text"
                         name={`link${linkNum}`}
+                        data-testid={`profile-info-form-link${linkNum}`}
                         placeholder="https://"
                         defaultValue={link || ""}
                         className="font-circular w-full border-none bg-transparent text-base font-normal text-neutral-900 placeholder:text-neutral-400 focus:outline-none dark:text-white dark:placeholder:text-neutral-500"
@@ -200,6 +209,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
 
           <div className="flex h-[50px] items-center justify-end gap-3 py-8">
             <Button
+              data-testid="profile-info-form-cancel"
               type="button"
               variant="secondary"
               className="font-circular h-[50px] rounded-[35px] bg-neutral-200 px-6 py-3 text-base font-medium text-neutral-800 transition-colors hover:bg-neutral-300 dark:border-neutral-700 dark:bg-neutral-700 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:bg-neutral-600"
@@ -210,6 +220,7 @@ export function ProfileInfoForm({ profile }: { profile: ProfileDetails }) {
               Cancel
             </Button>
             <Button
+              data-testid="profile-info-form-save"
               type="submit"
               disabled={isSubmitting}
               className="font-circular h-[50px] rounded-[35px] bg-neutral-800 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-neutral-900 dark:bg-neutral-200 dark:text-neutral-900 dark:hover:bg-neutral-100"

--- a/autogpt_platform/frontend/src/tests/pages/profile-form.page.ts
+++ b/autogpt_platform/frontend/src/tests/pages/profile-form.page.ts
@@ -1,0 +1,150 @@
+import { Locator, Page } from "@playwright/test";
+import { BasePage } from "./base.page";
+import { getSelectors } from "../utils/selectors";
+
+export class ProfileFormPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private getId(id: string | RegExp): Locator {
+    const { getId } = getSelectors(this.page);
+    return getId(id);
+  }
+
+  private async hideFloatingWidgets(): Promise<void> {
+    await this.page.addStyleTag({
+      content: `
+        [data-tally-open] { display: none !important; }
+      `,
+    });
+  }
+
+  // Locators
+  title(): Locator {
+    return this.getId("profile-info-form-title");
+  }
+
+  profilePhoto(): Locator {
+    return this.getId("profile-info-form-profile-photo");
+  }
+
+  editPhotoInput(): Locator {
+    return this.getId("profile-info-form-edit-photo");
+  }
+
+  displayNameField(): Locator {
+    return this.getId("profile-info-form-display-name");
+  }
+
+  handleField(): Locator {
+    return this.getId("profile-info-form-handle");
+  }
+
+  bioField(): Locator {
+    return this.getId("profile-info-form-bio");
+  }
+
+  linkField(index: number): Locator {
+    this.assertValidLinkIndex(index);
+    return this.getId(`profile-info-form-link${index}`);
+  }
+
+  cancelButton(): Locator {
+    return this.getId("profile-info-form-cancel");
+  }
+
+  saveButton(): Locator {
+    return this.getId("profile-info-form-save");
+  }
+
+  // State
+  async isLoaded(): Promise<boolean> {
+    try {
+      await this.title().waitFor({ state: "visible", timeout: 10_000 });
+      await this.displayNameField().waitFor({
+        state: "visible",
+        timeout: 10_000,
+      });
+      await this.handleField().waitFor({ state: "visible", timeout: 10_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // Actions
+  async uploadPhoto(filePath: string): Promise<void> {
+    await this.editPhotoInput().setInputFiles(filePath);
+  }
+
+  async setDisplayName(name: string): Promise<void> {
+    await this.displayNameField().fill(name);
+  }
+
+  async getDisplayName(): Promise<string> {
+    return this.displayNameField().inputValue();
+  }
+
+  async setHandle(handle: string): Promise<void> {
+    await this.handleField().fill(handle);
+  }
+
+  async getHandle(): Promise<string> {
+    return this.handleField().inputValue();
+  }
+
+  async setBio(bio: string): Promise<void> {
+    await this.bioField().fill(bio);
+  }
+
+  async getBio(): Promise<string> {
+    return this.bioField().inputValue();
+  }
+
+  async setLink(index: number, url: string): Promise<void> {
+    await this.linkField(index).fill(url);
+  }
+
+  async getLink(index: number): Promise<string> {
+    return this.linkField(index).inputValue();
+  }
+
+  async setLinks(links: Array<string | undefined>): Promise<void> {
+    for (let i = 1; i <= 5; i++) {
+      const val = links[i - 1] ?? "";
+      await this.setLink(i, val);
+    }
+  }
+
+  async clickCancel(): Promise<void> {
+    await this.cancelButton().click();
+  }
+
+  async clickSave(): Promise<void> {
+    await this.saveButton().click();
+  }
+
+  async saveChanges(): Promise<void> {
+    await this.hideFloatingWidgets();
+    await this.clickSave();
+    await this.waitForSaveComplete();
+  }
+
+  async waitForSaveComplete(timeoutMs: number = 15_000): Promise<void> {
+    await this.page.waitForSelector(
+      '[data-testid="profile-info-form-save"]:not([disabled])',
+      { timeout: timeoutMs },
+    );
+    await this.page.waitForSelector(
+      '[data-testid="profile-info-form-save"]:not(:has-text("Saving..."))',
+      { timeout: timeoutMs },
+    );
+  }
+
+  private assertValidLinkIndex(index: number) {
+    if (index < 1 || index > 5) {
+      throw new Error(`Link index must be between 1 and 5. Received: ${index}`);
+    }
+  }
+}

--- a/autogpt_platform/frontend/src/tests/profile-form.spec.ts
+++ b/autogpt_platform/frontend/src/tests/profile-form.spec.ts
@@ -1,0 +1,113 @@
+import test, { expect } from "@playwright/test";
+import { ProfileFormPage } from "./pages/profile-form.page";
+import { LoginPage } from "./pages/login.page";
+import { hasUrl } from "./utils/assertion";
+import { TEST_CREDENTIALS } from "./credentials";
+
+test.describe("Profile Form", () => {
+  let profileFormPage: ProfileFormPage;
+
+  test.beforeEach(async ({ page }) => {
+    profileFormPage = new ProfileFormPage(page);
+
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(TEST_CREDENTIALS.email, TEST_CREDENTIALS.password);
+    await hasUrl(page, "/marketplace");
+  });
+
+  test("redirects to login when user is not authenticated", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      await page.goto("/profile");
+      await hasUrl(page, "/login");
+    } finally {
+      await page.close();
+      await context.close();
+    }
+  });
+
+  test("can save profile changes successfully", async ({ page }) => {
+    await profileFormPage.navbar.clickProfileLink();
+
+    await expect(profileFormPage.isLoaded()).resolves.toBeTruthy();
+    await hasUrl(page, new RegExp("/profile"));
+
+    const suffix = Date.now().toString().slice(-6);
+    const newDisplayName = `E2E Name ${suffix}`;
+    const newHandle = `e2euser${suffix}`;
+    const newBio = `E2E bio ${suffix}`;
+    const newLinks = [
+      `https://example.com/${suffix}/1`,
+      `https://example.com/${suffix}/2`,
+      `https://example.com/${suffix}/3`,
+      `https://example.com/${suffix}/4`,
+      `https://example.com/${suffix}/5`,
+    ];
+
+    await profileFormPage.setDisplayName(newDisplayName);
+    await profileFormPage.setHandle(newHandle);
+    await profileFormPage.setBio(newBio);
+    await profileFormPage.setLinks(newLinks);
+
+    try {
+      await page.keyboard.press("Escape");
+    } catch {}
+
+    await profileFormPage.saveChanges();
+
+    expect(await profileFormPage.getDisplayName()).toBe(newDisplayName);
+    expect(await profileFormPage.getHandle()).toBe(newHandle);
+    expect(await profileFormPage.getBio()).toBe(newBio);
+    for (let i = 1; i <= 5; i++) {
+      expect(await profileFormPage.getLink(i)).toBe(newLinks[i - 1]);
+    }
+
+    await page.reload();
+    await expect(profileFormPage.isLoaded()).resolves.toBeTruthy();
+
+    expect(await profileFormPage.getDisplayName()).toBe(newDisplayName);
+    expect(await profileFormPage.getHandle()).toBe(newHandle);
+    expect(await profileFormPage.getBio()).toBe(newBio);
+    for (let i = 1; i <= 5; i++) {
+      expect(await profileFormPage.getLink(i)).toBe(newLinks[i - 1]);
+    }
+  });
+
+  // Currently we are not using hook form inside the profile form, so cancel button is not working as expected, once that's fixed, we can unskip this test
+  test.skip("can cancel profile changes", async ({ page }) => {
+    await profileFormPage.navbar.clickProfileLink();
+
+    await expect(profileFormPage.isLoaded()).resolves.toBeTruthy();
+    await hasUrl(page, new RegExp("/profile"));
+
+    const originalDisplayName = await profileFormPage.getDisplayName();
+    const originalHandle = await profileFormPage.getHandle();
+    const originalBio = await profileFormPage.getBio();
+    const originalLinks: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      originalLinks.push(await profileFormPage.getLink(i));
+    }
+
+    const suffix = `${Date.now().toString().slice(-6)}_cancel`;
+    await profileFormPage.setDisplayName(`Tmp Name ${suffix}`);
+    await profileFormPage.setHandle(`tmpuser${suffix}`);
+    await profileFormPage.setBio(`Tmp bio ${suffix}`);
+    for (let i = 1; i <= 5; i++) {
+      await profileFormPage.setLink(i, `https://tmp.example/${suffix}/${i}`);
+    }
+
+    await profileFormPage.clickCancel();
+
+    expect(await profileFormPage.getDisplayName()).toBe(originalDisplayName);
+    expect(await profileFormPage.getHandle()).toBe(originalHandle);
+    expect(await profileFormPage.getBio()).toBe(originalBio);
+    for (let i = 1; i <= 5; i++) {
+      expect(await profileFormPage.getLink(i)).toBe(originalLinks[i - 1]);
+    }
+  });
+});


### PR DESCRIPTION
This PR has added end-to-end tests for the profile form page. These tests include:

- Redirects to the login page when the user is not authenticated.
- Can save profile changes successfully.
- Can cancel profile changes (skipped because we need to fix the form for this test).

### Changes 🏗️
- Added test-id's inside the ProfileInfoForm.
- Created a page object for the profile form page.
- Added a test for this page in `profile-form.spec.ts`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] All test are working perfectly locally