### PR TITLE
fix(logging): remove uvicorn log config to prevent startup deadlock

### DIFF
--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -9,7 +9,6 @@ import fastapi.responses
 import pydantic
 import starlette.middleware.cors
 import uvicorn
-from autogpt_libs.logging.utils import generate_uvicorn_config
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 
@@ -247,7 +246,7 @@ class AgentServer(backend.util.service.AppProcess):
             server_app,
             host=backend.util.settings.Config().agent_api_host,
             port=backend.util.settings.Config().agent_api_port,
-            log_config=generate_uvicorn_config(),
+            log_config=None,  # Prevent logging reconfiguration deadlock
         )
 
     def cleanup(self):

--- a/autogpt_platform/backend/backend/server/ws_api.py
+++ b/autogpt_platform/backend/backend/server/ws_api.py
@@ -6,7 +6,6 @@ from typing import Protocol
 import pydantic
 import uvicorn
 from autogpt_libs.auth import parse_jwt_token
-from autogpt_libs.logging.utils import generate_uvicorn_config
 from fastapi import Depends, FastAPI, WebSocket, WebSocketDisconnect
 from starlette.middleware.cors import CORSMiddleware
 
@@ -309,7 +308,7 @@ class WebsocketServer(AppProcess):
             server_app,
             host=Config().websocket_server_host,
             port=Config().websocket_server_port,
-            log_config=generate_uvicorn_config(),
+            log_config=None,  # Prevent logging reconfiguration deadlock
         )
 
     def cleanup(self):

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -24,7 +24,6 @@ from typing import (
 
 import httpx
 import uvicorn
-from autogpt_libs.logging.utils import generate_uvicorn_config
 from fastapi import FastAPI, Request, responses
 from pydantic import BaseModel, TypeAdapter, create_model
 
@@ -266,7 +265,8 @@ class AppService(BaseAppService, ABC):
                 self.fastapi_app,
                 host=api_host,
                 port=self.get_port(),
-                log_config=generate_uvicorn_config(),
+                log_config=None,  # Explicitly None to prevent uvicorn from reconfiguring logging
+                # This avoids deadlock when dictConfig() calls shutdown() on BackgroundThreadTransport
                 log_level=self.log_level,
             )
         )


### PR DESCRIPTION
## Problem
After applying the CloudLoggingHandler fix to use BackgroundThreadTransport (#10634), scheduler pods entered a new deadlock during startup when uvicorn reconfigures logging.

## Root Cause
When uvicorn starts with a log_config parameter, it calls `logging.config.dictConfig()` which:
1. Calls `_clearExistingHandlers()` 
2. Which calls `logging.shutdown()`
3. Which tries to `flush()` all handlers including CloudLoggingHandler
4. CloudLoggingHandler with BackgroundThreadTransport tries to flush its queue
5. The background worker thread tries to acquire the logging module lock to check log levels
6. **Deadlock**: shutdown holds lock waiting for flush to complete, worker thread needs lock to continue

## Thread Dump Evidence
From py-spy analysis of the stuck pod:
- **Thread 21 (FastAPI)**: Stuck in `flush()` waiting for background thread to drain queue
- **Thread 13 (google.cloud.logging.Worker)**: Waiting for logging lock in `isEnabledFor()`
- **Thread 1 (MainThread)**: Waiting for logging lock in `getLogger()` during SQLAlchemy import
- **Threads 30, 31 (Sentry)**: Also waiting for logging lock

## Solution
Set `log_config=None` for all uvicorn servers. This prevents uvicorn from calling `dictConfig()` and avoids the deadlock entirely.

**Trade-off**: Uvicorn will use its default logging configuration which may produce duplicate log entries (one from uvicorn, one from the app), but the application will start successfully without deadlocks.

## Changes
- Set `log_config=None` in all uvicorn.Config() calls
- Remove unused `generate_uvicorn_config` imports

## Testing
- [x] Verified scheduler pods can start and become healthy
- [x] Health checks respond properly  
- [x] No deadlocks during startup
- [x] Application logs still appear (though may be duplicated)

## Related Issues
- Fixes the startup deadlock introduced after #10634