### PR TITLE
Fix captcha display bug

### DIFF
--- a/CAPTCHA_FIX_GUIDE.md
+++ b/CAPTCHA_FIX_GUIDE.md
@@ -1,0 +1,117 @@
+# CAPTCHA Display Issue Fix Guide
+
+## Root Cause Analysis
+
+The CAPTCHA is not displaying because the application is configured to bypass CAPTCHA verification entirely. Users see the message "please complete captcha first" but no CAPTCHA widget appears.
+
+## Issues Found
+
+### 1. Frontend Configuration Issues
+- `NEXT_PUBLIC_BEHAVE_AS=LOCAL` in `.env.default` → Should be `CLOUD` for CAPTCHA to show
+- `NEXT_PUBLIC_TURNSTILE=disabled` in `.env.default` → Should be `enabled`
+- Missing `NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY` → Required for CAPTCHA widget
+
+### 2. Backend Configuration Issues
+- Missing `TURNSTILE_SECRET_KEY` → Required for server-side token verification
+
+## How CAPTCHA Logic Works
+
+### Frontend Logic (useTurnstile.ts)
+```typescript
+// CAPTCHA only renders when ALL conditions are true:
+setBearerToken(
+  behaveAs === BehaveAs.CLOUD &&      // Must be CLOUD mode
+  hasTurnstileKey &&                  // Must have site key
+  !turnstileDisabled                  // Must not be disabled
+);
+
+// If any condition fails, CAPTCHA is bypassed:
+if (turnstileDisabled || behaveAs !== BehaveAs.CLOUD || !hasTurnstileKey) {
+  setVerified(true); // Bypasses CAPTCHA validation
+}
+```
+
+### UI Display Logic (signup/page.tsx)
+```tsx
+{/* CAPTCHA only shows when environment is cloud AND not verified */}
+{isCloudEnv && !turnstile.verified ? (
+  <Turnstile ... />
+) : null}
+```
+
+## Fix Instructions
+
+### For Production/Cloud Environment
+
+1. **Frontend Environment Variables** (`.env` or `.env.local`):
+```bash
+# Set behavior to cloud mode
+NEXT_PUBLIC_BEHAVE_AS=CLOUD
+
+# Enable Turnstile
+NEXT_PUBLIC_TURNSTILE=enabled
+
+# Add your Cloudflare Turnstile site key
+NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY=your_site_key_here
+```
+
+2. **Backend Environment Variables** (`.env` or environment config):
+```bash
+# Add your Cloudflare Turnstile secret key
+TURNSTILE_SECRET_KEY=your_secret_key_here
+```
+
+3. **Get Cloudflare Turnstile Keys**:
+   - Go to [Cloudflare Dashboard](https://dash.cloudflare.com/)
+   - Navigate to Turnstile
+   - Create a new site or use existing
+   - Copy Site Key (public) and Secret Key (private)
+
+### For Development/Testing Environment
+
+If you want to **disable** CAPTCHA intentionally:
+```bash
+# Keep as LOCAL to bypass CAPTCHA
+NEXT_PUBLIC_BEHAVE_AS=LOCAL
+NEXT_PUBLIC_TURNSTILE=disabled
+```
+
+### Immediate Fix for Current Users
+
+If you need to quickly fix the issue without setting up Cloudflare Turnstile:
+
+**Option 1: Disable CAPTCHA requirement temporarily**
+- Remove CAPTCHA validation from signup/login forms
+- Set `NEXT_PUBLIC_TURNSTILE=disabled` and `NEXT_PUBLIC_BEHAVE_AS=LOCAL`
+
+**Option 2: Show proper error message**
+- Update the UI to show "CAPTCHA is currently unavailable" instead of "please complete captcha first"
+- Allow users to proceed without CAPTCHA when it's not configured
+
+## Files Involved
+
+### Frontend Files
+- `autogpt_platform/frontend/src/hooks/useTurnstile.ts` - CAPTCHA logic
+- `autogpt_platform/frontend/src/app/(platform)/signup/page.tsx` - Signup page
+- `autogpt_platform/frontend/src/app/(platform)/login/page.tsx` - Login page  
+- `autogpt_platform/frontend/src/app/(platform)/reset-password/page.tsx` - Reset password page
+- `autogpt_platform/frontend/src/components/auth/Turnstile.tsx` - CAPTCHA widget component
+
+### Backend Files
+- `autogpt_platform/backend/backend/server/v2/turnstile/routes.py` - Verification endpoint
+- `autogpt_platform/backend/backend/util/settings.py` - Configuration settings
+
+## Testing the Fix
+
+1. Set the environment variables as described above
+2. Restart frontend and backend services
+3. Navigate to signup/login page
+4. Verify CAPTCHA widget appears
+5. Complete CAPTCHA and verify form submission works
+
+## Additional Improvements Recommended
+
+1. Add better error handling when CAPTCHA fails to load
+2. Show user-friendly messages when CAPTCHA is misconfigured
+3. Add health check endpoint for CAPTCHA configuration
+4. Consider adding retry mechanism for failed CAPTCHA verifications

--- a/autogpt_platform/frontend/src/app/(platform)/login/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/login/page.tsx
@@ -86,16 +86,29 @@ export default function LoginPage() {
 
             {/* Turnstile CAPTCHA Component */}
             {isCloudEnv && !turnstile.verified ? (
-              <Turnstile
-                key={captchaKey}
-                siteKey={turnstile.siteKey}
-                onVerify={turnstile.handleVerify}
-                onExpire={turnstile.handleExpire}
-                onError={turnstile.handleError}
-                setWidgetId={turnstile.setWidgetId}
-                action="login"
-                shouldRender={turnstile.shouldRender}
-              />
+              turnstile.shouldRender ? (
+                <Turnstile
+                  key={captchaKey}
+                  siteKey={turnstile.siteKey}
+                  onVerify={turnstile.handleVerify}
+                  onExpire={turnstile.handleExpire}
+                  onError={turnstile.handleError}
+                  setWidgetId={turnstile.setWidgetId}
+                  action="login"
+                  shouldRender={turnstile.shouldRender}
+                />
+              ) : (
+                <div className="my-4 rounded-md border border-yellow-200 bg-yellow-50 p-4">
+                  <div className="flex">
+                    <WarningOctagonIcon className="h-5 w-5 text-yellow-400" />
+                    <div className="ml-3">
+                      <Text variant="small-medium" className="text-yellow-800">
+                        CAPTCHA verification is currently unavailable. Please try again later or contact support.
+                      </Text>
+                    </div>
+                  </div>
+                </div>
+              )
             ) : null}
 
             <Button

--- a/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/page.tsx
@@ -163,16 +163,29 @@ export default function SignupPage() {
 
             {/* Turnstile CAPTCHA Component */}
             {isCloudEnv && !turnstile.verified ? (
-              <Turnstile
-                key={captchaKey}
-                siteKey={turnstile.siteKey}
-                onVerify={turnstile.handleVerify}
-                onExpire={turnstile.handleExpire}
-                onError={turnstile.handleError}
-                setWidgetId={turnstile.setWidgetId}
-                action="signup"
-                shouldRender={turnstile.shouldRender}
-              />
+              turnstile.shouldRender ? (
+                <Turnstile
+                  key={captchaKey}
+                  siteKey={turnstile.siteKey}
+                  onVerify={turnstile.handleVerify}
+                  onExpire={turnstile.handleExpire}
+                  onError={turnstile.handleError}
+                  setWidgetId={turnstile.setWidgetId}
+                  action="signup"
+                  shouldRender={turnstile.shouldRender}
+                />
+              ) : (
+                <div className="my-4 rounded-md border border-yellow-200 bg-yellow-50 p-4">
+                  <div className="flex">
+                    <WarningOctagonIcon className="h-5 w-5 text-yellow-400" />
+                    <div className="ml-3">
+                      <Text variant="small-medium" className="text-yellow-800">
+                        CAPTCHA verification is currently unavailable. Please try again later or contact support.
+                      </Text>
+                    </div>
+                  </div>
+                </div>
+              )
             ) : null}
 
             <Button


### PR DESCRIPTION
### Need 💡

This PR addresses SECRT-1448, where users reported that the CAPTCHA challenge was not displaying, preventing them from completing actions like registration. The root cause was identified as a misconfiguration of environment variables, which led the application to silently bypass CAPTCHA validation.

The changes improve the user experience by providing clear feedback when CAPTCHA is expected but misconfigured, and offer comprehensive documentation for correct setup.

### Changes 🏗️

*   **Added `CAPTCHA_FIX_GUIDE.md`**: A new markdown file detailing the root cause (environment variable misconfiguration), how CAPTCHA logic works, and step-by-step instructions for correctly configuring Cloudflare Turnstile for both frontend and backend.
*   **Updated `autogpt_platform/frontend/src/app/(platform)/login/page.tsx`**: Modified to display a user-friendly warning message ("CAPTCHA verification is currently unavailable. Please try again later or contact support.") when CAPTCHA is expected in a cloud environment but is not properly configured.
*   **Updated `autogpt_platform/frontend/src/app/(platform)/signup/page.tsx`**: Applied the same user-friendly warning message logic as the login page.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] **Verify CAPTCHA displays correctly:**
    - [ ] Set `NEXT_PUBLIC_BEHAVE_AS=CLOUD`, `NEXT_PUBLIC_TURNSTILE=enabled`, and provide valid `NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`.
    - [ ] Restart frontend and backend services.
    - [ ] Navigate to `/signup` and `/login` pages.
    - [ ] Confirm the CAPTCHA widget appears and functions correctly upon submission.
  - [ ] **Verify CAPTCHA unavailable message displays:**
    - [ ] Set `NEXT_PUBLIC_BEHAVE_AS=CLOUD` but either omit `NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY` or set `NEXT_PUBLIC_TURNSTILE=disabled`.
    - [ ] Restart frontend services.
    - [ ] Navigate to `/signup` and `/login` pages.
    - [ ] Confirm the warning message "CAPTCHA verification is currently unavailable. Please try again later or contact support." is displayed instead of the CAPTCHA widget.

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
  *Note: This PR introduces a guide for configuration, but does not modify `.env.default` directly. The guide explains how to set environment variables to override defaults.*
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

---
Linear Issue: [SECRT-1448](https://linear.app/autogpt/issue/SECRT-1448)

<a href="https://cursor.com/background-agent?bcId=bc-f2d16a65-29d2-4d5a-a542-1e02d36a1042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2d16a65-29d2-4d5a-a542-1e02d36a1042">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

