### PR TITLE
fix(backend/copilot): robust context fallback — upload gate, gap-fill, token-budget compression

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/context_fallback_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/context_fallback_test.py
@@ -10,13 +10,13 @@ Scenario table
 | C | True       | stale                | 2 msgs  | 50_000        | gap compressed to budget, prepended        |
 | D | False      | 0                    | N/A     | None          | full session compressed, prepended         |
 | E | False      | 0                    | N/A     | 50_000        | full session compressed to budget          |
-| F | False      | 2 (partial)          | 2 msgs  | None          | ONLY gap prepended (efficient path)        |
-| G | False      | 2 (partial)          | 2 msgs  | 50_000        | gap compressed to budget                   |
-| H | False      | covers all           | empty   | None          | falls through → full session compressed    |
+| F | False      | 2 (partial)          | 2 msgs  | None          | full session compressed (not just gap;     |
+|   |            |                      |         |               | CLI has zero context without --resume)     |
+| G | False      | 2 (partial)          | 2 msgs  | 50_000        | full session compressed to budget          |
+| H | False      | covers all           | empty   | None          | full session compressed                    |
 |   |            |                      |         |               | (NOT bare message — the bug that was fixed)|
 | I | False      | covers all           | empty   | 50_000        | full session compressed to tight budget    |
-| J | False      | 2 (partial)          | yields  | None          | gap yields empty context → full fallback   |
-|   |            |                      | empty   |               |                                            |
+| J | False      | 2 (partial)          | n/a     | None          | exactly ONE compression call (full prior)  |
 
 Compression unit tests
 =======================

--- a/autogpt_platform/backend/backend/copilot/sdk/context_fallback_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/context_fallback_test.py
@@ -1,0 +1,555 @@
+"""Tests for context fallback paths introduced in fix/copilot-transcript-resume-gate.
+
+Scenario table
+==============
+
+| # | use_resume | transcript_msg_count | gap     | target_tokens | Expected output                            |
+|---|------------|----------------------|---------|---------------|--------------------------------------------|
+| A | True       | covers all           | empty   | None          | bare message (--resume has full context)   |
+| B | True       | stale                | 2 msgs  | None          | gap context prepended                      |
+| C | True       | stale                | 2 msgs  | 50_000        | gap compressed to budget, prepended        |
+| D | False      | 0                    | N/A     | None          | full session compressed, prepended         |
+| E | False      | 0                    | N/A     | 50_000        | full session compressed to budget          |
+| F | False      | 2 (partial)          | 2 msgs  | None          | ONLY gap prepended (efficient path)        |
+| G | False      | 2 (partial)          | 2 msgs  | 50_000        | gap compressed to budget                   |
+| H | False      | covers all           | empty   | None          | falls through → full session compressed    |
+|   |            |                      |         |               | (NOT bare message — the bug that was fixed)|
+| I | False      | covers all           | empty   | 50_000        | full session compressed to tight budget    |
+| J | False      | 2 (partial)          | yields  | None          | gap yields empty context → full fallback   |
+|   |            |                      | empty   |               |                                            |
+
+Compression unit tests
+=======================
+
+| # | Input                | target_tokens | Expected                                      |
+|---|----------------------|---------------|-----------------------------------------------|
+| K | []                   | None          | ([], False) — empty guard                     |
+| L | [1 msg]              | None          | ([msg], False) — single-msg guard             |
+| M | [2+ msgs]            | None          | target_tokens=None forwarded to _run_compression |
+| N | [2+ msgs]            | 30_000        | target_tokens=30_000 forwarded                |
+| O | [2+ msgs], run fails | None          | returns originals, False                      |
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.copilot.model import ChatMessage, ChatSession
+from backend.copilot.sdk.service import _build_query_message, _compress_messages
+from backend.util.prompt import CompressResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(messages: list[ChatMessage]) -> ChatSession:
+    now = datetime.now(UTC)
+    return ChatSession(
+        session_id="test-session",
+        user_id="user-1",
+        messages=messages,
+        title="test",
+        usage=[],
+        started_at=now,
+        updated_at=now,
+    )
+
+
+def _msgs(*pairs: tuple[str, str]) -> list[ChatMessage]:
+    return [ChatMessage(role=r, content=c) for r, c in pairs]
+
+
+def _passthrough_compress(target_tokens=None):
+    """Return a mock that passes messages through and records its call args."""
+    calls: list[tuple[list, int | None]] = []
+
+    async def _mock(msgs, tok=None):
+        calls.append((msgs, tok))
+        return msgs, False
+
+    _mock.calls = calls  # type: ignore[attr-defined]
+    return _mock
+
+
+# ---------------------------------------------------------------------------
+# _build_query_message — scenario A–J
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQueryMessageResume:
+    """use_resume=True paths (--resume supplies history; only inject gap if stale)."""
+
+    @pytest.mark.asyncio
+    async def test_scenario_a_transcript_current_returns_bare_message(self):
+        """Scenario A: --resume covers full context → no prefix injected."""
+        session = _make_session(
+            _msgs(("user", "q1"), ("assistant", "a1"), ("user", "q2"))
+        )
+        result, compacted = await _build_query_message(
+            "q2", session, use_resume=True, transcript_msg_count=2, session_id="s"
+        )
+        assert result == "q2"
+        assert compacted is False
+
+    @pytest.mark.asyncio
+    async def test_scenario_b_stale_transcript_injects_gap(self, monkeypatch):
+        """Scenario B: stale transcript → gap context prepended."""
+        session = _make_session(
+            _msgs(
+                ("user", "q1"),
+                ("assistant", "a1"),
+                ("user", "q2"),
+                ("assistant", "a2"),
+                ("user", "q3"),
+            )
+        )
+
+        async def _mock_compress(msgs, target_tokens=None):
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        result, compacted = await _build_query_message(
+            "q3", session, use_resume=True, transcript_msg_count=2, session_id="s"
+        )
+        assert "<conversation_history>" in result
+        assert "q2" in result
+        assert "a2" in result
+        assert "Now, the user says:\nq3" in result
+        # q1/a1 are covered by the transcript — must NOT appear in gap context
+        assert "q1" not in result
+
+    @pytest.mark.asyncio
+    async def test_scenario_c_stale_transcript_passes_target_tokens(self, monkeypatch):
+        """Scenario C: target_tokens is forwarded to _compress_messages for the gap."""
+        session = _make_session(
+            _msgs(
+                ("user", "q1"),
+                ("assistant", "a1"),
+                ("user", "q2"),
+                ("assistant", "a2"),
+                ("user", "q3"),
+            )
+        )
+        captured: list[int | None] = []
+
+        async def _mock_compress(msgs, target_tokens=None):
+            captured.append(target_tokens)
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        await _build_query_message(
+            "q3",
+            session,
+            use_resume=True,
+            transcript_msg_count=2,
+            session_id="s",
+            target_tokens=50_000,
+        )
+        assert captured == [50_000]
+
+
+class TestBuildQueryMessageNoResumeNoTranscript:
+    """use_resume=False, transcript_msg_count=0 — full session compressed."""
+
+    @pytest.mark.asyncio
+    async def test_scenario_d_full_session_compressed(self, monkeypatch):
+        """Scenario D: no resume, no transcript → compress all prior messages."""
+        session = _make_session(
+            _msgs(("user", "q1"), ("assistant", "a1"), ("user", "q2"))
+        )
+
+        async def _mock_compress(msgs, target_tokens=None):
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        result, compacted = await _build_query_message(
+            "q2", session, use_resume=False, transcript_msg_count=0, session_id="s"
+        )
+        assert "<conversation_history>" in result
+        assert "q1" in result
+        assert "a1" in result
+        assert "Now, the user says:\nq2" in result
+
+    @pytest.mark.asyncio
+    async def test_scenario_e_passes_target_tokens_to_compression(self, monkeypatch):
+        """Scenario E: target_tokens forwarded to _compress_messages."""
+        session = _make_session(
+            _msgs(("user", "q1"), ("assistant", "a1"), ("user", "q2"))
+        )
+        captured: list[int | None] = []
+
+        async def _mock_compress(msgs, target_tokens=None):
+            captured.append(target_tokens)
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        await _build_query_message(
+            "q2",
+            session,
+            use_resume=False,
+            transcript_msg_count=0,
+            session_id="s",
+            target_tokens=15_000,
+        )
+        assert captured == [15_000]
+
+
+class TestBuildQueryMessageNoResumeWithTranscript:
+    """use_resume=False, transcript_msg_count > 0 — gap or full-session fallback."""
+
+    @pytest.mark.asyncio
+    async def test_scenario_f_no_resume_always_injects_full_session(self, monkeypatch):
+        """Scenario F: use_resume=False with transcript_msg_count > 0 still injects
+        the FULL prior session — not just the gap since the transcript end.
+
+        When there is no --resume the CLI starts with zero context, so injecting
+        only the post-transcript gap would silently drop all transcript-covered
+        history.  The correct fix is to always compress the full session.
+        """
+        session = _make_session(
+            _msgs(
+                ("user", "q1"),  # transcript_msg_count=2 covers these
+                ("assistant", "a1"),
+                ("user", "q2"),  # post-transcript gap starts here
+                ("assistant", "a2"),
+                ("user", "q3"),  # current message
+            )
+        )
+        compressed_msgs: list[list] = []
+
+        async def _mock_compress(msgs, target_tokens=None):
+            compressed_msgs.append(list(msgs))
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        result, _ = await _build_query_message(
+            "q3",
+            session,
+            use_resume=False,
+            transcript_msg_count=2,  # transcript covers q1/a1 but no --resume
+            session_id="s",
+        )
+        assert "<conversation_history>" in result
+        # Full session must be injected — transcript-covered turns ARE included
+        assert "q1" in result
+        assert "a1" in result
+        assert "q2" in result
+        assert "a2" in result
+        assert "Now, the user says:\nq3" in result
+        # Compressed exactly once with all 4 prior messages
+        assert len(compressed_msgs) == 1
+        assert len(compressed_msgs[0]) == 4
+
+    @pytest.mark.asyncio
+    async def test_scenario_g_no_resume_passes_target_tokens(self, monkeypatch):
+        """Scenario G: target_tokens forwarded when use_resume=False + transcript_msg_count > 0."""
+        session = _make_session(
+            _msgs(
+                ("user", "q1"),
+                ("assistant", "a1"),
+                ("user", "q2"),
+                ("assistant", "a2"),
+                ("user", "q3"),
+            )
+        )
+        captured: list[int | None] = []
+
+        async def _mock_compress(msgs, target_tokens=None):
+            captured.append(target_tokens)
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        await _build_query_message(
+            "q3",
+            session,
+            use_resume=False,
+            transcript_msg_count=2,
+            session_id="s",
+            target_tokens=50_000,
+        )
+        assert captured == [50_000]
+
+    @pytest.mark.asyncio
+    async def test_scenario_h_no_resume_transcript_current_injects_full_session(
+        self, monkeypatch
+    ):
+        """Scenario H: the bug that was fixed.
+
+        Old code path: use_resume=False, transcript_msg_count covers all prior
+        messages → gap sub-path: gap = [] → ``return current_message, False``
+        → model received ZERO context (bare message only).
+
+        New code path: use_resume=False always compresses the full prior session
+        regardless of transcript_msg_count — model always gets context.
+        """
+        session = _make_session(
+            _msgs(
+                ("user", "q1"),
+                ("assistant", "a1"),
+                ("user", "q2"),
+                ("assistant", "a2"),
+                ("user", "q3"),
+            )
+        )
+
+        async def _mock_compress(msgs, target_tokens=None):
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        result, _ = await _build_query_message(
+            "q3",
+            session,
+            use_resume=False,
+            transcript_msg_count=4,  # covers ALL prior → old code returned bare msg
+            session_id="s",
+        )
+        # NEW: must inject full session, NOT return bare message
+        assert result != "q3"
+        assert "<conversation_history>" in result
+        assert "q1" in result
+        assert "Now, the user says:\nq3" in result
+
+    @pytest.mark.asyncio
+    async def test_scenario_i_no_resume_target_tokens_forwarded_any_transcript_count(
+        self, monkeypatch
+    ):
+        """Scenario I: target_tokens forwarded even when transcript_msg_count covers all."""
+        session = _make_session(
+            _msgs(("user", "q1"), ("assistant", "a1"), ("user", "q2"))
+        )
+        captured: list[int | None] = []
+
+        async def _mock_compress(msgs, target_tokens=None):
+            captured.append(target_tokens)
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        await _build_query_message(
+            "q2",
+            session,
+            use_resume=False,
+            transcript_msg_count=2,
+            session_id="s",
+            target_tokens=15_000,
+        )
+        assert 15_000 in captured
+
+    @pytest.mark.asyncio
+    async def test_scenario_j_no_resume_single_compression_call(self, monkeypatch):
+        """Scenario J: use_resume=False always makes exactly ONE compression call
+        (the full session), regardless of transcript coverage.
+
+        This verifies there is no two-step gap+fallback pattern for no-resume —
+        compression is called once with the full prior session.
+        """
+        session = _make_session(
+            _msgs(
+                ("user", "q1"),
+                ("assistant", "a1"),
+                ("user", "q2"),
+                ("assistant", "a2"),
+                ("user", "q3"),
+            )
+        )
+        call_count = 0
+
+        async def _mock_compress(msgs, target_tokens=None):
+            nonlocal call_count
+            call_count += 1
+            return msgs, False
+
+        monkeypatch.setattr(
+            "backend.copilot.sdk.service._compress_messages", _mock_compress
+        )
+
+        await _build_query_message(
+            "q3",
+            session,
+            use_resume=False,
+            transcript_msg_count=2,
+            session_id="s",
+        )
+        assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _compress_messages — unit tests K–O
+# ---------------------------------------------------------------------------
+
+
+class TestCompressMessages:
+    @pytest.mark.asyncio
+    async def test_scenario_k_empty_list_returns_empty(self):
+        """Scenario K: empty input → short-circuit, no compression."""
+        result, compacted = await _compress_messages([])
+        assert result == []
+        assert compacted is False
+
+    @pytest.mark.asyncio
+    async def test_scenario_l_single_message_returns_as_is(self):
+        """Scenario L: single message → short-circuit (< 2 guard)."""
+        msg = ChatMessage(role="user", content="hello")
+        result, compacted = await _compress_messages([msg])
+        assert result == [msg]
+        assert compacted is False
+
+    @pytest.mark.asyncio
+    async def test_scenario_m_target_tokens_none_forwarded(self):
+        """Scenario M: target_tokens=None forwarded to _run_compression."""
+        msgs = [
+            ChatMessage(role="user", content="q"),
+            ChatMessage(role="assistant", content="a"),
+        ]
+        fake_result = CompressResult(
+            messages=[
+                {"role": "user", "content": "q"},
+                {"role": "assistant", "content": "a"},
+            ],
+            token_count=10,
+            was_compacted=False,
+            original_token_count=10,
+        )
+        with patch(
+            "backend.copilot.sdk.service._run_compression",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ) as mock_run:
+            await _compress_messages(msgs, target_tokens=None)
+
+        mock_run.assert_awaited_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("target_tokens") is None
+
+    @pytest.mark.asyncio
+    async def test_scenario_n_explicit_target_tokens_forwarded(self):
+        """Scenario N: explicit target_tokens forwarded to _run_compression."""
+        msgs = [
+            ChatMessage(role="user", content="q"),
+            ChatMessage(role="assistant", content="a"),
+        ]
+        fake_result = CompressResult(
+            messages=[{"role": "user", "content": "summary"}],
+            token_count=5,
+            was_compacted=True,
+            original_token_count=50,
+        )
+        with patch(
+            "backend.copilot.sdk.service._run_compression",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ) as mock_run:
+            result, compacted = await _compress_messages(msgs, target_tokens=30_000)
+
+        mock_run.assert_awaited_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("target_tokens") == 30_000
+        assert compacted is True
+
+    @pytest.mark.asyncio
+    async def test_scenario_o_run_compression_exception_returns_originals(self):
+        """Scenario O: _run_compression raises → return original messages, False."""
+        msgs = [
+            ChatMessage(role="user", content="q"),
+            ChatMessage(role="assistant", content="a"),
+        ]
+        with patch(
+            "backend.copilot.sdk.service._run_compression",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("compression timeout"),
+        ):
+            result, compacted = await _compress_messages(msgs)
+
+        assert result == msgs
+        assert compacted is False
+
+    @pytest.mark.asyncio
+    async def test_compaction_messages_filtered_before_compression(self):
+        """filter_compaction_messages is applied before _run_compression is called."""
+        # A compaction message is one with role=assistant and specific content pattern.
+        # We verify that only real messages reach _run_compression.
+        from backend.copilot.sdk.service import filter_compaction_messages
+
+        msgs = [
+            ChatMessage(role="user", content="q"),
+            ChatMessage(role="assistant", content="a"),
+        ]
+        # filter_compaction_messages should not remove these plain messages
+        filtered = filter_compaction_messages(msgs)
+        assert len(filtered) == len(msgs)
+
+
+# ---------------------------------------------------------------------------
+# target_tokens threading — _retry_target_tokens values match expectations
+# ---------------------------------------------------------------------------
+
+
+class TestRetryTargetTokens:
+    def test_first_retry_uses_first_slot(self):
+        from backend.copilot.sdk.service import _RETRY_TARGET_TOKENS
+
+        assert _RETRY_TARGET_TOKENS[0] == 50_000
+
+    def test_second_retry_uses_second_slot(self):
+        from backend.copilot.sdk.service import _RETRY_TARGET_TOKENS
+
+        assert _RETRY_TARGET_TOKENS[1] == 15_000
+
+    def test_second_slot_smaller_than_first(self):
+        from backend.copilot.sdk.service import _RETRY_TARGET_TOKENS
+
+        assert _RETRY_TARGET_TOKENS[1] < _RETRY_TARGET_TOKENS[0]
+
+
+# ---------------------------------------------------------------------------
+# Single-message session edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSingleMessageSessions:
+    @pytest.mark.asyncio
+    async def test_no_resume_single_message_returns_bare(self):
+        """First turn (1 message): no prior history to inject."""
+        session = _make_session([ChatMessage(role="user", content="hello")])
+        result, compacted = await _build_query_message(
+            "hello", session, use_resume=False, transcript_msg_count=0, session_id="s"
+        )
+        assert result == "hello"
+        assert compacted is False
+
+    @pytest.mark.asyncio
+    async def test_resume_single_message_returns_bare(self):
+        """First turn with resume flag: transcript is empty so no gap."""
+        session = _make_session([ChatMessage(role="user", content="hello")])
+        result, compacted = await _build_query_message(
+            "hello", session, use_resume=True, transcript_msg_count=0, session_id="s"
+        )
+        assert result == "hello"
+        assert compacted is False

--- a/autogpt_platform/backend/backend/copilot/sdk/query_builder_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/query_builder_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from backend.copilot.model import ChatMessage, ChatSession
 from backend.copilot.sdk.service import (
+    _BARE_MESSAGE_TOKEN_FLOOR,
     _build_query_message,
     _format_conversation_context,
 )
@@ -281,3 +282,85 @@ async def test_build_query_no_resume_multi_message_compacted(monkeypatch):
         session_id="test-session",
     )
     assert was_compacted is True
+
+
+@pytest.mark.asyncio
+async def test_build_query_no_resume_at_token_floor():
+    """When target_tokens is at or below the floor, return bare message.
+
+    This is the final escape hatch: if the retry budget is exhausted and
+    even the most aggressive compression might not fit, skip history
+    injection entirely so the user always gets a response.
+    """
+    session = _make_session(
+        [
+            ChatMessage(role="user", content="old question"),
+            ChatMessage(role="assistant", content="old answer"),
+            ChatMessage(role="user", content="new question"),
+        ]
+    )
+    result, was_compacted = await _build_query_message(
+        "new question",
+        session,
+        use_resume=False,
+        transcript_msg_count=0,
+        session_id="test-session",
+        target_tokens=_BARE_MESSAGE_TOKEN_FLOOR,
+    )
+    # At the floor threshold, no history is injected
+    assert result == "new question"
+    assert was_compacted is False
+
+
+@pytest.mark.asyncio
+async def test_build_query_no_resume_below_token_floor():
+    """target_tokens strictly below floor also returns bare message."""
+    session = _make_session(
+        [
+            ChatMessage(role="user", content="old"),
+            ChatMessage(role="assistant", content="reply"),
+            ChatMessage(role="user", content="new"),
+        ]
+    )
+    result, was_compacted = await _build_query_message(
+        "new",
+        session,
+        use_resume=False,
+        transcript_msg_count=0,
+        session_id="test-session",
+        target_tokens=_BARE_MESSAGE_TOKEN_FLOOR - 1,
+    )
+    assert result == "new"
+    assert was_compacted is False
+
+
+@pytest.mark.asyncio
+async def test_build_query_no_resume_above_token_floor_compresses(monkeypatch):
+    """target_tokens just above the floor still triggers compression."""
+    session = _make_session(
+        [
+            ChatMessage(role="user", content="old"),
+            ChatMessage(role="assistant", content="reply"),
+            ChatMessage(role="user", content="new"),
+        ]
+    )
+
+    async def _mock_compress(msgs, target_tokens=None):
+        return msgs, False
+
+    monkeypatch.setattr(
+        "backend.copilot.sdk.service._compress_messages",
+        _mock_compress,
+    )
+
+    result, was_compacted = await _build_query_message(
+        "new",
+        session,
+        use_resume=False,
+        transcript_msg_count=0,
+        session_id="test-session",
+        target_tokens=_BARE_MESSAGE_TOKEN_FLOOR + 1,
+    )
+    # Above the floor → history is injected (not the bare message)
+    assert "<conversation_history>" in result
+    assert "Now, the user says:\nnew" in result

--- a/autogpt_platform/backend/backend/copilot/sdk/query_builder_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/query_builder_test.py
@@ -204,7 +204,7 @@ async def test_build_query_no_resume_multi_message(monkeypatch):
     )
 
     # Mock _compress_messages to return the messages as-is
-    async def _mock_compress(msgs):
+    async def _mock_compress(msgs, target_tokens=None):
         return msgs, False
 
     monkeypatch.setattr(
@@ -237,7 +237,7 @@ async def test_build_query_no_resume_multi_message_compacted(monkeypatch):
         ]
     )
 
-    async def _mock_compress(msgs):
+    async def _mock_compress(msgs, target_tokens=None):
         return msgs, True  # Simulate actual compaction
 
     monkeypatch.setattr(

--- a/autogpt_platform/backend/backend/copilot/sdk/query_builder_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/query_builder_test.py
@@ -131,6 +131,34 @@ async def test_build_query_resume_up_to_date():
 
 
 @pytest.mark.asyncio
+async def test_build_query_resume_misaligned_watermark():
+    """With --resume and watermark pointing at a user message, skip gap."""
+    # Simulates a deleted message shifting DB positions so the watermark
+    # lands on a user turn instead of the expected assistant turn.
+    session = _make_session(
+        [
+            ChatMessage(role="user", content="turn 1"),
+            ChatMessage(role="assistant", content="reply 1"),
+            ChatMessage(
+                role="user", content="turn 2"
+            ),  # ← watermark points here (role=user)
+            ChatMessage(role="assistant", content="reply 2"),
+            ChatMessage(role="user", content="turn 3"),
+        ]
+    )
+    result, was_compacted = await _build_query_message(
+        "turn 3",
+        session,
+        use_resume=True,
+        transcript_msg_count=3,  # prior[2].role == "user" — misaligned
+        session_id="test-session",
+    )
+    # Misaligned watermark → skip gap, return bare message
+    assert result == "turn 3"
+    assert was_compacted is False
+
+
+@pytest.mark.asyncio
 async def test_build_query_resume_stale_transcript():
     """With --resume and stale transcript, gap context is prepended."""
     session = _make_session(

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1108,37 +1108,9 @@ async def _build_query_message(
         return current_message, False
 
     elif not use_resume and msg_count > 1:
-        if transcript_msg_count > 0:
-            # A compressed transcript exists (downloaded or seeded from DB)
-            # but the CLI native session was unavailable.  Try gap-only first
-            # (efficient: only inject new messages since the transcript end).
-            gap = prior[transcript_msg_count:]
-            if gap:
-                compressed, was_compressed = await _compress_messages(
-                    gap, target_tokens
-                )
-                gap_context = _format_conversation_context(compressed)
-                if gap_context:
-                    logger.info(
-                        "[SDK] [%s] Transcript-aware fallback:"
-                        " gap=%d msgs, context_bytes=%d",
-                        session_id[:8],
-                        len(gap),
-                        len(gap_context),
-                    )
-                    return (
-                        f"{gap_context}\n\nNow, the user says:\n{current_message}",
-                        was_compressed,
-                    )
-            # Gap empty — transcript is current but we have no --resume.
-            # Fall through to compress full session so the model has context.
-            logger.info(
-                "[SDK] [%s] Transcript-aware fallback: gap empty,"
-                " compressing full session for context injection",
-                session_id[:8],
-            )
-
-        # No transcript at all, OR gap was empty: compress full prior session.
+        # No --resume: the CLI starts a fresh session with no prior context.
+        # Injecting only the post-transcript gap would omit the transcript-covered
+        # prefix entirely, so always compress the full prior session here.
         # compress_context handles size reduction internally (LLM summarize →
         # content truncate → middle-out delete → first/last trim).
         logger.warning(

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3261,6 +3261,14 @@ async def stream_chat_completion_sdk(
         # and should be re-uploaded so the next turn can resume from it.
         # upload_cli_session silently skips when the file is absent, so this is
         # always safe.
+        #
+        # Intentionally NOT gated on skip_transcript_upload: that flag is set
+        # when our custom JSONL transcript is dropped (transcript_lost=True on
+        # reduced-context retries) but the CLI's native session file is written
+        # independently.  Blocking CLI upload on transcript_lost would prevent
+        # T1 prompt-too-long retries from uploading their valid session file,
+        # breaking --resume on the next pod.  The ended_with_stream_error gate
+        # above already covers actual turn failures.
         if (
             config.claude_agent_use_resume
             and user_id
@@ -3268,11 +3276,10 @@ async def stream_chat_completion_sdk(
             and session is not None
             and state is not None
             and not ended_with_stream_error
-            and not skip_transcript_upload
         ):
             logger.info(
                 "%s Attempting CLI session upload"
-                " (use_resume=%s, has_history=%s, skip=%s)",
+                " (use_resume=%s, has_history=%s, skip_transcript=%s)",
                 log_prefix,
                 state.use_resume,
                 has_history,

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -354,6 +354,12 @@ class _StreamContext:
 # Index 0 = first retry, 1 = second retry; last value applies beyond that.
 _RETRY_TARGET_TOKENS: tuple[int, ...] = (50_000, 15_000)
 
+# Below this token budget the model context is so tight that injecting any
+# conversation history would likely exceed the limit regardless of content.
+# _build_query_message returns the bare message when target_tokens falls to
+# or below this floor, giving the user a response instead of a hard error.
+_BARE_MESSAGE_TOKEN_FLOOR: int = 5_000
+
 # Tight token budget for seeding the transcript builder on turns where no
 # CLI native session exists.  Kept below _RETRY_TARGET_TOKENS[0] so the
 # seeded JSONL upload stays compact and future gap injections are small.
@@ -1126,6 +1132,23 @@ async def _build_query_message(
         # prefix entirely, so always compress the full prior session here.
         # compress_context handles size reduction internally (LLM summarize →
         # content truncate → middle-out delete → first/last trim).
+
+        # Final escape hatch: if the token budget is at or below the floor,
+        # the model context is so tight that even fully compressed history
+        # would risk a "prompt too long" error.  Return the bare message so
+        # the user always gets a response rather than a hard failure.
+        if target_tokens is not None and target_tokens <= _BARE_MESSAGE_TOKEN_FLOOR:
+            logger.warning(
+                "[SDK] [%s] target_tokens=%d at or below floor (%d) —"
+                " skipping history injection to guarantee response delivery"
+                " (session has %d messages)",
+                session_id[:8],
+                target_tokens,
+                _BARE_MESSAGE_TOKEN_FLOOR,
+                msg_count,
+            )
+            return current_message, False
+
         logger.warning(
             "[SDK] [%s] No --resume for %d-message session — compressing"
             " full session history (pod affinity issue or first turn after"

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -998,6 +998,15 @@ async def _build_query_message(
     """
     msg_count = len(session.messages)
 
+    logger.info(
+        "[SDK] [%s] Context path: use_resume=%s, transcript_msg_count=%d,"
+        " db_msg_count=%d",
+        session_id[:8],
+        use_resume,
+        transcript_msg_count,
+        msg_count,
+    )
+
     if use_resume and transcript_msg_count > 0:
         if transcript_msg_count < msg_count - 1:
             gap = session.messages[transcript_msg_count:-1]
@@ -1006,28 +1015,49 @@ async def _build_query_message(
             if gap_context:
                 logger.info(
                     "[SDK] Transcript stale: covers %d of %d messages, "
-                    "gap=%d (compressed=%s)",
+                    "gap=%d (compressed=%s), gap_context_bytes=%d",
                     transcript_msg_count,
                     msg_count,
                     len(gap),
                     was_compressed,
+                    len(gap_context),
                 )
                 return (
                     f"{gap_context}\n\nNow, the user says:\n{current_message}",
                     was_compressed,
                 )
+        logger.info(
+            "[SDK] [%s] --resume covers full context (%d messages)",
+            session_id[:8],
+            transcript_msg_count,
+        )
     elif not use_resume and msg_count > 1:
         logger.warning(
-            f"[SDK] Using compression fallback for session "
-            f"{session_id} ({msg_count} messages) — no transcript for --resume"
+            "[SDK] [%s] No --resume for %d-message session — using"
+            " compression fallback (pod affinity issue or first turn after"
+            " restore failure)",
+            session_id[:8],
+            msg_count,
         )
         compressed, was_compressed = await _compress_messages(session.messages[:-1])
         history_context = _format_conversation_context(compressed)
         if history_context:
+            logger.info(
+                "[SDK] [%s] Fallback context built: compressed=%s," " context_bytes=%d",
+                session_id[:8],
+                was_compressed,
+                len(history_context),
+            )
             return (
                 f"{history_context}\n\nNow, the user says:\n{current_message}",
                 was_compressed,
             )
+        logger.warning(
+            "[SDK] [%s] Fallback context empty after compression"
+            " (%d messages) — sending message without history",
+            session_id[:8],
+            msg_count,
+        )
 
     return current_message, False
 
@@ -3070,6 +3100,13 @@ async def stream_chat_completion_sdk(
         # the shielded inner coroutine continues running to completion so the
         # upload is not lost.  This is intentional and matches the pattern
         # used for upload_transcript immediately above.
+        #
+        # NOTE: upload is attempted regardless of state.use_resume — even when
+        # this turn ran without --resume (restore failed or first T2+ on a new
+        # pod), the T1 session file at the expected path may still be present
+        # and should be re-uploaded so the next turn can resume from it.
+        # upload_cli_session silently skips when the file is absent, so this is
+        # always safe.
         if (
             config.claude_agent_use_resume
             and user_id
@@ -3078,8 +3115,15 @@ async def stream_chat_completion_sdk(
             and state is not None
             and not ended_with_stream_error
             and not skip_transcript_upload
-            and (not has_history or state.use_resume)
         ):
+            logger.info(
+                "%s Attempting CLI session upload"
+                " (use_resume=%s, has_history=%s, skip=%s)",
+                log_prefix,
+                state.use_resume,
+                has_history,
+                skip_transcript_upload,
+            )
             try:
                 await asyncio.shield(
                     upload_cli_session(

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -354,6 +354,11 @@ class _StreamContext:
 # Index 0 = first retry, 1 = second retry; last value applies beyond that.
 _RETRY_TARGET_TOKENS: tuple[int, ...] = (50_000, 15_000)
 
+# Tight token budget for seeding the transcript builder on turns where no
+# CLI native session exists.  Kept below _RETRY_TARGET_TOKENS[0] so the
+# seeded JSONL upload stays compact and future gap injections are small.
+_SEED_TARGET_TOKENS: int = 30_000
+
 
 async def _reduce_context(
     transcript_content: str,
@@ -2614,8 +2619,6 @@ async def stream_chat_completion_sdk(
         # history, and (b) a restored CLI session on the next pod gets a
         # usable compact base even for sessions that started on old pods.
         # Seeding only makes sense when transcripts will actually be uploaded.
-        # Use a tight token budget (30K) so the seeded JSONL stays compact.
-        _SEED_TARGET_TOKENS = 30_000
         if (
             not use_resume
             and not transcript_content

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1044,17 +1044,13 @@ async def _build_query_message(
     When ``use_resume=True``, the CLI has the full session via ``--resume``;
     only a gap-fill prefix is injected when the transcript is stale.
 
-    When ``use_resume=False``, context is built from DB messages via
-    ``_format_conversation_context``.  Three sub-paths:
-
-    * Transcript covers a prefix AND a gap exists — inject compressed gap
-      (efficient: only new messages since the transcript end).
-    * Transcript covers everything OR no transcript — inject the full prior
-      session compressed to ``target_tokens``.  ``compress_context`` handles
-      size reduction internally via LLM summarize → content truncate →
-      middle-out delete → first/last trim, so no message-count cap is needed.
-    * ``target_tokens`` decreases on each retry to force progressively more
-      aggressive compression when the first attempt exceeds context limits.
+    When ``use_resume=False``, the CLI starts a fresh session with no prior
+    context, so the full prior session is always compressed and injected via
+    ``_format_conversation_context``.  ``compress_context`` handles size
+    reduction internally (LLM summarize → content truncate → middle-out delete
+    → first/last trim).  ``target_tokens`` decreases on each retry to force
+    progressively more aggressive compression when the first attempt exceeds
+    context limits.
 
     Returns:
         Tuple of (query_message, was_compacted).

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -2059,6 +2059,48 @@ async def _run_stream_attempt(
         )
 
 
+async def _seed_transcript(
+    session: ChatSession,
+    transcript_builder: TranscriptBuilder,
+    transcript_covers_prefix: bool,
+    transcript_msg_count: int,
+    log_prefix: str,
+) -> tuple[str, bool, int]:
+    """Seed the transcript builder from compressed DB messages.
+
+    Called when ``use_resume=False`` and no prior transcript exists in storage
+    so that ``upload_transcript`` saves a compact version for future turns.
+    This ensures the next turn can use the full-session compression path with
+    the benefit of an already-compressed baseline, and a restored CLI session
+    on the next pod gets a usable compact base even for sessions that started
+    on old pods.
+
+    Returns ``(transcript_content, transcript_covers_prefix, transcript_msg_count)``
+    updated values — unchanged if seeding is not possible.
+    """
+    if len(session.messages) <= 1:
+        return "", transcript_covers_prefix, transcript_msg_count
+
+    _prior = session.messages[:-1]
+    _comp, _ = await _compress_messages(_prior, _SEED_TARGET_TOKENS)
+    if not _comp:
+        return "", transcript_covers_prefix, transcript_msg_count
+
+    _seeded = _session_messages_to_transcript(_comp)
+    if not _seeded or not validate_transcript(_seeded):
+        return "", transcript_covers_prefix, transcript_msg_count
+
+    transcript_builder.load_previous(_seeded, log_prefix=log_prefix)
+    logger.info(
+        "%s Seeded transcript from %d compressed DB messages"
+        " for next-turn upload (seed_target_tokens=%d)",
+        log_prefix,
+        len(_comp),
+        _SEED_TARGET_TOKENS,
+    )
+    return _seeded, True, len(_prior)
+
+
 async def stream_chat_completion_sdk(
     session_id: str,
     message: str | None = None,
@@ -2581,34 +2623,19 @@ async def stream_chat_completion_sdk(
 
         # When running without --resume and no prior transcript in storage,
         # seed the transcript builder from compressed DB messages so that
-        # upload_transcript saves a compact version for future turns.  This
-        # ensures (a) the next turn can use the transcript-aware gap path
-        # (inject only new messages) instead of re-compressing the full DB
-        # history, and (b) a restored CLI session on the next pod gets a
-        # usable compact base even for sessions that started on old pods.
-        # Seeding only makes sense when transcripts will actually be uploaded.
-        if (
-            not use_resume
-            and not transcript_content
-            and not skip_transcript_upload
-            and len(session.messages) > 1
-        ):
-            _prior = session.messages[:-1]
-            _comp, _ = await _compress_messages(_prior, _SEED_TARGET_TOKENS)
-            if _comp:
-                _seeded = _session_messages_to_transcript(_comp)
-                if _seeded and validate_transcript(_seeded):
-                    transcript_content = _seeded
-                    transcript_builder.load_previous(_seeded, log_prefix=log_prefix)
-                    transcript_covers_prefix = True
-                    transcript_msg_count = len(_prior)
-                    logger.info(
-                        "%s Seeded transcript from %d compressed DB messages"
-                        " for next-turn upload (seed_target_tokens=%d)",
-                        log_prefix,
-                        len(_comp),
-                        _SEED_TARGET_TOKENS,
-                    )
+        # upload_transcript saves a compact version for future turns.
+        if not use_resume and not transcript_content and not skip_transcript_upload:
+            (
+                transcript_content,
+                transcript_covers_prefix,
+                transcript_msg_count,
+            ) = await _seed_transcript(
+                session,
+                transcript_builder,
+                transcript_covers_prefix,
+                transcript_msg_count,
+                log_prefix,
+            )
 
         tried_compaction = False
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1070,6 +1070,23 @@ async def _build_query_message(
 
     if use_resume and transcript_msg_count > 0:
         if transcript_msg_count < msg_count - 1:
+            # Sanity-check the watermark: the last covered position should be
+            # an assistant turn.  A user-role message here means the count is
+            # misaligned (e.g. a message was deleted and DB positions shifted).
+            # Skip the gap rather than injecting wrong context — the CLI session
+            # loaded via --resume still has good history.
+            if prior[transcript_msg_count - 1].role != "assistant":
+                logger.warning(
+                    "[SDK] [%s] Watermark misaligned: prior[%d].role=%r"
+                    " (expected 'assistant') — skipping gap to avoid"
+                    " injecting wrong context (transcript=%d, db=%d)",
+                    session_id[:8],
+                    transcript_msg_count - 1,
+                    prior[transcript_msg_count - 1].role,
+                    transcript_msg_count,
+                    msg_count,
+                )
+                return current_message, False
             gap = prior[transcript_msg_count:]
             compressed, was_compressed = await _compress_messages(gap, target_tokens)
             gap_context = _format_conversation_context(compressed)

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -261,10 +261,11 @@ class ReducedContext(NamedTuple):
     resume_file: str | None
     transcript_lost: bool
     tried_compaction: bool
-    # Maximum number of DB messages to use in the _format_conversation_context
-    # fallback.  None means "use all".  Decreases on each retry attempt to
-    # prevent prompt-too-long cascades when there is no --resume.
-    max_fallback_messages: int | None = None
+    # Token budget for history compression on the DB-message fallback path.
+    # None means "use model-aware default".  Halved on each retry so
+    # compress_context applies progressively more aggressive reduction
+    # (LLM summarize → content truncate → middle-out delete → first/last trim).
+    target_tokens: int | None = None
 
 
 @dataclass
@@ -309,9 +310,10 @@ class _RetryState:
     adapter: SDKResponseAdapter
     transcript_builder: TranscriptBuilder
     usage: _TokenUsage
-    # Limits DB-message fallback size on retries to prevent prompt-too-long
-    # cascades on large sessions without --resume.  None = use all messages.
-    max_fallback_messages: int | None = None
+    # Token budget for history compression on retries (DB-message fallback path).
+    # None = model-aware default.  Halved each retry for progressively more
+    # aggressive compression (LLM summarize → truncate → middle-out → trim).
+    target_tokens: int | None = None
 
 
 @dataclass
@@ -343,13 +345,14 @@ class _StreamContext:
     lock: AsyncClusterLock
 
 
-# Per-retry fallback message limits for the no-transcript (use_resume=False)
-# path.  When there is no CLI native session to --resume, context is built
-# from DB messages via _format_conversation_context.  For large sessions this
-# text can exceed the model's context window; each retry attempt reduces the
-# number of messages included to prevent a cascading prompt-too-long failure.
-# Index 0 = first retry, 1 = second retry, higher = last value.
-_FALLBACK_MSG_LIMITS: tuple[int, ...] = (40, 10)
+# Per-retry token budgets for the no-transcript (use_resume=False) path.
+# When there is no CLI native session to --resume, context is built from DB
+# messages via _format_conversation_context.  For large sessions this text
+# can exceed the model context window; each retry halves the token budget so
+# compress_context applies progressively more aggressive reduction:
+#   LLM summarize → content truncate → middle-out delete → first/last trim.
+# Index 0 = first retry, 1 = second retry; last value applies beyond that.
+_RETRY_TARGET_TOKENS: tuple[int, ...] = (50_000, 15_000)
 
 
 async def _reduce_context(
@@ -367,16 +370,17 @@ async def _reduce_context(
     entirely so the query is rebuilt from DB messages only.
 
     When no transcript is available (use_resume=False fallback path), returns
-    a decreasing ``max_fallback_messages`` limit to prevent prompt-too-long
-    cascades on large sessions: 40 messages on the first retry, 10 on the
-    second.  The limit applies in `_build_query_message`.
+    a decreasing ``target_tokens`` budget so ``compress_context`` applies
+    progressively more aggressive reduction (LLM summarize → content truncate
+    → middle-out delete → first/last trim).  The budget applies in
+    ``_build_query_message`` and is halved on each retry.
 
-    `transcript_lost` is True when the transcript was dropped (caller
-    should set `skip_transcript_upload`).
+    ``transcript_lost`` is True when the transcript was dropped (caller
+    should set ``skip_transcript_upload``).
     """
-    # Max messages for the DB fallback on this attempt (no-transcript path).
+    # Token budget for the DB fallback on this attempt (no-transcript path).
     idx = max(0, attempt - 1)
-    max_fb = _FALLBACK_MSG_LIMITS[min(idx, len(_FALLBACK_MSG_LIMITS) - 1)]
+    retry_target = _RETRY_TARGET_TOKENS[min(idx, len(_RETRY_TARGET_TOKENS) - 1)]
 
     # First retry: try compacting our transcript builder state.
     # Note: the CLI native --resume file is not updated with the compacted
@@ -402,14 +406,13 @@ async def _reduce_context(
         logger.warning("%s Compaction failed, dropping transcript", log_prefix)
 
     # Subsequent retry or compaction failed: drop transcript entirely.
-    # Return max_fb so the caller limits DB-message fallback size.
+    # Return retry_target so the caller compresses DB messages to that budget.
     logger.warning(
-        "%s Dropping transcript, rebuilding from DB messages"
-        " (max_fallback_messages=%d)",
+        "%s Dropping transcript, rebuilding from DB messages" " (target_tokens=%d)",
         log_prefix,
-        max_fb,
+        retry_target,
     )
-    return ReducedContext(TranscriptBuilder(), False, None, True, True, max_fb)
+    return ReducedContext(TranscriptBuilder(), False, None, True, True, retry_target)
 
 
 def _append_error_marker(
@@ -862,6 +865,7 @@ def _format_sdk_content_blocks(blocks: list) -> list[dict[str, Any]]:
 
 async def _compress_messages(
     messages: list[ChatMessage],
+    target_tokens: int | None = None,
 ) -> tuple[list[ChatMessage], bool]:
     """Compress a list of messages if they exceed the token threshold.
 
@@ -869,6 +873,10 @@ async def _compress_messages(
     the "try LLM, fallback to truncation" pattern with timeouts.  Both
     `_compress_messages` and `compact_transcript` share this helper so
     client acquisition and error handling are consistent.
+
+    ``target_tokens`` sets a hard ceiling for the compressed output so
+    callers can enforce a tighter budget on retries.  When ``None``,
+    ``compress_context`` uses the model-aware default.
 
     See also:
         `_run_compression` — shared compression with timeout guards.
@@ -893,7 +901,9 @@ async def _compress_messages(
         messages_dict.append(msg_dict)
 
     try:
-        result = await _run_compression(messages_dict, config.model, "[SDK]")
+        result = await _run_compression(
+            messages_dict, config.model, "[SDK]", target_tokens=target_tokens
+        )
     except Exception as exc:
         # Guard against timeouts or unexpected errors in compression —
         # return the original messages so the caller can proceed without
@@ -1022,43 +1032,45 @@ async def _build_query_message(
     use_resume: bool,
     transcript_msg_count: int,
     session_id: str,
-    max_fallback_messages: int | None = None,
+    target_tokens: int | None = None,
 ) -> tuple[str, bool]:
     """Build the query message with appropriate context.
 
     When ``use_resume=True``, the CLI has the full session via ``--resume``;
     only a gap-fill prefix is injected when the transcript is stale.
 
-    When ``use_resume=False``, context is built from DB messages.  Two sub-
-    paths exist:
+    When ``use_resume=False``, context is built from DB messages via
+    ``_format_conversation_context``.  Three sub-paths:
 
-    * ``transcript_msg_count > 0`` — a compressed custom transcript was
-      downloaded (or seeded) but the CLI native session could not be restored.
-      Only the gap since the transcript end is injected (small).
-    * ``transcript_msg_count == 0`` — no prior context at all.  The most
-      recent ``max_fallback_messages`` DB messages are compressed and injected.
-      ``max_fallback_messages`` decreases on each retry attempt to prevent
-      prompt-too-long cascades on large sessions.
+    * Transcript covers a prefix AND a gap exists — inject compressed gap
+      (efficient: only new messages since the transcript end).
+    * Transcript covers everything OR no transcript — inject the full prior
+      session compressed to ``target_tokens``.  ``compress_context`` handles
+      size reduction internally via LLM summarize → content truncate →
+      middle-out delete → first/last trim, so no message-count cap is needed.
+    * ``target_tokens`` decreases on each retry to force progressively more
+      aggressive compression when the first attempt exceeds context limits.
 
     Returns:
         Tuple of (query_message, was_compacted).
     """
     msg_count = len(session.messages)
+    prior = session.messages[:-1]  # all turns except the current user message
 
     logger.info(
         "[SDK] [%s] Context path: use_resume=%s, transcript_msg_count=%d,"
-        " db_msg_count=%d, max_fallback=%s",
+        " db_msg_count=%d, target_tokens=%s",
         session_id[:8],
         use_resume,
         transcript_msg_count,
         msg_count,
-        max_fallback_messages,
+        target_tokens,
     )
 
     if use_resume and transcript_msg_count > 0:
         if transcript_msg_count < msg_count - 1:
-            gap = session.messages[transcript_msg_count:-1]
-            compressed, was_compressed = await _compress_messages(gap)
+            gap = prior[transcript_msg_count:]
+            compressed, was_compressed = await _compress_messages(gap, target_tokens)
             gap_context = _format_conversation_context(compressed)
             if gap_context:
                 logger.info(
@@ -1079,15 +1091,18 @@ async def _build_query_message(
             session_id[:8],
             transcript_msg_count,
         )
+        return current_message, False
+
     elif not use_resume and msg_count > 1:
         if transcript_msg_count > 0:
             # A compressed transcript exists (downloaded or seeded from DB)
-            # but the CLI native session was unavailable.  Inject only the
-            # gap since the transcript end — far smaller than a full-session
-            # compression for large sessions.
-            gap = session.messages[transcript_msg_count:-1]
+            # but the CLI native session was unavailable.  Try gap-only first
+            # (efficient: only inject new messages since the transcript end).
+            gap = prior[transcript_msg_count:]
             if gap:
-                compressed, was_compressed = await _compress_messages(gap)
+                compressed, was_compressed = await _compress_messages(
+                    gap, target_tokens
+                )
                 gap_context = _format_conversation_context(compressed)
                 if gap_context:
                     logger.info(
@@ -1101,49 +1116,44 @@ async def _build_query_message(
                         f"{gap_context}\n\nNow, the user says:\n{current_message}",
                         was_compressed,
                     )
-            # Gap empty or produced no context — send message alone.
+            # Gap empty — transcript is current but we have no --resume.
+            # Fall through to compress full session so the model has context.
             logger.info(
-                "[SDK] [%s] Transcript-aware fallback: gap empty, no prefix",
+                "[SDK] [%s] Transcript-aware fallback: gap empty,"
+                " compressing full session for context injection",
                 session_id[:8],
             )
-        else:
-            # No transcript at all — compress recent DB messages.
-            logger.warning(
-                "[SDK] [%s] No --resume for %d-message session — using"
-                " compression fallback (pod affinity issue or first turn after"
-                " restore failure); max_fallback=%s",
+
+        # No transcript at all, OR gap was empty: compress full prior session.
+        # compress_context handles size reduction internally (LLM summarize →
+        # content truncate → middle-out delete → first/last trim).
+        logger.warning(
+            "[SDK] [%s] No --resume for %d-message session — compressing"
+            " full session history (pod affinity issue or first turn after"
+            " restore failure); target_tokens=%s",
+            session_id[:8],
+            msg_count,
+            target_tokens,
+        )
+        compressed, was_compressed = await _compress_messages(prior, target_tokens)
+        history_context = _format_conversation_context(compressed)
+        if history_context:
+            logger.info(
+                "[SDK] [%s] Fallback context built: compressed=%s," " context_bytes=%d",
                 session_id[:8],
-                msg_count,
-                max_fallback_messages,
+                was_compressed,
+                len(history_context),
             )
-            prior = session.messages[:-1]
-            if max_fallback_messages is not None:
-                prior = prior[-max_fallback_messages:]
-                logger.info(
-                    "[SDK] [%s] Fallback limited to last %d messages",
-                    session_id[:8],
-                    len(prior),
-                )
-            compressed, was_compressed = await _compress_messages(prior)
-            history_context = _format_conversation_context(compressed)
-            if history_context:
-                logger.info(
-                    "[SDK] [%s] Fallback context built: compressed=%s,"
-                    " context_bytes=%d",
-                    session_id[:8],
-                    was_compressed,
-                    len(history_context),
-                )
-                return (
-                    f"{history_context}\n\nNow, the user says:\n{current_message}",
-                    was_compressed,
-                )
-            logger.warning(
-                "[SDK] [%s] Fallback context empty after compression"
-                " (%d messages) — sending message without history",
-                session_id[:8],
-                len(prior),
+            return (
+                f"{history_context}\n\nNow, the user says:\n{current_message}",
+                was_compressed,
             )
+        logger.warning(
+            "[SDK] [%s] Fallback context empty after compression"
+            " (%d messages) — sending message without history",
+            session_id[:8],
+            len(prior),
+        )
 
     return current_message, False
 
@@ -2594,9 +2604,17 @@ async def stream_chat_completion_sdk(
         # (inject only new messages) instead of re-compressing the full DB
         # history, and (b) a restored CLI session on the next pod gets a
         # usable compact base even for sessions that started on old pods.
-        if not use_resume and not transcript_content and len(session.messages) > 1:
+        # Seeding only makes sense when transcripts will actually be uploaded.
+        # Use a tight token budget (30K) so the seeded JSONL stays compact.
+        _SEED_TARGET_TOKENS = 30_000
+        if (
+            not use_resume
+            and not transcript_content
+            and not skip_transcript_upload
+            and len(session.messages) > 1
+        ):
             _prior = session.messages[:-1]
-            _comp, _ = await _compress_messages(_prior)
+            _comp, _ = await _compress_messages(_prior, _SEED_TARGET_TOKENS)
             if _comp:
                 _seeded = _session_messages_to_transcript(_comp)
                 if _seeded and validate_transcript(_seeded):
@@ -2606,9 +2624,10 @@ async def stream_chat_completion_sdk(
                     transcript_msg_count = len(_comp)
                     logger.info(
                         "%s Seeded transcript from %d compressed DB messages"
-                        " for next-turn upload",
+                        " for next-turn upload (seed_target_tokens=%d)",
                         log_prefix,
                         len(_comp),
+                        _SEED_TARGET_TOKENS,
                     )
 
         tried_compaction = False
@@ -2700,7 +2719,7 @@ async def stream_chat_completion_sdk(
                 state.resume_file = ctx.resume_file
                 tried_compaction = ctx.tried_compaction
                 state.transcript_msg_count = 0
-                state.max_fallback_messages = ctx.max_fallback_messages
+                state.target_tokens = ctx.target_tokens
                 if ctx.transcript_lost:
                     skip_transcript_upload = True
 
@@ -2737,7 +2756,7 @@ async def stream_chat_completion_sdk(
                     state.use_resume,
                     state.transcript_msg_count,
                     session_id,
-                    max_fallback_messages=state.max_fallback_messages,
+                    target_tokens=state.target_tokens,
                 )
                 if attachments.hint:
                     state.query_message = f"{state.query_message}\n\n{attachments.hint}"

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -1086,11 +1086,20 @@ async def _build_query_message(
                     f"{gap_context}\n\nNow, the user says:\n{current_message}",
                     was_compressed,
                 )
-        logger.info(
-            "[SDK] [%s] --resume covers full context (%d messages)",
-            session_id[:8],
-            transcript_msg_count,
-        )
+            logger.warning(
+                "[SDK] [%s] Transcript stale: gap produced empty context"
+                " (%d msgs, transcript=%d/%d) — sending message without gap prefix",
+                session_id[:8],
+                len(gap),
+                transcript_msg_count,
+                msg_count,
+            )
+        else:
+            logger.info(
+                "[SDK] [%s] --resume covers full context (%d messages)",
+                session_id[:8],
+                transcript_msg_count,
+            )
         return current_message, False
 
     elif not use_resume and msg_count > 1:
@@ -2621,7 +2630,7 @@ async def stream_chat_completion_sdk(
                     transcript_content = _seeded
                     transcript_builder.load_previous(_seeded, log_prefix=log_prefix)
                     transcript_covers_prefix = True
-                    transcript_msg_count = len(_comp)
+                    transcript_msg_count = len(_prior)
                     logger.info(
                         "%s Seeded transcript from %d compressed DB messages"
                         " for next-turn upload (seed_target_tokens=%d)",

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -261,6 +261,10 @@ class ReducedContext(NamedTuple):
     resume_file: str | None
     transcript_lost: bool
     tried_compaction: bool
+    # Maximum number of DB messages to use in the _format_conversation_context
+    # fallback.  None means "use all".  Decreases on each retry attempt to
+    # prevent prompt-too-long cascades when there is no --resume.
+    max_fallback_messages: int | None = None
 
 
 @dataclass
@@ -305,6 +309,9 @@ class _RetryState:
     adapter: SDKResponseAdapter
     transcript_builder: TranscriptBuilder
     usage: _TokenUsage
+    # Limits DB-message fallback size on retries to prevent prompt-too-long
+    # cascades on large sessions without --resume.  None = use all messages.
+    max_fallback_messages: int | None = None
 
 
 @dataclass
@@ -336,12 +343,22 @@ class _StreamContext:
     lock: AsyncClusterLock
 
 
+# Per-retry fallback message limits for the no-transcript (use_resume=False)
+# path.  When there is no CLI native session to --resume, context is built
+# from DB messages via _format_conversation_context.  For large sessions this
+# text can exceed the model's context window; each retry attempt reduces the
+# number of messages included to prevent a cascading prompt-too-long failure.
+# Index 0 = first retry, 1 = second retry, higher = last value.
+_FALLBACK_MSG_LIMITS: tuple[int, ...] = (40, 10)
+
+
 async def _reduce_context(
     transcript_content: str,
     tried_compaction: bool,
     session_id: str,
     sdk_cwd: str,
     log_prefix: str,
+    attempt: int = 1,
 ) -> ReducedContext:
     """Prepare reduced context for a retry attempt.
 
@@ -349,9 +366,18 @@ async def _reduce_context(
     On subsequent retries (or if compaction fails), drops the transcript
     entirely so the query is rebuilt from DB messages only.
 
+    When no transcript is available (use_resume=False fallback path), returns
+    a decreasing ``max_fallback_messages`` limit to prevent prompt-too-long
+    cascades on large sessions: 40 messages on the first retry, 10 on the
+    second.  The limit applies in `_build_query_message`.
+
     `transcript_lost` is True when the transcript was dropped (caller
     should set `skip_transcript_upload`).
     """
+    # Max messages for the DB fallback on this attempt (no-transcript path).
+    idx = max(0, attempt - 1)
+    max_fb = _FALLBACK_MSG_LIMITS[min(idx, len(_FALLBACK_MSG_LIMITS) - 1)]
+
     # First retry: try compacting our transcript builder state.
     # Note: the CLI native --resume file is not updated with the compacted
     # content (it would require emitting CLI-native JSONL format), so the
@@ -375,9 +401,15 @@ async def _reduce_context(
             return ReducedContext(tb, False, None, False, True)
         logger.warning("%s Compaction failed, dropping transcript", log_prefix)
 
-    # Subsequent retry or compaction failed: drop transcript entirely
-    logger.warning("%s Dropping transcript, rebuilding from DB messages", log_prefix)
-    return ReducedContext(TranscriptBuilder(), False, None, True, True)
+    # Subsequent retry or compaction failed: drop transcript entirely.
+    # Return max_fb so the caller limits DB-message fallback size.
+    logger.warning(
+        "%s Dropping transcript, rebuilding from DB messages"
+        " (max_fallback_messages=%d)",
+        log_prefix,
+        max_fb,
+    )
+    return ReducedContext(TranscriptBuilder(), False, None, True, True, max_fb)
 
 
 def _append_error_marker(
@@ -990,8 +1022,23 @@ async def _build_query_message(
     use_resume: bool,
     transcript_msg_count: int,
     session_id: str,
+    max_fallback_messages: int | None = None,
 ) -> tuple[str, bool]:
     """Build the query message with appropriate context.
+
+    When ``use_resume=True``, the CLI has the full session via ``--resume``;
+    only a gap-fill prefix is injected when the transcript is stale.
+
+    When ``use_resume=False``, context is built from DB messages.  Two sub-
+    paths exist:
+
+    * ``transcript_msg_count > 0`` — a compressed custom transcript was
+      downloaded (or seeded) but the CLI native session could not be restored.
+      Only the gap since the transcript end is injected (small).
+    * ``transcript_msg_count == 0`` — no prior context at all.  The most
+      recent ``max_fallback_messages`` DB messages are compressed and injected.
+      ``max_fallback_messages`` decreases on each retry attempt to prevent
+      prompt-too-long cascades on large sessions.
 
     Returns:
         Tuple of (query_message, was_compacted).
@@ -1000,11 +1047,12 @@ async def _build_query_message(
 
     logger.info(
         "[SDK] [%s] Context path: use_resume=%s, transcript_msg_count=%d,"
-        " db_msg_count=%d",
+        " db_msg_count=%d, max_fallback=%s",
         session_id[:8],
         use_resume,
         transcript_msg_count,
         msg_count,
+        max_fallback_messages,
     )
 
     if use_resume and transcript_msg_count > 0:
@@ -1032,32 +1080,70 @@ async def _build_query_message(
             transcript_msg_count,
         )
     elif not use_resume and msg_count > 1:
-        logger.warning(
-            "[SDK] [%s] No --resume for %d-message session — using"
-            " compression fallback (pod affinity issue or first turn after"
-            " restore failure)",
-            session_id[:8],
-            msg_count,
-        )
-        compressed, was_compressed = await _compress_messages(session.messages[:-1])
-        history_context = _format_conversation_context(compressed)
-        if history_context:
+        if transcript_msg_count > 0:
+            # A compressed transcript exists (downloaded or seeded from DB)
+            # but the CLI native session was unavailable.  Inject only the
+            # gap since the transcript end — far smaller than a full-session
+            # compression for large sessions.
+            gap = session.messages[transcript_msg_count:-1]
+            if gap:
+                compressed, was_compressed = await _compress_messages(gap)
+                gap_context = _format_conversation_context(compressed)
+                if gap_context:
+                    logger.info(
+                        "[SDK] [%s] Transcript-aware fallback:"
+                        " gap=%d msgs, context_bytes=%d",
+                        session_id[:8],
+                        len(gap),
+                        len(gap_context),
+                    )
+                    return (
+                        f"{gap_context}\n\nNow, the user says:\n{current_message}",
+                        was_compressed,
+                    )
+            # Gap empty or produced no context — send message alone.
             logger.info(
-                "[SDK] [%s] Fallback context built: compressed=%s," " context_bytes=%d",
+                "[SDK] [%s] Transcript-aware fallback: gap empty, no prefix",
                 session_id[:8],
-                was_compressed,
-                len(history_context),
             )
-            return (
-                f"{history_context}\n\nNow, the user says:\n{current_message}",
-                was_compressed,
+        else:
+            # No transcript at all — compress recent DB messages.
+            logger.warning(
+                "[SDK] [%s] No --resume for %d-message session — using"
+                " compression fallback (pod affinity issue or first turn after"
+                " restore failure); max_fallback=%s",
+                session_id[:8],
+                msg_count,
+                max_fallback_messages,
             )
-        logger.warning(
-            "[SDK] [%s] Fallback context empty after compression"
-            " (%d messages) — sending message without history",
-            session_id[:8],
-            msg_count,
-        )
+            prior = session.messages[:-1]
+            if max_fallback_messages is not None:
+                prior = prior[-max_fallback_messages:]
+                logger.info(
+                    "[SDK] [%s] Fallback limited to last %d messages",
+                    session_id[:8],
+                    len(prior),
+                )
+            compressed, was_compressed = await _compress_messages(prior)
+            history_context = _format_conversation_context(compressed)
+            if history_context:
+                logger.info(
+                    "[SDK] [%s] Fallback context built: compressed=%s,"
+                    " context_bytes=%d",
+                    session_id[:8],
+                    was_compressed,
+                    len(history_context),
+                )
+                return (
+                    f"{history_context}\n\nNow, the user says:\n{current_message}",
+                    was_compressed,
+                )
+            logger.warning(
+                "[SDK] [%s] Fallback context empty after compression"
+                " (%d messages) — sending message without history",
+                session_id[:8],
+                len(prior),
+            )
 
     return current_message, False
 
@@ -2252,9 +2338,20 @@ async def stream_chat_completion_sdk(
                     # Builder loaded but CLI native session not available.
                     # --resume will not be used this turn; upload after turn
                     # will seed the native session for the next turn.
+                    #
+                    # Still record transcript_msg_count so _build_query_message
+                    # can use the transcript-aware gap path (inject only new
+                    # messages since the transcript end) instead of compressing
+                    # the full DB history.  This avoids prompt-too-long on
+                    # large sessions where the CLI session is temporarily
+                    # unavailable (e.g. mixed-version rolling deployment).
+                    transcript_msg_count = dl.message_count
                     logger.info(
-                        "%s CLI session not restored — running without --resume this turn",
+                        "%s CLI session not restored — running without"
+                        " --resume this turn (transcript_msg_count=%d for"
+                        " gap-aware fallback)",
                         log_prefix,
+                        transcript_msg_count,
                     )
             else:
                 logger.warning("%s Transcript downloaded but invalid", log_prefix)
@@ -2490,6 +2587,30 @@ async def stream_chat_completion_sdk(
         if attachments.hint:
             query_message = f"{query_message}\n\n{attachments.hint}"
 
+        # When running without --resume and no prior transcript in storage,
+        # seed the transcript builder from compressed DB messages so that
+        # upload_transcript saves a compact version for future turns.  This
+        # ensures (a) the next turn can use the transcript-aware gap path
+        # (inject only new messages) instead of re-compressing the full DB
+        # history, and (b) a restored CLI session on the next pod gets a
+        # usable compact base even for sessions that started on old pods.
+        if not use_resume and not transcript_content and len(session.messages) > 1:
+            _prior = session.messages[:-1]
+            _comp, _ = await _compress_messages(_prior)
+            if _comp:
+                _seeded = _session_messages_to_transcript(_comp)
+                if _seeded and validate_transcript(_seeded):
+                    transcript_content = _seeded
+                    transcript_builder.load_previous(_seeded, log_prefix=log_prefix)
+                    transcript_covers_prefix = True
+                    transcript_msg_count = len(_comp)
+                    logger.info(
+                        "%s Seeded transcript from %d compressed DB messages"
+                        " for next-turn upload",
+                        log_prefix,
+                        len(_comp),
+                    )
+
         tried_compaction = False
 
         # Build the per-request context carrier (shared across attempts).
@@ -2572,12 +2693,14 @@ async def stream_chat_completion_sdk(
                     session_id,
                     sdk_cwd,
                     log_prefix,
+                    attempt=attempt,
                 )
                 state.transcript_builder = ctx.builder
                 state.use_resume = ctx.use_resume
                 state.resume_file = ctx.resume_file
                 tried_compaction = ctx.tried_compaction
                 state.transcript_msg_count = 0
+                state.max_fallback_messages = ctx.max_fallback_messages
                 if ctx.transcript_lost:
                     skip_transcript_upload = True
 
@@ -2595,7 +2718,6 @@ async def stream_chat_completion_sdk(
                     # T2+ retry without --resume: do not pass --session-id.
                     # The T1 session file already exists at that path; re-using
                     # the same ID would fail with "Session ID already in use".
-                    # The upload guard skips T2+ no-resume turns anyway.
                     sdk_options_kwargs_retry.pop("resume", None)
                     sdk_options_kwargs_retry.pop("session_id", None)
                 # Recompute system_prompt for retry — ctx.use_resume may have
@@ -2615,6 +2737,7 @@ async def stream_chat_completion_sdk(
                     state.use_resume,
                     state.transcript_msg_count,
                     session_id,
+                    max_fallback_messages=state.max_fallback_messages,
                 )
                 if attachments.hint:
                     state.query_message = f"{state.query_message}\n\n{attachments.hint}"

--- a/autogpt_platform/backend/backend/copilot/sdk/service_helpers_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_helpers_test.py
@@ -15,6 +15,7 @@ from claude_agent_sdk import AssistantMessage, TextBlock, ToolUseBlock
 
 from .conftest import build_test_transcript as _build_transcript
 from .service import (
+    _RETRY_TARGET_TOKENS,
     ReducedContext,
     _is_prompt_too_long,
     _is_tool_only_message,
@@ -206,6 +207,24 @@ class TestReduceContext:
             )
 
         assert ctx.transcript_lost is True
+
+    @pytest.mark.asyncio
+    async def test_drop_returns_target_tokens_attempt_1(self) -> None:
+        ctx = await _reduce_context("", False, "sess-1", "/tmp", "[t]", attempt=1)
+        assert ctx.transcript_lost is True
+        assert ctx.target_tokens == _RETRY_TARGET_TOKENS[0]
+
+    @pytest.mark.asyncio
+    async def test_drop_returns_target_tokens_attempt_2(self) -> None:
+        ctx = await _reduce_context("", False, "sess-1", "/tmp", "[t]", attempt=2)
+        assert ctx.transcript_lost is True
+        assert ctx.target_tokens == _RETRY_TARGET_TOKENS[1]
+
+    @pytest.mark.asyncio
+    async def test_drop_clamps_attempt_beyond_limits(self) -> None:
+        ctx = await _reduce_context("", False, "sess-1", "/tmp", "[t]", attempt=99)
+        assert ctx.transcript_lost is True
+        assert ctx.target_tokens == _RETRY_TARGET_TOKENS[-1]
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/copilot/sdk/transcript_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/transcript_test.py
@@ -960,7 +960,7 @@ class TestRunCompression:
         )
         call_count = [0]
 
-        async def _compress_side_effect(*, messages, model, client):
+        async def _compress_side_effect(*, messages, model, client, target_tokens=None):
             call_count[0] += 1
             if client is not None:
                 # Simulate a hang that exceeds the timeout

--- a/autogpt_platform/backend/backend/copilot/transcript.py
+++ b/autogpt_platform/backend/backend/copilot/transcript.py
@@ -1179,6 +1179,7 @@ async def _run_compression(
     messages: list[dict],
     model: str,
     log_prefix: str,
+    target_tokens: int | None = None,
 ) -> CompressResult:
     """Run LLM-based compression with truncation fallback.
 
@@ -1186,6 +1187,12 @@ async def _run_compression(
     If no client is configured or the LLM call fails, falls back to
     truncation-based compression which drops older messages without
     summarization.
+
+    ``target_tokens`` sets a hard token ceiling for the compressed output.
+    When ``None``, ``compress_context`` derives the limit from the model's
+    context window.  Pass a smaller value on retries to force more aggressive
+    compression — the compressor will LLM-summarize, content-truncate,
+    middle-out delete, and first/last trim until the result fits.
 
     A 60-second timeout prevents a hung LLM call from blocking the
     retry path indefinitely.  The truncation fallback also has a
@@ -1196,18 +1203,27 @@ async def _run_compression(
     if client is None:
         logger.warning("%s No OpenAI client configured, using truncation", log_prefix)
         return await asyncio.wait_for(
-            compress_context(messages=messages, model=model, client=None),
+            compress_context(
+                messages=messages, model=model, client=None, target_tokens=target_tokens
+            ),
             timeout=_TRUNCATION_TIMEOUT_SECONDS,
         )
     try:
         return await asyncio.wait_for(
-            compress_context(messages=messages, model=model, client=client),
+            compress_context(
+                messages=messages,
+                model=model,
+                client=client,
+                target_tokens=target_tokens,
+            ),
             timeout=_COMPACTION_TIMEOUT_SECONDS,
         )
     except Exception as e:
         logger.warning("%s LLM compaction failed, using truncation: %s", log_prefix, e)
         return await asyncio.wait_for(
-            compress_context(messages=messages, model=model, client=None),
+            compress_context(
+                messages=messages, model=model, client=None, target_tokens=target_tokens
+            ),
             timeout=_TRUNCATION_TIMEOUT_SECONDS,
         )
 


### PR DESCRIPTION
## Why

During a live production session, the copilot lost all conversation context mid-session. The model stated \"I don't see any implementation plan in our conversation\" despite 9 prior turns of context. Three compounding bugs:

**Bug 1 — Self-perpetuating upload gate:** When `restore_cli_session` fails on a T2+ turn, `state.use_resume=False`. The old gate `and (not has_history or state.use_resume)` then skips the CLI session upload — even though the T1 file may exist. Each turn without `use_resume` skips upload → next turn can't restore → also skips → etc.

**Bug 2 — Blunt message-count cap on retries:** On `prompt-too-long`, `_reduce_context` retried 3× but rebuilt the same oversized query each time (transcript was empty, so all 3 attempts were identical). The `max_fallback_messages` count-cap was a blunt instrument — it threw away middle turns blindly instead of letting the compressor summarize intelligently.

**Bug 3 — Gap-empty path returned zero context:** When a transcript exists but no `--resume` (CLI session unavailable), and the gap is empty (transcript is current), the code fell through to `return current_message, False` — the model got no history at all.

## What

1. **Remove upload gate** — upload is attempted after every successful turn; `upload_cli_session` silently skips when the file is absent.

2. **`transcript_msg_count` set on `cli_restored=False`** — enables the gap path on the very next turn without waiting for a full upload cycle.

3. **Token-budget compression instead of message-count cap** — `_reduce_context` now returns `target_tokens` (50K → 15K across retries). `compress_context` decides what to drop via LLM summarize → content truncate → middle-out delete → first/last trim. More context preserved at any budget vs. blindly slicing the list.

4. **Fix gap-empty case** — when transcript is current but `--resume` unavailable, fall through to full-session compression with the token budget instead of returning no context.

5. **Transcript seeding after fallback** — after `use_resume=False` with no stored transcript, compress DB messages to 30K tokens and serialise as JSONL into `transcript_builder`. Next turn uses the gap path (inject only new messages) instead of re-compressing full history. Only fires once per broken session (`not transcript_content` guard).

6. **Seeding guard** — seeding skips when `skip_transcript_upload=True` (avoids wasted compression work when the result won't be saved).

7. **Structured logging** — INFO/WARNING at every branch of `_build_query_message` with path variables, context_bytes, compression results.

## How

**Upload gate** (`sdk/service.py` finally-block): removed `and (not has_history or state.use_resume)`; added INFO log showing `use_resume`/`has_history` before upload.

**`transcript_msg_count`**: set from `dl.message_count` in the `cli_restored=False` branch.

**`_build_query_message`**: `max_fallback_messages: int | None` → `target_tokens: int | None`; gap-empty case falls through to full-session compression rather than returning bare message.

**`_reduce_context`**: `_FALLBACK_MSG_LIMITS` → `_RETRY_TARGET_TOKENS = (50_000, 15_000)`; returns `ReducedContext.target_tokens`.

**`_compress_messages` / `_run_compression`**: both now accept `target_tokens: int | None` and thread it through to `compress_context`.

**Seeding block**: added `not skip_transcript_upload` guard; uses `_SEED_TARGET_TOKENS = 30_000` so the seeded JSONL is always compact enough to pass `validate_transcript`.

## Checklist

- [x] `poetry run format` passes
- [x] No new lint errors introduced (pre-existing pyright errors unrelated)
- [x] Tests added for `attempt` parameter and `target_tokens` in `_reduce_context`