### PR TITLE
feat(frontend): smol improvements on new run view

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/AgentRunsView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/AgentRunsView.tsx
@@ -101,6 +101,7 @@ export function AgentRunsView() {
               <ScheduleDetails
                 agent={agent}
                 scheduleId={selectedRun.replace("schedule:", "")}
+                onClearSelectedRun={clearSelectedRun}
               />
             ) : (
               <RunDetails

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/EmptyAgentRuns/EmptyAgentRuns.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/EmptyAgentRuns/EmptyAgentRuns.tsx
@@ -1,0 +1,70 @@
+import { ShowMoreText } from "@/components/molecules/ShowMoreText/ShowMoreText";
+import { RunDetailCard } from "../RunDetailCard/RunDetailCard";
+import { Text } from "@/components/atoms/Text/Text";
+import { RunAgentModal } from "../RunAgentModal/RunAgentModal";
+import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { Button } from "@/components/atoms/Button/Button";
+import { PlusIcon } from "@phosphor-icons/react";
+
+type Props = {
+  agentName: string;
+  creatorName: string;
+  description: string;
+  agent: LibraryAgent;
+};
+
+export function EmptyAgentRuns({
+  agentName,
+  creatorName,
+  description,
+  agent,
+}: Props) {
+  const isUnknownCreator = creatorName === "Unknown";
+
+  return (
+    <div className="mt-6 px-2">
+      <RunDetailCard className="relative min-h-[70vh]">
+        <div className="absolute left-1/2 top-1/2 flex w-[80%] -translate-x-1/2 -translate-y-1/2 flex-col gap-6 md:w-[60%] lg:w-auto">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Text
+                variant="h3"
+                className="truncate text-ellipsis !font-normal"
+              >
+                {agentName}
+              </Text>
+              {!isUnknownCreator ? (
+                <Text variant="body-medium">by {creatorName}</Text>
+              ) : null}
+            </div>
+            {description ? (
+              <ShowMoreText
+                previewLimit={80}
+                variant="small"
+                className="mt-4 !text-zinc-700"
+              >
+                {description}
+              </ShowMoreText>
+            ) : null}
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <Text variant="h4">You don’t have any runs</Text>
+            <Text variant="large">
+              Get started with creating a run, and you’ll see information here
+            </Text>
+          </div>
+          <RunAgentModal
+            triggerSlot={
+              <Button variant="primary" size="large" className="w-full">
+                <PlusIcon size={20} /> New Run
+              </Button>
+            }
+            agent={agent}
+            agentId={agent.id.toString()}
+          />
+        </div>
+      </RunDetailCard>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailCard/RunDetailCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetailCard/RunDetailCard.tsx
@@ -1,10 +1,18 @@
+import { cn } from "@/lib/utils";
+
 type Props = {
   children: React.ReactNode;
+  className?: string;
 };
 
-export function RunDetailCard({ children }: Props) {
+export function RunDetailCard({ children, className }: Props) {
   return (
-    <div className="min-h-20 rounded-xlarge border border-slate-50/70 bg-white p-6">
+    <div
+      className={cn(
+        "min-h-20 rounded-xlarge border border-slate-50/70 bg-white p-6",
+        className,
+      )}
+    >
       {children}
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetails/useRunDetails.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunDetails/useRunDetails.ts
@@ -2,9 +2,32 @@
 
 import { useGetV1GetExecutionDetails } from "@/app/api/__generated__/endpoints/graphs/graphs";
 import type { GetV1GetExecutionDetails200 } from "@/app/api/__generated__/models/getV1GetExecutionDetails200";
+import { AgentExecutionStatus } from "@/app/api/__generated__/models/agentExecutionStatus";
 
 export function useRunDetails(graphId: string, runId: string) {
-  const query = useGetV1GetExecutionDetails(graphId, runId);
+  const query = useGetV1GetExecutionDetails(graphId, runId, {
+    query: {
+      refetchInterval: (q) => {
+        const isSuccess = q.state.data?.status === 200;
+
+        if (!isSuccess) return false;
+
+        const status =
+          q.state.data?.status === 200 ? q.state.data.data.status : undefined;
+
+        if (!status) return false;
+        if (
+          status === AgentExecutionStatus.RUNNING ||
+          status === AgentExecutionStatus.QUEUED ||
+          status === AgentExecutionStatus.INCOMPLETE
+        )
+          return 1500;
+        return false;
+      },
+      refetchIntervalInBackground: true,
+      refetchOnWindowFocus: false,
+    },
+  });
 
   const status = query.data?.status;
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/RunsSidebar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/RunsSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import {
   TabsLine,
   TabsLineList,
@@ -23,12 +23,17 @@ interface RunsSidebarProps {
   agent: LibraryAgent;
   selectedRunId?: string;
   onSelectRun: (id: string) => void;
+  onCountsChange?: (info: {
+    runsCount: number;
+    schedulesCount: number;
+  }) => void;
 }
 
 export function RunsSidebar({
   agent,
   selectedRunId,
   onSelectRun,
+  onCountsChange,
 }: RunsSidebarProps) {
   const {
     runs,
@@ -43,6 +48,10 @@ export function RunsSidebar({
     tabValue,
     setTabValue,
   } = useRunsSidebar({ graphId: agent.graph_id, onSelectRun });
+
+  useEffect(() => {
+    if (onCountsChange) onCountsChange({ runsCount, schedulesCount });
+  }, [runsCount, schedulesCount, onCountsChange]);
 
   if (error) {
     return <ErrorCard responseError={error} />;

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/useRunsSidebar.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/components/RunsSidebar/useRunsSidebar.ts
@@ -8,6 +8,8 @@ import { GraphExecutionsPaginated } from "@/app/api/__generated__/models/graphEx
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { useSearchParams } from "next/navigation";
 
+const AGENT_RUNNING_POLL_INTERVAL = 1500;
+
 type Args = {
   graphId?: string;
   onSelectRun: (runId: string) => void;
@@ -40,7 +42,7 @@ export function useRunsSidebar({ graphId, onSelectRun }: Args) {
               (e: { status?: string }) =>
                 e.status === "RUNNING" || e.status === "QUEUED",
             );
-            return hasActive ? 3000 : false;
+            return hasActive ? AGENT_RUNNING_POLL_INTERVAL : false;
           } catch {
             return false;
           }

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/useAgentRunsView.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/AgentRunsView/useAgentRunsView.ts
@@ -7,7 +7,7 @@ export function useAgentRunsView() {
   const agentId = id as string;
   const { data: response, isSuccess, error } = useGetV2GetLibraryAgent(agentId);
 
-  const [runParam, setRunParam] = useQueryState("run", parseAsString);
+  const [runParam, setRunParam] = useQueryState("executionId", parseAsString);
   const selectedRun = runParam ?? undefined;
 
   function handleSelectRun(id: string) {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
@@ -6,5 +6,5 @@ import { OldAgentLibraryView } from "./components/OldAgentLibraryView/OldAgentLi
 
 export default function AgentLibraryPage() {
   const isNewLibraryPageEnabled = useGetFlag(Flag.NEW_AGENT_RUNS);
-  return isNewLibraryPageEnabled ? <AgentRunsView /> : <OldAgentLibraryView />;
+  return true ? <AgentRunsView /> : <OldAgentLibraryView />;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/page.tsx
@@ -6,5 +6,5 @@ import { OldAgentLibraryView } from "./components/OldAgentLibraryView/OldAgentLi
 
 export default function AgentLibraryPage() {
   const isNewLibraryPageEnabled = useGetFlag(Flag.NEW_AGENT_RUNS);
-  return true ? <AgentRunsView /> : <OldAgentLibraryView />;
+  return isNewLibraryPageEnabled ? <AgentRunsView /> : <OldAgentLibraryView />;
 }


### PR DESCRIPTION
## Changes 🏗️

<img width="800" height="790" alt="Screenshot 2025-09-05 at 17 22 36" src="https://github.com/user-attachments/assets/8b22424c-1968-4c4f-9eed-3d5d5185751d" />

- Make a nicer empty state and display it when there are no runs/schedules
- Rename search param to `executionId` to mirror what was on the old page
- Reduce polling when execution is happening to 1.5s ( 3.s is too slow maybe... )
- Make sure the run details page also updates when a run is happening

## Checklist 📋

### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Run the app
  - [x] Tested the above 

### For configuration changes:

None

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
