### PR TITLE
feat(backend/infra): Cleanup platform and db docker compose files

### DIFF
--- a/autogpt_platform/db/docker/docker-compose.yml
+++ b/autogpt_platform/db/docker/docker-compose.yml
@@ -25,83 +25,10 @@ x-supabase-env-files: &supabase-env-files
 
 # Common Supabase environment - hardcoded defaults to avoid variable substitution
 x-supabase-env: &supabase-env
-  # Core PostgreSQL settings
-  POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
-  POSTGRES_HOST: db
-  POSTGRES_PORT: "5432"
-  POSTGRES_DB: postgres
-  
-  # Authentication & Security
-  JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters-long
-  ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
-  SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
-  DASHBOARD_USERNAME: supabase
-  DASHBOARD_PASSWORD: this_password_is_insecure_and_should_be_updated
-  SECRET_KEY_BASE: UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
-  VAULT_ENC_KEY: your-encryption-key-32-chars-min
-  
-  # URLs and Endpoints
-  SITE_URL: http://localhost:3000
-  API_EXTERNAL_URL: http://localhost:8000
-  SUPABASE_PUBLIC_URL: http://localhost:8000
-  ADDITIONAL_REDIRECT_URLS: ""
-  
-  # Feature Flags
-  DISABLE_SIGNUP: "false"
-  ENABLE_EMAIL_SIGNUP: "true"
-  ENABLE_EMAIL_AUTOCONFIRM: "false"
-  ENABLE_ANONYMOUS_USERS: "false"
-  ENABLE_PHONE_SIGNUP: "true"
-  ENABLE_PHONE_AUTOCONFIRM: "true"
-  FUNCTIONS_VERIFY_JWT: "false"
-  IMGPROXY_ENABLE_WEBP_DETECTION: "true"
-  
-  # Email/SMTP Configuration
-  SMTP_ADMIN_EMAIL: admin@example.com
-  SMTP_HOST: supabase-mail
-  SMTP_PORT: "2500"
-  SMTP_USER: fake_mail_user
-  SMTP_PASS: fake_mail_password
-  SMTP_SENDER_NAME: fake_sender
-  
-  # Mailer URLs
-  MAILER_URLPATHS_CONFIRMATION: /auth/v1/verify
-  MAILER_URLPATHS_INVITE: /auth/v1/verify
-  MAILER_URLPATHS_RECOVERY: /auth/v1/verify
-  MAILER_URLPATHS_EMAIL_CHANGE: /auth/v1/verify
-  
-  # JWT Settings
-  JWT_EXPIRY: "3600"
-  
-  # Database Schemas
-  PGRST_DB_SCHEMAS: public,storage,graphql_public
-  
-  # Studio Settings
-  STUDIO_DEFAULT_ORGANIZATION: Default Organization
-  STUDIO_DEFAULT_PROJECT: Default Project
-  
-  # Logging
-  LOGFLARE_API_KEY: your-super-secret-and-long-logflare-key
-  
-  # Pooler Settings
-  POOLER_DEFAULT_POOL_SIZE: "20"
-  POOLER_MAX_CLIENT_CONN: "100"
-  POOLER_TENANT_ID: your-tenant-id
-  POOLER_PROXY_PORT_TRANSACTION: "6543"
-  
-  # Kong Ports
-  KONG_HTTP_PORT: "8000"
-  KONG_HTTPS_PORT: "8443"
-  
-  # Docker
-  DOCKER_SOCKET_LOCATION: /var/run/docker.sock
-  
-  # Google Cloud (if needed)
-  GOOGLE_PROJECT_ID: GOOGLE_PROJECT_ID
-  GOOGLE_PROJECT_NUMBER: GOOGLE_PROJECT_NUMBER
+  SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
+  SUPABASE_SERVICE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
 
 services:
-
   studio:
     container_name: supabase-studio
     image: supabase/studio:20250224-d10db0f
@@ -122,16 +49,9 @@ services:
       <<: *supabase-env
       # Keep any existing environment variables specific to that service
       STUDIO_PG_META_URL: http://meta:8080
-      POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
-
       DEFAULT_ORGANIZATION_NAME: Default Organization
       DEFAULT_PROJECT_NAME: Default Project
-      OPENAI_API_KEY: ""
-
       SUPABASE_URL: http://kong:8000
-      SUPABASE_PUBLIC_URL: http://localhost:8000
-      SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
-      SUPABASE_SERVICE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
       AUTH_JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters-long
 
       LOGFLARE_API_KEY: your-super-secret-and-long-logflare-key
@@ -163,10 +83,6 @@ services:
       KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth
       KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
-      SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
-      SUPABASE_SERVICE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
-      DASHBOARD_USERNAME: supabase
-      DASHBOARD_PASSWORD: this_password_is_insecure_and_should_be_updated
     # https://unix.stackexchange.com/a/294837
     entrypoint: bash -c 'eval "echo \"$$(cat ~/temp.yml)\"" > ~/kong.yml && /docker-entrypoint.sh kong docker-start'
 
@@ -197,7 +113,6 @@ services:
       # Keep any existing environment variables specific to that service
       GOTRUE_API_HOST: 0.0.0.0
       GOTRUE_API_PORT: 9999
-      API_EXTERNAL_URL: http://localhost:8000
 
       GOTRUE_DB_DRIVER: postgres
       GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:your-super-secret-and-long-postgres-password@db:5432/postgres
@@ -425,9 +340,7 @@ services:
     environment:
       <<: *supabase-env
       # Keep any existing environment variables specific to that service
-      JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters-long
       SUPABASE_URL: http://kong:8000
-      SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJhbm9uIiwKICAgICJpc3MiOiAic3VwYWJhc2UtZGVtbyIsCiAgICAiaWF0IjogMTY0MTc2OTIwMCwKICAgICJleHAiOiAxNzk5NTM1NjAwCn0.dc_X5iR_VP_qT0zsiyj_I_OZ2T9FtRU2BBNWN8Bu4GE
       SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyAgCiAgICAicm9sZSI6ICJzZXJ2aWNlX3JvbGUiLAogICAgImlzcyI6ICJzdXBhYmFzZS1kZW1vIiwKICAgICJpYXQiOiAxNjQxNzY5MjAwLAogICAgImV4cCI6IDE3OTk1MzU2MDAKfQ.DaYlNEoUrrEn2Ig7tqibS-PHK5vgusbcbo7X36XVt4Q
       SUPABASE_DB_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres
       # TODO: Allow configuring VERIFY_JWT per function. This PR might help: https://github.com/supabase/cli/pull/786
@@ -531,12 +444,8 @@ services:
       # Keep any existing environment variables specific to that service
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: 5432
-      POSTGRES_PORT: 5432
       PGPASSWORD: your-super-secret-and-long-postgres-password
-      POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
       PGDATABASE: postgres
-      POSTGRES_DB: postgres
-      JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters-long
       JWT_EXP: 3600
     command:
       [
@@ -570,8 +479,6 @@ services:
     <<: *supabase-env-files
     environment:
       <<: *supabase-env
-      # Keep any existing environment variables specific to that service
-      LOGFLARE_API_KEY: your-super-secret-and-long-logflare-key
     command:
       [
         "--config",
@@ -612,9 +519,6 @@ services:
       <<: *supabase-env
       # Keep any existing environment variables specific to that service
       PORT: 4000
-      POSTGRES_PORT: 5432
-      POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: your-super-secret-and-long-postgres-password
       DATABASE_URL: ecto://supabase_admin:your-super-secret-and-long-postgres-password@db:5432/_supabase
       CLUSTER_POSTGRES: true
       SECRET_KEY_BASE: UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -6,8 +6,7 @@
 # 5. CLI arguments - docker compose run -e VAR=value
 
 # Common backend environment - Docker service names
-x-backend-env:
-  &backend-env # Docker internal service hostnames (override localhost defaults)
+x-backend-env: &backend-env # Docker internal service hostnames (override localhost defaults)
   PYRO_HOST: "0.0.0.0"
   AGENTSERVER_HOST: rest_server
   SCHEDULER_HOST: scheduler_server
@@ -20,6 +19,10 @@ x-backend-env:
   RABBITMQ_HOST: rabbitmq
   # Override Supabase URL for Docker network
   SUPABASE_URL: http://kong:8000
+  # Database connection string for Docker network
+  # This cannot be constructed like in .env because we cannot interpolate values set here (DB_HOST)
+  DATABASE_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
+  DIRECT_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
 
 # Common env_file configuration for backend services
 x-backend-env-files: &backend-env-files
@@ -43,9 +46,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    <<: *backend-env-files
     environment:
-      - DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
-      - DIRECT_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
+      <<: *backend-env
     networks:
       - app-network
     restart: on-failure
@@ -77,9 +80,9 @@ services:
       timeout: 10s
       retries: 5
       start_period: 10s
+    <<: *backend-env-files
     environment:
-      - RABBITMQ_DEFAULT_USER=rabbitmq_user_default
-      - RABBITMQ_DEFAULT_PASS=k0VMxyIJF9S35f3x2uaw5IWAl6Y536O7 # CHANGE THIS TO A RANDOM PASSWORD IN PRODUCTION -- everywhere lol
+      <<: *backend-env
     ports:
       - "5672:5672"
       - "15672:15672"
@@ -107,9 +110,6 @@ services:
     <<: *backend-env-files
     environment:
       <<: *backend-env
-      # Service-specific overrides
-      DATABASE_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
-      DIRECT_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
     ports:
       - "8006:8006"
     networks:
@@ -140,9 +140,6 @@ services:
     <<: *backend-env-files
     environment:
       <<: *backend-env
-      # Service-specific overrides
-      DATABASE_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
-      DIRECT_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
     ports:
       - "8002:8002"
     networks:
@@ -171,9 +168,6 @@ services:
     <<: *backend-env-files
     environment:
       <<: *backend-env
-      # Service-specific overrides
-      DATABASE_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
-      DIRECT_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
     ports:
       - "8001:8001"
     networks:
@@ -198,9 +192,6 @@ services:
     <<: *backend-env-files
     environment:
       <<: *backend-env
-      # Service-specific overrides
-      DATABASE_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
-      DIRECT_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
     ports:
       - "8005:8005"
     networks:
@@ -244,9 +235,6 @@ services:
     <<: *backend-env-files
     environment:
       <<: *backend-env
-      # Service-specific overrides
-      DATABASE_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
-      DIRECT_URL: postgresql://postgres:your-super-secret-and-long-postgres-password@db:5432/postgres?connect_timeout=60&schema=platform
     ports:
       - "8003:8003"
     networks:


### PR DESCRIPTION
Supabase `db/docker/docker-compose.yml` overrides env vars set in `autogpt_platform/.env` file. This PR fixes that and simplifies the compose files further.

### Changes 🏗️

`autogpt_platform/docker-compose.platform.yml`:
- Move hardcoded `DATABASE_URL` and `DIRECT_URL` to `x-backend-env` on top as it repeats for most services.
- Remove `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` from `rabbitmq` service and use env files instead

`autogpt_platform/db/docker/docker-compose.yml`:
- Remove hardcoded env vars from `x-supabase-env` - these are already defined in `.env`
- Remove env vars from services that are already defined in `.env` files

*Changes to db compose file only affect self-hosted Supabase*

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Platform, db works when self-hosting
