### PR TITLE
fix(blocks): handle empty response body gracefully for HTTP 204

### DIFF
--- a/autogpt_platform/backend/backend/blocks/http.py
+++ b/autogpt_platform/backend/backend/blocks/http.py
@@ -207,8 +207,10 @@ class SendWebRequestBlock(Block):
         )
 
         # Decide how to parse the response
-        if response.headers.get("content-type", "").startswith("application/json"):
-            result = None if response.status == 204 else response.json()
+        if response.status == 204 or not response.content:
+            result = None
+        elif response.headers.get("content-type", "").startswith("application/json"):
+            result = response.json()
         else:
             result = response.text()
 

--- a/autogpt_platform/backend/backend/blocks/test/test_http.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_http.py
@@ -495,3 +495,101 @@ class TestHttpBlockWithHostScopedCredentials:
                 # Should only include user headers
                 assert "Authorization" not in headers
                 assert headers["User-Agent"] == "test-agent"
+
+
+class TestHttpBlock204NoContent:
+    """Test suite for HTTP block handling of 204 No Content responses."""
+
+    @pytest.fixture
+    def send_web_request_block(self):
+        """Create a SendWebRequestBlock instance."""
+        from backend.blocks.http import SendWebRequestBlock
+
+        return SendWebRequestBlock()
+
+    @pytest.fixture
+    def mock_204_response(self):
+        """Mock a 204 No Content response."""
+        response = MagicMock(spec=Response)
+        response.status = 204
+        response.headers = {"content-type": "application/json"}
+        response.content = b""
+        return response
+
+    @pytest.fixture
+    def mock_204_response_empty_string_body(self):
+        """Mock a 204 response with empty string body that still has JSON content-type."""
+        response = MagicMock(spec=Response)
+        response.status = 204
+        response.headers = {"content-type": "application/json"}
+        response.content = b""
+        return response
+
+    @pytest.mark.asyncio
+    @patch("backend.blocks.http.Requests")
+    async def test_http_block_204_no_content_success(
+        self,
+        mock_requests_class,
+        send_web_request_block,
+        mock_204_response,
+    ):
+        """Test that 204 No Content responses are handled gracefully."""
+        mock_requests = AsyncMock()
+        mock_requests.request.return_value = mock_204_response
+        mock_requests_class.return_value = mock_requests
+
+        input_data = send_web_request_block.Input(
+            url="https://discord.com/api/webhooks/test",
+            method=HttpMethod.POST,
+            headers={},
+            json_format=True,
+            body={"content": "Hello from AutoGPT"},
+        )
+
+        result = []
+        async for output_name, output_data in send_web_request_block.run(
+            input_data,
+            execution_context=make_test_context(),
+        ):
+            result.append((output_name, output_data))
+
+        assert len(result) == 1
+        assert result[0][0] == "response"
+        assert result[0][1] is None
+
+    @pytest.mark.asyncio
+    @patch("backend.blocks.http.Requests")
+    async def test_http_block_204_with_json_content_type_and_empty_body(
+        self,
+        mock_requests_class,
+        send_web_request_block,
+        mock_204_response_empty_string_body,
+    ):
+        """Test 204 with application/json content-type but empty body doesn't crash.
+
+        This is the bug reported in issue #9883:
+        When Discord webhooks return 204, the response has content-type: application/json
+        but body is empty. The block should not try to parse empty body as JSON.
+        """
+        mock_requests = AsyncMock()
+        mock_requests.request.return_value = mock_204_response_empty_string_body
+        mock_requests_class.return_value = mock_requests
+
+        input_data = send_web_request_block.Input(
+            url="https://discord.com/api/webhooks/test",
+            method=HttpMethod.POST,
+            headers={},
+            json_format=True,
+            body={"content": "Hello from AutoGPT"},
+        )
+
+        result = []
+        async for output_name, output_data in send_web_request_block.run(
+            input_data,
+            execution_context=make_test_context(),
+        ):
+            result.append((output_name, output_data))
+
+        assert len(result) == 1
+        assert result[0][0] == "response"
+        assert result[0][1] is None


### PR DESCRIPTION
## Why

The Send Web Request block crashes when receiving HTTP 204 No Content responses from APIs like Discord webhooks. The error `Expecting value: line 1 column 1 (char 0)` occurs because the code attempts to parse an empty body as JSON when `json_format=True`.

This affects interoperability with webhooks and APIs that return 204 responses.

## What

- Check for 204 status OR empty response content before attempting JSON parsing
- Return `None` for empty responses instead of crashing
- Added test cases for 204 No Content handling

## How

Modified the response parsing logic in `SendWebRequestBlock.run()`:
- Check `response.status == 204 or not response.content` first
- Only parse JSON if response has content
- Added `TestHttpBlock204NoContent` test class with two test cases

Closes #9883