### PR TITLE
ci(backend): Update redis image

### DIFF
--- a/.github/workflows/platform-backend-ci.yml
+++ b/.github/workflows/platform-backend-ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     services:
       redis:
-        image: bitnami/redis:6.2
+        image: redis:latest
         env:
           REDIS_PASSWORD: testpassword
         ports:


### PR DESCRIPTION
CI is currently broken because Bitnami has pulled all `bitnami/redis` images.
The current official Redis image on Docker Hub is `redis`.

### Changes 🏗️

- Replace `bitnami/redis:6.2` by `redis:latest` in Backend CI workflow file

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] CI no longer broken
