### PR TITLE
feat(backend): Add platform.auth_sessions for long-term session storage

### DIFF
--- a/autogpt_platform/backend/migrations/20250827135347_add_platform_auth_sessions/migration.sql
+++ b/autogpt_platform/backend/migrations/20250827135347_add_platform_auth_sessions/migration.sql
@@ -1,0 +1,123 @@
+-- Migration: Add platform.auth_sessions table for long-term storage
+-- This creates a copy of auth.sessions in the platform schema for permanent storage
+-- since auth.sessions only retains data for ~1 month
+
+-- Create the platform.auth_sessions table
+-- This mirrors the structure of auth.sessions but in the platform schema for long-term storage
+-- Using TEXT for aal column to avoid enum type dependency issues
+CREATE TABLE "auth_sessions" (
+  "id" uuid PRIMARY KEY,
+  "user_id" uuid NOT NULL,
+  "created_at" TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  "factor_id" uuid,
+  "aal" TEXT,
+  "not_after" TIMESTAMP WITH TIME ZONE,
+  "refreshed_at" TIMESTAMP WITH TIME ZONE,
+  "user_agent" TEXT,
+  "ip" inet,
+  "tag" TEXT
+);
+
+-- Add indexes for performance
+CREATE INDEX "idx_auth_sessions_user_id" ON "auth_sessions" ("user_id");
+CREATE INDEX "idx_auth_sessions_created_at" ON "auth_sessions" ("created_at");
+CREATE INDEX "idx_auth_sessions_updated_at" ON "auth_sessions" ("updated_at");
+
+-- Create trigger function to copy data from auth.sessions to platform.auth_sessions
+-- This function will only be created if the auth schema exists
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'auth') THEN
+        CREATE OR REPLACE FUNCTION copy_auth_session_to_platform()
+        RETURNS TRIGGER AS $func$
+        BEGIN
+          -- Insert or update the session in the platform schema
+          INSERT INTO "auth_sessions" (
+            "id",
+            "user_id", 
+            "created_at",
+            "updated_at",
+            "factor_id",
+            "aal",
+            "not_after",
+            "refreshed_at",
+            "user_agent",
+            "ip",
+            "tag"
+          ) VALUES (
+            NEW.id,
+            NEW.user_id,
+            NEW.created_at,
+            NEW.updated_at,
+            NEW.factor_id,
+            NEW.aal::text,
+            NEW.not_after,
+            NEW.refreshed_at,
+            NEW.user_agent,
+            NEW.ip,
+            NEW.tag
+          )
+          ON CONFLICT (id) 
+          DO UPDATE SET
+            "user_id" = NEW.user_id,
+            "updated_at" = NEW.updated_at,
+            "factor_id" = NEW.factor_id,
+            "aal" = NEW.aal::text::"aal_level",
+            "not_after" = NEW.not_after,
+            "refreshed_at" = NEW.refreshed_at,
+            "user_agent" = NEW.user_agent,
+            "ip" = NEW.ip,
+            "tag" = NEW.tag;
+          
+          RETURN NEW;
+        END;
+        $func$ LANGUAGE plpgsql;
+
+        -- Create triggers on auth.sessions table if it exists
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'auth' AND table_name = 'sessions') THEN
+            DROP TRIGGER IF EXISTS trigger_copy_auth_session_insert ON "auth"."sessions";
+            DROP TRIGGER IF EXISTS trigger_copy_auth_session_update ON "auth"."sessions";
+            
+            CREATE TRIGGER trigger_copy_auth_session_insert
+              AFTER INSERT ON "auth"."sessions"
+              FOR EACH ROW
+              EXECUTE FUNCTION copy_auth_session_to_platform();
+
+            CREATE TRIGGER trigger_copy_auth_session_update
+              AFTER UPDATE ON "auth"."sessions"
+              FOR EACH ROW
+              EXECUTE FUNCTION copy_auth_session_to_platform();
+
+            -- Copy existing data from auth.sessions to platform.auth_sessions
+            -- This ensures we don't lose any current session data
+            INSERT INTO "auth_sessions" (
+              "id",
+              "user_id", 
+              "created_at",
+              "updated_at",
+              "factor_id",
+              "aal",
+              "not_after",
+              "refreshed_at",
+              "user_agent",
+              "ip",
+              "tag"
+            )
+            SELECT 
+              "id",
+              "user_id",
+              "created_at",
+              "updated_at",
+              "factor_id",
+              "aal"::text,
+              "not_after",
+              "refreshed_at",
+              "user_agent",
+              "ip",
+              "tag"
+            FROM "auth"."sessions"
+            ON CONFLICT (id) DO NOTHING;
+        END IF;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

- Create `auth_sessions` table in platform schema for permanent session storage
- Add automatic triggers to copy data from `auth.sessions` to `platform.auth_sessions`
- Include performance indexes on `user_id`, `created_at`, `updated_at`
- Handle cases where auth schema may not exist in test environments

## Problem

The `auth.sessions` table only retains data for approximately 1 month. We need long-term storage of authentication session data in the platform schema for analytics, auditing, and user management purposes.

## Solution

1. **New table**: `auth_sessions` in platform schema mirrors the structure of `auth.sessions`
2. **Automatic sync**: Triggers on `auth.sessions` INSERT/UPDATE automatically copy data to platform schema
3. **Performance**: Indexes added on frequently queried columns
4. **Robust migration**: Handles environments where auth schema doesn't exist (like tests)

## Technical Details

- Uses TEXT for `aal` column instead of enum to avoid cross-schema type dependencies
- Conditional logic checks for auth schema existence before creating triggers
- Initial data migration copies existing sessions from auth schema
- ON CONFLICT handling prevents duplicate entries

## Test Plan

- [x] Migration runs successfully in test environment without auth schema
- [x] Table structure created correctly with proper indexes
- [ ] Test trigger functionality in environment with auth schema
- [ ] Verify data copying works correctly
- [ ] Performance test with large session datasets

🤖 Generated with [Claude Code](https://claude.ai/code)