### PR TITLE
hotfix: Fix Agent node missing inputs and outputs

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -815,9 +815,9 @@ async def list_graphs_paginated(
         where=where_clause,
         distinct=["id"],
         order={"version": "desc"},
+        include=AGENT_GRAPH_INCLUDE,
         skip=offset,
         take=page_size,
-        # Don't include nodes for list endpoint - GraphMeta excludes them anyway
     )
 
     graph_models: list[GraphMeta] = []


### PR DESCRIPTION
Restore `include=AGENT_GRAPH_INCLUDE` that is needed to build schema from the nodes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] I/O is back on the Agent node