### PR TITLE
Revert "fix(backend): Improve GitHub PR URL validation and API URL generation"

### DIFF
--- a/autogpt_platform/backend/backend/blocks/github/pull_requests.py
+++ b/autogpt_platform/backend/backend/blocks/github/pull_requests.py
@@ -553,12 +553,11 @@ class GithubListPRReviewersBlock(Block):
 
 
 def prepare_pr_api_url(pr_url: str, path: str) -> str:
-    pattern = r"^(?:https?://)?github\.com/([^/]+/[^/]+)/pull/(\d+)"
+    # Pattern to capture the base repository URL and the pull request number
+    pattern = r"^(?:https?://)?([^/]+/[^/]+/[^/]+)/pull/(\d+)"
     match = re.match(pattern, pr_url)
     if not match:
-        raise ValueError(
-            f"Invalid GitHub PR URL: {pr_url}. URL must be a valid pull request URL, e.g., https://github.com/owner/repo/pull/123"
-        )
+        return pr_url
 
-    repo_path, pr_number = match.groups()
-    return f"{repo_path}/pulls/{pr_number}/{path}"
+    base_url, pr_number = match.groups()
+    return f"{base_url}/pulls/{pr_number}/{path}"


### PR DESCRIPTION
Reverts Significant-Gravitas/AutoGPT#10317

The changes omit the hostname from the "prepared" URL, breaking some GitHub blocks.