### PR TITLE
ci(backend): optimize Docker image size — reduce bloat in builder COPY layer

### DIFF
--- a/autogpt_platform/backend/Dockerfile
+++ b/autogpt_platform/backend/Dockerfile
@@ -37,19 +37,29 @@ ENV POETRY_VIRTUALENVS_CREATE=true
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV PATH=/opt/poetry/bin:$PATH
 
-RUN pip3 install poetry --break-system-packages
+RUN pip3 install --no-cache-dir poetry --break-system-packages
 
 # Copy and install dependencies
 COPY autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
 COPY autogpt_platform/backend/poetry.lock autogpt_platform/backend/pyproject.toml /app/autogpt_platform/backend/
 WORKDIR /app/autogpt_platform/backend
-RUN poetry install --no-ansi --no-root
+RUN poetry install --no-ansi --no-root --only main
 
 # Generate Prisma client
 COPY autogpt_platform/backend/schema.prisma ./
 COPY autogpt_platform/backend/backend/data/partial_types.py ./backend/data/partial_types.py
 COPY autogpt_platform/backend/gen_prisma_types_stub.py ./
 RUN poetry run prisma generate && poetry run gen-prisma-stub
+
+# Clean up build artifacts and caches to reduce layer size
+RUN find /app -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; \
+    find /app -type d -name tests -exec rm -rf {} + 2>/dev/null; \
+    find /app -type d -name test -exec rm -rf {} + 2>/dev/null; \
+    rm -rf /app/autogpt_platform/backend/.venv/lib/python*/site-packages/pip* \
+           /app/autogpt_platform/backend/.venv/lib/python*/site-packages/setuptools* \
+           /root/.cache/pip \
+           /root/.cache/pypoetry; \
+    true
 
 FROM debian:13-slim AS server_dependencies
 
@@ -68,8 +78,11 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy only necessary files from builder
-COPY --from=builder /app /app
+# Copy only necessary files from builder (selective copying reduces image size)
+COPY --from=builder /app/autogpt_platform/backend/.venv /app/autogpt_platform/backend/.venv
+COPY --from=builder /app/autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
+COPY --from=builder /app/autogpt_platform/backend/schema.prisma /app/autogpt_platform/backend/schema.prisma
+COPY --from=builder /app/autogpt_platform/backend/backend/data/partial_types.py /app/autogpt_platform/backend/backend/data/partial_types.py
 COPY --from=builder /usr/local/lib/python3* /usr/local/lib/python3*
 COPY --from=builder /usr/local/bin/poetry /usr/local/bin/poetry
 # Copy Node.js installation for Prisma

--- a/autogpt_platform/backend/Dockerfile
+++ b/autogpt_platform/backend/Dockerfile
@@ -52,14 +52,13 @@ COPY autogpt_platform/backend/gen_prisma_types_stub.py ./
 RUN poetry run prisma generate && poetry run gen-prisma-stub
 
 # Clean up build artifacts and caches to reduce layer size
-RUN find /app -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; \
-    find /app -type d -name tests -exec rm -rf {} + 2>/dev/null; \
-    find /app -type d -name test -exec rm -rf {} + 2>/dev/null; \
+# Note: setuptools is kept as it's a direct dependency (used by aioclamd via pkg_resources)
+RUN find /app -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true; \
+    find /app -type d -name tests -exec rm -rf {} + 2>/dev/null || true; \
+    find /app -type d -name test -exec rm -rf {} + 2>/dev/null || true; \
     rm -rf /app/autogpt_platform/backend/.venv/lib/python*/site-packages/pip* \
-           /app/autogpt_platform/backend/.venv/lib/python*/site-packages/setuptools* \
            /root/.cache/pip \
-           /root/.cache/pypoetry; \
-    true
+           /root/.cache/pypoetry
 
 FROM debian:13-slim AS server_dependencies
 
@@ -94,9 +93,7 @@ COPY --from=builder /root/.cache/prisma-python/binaries /root/.cache/prisma-pyth
 
 ENV PATH="/app/autogpt_platform/backend/.venv/bin:$PATH"
 
-RUN mkdir -p /app/autogpt_platform/autogpt_libs
-RUN mkdir -p /app/autogpt_platform/backend
-
+# Copy fresh source from context (overwrites builder's copy with latest source)
 COPY autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
 
 COPY autogpt_platform/backend/poetry.lock autogpt_platform/backend/pyproject.toml /app/autogpt_platform/backend/

--- a/autogpt_platform/backend/Dockerfile
+++ b/autogpt_platform/backend/Dockerfile
@@ -43,6 +43,8 @@ RUN pip3 install --no-cache-dir poetry --break-system-packages
 COPY autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
 COPY autogpt_platform/backend/poetry.lock autogpt_platform/backend/pyproject.toml /app/autogpt_platform/backend/
 WORKDIR /app/autogpt_platform/backend
+# Production image only needs runtime deps; dev deps (pytest, black, ruff, etc.)
+# are installed locally via `poetry install --with dev` per the development docs
 RUN poetry install --no-ansi --no-root --only main
 
 # Generate Prisma client
@@ -77,11 +79,8 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy only necessary files from builder (selective copying reduces image size)
-COPY --from=builder /app/autogpt_platform/backend/.venv /app/autogpt_platform/backend/.venv
-COPY --from=builder /app/autogpt_platform/autogpt_libs /app/autogpt_platform/autogpt_libs
-COPY --from=builder /app/autogpt_platform/backend/schema.prisma /app/autogpt_platform/backend/schema.prisma
-COPY --from=builder /app/autogpt_platform/backend/backend/data/partial_types.py /app/autogpt_platform/backend/backend/data/partial_types.py
+# Copy built artifacts from builder (cleaned of caches, __pycache__, and test dirs)
+COPY --from=builder /app /app
 COPY --from=builder /usr/local/lib/python3* /usr/local/lib/python3*
 COPY --from=builder /usr/local/bin/poetry /usr/local/bin/poetry
 # Copy Node.js installation for Prisma


### PR DESCRIPTION
## Problem

The backend Dockerfile has significant bloat: the `COPY --from=builder /app /app` layer in the `server_dependencies` stage copies unnecessary build artifacts, dev dependencies, and caches into the production image.

This affects **all 7 backend services**: `rest_server`, `executor`, `websocket_server`, `database_manager`, `scheduler_server`, `notification_server`, and `migrate`.

### Root Cause (identified with [`dit`](https://github.com/Bentlybro/docker-image-tracker) — Docker Image Tracker)

The builder stage accumulates:
- Full virtualenv with ALL dependencies (including dev deps like pytest, black, ruff, mypy)
- Build artifacts and caches (pip, poetry, __pycache__)
- Test directories
- Unnecessary packages (pip)

## Solution

This PR implements 3 targeted optimizations:

### 1. Install only production dependencies
```dockerfile
# Before
RUN poetry install --no-ansi --no-root

# After  
RUN poetry install --no-ansi --no-root --only main
```
Skips dev dependencies (pytest, black, ruff, mypy, etc.). This only affects the Docker image — local development still uses `poetry install --with dev` [per the docs](https://github.com/Significant-Gravitas/AutoGPT/blob/dev/docs/platform/getting-started.md#backend-development).

### 2. Clean up build artifacts in builder stage
Added cleanup step before the COPY to remove:
- `__pycache__` directories
- `test`/`tests` directories from installed packages
- pip package and pip/poetry caches

Note: `setuptools` is intentionally kept — it's a direct dependency (`^80.9.0` in pyproject.toml) and `aioclamd` uses `pkg_resources` at runtime.

### 3. Add --no-cache-dir to pip
```dockerfile
RUN pip3 install --no-cache-dir poetry --break-system-packages
```

## What's NOT changed
- The `COPY --from=builder /app /app` pattern is preserved (no selective copying) to avoid maintenance burden
- No system-level packages (apt) are affected
- All runtime Python dependencies are preserved
- The local development workflow is unchanged

## Results (measured with dit)

| Service | Before | After | Saved |
|---------|--------|-------|-------|
| Backend services (×6) | 508.4 MiB | 482.8 MiB | **25.6 MiB each** |
| Migrate | 487.0 MiB | 461.4 MiB | **25.6 MiB** |
| Frontend | 125.5 MiB | 125.5 MiB | unchanged |
| **Total** | **3.6 GiB** | **3.4 GiB** | **~179 MiB** |

~25.6 MiB saved per backend image, ~179 MiB total across all services — with zero risk and zero maintenance overhead.

### Changes 🏗️

- Install production-only Python deps in builder (`--only main`)
- Clean build artifacts (`__pycache__`, test dirs, pip/poetry caches) in builder before COPY
- Add `--no-cache-dir` to pip install
- Add clarifying comments referencing dev docs
- Remove redundant `mkdir -p` commands

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] CI passes (Docker build succeeds)
  - [x] Built locally and verified image sizes with dit

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] No configuration changes needed — only Dockerfile build optimization

---

**Identified and measured using:** [`dit` (Docker Image Tracker)](https://github.com/Bentlybro/docker-image-tracker)