### PR TITLE
fix(frontend): add AutoGPT to password reset email title

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/reset-password/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/reset-password/actions.ts
@@ -28,6 +28,7 @@ export async function sendResetEmail(email: string, turnstileToken: string) {
 
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
         redirectTo: `${origin}/api/auth/callback/reset-password`,
+        data: { title: "AutoGPT Reset Password" },
       });
 
       if (error) {


### PR DESCRIPTION
## Summary
- include AutoGPT name in password reset email

## Testing
- `pnpm format`
- `pnpm test` *(fails: Module not found: Can't resolve '@/app/api/__generated__/endpoints/store/store')*


------
https://chatgpt.com/codex/tasks/task_b_68a4f87856088327b70e09bd5d01f9b4