### PR TITLE
fix(frontend): clear agent name and description on agent file removal

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryUploadAgentDialog/LibraryUploadAgentDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryUploadAgentDialog/LibraryUploadAgentDialog.tsx
@@ -45,6 +45,7 @@ export default function LibraryUploadAgentDialog(): React.ReactNode {
     form,
     setisDroped,
     agentObject,
+    clearAgentFile,
   } = useLibraryUploadAgentDialog();
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -105,9 +106,7 @@ export default function LibraryUploadAgentDialog(): React.ReactNode {
                       <div className="relative flex rounded-[10px] border p-2 font-sans text-sm font-medium text-[#525252] outline-none">
                         <span className="line-clamp-1">{field.value.name}</span>
                         <Button
-                          onClick={() =>
-                            form.setValue("agentFile", undefined as any)
-                          }
+                          onClick={clearAgentFile}
                           className="absolute left-[-10px] top-[-16px] mt-2 h-fit border-none bg-red-200 p-1"
                         >
                           <X

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryUploadAgentDialog/useLibraryUploadAgentDialog.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryUploadAgentDialog/useLibraryUploadAgentDialog.ts
@@ -102,6 +102,22 @@ export const useLibraryUploadAgentDialog = () => {
     setisDroped(false);
   };
 
+  const clearAgentFile = () => {
+    const currentName = form.getValues("agentName")
+    const currentDescription = form.getValues("agentDescription")
+    const prevAgent = agentObject
+
+    form.setValue("agentFile", undefined as any);
+    if(prevAgent && currentName === prevAgent.name) {
+      form.setValue("agentName", "");
+    }
+    if(prevAgent && currentDescription === prevAgent.description) {
+      form.setValue("agentDescription", "");
+    }
+
+    setAgentObject(null);
+  };
+
   return {
     onSubmit,
     isUploading,
@@ -112,5 +128,6 @@ export const useLibraryUploadAgentDialog = () => {
     isDroped,
     handleChange,
     setisDroped,
+    clearAgentFile,
   };
 };

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryUploadAgentDialog/useLibraryUploadAgentDialog.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/LibraryUploadAgentDialog/useLibraryUploadAgentDialog.ts
@@ -103,15 +103,15 @@ export const useLibraryUploadAgentDialog = () => {
   };
 
   const clearAgentFile = () => {
-    const currentName = form.getValues("agentName")
-    const currentDescription = form.getValues("agentDescription")
-    const prevAgent = agentObject
+    const currentName = form.getValues("agentName");
+    const currentDescription = form.getValues("agentDescription");
+    const prevAgent = agentObject;
 
     form.setValue("agentFile", undefined as any);
-    if(prevAgent && currentName === prevAgent.name) {
+    if (prevAgent && currentName === prevAgent.name) {
       form.setValue("agentName", "");
     }
-    if(prevAgent && currentDescription === prevAgent.description) {
+    if (prevAgent && currentDescription === prevAgent.description) {
       form.setValue("agentDescription", "");
     }
 


### PR DESCRIPTION
With this PR, when a user removes the agent file, the agent name and description will also be removed if they haven’t been changed. However, if the user has modified either of them, they will remain.

### Checklist 📋
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Everything works perfectly on local, and the tests are also passing.