### PR TITLE
feat(platform): Simplify running of core docker services

### DIFF
--- a/autogpt_platform/Makefile
+++ b/autogpt_platform/Makefile
@@ -1,0 +1,19 @@
+.PHONY: core-services stop-core logs-core
+
+# Run just Supabase + Redis + RabbitMQ
+core-services:
+	docker compose up -d kong auth db redis rabbitmq
+
+# Stop core services
+stop-core:
+	docker compose stop kong auth db redis rabbitmq
+
+# View logs for core services
+logs-core:
+	docker compose logs -f kong auth db redis rabbitmq
+
+# Run formatting and linting for backend and frontend
+format:
+	cd backend && poetry run format
+	cd frontend && pnpm format
+	cd frontend && pnpm lint

--- a/autogpt_platform/README.md
+++ b/autogpt_platform/README.md
@@ -38,6 +38,29 @@ To run the AutoGPT Platform, follow these steps:
 
 4. After all the services are in ready state, open your browser and navigate to `http://localhost:3000` to access the AutoGPT Platform frontend.
 
+### Running Just Core services
+
+You can now run the following to enable just the core services.
+
+```
+# Run just Supabase + Redis + RabbitMQ
+core-services
+
+# Stop core services
+make logs-core
+
+logs-core
+make logs-core
+```
+
+Then in the backend folder you will need to run:
+
+`poetry run app`
+
+In the frontend folder you will need to run:
+
+`pnpm dev`
+
 ### Docker Compose Commands
 
 Here are some useful Docker Compose commands for managing your AutoGPT Platform:


### PR DESCRIPTION
As a dev I want to be able to run our core services without deploying our platform locally. This PR adds a make file which makes doing this easy

### Changes 🏗️

- added make file with commands for managing core services

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] I have tested each of the commands