### PR TITLE
fix(backend): Report process errors to Sentry before cleanup

### DIFF
--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -33,7 +33,7 @@ def sentry_init():
     )
 
 
-def sentry_capture_error(error: Exception):
+def sentry_capture_error(error: BaseException):
     sentry_sdk.capture_exception(error)
     sentry_sdk.flush()
 

--- a/autogpt_platform/backend/backend/util/process.py
+++ b/autogpt_platform/backend/backend/util/process.py
@@ -76,6 +76,14 @@ class AppProcess(ABC):
             logger.warning(
                 f"[{self.service_name}] Termination request: {type(e).__name__}; {e} executing cleanup."
             )
+            # Send error to Sentry before cleanup
+            if not isinstance(e, (KeyboardInterrupt, SystemExit)):
+                try:
+                    from backend.util.metrics import sentry_capture_error
+
+                    sentry_capture_error(e)
+                except Exception:
+                    pass  # Silently ignore if Sentry isn't available
         finally:
             self.cleanup()
             logger.info(f"[{self.service_name}] Terminated.")


### PR DESCRIPTION
Adds error reporting to Sentry for exceptions (excluding KeyboardInterrupt and SystemExit) before executing process cleanup. Silently ignores failures if Sentry is unavailable.

<!-- Clearly explain the need for these changes: -->

### Changes 🏗️
Adds cleanup for sentry
Adds disabling for sentry
<!-- Concisely describe all of the changes made in this pull request: -->

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Test all services with manual exception raising
  - [x] Remove those excptions
  - [x] Make sure they show up in sentry