### PR TITLE
refactor(autogpt_libs/auth): Eliminate breaking global config init

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/__init__.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/__init__.py
@@ -1,9 +1,13 @@
+from .config import verify_settings
 from .dependencies import get_user_id, requires_admin_user, requires_user
+from .helpers import add_auth_responses_to_openapi
 from .models import User
 
 __all__ = [
-    "requires_user",
-    "requires_admin_user",
+    "verify_settings",
     "get_user_id",
+    "requires_admin_user",
+    "requires_user",
+    "add_auth_responses_to_openapi",
     "User",
 ]

--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/config.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/config.py
@@ -27,6 +27,9 @@ class Settings:
         ).strip()
         self.JWT_ALGORITHM: str = os.getenv("JWT_SIGN_ALGORITHM", "HS256").strip()
 
+        self.validate()
+
+    def validate(self):
         if not self.JWT_VERIFY_KEY:
             raise AuthConfigError(
                 "JWT_VERIFY_KEY must be set. "
@@ -65,4 +68,23 @@ class Settings:
             )
 
 
-settings = Settings()
+_settings: Settings = None  # type: ignore
+
+
+def get_settings() -> Settings:
+    global _settings
+
+    if not _settings:
+        _settings = Settings()
+
+    return _settings
+
+
+def verify_settings() -> None:
+    global _settings
+
+    if not _settings:
+        _settings = Settings()  # calls validation indirectly
+        return
+
+    _settings.validate()

--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/jwt_utils.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/jwt_utils.py
@@ -5,7 +5,7 @@ import jwt
 from fastapi import HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from .config import settings
+from .config import get_settings
 from .models import User
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,7 @@ def parse_jwt_token(token: str) -> dict[str, Any]:
     :return: The decoded payload
     :raises ValueError: If the token is invalid or expired
     """
+    settings = get_settings()
     try:
         payload = jwt.decode(
             token,

--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/jwt_utils_test.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/jwt_utils_test.py
@@ -12,380 +12,297 @@ from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 from pytest_mock import MockerFixture
 
+from autogpt_libs.auth import config, jwt_utils
 from autogpt_libs.auth.config import Settings
-from autogpt_libs.auth.jwt_utils import (
-    get_jwt_payload,
-    parse_jwt_token,
-    verify_user,
-)
 from autogpt_libs.auth.models import User
 
+MOCK_JWT_SECRET = "test-secret-key-with-at-least-32-characters"
+TEST_USER_PAYLOAD = {
+    "sub": "test-user-id",
+    "role": "user",
+    "aud": "authenticated",
+    "email": "test@example.com",
+}
+TEST_ADMIN_PAYLOAD = {
+    "sub": "admin-user-id",
+    "role": "admin",
+    "aud": "authenticated",
+    "email": "admin@example.com",
+}
 
-class TestJWTUtils:
-    """Test suite for JWT utility functions."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        """Set up test environment with proper JWT secret."""
-        self.valid_secret = "test-secret-key-with-at-least-32-characters"
-        self.test_payload = {
-            "sub": "test-user-id",
-            "role": "user",
-            "aud": "authenticated",
-            "email": "test@example.com",
-        }
-        self.admin_payload = {
-            "sub": "admin-user-id",
-            "role": "admin",
-            "aud": "authenticated",
-            "email": "admin@example.com",
-        }
+@pytest.fixture(autouse=True)
+def mock_config(mocker: MockerFixture):
+    mocker.patch.dict(os.environ, {"JWT_VERIFY_KEY": MOCK_JWT_SECRET}, clear=True)
+    mocker.patch.object(config, "_settings", Settings())
+    yield
 
-    def create_token(self, payload, secret=None, algorithm="HS256"):
-        """Helper to create JWT tokens."""
-        if secret is None:
-            secret = self.valid_secret
-        return jwt.encode(payload, secret, algorithm=algorithm)
 
-    def test_parse_jwt_token_valid(self, mocker: MockerFixture):
-        """Test parsing a valid JWT token."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        # Need to reimport to get new settings
-        from autogpt_libs.auth import jwt_utils
+def create_token(payload, secret=None, algorithm="HS256"):
+    """Helper to create JWT tokens."""
+    if secret is None:
+        secret = MOCK_JWT_SECRET
+    return jwt.encode(payload, secret, algorithm=algorithm)
 
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        token = self.create_token(self.test_payload)
-        result = parse_jwt_token(token)
 
-        assert result["sub"] == "test-user-id"
-        assert result["role"] == "user"
-        assert result["aud"] == "authenticated"
+def test_parse_jwt_token_valid():
+    """Test parsing a valid JWT token."""
+    token = create_token(TEST_USER_PAYLOAD)
+    result = jwt_utils.parse_jwt_token(token)
 
-    def test_parse_jwt_token_expired(self, mocker: MockerFixture):
-        """Test parsing an expired JWT token."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
+    assert result["sub"] == "test-user-id"
+    assert result["role"] == "user"
+    assert result["aud"] == "authenticated"
 
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        expired_payload = {
-            **self.test_payload,
-            "exp": datetime.now(timezone.utc) - timedelta(hours=1),
-        }
-        token = self.create_token(expired_payload)
 
+def test_parse_jwt_token_expired():
+    """Test parsing an expired JWT token."""
+    expired_payload = {
+        **TEST_USER_PAYLOAD,
+        "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+    }
+    token = create_token(expired_payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Token has expired" in str(exc_info.value)
+
+
+def test_parse_jwt_token_invalid_signature():
+    """Test parsing a token with invalid signature."""
+    # Create token with different secret
+    token = create_token(TEST_USER_PAYLOAD, secret="wrong-secret")
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Invalid token" in str(exc_info.value)
+
+
+def test_parse_jwt_token_malformed():
+    """Test parsing a malformed token."""
+    malformed_tokens = [
+        "not.a.token",
+        "invalid",
+        "",
+        # Header only
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9",
+        # No signature
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0",
+    ]
+
+    for token in malformed_tokens:
         with pytest.raises(ValueError) as exc_info:
-            parse_jwt_token(token)
-        assert "Token has expired" in str(exc_info.value)
-
-    def test_parse_jwt_token_invalid_signature(self, mocker: MockerFixture):
-        """Test parsing a token with invalid signature."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        # Create token with different secret
-        token = self.create_token(self.test_payload, secret="wrong-secret")
-
-        with pytest.raises(ValueError) as exc_info:
-            parse_jwt_token(token)
+            jwt_utils.parse_jwt_token(token)
         assert "Invalid token" in str(exc_info.value)
 
-    def test_parse_jwt_token_malformed(self, mocker: MockerFixture):
-        """Test parsing a malformed token."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
 
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        malformed_tokens = [
-            "not.a.token",
-            "invalid",
-            "",
-            # Header only
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9",
-            # No signature
-            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0",
-        ]
+def test_parse_jwt_token_wrong_audience():
+    """Test parsing a token with wrong audience."""
+    wrong_aud_payload = {**TEST_USER_PAYLOAD, "aud": "wrong-audience"}
+    token = create_token(wrong_aud_payload)
 
-        for token in malformed_tokens:
-            with pytest.raises(ValueError) as exc_info:
-                parse_jwt_token(token)
-            assert "Invalid token" in str(exc_info.value)
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Invalid token" in str(exc_info.value)
 
-    def test_parse_jwt_token_wrong_audience(self, mocker: MockerFixture):
-        """Test parsing a token with wrong audience."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
 
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        wrong_aud_payload = {**self.test_payload, "aud": "wrong-audience"}
-        token = self.create_token(wrong_aud_payload)
+def test_parse_jwt_token_missing_audience():
+    """Test parsing a token without audience claim."""
+    no_aud_payload = {k: v for k, v in TEST_USER_PAYLOAD.items() if k != "aud"}
+    token = create_token(no_aud_payload)
+
+    with pytest.raises(ValueError) as exc_info:
+        jwt_utils.parse_jwt_token(token)
+    assert "Invalid token" in str(exc_info.value)
+
+
+def test_get_jwt_payload_with_valid_token():
+    """Test extracting JWT payload with valid bearer token."""
+    token = create_token(TEST_USER_PAYLOAD)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    result = jwt_utils.get_jwt_payload(credentials)
+    assert result["sub"] == "test-user-id"
+    assert result["role"] == "user"
+
+
+def test_get_jwt_payload_no_credentials():
+    """Test JWT payload when no credentials provided."""
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.get_jwt_payload(None)
+    assert exc_info.value.status_code == 401
+    assert "Authorization header is missing" in exc_info.value.detail
+
+
+def test_get_jwt_payload_invalid_token():
+    """Test JWT payload extraction with invalid token."""
+    credentials = HTTPAuthorizationCredentials(
+        scheme="Bearer", credentials="invalid.token.here"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.get_jwt_payload(credentials)
+    assert exc_info.value.status_code == 401
+    assert "Invalid token" in exc_info.value.detail
+
+
+def test_verify_user_with_valid_user():
+    """Test verifying a valid user."""
+    user = jwt_utils.verify_user(TEST_USER_PAYLOAD, admin_only=False)
+    assert isinstance(user, User)
+    assert user.user_id == "test-user-id"
+    assert user.role == "user"
+    assert user.email == "test@example.com"
+
+
+def test_verify_user_with_admin():
+    """Test verifying an admin user."""
+    user = jwt_utils.verify_user(TEST_ADMIN_PAYLOAD, admin_only=True)
+    assert isinstance(user, User)
+    assert user.user_id == "admin-user-id"
+    assert user.role == "admin"
+
+
+def test_verify_user_admin_only_with_regular_user():
+    """Test verifying regular user when admin is required."""
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(TEST_USER_PAYLOAD, admin_only=True)
+    assert exc_info.value.status_code == 403
+    assert "Admin access required" in exc_info.value.detail
+
+
+def test_verify_user_no_payload():
+    """Test verifying user with no payload."""
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(None, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "Authorization header is missing" in exc_info.value.detail
+
+
+def test_verify_user_missing_sub():
+    """Test verifying user with payload missing 'sub' field."""
+    invalid_payload = {"role": "user", "email": "test@example.com"}
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(invalid_payload, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "User ID not found in token" in exc_info.value.detail
+
+
+def test_verify_user_empty_sub():
+    """Test verifying user with empty 'sub' field."""
+    invalid_payload = {"sub": "", "role": "user"}
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(invalid_payload, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "User ID not found in token" in exc_info.value.detail
+
+
+def test_verify_user_none_sub():
+    """Test verifying user with None 'sub' field."""
+    invalid_payload = {"sub": None, "role": "user"}
+    with pytest.raises(HTTPException) as exc_info:
+        jwt_utils.verify_user(invalid_payload, admin_only=False)
+    assert exc_info.value.status_code == 401
+    assert "User ID not found in token" in exc_info.value.detail
+
+
+def test_verify_user_missing_role_admin_check():
+    """Test verifying admin when role field is missing."""
+    no_role_payload = {"sub": "user-id"}
+    with pytest.raises(KeyError):
+        # This will raise KeyError when checking payload["role"]
+        jwt_utils.verify_user(no_role_payload, admin_only=True)
+
+
+# ======================== EDGE CASES ======================== #
+
+
+def test_jwt_with_additional_claims():
+    """Test JWT token with additional custom claims."""
+    extra_claims_payload = {
+        "sub": "user-id",
+        "role": "user",
+        "aud": "authenticated",
+        "custom_claim": "custom_value",
+        "permissions": ["read", "write"],
+        "metadata": {"key": "value"},
+    }
+    token = create_token(extra_claims_payload)
+
+    result = jwt_utils.parse_jwt_token(token)
+    assert result["sub"] == "user-id"
+    assert result["custom_claim"] == "custom_value"
+    assert result["permissions"] == ["read", "write"]
+
+
+def test_jwt_with_numeric_sub():
+    """Test JWT token with numeric user ID."""
+    payload = {
+        "sub": 12345,  # Numeric ID
+        "role": "user",
+        "aud": "authenticated",
+    }
+    # Should convert to string internally
+    user = jwt_utils.verify_user(payload, admin_only=False)
+    assert user.user_id == 12345
+
+
+def test_jwt_with_very_long_sub():
+    """Test JWT token with very long user ID."""
+    long_id = "a" * 1000
+    payload = {
+        "sub": long_id,
+        "role": "user",
+        "aud": "authenticated",
+    }
+    user = jwt_utils.verify_user(payload, admin_only=False)
+    assert user.user_id == long_id
+
+
+def test_jwt_with_special_characters_in_claims():
+    """Test JWT token with special characters in claims."""
+    payload = {
+        "sub": "user@example.com/special-chars!@#$%",
+        "role": "admin",
+        "aud": "authenticated",
+        "email": "test+special@example.com",
+    }
+    user = jwt_utils.verify_user(payload, admin_only=True)
+    assert "special-chars!@#$%" in user.user_id
+
+
+def test_jwt_with_future_iat():
+    """Test JWT token with issued-at time in future."""
+    future_payload = {
+        "sub": "user-id",
+        "role": "user",
+        "aud": "authenticated",
+        "iat": datetime.now(timezone.utc) + timedelta(hours=1),
+    }
+    token = create_token(future_payload)
+
+    # PyJWT validates iat claim and should reject future tokens
+    with pytest.raises(ValueError, match="not yet valid"):
+        jwt_utils.parse_jwt_token(token)
+
+
+def test_jwt_with_different_algorithms():
+    """Test that only HS256 algorithm is accepted."""
+    payload = {
+        "sub": "user-id",
+        "role": "user",
+        "aud": "authenticated",
+    }
+
+    # Try different algorithms
+    algorithms = ["HS384", "HS512", "none"]
+    for algo in algorithms:
+        if algo == "none":
+            # Special case for 'none' algorithm (security vulnerability if accepted)
+            token = create_token(payload, "", algorithm="none")
+        else:
+            token = create_token(payload, algorithm=algo)
 
         with pytest.raises(ValueError) as exc_info:
-            parse_jwt_token(token)
+            jwt_utils.parse_jwt_token(token)
         assert "Invalid token" in str(exc_info.value)
-
-    def test_parse_jwt_token_missing_audience(self, mocker: MockerFixture):
-        """Test parsing a token without audience claim."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        no_aud_payload = {k: v for k, v in self.test_payload.items() if k != "aud"}
-        token = self.create_token(no_aud_payload)
-
-        with pytest.raises(ValueError) as exc_info:
-            parse_jwt_token(token)
-        assert "Invalid token" in str(exc_info.value)
-
-    def test_get_jwt_payload_with_valid_token(self, mocker: MockerFixture):
-        """Test extracting JWT payload with valid bearer token."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        token = self.create_token(self.test_payload)
-        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
-
-        result = get_jwt_payload(credentials)
-        assert result["sub"] == "test-user-id"
-        assert result["role"] == "user"
-
-    def test_get_jwt_payload_no_credentials(self, mocker: MockerFixture):
-        """Test JWT payload when no credentials provided."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        with pytest.raises(HTTPException) as exc_info:
-            get_jwt_payload(None)
-        assert exc_info.value.status_code == 401
-        assert "Authorization header is missing" in exc_info.value.detail
-
-    def test_get_jwt_payload_invalid_token(self, mocker: MockerFixture):
-        """Test JWT payload extraction with invalid token."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        credentials = HTTPAuthorizationCredentials(
-            scheme="Bearer", credentials="invalid.token.here"
-        )
-
-        with pytest.raises(HTTPException) as exc_info:
-            get_jwt_payload(credentials)
-        assert exc_info.value.status_code == 401
-        assert "Invalid token" in exc_info.value.detail
-
-    def test_verify_user_with_valid_user(self):
-        """Test verifying a valid user."""
-        user = verify_user(self.test_payload, admin_only=False)
-        assert isinstance(user, User)
-        assert user.user_id == "test-user-id"
-        assert user.role == "user"
-        assert user.email == "test@example.com"
-
-    def test_verify_user_with_admin(self):
-        """Test verifying an admin user."""
-        user = verify_user(self.admin_payload, admin_only=True)
-        assert isinstance(user, User)
-        assert user.user_id == "admin-user-id"
-        assert user.role == "admin"
-
-    def test_verify_user_admin_only_with_regular_user(self):
-        """Test verifying regular user when admin is required."""
-        with pytest.raises(HTTPException) as exc_info:
-            verify_user(self.test_payload, admin_only=True)
-        assert exc_info.value.status_code == 403
-        assert "Admin access required" in exc_info.value.detail
-
-    def test_verify_user_no_payload(self):
-        """Test verifying user with no payload."""
-        with pytest.raises(HTTPException) as exc_info:
-            verify_user(None, admin_only=False)
-        assert exc_info.value.status_code == 401
-        assert "Authorization header is missing" in exc_info.value.detail
-
-    def test_verify_user_missing_sub(self):
-        """Test verifying user with payload missing 'sub' field."""
-        invalid_payload = {"role": "user", "email": "test@example.com"}
-        with pytest.raises(HTTPException) as exc_info:
-            verify_user(invalid_payload, admin_only=False)
-        assert exc_info.value.status_code == 401
-        assert "User ID not found in token" in exc_info.value.detail
-
-    def test_verify_user_empty_sub(self):
-        """Test verifying user with empty 'sub' field."""
-        invalid_payload = {"sub": "", "role": "user"}
-        with pytest.raises(HTTPException) as exc_info:
-            verify_user(invalid_payload, admin_only=False)
-        assert exc_info.value.status_code == 401
-        assert "User ID not found in token" in exc_info.value.detail
-
-    def test_verify_user_none_sub(self):
-        """Test verifying user with None 'sub' field."""
-        invalid_payload = {"sub": None, "role": "user"}
-        with pytest.raises(HTTPException) as exc_info:
-            verify_user(invalid_payload, admin_only=False)
-        assert exc_info.value.status_code == 401
-        assert "User ID not found in token" in exc_info.value.detail
-
-    def test_verify_user_missing_role_admin_check(self):
-        """Test verifying admin when role field is missing."""
-        no_role_payload = {"sub": "user-id"}
-        with pytest.raises(KeyError):
-            # This will raise KeyError when checking payload["role"]
-            verify_user(no_role_payload, admin_only=True)
-
-
-class TestJWTEdgeCases:
-    """Edge case tests for JWT token handling."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        """Set up test environment."""
-        self.valid_secret = "edge-case-secret-with-proper-length-12345"
-
-    def test_jwt_with_additional_claims(self, mocker: MockerFixture):
-        """Test JWT token with additional custom claims."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        extra_claims_payload = {
-            "sub": "user-id",
-            "role": "user",
-            "aud": "authenticated",
-            "custom_claim": "custom_value",
-            "permissions": ["read", "write"],
-            "metadata": {"key": "value"},
-        }
-        token = jwt.encode(extra_claims_payload, self.valid_secret, algorithm="HS256")
-
-        result = parse_jwt_token(token)
-        assert result["sub"] == "user-id"
-        assert result["custom_claim"] == "custom_value"
-        assert result["permissions"] == ["read", "write"]
-
-    def test_jwt_with_numeric_sub(self):
-        """Test JWT token with numeric user ID."""
-        payload = {
-            "sub": 12345,  # Numeric ID
-            "role": "user",
-            "aud": "authenticated",
-        }
-        # Should convert to string internally
-        user = verify_user(payload, admin_only=False)
-        assert user.user_id == 12345
-
-    def test_jwt_with_very_long_sub(self):
-        """Test JWT token with very long user ID."""
-        long_id = "a" * 1000
-        payload = {
-            "sub": long_id,
-            "role": "user",
-            "aud": "authenticated",
-        }
-        user = verify_user(payload, admin_only=False)
-        assert user.user_id == long_id
-
-    def test_jwt_with_special_characters_in_claims(self):
-        """Test JWT token with special characters in claims."""
-        payload = {
-            "sub": "user@example.com/special-chars!@#$%",
-            "role": "admin",
-            "aud": "authenticated",
-            "email": "test+special@example.com",
-        }
-        user = verify_user(payload, admin_only=True)
-        assert "special-chars!@#$%" in user.user_id
-
-    def test_jwt_with_future_iat(self, mocker: MockerFixture):
-        """Test JWT token with issued-at time in future."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        future_payload = {
-            "sub": "user-id",
-            "role": "user",
-            "aud": "authenticated",
-            "iat": datetime.now(timezone.utc) + timedelta(hours=1),
-        }
-        token = jwt.encode(future_payload, self.valid_secret, algorithm="HS256")
-
-        # PyJWT validates iat claim and should reject future tokens
-        with pytest.raises(ValueError, match="not yet valid"):
-            parse_jwt_token(token)
-
-    def test_jwt_with_different_algorithms(self, mocker: MockerFixture):
-        """Test that only HS256 algorithm is accepted."""
-        mocker.patch.dict(
-            os.environ,
-            {"JWT_VERIFY_KEY": self.valid_secret},
-            clear=True,
-        )
-        from autogpt_libs.auth import jwt_utils
-
-        mocker.patch.object(jwt_utils, "settings", Settings())
-        payload = {
-            "sub": "user-id",
-            "role": "user",
-            "aud": "authenticated",
-        }
-
-        # Try different algorithms
-        algorithms = ["HS384", "HS512", "none"]
-        for algo in algorithms:
-            if algo == "none":
-                # Special case for 'none' algorithm (security vulnerability if accepted)
-                token = jwt.encode(payload, "", algorithm="none")
-            else:
-                token = jwt.encode(payload, self.valid_secret, algorithm=algo)
-
-            with pytest.raises(ValueError) as exc_info:
-                parse_jwt_token(token)
-            assert "Invalid token" in str(exc_info.value)

--- a/autogpt_platform/autogpt_libs/autogpt_libs/conftest.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/conftest.py
@@ -1,4 +1,0 @@
-import os
-
-# Set JWT_VERIFY_KEY, otherwise the config module fails to load
-os.environ["JWT_VERIFY_KEY"] = "placeholder-secret-key-that-is-long-enough"

--- a/autogpt_platform/backend/backend/server/rest_api.py
+++ b/autogpt_platform/backend/backend/server/rest_api.py
@@ -8,7 +8,8 @@ import fastapi.responses
 import pydantic
 import starlette.middleware.cors
 import uvicorn
-from autogpt_libs.auth.helpers import add_auth_responses_to_openapi
+from autogpt_libs.auth import add_auth_responses_to_openapi
+from autogpt_libs.auth import verify_settings as verify_auth_settings
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 
@@ -61,6 +62,8 @@ def launch_darkly_context():
 
 @contextlib.asynccontextmanager
 async def lifespan_context(app: fastapi.FastAPI):
+    verify_auth_settings()
+
     await backend.data.db.connect()
 
     # Ensure SDK auto-registration is patched before initializing blocks


### PR DESCRIPTION
- Resolves #10754

### Changes 🏗️

- Implement lazy config loading in `autogpt_libs.auth`
- Add explicit config init+validation to `backend.server.rest_api:app` lifespan
- Move config management in tests to a fixture

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] All tests pass
