### PR TITLE
fix(backend): resolve two critical long-running agent execution failures

### DIFF
--- a/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
+++ b/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
@@ -556,33 +556,22 @@ class SmartDecisionMakerBlock(Block):
                 None,
             )
 
+            # Get parameters schema from tool definition
             if (
                 tool_def
                 and "function" in tool_def
                 and "parameters" in tool_def["function"]
             ):
-                expected_args = tool_def["function"]["parameters"].get("properties", {})
+                parameters = tool_def["function"]["parameters"]
+                expected_args = parameters.get("properties", {})
+                required_params = set(parameters.get("required", []))
             else:
-                expected_args = tool_args.keys()
+                expected_args = {arg: {} for arg in tool_args.keys()}
+                required_params = set()
 
             # Validate tool call arguments and provide detailed error messages
             provided_args = set(tool_args.keys())
-            expected_args_set = (
-                set(expected_args.keys())
-                if isinstance(expected_args, dict)
-                else set(expected_args)
-            )
-
-            # Get required parameters from the schema
-            required_params = set()
-            if (
-                tool_def
-                and "function" in tool_def
-                and "parameters" in tool_def["function"]
-            ):
-                required_params = set(
-                    tool_def["function"]["parameters"].get("required", [])
-                )
+            expected_args_set = set(expected_args.keys())
 
             # Check for unexpected arguments (typos)
             unexpected_args = provided_args - expected_args_set

--- a/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
+++ b/autogpt_platform/backend/backend/blocks/smart_decision_maker.py
@@ -565,12 +565,44 @@ class SmartDecisionMakerBlock(Block):
             else:
                 expected_args = tool_args.keys()
 
-            # Yield provided arguments and None for missing ones
+            # Validate tool call arguments and provide detailed error messages
+            provided_args = set(tool_args.keys())
+            expected_args_set = (
+                set(expected_args.keys())
+                if isinstance(expected_args, dict)
+                else set(expected_args)
+            )
+
+            # Get required parameters from the schema
+            required_params = set()
+            if (
+                tool_def
+                and "function" in tool_def
+                and "parameters" in tool_def["function"]
+            ):
+                required_params = set(
+                    tool_def["function"]["parameters"].get("required", [])
+                )
+
+            # Check for unexpected arguments (typos)
+            unexpected_args = provided_args - expected_args_set
+            # Only check for missing REQUIRED parameters
+            missing_required_args = required_params - provided_args
+
+            if unexpected_args or missing_required_args:
+                error_msg = f"Tool call '{tool_name}' has parameter errors:"
+                if unexpected_args:
+                    error_msg += f" Unknown parameters: {sorted(unexpected_args)}."
+                if missing_required_args:
+                    error_msg += f" Missing required parameters: {sorted(missing_required_args)}."
+                error_msg += f" Expected parameters: {sorted(expected_args_set)}."
+                if required_params:
+                    error_msg += f" Required parameters: {sorted(required_params)}."
+                raise ValueError(error_msg)
+
+            # Yield provided arguments, use .get() for optional parameters
             for arg_name in expected_args:
-                if arg_name in tool_args:
-                    yield f"tools_^_{tool_name}_~_{arg_name}", tool_args[arg_name]
-                else:
-                    yield f"tools_^_{tool_name}_~_{arg_name}", None
+                yield f"tools_^_{tool_name}_~_{arg_name}", tool_args.get(arg_name)
 
         # Add reasoning to conversation history if available
         if response.reasoning:

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -1735,7 +1735,10 @@ async def synchronized(key: str, timeout: int = settings.config.cluster_lock_tim
         yield
     finally:
         if await lock.locked() and await lock.owned():
-            await lock.release()
+            try:
+                await lock.release()
+            except Exception as e:
+                logger.warning(f"Failed to release lock for key {key}: {e}")
 
 
 def increment_execution_count(user_id: str) -> int:


### PR DESCRIPTION
## Summary

Fix two production issues causing agent execution failures that occurred this morning:

1. **AsyncRedisLock Release Error** (ExecutionID: 08b2c251-ee27-45de-b88d-1792823ca3ee)
   - Error: "Cannot release a lock that's no longer owned" 
   - Root cause: Race condition where lock expires during long database operations
   - Location: backend/executor/manager.py synchronized context manager

2. **Tool Call Parameter Validation** (ExecutionID: 766fd9a0-5f22-4a77-96e8-14c9d02f3292)
   - Issue: LLM used typo'd parameter 'maximum_keyword_difficulty' instead of 'max_keyword_difficulty'
   - SmartDecisionMakerBlock silently accepted typo, setting correct parameter to null
   - Result: Downstream blocks received null values causing execution failures

## Changes Made

### AsyncRedisLock Error Handling
- Add try-catch blocks around AsyncRedisLock.release() calls in ExecutionManager and OAuth refresh
- Prevent crashes when locks expire between ownership check and release
- Log warnings instead of crashing execution

### Tool Call Parameter Validation  
- **Reject unknown parameters**: Raise ValueError for typo'd parameter names with detailed error messages
- **Allow optional parameters**: Only validate missing REQUIRED parameters 
- **Safe parameter access**: Use .get() to handle optional parameters with defaults
- **Clean code**: Extract parameters object once to eliminate duplication

## Technical Implementation

**Lock Release Protection:**
```python
if await lock.locked() and await lock.owned():
    try:
        await lock.release()
    except Exception as e:
        logger.warning(f"Failed to release lock for key {key}: {e}")
```

**Parameter Validation Logic:**
```python
# Get parameters schema from tool definition  
if tool_def and "function" in tool_def and "parameters" in tool_def["function"]:
    parameters = tool_def["function"]["parameters"]
    expected_args = parameters.get("properties", {})
    required_params = set(parameters.get("required", []))

# Detect parameter typos and missing required params
unexpected_args = provided_args - expected_args_set  
missing_required_args = required_params - provided_args

if unexpected_args or missing_required_args:
    raise ValueError(error_msg)  # Detailed error explaining the problem
```

## Testing

- [x] All existing tests pass
- [x] Lock error handling prevents execution crashes  
- [x] Tool validation catches typos while allowing optional parameters
- [x] Maintains backward compatibility with existing workflows

## Impact

- ✅ No more "Cannot release a lock" crashes during long database operations
- ✅ Tool calls with typo'd parameters are rejected with clear error messages
- ✅ Optional parameters work correctly with default values  
- ✅ Production stability improved with graceful error handling

## Files Modified

- `backend/executor/manager.py` - AsyncRedisLock error handling in synchronized context
- `backend/integrations/creds_manager.py` - OAuth refresh lock error handling  
- `backend/blocks/smart_decision_maker.py` - Tool call parameter validation with typo detection

Fixes two critical production failures that were causing 2/5 agent runs to fail this morning.