### PR TITLE
fix(frontend): announce block form field errors to screen readers

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -174,14 +174,18 @@ sandbox so `bash_exec` can access it for further processing.
 The exact sandbox path is shown in the `[Sandbox copy available at ...]` note.
 
 ### GitHub CLI (`gh`) and git
-- To check if the user has their GitHub account already connected, run `gh auth status`. Always check this before asking them to connect it.
+- To check if the user has their GitHub account already connected, run `gh auth status`. Always check this before running `connect_integration(provider="github")` which will ask the user to connect their GitHub regardless if it's already connected.
 - If the user has connected their GitHub account, both `gh` and `git` are
   pre-authenticated — use them directly without any manual login step.
   `git` HTTPS operations (clone, push, pull) work automatically.
 - If the token changes mid-session (e.g. user reconnects with a new token),
   run `gh auth setup-git` to re-register the credential helper.
-- If `gh` or `git` fails with an authentication error (e.g. "authentication
-  required", "could not read Username", or exit code 128), call
+- **MANDATORY:** You MUST run `gh auth status` before EVER calling
+  `connect_integration(provider="github")`. If it shows `Logged in`,
+  proceed directly — no integration connection needed. Never skip this check.
+- If `gh auth status` shows NOT logged in, or `gh`/`git` fails with an
+  authentication error (e.g. "authentication required", "could not read
+  Username", or exit code 128), THEN call
   `connect_integration(provider="github")` to surface the GitHub credentials
   setup card so the user can connect their account. Once connected, retry
   the operation.

--- a/autogpt_platform/frontend/src/components/atoms/DateInput/DateInput.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/DateInput/DateInput.tsx
@@ -41,6 +41,7 @@ export interface DateInputProps {
   error?: string;
   id?: string;
   size?: "default" | "small";
+  "aria-describedby"?: string;
 }
 
 export const DateInput = ({
@@ -56,6 +57,7 @@ export const DateInput = ({
   error,
   id,
   size = "default",
+  "aria-describedby": ariaDescribedBy,
 }: DateInputProps) => {
   const selected = React.useMemo(() => parseISODateString(value), [value]);
   const [open, setOpen] = React.useState(false);
@@ -117,6 +119,7 @@ export const DateInput = ({
             autoFocus={autoFocus}
             id={id}
             {...(hideLabel && label ? { "aria-label": label } : {})}
+            aria-describedby={ariaDescribedBy}
           >
             <CalendarIcon
               className={cn("mr-2", size === "default" ? "h-4 w-4" : "h-3 w-3")}

--- a/autogpt_platform/frontend/src/components/atoms/DateTimeInput/DateTimeInput.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/DateTimeInput/DateTimeInput.tsx
@@ -45,6 +45,7 @@ export interface DateTimeInputProps {
   id?: string;
   size?: "default" | "small";
   wrapperClassName?: string;
+  "aria-describedby"?: string;
 }
 
 export const DateTimeInput = ({
@@ -62,6 +63,7 @@ export const DateTimeInput = ({
   id,
   size = "default",
   wrapperClassName,
+  "aria-describedby": ariaDescribedBy,
 }: DateTimeInputProps) => {
   const selected = React.useMemo(() => parseISODateTimeString(value), [value]);
   const [open, setOpen] = React.useState(false);
@@ -181,6 +183,7 @@ export const DateTimeInput = ({
             autoFocus={autoFocus}
             id={id}
             {...(hideLabel && label ? { "aria-label": label } : {})}
+            aria-describedby={ariaDescribedBy}
           >
             <CalendarIcon
               className={cn("mr-2", size === "default" ? "h-4 w-4" : "h-3 w-3")}

--- a/autogpt_platform/frontend/src/components/atoms/Input/Input.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Input/Input.tsx
@@ -114,6 +114,7 @@ export function Input({
           }
           rows={props.rows || 3}
           {...(hideLabel ? { "aria-label": label } : {})}
+          aria-describedby={props["aria-describedby"]}
           id={props.id}
           disabled={props.disabled}
           value={props.value}
@@ -150,6 +151,7 @@ export function Input({
           decimalSeparator="."
           allowNegativeValue
           {...(hideLabel ? { "aria-label": label } : {})}
+          aria-describedby={props["aria-describedby"]}
           // Pass through common handlers
           onBlur={props.onBlur as any}
           onFocus={props.onFocus as any}

--- a/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
@@ -37,6 +37,7 @@ export interface SelectFieldProps {
   size?: "small" | "medium";
   renderItem?: (option: SelectOption) => React.ReactNode;
   wrapperClassName?: string;
+  "aria-describedby"?: string;
 }
 
 export function Select({
@@ -54,6 +55,7 @@ export function Select({
   size = "medium",
   renderItem,
   wrapperClassName,
+  "aria-describedby": ariaDescribedBy,
 }: SelectFieldProps) {
   const triggerStyles = cn(
     // Base styles matching Input
@@ -83,6 +85,7 @@ export function Select({
       <SelectTrigger
         className={triggerStyles}
         {...(hideLabel ? { "aria-label": label } : {})}
+        aria-describedby={ariaDescribedBy}
         id={id}
       >
         <SelectValue placeholder={placeholder || label} />

--- a/autogpt_platform/frontend/src/components/atoms/TimeInput/TimeInput.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/TimeInput/TimeInput.tsx
@@ -15,6 +15,7 @@ interface TimeInputProps {
   hint?: ReactNode;
   size?: "small" | "medium";
   wrapperClassName?: string;
+  "aria-describedby"?: string;
 }
 
 export const TimeInput: React.FC<TimeInputProps> = ({
@@ -30,6 +31,7 @@ export const TimeInput: React.FC<TimeInputProps> = ({
   hint,
   size = "medium",
   wrapperClassName,
+  "aria-describedby": ariaDescribedBy,
 }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onChange?.(e.target.value);
@@ -72,6 +74,7 @@ export const TimeInput: React.FC<TimeInputProps> = ({
         disabled={disabled}
         placeholder={placeholder || label}
         {...(hideLabel ? { "aria-label": label } : {})}
+        aria-describedby={ariaDescribedBy}
         id={id}
       />
     </div>

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/object/WrapIfAdditionalTemplate.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/object/WrapIfAdditionalTemplate.tsx
@@ -93,6 +93,7 @@ export default function WrapIfAdditionalTemplate(
               onBlur={!readonly ? handleBlur : undefined}
               type="text"
               size="small"
+              aria-describedby={`${id}-error`}
             />
             <div className="mt-2"> {children}</div>
           </div>

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/FieldError.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/FieldError.tsx
@@ -4,9 +4,11 @@ import { Text } from "@/components/atoms/Text/Text";
 export const FieldError = ({
   nodeId,
   fieldId,
+  id,
 }: {
   nodeId: string;
   fieldId: string;
+  id?: string;
 }) => {
   const nodeErrors = useNodeStore((state) => {
     const node = state.nodes.find((n) => n.id === nodeId);
@@ -16,7 +18,7 @@ export const FieldError = ({
     nodeErrors?.[fieldId] || nodeErrors?.[fieldId.replace(/_%_/g, ".")] || null;
 
   return (
-    <div>
+    <div id={id} aria-live="polite" aria-atomic="true">
       {fieldError && (
         <Text variant="small" className="mt-1 pl-4 !text-red-600">
           {fieldError}

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/FieldTemplate.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/FieldTemplate.tsx
@@ -138,7 +138,11 @@ export default function FieldTemplate(props: FieldTemplateProps) {
         )}
         {shouldShowChildren && children}
 
-        <FieldError nodeId={nodeId} fieldId={cleanUpHandleId(id)} />
+        <FieldError
+          nodeId={nodeId}
+          fieldId={cleanUpHandleId(id)}
+          id={`${id}-error`}
+        />
       </div>
     </WrapIfAdditionalTemplate>
   );

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/CheckboxInput/CheckBoxWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/CheckboxInput/CheckBoxWidget.tsx
@@ -11,6 +11,7 @@ export function CheckboxWidget(props: WidgetProps) {
       onCheckedChange={(checked) => onChange(checked)}
       disabled={disabled || readonly}
       autoFocus={autofocus}
+      aria-describedby={`${id}-error`}
     />
   );
 }

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/DateInput/DateWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/DateInput/DateWidget.tsx
@@ -29,6 +29,7 @@ export const DateWidget = (props: WidgetProps) => {
       disabled={disabled}
       readonly={readonly}
       autoFocus={autofocus}
+      aria-describedby={`${id}-error`}
     />
   );
 };

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/DateTimeInput/DateTimeWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/DateTimeInput/DateTimeWidget.tsx
@@ -29,6 +29,7 @@ export const DateTimeWidget = (props: WidgetProps) => {
       disabled={disabled}
       readonly={readonly}
       autoFocus={autofocus}
+      aria-describedby={`${id}-error`}
     />
   );
 };

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/SelectInput/SelectWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/SelectInput/SelectWidget.tsx
@@ -27,6 +27,7 @@ export const SelectWidget = (props: WidgetProps) => {
   const enumOptions = options.enumOptions || [];
   const type = mapJsonSchemaTypeToInputType(props.schema);
   const { size = "small" } = formContext || {};
+  const errorId = `${id}-error`;
 
   // Determine select size based on context
   const selectSize = size === "large" ? "medium" : "small";
@@ -39,7 +40,7 @@ export const SelectWidget = (props: WidgetProps) => {
           onValuesChange={onChange}
           className="w-full"
         >
-          <MultiSelectorTrigger>
+          <MultiSelectorTrigger aria-describedby={errorId}>
             <MultiSelectorInput placeholder="Select options..." />
           </MultiSelectorTrigger>
           <MultiSelectorContent>
@@ -71,6 +72,7 @@ export const SelectWidget = (props: WidgetProps) => {
         }
         wrapperClassName="!mb-0 "
         className={className}
+        aria-describedby={errorId}
       />
     );
   };

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TextInput/TextWidget.tsx
@@ -103,6 +103,7 @@ export default function TextWidget(props: WidgetProps) {
         placeholder={"Write your note here..."}
         required={props.required}
         disabled={props.disabled}
+        aria-describedby={`${props.id}-error`}
       />
     );
   }
@@ -123,6 +124,7 @@ export default function TextWidget(props: WidgetProps) {
           required={props.required}
           disabled={props.disabled}
           className={showExpandButton ? "pr-8" : ""}
+          aria-describedby={`${props.id}-error`}
         />
         {showExpandButton && (
           <Tooltip delayDuration={0}>

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TimeInput/TimeWidget.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/standard/widgets/TimeInput/TimeWidget.tsx
@@ -21,6 +21,7 @@ export const TimeWidget = (props: WidgetProps) => {
       wrapperClassName="!mb-0 "
       disabled={disabled || readonly}
       placeholder={placeholder}
+      aria-describedby={id ? `${id}-error` : undefined}
     />
   );
 };

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/JsonTextField/JsonTextField.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/JsonTextField/JsonTextField.tsx
@@ -86,6 +86,7 @@ export const JsonTextField = (props: FieldProps) => {
           required={required}
           disabled={props.disabled}
           className="min-h-[60px] pr-8 font-mono text-xs"
+          aria-describedby={`${fieldId}-error`}
         />
 
         <Tooltip delayDuration={0}>


### PR DESCRIPTION
### Why / What / How

**Why:** `FieldError` rendered block-form validation errors as a plain `<Text>` with no `id`, no `aria-live`, and no `aria-describedby` link from the input. Two screen reader failures:
1. A user tabbing into a field that already has an error hears nothing about it.
2. A newly appearing error isn't announced at all.

WCAG 3.3.1, 3.3.3, 4.1.3.

**What:** Makes `FieldError` a stable aria-live region and links every widget input to it via `aria-describedby`.

**How:**
- `FieldError` takes an `id` prop and renders the wrapper as `aria-live="polite" aria-atomic="true"`. The wrapper is always in the DOM (empty when no error) so the live region can detect changes.
- `FieldTemplate` passes `id={\`${fieldId}-error\`}` to `FieldError`.
- Atoms (`Input.tsx` textarea/amount paths, `Select.tsx`, `TimeInput.tsx`, `DateInput.tsx`, `DateTimeInput.tsx`) now forward `aria-describedby` to the underlying input element. The `BaseInput` text path already forwarded via `{...props}`.
- Every widget (`TextWidget`, `SelectWidget`, `DateWidget`, `TimeWidget`, `DateTimeWidget`, `CheckBoxWidget`, `JsonTextField`, `WrapIfAdditionalTemplate` dict-key) sets `aria-describedby={\`${id}-error\`}` so focusing a field with an existing error reads the error text immediately.

### Changes 🏗️

- `FieldError.tsx` — accept `id`, wrap in `aria-live="polite" aria-atomic="true"`
- `FieldTemplate.tsx` — pass `id={\`${id}-error\`}`
- 5 atom files — add `aria-describedby` pass-through (2 destructured prop, 3 explicit pass-through in non-spread paths)
- 8 widget files — set `aria-describedby` on the atom/widget call

Dangling-id safety: if no error is rendered, the referenced element is still in the DOM as an empty live region — `aria-describedby` points at a real (empty) element, not a dangling reference. Harmless.

**Not in scope:**
- `aria-invalid` on inputs (needs per-widget node-store access to know error state). This PR relies on the aria-live announcement path and the describedby linkage; aria-invalid would be a follow-up.
- Top-of-form `ErrorList` — the shared `Alert` molecule already provides `role="alert"` semantics, so it's already covered.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `pnpm types` passes for every touched file
  - [ ] Block with a required field, submit empty so RJSF produces a validation error — SR announces the error text when focus enters the field (`aria-describedby`)
  - [ ] Block where a validation error appears after editing — SR announces the change (`aria-live="polite"`)
  - [ ] Block where the error is cleared by fixing the input — live region update is announced or silent (polite, not barging)
  - [ ] Visual regression — `FieldError` now renders an empty `<div>` when there's no error (previously an empty `<div>` too). No visible change.

Part of a six-branch accessibility pass. Does not depend on the other five branches.
