### PR TITLE
feat(frontend): Add editable node titles with hover pencil icon

### DIFF
--- a/autogpt_platform/frontend/src/components/CustomNode.tsx
+++ b/autogpt_platform/frontend/src/components/CustomNode.tsx
@@ -53,11 +53,19 @@ import {
   TrashIcon,
   CopyIcon,
   ExitIcon,
+  Pencil1Icon,
 } from "@radix-ui/react-icons";
 import { Key } from "@phosphor-icons/react";
 import useCredits from "@/hooks/useCredits";
 import { getV1GetAyrshareSsoUrl } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export type ConnectionData = Array<{
   edge_id: string;
@@ -92,6 +100,7 @@ export type CustomNodeData = {
   errors?: { [key: string]: string };
   isOutputStatic?: boolean;
   uiType: BlockUIType;
+  metadata?: { [key: string]: any };
 };
 
 export type CustomNode = XYNode<CustomNodeData, "custom">;
@@ -106,6 +115,12 @@ export const CustomNode = React.memo(
     const [activeKey, setActiveKey] = useState<string | null>(null);
     const [inputModalValue, setInputModalValue] = useState<string>("");
     const [isOutputModalOpen, setIsOutputModalOpen] = useState(false);
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const [customTitle, setCustomTitle] = useState(
+      data.metadata?.customized_name || "",
+    );
+    const [isTitleHovered, setIsTitleHovered] = useState(false);
+    const titleInputRef = useRef<HTMLInputElement>(null);
     const { updateNodeData, deleteElements, addNodes, getNode } = useReactFlow<
       CustomNode,
       Edge
@@ -184,6 +199,39 @@ export const CustomNode = React.memo(
       },
       [id, updateNodeData],
     );
+
+    const handleTitleEdit = useCallback(() => {
+      setIsEditingTitle(true);
+      setTimeout(() => {
+        titleInputRef.current?.focus();
+        titleInputRef.current?.select();
+      }, 0);
+    }, []);
+
+    const handleTitleSave = useCallback(() => {
+      setIsEditingTitle(false);
+      const newMetadata = {
+        ...data.metadata,
+        customized_name: customTitle.trim() || undefined,
+      };
+      updateNodeData(id, { metadata: newMetadata });
+    }, [customTitle, data.metadata, id, updateNodeData]);
+
+    const handleTitleKeyDown = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+          handleTitleSave();
+        } else if (e.key === "Escape") {
+          setCustomTitle(data.metadata?.customized_name || "");
+          setIsEditingTitle(false);
+        }
+      },
+      [handleTitleSave, data.metadata],
+    );
+
+    const displayTitle =
+      customTitle ||
+      beautifyString(data.blockType?.replace(/Block$/, "") || data.title);
 
     useEffect(() => {
       isInitialSetup.current = false;
@@ -549,6 +597,10 @@ export const CustomNode = React.memo(
           block_id: data.block_id,
           connections: [],
           isOutputOpen: false,
+          metadata: {
+            ...data.metadata,
+            customized_name: undefined, // Don't copy the custom name
+          },
         },
       };
 
@@ -815,14 +867,58 @@ export const CustomNode = React.memo(
 
           <div className="flex w-full flex-col justify-start space-y-2.5 px-4 pt-4">
             <div className="flex flex-row items-center space-x-2 font-semibold">
-              <h3 className="font-roboto text-lg">
-                <TextRenderer
-                  value={beautifyString(
-                    data.blockType?.replace(/Block$/, "") || data.title,
-                  )}
-                  truncateLengthLimit={80}
-                />
-              </h3>
+              <div
+                className="group flex items-center gap-1"
+                onMouseEnter={() => setIsTitleHovered(true)}
+                onMouseLeave={() => setIsTitleHovered(false)}
+              >
+                {isEditingTitle ? (
+                  <Input
+                    ref={titleInputRef}
+                    value={customTitle}
+                    onChange={(e) => setCustomTitle(e.target.value)}
+                    onBlur={handleTitleSave}
+                    onKeyDown={handleTitleKeyDown}
+                    className="h-7 w-auto min-w-[100px] max-w-[200px] px-2 py-1 text-lg font-semibold"
+                    placeholder={beautifyString(
+                      data.blockType?.replace(/Block$/, "") || data.title,
+                    )}
+                  />
+                ) : (
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <h3 className="font-roboto cursor-default text-lg">
+                          <TextRenderer
+                            value={displayTitle}
+                            truncateLengthLimit={80}
+                          />
+                        </h3>
+                      </TooltipTrigger>
+                      {customTitle && (
+                        <TooltipContent>
+                          <p>
+                            Type:{" "}
+                            {beautifyString(
+                              data.blockType?.replace(/Block$/, "") ||
+                                data.title,
+                            )}
+                          </p>
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
+                {isTitleHovered && !isEditingTitle && (
+                  <button
+                    onClick={handleTitleEdit}
+                    className="cursor-pointer rounded p-1 opacity-0 transition-opacity hover:bg-gray-100 group-hover:opacity-100"
+                    aria-label="Edit title"
+                  >
+                    <Pencil1Icon className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
               <span className="text-xs text-gray-500">#{id.split("-")[0]}</span>
 
               <div className="w-auto grow" />

--- a/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
+++ b/autogpt_platform/frontend/src/hooks/useAgentGraph.tsx
@@ -196,6 +196,7 @@ export default function useAgentGraph(
             hardcodedValues: node.input_default,
             webhook: node.webhook,
             uiType: block.uiType,
+            metadata: node.metadata,
             connections: graph.links
               .filter((l) => [l.source_id, l.sink_id].includes(node.id))
               .map((link) => ({
@@ -601,7 +602,10 @@ export default function useAgentGraph(
           id: node.id,
           block_id: node.data.block_id,
           input_default: prepareNodeInputData(node),
-          metadata: { position: node.position },
+          metadata: {
+            position: node.position,
+            ...(node.data.metadata || {}),
+          },
         }),
       ),
       links: links,
@@ -680,6 +684,7 @@ export default function useAgentGraph(
                   backend_id: backendNode.id,
                   webhook: backendNode.webhook,
                   executionResults: [],
+                  metadata: backendNode.metadata,
                 },
               }
             : null;


### PR DESCRIPTION
## Summary
- Adds ability to edit custom node titles by clicking a pencil icon that appears on hover
- Custom titles are saved in node metadata and persist across saves
- Original node type is shown in tooltip when hovering over custom titles

## Changes
- **CustomNode.tsx**: 
  - Added inline title editing with pencil icon on hover
  - Implemented state management for title editing mode
  - Added tooltip to show original node type for custom titles
  - Prevents custom names from being copied when duplicating nodes

- **useAgentGraph.tsx**:
  - Updated graph save/load logic to preserve metadata including custom titles
  - Ensures metadata persistence through all node operations

## Technical Details
- Uses existing `metadata` JSON field in AgentNode model (no database changes needed)
- Stores custom title in `metadata.customized_name`
- Backward compatible - nodes without custom titles display normally

## Test Plan
- [x] Hover over node title shows pencil icon
- [x] Click pencil icon to edit title
- [x] Press Enter or blur to save, Escape to cancel
- [x] Custom title persists after saving graph
- [x] Tooltip shows original node type when hovering over custom title
- [x] Copying node doesn't copy custom name
- [x] Backward compatible with existing graphs