### PR TITLE
fix(backend): handle soft-deleted ghost rows in workspace file overwrite

### DIFF
--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -112,6 +112,7 @@ from backend.data.user import (
 from backend.data.workspace import (
     count_workspace_files,
     create_workspace_file,
+    free_deleted_path,
     get_or_create_workspace,
     get_workspace_file,
     get_workspace_file_by_path,
@@ -313,6 +314,7 @@ class DatabaseManager(AppService):
     # ============ Workspace ============ #
     count_workspace_files = _(count_workspace_files)
     create_workspace_file = _(create_workspace_file)
+    free_deleted_path = _(free_deleted_path)
     get_or_create_workspace = _(get_or_create_workspace)
     get_workspace_file = _(get_workspace_file)
     get_workspace_file_by_path = _(get_workspace_file_by_path)
@@ -506,6 +508,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     # ============ Workspace ============ #
     count_workspace_files = d.count_workspace_files
     create_workspace_file = d.create_workspace_file
+    free_deleted_path = d.free_deleted_path
     get_or_create_workspace = d.get_or_create_workspace
     get_workspace_file = d.get_workspace_file
     get_workspace_file_by_path = d.get_workspace_file_by_path

--- a/autogpt_platform/backend/backend/data/workspace.py
+++ b/autogpt_platform/backend/backend/data/workspace.py
@@ -344,7 +344,7 @@ async def free_deleted_path(file_id: str, workspace_id: str) -> bool:
     """
     deleted_at = datetime.now(timezone.utc)
     try:
-        await UserWorkspaceFile.prisma().update_many(
+        count = await UserWorkspaceFile.prisma().update_many(
             where={
                 "id": file_id,
                 "workspaceId": workspace_id,
@@ -354,8 +354,10 @@ async def free_deleted_path(file_id: str, workspace_id: str) -> bool:
                 "path": f"__freed__{file_id}__{int(deleted_at.timestamp())}",
             },
         )
-        logger.info(f"Freed path for soft-deleted ghost row {file_id}")
-        return True
+        if count > 0:
+            logger.info(f"Freed path for soft-deleted ghost row {file_id}")
+            return True
+        return False
     except Exception:
         logger.warning(f"Failed to free path for ghost row {file_id}")
         return False

--- a/autogpt_platform/backend/backend/data/workspace.py
+++ b/autogpt_platform/backend/backend/data/workspace.py
@@ -189,6 +189,7 @@ async def get_workspace_file(
 async def get_workspace_file_by_path(
     workspace_id: str,
     path: str,
+    include_deleted: bool = False,
 ) -> Optional[WorkspaceFile]:
     """
     Get a workspace file by its virtual path.
@@ -196,6 +197,8 @@ async def get_workspace_file_by_path(
     Args:
         workspace_id: The workspace ID
         path: Virtual path
+        include_deleted: If True, also match soft-deleted records that still
+                         occupy the path in the unique constraint.
 
     Returns:
         WorkspaceFile instance or None
@@ -204,13 +207,14 @@ async def get_workspace_file_by_path(
     if not path.startswith("/"):
         path = f"/{path}"
 
-    file = await UserWorkspaceFile.prisma().find_first(
-        where={
-            "workspaceId": workspace_id,
-            "path": path,
-            "isDeleted": False,
-        }
-    )
+    where_clause: UserWorkspaceFileWhereInput = {
+        "workspaceId": workspace_id,
+        "path": path,
+    }
+    if not include_deleted:
+        where_clause["isDeleted"] = False
+
+    file = await UserWorkspaceFile.prisma().find_first(where=where_clause)
     return WorkspaceFile.from_db(file) if file else None
 
 
@@ -321,6 +325,40 @@ async def soft_delete_workspace_file(
 
     logger.info(f"Soft-deleted workspace file {file_id}")
     return WorkspaceFile.from_db(updated) if updated else None
+
+
+async def free_deleted_path(file_id: str, workspace_id: str) -> bool:
+    """
+    Rename a soft-deleted file's path to free the unique constraint slot.
+
+    This handles "ghost rows" — records that are already soft-deleted but whose
+    path was never renamed, so they still block the ``@@unique([workspaceId, path])``
+    constraint for new files.
+
+    Args:
+        file_id: The file ID
+        workspace_id: Workspace ID for scoping
+
+    Returns:
+        True if the path was freed, False if the file was not found
+    """
+    deleted_at = datetime.now(timezone.utc)
+    try:
+        await UserWorkspaceFile.prisma().update_many(
+            where={
+                "id": file_id,
+                "workspaceId": workspace_id,
+                "isDeleted": True,
+            },
+            data={
+                "path": f"__freed__{file_id}__{int(deleted_at.timestamp())}",
+            },
+        )
+        logger.info(f"Freed path for soft-deleted ghost row {file_id}")
+        return True
+    except Exception:
+        logger.warning(f"Failed to free path for ghost row {file_id}")
+        return False
 
 
 async def get_workspace_total_size(workspace_id: str) -> int:

--- a/autogpt_platform/backend/backend/util/workspace.py
+++ b/autogpt_platform/backend/backend/util/workspace.py
@@ -248,12 +248,20 @@ class WorkspaceManager:
                 )
             except UniqueViolationError:
                 if retries > 0:
-                    # Delete conflicting file and retry
+                    # Delete conflicting file and retry.
                     existing = await db.get_workspace_file_by_path(
                         self.workspace_id, path
                     )
                     if existing:
                         await self.delete_file(existing.id)
+                    else:
+                        # Check for soft-deleted "ghost rows" that still
+                        # occupy the unique constraint slot.
+                        ghost = await db.get_workspace_file_by_path(
+                            self.workspace_id, path, include_deleted=True
+                        )
+                        if ghost:
+                            await db.free_deleted_path(ghost.id, self.workspace_id)
                     return await _persist_db_record(retries=retries - 1)
                 if overwrite:
                     raise ValueError(

--- a/autogpt_platform/backend/backend/util/workspace_test.py
+++ b/autogpt_platform/backend/backend/util/workspace_test.py
@@ -156,3 +156,33 @@ async def test_write_file_overwrite_exhausted_retries_raises_and_cleans_up(
             )
 
     mock_storage.delete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_write_file_overwrite_ghost_row_freed_then_retry_succeeds(
+    manager, mock_storage, mock_db
+):
+    """overwrite=True + ghost soft-deleted row → free path → retry succeeds."""
+    created_file = _make_workspace_file()
+    ghost_file = _make_workspace_file(id="ghost-id")
+
+    # First call (active lookup) returns None; second call (include_deleted) returns ghost
+    mock_db.get_workspace_file_by_path.side_effect = [None, ghost_file]
+    mock_db.free_deleted_path = AsyncMock(return_value=True)
+    mock_db.create_workspace_file.side_effect = [_unique_violation(), created_file]
+
+    with (
+        patch(
+            "backend.util.workspace.get_workspace_storage",
+            return_value=mock_storage,
+        ),
+        patch("backend.util.workspace.workspace_db", return_value=mock_db),
+        patch("backend.util.workspace.scan_content_safe", new_callable=AsyncMock),
+    ):
+        result = await manager.write_file(
+            filename="test.txt", content=b"hello", overwrite=True
+        )
+
+    assert result == created_file
+    mock_db.free_deleted_path.assert_called_once_with("ghost-id", "ws-123")
+    mock_storage.delete.assert_not_called()


### PR DESCRIPTION
When overwriting a workspace file, a `UniqueViolationError` could occur if a soft-deleted record still occupied the `@@unique([workspaceId, path])` constraint slot. The retry logic only looked for active (non-deleted) files, missing these "ghost rows" entirely — causing the overwrite to fail with a confusing error.

### Changes 🏗️

- **`data/workspace.py`**: Added `include_deleted` parameter to `get_workspace_file_by_path()` so it can find soft-deleted ghost rows. Added `free_deleted_path()` to rename a ghost row's path and free the unique constraint slot.
- **`util/workspace.py`**: Updated `_persist_db_record`'s `UniqueViolationError` handler — when the active file lookup returns `None`, it now checks for soft-deleted ghost rows and frees their path before retrying.
- **`util/workspace_test.py`**: Added test covering the ghost row scenario.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] All 4 unit tests pass (3 existing + 1 new ghost row test)
  - [x] `ruff check`, `isort`, and `black` pass with no issues
  - [x] Verified the fix handles: active file conflict (existing behavior), ghost row conflict (new), and exhausted retries (existing)

Closes #12345

🤖 Generated with [Claude Code](https://claude.com/claude-code)