### PR TITLE
Update linear oauth to use refresh tokens

### DIFF
--- a/LINEAR_OAUTH_IMPLEMENTATION.md
+++ b/LINEAR_OAUTH_IMPLEMENTATION.md
@@ -1,0 +1,108 @@
+# Linear OAuth Refresh Token Implementation
+
+## Overview
+
+This document describes the implementation of Linear's new OAuth2 refresh token system in the AutoGPT platform. Linear is migrating from long-lived access tokens to short-lived access tokens with refresh tokens, with full transition required by April 1, 2026.
+
+## Changes Made
+
+### 1. Updated Linear OAuth Handler (`/autogpt_platform/backend/backend/blocks/linear/_oauth.py`)
+
+#### Key Improvements:
+
+1. **Refresh Token Support**: 
+   - Added support for refresh tokens in token requests
+   - Implemented HTTP Basic Authentication for refresh token requests (preferred by Linear)
+   - Enhanced error handling with detailed error descriptions
+
+2. **Token Migration**:
+   - Added `migrate_old_token()` method to migrate old long-lived tokens to new short-lived tokens with refresh tokens
+   - Added `needs_migration()` method to detect old tokens that need migration
+   - Overridden `get_access_token()` to automatically handle migration when needed
+
+3. **Enhanced Token Handling**:
+   - Updated `_request_tokens()` to handle both authorization code and refresh token flows
+   - Added proper token expiration handling for short-lived tokens
+   - Improved username extraction and preservation during token refresh
+
+4. **Backward Compatibility**:
+   - Maintains support for existing long-lived tokens
+   - Graceful fallback if migration fails
+   - Automatic detection of token types
+
+#### New Methods:
+
+- `migrate_old_token(credentials)`: Migrates old tokens using Linear's `/oauth/migrate_old_token` endpoint
+- `needs_migration(credentials)`: Checks if credentials need migration
+- `get_access_token(credentials)`: Enhanced method with automatic migration support
+
+### 2. Updated Test Credentials (`/autogpt_platform/backend/backend/blocks/linear/_config.py`)
+
+- Updated mock credentials to include proper expiration times for testing short-lived tokens
+- Added realistic scope examples
+
+## Technical Details
+
+### Authentication Methods
+
+The implementation supports both authentication methods recommended by Linear:
+
+1. **HTTP Basic Authentication** (preferred for refresh tokens):
+   ```http
+   Authorization: Basic <base64(client_id:client_secret)>
+   ```
+
+2. **Form Parameters**:
+   ```http
+   client_id=...&client_secret=...
+   ```
+
+### Token Flow
+
+1. **New Tokens**: Receive both access and refresh tokens with expiration
+2. **Old Token Migration**: Automatically detects and migrates old tokens
+3. **Token Refresh**: Uses refresh tokens to get new access tokens when needed
+4. **Fallback**: Maintains backward compatibility with old long-lived tokens
+
+### Error Handling
+
+- Enhanced error messages with both error and error_description fields
+- Graceful handling of migration failures
+- Proper exception types for different failure scenarios
+
+## Migration Strategy
+
+The implementation provides a seamless migration path:
+
+1. **Automatic Detection**: Old tokens are detected by having no expiration and no refresh token
+2. **On-Demand Migration**: When `get_access_token()` is called on old tokens, migration is attempted
+3. **Fallback**: If migration fails, the old token is used as-is for backward compatibility
+4. **Manual Migration**: The `migrate_old_token()` method can be called explicitly if needed
+
+## Testing
+
+The implementation has been tested for:
+
+- ✅ OAuth URL generation with proper parameter encoding
+- ✅ HTTP Basic Authentication header generation
+- ✅ Token expiration logic with 5-minute buffer
+- ✅ Migration detection for old vs new tokens
+- ✅ Syntax and import compatibility
+
+## Next Steps
+
+1. **Enable Refresh Tokens in Linear Console**: Navigate to Linear OAuth application settings and enable refresh tokens
+2. **Monitor Token Usage**: Watch for automatic migrations in logs
+3. **Update Credentials Store**: Consider implementing automatic credential updates when migration occurs
+4. **Testing**: Test with real Linear OAuth flow once refresh tokens are enabled
+
+## Important Dates
+
+- **October 1, 2025**: New OAuth applications use refresh tokens by default
+- **April 1, 2026**: All newly issued tokens will be short-lived (deadline for migration)
+
+## References
+
+- [Linear OAuth Documentation](https://linear.app/developers/oauth-2-0-authentication)
+- [Linear Token Refresh Guide](https://linear.app/developers/oauth-2-0-authentication#refresh-an-access-token)
+- [Linear Migration Guide](https://linear.app/developers/oauth-2-0-authentication#migrate-to-using-refresh-tokens)

--- a/autogpt_platform/backend/backend/blocks/linear/_config.py
+++ b/autogpt_platform/backend/backend/blocks/linear/_config.py
@@ -62,10 +62,10 @@ TEST_CREDENTIALS_OAUTH = OAuth2Credentials(
     title="Mock Linear API key",
     username="mock-linear-username",
     access_token=SecretStr("mock-linear-access-token"),
-    access_token_expires_at=None,
+    access_token_expires_at=1672531200,  # Mock expiration time for short-lived token
     refresh_token=SecretStr("mock-linear-refresh-token"),
     refresh_token_expires_at=None,
-    scopes=["mock-linear-scopes"],
+    scopes=["read", "write"],
 )
 
 TEST_CREDENTIALS_API_KEY = APIKeyCredentials(

--- a/autogpt_platform/backend/backend/blocks/linear/_oauth.py
+++ b/autogpt_platform/backend/backend/blocks/linear/_oauth.py
@@ -2,7 +2,9 @@
 Linear OAuth handler implementation.
 """
 
+import base64
 import json
+import time
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -38,8 +40,9 @@ class LinearOAuthHandler(BaseOAuthHandler):
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
         self.auth_base_url = "https://linear.app/oauth/authorize"
-        self.token_url = "https://api.linear.app/oauth/token"  # Correct token URL
+        self.token_url = "https://api.linear.app/oauth/token"
         self.revoke_url = "https://api.linear.app/oauth/revoke"
+        self.migrate_url = "https://api.linear.app/oauth/migrate_old_token"
 
     def get_login_url(
         self, scopes: list[str], state: str, code_challenge: Optional[str]
@@ -82,19 +85,84 @@ class LinearOAuthHandler(BaseOAuthHandler):
 
         return True  # Linear doesn't return JSON on successful revoke
 
+    async def migrate_old_token(
+        self, credentials: OAuth2Credentials
+    ) -> OAuth2Credentials:
+        """
+        Migrate an old long-lived token to a new short-lived token with refresh token.
+        
+        This uses Linear's /oauth/migrate_old_token endpoint to exchange current 
+        long-lived tokens for short-lived tokens with refresh tokens without 
+        requiring users to re-authorize.
+        """
+        if not credentials.access_token:
+            raise ValueError("No access token to migrate")
+
+        request_body = {
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {credentials.access_token.get_secret_value()}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        response = await Requests().post(
+            self.migrate_url, data=request_body, headers=headers
+        )
+
+        if not response.ok:
+            try:
+                error_data = response.json()
+                error_message = error_data.get("error", "Unknown error")
+                error_description = error_data.get("error_description", "")
+                if error_description:
+                    error_message = f"{error_message}: {error_description}"
+            except json.JSONDecodeError:
+                error_message = response.text
+            raise LinearAPIException(
+                f"Failed to migrate Linear token ({response.status}): {error_message}",
+                response.status,
+            )
+
+        token_data = response.json()
+
+        # Extract token expiration
+        now = int(time.time())
+        expires_in = token_data.get("expires_in")
+        access_token_expires_at = None
+        if expires_in:
+            access_token_expires_at = now + expires_in
+
+        new_credentials = OAuth2Credentials(
+            provider=self.PROVIDER_NAME,
+            title=credentials.title,
+            username=credentials.username,
+            access_token=token_data["access_token"],
+            scopes=credentials.scopes,  # Preserve original scopes
+            refresh_token=token_data.get("refresh_token"),
+            access_token_expires_at=access_token_expires_at,
+            refresh_token_expires_at=None,
+        )
+        
+        new_credentials.id = credentials.id
+        return new_credentials
+
     async def _refresh_tokens(
         self, credentials: OAuth2Credentials
     ) -> OAuth2Credentials:
         if not credentials.refresh_token:
             raise ValueError(
-                "No refresh token available."
-            )  # Linear uses non-expiring tokens
+                "No refresh token available. Token may need to be migrated to the new refresh token system."
+            )
 
         return await self._request_tokens(
             {
                 "refresh_token": credentials.refresh_token.get_secret_value(),
                 "grant_type": "refresh_token",
-            }
+            },
+            current_credentials=credentials,
         )
 
     async def _request_tokens(
@@ -102,16 +170,35 @@ class LinearOAuthHandler(BaseOAuthHandler):
         params: dict[str, str],
         current_credentials: Optional[OAuth2Credentials] = None,
     ) -> OAuth2Credentials:
+        # Determine if this is a refresh token request
+        is_refresh = params.get("grant_type") == "refresh_token"
+        
+        # Build request body with appropriate grant_type
         request_body = {
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "grant_type": "authorization_code",  # Ensure grant_type is correct
             **params,
         }
+        
+        # Set default grant_type if not provided
+        if "grant_type" not in request_body:
+            request_body["grant_type"] = "authorization_code"
 
         headers = {
             "Content-Type": "application/x-www-form-urlencoded"
-        }  # Correct header for token request
+        }
+        
+        # For refresh token requests, support HTTP Basic Authentication as recommended
+        if is_refresh:
+            # Option 1: Use HTTP Basic Auth (preferred by Linear)
+            client_credentials = f"{self.client_id}:{self.client_secret}"
+            encoded_credentials = base64.b64encode(client_credentials.encode()).decode()
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+            
+            # Remove client credentials from body when using Basic Auth
+            request_body.pop("client_id", None)
+            request_body.pop("client_secret", None)
+
         response = await Requests().post(
             self.token_url, data=request_body, headers=headers
         )
@@ -120,6 +207,9 @@ class LinearOAuthHandler(BaseOAuthHandler):
             try:
                 error_data = response.json()
                 error_message = error_data.get("error", "Unknown error")
+                error_description = error_data.get("error_description", "")
+                if error_description:
+                    error_message = f"{error_message}: {error_description}"
             except json.JSONDecodeError:
                 error_message = response.text
             raise LinearAPIException(
@@ -129,26 +219,79 @@ class LinearOAuthHandler(BaseOAuthHandler):
 
         token_data = response.json()
 
-        # Note: Linear access tokens do not expire, so we set expires_at to None
+        # Extract token expiration if provided (for new refresh token implementation)
+        now = int(time.time())
+        expires_in = token_data.get("expires_in")
+        access_token_expires_at = None
+        if expires_in:
+            access_token_expires_at = now + expires_in
+
+        # Get username - preserve from current credentials if refreshing
+        username = None
+        if current_credentials and is_refresh:
+            username = current_credentials.username
+        elif "user" in token_data:
+            username = token_data["user"].get("name", "Unknown User")
+        else:
+            # Fetch username using the access token
+            username = await self._request_username(token_data["access_token"])
+
         new_credentials = OAuth2Credentials(
             provider=self.PROVIDER_NAME,
             title=current_credentials.title if current_credentials else None,
-            username=token_data.get("user", {}).get(
-                "name", "Unknown User"
-            ),  # extract name or set appropriate
+            username=username or "Unknown User",
             access_token=token_data["access_token"],
-            scopes=token_data["scope"].split(
-                ","
-            ),  # Linear returns comma-separated scopes
-            refresh_token=token_data.get(
-                "refresh_token"
-            ),  # Linear uses non-expiring tokens so this might be null
-            access_token_expires_at=None,
-            refresh_token_expires_at=None,
+            scopes=token_data["scope"].split(",") if "scope" in token_data else (
+                current_credentials.scopes if current_credentials else []
+            ),
+            refresh_token=token_data.get("refresh_token"),
+            access_token_expires_at=access_token_expires_at,
+            refresh_token_expires_at=None,  # Linear doesn't provide refresh token expiration
         )
+        
         if current_credentials:
             new_credentials.id = current_credentials.id
+            
         return new_credentials
+
+    async def get_access_token(self, credentials: OAuth2Credentials) -> str:
+        """
+        Returns a valid access token, handling migration and refresh as needed.
+        
+        This overrides the base implementation to handle Linear's token migration
+        from old long-lived tokens to new short-lived tokens with refresh tokens.
+        """
+        # If token has no expiration and no refresh token, it might be an old token
+        # that needs migration
+        if (credentials.access_token_expires_at is None and 
+            credentials.refresh_token is None):
+            try:
+                # Attempt to migrate the old token
+                migrated_credentials = await self.migrate_old_token(credentials)
+                # Update the credentials store would need to be handled by the caller
+                # For now, use the migrated credentials for this request
+                credentials = migrated_credentials
+            except LinearAPIException:
+                # Migration failed, try to use the old token as-is
+                # This maintains backward compatibility
+                pass
+
+        # Use the standard refresh logic from the base class
+        if self.needs_refresh(credentials):
+            credentials = await self.refresh_tokens(credentials)
+            
+        return credentials.access_token.get_secret_value()
+
+    def needs_migration(self, credentials: OAuth2Credentials) -> bool:
+        """
+        Check if credentials represent an old long-lived token that needs migration.
+        
+        Old tokens have no expiration time and no refresh token.
+        """
+        return (
+            credentials.access_token_expires_at is None and 
+            credentials.refresh_token is None
+        )
 
     async def _request_username(self, access_token: str) -> Optional[str]:
         # Use the LinearClient to fetch user details using GraphQL


### PR DESCRIPTION
<!-- Clearly explain the need for these changes: -->

### Need 💡

This PR addresses Linear issue SECRT-1665, which mandates an update to Linear's OAuth2 implementation. Linear is transitioning from long-lived access tokens to short-lived access tokens with refresh tokens, with a deadline of April 1, 2026. This change is crucial to ensure continued integration with Linear and to support their new token management system, including a migration path for existing long-lived tokens.

### Changes 🏗️

-   **`autogpt_platform/backend/backend/blocks/linear/_oauth.py`**:
    -   Implemented full support for refresh tokens, including HTTP Basic Authentication for token refresh requests.
    -   Added `migrate_old_token()` method to exchange old long-lived access tokens for new short-lived tokens with refresh tokens using Linear's `/oauth/migrate_old_token` endpoint.
    -   Enhanced `get_access_token()` to automatically detect and attempt migration for old tokens, and to refresh short-lived tokens when they expire.
    -   Improved error handling and token expiration management.
    -   Updated `_request_tokens` to handle both authorization code and refresh token flows, supporting Linear's recommended authentication methods.
-   **`autogpt_platform/backend/backend/blocks/linear/_config.py`**:
    -   Updated `TEST_CREDENTIALS_OAUTH` mock data to include realistic `access_token_expires_at` and `refresh_token` for testing the new token lifecycle.
-   **`LINEAR_OAUTH_IMPLEMENTATION.md`**:
    -   Added documentation detailing the new Linear OAuth refresh token implementation, including technical details, migration strategy, and testing notes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified OAuth URL generation and parameter encoding.
  - [x] Confirmed HTTP Basic Authentication header creation for refresh requests.
  - [x] Tested token expiration logic with a 5-minute buffer.
  - [x] Validated migration detection for old vs. new token types.
  - [x] Checked code syntax and import compatibility.

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

---
Linear Issue: [SECRT-1665](https://linear.app/autogpt/issue/SECRT-1665)

<a href="https://cursor.com/background-agent?bcId=bc-95f4c668-f7fa-4057-87e5-622ac81c0783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95f4c668-f7fa-4057-87e5-622ac81c0783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

