### PR TITLE
feat(block): Remove paralel tool-call system prompting

### DIFF
--- a/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
+++ b/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
@@ -478,10 +478,6 @@ class SmartDecisionMakerBlock(Block):
                 }
             )
             prompt.extend(tool_output)
-        if input_data.multiple_tool_calls:
-            input_data.sys_prompt += "\nYou can call a tool (different tools) multiple times in a single response."
-        else:
-            input_data.sys_prompt += "\nOnly provide EXACTLY one function call, multiple tool calls is strictly prohibited."
 
         values = input_data.prompt_values
         if values:


### PR DESCRIPTION
We're forcing this note to the end of the system prompt SDM block: 
Only provide EXACTLY one function call; multiple tool calls are strictly prohibited., this is being interpreted by GPT5 as "Only call one tool per task," which is resulting in many agent runs that only use a tool once (i.e., useless low low-effort answers)

### Changes 🏗️

Remove parallel tool-call system prompting entirely.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] automated tests.
