### PR TITLE
fix(backend/AM): Fix AutoMod api key issue

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/AutoMod/manager.py
+++ b/autogpt_platform/backend/backend/server/v2/AutoMod/manager.py
@@ -320,7 +320,7 @@ class AutoModManager:
         url = f"{self.config.api_url}/moderate"
         headers = {
             "Content-Type": "application/json",
-            "X-API-Key": self.config.api_key,
+            "X-API-Key": self.config.api_key.strip(),
         }
 
         # Create requests instance with timeout and retry configuration


### PR DESCRIPTION
### Changes 🏗️
Calls to the moderation API now strip whitespace from the API key before including it in the 'X-API-Key' header, preventing authentication issues due to accidental leading or trailing spaces.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
- [x] Setup and run the platform with moderation and test it works


