### PR TITLE
chore(api): remove launch darkly feature flags from api key endpoints

### DIFF
--- a/autogpt_platform/backend/backend/server/routers/v1.py
+++ b/autogpt_platform/backend/backend/server/routers/v1.py
@@ -1099,7 +1099,6 @@ async def delete_api_key(
     tags=["api-keys"],
     dependencies=[Depends(auth_middleware)],
 )
-@feature_flag("api-keys-enabled")
 async def suspend_key(
     key_id: str, user_id: Annotated[str, Depends(get_user_id)]
 ) -> Optional[APIKeyWithoutHash]:
@@ -1125,7 +1124,6 @@ async def suspend_key(
     tags=["api-keys"],
     dependencies=[Depends(auth_middleware)],
 )
-@feature_flag("api-keys-enabled")
 async def update_permissions(
     key_id: str,
     request: UpdatePermissionsRequest,


### PR DESCRIPTION
Some API key endpoints have the Launch Darkly feature flag enabled, while others don’t. To ensure consistency and remove the API key flag from the Launch Darkly dashboard, I’m also removing it from the left endpoints.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Everything is working fine locally