### PR TITLE
feat(blocks): Add WordPress Get All Posts block and Publish Post draft toggle

### DIFF
--- a/autogpt_platform/backend/backend/blocks/wordpress/__init__.py
+++ b/autogpt_platform/backend/backend/blocks/wordpress/__init__.py
@@ -1,3 +1,3 @@
-from .blog import WordPressCreatePostBlock
+from .blog import WordPressCreatePostBlock, WordPressGetAllPostsBlock
 
-__all__ = ["WordPressCreatePostBlock"]
+__all__ = ["WordPressCreatePostBlock", "WordPressGetAllPostsBlock"]


### PR DESCRIPTION
Implements issue #11002

## Summary
- Add new WordPressGetAllPostsBlock that fetches all posts from WordPress
- Support filtering posts by status (published/draft/pending/etc)
- Add pagination support with number and offset parameters
- Enhance WordPressCreatePostBlock with publish_as_draft toggle
- Allow publishing posts as draft or public based on user preference

Fixes #11002

Generated with [Claude Code](https://claude.ai/code)