### PR TITLE
fix(blocks): Default disable HTML escaping in all blocks with templating features

### DIFF
--- a/autogpt_platform/backend/backend/blocks/io.py
+++ b/autogpt_platform/backend/backend/blocks/io.py
@@ -10,7 +10,6 @@ from backend.util.settings import Config
 from backend.util.text import TextFormatter
 from backend.util.type import LongTextType, MediaFileType, ShortTextType
 
-formatter = TextFormatter()
 config = Config()
 
 
@@ -132,6 +131,11 @@ class AgentOutputBlock(Block):
             default="",
             advanced=True,
         )
+        escape_html: bool = SchemaField(
+            default=False,
+            advanced=True,
+            description="Whether to escape special characters in the inserted values to be HTML-safe. Enable for HTML output, disable for plain text.",
+        )
         advanced: bool = SchemaField(
             description="Whether to treat the output as advanced.",
             default=False,
@@ -193,6 +197,7 @@ class AgentOutputBlock(Block):
         """
         if input_data.format:
             try:
+                formatter = TextFormatter(autoescape=input_data.escape_html)
                 yield "output", formatter.format_string(
                     input_data.format, {input_data.name: input_data.value}
                 )

--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -27,7 +27,7 @@ from backend.util.prompt import compress_prompt, estimate_token_count
 from backend.util.text import TextFormatter
 
 logger = TruncatedLogger(logging.getLogger(__name__), "[LLM-Block]")
-fmt = TextFormatter()
+fmt = TextFormatter(autoescape=False)
 
 LLMProviderName = Literal[
     ProviderName.AIML_API,

--- a/autogpt_platform/backend/backend/blocks/text.py
+++ b/autogpt_platform/backend/backend/blocks/text.py
@@ -172,6 +172,11 @@ class FillTextTemplateBlock(Block):
         format: str = SchemaField(
             description="Template to format the text using `values`. Use Jinja2 syntax."
         )
+        escape_html: bool = SchemaField(
+            default=False,
+            advanced=True,
+            description="Whether to escape special characters in the inserted values to be HTML-safe. Enable for HTML output, disable for plain text.",
+        )
 
     class Output(BlockSchema):
         output: str = SchemaField(description="Formatted text")
@@ -205,6 +210,7 @@ class FillTextTemplateBlock(Block):
         )
 
     async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        formatter = text.TextFormatter(autoescape=input_data.escape_html)
         yield "output", formatter.format_string(input_data.format, input_data.values)
 
 

--- a/autogpt_platform/backend/backend/util/text.py
+++ b/autogpt_platform/backend/backend/util/text.py
@@ -16,8 +16,8 @@ def format_filter_for_jinja2(value, format_string=None):
 
 
 class TextFormatter:
-    def __init__(self):
-        self.env = SandboxedEnvironment(loader=BaseLoader(), autoescape=True)
+    def __init__(self, autoescape: bool = True):
+        self.env = SandboxedEnvironment(loader=BaseLoader(), autoescape=autoescape)
         self.env.globals.clear()
 
         # Instead of clearing all filters, just remove potentially unsafe ones


### PR DESCRIPTION
- Resolves #10954

Unnecessary escaping distorts content and so should be disabled wherever the output isn't used in HTML.

### Changes 🏗️

- Disable HTML escaping on prompt value insertion in AI blocks
- Make HTML escaping optional in text formatting and output blocks

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `SandboxedEnvironment(autoescape=False).from_string(template_str).render(values)` doesn't escape characters with HTML entities
