### PR TITLE
fix(backend): improve database health check and service retry resilience

### DIFF
--- a/autogpt_platform/backend/backend/executor/database.py
+++ b/autogpt_platform/backend/backend/executor/database.py
@@ -85,6 +85,16 @@ class DatabaseManager(AppService):
     async def health_check(self) -> str:
         if not db.is_connected():
             raise UnhealthyServiceError("Database is not connected")
+
+        try:
+            # Test actual database connectivity by executing a simple query
+            # This will fail if Prisma query engine is not responding
+            result = await db.query_raw_with_schema("SELECT 1 as health_check")
+            if not result or result[0].get("health_check") != 1:
+                raise UnhealthyServiceError("Database query test failed")
+        except Exception as e:
+            raise UnhealthyServiceError(f"Database health check failed: {e}")
+
         return await super().health_check()
 
     @classmethod

--- a/autogpt_platform/backend/backend/util/service.py
+++ b/autogpt_platform/backend/backend/util/service.py
@@ -43,6 +43,7 @@ api_host = config.pyro_host
 api_comm_retry = config.pyro_client_comm_retry
 api_comm_timeout = config.pyro_client_comm_timeout
 api_call_timeout = config.rpc_client_call_timeout
+api_comm_max_wait = config.pyro_client_max_wait
 
 
 def _validate_no_prisma_objects(obj: Any, path: str = "result") -> None:
@@ -352,7 +353,7 @@ def get_service_client(
         # Use preconfigured retry decorator for service communication
         return create_retry_decorator(
             max_attempts=api_comm_retry,
-            max_wait=5.0,
+            max_wait=api_comm_max_wait,
             context="Service communication",
             exclude_exceptions=(
                 # Don't retry these specific exceptions that won't be fixed by retrying

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -68,8 +68,12 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         description="The default timeout in seconds, for Pyro client connections.",
     )
     pyro_client_comm_retry: int = Field(
-        default=5,
+        default=8,
         description="The default number of retries for Pyro client connections.",
+    )
+    pyro_client_max_wait: float = Field(
+        default=15.0,
+        description="The maximum wait time in seconds for Pyro client retries.",
     )
     rpc_client_call_timeout: int = Field(
         default=300,


### PR DESCRIPTION
## Summary

Fixes critical intermittent execution failures where workflows stop prematurely due to database connectivity issues between the database manager and Supabase.

**Root Cause:** Execution ID `230a8036-9ba7-47c3-8f01-40bf21a9ff42` failed because:
- Database manager returned HTTP 500 errors during `get_node()` calls
- Existing health checks only tested connection state, not actual query execution
- Insufficient retry attempts (5) and short max wait time (5s) for transient issues

## Database Manager Health Check Improvements

- **Replace ineffective health check** that only checked `db.is_connected()`
- **Add actual database query test** using `db.query_raw_with_schema("SELECT 1 as health_check")`
- **Detect Prisma query engine failures** that cause HTTP 500 errors during execution
- **Detailed error messaging** for better observability and debugging

**Before:** Health check passed even when Prisma query engine was failing
**After:** Health check fails when database queries fail, triggering pod restarts

## Service Communication Retry Enhancements  

- **Increase retry attempts** from 5 to 8 for better resilience  
- **Add configurable max wait time** (`pyro_client_max_wait`, default 15s vs 5s hardcoded)
- **Longer retry intervals** help handle intermittent Supabase connectivity issues
- **Maintains existing exception exclusions** for non-retryable errors (4xx, validation, etc.)

## Impact

- ✅ **Prevents execution engine failures** from database connectivity issues
- ✅ **Kubernetes will restart unhealthy pods** when real database problems occur  
- ✅ **Better handling of intermittent Supabase service degradation**
- ✅ **More resilient service-to-service communication** across the platform
- ✅ **Reduces false-positive executions** that appear successful but stop prematurely

## Test plan

- [x] Health check properly fails when database queries fail
- [x] Health check passes when database is working correctly  
- [x] Retry configuration is applied to database manager calls
- [x] Code formatting and linting pass
- [ ] Deploy to dev environment and monitor execution success rates
- [ ] Monitor pod restart frequency in production

🤖 Generated with [Claude Code](https://claude.ai/code)