### PR TITLE
test(frontend): fix library flaky e2e test

### DIFF
--- a/autogpt_platform/frontend/src/tests/pages/library.page.ts
+++ b/autogpt_platform/frontend/src/tests/pages/library.page.ts
@@ -206,6 +206,7 @@ export class LibraryPage extends BasePage {
   async clickAgent(agent: Agent): Promise<void> {
     await this.page
       .getByRole("heading", { name: agent.name, level: 3 })
+      .first()
       .click();
   }
 


### PR DESCRIPTION
A test in one of my pr is failing something like… 

<img width="1044" height="452" alt="Screenshot 2025-08-28 at 9 39 07 AM" src="https://github.com/user-attachments/assets/9c8b8996-50a2-44c6-8a2c-c3904f07ced5" />

That’s why I fixed it.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] All E2E tests are now working correctly.