### PR TITLE
feat: Separate OpenAI key for smart agent execution summary and other internal AI calls

### DIFF
--- a/autogpt_platform/backend/backend/executor/activity_status_generator.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator.py
@@ -107,7 +107,7 @@ async def generate_activity_status_for_execution(
     # Check if we have OpenAI API key
     try:
         settings = Settings()
-        if not settings.secrets.openai_api_key:
+        if not settings.secrets.openai_internal_api_key:
             logger.debug(
                 "OpenAI API key not configured, skipping activity status generation"
             )
@@ -187,7 +187,7 @@ async def generate_activity_status_for_execution(
         credentials = APIKeyCredentials(
             id="openai",
             provider="openai",
-            api_key=SecretStr(settings.secrets.openai_api_key),
+            api_key=SecretStr(settings.secrets.openai_internal_api_key),
             title="System OpenAI",
         )
 

--- a/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
@@ -468,7 +468,7 @@ class TestGenerateActivityStatusForExecution:
         ):
 
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
-            mock_settings.return_value.secrets.openai_api_key = "test_key"
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
             mock_llm.return_value = (
                 "I analyzed your data and provided the requested insights."
             )
@@ -520,7 +520,7 @@ class TestGenerateActivityStatusForExecution:
             "backend.executor.activity_status_generator.is_feature_enabled",
             return_value=True,
         ):
-            mock_settings.return_value.secrets.openai_api_key = ""
+            mock_settings.return_value.secrets.openai_internal_api_key = ""
 
             result = await generate_activity_status_for_execution(
                 graph_exec_id="test_exec",
@@ -546,7 +546,7 @@ class TestGenerateActivityStatusForExecution:
             "backend.executor.activity_status_generator.is_feature_enabled",
             return_value=True,
         ):
-            mock_settings.return_value.secrets.openai_api_key = "test_key"
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
 
             result = await generate_activity_status_for_execution(
                 graph_exec_id="test_exec",
@@ -581,7 +581,7 @@ class TestGenerateActivityStatusForExecution:
         ):
 
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
-            mock_settings.return_value.secrets.openai_api_key = "test_key"
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
             mock_llm.return_value = "Agent completed execution."
 
             result = await generate_activity_status_for_execution(
@@ -633,7 +633,7 @@ class TestIntegration:
         ):
 
             mock_get_block.side_effect = lambda block_id: mock_blocks.get(block_id)
-            mock_settings.return_value.secrets.openai_api_key = "test_key"
+            mock_settings.return_value.secrets.openai_internal_api_key = "test_key"
 
             mock_response = LLMResponse(
                 raw_response={},

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -479,6 +479,9 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
     )
 
     openai_api_key: str = Field(default="", description="OpenAI API key")
+    openai_internal_api_key: str = Field(
+        default="", description="OpenAI Internal API key"
+    )
     aiml_api_key: str = Field(default="", description="'AI/ML API' key")
     anthropic_api_key: str = Field(default="", description="Anthropic API key")
     groq_api_key: str = Field(default="", description="Groq API key")


### PR DESCRIPTION
### Changes 🏗️

Separate the API key for internal usage (smart agent execution summary) and block usage.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  <!-- Put your test plan here: -->
  - [x] Manual test after deployment

