### PR TITLE
feat(AutoMod): add ``moderation id`` to moderation message

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/AutoMod/manager.py
+++ b/autogpt_platform/backend/backend/server/v2/AutoMod/manager.py
@@ -277,7 +277,9 @@ class AutoModManager:
             ]
         )
 
-    async def _moderate_content(self, content: str, metadata: dict[str, Any]) -> tuple[bool, str | None]:
+    async def _moderate_content(
+        self, content: str, metadata: dict[str, Any]
+    ) -> tuple[bool, str | None]:
         """Moderate content using AutoMod API
 
         Returns:

--- a/autogpt_platform/backend/backend/server/v2/AutoMod/models.py
+++ b/autogpt_platform/backend/backend/server/v2/AutoMod/models.py
@@ -26,6 +26,7 @@ class AutoModResponse(BaseModel):
     """Response model for AutoMod API"""
 
     success: bool = Field(..., description="Whether the request was successful")
+    content_id: str = Field(..., description="Unique reference ID for this moderation request")
     status: str = Field(
         ..., description="Overall status: 'approved', 'rejected', 'flagged', 'pending'"
     )

--- a/autogpt_platform/backend/backend/server/v2/AutoMod/models.py
+++ b/autogpt_platform/backend/backend/server/v2/AutoMod/models.py
@@ -26,7 +26,9 @@ class AutoModResponse(BaseModel):
     """Response model for AutoMod API"""
 
     success: bool = Field(..., description="Whether the request was successful")
-    content_id: str = Field(..., description="Unique reference ID for this moderation request")
+    content_id: str = Field(
+        ..., description="Unique reference ID for this moderation request"
+    )
     status: str = Field(
         ..., description="Overall status: 'approved', 'rejected', 'flagged', 'pending'"
     )

--- a/autogpt_platform/backend/backend/util/exceptions.py
+++ b/autogpt_platform/backend/backend/util/exceptions.py
@@ -40,6 +40,7 @@ class ModerationError(ValueError):
     message: str
     graph_exec_id: str
     moderation_type: str
+    content_id: str | None
 
     def __init__(
         self,
@@ -47,16 +48,20 @@ class ModerationError(ValueError):
         user_id: str,
         graph_exec_id: str,
         moderation_type: str = "content",
+        content_id: str | None = None,
     ):
         super().__init__(message)
-        self.args = (message, user_id, graph_exec_id, moderation_type)
+        self.args = (message, user_id, graph_exec_id, moderation_type, content_id)
         self.message = message
         self.user_id = user_id
         self.graph_exec_id = graph_exec_id
         self.moderation_type = moderation_type
+        self.content_id = content_id
 
     def __str__(self):
         """Used to display the error message in the frontend, because we str() the error when sending the execution update"""
+        if self.content_id:
+            return f"{self.message} (Moderation ID: {self.content_id})"
         return self.message
 
 


### PR DESCRIPTION
AutoModManager now captures and propagates the content_id from the moderation API for both input and output moderation. AutoModResponse and ModerationError are updated to include content_id, allowing better traceability of moderation actions and error reporting, with this the error message will now show ``Failed due to content moderation (Moderation ID: uuid-here)``

This is good for if a user is having a issue with automod and its falsely flagging there runs we can use the moderation ID to look at automod to see whats going on

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️

Just some updates to receive the content_id from AutoMod and then show it in the "Failed due to content moderation" message

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Run autogpt with AM and trigger it and it will show the content_id in the error message