### PR TITLE
fix(frontend): Fix checking of `Date` and `NaN` input values

### DIFF
--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -395,7 +395,9 @@ export function isEmpty(value: any): boolean {
   return (
     value === undefined ||
     value === "" ||
-    (typeof value === "object" && _isEmpty(value))
+    (typeof value === "object" &&
+      (value instanceof Date ? isNaN(value.getTime()) : _isEmpty(value))) ||
+    (typeof value === "number" && isNaN(value))
   );
 }
 


### PR DESCRIPTION
Date values were being rejected as "empty" by the run input form.

![screenshot demonstrating the issue](https://github.com/user-attachments/assets/cf89414d-9b27-4da5-8a4a-64d9439c7084)

### Changes 🏗️

- Specifically handle `Date` type values in `isEmpty`
- Specifically handle `NaN` values in `isEmpty`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Date values are no longer rejected as "empty"
