### PR TITLE
fix(frontend): Fix environment variable handling in Docker builds for dev/prod deployments

### DIFF
--- a/autogpt_platform/frontend/.prettierignore
+++ b/autogpt_platform/frontend/.prettierignore
@@ -4,3 +4,5 @@ pnpm-lock.yaml
 .auth
 build
 public
+Dockerfile
+.prettierignore

--- a/autogpt_platform/frontend/Dockerfile
+++ b/autogpt_platform/frontend/Dockerfile
@@ -12,9 +12,16 @@ COPY autogpt_platform/frontend/ .
 # Allow CI to opt-in to Playwright test build-time flags
 ARG NEXT_PUBLIC_PW_TEST="false"
 ENV NEXT_PUBLIC_PW_TEST=$NEXT_PUBLIC_PW_TEST
-RUN if [ -f .env ]; then \
+ENV NODE_ENV="production"
+# Merge env files appropriately based on environment
+RUN if [ -f .env.production ]; then \
+      # In CI/CD: merge defaults with production (production takes precedence)
+      cat .env.default .env.production > .env.merged && mv .env.merged .env.production; \
+    elif [ -f .env ]; then \
+      # Local with custom .env: merge defaults with .env
       cat .env.default .env > .env.merged && mv .env.merged .env; \
     else \
+      # Local without custom .env: use defaults
       cp .env.default .env; \
     fi
 RUN pnpm run generate:api

--- a/autogpt_platform/frontend/instrumentation-client.ts
+++ b/autogpt_platform/frontend/instrumentation-client.ts
@@ -18,7 +18,10 @@ const isDisabled = process.env.DISABLE_SENTRY === "true";
 
 const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 
-console.log(`shouldEnableSentry: ${shouldEnable}`);
+console.log(`shouldEnableSentry: ${shouldEnable} (instrumentation)`);
+console.log(`isCloud: ${isCloud} (instrumentation)`);
+console.log(`isDisabled: ${isDisabled} (instrumentation)`);
+console.log(`isProdOrDev: ${isProdOrDev} (instrumentation)`);
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/instrumentation-client.ts
+++ b/autogpt_platform/frontend/instrumentation-client.ts
@@ -21,6 +21,7 @@ const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 console.log(`shouldEnableSentry: ${shouldEnable} (instrumentation)`);
 console.log(`isCloud: ${isCloud} (instrumentation)`);
 console.log(`isDisabled: ${isDisabled} (instrumentation)`);
+console.log(`AppEnv: ${getAppEnv()} (instrumentation)`);
 console.log(`isProdOrDev: ${isProdOrDev} (instrumentation)`);
 
 Sentry.init({

--- a/autogpt_platform/frontend/instrumentation-client.ts
+++ b/autogpt_platform/frontend/instrumentation-client.ts
@@ -5,15 +5,17 @@
 import { BehaveAs, getBehaveAs, getEnvironmentStr } from "@/lib/utils";
 import * as Sentry from "@sentry/nextjs";
 
-const isProductionCloud =
-  process.env.NODE_ENV === "production" && getBehaveAs() === BehaveAs.CLOUD;
+const shouldEnable =
+  (process.env.NODE_ENV === "production" ||
+    process.env.NODE_ENV === "development") &&
+  getBehaveAs() === BehaveAs.CLOUD;
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",
 
   environment: getEnvironmentStr(),
 
-  enabled: isProductionCloud,
+  enabled: shouldEnable,
 
   // Add optional integrations for additional features
   integrations: [
@@ -56,10 +58,7 @@ Sentry.init({
   // For example, a tracesSampleRate of 0.5 and profilesSampleRate of 0.5 would
   // result in 25% of transactions being profiled (0.5*0.5=0.25)
   profilesSampleRate: 1.0,
-  _experiments: {
-    // Enable logs to be sent to Sentry.
-    enableLogs: true,
-  },
+  enableLogs: true,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/autogpt_platform/frontend/instrumentation-client.ts
+++ b/autogpt_platform/frontend/instrumentation-client.ts
@@ -5,10 +5,14 @@
 import { BehaveAs, getBehaveAs, getEnvironmentStr } from "@/lib/utils";
 import * as Sentry from "@sentry/nextjs";
 
-const shouldEnable =
-  (process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "development") &&
-  getBehaveAs() === BehaveAs.CLOUD;
+const isProdOrDev =
+  process.env.NODE_ENV === "production" ||
+  process.env.NODE_ENV === "development";
+
+const isCloud = getBehaveAs() === BehaveAs.CLOUD;
+const isDisabled = process.env.DISABLE_SENTRY === "true";
+
+const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/instrumentation-client.ts
+++ b/autogpt_platform/frontend/instrumentation-client.ts
@@ -2,17 +2,23 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { BehaveAs, getBehaveAs, getEnvironmentStr } from "@/lib/utils";
+import {
+  AppEnv,
+  BehaveAs,
+  getAppEnv,
+  getBehaveAs,
+  getEnvironmentStr,
+} from "@/lib/utils";
 import * as Sentry from "@sentry/nextjs";
 
-const isProdOrDev =
-  process.env.NODE_ENV === "production" ||
-  process.env.NODE_ENV === "development";
+const isProdOrDev = getAppEnv() === AppEnv.PROD || getAppEnv() === AppEnv.DEV;
 
 const isCloud = getBehaveAs() === BehaveAs.CLOUD;
 const isDisabled = process.env.DISABLE_SENTRY === "true";
 
 const shouldEnable = !isDisabled && isProdOrDev && isCloud;
+
+console.log(`shouldEnableSentry: ${shouldEnable}`);
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/sentry.edge.config.ts
+++ b/autogpt_platform/frontend/sentry.edge.config.ts
@@ -19,7 +19,10 @@ const isDisabled = process.env.DISABLE_SENTRY === "true";
 
 const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 
-console.log(`shouldEnableSentry: ${shouldEnable}`);
+console.log(`shouldEnableSentry: ${shouldEnable} (edge)`);
+console.log(`isCloud: ${isCloud} (edge)`);
+console.log(`isDisabled: ${isDisabled} (edge)`);
+console.log(`isProdOrDev: ${isProdOrDev} (edge)`);
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/sentry.edge.config.ts
+++ b/autogpt_platform/frontend/sentry.edge.config.ts
@@ -4,16 +4,22 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { BehaveAs, getBehaveAs, getEnvironmentStr } from "./src/lib/utils";
+import {
+  AppEnv,
+  BehaveAs,
+  getAppEnv,
+  getBehaveAs,
+  getEnvironmentStr,
+} from "./src/lib/utils";
 
-const isProdOrDev =
-  process.env.NODE_ENV === "production" ||
-  process.env.NODE_ENV === "development";
+const isProdOrDev = getAppEnv() === AppEnv.PROD || getAppEnv() === AppEnv.DEV;
 
 const isCloud = getBehaveAs() === BehaveAs.CLOUD;
 const isDisabled = process.env.DISABLE_SENTRY === "true";
 
 const shouldEnable = !isDisabled && isProdOrDev && isCloud;
+
+console.log(`shouldEnableSentry: ${shouldEnable}`);
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/sentry.edge.config.ts
+++ b/autogpt_platform/frontend/sentry.edge.config.ts
@@ -22,6 +22,7 @@ const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 console.log(`shouldEnableSentry: ${shouldEnable} (edge)`);
 console.log(`isCloud: ${isCloud} (edge)`);
 console.log(`isDisabled: ${isDisabled} (edge)`);
+console.log(`AppEnv: ${getAppEnv()} (edge)`);
 console.log(`isProdOrDev: ${isProdOrDev} (edge)`);
 
 Sentry.init({

--- a/autogpt_platform/frontend/sentry.edge.config.ts
+++ b/autogpt_platform/frontend/sentry.edge.config.ts
@@ -6,10 +6,14 @@
 import * as Sentry from "@sentry/nextjs";
 import { BehaveAs, getBehaveAs, getEnvironmentStr } from "./src/lib/utils";
 
-const shouldEnable =
-  (process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "development") &&
-  getBehaveAs() === BehaveAs.CLOUD;
+const isProdOrDev =
+  process.env.NODE_ENV === "production" ||
+  process.env.NODE_ENV === "development";
+
+const isCloud = getBehaveAs() === BehaveAs.CLOUD;
+const isDisabled = process.env.DISABLE_SENTRY === "true";
+
+const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/sentry.edge.config.ts
+++ b/autogpt_platform/frontend/sentry.edge.config.ts
@@ -6,15 +6,17 @@
 import * as Sentry from "@sentry/nextjs";
 import { BehaveAs, getBehaveAs, getEnvironmentStr } from "./src/lib/utils";
 
-const isProductionCloud =
-  process.env.NODE_ENV === "production" && getBehaveAs() === BehaveAs.CLOUD;
+const shouldEnable =
+  (process.env.NODE_ENV === "production" ||
+    process.env.NODE_ENV === "development") &&
+  getBehaveAs() === BehaveAs.CLOUD;
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",
 
   environment: getEnvironmentStr(),
 
-  enabled: isProductionCloud,
+  enabled: shouldEnable,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
@@ -28,8 +30,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  _experiments: {
-    // Enable logs to be sent to Sentry.
-    enableLogs: true,
-  },
+  enableLogs: true,
 });

--- a/autogpt_platform/frontend/sentry.server.config.ts
+++ b/autogpt_platform/frontend/sentry.server.config.ts
@@ -22,6 +22,7 @@ const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 console.log(`shouldEnableSentry: ${shouldEnable} (server)`);
 console.log(`isCloud: ${isCloud} (server)`);
 console.log(`isDisabled: ${isDisabled} (server)`);
+console.log(`AppEnv: ${getAppEnv()} (server)`);
 console.log(`isProdOrDev: ${isProdOrDev} (server)`);
 
 Sentry.init({

--- a/autogpt_platform/frontend/sentry.server.config.ts
+++ b/autogpt_platform/frontend/sentry.server.config.ts
@@ -19,7 +19,10 @@ const isDisabled = process.env.DISABLE_SENTRY === "true";
 
 const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 
-console.log(`shouldEnableSentry: ${shouldEnable}`);
+console.log(`shouldEnableSentry: ${shouldEnable} (server)`);
+console.log(`isCloud: ${isCloud} (server)`);
+console.log(`isDisabled: ${isDisabled} (server)`);
+console.log(`isProdOrDev: ${isProdOrDev} (server)`);
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/sentry.server.config.ts
+++ b/autogpt_platform/frontend/sentry.server.config.ts
@@ -6,10 +6,14 @@ import { BehaveAs, getBehaveAs, getEnvironmentStr } from "@/lib/utils";
 import * as Sentry from "@sentry/nextjs";
 // import { NodeProfilingIntegration } from "@sentry/profiling-node";
 
-const shouldEnable =
-  (process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "development") &&
-  getBehaveAs() === BehaveAs.CLOUD;
+const isProdOrDev =
+  process.env.NODE_ENV === "production" ||
+  process.env.NODE_ENV === "development";
+
+const isCloud = getBehaveAs() === BehaveAs.CLOUD;
+const isDisabled = process.env.DISABLE_SENTRY === "true";
+
+const shouldEnable = !isDisabled && isProdOrDev && isCloud;
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/sentry.server.config.ts
+++ b/autogpt_platform/frontend/sentry.server.config.ts
@@ -6,15 +6,17 @@ import { BehaveAs, getBehaveAs, getEnvironmentStr } from "@/lib/utils";
 import * as Sentry from "@sentry/nextjs";
 // import { NodeProfilingIntegration } from "@sentry/profiling-node";
 
-const isProductionCloud =
-  process.env.NODE_ENV === "production" && getBehaveAs() === BehaveAs.CLOUD;
+const shouldEnable =
+  (process.env.NODE_ENV === "production" ||
+    process.env.NODE_ENV === "development") &&
+  getBehaveAs() === BehaveAs.CLOUD;
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",
 
   environment: getEnvironmentStr(),
 
-  enabled: isProductionCloud,
+  enabled: shouldEnable,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
@@ -35,8 +37,5 @@ Sentry.init({
     // Sentry.fsIntegration(),
   ],
 
-  _experiments: {
-    // Enable logs to be sent to Sentry.
-    enableLogs: true,
-  },
+  enableLogs: true,
 });

--- a/autogpt_platform/frontend/sentry.server.config.ts
+++ b/autogpt_platform/frontend/sentry.server.config.ts
@@ -2,18 +2,24 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { BehaveAs, getBehaveAs, getEnvironmentStr } from "@/lib/utils";
+import {
+  AppEnv,
+  BehaveAs,
+  getAppEnv,
+  getBehaveAs,
+  getEnvironmentStr,
+} from "@/lib/utils";
 import * as Sentry from "@sentry/nextjs";
 // import { NodeProfilingIntegration } from "@sentry/profiling-node";
 
-const isProdOrDev =
-  process.env.NODE_ENV === "production" ||
-  process.env.NODE_ENV === "development";
+const isProdOrDev = getAppEnv() === AppEnv.PROD || getAppEnv() === AppEnv.DEV;
 
 const isCloud = getBehaveAs() === BehaveAs.CLOUD;
 const isDisabled = process.env.DISABLE_SENTRY === "true";
 
 const shouldEnable = !isDisabled && isProdOrDev && isCloud;
+
+console.log(`shouldEnableSentry: ${shouldEnable}`);
 
 Sentry.init({
   dsn: "https://fe4e4aa4a283391808a5da396da20159@o4505260022104064.ingest.us.sentry.io/4507946746380288",

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -246,7 +246,7 @@ export enum AppEnv {
 }
 
 export function getAppEnv(): AppEnv {
-  const env = process.env.NEXT_PUBLIC_APP_ENV;
+  const env = process.env.NEXT_PUBLIC_APP_ENV || process.env.APP_ENV;
   if (env === "dev") return AppEnv.DEV;
   if (env === "prod") return AppEnv.PROD;
   // Some places use prod and others production


### PR DESCRIPTION
## Summary
- Fixed Dockerfile environment variable merging that was causing Sentry to be disabled in dev/prod deployments
- Added authentication check to onboarding timezone detection to prevent unauthorized API calls
- Added Dockerfile to .prettierignore

## Problem
The dev and prod deployments had `isProdOrDev` evaluating to `false`, causing Sentry to be disabled even though `NEXT_PUBLIC_APP_ENV=dev` was set in the pod environment.

### Root Cause
1. CI/CD workflow creates `.env.production` with correct values
2. Dockerfile's env merging logic always created `.env` from `.env.default` 
3. Next.js loads `.env.production` first, then `.env` (which overwrites values)
4. `.env.default` has `NEXT_PUBLIC_APP_ENV=local`, overwriting the production value
5. This caused `getAppEnv()` to return "local" instead of "dev"/"prod"

## Solution
Updated Dockerfile to:
- Only merge `.env.default` with `.env` when NOT in CI/CD (no `.env.production` exists)
- When `.env.production` exists, merge it with `.env.default` to ensure all defaults are available
- Production values take precedence over defaults

## Additional Fixes
- Added authentication check to `useOnboardingTimezoneDetection` hook to prevent calling `/api/auth/user/timezone` when not logged in
- Added Dockerfile to .prettierignore to prevent formatter errors

## Test Plan
- [ ] Verify local Docker builds still work with `docker compose up`
- [ ] Verify dev deployment has `NEXT_PUBLIC_APP_ENV=dev` and Sentry enabled
- [ ] Verify prod deployment has `NEXT_PUBLIC_APP_ENV=prod` and Sentry enabled
- [ ] Verify onboarding timezone detection only runs when authenticated

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>