### PR TITLE
fix(frontend): upgrade Docker Node.js from v21 (EOL) to v22 LTS

### DIFF
--- a/autogpt_platform/frontend/Dockerfile
+++ b/autogpt_platform/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base stage for both dev and prod
-FROM node:21-alpine AS base
+FROM node:22.22-alpine3.23 AS base
 WORKDIR /app
 RUN corepack enable
 COPY autogpt_platform/frontend/package.json autogpt_platform/frontend/pnpm-lock.yaml ./
@@ -33,7 +33,7 @@ ENV NEXT_PUBLIC_SOURCEMAPS="false"
 RUN if [ "$NEXT_PUBLIC_PW_TEST" = "true" ]; then NEXT_PUBLIC_PW_TEST=true NODE_OPTIONS="--max-old-space-size=8192" pnpm build; else NODE_OPTIONS="--max-old-space-size=8192" pnpm build; fi
 
 # Prod stage - based on NextJS reference Dockerfile https://github.com/vercel/next.js/blob/64271354533ed16da51be5dce85f0dbd15f17517/examples/with-docker/Dockerfile
-FROM node:21-alpine AS prod
+FROM node:22.22-alpine3.23 AS prod
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 WORKDIR /app


### PR DESCRIPTION
## Summary
Upgrade the frontend **Docker image** from **Node.js v21** (EOL since June 2024) to **Node.js v22 LTS** (supported through April 2027).

> **Scope:** This only affects the **Dockerfile** used for local development (`docker compose`) and CI. It does **not** affect Vercel (which manages its own Node.js runtime) or Kubernetes (the frontend Helm chart was removed in Dec 2025 — the frontend is deployed exclusively via Vercel).

## Why
- Node v21.7.3 has a **known TransformStream race condition bug** causing `TypeError: controller[kState].transformAlgorithm is not a function` — this is [BUILDER-3KF](https://significant-gravitas.sentry.io/issues/BUILDER-3KF) with **567,000+ Sentry events**
- The error is entirely in Node.js internals (`node:internal/webstreams/transformstream`), zero first-party code
- Node 21 is **not an LTS release** and has been EOL since June 2024
- `package.json` already declares `"engines": { "node": "22.x" }` — the Dockerfile was inconsistent
- Node 22.x LTS (v22.22.1) fixes the TransformStream bug
- Next.js 15.4.x requires Node 18.18+, so Node 22 is fully compatible

## Changes
- `autogpt_platform/frontend/Dockerfile`: `node:21-alpine` → `node:22.22-alpine3.23` (both `base` and `prod` stages)

## Test plan
- [ ] Verify frontend Docker image builds successfully via `docker compose`
- [ ] Verify frontend starts and serves pages correctly in local Docker environment
- [ ] Monitor Sentry for BUILDER-3KF — should drop to zero for Docker-based runs