### PR TITLE
docs(frontend): update README with Docker instructions

### DIFF
--- a/autogpt_platform/frontend/README.md
+++ b/autogpt_platform/frontend/README.md
@@ -38,6 +38,15 @@ Make sure you have Node.js 16.10+ installed. Corepack is included with Node.js b
    ```bash
    pnpm dev
    ```
+   > Note that you will need to have the Back-end running for the Front-end to successfully get data.
+   > For so, run the following command in the `autogpt_platform` folder:
+   >
+   > ```bash
+   > docker compose --profile local up deps_backend -d
+   > ```
+   >
+   > This will run only the Back-end in docker. If you run `docker compose up -d` it will run the Front-end
+   > in Docker too, which might not be what you want given you won't have easy access to the dev server.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/autogpt_platform/frontend/README.md
+++ b/autogpt_platform/frontend/README.md
@@ -18,39 +18,55 @@ Make sure you have Node.js 16.10+ installed. Corepack is included with Node.js b
 >
 > Then follow the setup steps below.
 
-### Setup
+## Setup
 
-1. **Enable corepack** (run this once on your system):
+### 1. **Enable corepack** (run this once on your system):
 
-   ```bash
-   corepack enable
-   ```
+```bash
+corepack enable
+```
 
-   This enables corepack to automatically manage pnpm based on the `packageManager` field in `package.json`.
+This enables corepack to automatically manage pnpm based on the `packageManager` field in `package.json`.
 
-2. **Install dependencies**:
+### 2. **Install dependencies**:
 
-   ```bash
-   pnpm i
-   ```
+```bash
+pnpm i
+```
 
-3. **Start the development server**:
-   ```bash
-   pnpm dev
-   ```
-   > Note that you will need to have the Back-end running for the Front-end to successfully get data.
-   > For so, run the following command in the `autogpt_platform` folder:
-   >
-   > ```bash
-   > docker compose --profile local up deps_backend -d
-   > ```
-   >
-   > This will run only the Back-end in docker. If you run `docker compose up -d` it will run the Front-end
-   > in Docker too, which might not be what you want given you won't have easy access to the dev server.
+### 3. **Start the development server**:
+
+#### Running the Front-end & Back-end separately
+
+We recommend this approach if you are doing active development on the project. First spin up the Back-end:
+
+```bash
+# On `autogpt_platform`
+docker compose --profile local up deps_backend -d
+```
+
+Then start the Front-end:
+
+```bash
+# on `autogpt_platform/frontend`
+pnpm dev
+```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+#### Running both the Front-end and Back-end via Docker
+
+If you run:
+
+```bash
+# on `autogpt_platform`
+docker compose up -d
+```
+
+It will spin up the Back-end and Front-end via Docker. The Front-end will start on port `3000`. This might not be
+what you want when actively contributing to the Front-end as you won't have direct/easy access to the Next.js dev server.
 
 ### Subsequent Runs
 

--- a/autogpt_platform/frontend/README.md
+++ b/autogpt_platform/frontend/README.md
@@ -52,7 +52,7 @@ Then start the Front-end:
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. If the server starts on `http://localhost:3001` it means the Front-end is already running via Docker. You have to kill the container then.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 


### PR DESCRIPTION
## Changes 🏗️

Update the Front-end `README` to clarify how to run the Front-end and Back-end separately or together via Docker.

You can [preview the README here](https://github.com/Significant-Gravitas/AutoGPT/blob/8f607ca85225b41804e000810f57186157ee4138/autogpt_platform/frontend/README.md).

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `README` makes sense and looks good formatting wise

### For configuration changes:

None
