### PR TITLE
fix(frontend): add AutoGPT to reset password title

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx
@@ -185,7 +185,7 @@ function ResetPasswordContent() {
 
   return (
     <div className="flex h-full min-h-[85vh] w-full flex-col items-center justify-center">
-      <AuthCard title="Reset Password">
+      <AuthCard title="AutoGPT Reset Password">
         {user ? (
           <form
             onSubmit={changePasswordForm.handleSubmit(onChangePassword)}


### PR DESCRIPTION
### Changes 🏗️
- Include "AutoGPT" in reset password page title.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm format`
  - [ ] `pnpm test` (module resolution errors)

#### For configuration changes:
- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)


------
https://chatgpt.com/codex/tasks/task_b_68a4f09a62ec8327a3c32c3ba573d34a