### PR TITLE
feat(platform): add HeyGen avatar video generation block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import Any, Literal
+from urllib.parse import quote
 
 from pydantic import SecretStr
 
@@ -52,6 +53,7 @@ class HeyGenCreateVideoBlock(Block):
             description="The text script for the avatar to speak",
             placeholder="e.g., 'Hello, welcome to our platform!'",
             title="Text Script",
+            min_length=1,
         )
         avatar_id: str = SchemaField(
             description="The HeyGen avatar ID to use for the video",
@@ -65,15 +67,17 @@ class HeyGenCreateVideoBlock(Block):
         )
         max_polling_attempts: int = SchemaField(
             description="Maximum number of polling attempts",
-            default=30,
+            default=60,
             ge=5,
+            le=120,
             title="Max Polling Attempts",
             advanced=True,
         )
         polling_interval: int = SchemaField(
             description="Interval between polling attempts in seconds",
-            default=10,
+            default=5,
             ge=5,
+            le=30,
             title="Polling Interval",
             advanced=True,
         )
@@ -135,20 +139,24 @@ class HeyGenCreateVideoBlock(Block):
         }
         response = await Requests().post(url, json=payload, headers=headers)
         result = response.json()
-        if result.get("error"):
-            raise RuntimeError(f"HeyGen API error: {result['error']}")
+        if result.get("error") or result.get("code") not in (None, 100):
+            error_detail = result.get("error") or result.get("message", "Unknown error")
+            raise RuntimeError(f"HeyGen API error: {error_detail}")
         return result.get("data", {})
 
     async def get_video_status(self, api_key: SecretStr, video_id: str) -> dict:
-        url = f"https://api.heygen.com/v1/video_status.get?video_id={video_id}"
+        url = (
+            "https://api.heygen.com/v1/video_status.get" f"?video_id={quote(video_id)}"
+        )
         headers = {
             "Accept": "application/json",
             "X-Api-Key": api_key.get_secret_value(),
         }
         response = await Requests().get(url, headers=headers)
         result = response.json()
-        if result.get("error"):
-            raise RuntimeError(f"HeyGen API error: {result['error']}")
+        if result.get("error") or result.get("code") not in (None, 100):
+            error_detail = result.get("error") or result.get("message", "Unknown error")
+            raise RuntimeError(f"HeyGen API error: {error_detail}")
         return result.get("data", {})
 
     async def run(
@@ -190,8 +198,11 @@ class HeyGenCreateVideoBlock(Block):
                 )
                 status = status_response.get("status")
                 logger.debug(
-                    f"Polling HeyGen video {video_id}: status={status} "
-                    f"(attempt {attempt + 1}/{input_data.max_polling_attempts})"
+                    "Polling HeyGen video %s: status=%s (attempt %d/%d)",
+                    video_id,
+                    status,
+                    attempt + 1,
+                    input_data.max_polling_attempts,
                 )
 
                 if status == "completed":

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import SecretStr
 
@@ -153,7 +153,7 @@ class HeyGenCreateVideoBlock(Block):
         credentials: APIKeyCredentials,
         **kwargs,
     ) -> BlockOutput:
-        payload = {
+        payload: dict[str, Any] = {
             "video_inputs": [
                 {
                     "character": {

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -1,0 +1,193 @@
+import asyncio
+import logging
+from typing import Literal, Optional
+
+from pydantic import SecretStr
+
+from backend.blocks._base import (
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+)
+from backend.data.model import (
+    APIKeyCredentials,
+    CredentialsField,
+    CredentialsMetaInput,
+    SchemaField,
+)
+from backend.integrations.providers import ProviderName
+from backend.util.request import Requests
+
+logger = logging.getLogger(__name__)
+
+TEST_CREDENTIALS = APIKeyCredentials(
+    id="01234567-89ab-cdef-0123-456789abcdef",
+    provider="heygen",
+    api_key=SecretStr("mock-heygen-api-key"),
+    title="Mock HeyGen API key",
+    expires_at=None,
+)
+TEST_CREDENTIALS_INPUT = {
+    "provider": TEST_CREDENTIALS.provider,
+    "id": TEST_CREDENTIALS.id,
+    "type": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.type,
+}
+
+
+class HeyGenCreateVideoBlock(Block):
+    class Input(BlockSchemaInput):
+        credentials: CredentialsMetaInput[
+            Literal[ProviderName.HEYGEN], Literal["api_key"]
+        ] = CredentialsField(
+            description="The HeyGen integration can be used with "
+            "any API key with sufficient permissions for the blocks it is used on.",
+        )
+        text: str = SchemaField(
+            description="The text script for the avatar to speak",
+            placeholder="e.g., 'Hello, welcome to our platform!'",
+            title="Text Script",
+        )
+        avatar_id: str = SchemaField(
+            description="The HeyGen avatar ID to use for the video",
+            default="Daisy-inskirt-20220818",
+            title="Avatar ID",
+        )
+        voice_id: str = SchemaField(
+            description="The voice ID to use for the avatar",
+            default="1bd001e7e50f421d891986aad5571571",
+            title="Voice ID",
+        )
+        max_polling_attempts: int = SchemaField(
+            description="Maximum number of polling attempts",
+            default=30,
+            ge=5,
+            title="Max Polling Attempts",
+            advanced=True,
+        )
+        polling_interval: int = SchemaField(
+            description="Interval between polling attempts in seconds",
+            default=10,
+            ge=5,
+            title="Polling Interval",
+            advanced=True,
+        )
+        test: Optional[bool] = SchemaField(
+            description="Enable test mode to generate a free video with watermark",
+            default=False,
+            title="Test Mode",
+            advanced=True,
+        )
+
+    class Output(BlockSchemaOutput):
+        video_url: str = SchemaField(
+            description="The URL of the generated avatar video"
+        )
+
+    def __init__(self):
+        super().__init__(
+            id="5b315ef2-f755-4637-a1ba-503924232737",
+            description="This block uses HeyGen to create avatar videos "
+            "from a text script.",
+            categories={BlockCategory.AI, BlockCategory.MULTIMEDIA},
+            input_schema=HeyGenCreateVideoBlock.Input,
+            output_schema=HeyGenCreateVideoBlock.Output,
+            test_input={
+                "credentials": TEST_CREDENTIALS_INPUT,
+                "text": "Hello, welcome to our platform!",
+                "avatar_id": "Daisy-inskirt-20220818",
+                "voice_id": "1bd001e7e50f421d891986aad5571571",
+                "max_polling_attempts": 5,
+                "polling_interval": 5,
+                "test": False,
+            },
+            test_output=[
+                (
+                    "video_url",
+                    "https://files.heygen.ai/video/test-video.mp4",
+                ),
+            ],
+            test_mock={
+                "create_video": lambda *args, **kwargs: {
+                    "video_id": "test-video-id-1234",
+                },
+                "get_video_status": lambda *args, **kwargs: {
+                    "status": "completed",
+                    "video_url": "https://files.heygen.ai/video/test-video.mp4",
+                },
+            },
+            test_credentials=TEST_CREDENTIALS,
+        )
+
+    async def create_video(self, api_key: SecretStr, payload: dict) -> dict:
+        url = "https://api.heygen.com/v2/video/generate"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Api-Key": api_key.get_secret_value(),
+        }
+        response = await Requests().post(url, json=payload, headers=headers)
+        result = response.json()
+        if result.get("error"):
+            raise RuntimeError(f"HeyGen API error: {result['error']}")
+        return result.get("data", {})
+
+    async def get_video_status(self, api_key: SecretStr, video_id: str) -> dict:
+        url = f"https://api.heygen.com/v1/video_status.get?video_id={video_id}"
+        headers = {
+            "Accept": "application/json",
+            "X-Api-Key": api_key.get_secret_value(),
+        }
+        response = await Requests().get(url, headers=headers)
+        result = response.json()
+        if result.get("error"):
+            raise RuntimeError(f"HeyGen API error: {result['error']}")
+        return result.get("data", {})
+
+    async def run(
+        self,
+        input_data: Input,
+        *,
+        credentials: APIKeyCredentials,
+        **kwargs,
+    ) -> BlockOutput:
+        payload = {
+            "video_inputs": [
+                {
+                    "character": {
+                        "type": "avatar",
+                        "avatar_id": input_data.avatar_id,
+                        "avatar_style": "normal",
+                    },
+                    "voice": {
+                        "type": "text",
+                        "input_text": input_data.text,
+                        "voice_id": input_data.voice_id,
+                    },
+                }
+            ],
+        }
+        if input_data.test:
+            payload["test"] = True
+
+        response = await self.create_video(credentials.api_key, payload)
+        video_id = response["video_id"]
+
+        for _ in range(input_data.max_polling_attempts):
+            status_response = await self.get_video_status(
+                credentials.api_key, video_id
+            )
+            status = status_response.get("status")
+
+            if status == "completed":
+                yield "video_url", status_response["video_url"]
+                return
+            elif status == "failed":
+                error_msg = status_response.get("error", "Unknown error")
+                raise RuntimeError(f"Video generation failed: {error_msg}")
+
+            await asyncio.sleep(input_data.polling_interval)
+
+        raise TimeoutError("Video generation timed out")

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from pydantic import SecretStr
 
@@ -11,6 +11,7 @@ from backend.blocks._base import (
     BlockSchemaInput,
     BlockSchemaOutput,
 )
+from backend.data.execution import ExecutionContext
 from backend.data.model import (
     APIKeyCredentials,
     CredentialsField,
@@ -18,7 +19,9 @@ from backend.data.model import (
     SchemaField,
 )
 from backend.integrations.providers import ProviderName
+from backend.util.file import store_media_file
 from backend.util.request import Requests
+from backend.util.type import MediaFileType
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +77,7 @@ class HeyGenCreateVideoBlock(Block):
             title="Polling Interval",
             advanced=True,
         )
-        test: Optional[bool] = SchemaField(
+        test: bool = SchemaField(
             description="Enable test mode to generate a free video with watermark",
             default=False,
             title="Test Mode",
@@ -85,6 +88,7 @@ class HeyGenCreateVideoBlock(Block):
         video_url: str = SchemaField(
             description="The URL of the generated avatar video"
         )
+        error: str = SchemaField(description="Error message if video generation failed")
 
     def __init__(self):
         super().__init__(
@@ -151,6 +155,7 @@ class HeyGenCreateVideoBlock(Block):
         input_data: Input,
         *,
         credentials: APIKeyCredentials,
+        execution_context: ExecutionContext,
         **kwargs,
     ) -> BlockOutput:
         payload: dict[str, Any] = {
@@ -180,7 +185,13 @@ class HeyGenCreateVideoBlock(Block):
             status = status_response.get("status")
 
             if status == "completed":
-                yield "video_url", status_response["video_url"]
+                video_url = status_response["video_url"]
+                stored_url = await store_media_file(
+                    file=MediaFileType(video_url),
+                    execution_context=execution_context,
+                    return_format="for_block_output",
+                )
+                yield "video_url", stored_url
                 return
             elif status == "failed":
                 error_msg = status_response.get("error", "Unknown error")

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -176,9 +176,7 @@ class HeyGenCreateVideoBlock(Block):
         video_id = response["video_id"]
 
         for _ in range(input_data.max_polling_attempts):
-            status_response = await self.get_video_status(
-                credentials.api_key, video_id
-            )
+            status_response = await self.get_video_status(credentials.api_key, video_id)
             status = status_response.get("status")
 
             if status == "completed":

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -110,16 +110,17 @@ class HeyGenCreateVideoBlock(Block):
             test_output=[
                 (
                     "video_url",
-                    "https://files.heygen.ai/video/test-video.mp4",
+                    lambda x: x.startswith(("workspace://", "data:")),
                 ),
             ],
             test_mock={
                 "create_video": lambda *args, **kwargs: {
                     "video_id": "test-video-id-1234",
                 },
+                # Use data URI to avoid HTTP requests during tests
                 "get_video_status": lambda *args, **kwargs: {
                     "status": "completed",
-                    "video_url": "https://files.heygen.ai/video/test-video.mp4",
+                    "video_url": "data:video/mp4;base64,AAAA",
                 },
             },
             test_credentials=TEST_CREDENTIALS,

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -33,7 +33,7 @@ TEST_CREDENTIALS_INPUT = {
     "provider": TEST_CREDENTIALS.provider,
     "id": TEST_CREDENTIALS.id,
     "type": TEST_CREDENTIALS.type,
-    "title": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.title,
 }
 
 

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -177,26 +177,41 @@ class HeyGenCreateVideoBlock(Block):
         if input_data.test:
             payload["test"] = True
 
-        response = await self.create_video(credentials.api_key, payload)
-        video_id = response["video_id"]
+        try:
+            response = await self.create_video(credentials.api_key, payload)
+            video_id = response.get("video_id")
+            if not video_id:
+                raise RuntimeError("HeyGen API did not return a video_id")
 
-        for _ in range(input_data.max_polling_attempts):
-            status_response = await self.get_video_status(credentials.api_key, video_id)
-            status = status_response.get("status")
-
-            if status == "completed":
-                video_url = status_response["video_url"]
-                stored_url = await store_media_file(
-                    file=MediaFileType(video_url),
-                    execution_context=execution_context,
-                    return_format="for_block_output",
+            for attempt in range(input_data.max_polling_attempts):
+                status_response = await self.get_video_status(
+                    credentials.api_key, video_id
                 )
-                yield "video_url", stored_url
-                return
-            elif status == "failed":
-                error_msg = status_response.get("error", "Unknown error")
-                raise RuntimeError(f"Video generation failed: {error_msg}")
+                status = status_response.get("status")
+                logger.debug(
+                    f"Polling HeyGen video {video_id}: status={status} "
+                    f"(attempt {attempt + 1}/{input_data.max_polling_attempts})"
+                )
 
-            await asyncio.sleep(input_data.polling_interval)
+                if status == "completed":
+                    video_url = status_response.get("video_url")
+                    if not video_url:
+                        raise RuntimeError(
+                            "HeyGen API returned completed status without video_url"
+                        )
+                    stored_url = await store_media_file(
+                        file=MediaFileType(video_url),
+                        execution_context=execution_context,
+                        return_format="for_block_output",
+                    )
+                    yield "video_url", stored_url
+                    return
+                elif status == "failed":
+                    error_msg = status_response.get("error", "Unknown error")
+                    raise RuntimeError(f"Video generation failed: {error_msg}")
 
-        raise TimeoutError("Video generation timed out")
+                await asyncio.sleep(input_data.polling_interval)
+
+            raise TimeoutError("Video generation timed out")
+        except Exception as e:
+            yield "error", str(e)

--- a/autogpt_platform/backend/backend/blocks/heygen.py
+++ b/autogpt_platform/backend/backend/blocks/heygen.py
@@ -42,6 +42,8 @@ TEST_CREDENTIALS_INPUT = {
 
 
 class HeyGenCreateVideoBlock(Block):
+    """Create avatar videos using the HeyGen API."""
+
     class Input(BlockSchemaInput):
         credentials: CredentialsMetaInput[
             Literal[ProviderName.HEYGEN], Literal["api_key"]
@@ -131,6 +133,7 @@ class HeyGenCreateVideoBlock(Block):
         )
 
     async def create_video(self, api_key: SecretStr, payload: dict) -> dict:
+        """Send a video generation request to the HeyGen API."""
         url = "https://api.heygen.com/v2/video/generate"
         headers = {
             "Accept": "application/json",
@@ -145,6 +148,7 @@ class HeyGenCreateVideoBlock(Block):
         return result.get("data", {})
 
     async def get_video_status(self, api_key: SecretStr, video_id: str) -> dict:
+        """Poll the HeyGen API for the status of a video generation job."""
         url = (
             "https://api.heygen.com/v1/video_status.get" f"?video_id={quote(video_id)}"
         )
@@ -167,6 +171,7 @@ class HeyGenCreateVideoBlock(Block):
         execution_context: ExecutionContext,
         **kwargs,
     ) -> BlockOutput:
+        """Create an avatar video, poll until complete, and return the stored URL."""
         payload: dict[str, Any] = {
             "video_inputs": [
                 {

--- a/autogpt_platform/backend/backend/integrations/providers.py
+++ b/autogpt_platform/backend/backend/integrations/providers.py
@@ -24,6 +24,7 @@ class ProviderName(str, Enum):
     GOOGLE = "google"
     GOOGLE_MAPS = "google_maps"
     GROQ = "groq"
+    HEYGEN = "heygen"
     HTTP = "http"
     HUBSPOT = "hubspot"
     ENRICHLAYER = "enrichlayer"

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -227,6 +227,7 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [Exa Answer](block-integrations/exa/answers.md#exa-answer) | Get an LLM answer to a question informed by Exa search results |
 | [Exa Create Enrichment](block-integrations/exa/websets_enrichment.md#exa-create-enrichment) | Create enrichments to extract additional structured data from webset items |
 | [Exa Create Research](block-integrations/exa/research.md#exa-create-research) | Create research task with optional waiting - explores web and synthesizes findings with citations |
+| [Hey Gen Create Video](block-integrations/llm.md#hey-gen-create-video) | This block uses HeyGen to create avatar videos from a text script |
 | [Ideogram Model](block-integrations/llm.md#ideogram-model) | This block runs Ideogram models with both simple and advanced settings |
 | [Jina Chunking](block-integrations/jina/chunking.md#jina-chunking) | Chunks texts using Jina AI's segmentation service |
 | [Jina Embedding](block-integrations/jina/embeddings.md#jina-embedding) | Generates embeddings using Jina AI |

--- a/docs/integrations/block-integrations/llm.md
+++ b/docs/integrations/block-integrations/llm.md
@@ -661,6 +661,47 @@ A marketing team could use this block to create engaging video content for socia
 
 ---
 
+## Hey Gen Create Video
+
+### What it is
+This block uses HeyGen to create avatar videos from a text script.
+
+### How it works
+<!-- MANUAL: how_it_works -->
+The block sends a video generation request to the HeyGen API with your specified avatar and voice configuration. It then polls the API for completion status, returning the stored video URL once the video is ready.
+
+Configure polling behavior with max attempts and interval settings. Enable test mode to generate free watermarked videos for testing purposes.
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| text | The text script for the avatar to speak | str | Yes |
+| avatar_id | The HeyGen avatar ID to use for the video | str | No |
+| voice_id | The voice ID to use for the avatar | str | No |
+| max_polling_attempts | Maximum number of polling attempts | int | No |
+| polling_interval | Interval between polling attempts in seconds | int | No |
+| test | Enable test mode to generate a free video with watermark | bool | No |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| error | Error message if video generation failed | str |
+| video_url | The URL of the generated avatar video | str |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+**Personalized Welcome Videos**: Create custom avatar-narrated welcome messages for new users or customers by feeding in personalized scripts.
+
+**Training Content**: Generate talking-head explainer videos from training scripts for employee onboarding or product tutorials.
+
+**Social Media Content**: Produce short avatar videos for social media posts by automating video creation from text-based content calendars.
+<!-- END MANUAL -->
+
+---
+
 ## Ideogram Model
 
 ### What it is


### PR DESCRIPTION
## Why
Users need a way to generate AI avatar videos from text scripts within their workflows. HeyGen provides a mature API for this, and adding it as a block enables text-to-video avatar workflows.

Fixes #9193

## What
- New `HeyGenCreateVideoBlock` that calls the HeyGen API v2 to create avatar videos from text scripts
- Polls for completion status and returns the stored video URL via `store_media_file`
- Added `HEYGEN` to `ProviderName` enum for API key credential integration

## How
- Submits a video generation request to `POST /v2/video/generate` with avatar/voice config
- Polls `GET /v1/video_status.get` until completion, failure, or timeout
- Uses `store_media_file(return_format="for_block_output")` to store the video in the user's workspace
- Configurable polling interval and max attempts (advanced inputs)
- Test mode support for watermarked free-tier videos