### PR TITLE
fix(frontend): add min-width to agent run draft view component

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-draft-view.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/OldAgentLibraryView/components/agent-run-draft-view.tsx
@@ -509,7 +509,7 @@ export function AgentRunDraftView({
 
   return (
     <div className={cn("agpt-div flex gap-6", className)}>
-      <div className="flex flex-1 flex-col gap-4">
+      <div className="flex flex-1 flex-col gap-4 min-w-0">
         <Card className="agpt-box">
           <CardHeader>
             <CardTitle className="font-poppins text-lg">Input</CardTitle>


### PR DESCRIPTION
- resolves - https://github.com/Significant-Gravitas/AutoGPT/issues/10618

When we have a dropdown with a large description, the actions button is moved out of the dialog box. To fix this, I’ve added a temporary solution, but in the future, we need to change the entire layout.


### Checklist 📋
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Everything works perfectly locally.
