### PR TITLE
fix(backend): clarify Ollama does not require API credentials

### DIFF
--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -43,12 +43,13 @@ def provider_matches(stored: str, expected: str) -> bool:
     return False
 
 
-# This is an overrride since ollama doesn't actually require an API key, but the creddential system enforces one be attached
+# Ollama runs locally and does not require an API key.
+# This placeholder credential satisfies the credential system requirement.
 ollama_credentials = APIKeyCredentials(
     id="744fdc56-071a-4761-b5a5-0af0ce10a2b5",
     provider="ollama",
-    api_key=SecretStr("FAKE_API_KEY"),
-    title="Use Credits for Ollama",
+    api_key=SecretStr("ollama-no-key-required"),
+    title="Ollama (local — no API key needed)",
     expires_at=None,
 )
 

--- a/autogpt_platform/backend/backend/integrations/credentials_store.py
+++ b/autogpt_platform/backend/backend/integrations/credentials_store.py
@@ -49,7 +49,7 @@ ollama_credentials = APIKeyCredentials(
     id="744fdc56-071a-4761-b5a5-0af0ce10a2b5",
     provider="ollama",
     api_key=SecretStr("ollama-no-key-required"),
-    title="Ollama (local — no API key needed)",
+    title="Use Credits for Ollama (no API key needed)",
     expires_at=None,
 )
 

--- a/docs/platform/ollama.md
+++ b/docs/platform/ollama.md
@@ -101,7 +101,7 @@ Now that both Ollama and the AutoGPT platform are running, we can use Ollama wit
 1. Add an AI Text Generator block to your workspace (it can work with any AI LLM block but for this example will be using the AI Text Generator block):
    ![Add AI Text Generator Block](../imgs/ollama/Select-AI-block.png)
 
-2. **Configure the API Key field**: Enter any value (e.g., "dummy" or "not-needed") since Ollama doesn't require authentication.
+2. **Configure the API Key field**: Select the pre-configured "Use Credits for Ollama" credential from the dropdown. Ollama runs locally and does not require an API key — the platform provides this built-in credential automatically.
 
 3. In the "LLM Model" dropdown, select "llama3.2" (This is the model we downloaded earlier)
    ![Select Ollama Model](../imgs/ollama/Ollama-Select-Llama32.png)
@@ -259,7 +259,7 @@ If you encounter any issues, verify that:
   ```
 
 #### API Key Errors
-- Remember that Ollama doesn't require authentication - any value works for the API key field
+- Ollama does not require authentication. Select the built-in "Use Credits for Ollama" credential from the dropdown — no real API key is needed
 
 #### Model Selection Issues
 - Look for models with "ollama" in their description in the dropdown

--- a/docs/platform/ollama.md
+++ b/docs/platform/ollama.md
@@ -101,7 +101,7 @@ Now that both Ollama and the AutoGPT platform are running, we can use Ollama wit
 1. Add an AI Text Generator block to your workspace (it can work with any AI LLM block but for this example will be using the AI Text Generator block):
    ![Add AI Text Generator Block](../imgs/ollama/Select-AI-block.png)
 
-2. **Configure the API Key field**: Select the pre-configured "Use Credits for Ollama" credential from the dropdown. Ollama runs locally and does not require an API key — the platform provides this built-in credential automatically.
+2. **Configure the API Key field**: Select the pre-configured "Use Credits for Ollama (no API key needed)" credential from the dropdown. Ollama runs locally and does not require an API key — the platform provides this built-in credential automatically.
 
 3. In the "LLM Model" dropdown, select "llama3.2" (This is the model we downloaded earlier)
    ![Select Ollama Model](../imgs/ollama/Ollama-Select-Llama32.png)
@@ -259,7 +259,7 @@ If you encounter any issues, verify that:
   ```
 
 #### API Key Errors
-- Ollama does not require authentication. Select the built-in "Use Credits for Ollama" credential from the dropdown — no real API key is needed
+- Ollama does not require authentication. Select the built-in "Use Credits for Ollama (no API key needed)" credential from the dropdown — no real API key is needed
 
 #### Model Selection Issues
 - Look for models with "ollama" in their description in the dropdown


### PR DESCRIPTION
## Summary
- Renamed the Ollama placeholder credential from "Use Credits for Ollama" to **"Ollama (local — no API key needed)"** so users understand no real key is required
- Changed the fake API key value from `FAKE_API_KEY` to `ollama-no-key-required` for clarity
- Fixed misleading comments with typos (`overrride`, `creddential`) in `credentials_store.py`
- Updated `docs/platform/ollama.md` to direct users to select the built-in credential instead of entering "dummy" values

### Context
Ollama runs locally and does not need authentication. However, the credential system requires a credential to be attached. The platform already auto-injects a placeholder credential for Ollama, but the title and docs were confusing — users were told to "enter any value (e.g., dummy)" instead of selecting the built-in credential.

### Changes
- **`autogpt_platform/backend/backend/integrations/credentials_store.py`** — improved credential title, API key value, and comments
- **`docs/platform/ollama.md`** — updated setup instructions and troubleshooting section

## Test plan
- [ ] Ollama blocks still work with the renamed placeholder credential
- [ ] The credential dropdown shows "Ollama (local — no API key needed)" instead of "Use Credits for Ollama"
- [ ] Ollama docs accurately describe the setup flow

Relates to #8952

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Renamed Ollama placeholder credential from "Use Credits for Ollama" to "Ollama (local — no API key needed)" and changed the fake API key from `FAKE_API_KEY` to `ollama-no-key-required` for better clarity. Fixed typos in comments (`overrride` → override, `creddential` → credential).

**Critical Issue Found:**
- The documentation in `docs/platform/ollama.md` still references the old credential title "Use Credits for Ollama" in two places (lines 104 and 262), but the code has changed it to "Ollama (local — no API key needed)". This mismatch will confuse users when they follow the documentation.

**Changes are otherwise good:**
- Comment improvements in `credentials_store.py` are clearer and more professional
- The new credential title better explains that no real API key is needed
- The new API key value `ollama-no-key-required` is more descriptive than `FAKE_API_KEY`
</details>


<details><summary><h3>Confidence Score: 2/5</h3></summary>

- PR has a critical documentation inconsistency that will confuse users
- Score of 2 because the documentation still references the old credential title "Use Credits for Ollama" while the code changed it to "Ollama (local — no API key needed)". This mismatch will lead to user confusion when following the docs. The code changes themselves are good and well-intentioned, but the incomplete documentation update is a blocker.
- Pay close attention to `docs/platform/ollama.md` lines 104 and 262 which need to be updated to match the new credential title
</details>


<sub>Last reviewed commit: ef6a056</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->