### PR TITLE
Refactor database manager clients for specific methods

### DIFF
--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -173,9 +173,6 @@ class DatabaseManagerClient(AppServiceClient):
     spend_credits = _(d.spend_credits)
     get_credits = _(d.get_credits)
 
-    # Summary data - async
-    get_user_execution_summary_data = _(d.get_user_execution_summary_data)
-
     # Block error monitoring
     get_block_error_stats = _(d.get_block_error_stats)
 
@@ -192,7 +189,6 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     get_latest_node_execution = d.get_latest_node_execution
     get_graph = d.get_graph
     get_graph_metadata = d.get_graph_metadata
-    get_graph_execution_meta = d.get_graph_execution_meta
     get_node = d.get_node
     get_node_execution = d.get_node_execution
     get_node_executions = d.get_node_executions


### PR DESCRIPTION
### Need for these changes 💡

This PR addresses Linear issue [OPEN-2634](https://linear.app/autogpt/issue/OPEN-2634), aiming to improve the design of the database manager clients. The goal is to ensure that each client (synchronous and asynchronous) only exposes the methods it actually uses, thereby reducing unnecessary code duplication and adhering to the principle of least privilege.

### Changes 🏗️

-   Removed `get_user_execution_summary_data` from `DatabaseManagerClient` (synchronous client), as it was exclusively used by the asynchronous client.
-   Removed `get_graph_execution_meta` from `DatabaseManagerAsyncClient` (asynchronous client), as it was exclusively used by the synchronous client.

These changes ensure that each client's interface accurately reflects its operational needs, while the base `DatabaseManager` retains access to the union of all necessary functions.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified that `get_user_execution_summary_data` is only called on `DatabaseManagerAsyncClient` (or base).
  - [x] Verified that `get_graph_execution_meta` is only called on `DatabaseManagerClient` (or base).
  - [x] Confirmed that the codebase passes syntax validation.
  - [x] Ran existing unit/integration tests for `DatabaseManagerClient` and `DatabaseManagerAsyncClient` to ensure no regressions.

---
Linear Issue: [OPEN-2634](https://linear.app/autogpt/issue/OPEN-2634/ensure-each-client-of-database-manager-includes-only-the-methods)

<a href="https://cursor.com/background-agent?bcId=bc-cabb1b36-5282-422a-834d-aeef7b398c6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cabb1b36-5282-422a-834d-aeef7b398c6b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

