### PR TITLE
Find duplicate user slug pairs on prod

### DIFF
--- a/README_duplicate_check.md
+++ b/README_duplicate_check.md
@@ -1,0 +1,88 @@
+# User/Slug Duplicate Check Scripts
+
+This directory contains scripts to check for duplicate user/slug pairs in the `StoreListing` table to verify that the unique constraint `@@unique([owningUserId, slug])` is working properly.
+
+## Files Created
+
+### 1. `production_duplicate_check.sql`
+**RECOMMENDED FOR PRODUCTION**
+
+A comprehensive SQL script that can be run directly against your production database. This script provides:
+- Summary statistics about the StoreListing table
+- Verification that the unique constraint exists
+- Detection of any duplicate user/slug pairs
+- Detailed analysis (commented out by default)
+
+**Usage:**
+```bash
+# Connect to your production database and run:
+psql -h your-prod-host -U your-user -d your-database -f production_duplicate_check.sql
+```
+
+### 2. `check_duplicate_user_slug_pairs.sql`
+A simpler SQL query that focuses on finding duplicates using GROUP BY and HAVING clauses.
+
+### 3. `check_user_slug_duplicates.py`
+A Python script that uses the application's database connection to check for duplicates. Provides detailed output and appropriate exit codes.
+
+**Usage:**
+```bash
+# From the workspace root:
+python3 check_user_slug_duplicates.py
+```
+
+## Expected Results
+
+### If NO duplicates exist (expected):
+- The main duplicate check query should return **0 rows**
+- This indicates the unique constraint is working properly
+- Data integrity is maintained
+
+### If duplicates exist (problem):
+- The query will return rows showing:
+  - `owningUserId`: The user ID
+  - `slug`: The duplicate slug
+  - `duplicate_count`: How many duplicates exist
+  - `listing_ids`: The IDs of the duplicate listings
+
+## Understanding the Schema
+
+From the Prisma schema (`schema.prisma`):
+
+```prisma
+model StoreListing {
+  // ... other fields ...
+  slug String                    // URL-friendly identifier
+  owningUserId String            // User who owns this listing
+  OwningUser   User   @relation(fields: [owningUserId], references: [id])
+  
+  @@unique([owningUserId, slug]) // This constraint prevents duplicates
+}
+```
+
+The unique constraint ensures that:
+- Each user can only have ONE listing with a specific slug
+- Different users CAN have listings with the same slug
+- The same user CANNOT have multiple listings with the same slug
+
+## Database Migration History
+
+The unique constraint was added in migration `20250318043016_update_store_submissions_format`:
+```sql
+CREATE UNIQUE INDEX "StoreListing_owningUserId_slug_key" ON "StoreListing"("owningUserId", "slug");
+```
+
+## Troubleshooting
+
+If duplicates are found:
+
+1. **Check constraint existence**: Verify the unique index exists in the database
+2. **Review migration history**: Ensure the migration was applied successfully
+3. **Data cleanup**: Remove duplicate entries (keeping the most recent or appropriate one)
+4. **Re-apply constraint**: If missing, recreate the unique constraint
+
+## Related Linear Issue
+
+This addresses Linear issue **SECRT-1197**: "write a query to check that there's now duplicate user/slug pairs on prod"
+
+The query verifies that the database maintains data integrity for the user/slug relationship in the StoreListing table.

--- a/check_duplicate_user_slug_pairs.sql
+++ b/check_duplicate_user_slug_pairs.sql
@@ -1,0 +1,45 @@
+-- Query to check for duplicate user/slug pairs in the StoreListing table
+-- This should return 0 rows if the unique constraint is working properly
+-- If any rows are returned, there are duplicate user/slug combinations
+
+-- Method 1: Check for actual duplicates using GROUP BY and HAVING
+SELECT 
+    "owningUserId",
+    "slug",
+    COUNT(*) as duplicate_count,
+    string_agg("id", ', ') as listing_ids
+FROM "StoreListing"
+WHERE "isDeleted" = false  -- Only check non-deleted listings
+GROUP BY "owningUserId", "slug"
+HAVING COUNT(*) > 1
+ORDER BY duplicate_count DESC, "owningUserId", "slug";
+
+-- Method 2: Alternative approach - find all records that have duplicates
+-- WITH duplicates AS (
+--     SELECT "owningUserId", "slug"
+--     FROM "StoreListing"
+--     WHERE "isDeleted" = false
+--     GROUP BY "owningUserId", "slug"
+--     HAVING COUNT(*) > 1
+-- )
+-- SELECT 
+--     sl."id",
+--     sl."owningUserId", 
+--     sl."slug",
+--     sl."createdAt",
+--     sl."updatedAt",
+--     u."email" as owner_email,
+--     u."name" as owner_name
+-- FROM "StoreListing" sl
+-- JOIN duplicates d ON sl."owningUserId" = d."owningUserId" AND sl."slug" = d."slug"
+-- JOIN "User" u ON sl."owningUserId" = u."id"
+-- WHERE sl."isDeleted" = false
+-- ORDER BY sl."owningUserId", sl."slug", sl."createdAt";
+
+-- Method 3: Summary statistics
+-- SELECT 
+--     COUNT(*) as total_listings,
+--     COUNT(DISTINCT ("owningUserId", "slug")) as unique_user_slug_pairs,
+--     (COUNT(*) - COUNT(DISTINCT ("owningUserId", "slug"))) as potential_duplicates
+-- FROM "StoreListing"
+-- WHERE "isDeleted" = false;

--- a/check_user_slug_duplicates.py
+++ b/check_user_slug_duplicates.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Script to check for duplicate user/slug pairs in the StoreListing table.
+This verifies that the unique constraint @@unique([owningUserId, slug]) is working properly.
+"""
+
+import asyncio
+import os
+import sys
+from typing import List, Dict, Any
+
+# Add the backend directory to the Python path
+sys.path.append(os.path.join(os.path.dirname(__file__), 'autogpt_platform', 'backend'))
+
+from backend.data.db import DatabaseManager
+
+
+async def check_duplicate_user_slug_pairs() -> Dict[str, Any]:
+    """
+    Check for duplicate user/slug pairs in the StoreListing table.
+    
+    Returns:
+        Dict containing the results of the duplicate check
+    """
+    db = DatabaseManager()
+    
+    print("🔍 Checking for duplicate user/slug pairs in StoreListing table...")
+    print("=" * 60)
+    
+    # Query 1: Find actual duplicates
+    duplicate_query = """
+        SELECT 
+            "owningUserId",
+            "slug",
+            COUNT(*) as duplicate_count,
+            string_agg("id", ', ') as listing_ids
+        FROM "StoreListing"
+        WHERE "isDeleted" = false
+        GROUP BY "owningUserId", "slug"
+        HAVING COUNT(*) > 1
+        ORDER BY duplicate_count DESC, "owningUserId", "slug";
+    """
+    
+    duplicates = await db.prisma.query_raw(duplicate_query)
+    
+    # Query 2: Get summary statistics
+    stats_query = """
+        SELECT 
+            COUNT(*) as total_listings,
+            COUNT(DISTINCT CONCAT("owningUserId", '|', "slug")) as unique_user_slug_pairs,
+            (COUNT(*) - COUNT(DISTINCT CONCAT("owningUserId", '|', "slug"))) as potential_duplicates
+        FROM "StoreListing"
+        WHERE "isDeleted" = false;
+    """
+    
+    stats = await db.prisma.query_raw(stats_query)
+    
+    # Query 3: Check the unique constraint exists
+    constraint_query = """
+        SELECT 
+            indexname,
+            indexdef
+        FROM pg_indexes 
+        WHERE tablename = 'StoreListing' 
+        AND indexdef LIKE '%owningUserId%slug%'
+        AND indexdef LIKE '%UNIQUE%';
+    """
+    
+    constraints = await db.prisma.query_raw(constraint_query)
+    
+    results = {
+        'duplicates': duplicates,
+        'stats': stats[0] if stats else {},
+        'constraints': constraints,
+        'has_duplicates': len(duplicates) > 0
+    }
+    
+    return results
+
+
+def print_results(results: Dict[str, Any]) -> None:
+    """Print the results in a readable format."""
+    
+    print("📊 SUMMARY STATISTICS")
+    print("-" * 30)
+    if results['stats']:
+        stats = results['stats']
+        print(f"Total listings (non-deleted): {stats.get('total_listings', 'N/A')}")
+        print(f"Unique user/slug pairs: {stats.get('unique_user_slug_pairs', 'N/A')}")
+        print(f"Potential duplicates: {stats.get('potential_duplicates', 'N/A')}")
+    else:
+        print("No statistics available")
+    
+    print("\n🔒 UNIQUE CONSTRAINTS")
+    print("-" * 30)
+    if results['constraints']:
+        for constraint in results['constraints']:
+            print(f"Index: {constraint.get('indexname')}")
+            print(f"Definition: {constraint.get('indexdef')}")
+    else:
+        print("⚠️  No unique constraint found on (owningUserId, slug)")
+    
+    print(f"\n🚨 DUPLICATE CHECK RESULTS")
+    print("-" * 30)
+    if results['has_duplicates']:
+        print(f"❌ FOUND {len(results['duplicates'])} DUPLICATE USER/SLUG PAIRS:")
+        print()
+        for dup in results['duplicates']:
+            print(f"User ID: {dup.get('owningUserId')}")
+            print(f"Slug: {dup.get('slug')}")
+            print(f"Count: {dup.get('duplicate_count')}")
+            print(f"Listing IDs: {dup.get('listing_ids')}")
+            print("-" * 40)
+    else:
+        print("✅ NO DUPLICATE USER/SLUG PAIRS FOUND")
+        print("The unique constraint is working properly!")
+
+
+async def main():
+    """Main function to run the duplicate check."""
+    try:
+        results = await check_duplicate_user_slug_pairs()
+        print_results(results)
+        
+        # Return appropriate exit code
+        if results['has_duplicates']:
+            print("\n⚠️  ATTENTION: Duplicate user/slug pairs found!")
+            print("This indicates the unique constraint may not be enforced properly.")
+            sys.exit(1)
+        else:
+            print("\n✅ All checks passed! No duplicate user/slug pairs found.")
+            sys.exit(0)
+            
+    except Exception as e:
+        print(f"❌ Error running duplicate check: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/production_duplicate_check.sql
+++ b/production_duplicate_check.sql
@@ -1,0 +1,125 @@
+-- ================================================
+-- PRODUCTION DUPLICATE USER/SLUG PAIRS CHECK
+-- ================================================
+-- This script checks for duplicate user/slug pairs in the StoreListing table
+-- Run this query against your production database to verify data integrity
+
+-- 1. SUMMARY STATISTICS
+-- ---------------------
+SELECT 
+    '=== SUMMARY STATISTICS ===' as section,
+    NULL as user_id,
+    NULL as slug,
+    NULL as count,
+    NULL as details;
+
+SELECT 
+    'Total Listings' as metric,
+    NULL as user_id,
+    NULL as slug,
+    COUNT(*) as count,
+    'Non-deleted StoreListing records' as details
+FROM "StoreListing"
+WHERE "isDeleted" = false;
+
+SELECT 
+    'Unique User/Slug Pairs' as metric,
+    NULL as user_id,
+    NULL as slug,
+    COUNT(DISTINCT CONCAT("owningUserId", '|', "slug")) as count,
+    'Distinct combinations' as details
+FROM "StoreListing"
+WHERE "isDeleted" = false;
+
+-- 2. CONSTRAINT CHECK
+-- -------------------
+SELECT 
+    '=== CONSTRAINT CHECK ===' as section,
+    NULL as user_id,
+    NULL as slug,
+    NULL as count,
+    NULL as details;
+
+SELECT 
+    'Unique Constraint' as metric,
+    NULL as user_id,
+    NULL as slug,
+    CASE 
+        WHEN COUNT(*) > 0 THEN 1 
+        ELSE 0 
+    END as count,
+    CASE 
+        WHEN COUNT(*) > 0 THEN 'Constraint exists'
+        ELSE 'Constraint missing!'
+    END as details
+FROM pg_indexes 
+WHERE tablename = 'StoreListing' 
+  AND indexdef LIKE '%owningUserId%slug%'
+  AND indexdef LIKE '%UNIQUE%';
+
+-- 3. DUPLICATE CHECK (MAIN QUERY)
+-- --------------------------------
+SELECT 
+    '=== DUPLICATE PAIRS ===' as section,
+    NULL as user_id,
+    NULL as slug,
+    NULL as count,
+    NULL as details;
+
+-- This is the main query - if it returns any rows, you have duplicates
+SELECT 
+    'DUPLICATE FOUND' as section,
+    "owningUserId" as user_id,
+    "slug" as slug,
+    COUNT(*) as count,
+    string_agg("id", ', ') as details
+FROM "StoreListing"
+WHERE "isDeleted" = false
+GROUP BY "owningUserId", "slug"
+HAVING COUNT(*) > 1
+ORDER BY COUNT(*) DESC, "owningUserId", "slug";
+
+-- 4. DETAILED DUPLICATE ANALYSIS
+-- -------------------------------
+-- Uncomment this section if duplicates are found above
+-- to get more details about the duplicate records
+
+/*
+WITH duplicates AS (
+    SELECT "owningUserId", "slug"
+    FROM "StoreListing"
+    WHERE "isDeleted" = false
+    GROUP BY "owningUserId", "slug"
+    HAVING COUNT(*) > 1
+)
+SELECT 
+    '=== DUPLICATE DETAILS ===' as analysis,
+    sl."id" as listing_id,
+    sl."owningUserId" as user_id,
+    sl."slug" as slug,
+    sl."createdAt",
+    sl."updatedAt",
+    u."email" as owner_email,
+    u."name" as owner_name
+FROM "StoreListing" sl
+JOIN duplicates d ON sl."owningUserId" = d."owningUserId" AND sl."slug" = d."slug"
+LEFT JOIN "User" u ON sl."owningUserId" = u."id"
+WHERE sl."isDeleted" = false
+ORDER BY sl."owningUserId", sl."slug", sl."createdAt";
+*/
+
+-- 5. FINAL RESULT INTERPRETATION
+-- ------------------------------
+SELECT 
+    '=== INTERPRETATION ===' as section,
+    NULL as user_id,
+    NULL as slug,
+    NULL as count,
+    'If no rows returned in DUPLICATE PAIRS section above, then NO duplicates exist' as details;
+
+SELECT 
+    '=== EXPECTED RESULT ===' as section,
+    NULL as user_id,
+    NULL as slug,
+    NULL as count,
+    'Zero rows in DUPLICATE PAIRS = Database constraint is working correctly' as details;


### PR DESCRIPTION
### Problem Statement Why these changes are needed:

This PR addresses Linear issue SECRT-1197 by providing a robust solution to verify the data integrity of the `StoreListing` table in production. The goal is to confirm that the unique constraint `@@unique([owningUserId, slug])` is correctly enforced, ensuring no duplicate `user/slug` pairs exist, and to detect any potential data corruption.

### Changes 🏗️

-   **`production_duplicate_check.sql`**: A comprehensive SQL script designed for production environments. It includes summary statistics, verification of the unique constraint, and detection of any duplicate `user/slug` pairs.
-   **`check_duplicate_user_slug_pairs.sql`**: A simpler, focused SQL query to identify duplicate `user/slug` entries.
-   **`check_user_slug_duplicates.py`**: An executable Python script that utilizes the application's database connection to perform the duplicate check, providing detailed output and appropriate exit codes.
-   **`README_duplicate_check.md`**: Documentation explaining the purpose, usage, expected results, relevant schema context, and migration history for these scripts.
-   Made `check_user_slug_duplicates.py` executable.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] Verified SQL syntax of `production_duplicate_check.sql` using `psql`.
  - [ ] Run `production_duplicate_check.sql` against a development/staging database to confirm expected output (0 duplicates).
  - [ ] Run `check_user_slug_duplicates.py` against a development/staging database to confirm expected output (0 duplicates).

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

---
Linear Issue: [SECRT-1197](https://linear.app/autogpt/issue/SECRT-1197)

<a href="https://cursor.com/background-agent?bcId=bc-74c88f9a-2cac-4832-9d3d-4f2fabad4ad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74c88f9a-2cac-4832-9d3d-4f2fabad4ad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

