### PR TITLE
feat(backend): enhance agent retrieval logic in store agent page

### DIFF
--- a/autogpt_platform/backend/backend/server/v2/store/db.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db.py
@@ -183,6 +183,29 @@ async def get_store_agent_details(
             store_listing.hasApprovedVersion if store_listing else False
         )
 
+        if active_version_id:
+            agent_by_active = await prisma.models.StoreAgent.prisma().find_first(
+                where={"storeListingVersionId": active_version_id}
+            )
+            if agent_by_active:
+                agent = agent_by_active
+        elif store_listing:
+            latest_approved = (
+                await prisma.models.StoreListingVersion.prisma().find_first(
+                    where={
+                        "storeListingId": store_listing.id,
+                        "submissionStatus": prisma.enums.SubmissionStatus.APPROVED,
+                    },
+                    order=[{"version": "desc"}],
+                )
+            )
+            if latest_approved:
+                agent_latest = await prisma.models.StoreAgent.prisma().find_first(
+                    where={"storeListingVersionId": latest_approved.id}
+                )
+                if agent_latest:
+                    agent = agent_latest
+
         if store_listing and store_listing.ActiveVersion:
             recommended_schedule_cron = (
                 store_listing.ActiveVersion.recommendedScheduleCron
@@ -1141,7 +1164,20 @@ async def get_my_agents(
     try:
         search_filter: prisma.types.LibraryAgentWhereInput = {
             "userId": user_id,
-            "AgentGraph": {"is": {"StoreListings": {"none": {"isDeleted": False}}}},
+            "AgentGraph": {
+                "is": {
+                    "StoreListings": {
+                        "none": {
+                            "isDeleted": False,
+                            "Versions": {
+                                "some": {
+                                    "isAvailable": True,
+                                }
+                            },
+                        }
+                    }
+                }
+            },
             "isArchived": False,
             "isDeleted": False,
         }

--- a/autogpt_platform/backend/backend/server/v2/store/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db_test.py
@@ -139,6 +139,7 @@ async def test_get_store_agent_details(mocker):
         return_value=mock_profile
     )
 
+    # Mock StoreListing prisma call
     mock_store_listing_db = mocker.patch("prisma.models.StoreListing.prisma")
     mock_store_listing_db.return_value.find_first = mocker.AsyncMock(
         return_value=mock_store_listing
@@ -166,66 +167,6 @@ async def test_get_store_agent_details(mocker):
     )
     assert calls[1] == mocker.call(where={"storeListingVersionId": "active-version-id"})
 
-    mock_store_listing_db.return_value.find_first.assert_called_once()
-    # Mock data
-    mock_agent = prisma.models.StoreAgent(
-        listing_id="test-id",
-        storeListingVersionId="version123",
-        slug="test-agent",
-        agent_name="Test Agent",
-        agent_video="video.mp4",
-        agent_image=["image.jpg"],
-        featured=False,
-        creator_username="creator",
-        creator_avatar="avatar.jpg",
-        sub_heading="Test heading",
-        description="Test description",
-        categories=["test"],
-        runs=10,
-        rating=4.5,
-        versions=["1.0"],
-        updated_at=datetime.now(),
-        is_available=False,
-    )
-
-    # Create a mock StoreListing result
-    mock_store_listing = mocker.MagicMock()
-    mock_store_listing.activeVersionId = "active-version-id"
-    mock_store_listing.hasApprovedVersion = True
-    mock_store_listing.ActiveVersion = mocker.MagicMock()
-    mock_store_listing.ActiveVersion.recommendedScheduleCron = None
-
-    # Mock StoreAgent prisma call
-    mock_store_agent = mocker.patch("prisma.models.StoreAgent.prisma")
-    mock_store_agent.return_value.find_first = mocker.AsyncMock(return_value=mock_agent)
-
-    # Mock Profile prisma call
-    mock_profile = mocker.MagicMock()
-    mock_profile.userId = "user-id-123"
-    mock_profile_db = mocker.patch("prisma.models.Profile.prisma")
-    mock_profile_db.return_value.find_first = mocker.AsyncMock(
-        return_value=mock_profile
-    )
-
-    # Mock StoreListing prisma call - this is what was missing
-    mock_store_listing_db = mocker.patch("prisma.models.StoreListing.prisma")
-    mock_store_listing_db.return_value.find_first = mocker.AsyncMock(
-        return_value=mock_store_listing
-    )
-
-    # Call function
-    result = await db.get_store_agent_details("creator", "test-agent")
-
-    # Verify results
-    assert result.slug == "test-agent"
-    assert result.agent_name == "Test Agent"
-    assert result.active_version_id == "active-version-id"
-    assert result.has_approved_version is True
-
-    # Verify mocks called correctly
-    mock_store_agent.return_value.find_first.assert_called_once_with(
-        where={"creator_username": "creator", "slug": "test-agent"}
-    )
     mock_store_listing_db.return_value.find_first.assert_called_once()
 
 

--- a/autogpt_platform/backend/backend/server/v2/store/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db_test.py
@@ -86,6 +86,105 @@ async def test_get_store_agent_details(mocker):
         is_available=False,
     )
 
+    # Mock active version agent (what we want to return for active version)
+    mock_active_agent = prisma.models.StoreAgent(
+        listing_id="test-id",
+        storeListingVersionId="active-version-id",
+        slug="test-agent",
+        agent_name="Test Agent Active",
+        agent_video="active_video.mp4",
+        agent_image=["active_image.jpg"],
+        featured=False,
+        creator_username="creator",
+        creator_avatar="avatar.jpg",
+        sub_heading="Test heading active",
+        description="Test description active",
+        categories=["test"],
+        runs=15,
+        rating=4.8,
+        versions=["1.0", "2.0"],
+        updated_at=datetime.now(),
+        is_available=True,
+    )
+
+    # Create a mock StoreListing result
+    mock_store_listing = mocker.MagicMock()
+    mock_store_listing.activeVersionId = "active-version-id"
+    mock_store_listing.hasApprovedVersion = True
+    mock_store_listing.ActiveVersion = mocker.MagicMock()
+    mock_store_listing.ActiveVersion.recommendedScheduleCron = None
+
+    # Mock StoreAgent prisma call - need to handle multiple calls
+    mock_store_agent = mocker.patch("prisma.models.StoreAgent.prisma")
+    
+    # Set up side_effect to return different results for different calls
+    def mock_find_first_side_effect(*args, **kwargs):
+        where_clause = kwargs.get('where', {})
+        if 'storeListingVersionId' in where_clause:
+            # Second call for active version
+            return mock_active_agent
+        else:
+            # First call for initial lookup
+            return mock_agent
+    
+    mock_store_agent.return_value.find_first = mocker.AsyncMock(
+        side_effect=mock_find_first_side_effect
+    )
+
+    # Mock Profile prisma call
+    mock_profile = mocker.MagicMock()
+    mock_profile.userId = "user-id-123"
+    mock_profile_db = mocker.patch("prisma.models.Profile.prisma")
+    mock_profile_db.return_value.find_first = mocker.AsyncMock(
+        return_value=mock_profile
+    )
+
+    # Mock StoreListing prisma call - this is what was missing
+    mock_store_listing_db = mocker.patch("prisma.models.StoreListing.prisma")
+    mock_store_listing_db.return_value.find_first = mocker.AsyncMock(
+        return_value=mock_store_listing
+    )
+
+    # Call function
+    result = await db.get_store_agent_details("creator", "test-agent")
+
+    # Verify results - should use active version data
+    assert result.slug == "test-agent"
+    assert result.agent_name == "Test Agent Active"  # From active version
+    assert result.active_version_id == "active-version-id"
+    assert result.has_approved_version is True
+    assert result.store_listing_version_id == "active-version-id"  # Should be active version ID
+
+    # Verify mocks called correctly - now expecting 2 calls
+    assert mock_store_agent.return_value.find_first.call_count == 2
+    
+    # Check the specific calls
+    calls = mock_store_agent.return_value.find_first.call_args_list
+    assert calls[0] == mocker.call(where={"creator_username": "creator", "slug": "test-agent"})
+    assert calls[1] == mocker.call(where={"storeListingVersionId": "active-version-id"})
+    
+    mock_store_listing_db.return_value.find_first.assert_called_once()
+    # Mock data
+    mock_agent = prisma.models.StoreAgent(
+        listing_id="test-id",
+        storeListingVersionId="version123",
+        slug="test-agent",
+        agent_name="Test Agent",
+        agent_video="video.mp4",
+        agent_image=["image.jpg"],
+        featured=False,
+        creator_username="creator",
+        creator_avatar="avatar.jpg",
+        sub_heading="Test heading",
+        description="Test description",
+        categories=["test"],
+        runs=10,
+        rating=4.5,
+        versions=["1.0"],
+        updated_at=datetime.now(),
+        is_available=False,
+    )
+
     # Create a mock StoreListing result
     mock_store_listing = mocker.MagicMock()
     mock_store_listing.activeVersionId = "active-version-id"

--- a/autogpt_platform/backend/backend/server/v2/store/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db_test.py
@@ -116,17 +116,17 @@ async def test_get_store_agent_details(mocker):
 
     # Mock StoreAgent prisma call - need to handle multiple calls
     mock_store_agent = mocker.patch("prisma.models.StoreAgent.prisma")
-    
+
     # Set up side_effect to return different results for different calls
     def mock_find_first_side_effect(*args, **kwargs):
-        where_clause = kwargs.get('where', {})
-        if 'storeListingVersionId' in where_clause:
+        where_clause = kwargs.get("where", {})
+        if "storeListingVersionId" in where_clause:
             # Second call for active version
             return mock_active_agent
         else:
             # First call for initial lookup
             return mock_agent
-    
+
     mock_store_agent.return_value.find_first = mocker.AsyncMock(
         side_effect=mock_find_first_side_effect
     )
@@ -152,16 +152,20 @@ async def test_get_store_agent_details(mocker):
     assert result.agent_name == "Test Agent Active"  # From active version
     assert result.active_version_id == "active-version-id"
     assert result.has_approved_version is True
-    assert result.store_listing_version_id == "active-version-id"  # Should be active version ID
+    assert (
+        result.store_listing_version_id == "active-version-id"
+    )  # Should be active version ID
 
     # Verify mocks called correctly - now expecting 2 calls
     assert mock_store_agent.return_value.find_first.call_count == 2
-    
+
     # Check the specific calls
     calls = mock_store_agent.return_value.find_first.call_args_list
-    assert calls[0] == mocker.call(where={"creator_username": "creator", "slug": "test-agent"})
+    assert calls[0] == mocker.call(
+        where={"creator_username": "creator", "slug": "test-agent"}
+    )
     assert calls[1] == mocker.call(where={"storeListingVersionId": "active-version-id"})
-    
+
     mock_store_listing_db.return_value.find_first.assert_called_once()
     # Mock data
     mock_agent = prisma.models.StoreAgent(

--- a/autogpt_platform/backend/backend/server/v2/store/db_test.py
+++ b/autogpt_platform/backend/backend/server/v2/store/db_test.py
@@ -139,7 +139,6 @@ async def test_get_store_agent_details(mocker):
         return_value=mock_profile
     )
 
-    # Mock StoreListing prisma call - this is what was missing
     mock_store_listing_db = mocker.patch("prisma.models.StoreListing.prisma")
     mock_store_listing_db.return_value.find_first = mocker.AsyncMock(
         return_value=mock_store_listing


### PR DESCRIPTION
This PR enhances the agent retrieval logic in the store database to ensure accurate fetching of the latest approved agent versions. The changes address scenarios where agents may have multiple versions with different approval statuses.

## 🔧 Changes Made

### Enhanced Agent Retrieval Logic (`get_store_agent_details`)
- **Active Version Priority**: Added logic to prioritize fetching agents based on the `activeVersionId` when available
- **Fallback to Latest Approved**: When no active version is set, the system now falls back to the latest approved version (sorted by version number descending)
- **Improved Accuracy**: Ensures users always see the most relevant agent version based on the current store listing state

### Improved Agent Filtering (`get_my_agents`)
- **Enhanced Store Listing Filter**: Modified the filter to only include store listings that have at least one available version
- **Nested Version Check**: Added nested filtering to check for `isAvailable: true` in the versions, preventing empty or unavailable listings from appearing

## ✅ Testing Checklist

- [x] Test fetching agent details with an active version set
- [x] Test fetching agent details without an active version (should fall back to latest approved)
- [x] Test `get_my_agents` returns only agents with available store listing versions
- [x] Verify no agents with only unavailable versions appear in results
- [x] Test with agents having multiple versions with different approval statuses