### PR TITLE
feat(backend): DiscordGetCurrentUserBlock to fetch authenticated user details via OAuth2

### DIFF
--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -106,6 +106,15 @@ TODOIST_CLIENT_SECRET=
 
 NOTION_CLIENT_ID=
 NOTION_CLIENT_SECRET=
+
+# Discord OAuth App credentials
+# 1. Go to https://discord.com/developers/applications
+# 2. Create a new application
+# 3. Go to OAuth2 section and add redirect URI: http://localhost:3000/auth/integrations/oauth_callback
+# 4. Copy Client ID and Client Secret below
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
 REDDIT_CLIENT_ID=
 REDDIT_CLIENT_SECRET=
 

--- a/autogpt_platform/backend/backend/blocks/discord/_api.py
+++ b/autogpt_platform/backend/backend/blocks/discord/_api.py
@@ -42,7 +42,7 @@ def get_api(credentials: OAuth2Credentials) -> Requests:
         A configured Requests instance for Discord API calls.
     """
     return Requests(
-        trusted_origins=["discord.com", "discordapp.com"],
+        trusted_origins=[],
         extra_headers={
             "Authorization": f"Bearer {credentials.access_token.get_secret_value()}",
             "Content-Type": "application/json",

--- a/autogpt_platform/backend/backend/blocks/discord/_api.py
+++ b/autogpt_platform/backend/backend/blocks/discord/_api.py
@@ -1,0 +1,117 @@
+"""
+Discord API helper functions for making authenticated requests.
+"""
+
+import logging
+from typing import Optional
+
+from pydantic import BaseModel
+
+from backend.data.model import OAuth2Credentials
+from backend.util.request import Requests
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordAPIException(Exception):
+    """Exception raised for Discord API errors."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class DiscordOAuthUser(BaseModel):
+    """Model for Discord OAuth user response."""
+
+    user_id: str
+    username: str
+    avatar_url: str
+    banner: Optional[str] = None
+    accent_color: Optional[int] = None
+
+
+def get_api(credentials: OAuth2Credentials) -> Requests:
+    """
+    Create a Requests instance configured for Discord API calls with OAuth2 credentials.
+
+    Args:
+        credentials: The OAuth2 credentials containing the access token.
+
+    Returns:
+        A configured Requests instance for Discord API calls.
+    """
+    return Requests(
+        trusted_origins=["discord.com", "discordapp.com"],
+        extra_headers={
+            "Authorization": f"Bearer {credentials.access_token.get_secret_value()}",
+            "Content-Type": "application/json",
+        },
+        raise_for_status=False,
+    )
+
+
+async def get_current_user(credentials: OAuth2Credentials) -> DiscordOAuthUser:
+    """
+    Fetch the current user's information using Discord OAuth2 API.
+
+    Reference: https://discord.com/developers/docs/resources/user#get-current-user
+
+    Args:
+        credentials: The OAuth2 credentials.
+
+    Returns:
+        A model containing user data with avatar URL.
+
+    Raises:
+        DiscordAPIException: If the API request fails.
+    """
+    api = get_api(credentials)
+    response = await api.get("https://discord.com/api/oauth2/@me")
+
+    if not response.ok:
+        error_text = response.text()
+        raise DiscordAPIException(
+            f"Failed to fetch user info: {response.status} - {error_text}",
+            response.status,
+        )
+
+    data = response.json()
+    logger.info(f"Discord OAuth2 API Response: {data}")
+
+    # The /api/oauth2/@me endpoint returns a user object nested in the response
+    user_info = data.get("user", {})
+    logger.info(f"User info extracted: {user_info}")
+
+    # Build avatar URL
+    user_id = user_info.get("id")
+    avatar_hash = user_info.get("avatar")
+    if avatar_hash:
+        # Custom avatar
+        avatar_ext = "gif" if avatar_hash.startswith("a_") else "png"
+        avatar_url = (
+            f"https://cdn.discordapp.com/avatars/{user_id}/{avatar_hash}.{avatar_ext}"
+        )
+    else:
+        # Default avatar based on discriminator or user ID
+        discriminator = user_info.get("discriminator", "0")
+        if discriminator == "0":
+            # New username system - use user ID for default avatar
+            default_avatar_index = (int(user_id) >> 22) % 6
+        else:
+            # Legacy discriminator system
+            default_avatar_index = int(discriminator) % 5
+        avatar_url = (
+            f"https://cdn.discordapp.com/embed/avatars/{default_avatar_index}.png"
+        )
+
+    result = DiscordOAuthUser(
+        user_id=user_id,
+        username=user_info.get("username", ""),
+        avatar_url=avatar_url,
+        banner=user_info.get("banner"),
+        accent_color=user_info.get("accent_color"),
+    )
+
+    logger.info(f"Returning user data: {result.model_dump()}")
+    return result

--- a/autogpt_platform/backend/backend/blocks/discord/_auth.py
+++ b/autogpt_platform/backend/backend/blocks/discord/_auth.py
@@ -36,10 +36,6 @@ def DiscordBotCredentialsField() -> DiscordBotCredentialsInput:
 
 def DiscordOAuthCredentialsField(scopes: list[str]) -> DiscordOAuthCredentialsInput:
     """Creates a Discord OAuth2 credentials field."""
-    if not DISCORD_OAUTH_IS_CONFIGURED:
-        raise ValueError(
-            "Discord OAuth is not configured. Please set DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET environment variables."
-        )
     return CredentialsField(
         description="Discord OAuth2 credentials",
         required_scopes=set(scopes) | {"identify"},  # Basic user info scope

--- a/autogpt_platform/backend/backend/blocks/discord/_auth.py
+++ b/autogpt_platform/backend/backend/blocks/discord/_auth.py
@@ -1,0 +1,78 @@
+from typing import Literal
+
+from pydantic import SecretStr
+
+from backend.data.model import (
+    APIKeyCredentials,
+    CredentialsField,
+    CredentialsMetaInput,
+    OAuth2Credentials,
+)
+from backend.integrations.providers import ProviderName
+from backend.util.settings import Secrets
+
+secrets = Secrets()
+DISCORD_OAUTH_IS_CONFIGURED = bool(
+    secrets.discord_client_id and secrets.discord_client_secret
+)
+
+# Bot token credentials (existing)
+DiscordBotCredentials = APIKeyCredentials
+DiscordBotCredentialsInput = CredentialsMetaInput[
+    Literal[ProviderName.DISCORD], Literal["api_key"]
+]
+
+# OAuth2 credentials (new)
+DiscordOAuthCredentials = OAuth2Credentials
+DiscordOAuthCredentialsInput = CredentialsMetaInput[
+    Literal[ProviderName.DISCORD], Literal["oauth2"]
+]
+
+
+def DiscordBotCredentialsField() -> DiscordBotCredentialsInput:
+    """Creates a Discord bot token credentials field."""
+    return CredentialsField(description="Discord bot token")
+
+
+def DiscordOAuthCredentialsField(scopes: list[str]) -> DiscordOAuthCredentialsInput:
+    """Creates a Discord OAuth2 credentials field."""
+    if not DISCORD_OAUTH_IS_CONFIGURED:
+        raise ValueError(
+            "Discord OAuth is not configured. Please set DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET environment variables."
+        )
+    return CredentialsField(
+        description="Discord OAuth2 credentials",
+        required_scopes=set(scopes) | {"identify"},  # Basic user info scope
+    )
+
+
+# Test credentials for bot tokens
+TEST_BOT_CREDENTIALS = APIKeyCredentials(
+    id="01234567-89ab-cdef-0123-456789abcdef",
+    provider="discord",
+    api_key=SecretStr("test_api_key"),
+    title="Mock Discord API key",
+    expires_at=None,
+)
+TEST_BOT_CREDENTIALS_INPUT = {
+    "provider": TEST_BOT_CREDENTIALS.provider,
+    "id": TEST_BOT_CREDENTIALS.id,
+    "type": TEST_BOT_CREDENTIALS.type,
+    "title": TEST_BOT_CREDENTIALS.type,
+}
+
+# Test credentials for OAuth2
+TEST_OAUTH_CREDENTIALS = OAuth2Credentials(
+    id="01234567-89ab-cdef-0123-456789abcdef",
+    provider="discord",
+    access_token=SecretStr("test_access_token"),
+    title="Mock Discord OAuth",
+    scopes=["identify"],
+    username="testuser",
+)
+TEST_OAUTH_CREDENTIALS_INPUT = {
+    "provider": TEST_OAUTH_CREDENTIALS.provider,
+    "id": TEST_OAUTH_CREDENTIALS.id,
+    "type": TEST_OAUTH_CREDENTIALS.type,
+    "title": TEST_OAUTH_CREDENTIALS.type,
+}

--- a/autogpt_platform/backend/backend/blocks/discord/bot_blocks.py
+++ b/autogpt_platform/backend/backend/blocks/discord/bot_blocks.py
@@ -2,45 +2,29 @@ import base64
 import io
 import mimetypes
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import aiohttp
 import discord
 from pydantic import SecretStr
 
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
-from backend.data.model import (
-    APIKeyCredentials,
-    CredentialsField,
-    CredentialsMetaInput,
-    SchemaField,
-)
-from backend.integrations.providers import ProviderName
+from backend.data.model import APIKeyCredentials, SchemaField
 from backend.util.file import store_media_file
 from backend.util.type import MediaFileType
 
-DiscordCredentials = CredentialsMetaInput[
-    Literal[ProviderName.DISCORD], Literal["api_key"]
-]
-
-
-def DiscordCredentialsField() -> DiscordCredentials:
-    return CredentialsField(description="Discord bot token")
-
-
-TEST_CREDENTIALS = APIKeyCredentials(
-    id="01234567-89ab-cdef-0123-456789abcdef",
-    provider="discord",
-    api_key=SecretStr("test_api_key"),
-    title="Mock Discord API key",
-    expires_at=None,
+from ._auth import (
+    TEST_BOT_CREDENTIALS,
+    TEST_BOT_CREDENTIALS_INPUT,
+    DiscordBotCredentialsField,
+    DiscordBotCredentialsInput,
 )
-TEST_CREDENTIALS_INPUT = {
-    "provider": TEST_CREDENTIALS.provider,
-    "id": TEST_CREDENTIALS.id,
-    "type": TEST_CREDENTIALS.type,
-    "title": TEST_CREDENTIALS.type,
-}
+
+# Keep backward compatibility alias
+DiscordCredentials = DiscordBotCredentialsInput
+DiscordCredentialsField = DiscordBotCredentialsField
+TEST_CREDENTIALS = TEST_BOT_CREDENTIALS
+TEST_CREDENTIALS_INPUT = TEST_BOT_CREDENTIALS_INPUT
 
 
 class ReadDiscordMessagesBlock(Block):

--- a/autogpt_platform/backend/backend/blocks/discord/oauth_blocks.py
+++ b/autogpt_platform/backend/backend/blocks/discord/oauth_blocks.py
@@ -5,7 +5,7 @@ Discord OAuth-based blocks.
 from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
 from backend.data.model import OAuth2Credentials, SchemaField
 
-from ._api import get_current_user
+from ._api import DiscordOAuthUser, get_current_user
 from ._auth import (
     TEST_OAUTH_CREDENTIALS,
     TEST_OAUTH_CREDENTIALS_INPUT,
@@ -58,21 +58,26 @@ class DiscordGetCurrentUserBlock(Block):
                 ("accent_color", 0),
             ],
             test_mock={
-                "get_current_user": lambda: {
-                    "user_id": "123456789012345678",
-                    "username": "testuser",
-                    "avatar_url": "https://cdn.discordapp.com/avatars/123456789012345678/avatar.png",
-                    "banner": None,
-                    "accent_color": 0,
-                }
+                "get_user": lambda _: DiscordOAuthUser(
+                    user_id="123456789012345678",
+                    username="testuser",
+                    avatar_url="https://cdn.discordapp.com/avatars/123456789012345678/avatar.png",
+                    banner=None,
+                    accent_color=0,
+                )
             },
         )
+
+    @staticmethod
+    async def get_user(credentials: OAuth2Credentials) -> DiscordOAuthUser:
+        user_info = await get_current_user(credentials)
+        return user_info
 
     async def run(
         self, input_data: Input, *, credentials: OAuth2Credentials, **kwargs
     ) -> BlockOutput:
         try:
-            result = await get_current_user(credentials)
+            result = await self.get_user(credentials)
 
             # Yield each output field
             yield "user_id", result.user_id

--- a/autogpt_platform/backend/backend/blocks/discord/oauth_blocks.py
+++ b/autogpt_platform/backend/backend/blocks/discord/oauth_blocks.py
@@ -7,6 +7,7 @@ from backend.data.model import OAuth2Credentials, SchemaField
 
 from ._api import DiscordOAuthUser, get_current_user
 from ._auth import (
+    DISCORD_OAUTH_IS_CONFIGURED,
     TEST_OAUTH_CREDENTIALS,
     TEST_OAUTH_CREDENTIALS_INPUT,
     DiscordOAuthCredentialsField,
@@ -43,6 +44,7 @@ class DiscordGetCurrentUserBlock(Block):
             output_schema=DiscordGetCurrentUserBlock.Output,
             description="Gets information about the currently authenticated Discord user using OAuth2 credentials.",
             categories={BlockCategory.SOCIAL},
+            disabled=not DISCORD_OAUTH_IS_CONFIGURED,
             test_input={
                 "credentials": TEST_OAUTH_CREDENTIALS_INPUT,
             },

--- a/autogpt_platform/backend/backend/blocks/discord/oauth_blocks.py
+++ b/autogpt_platform/backend/backend/blocks/discord/oauth_blocks.py
@@ -1,0 +1,92 @@
+"""
+Discord OAuth-based blocks.
+"""
+
+from backend.data.block import Block, BlockCategory, BlockOutput, BlockSchema
+from backend.data.model import OAuth2Credentials, SchemaField
+
+from ._api import get_current_user
+from ._auth import (
+    TEST_OAUTH_CREDENTIALS,
+    TEST_OAUTH_CREDENTIALS_INPUT,
+    DiscordOAuthCredentialsField,
+    DiscordOAuthCredentialsInput,
+)
+
+
+class DiscordGetCurrentUserBlock(Block):
+    """
+    Gets information about the currently authenticated Discord user using OAuth2.
+    This block requires Discord OAuth2 credentials (not bot tokens).
+    """
+
+    class Input(BlockSchema):
+        credentials: DiscordOAuthCredentialsInput = DiscordOAuthCredentialsField(
+            ["identify"]
+        )
+
+    class Output(BlockSchema):
+        user_id: str = SchemaField(description="The authenticated user's Discord ID")
+        username: str = SchemaField(description="The user's username")
+        avatar_url: str = SchemaField(description="URL to the user's avatar image")
+        banner_url: str = SchemaField(
+            description="URL to the user's banner image (if set)", default=""
+        )
+        accent_color: int = SchemaField(
+            description="The user's accent color as an integer", default=0
+        )
+
+    def __init__(self):
+        super().__init__(
+            id="8c7e39b8-4e9d-4f3a-b4e1-2a8c9d5f6e3b",
+            input_schema=DiscordGetCurrentUserBlock.Input,
+            output_schema=DiscordGetCurrentUserBlock.Output,
+            description="Gets information about the currently authenticated Discord user using OAuth2 credentials.",
+            categories={BlockCategory.SOCIAL},
+            test_input={
+                "credentials": TEST_OAUTH_CREDENTIALS_INPUT,
+            },
+            test_credentials=TEST_OAUTH_CREDENTIALS,
+            test_output=[
+                ("user_id", "123456789012345678"),
+                ("username", "testuser"),
+                (
+                    "avatar_url",
+                    "https://cdn.discordapp.com/avatars/123456789012345678/avatar.png",
+                ),
+                ("banner_url", ""),
+                ("accent_color", 0),
+            ],
+            test_mock={
+                "get_current_user": lambda: {
+                    "user_id": "123456789012345678",
+                    "username": "testuser",
+                    "avatar_url": "https://cdn.discordapp.com/avatars/123456789012345678/avatar.png",
+                    "banner": None,
+                    "accent_color": 0,
+                }
+            },
+        )
+
+    async def run(
+        self, input_data: Input, *, credentials: OAuth2Credentials, **kwargs
+    ) -> BlockOutput:
+        try:
+            result = await get_current_user(credentials)
+
+            # Yield each output field
+            yield "user_id", result.user_id
+            yield "username", result.username
+            yield "avatar_url", result.avatar_url
+
+            # Handle banner URL if banner hash exists
+            if result.banner:
+                banner_url = f"https://cdn.discordapp.com/banners/{result.user_id}/{result.banner}.png"
+                yield "banner_url", banner_url
+            else:
+                yield "banner_url", ""
+
+            yield "accent_color", result.accent_color or 0
+
+        except Exception as e:
+            raise ValueError(f"Failed to get Discord user info: {e}")

--- a/autogpt_platform/backend/backend/integrations/oauth/__init__.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/__init__.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 from backend.integrations.oauth.todoist import TodoistOAuthHandler
 
+from .discord import DiscordOAuthHandler
 from .github import GitHubOAuthHandler
 from .google import GoogleOAuthHandler
 from .notion import NotionOAuthHandler
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 # --8<-- [start:HANDLERS_BY_NAMEExample]
 # Build handlers dict with string keys for compatibility with SDK auto-registration
 _ORIGINAL_HANDLERS = [
+    DiscordOAuthHandler,
     GitHubOAuthHandler,
     GoogleOAuthHandler,
     NotionOAuthHandler,

--- a/autogpt_platform/backend/backend/integrations/oauth/discord.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/discord.py
@@ -1,0 +1,175 @@
+import time
+from typing import Optional
+from urllib.parse import urlencode
+
+from backend.data.model import OAuth2Credentials
+from backend.integrations.providers import ProviderName
+from backend.util.request import Requests
+
+from .base import BaseOAuthHandler
+
+
+class DiscordOAuthHandler(BaseOAuthHandler):
+    """
+    Discord OAuth2 handler implementation.
+
+    Based on the documentation at:
+    - https://discord.com/developers/docs/topics/oauth2
+
+    Discord OAuth2 tokens expire after 7 days by default and include refresh tokens.
+    """
+
+    PROVIDER_NAME = ProviderName.DISCORD
+    DEFAULT_SCOPES = ["identify"]  # Basic user information
+
+    def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.auth_base_url = "https://discord.com/oauth2/authorize"
+        self.token_url = "https://discord.com/api/oauth2/token"
+        self.revoke_url = "https://discord.com/api/oauth2/token/revoke"
+
+    def get_login_url(
+        self, scopes: list[str], state: str, code_challenge: Optional[str]
+    ) -> str:
+        # Handle default scopes
+        scopes = self.handle_default_scopes(scopes)
+
+        params = {
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "response_type": "code",
+            "scope": " ".join(scopes),
+            "state": state,
+        }
+
+        # Discord supports PKCE
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
+
+        return f"{self.auth_base_url}?{urlencode(params)}"
+
+    async def exchange_code_for_tokens(
+        self, code: str, scopes: list[str], code_verifier: Optional[str]
+    ) -> OAuth2Credentials:
+        params = {
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "grant_type": "authorization_code",
+        }
+
+        # Include PKCE verifier if provided
+        if code_verifier:
+            params["code_verifier"] = code_verifier
+
+        return await self._request_tokens(params)
+
+    async def revoke_tokens(self, credentials: OAuth2Credentials) -> bool:
+        if not credentials.access_token:
+            raise ValueError("No access token to revoke")
+
+        # Discord requires client authentication for token revocation
+        data = {
+            "token": credentials.access_token.get_secret_value(),
+            "token_type_hint": "access_token",
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        response = await Requests().post(
+            url=self.revoke_url,
+            data=data,
+            headers=headers,
+            auth=(self.client_id, self.client_secret),
+        )
+
+        # Discord returns 200 OK for successful revocation
+        return response.status == 200
+
+    async def _refresh_tokens(
+        self, credentials: OAuth2Credentials
+    ) -> OAuth2Credentials:
+        if not credentials.refresh_token:
+            return credentials
+
+        return await self._request_tokens(
+            {
+                "refresh_token": credentials.refresh_token.get_secret_value(),
+                "grant_type": "refresh_token",
+            },
+            current_credentials=credentials,
+        )
+
+    async def _request_tokens(
+        self,
+        params: dict[str, str],
+        current_credentials: Optional[OAuth2Credentials] = None,
+    ) -> OAuth2Credentials:
+        request_body = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            **params,
+        }
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        response = await Requests().post(
+            self.token_url, data=request_body, headers=headers
+        )
+        token_data: dict = response.json()
+
+        # Get username if this is a new token request
+        username = None
+        if "access_token" in token_data:
+            username = await self._request_username(token_data["access_token"])
+
+        now = int(time.time())
+        new_credentials = OAuth2Credentials(
+            provider=self.PROVIDER_NAME,
+            title=current_credentials.title if current_credentials else None,
+            username=username,
+            access_token=token_data["access_token"],
+            scopes=token_data.get("scope", "").split()
+            or (current_credentials.scopes if current_credentials else []),
+            refresh_token=token_data.get("refresh_token"),
+            # Discord tokens expire after expires_in seconds (typically 7 days)
+            access_token_expires_at=(
+                now + expires_in
+                if (expires_in := token_data.get("expires_in", None))
+                else None
+            ),
+            # Discord doesn't provide separate refresh token expiration
+            refresh_token_expires_at=None,
+        )
+
+        if current_credentials:
+            new_credentials.id = current_credentials.id
+
+        return new_credentials
+
+    async def _request_username(self, access_token: str) -> str | None:
+        """
+        Fetch the username using the Discord OAuth2 @me endpoint.
+        """
+        url = "https://discord.com/api/oauth2/@me"
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+        }
+
+        response = await Requests().get(url, headers=headers)
+
+        if not response.ok:
+            return None
+
+        # Get user info from the response
+        data = response.json()
+        user_info = data.get("user", {})
+
+        # Return username (without discriminator)
+        return user_info.get("username")

--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -33,7 +33,7 @@ def sentry_capture_error(error: Exception):
 
 
 async def discord_send_alert(content: str):
-    from backend.blocks.discord import SendDiscordMessageBlock
+    from backend.blocks.discord.bot_blocks import SendDiscordMessageBlock
     from backend.data.model import APIKeyCredentials, CredentialsMetaInput, ProviderName
 
     creds = APIKeyCredentials(

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -465,6 +465,10 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     twitter_client_secret: str = Field(
         default="", description="Twitter/X OAuth client secret"
     )
+    discord_client_id: str = Field(default="", description="Discord OAuth client ID")
+    discord_client_secret: str = Field(
+        default="", description="Discord OAuth client secret"
+    )
 
     openai_api_key: str = Field(default="", description="OpenAI API key")
     aiml_api_key: str = Field(default="", description="'AI/ML API' key")


### PR DESCRIPTION

<!-- Clearly explain the need for these changes: -->

We want a way to get the user's id from discord without them having to enable dev mode so this is a way -- oauth login

<img width="2551" height="1202" alt="image" src="https://github.com/user-attachments/assets/71be07a9-fd37-4ea7-91a1-ced8972fda29" />


### Changes 🏗️
- Created DiscordOAuthHandler for managing OAuth2 flow, including login URL generation, token exchange, and revocation.
- Implemented support for PKCE in the OAuth2 flow.
- Enhanced error handling for user info retrieval and token management.
- Add discord block for getting the logged in user
- Add new client secret field to .env.default

<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] add the blocks and test they all work


#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

