### PR TITLE
feat(platform): estimate CoPilot turn cost and require approval for high-cost requests

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -15,7 +15,15 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from backend.copilot import service as chat_service
 from backend.copilot import stream_registry
+from backend.copilot.cost_approval import (
+    generate_cost_approval_token,
+    validate_cost_approval_token,
+)
 from backend.copilot.config import ChatConfig, CopilotLlmModel, CopilotMode
+from backend.copilot.cost_estimation import (
+    CoPilotTurnCostEstimate,
+    estimate_copilot_turn_cost,
+)
 from backend.copilot.db import get_chat_messages_paginated
 from backend.copilot.executor.utils import enqueue_cancel_task, enqueue_copilot_turn
 from backend.copilot.message_dedup import acquire_dedup_lock
@@ -149,6 +157,10 @@ class StreamChatRequest(BaseModel):
         default=None,
         description="Model tier: 'standard' for the default model, 'advanced' for the highest-capability model. "
         "If None, the server applies per-user LD targeting then falls back to config.",
+    )
+    approval_token: str | None = Field(
+        default=None,
+        description="Short-lived approval token for high-cost requests returned by /estimate.",
     )
 
 
@@ -732,6 +744,43 @@ async def reset_copilot_usage(
 
 
 @router.post(
+    "/sessions/{session_id}/estimate",
+)
+async def estimate_chat_turn_cost(
+    session_id: str,
+    request: StreamChatRequest,
+    user_id: str = Security(auth.get_user_id),
+) -> CoPilotTurnCostEstimate:
+    """Estimate CoPilot token usage and cost before execution."""
+    session = await _validate_and_get_session(session_id, user_id)
+    estimate = await estimate_copilot_turn_cost(
+        session_id=session_id,
+        user_id=user_id,
+        session=session,
+        message=request.message,
+        is_user_message=request.is_user_message,
+        context=request.context,
+        file_ids=request.file_ids,
+        mode=request.mode,
+        model=request.model,
+    )
+    if estimate.requires_confirmation:
+        token = await generate_cost_approval_token(
+            user_id=user_id,
+            session_id=session_id,
+            message=request.message,
+            is_user_message=request.is_user_message,
+            context=request.context,
+            file_ids=request.file_ids,
+            mode=request.mode,
+            model=request.model,
+            ttl_seconds=config.copilot_cost_approval_ttl_seconds,
+        )
+        estimate = estimate.model_copy(update={"approval_token": token})
+    return estimate
+
+
+@router.post(
     "/sessions/{session_id}/cancel",
     status_code=200,
 )
@@ -815,7 +864,7 @@ async def stream_chat_post(
         f"user={user_id}, message_len={len(request.message)}",
         extra={"json_fields": log_meta},
     )
-    await _validate_and_get_session(session_id, user_id)
+    session = await _validate_and_get_session(session_id, user_id)
     logger.info(
         f"[TIMING] session validated in {(time.perf_counter() - stream_start_time) * 1000:.1f}ms",
         extra={
@@ -841,6 +890,43 @@ async def stream_chat_post(
             )
         except RateLimitExceeded as e:
             raise HTTPException(status_code=429, detail=str(e)) from e
+
+    estimate = await estimate_copilot_turn_cost(
+        session_id=session_id,
+        user_id=user_id,
+        session=session,
+        message=request.message,
+        is_user_message=request.is_user_message,
+        context=request.context,
+        file_ids=request.file_ids,
+        mode=request.mode,
+        model=request.model,
+    )
+    if estimate.requires_confirmation:
+        if not request.approval_token:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "This task requires cost confirmation before execution. "
+                    "Request an estimate and confirm to continue."
+                ),
+            )
+        approved = await validate_cost_approval_token(
+            token=request.approval_token,
+            user_id=user_id,
+            session_id=session_id,
+            message=request.message,
+            is_user_message=request.is_user_message,
+            context=request.context,
+            file_ids=request.file_ids,
+            mode=request.mode,
+            model=request.model,
+        )
+        if not approved:
+            raise HTTPException(
+                status_code=403,
+                detail="Cost confirmation token is invalid or expired.",
+            )
 
     # Enrich message with file metadata if file_ids are provided.
     # Also sanitise file_ids so only validated, workspace-scoped IDs are

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -10,6 +10,7 @@ import pytest_mock
 
 from backend.api.features.chat import routes as chat_routes
 from backend.api.features.chat.routes import _strip_injected_context
+from backend.copilot.cost_estimation import CoPilotTurnCostEstimate
 from backend.copilot.rate_limit import SubscriptionTier
 
 app = fastapi.FastAPI()
@@ -18,6 +19,23 @@ app.include_router(chat_routes.router)
 client = fastapi.testclient.TestClient(app)
 
 TEST_USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
+
+
+@pytest.fixture
+def test_user_id() -> str:
+    return TEST_USER_ID
+
+
+@pytest.fixture
+def mock_jwt_user(test_user_id: str):
+    def _get_jwt_payload():
+        return {
+            "sub": test_user_id,
+            "role": "authenticated",
+            "email": "test@example.com",
+        }
+
+    return {"get_jwt_payload": _get_jwt_payload}
 
 
 @pytest.fixture(autouse=True)
@@ -152,9 +170,18 @@ def _mock_stream_internals(
     """
     import types
 
+    fake_session = MagicMock()
+    fake_session.messages = []
+
     mocker.patch(
         "backend.api.features.chat.routes._validate_and_get_session",
-        return_value=None,
+        new_callable=AsyncMock,
+        return_value=fake_session,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.estimate_copilot_turn_cost",
+        new_callable=AsyncMock,
+        return_value=MagicMock(requires_confirmation=False),
     )
     mock_save = mocker.patch(
         "backend.api.features.chat.routes.append_and_save_message",
@@ -350,6 +377,127 @@ def test_stream_chat_429_includes_reset_time(mocker: pytest_mock.MockerFixture):
     detail = response.json()["detail"]
     assert "2h" in detail
     assert "Resets in" in detail
+
+
+def test_estimate_returns_approval_token_when_confirmation_required(
+    mocker: pytest_mock.MockerFixture,
+):
+    """Estimate endpoint returns approval token when confirmation is required."""
+    fake_session = MagicMock()
+    fake_session.messages = []
+    mocker.patch(
+        "backend.api.features.chat.routes._validate_and_get_session",
+        new_callable=AsyncMock,
+        return_value=fake_session,
+    )
+
+    mocker.patch(
+        "backend.api.features.chat.routes.estimate_copilot_turn_cost",
+        new_callable=AsyncMock,
+        return_value=CoPilotTurnCostEstimate(
+            resolved_path="sdk",
+            resolved_model="claude-sonnet-4-6",
+            estimated_llm_calls=6,
+            estimated_prompt_tokens=120000,
+            estimated_completion_tokens=18000,
+            estimated_total_tokens=138000,
+            estimated_cost_usd=11.42,
+            confirmation_threshold_usd=10.0,
+            threshold_source="launchdarkly",
+            requires_confirmation=True,
+            rationale="Complex multi-step task",
+        ),
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.generate_cost_approval_token",
+        new_callable=AsyncMock,
+        return_value="approval-token-123",
+    )
+
+    response = client.post(
+        "/sessions/sess-1/estimate",
+        json={"message": "Plan and execute this in multiple steps"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["requires_confirmation"] is True
+    assert data["approval_token"] == "approval-token-123"
+
+
+def test_stream_chat_rejects_when_confirmation_required_and_token_missing(
+    mocker: pytest_mock.MockerFixture,
+):
+    """Stream endpoint should block execution when approval is required."""
+    internals = _mock_stream_internals(mocker)
+
+    mocker.patch(
+        "backend.api.features.chat.routes.estimate_copilot_turn_cost",
+        new_callable=AsyncMock,
+        return_value=CoPilotTurnCostEstimate(
+            resolved_path="sdk",
+            resolved_model="claude-sonnet-4-6",
+            estimated_llm_calls=6,
+            estimated_prompt_tokens=120000,
+            estimated_completion_tokens=18000,
+            estimated_total_tokens=138000,
+            estimated_cost_usd=11.42,
+            confirmation_threshold_usd=10.0,
+            threshold_source="launchdarkly",
+            requires_confirmation=True,
+            rationale="Complex multi-step task",
+        ),
+    )
+
+    response = client.post(
+        "/sessions/sess-1/stream",
+        json={"message": "Run a costly multi-step task"},
+    )
+
+    assert response.status_code == 403
+    assert "confirmation" in response.json()["detail"].lower()
+    internals.enqueue.assert_not_called()
+
+
+def test_stream_chat_accepts_when_confirmation_required_and_token_valid(
+    mocker: pytest_mock.MockerFixture,
+):
+    """Stream endpoint should proceed with a valid approval token."""
+    internals = _mock_stream_internals(mocker)
+
+    mocker.patch(
+        "backend.api.features.chat.routes.estimate_copilot_turn_cost",
+        new_callable=AsyncMock,
+        return_value=CoPilotTurnCostEstimate(
+            resolved_path="sdk",
+            resolved_model="claude-sonnet-4-6",
+            estimated_llm_calls=6,
+            estimated_prompt_tokens=120000,
+            estimated_completion_tokens=18000,
+            estimated_total_tokens=138000,
+            estimated_cost_usd=11.42,
+            confirmation_threshold_usd=10.0,
+            threshold_source="launchdarkly",
+            requires_confirmation=True,
+            rationale="Complex multi-step task",
+        ),
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.validate_cost_approval_token",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+
+    response = client.post(
+        "/sessions/sess-1/stream",
+        json={
+            "message": "Run a costly multi-step task",
+            "approval_token": "approval-token-123",
+        },
+    )
+
+    assert response.status_code == 200
+    internals.enqueue.assert_called_once()
 
 
 # ─── Usage endpoint ───────────────────────────────────────────────────

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -117,6 +117,22 @@ class ChatConfig(BaseSettings):
         description="Max tokens per week, resets Monday 00:00 UTC (0 = unlimited)",
     )
 
+    # Cost-estimation confirmation threshold for CoPilot turns.
+    # Users exceeding this estimated USD cost must confirm before execution.
+    # LaunchDarkly can override this per user (and org/domain via targeting).
+    copilot_cost_confirmation_threshold_usd: float = Field(
+        default=10.0,
+        ge=0.0,
+        le=1000.0,
+        description="Estimated USD threshold that requires user confirmation before running a CoPilot turn. 0 disables confirmation gating.",
+    )
+    copilot_cost_approval_ttl_seconds: int = Field(
+        default=600,
+        ge=60,
+        le=86400,
+        description="TTL in seconds for a high-cost confirmation approval token.",
+    )
+
     # Cost (in credits / cents) to reset the daily rate limit using credits.
     # When a user hits their daily limit, they can spend this amount to reset
     # the daily counter and keep working.  Set to 0 to disable the feature.

--- a/autogpt_platform/backend/backend/copilot/cost_approval.py
+++ b/autogpt_platform/backend/backend/copilot/cost_approval.py
@@ -1,0 +1,146 @@
+"""Approval token helpers for high-cost CoPilot requests."""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from typing import Literal
+
+from backend.util.settings import Settings
+
+CopilotMode = Literal["fast", "extended_thinking"]
+CopilotLlmModel = Literal["standard", "advanced"]
+
+settings = Settings()
+_ephemeral_secret = secrets.token_bytes(32)
+
+
+async def generate_cost_approval_token(
+    *,
+    user_id: str,
+    session_id: str,
+    message: str,
+    is_user_message: bool,
+    context: dict[str, str] | None,
+    file_ids: list[str] | None,
+    mode: CopilotMode | None,
+    model: CopilotLlmModel | None,
+    ttl_seconds: int,
+) -> str:
+    """Generate a signed approval token for high-cost estimates."""
+    payload = {
+        "u": user_id,
+        "s": session_id,
+        "h": build_cost_approval_fingerprint(
+            message=message,
+            is_user_message=is_user_message,
+            context=context,
+            file_ids=file_ids,
+            mode=mode,
+            model=model,
+        ),
+        "e": int(time.time()) + ttl_seconds,
+    }
+    encoded = _urlsafe_encode_json(payload)
+    signature = _sign_payload(encoded)
+    return f"{encoded}.{signature}"
+
+
+async def validate_cost_approval_token(
+    *,
+    token: str,
+    user_id: str,
+    session_id: str,
+    message: str,
+    is_user_message: bool,
+    context: dict[str, str] | None,
+    file_ids: list[str] | None,
+    mode: CopilotMode | None,
+    model: CopilotLlmModel | None,
+) -> bool:
+    """Validate approval token signature, expiry, and request fingerprint."""
+    try:
+        encoded, signature = token.split(".", 1)
+    except ValueError:
+        return False
+    expected_signature = _sign_payload(encoded)
+    if not hmac.compare_digest(signature, expected_signature):
+        return False
+    try:
+        payload = _decode_urlsafe_json(encoded)
+    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    try:
+        expires_at = int(payload.get("e", 0))
+    except (TypeError, ValueError):
+        return False
+    if expires_at < int(time.time()):
+        return False
+    if payload.get("u") != user_id or payload.get("s") != session_id:
+        return False
+    expected_hash = build_cost_approval_fingerprint(
+        message=message,
+        is_user_message=is_user_message,
+        context=context,
+        file_ids=file_ids,
+        mode=mode,
+        model=model,
+    )
+    return payload.get("h") == expected_hash
+
+
+def build_cost_approval_fingerprint(
+    *,
+    message: str,
+    is_user_message: bool,
+    context: dict[str, str] | None,
+    file_ids: list[str] | None,
+    mode: CopilotMode | None,
+    model: CopilotLlmModel | None,
+) -> str:
+    """Build a stable hash for cost-approval token binding."""
+    payload = {
+        "message": message,
+        "is_user_message": is_user_message,
+        "context": context,
+        "file_ids": file_ids or [],
+        "mode": mode,
+        "model": model,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _approval_secret() -> bytes:
+    candidates = (
+        settings.secrets.encryption_key,
+        settings.secrets.unsubscribe_secret_key,
+        settings.secrets.supabase_service_role_key,
+    )
+    for value in candidates:
+        if value:
+            return value.encode("utf-8")
+    return _ephemeral_secret
+
+
+def _sign_payload(encoded_payload: str) -> str:
+    signature = hmac.new(
+        _approval_secret(), encoded_payload.encode("utf-8"), hashlib.sha256
+    )
+    return signature.hexdigest()
+
+
+def _urlsafe_encode_json(payload: dict[str, str | int]) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return base64.urlsafe_b64encode(body.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def _decode_urlsafe_json(encoded_payload: str) -> object:
+    padding = "=" * (-len(encoded_payload) % 4)
+    decoded = base64.urlsafe_b64decode(encoded_payload + padding)
+    return json.loads(decoded.decode("utf-8"))

--- a/autogpt_platform/backend/backend/copilot/cost_estimation.py
+++ b/autogpt_platform/backend/backend/copilot/cost_estimation.py
@@ -1,0 +1,253 @@
+"""CoPilot pre-execution cost estimation."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from backend.copilot.baseline.service import _resolve_baseline_model
+from backend.copilot.config import ChatConfig, CopilotLlmModel, CopilotMode
+from backend.copilot.executor.processor import (
+    resolve_effective_mode,
+    resolve_use_sdk_for_mode,
+)
+from backend.copilot.model import ChatSession
+from backend.copilot.sdk.service import _resolve_model_and_multiplier
+from backend.util.feature_flag import Flag, get_feature_flag_value
+from backend.util.prompt import estimate_token_count, estimate_token_count_str
+
+config = ChatConfig()
+
+
+class CoPilotTurnCostEstimate(BaseModel):
+    """Estimated token usage and USD cost for a CoPilot turn."""
+
+    resolved_path: Literal["baseline", "sdk"]
+    resolved_model: str
+    estimated_llm_calls: int = Field(ge=1)
+    estimated_prompt_tokens: int = Field(ge=0)
+    estimated_completion_tokens: int = Field(ge=0)
+    estimated_total_tokens: int = Field(ge=0)
+    estimated_cost_usd: float = Field(ge=0)
+    confirmation_threshold_usd: float = Field(ge=0)
+    threshold_source: Literal["launchdarkly", "default"]
+    requires_confirmation: bool
+    rationale: str
+    approval_token: str | None = None
+
+
+async def estimate_copilot_turn_cost(
+    *,
+    session_id: str,
+    user_id: str | None,
+    session: ChatSession,
+    message: str,
+    is_user_message: bool,
+    context: dict[str, str] | None,
+    file_ids: list[str] | None,
+    mode: CopilotMode | None,
+    model: CopilotLlmModel | None,
+) -> CoPilotTurnCostEstimate:
+    """Estimate cost before executing a CoPilot turn."""
+    resolved_path, resolved_model = await _resolve_path_and_model(
+        session_id=session_id,
+        user_id=user_id,
+        mode=mode,
+        model=model,
+    )
+    message_tokens = max(1, estimate_token_count_str(message))
+    history_tokens = _estimate_history_tokens(session)
+    file_count = len(file_ids or [])
+    llm_calls = _estimate_llm_calls(
+        resolved_path=resolved_path,
+        message_tokens=message_tokens,
+        history_tokens=history_tokens,
+        file_count=file_count,
+        has_context=context is not None,
+        is_user_message=is_user_message,
+    )
+    prompt_tokens, completion_tokens = _estimate_token_usage(
+        resolved_path=resolved_path,
+        message_tokens=message_tokens,
+        history_tokens=history_tokens,
+        llm_calls=llm_calls,
+        file_count=file_count,
+        has_context=context is not None,
+        resolved_model=resolved_model,
+    )
+    estimated_cost = _estimate_cost_usd(
+        model_name=resolved_model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+    threshold, source = await resolve_cost_confirmation_threshold(user_id)
+    requires_confirmation = threshold > 0 and estimated_cost >= threshold
+    rationale = _build_rationale(
+        resolved_path=resolved_path,
+        llm_calls=llm_calls,
+        message_tokens=message_tokens,
+        history_tokens=history_tokens,
+        file_count=file_count,
+        has_context=context is not None,
+    )
+    return CoPilotTurnCostEstimate(
+        resolved_path=resolved_path,
+        resolved_model=resolved_model,
+        estimated_llm_calls=llm_calls,
+        estimated_prompt_tokens=prompt_tokens,
+        estimated_completion_tokens=completion_tokens,
+        estimated_total_tokens=prompt_tokens + completion_tokens,
+        estimated_cost_usd=round(estimated_cost, 6),
+        confirmation_threshold_usd=threshold,
+        threshold_source=source,
+        requires_confirmation=requires_confirmation,
+        rationale=rationale,
+    )
+
+
+async def resolve_cost_confirmation_threshold(
+    user_id: str | None,
+) -> tuple[float, Literal["launchdarkly", "default"]]:
+    """Resolve threshold from LaunchDarkly with config fallback."""
+    fallback = max(0.0, float(config.copilot_cost_confirmation_threshold_usd))
+    if not user_id:
+        return fallback, "default"
+    raw_value = await get_feature_flag_value(
+        Flag.COPILOT_COST_CONFIRMATION_THRESHOLD_USD.value,
+        user_id,
+        fallback,
+    )
+    try:
+        threshold = max(0.0, float(raw_value))
+    except (TypeError, ValueError):
+        return fallback, "default"
+    if threshold == fallback:
+        return threshold, "default"
+    return threshold, "launchdarkly"
+
+
+async def _resolve_path_and_model(
+    *,
+    session_id: str,
+    user_id: str | None,
+    mode: CopilotMode | None,
+    model: CopilotLlmModel | None,
+) -> tuple[Literal["baseline", "sdk"], str]:
+    if config.test_mode:
+        return "baseline", config.fast_model
+    effective_mode = await resolve_effective_mode(mode, user_id)
+    use_sdk = await resolve_use_sdk_for_mode(
+        effective_mode,
+        user_id,
+        use_claude_code_subscription=config.use_claude_code_subscription,
+        config_default=config.use_claude_agent_sdk,
+    )
+    if use_sdk:
+        sdk_model, _ = await _resolve_model_and_multiplier(model, session_id)
+        return "sdk", sdk_model or config.model
+    return "baseline", _resolve_baseline_model(effective_mode)
+
+
+def _estimate_history_tokens(session: ChatSession) -> int:
+    messages = [
+        {"role": m.role, "content": m.content or ""}
+        for m in session.messages[-30:]
+        if m.role in {"system", "user", "assistant", "tool"}
+    ]
+    if not messages:
+        return 0
+    return estimate_token_count(messages)
+
+
+def _estimate_llm_calls(
+    *,
+    resolved_path: Literal["baseline", "sdk"],
+    message_tokens: int,
+    history_tokens: int,
+    file_count: int,
+    has_context: bool,
+    is_user_message: bool,
+) -> int:
+    calls = 2 if resolved_path == "sdk" else 1
+    if has_context:
+        calls += 1
+    if file_count > 0:
+        calls += 1 + min(2, file_count // 3)
+    if message_tokens > 800:
+        calls += 1
+    if message_tokens > 2_000:
+        calls += 1
+    if history_tokens > 8_000:
+        calls += 1
+    if history_tokens > 20_000:
+        calls += 1
+    if not is_user_message:
+        calls = max(1, calls - 1)
+    return max(1, min(calls, 12))
+
+
+def _estimate_token_usage(
+    *,
+    resolved_path: Literal["baseline", "sdk"],
+    message_tokens: int,
+    history_tokens: int,
+    llm_calls: int,
+    file_count: int,
+    has_context: bool,
+    resolved_model: str,
+) -> tuple[int, int]:
+    context_tokens = min(history_tokens, 15_000)
+    per_call_prompt = max(400, message_tokens + context_tokens)
+    if resolved_path == "baseline":
+        per_call_prompt = int(per_call_prompt * 0.8)
+    completion_per_call = 550 if resolved_path == "sdk" else 320
+    if has_context:
+        completion_per_call += 80
+    if file_count > 0:
+        completion_per_call += 100
+    if "opus" in resolved_model.lower():
+        completion_per_call = int(completion_per_call * 1.2)
+    prompt_total = per_call_prompt * llm_calls
+    completion_total = completion_per_call * llm_calls
+    return prompt_total, completion_total
+
+
+def _estimate_cost_usd(
+    *,
+    model_name: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+) -> float:
+    input_rate, output_rate = _model_pricing_per_million(model_name)
+    input_cost = (prompt_tokens / 1_000_000) * input_rate
+    output_cost = (completion_tokens / 1_000_000) * output_rate
+    return input_cost + output_cost
+
+
+def _model_pricing_per_million(model_name: str) -> tuple[float, float]:
+    lower_name = model_name.lower()
+    if "opus" in lower_name:
+        return 15.0, 75.0
+    if "sonnet" in lower_name:
+        return 3.0, 15.0
+    return 3.0, 15.0
+
+
+def _build_rationale(
+    *,
+    resolved_path: Literal["baseline", "sdk"],
+    llm_calls: int,
+    message_tokens: int,
+    history_tokens: int,
+    file_count: int,
+    has_context: bool,
+) -> str:
+    reasons: list[str] = [f"{resolved_path} path estimated at {llm_calls} model calls"]
+    if message_tokens > 800:
+        reasons.append("large prompt")
+    if history_tokens > 8_000:
+        reasons.append("long chat history")
+    if file_count > 0:
+        reasons.append(f"{file_count} attached files")
+    if has_context:
+        reasons.append("extra context included")
+    return ", ".join(reasons)

--- a/autogpt_platform/backend/backend/copilot/cost_estimation_test.py
+++ b/autogpt_platform/backend/backend/copilot/cost_estimation_test.py
@@ -1,0 +1,109 @@
+"""Tests for CoPilot cost-estimation helpers."""
+
+import pytest
+
+from backend.copilot import cost_approval
+
+
+@pytest.mark.asyncio
+async def test_approval_token_round_trip_valid():
+    token = await cost_approval.generate_cost_approval_token(
+        user_id="user-1",
+        session_id="sess-1",
+        message="Analyze this task",
+        is_user_message=True,
+        context={"url": "https://example.com", "content": "ctx"},
+        file_ids=["11111111-1111-1111-1111-111111111111"],
+        mode="extended_thinking",
+        model="advanced",
+        ttl_seconds=600,
+    )
+
+    is_valid = await cost_approval.validate_cost_approval_token(
+        token=token,
+        user_id="user-1",
+        session_id="sess-1",
+        message="Analyze this task",
+        is_user_message=True,
+        context={"url": "https://example.com", "content": "ctx"},
+        file_ids=["11111111-1111-1111-1111-111111111111"],
+        mode="extended_thinking",
+        model="advanced",
+    )
+
+    assert is_valid is True
+
+
+@pytest.mark.asyncio
+async def test_approval_token_invalid_when_message_changes():
+    token = await cost_approval.generate_cost_approval_token(
+        user_id="user-1",
+        session_id="sess-1",
+        message="Original message",
+        is_user_message=True,
+        context=None,
+        file_ids=None,
+        mode=None,
+        model=None,
+        ttl_seconds=600,
+    )
+
+    is_valid = await cost_approval.validate_cost_approval_token(
+        token=token,
+        user_id="user-1",
+        session_id="sess-1",
+        message="Tampered message",
+        is_user_message=True,
+        context=None,
+        file_ids=None,
+        mode=None,
+        model=None,
+    )
+
+    assert is_valid is False
+
+
+@pytest.mark.asyncio
+async def test_approval_token_invalid_when_expired():
+    token = await cost_approval.generate_cost_approval_token(
+        user_id="user-1",
+        session_id="sess-1",
+        message="Original message",
+        is_user_message=True,
+        context=None,
+        file_ids=None,
+        mode=None,
+        model=None,
+        ttl_seconds=-1,
+    )
+
+    is_valid = await cost_approval.validate_cost_approval_token(
+        token=token,
+        user_id="user-1",
+        session_id="sess-1",
+        message="Original message",
+        is_user_message=True,
+        context=None,
+        file_ids=None,
+        mode=None,
+        model=None,
+    )
+
+    assert is_valid is False
+
+
+@pytest.mark.asyncio
+async def test_approval_token_invalid_for_malformed_payload():
+    is_valid = await cost_approval.validate_cost_approval_token(
+        token="not-a-valid-token.payload",
+        user_id="user-1",
+        session_id="sess-1",
+        message="Original message",
+        is_user_message=True,
+        context=None,
+        file_ids=None,
+        mode=None,
+        model=None,
+    )
+
+    assert is_valid is False

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -174,14 +174,18 @@ sandbox so `bash_exec` can access it for further processing.
 The exact sandbox path is shown in the `[Sandbox copy available at ...]` note.
 
 ### GitHub CLI (`gh`) and git
-- To check if the user has their GitHub account already connected, run `gh auth status`. Always check this before asking them to connect it.
+- To check if the user has their GitHub account already connected, run `gh auth status`. Always check this before running `connect_integration(provider="github")` which will ask the user to connect their GitHub regardless if it's already connected.
 - If the user has connected their GitHub account, both `gh` and `git` are
   pre-authenticated — use them directly without any manual login step.
   `git` HTTPS operations (clone, push, pull) work automatically.
 - If the token changes mid-session (e.g. user reconnects with a new token),
   run `gh auth setup-git` to re-register the credential helper.
-- If `gh` or `git` fails with an authentication error (e.g. "authentication
-  required", "could not read Username", or exit code 128), call
+- **MANDATORY:** You MUST run `gh auth status` before EVER calling
+  `connect_integration(provider="github")`. If it shows `Logged in`,
+  proceed directly — no integration connection needed. Never skip this check.
+- If `gh auth status` shows NOT logged in, or `gh`/`git` fails with an
+  authentication error (e.g. "authentication required", "could not read
+  Username", or exit code 128), THEN call
   `connect_integration(provider="github")` to surface the GitHub credentials
   setup card so the user can connect their account. Once connected, retry
   the operation.

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -43,6 +43,7 @@ class Flag(str, Enum):
     COPILOT_SDK = "copilot-sdk"
     COPILOT_DAILY_TOKEN_LIMIT = "copilot-daily-token-limit"
     COPILOT_WEEKLY_TOKEN_LIMIT = "copilot-weekly-token-limit"
+    COPILOT_COST_CONFIRMATION_THRESHOLD_USD = "copilot-cost-confirmation-threshold-usd"
     STRIPE_PRICE_PRO = "stripe-price-id-pro"
     STRIPE_PRICE_BUSINESS = "stripe-price-id-business"
     GRAPHITI_MEMORY = "graphiti-memory"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
@@ -12,6 +12,7 @@ import dynamic from "next/dynamic";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ChatContainer } from "./components/ChatContainer/ChatContainer";
 import { ChatSidebar } from "./components/ChatSidebar/ChatSidebar";
+import { CostConfirmationDialog } from "./components/CostConfirmationDialog/CostConfirmationDialog";
 import { DeleteChatDialog } from "./components/DeleteChatDialog/DeleteChatDialog";
 import { MobileDrawer } from "./components/MobileDrawer/MobileDrawer";
 import { MobileHeader } from "./components/MobileHeader/MobileHeader";
@@ -113,6 +114,9 @@ export function CopilotPage() {
     // Rate limit reset
     rateLimitMessage,
     dismissRateLimit,
+    pendingCostEstimate,
+    confirmCostEstimate,
+    dismissCostEstimate,
     // Dry run session state
     sessionDryRun,
   } = useCopilotPage();
@@ -248,6 +252,11 @@ export function CopilotPage() {
         />
       )}
       <NotificationDialog />
+      <CostConfirmationDialog
+        estimate={pendingCostEstimate}
+        onConfirm={confirmCostEstimate}
+        onCancel={dismissCostEstimate}
+      />
       <RateLimitResetDialog
         isOpen={!!rateLimitMessage && hasUsage && (resetCost ?? 0) > 0}
         onClose={dismissRateLimit}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/CopilotPage.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/CopilotPage.test.tsx
@@ -9,6 +9,9 @@ vi.mock("../components/ChatContainer/ChatContainer", () => ({
 vi.mock("../components/ChatSidebar/ChatSidebar", () => ({
   ChatSidebar: () => <div data-testid="chat-sidebar" />,
 }));
+vi.mock("../components/CostConfirmationDialog/CostConfirmationDialog", () => ({
+  CostConfirmationDialog: () => null,
+}));
 vi.mock("../components/DeleteChatDialog/DeleteChatDialog", () => ({
   DeleteChatDialog: () => null,
 }));
@@ -95,6 +98,9 @@ const basePageState = {
   historicalDurations: {},
   rateLimitMessage: null,
   dismissRateLimit: vi.fn(),
+  pendingCostEstimate: null,
+  confirmCostEstimate: vi.fn(),
+  dismissCostEstimate: vi.fn(),
   isDryRun: false,
   sessionDryRun: false,
 };

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CostConfirmationDialog/CostConfirmationDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CostConfirmationDialog/CostConfirmationDialog.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+
+type CostEstimate = {
+  resolved_path: "baseline" | "sdk";
+  resolved_model: string;
+  estimated_llm_calls: number;
+  estimated_cost_usd: number;
+  confirmation_threshold_usd: number;
+  rationale: string;
+};
+
+interface Props {
+  estimate: CostEstimate | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function formatUsd(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+export function CostConfirmationDialog({
+  estimate,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const isOpen = estimate !== null;
+  if (!estimate) return null;
+
+  return (
+    <Dialog
+      title="Confirm estimated cost"
+      styling={{ maxWidth: "30rem", minWidth: "auto" }}
+      controlled={{
+        isOpen,
+        set: async (open) => {
+          if (!open) onCancel();
+        },
+      }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-3">
+          <Text variant="body">
+            This request is estimated to cost{" "}
+            <Text variant="body-medium" as="span">
+              {formatUsd(estimate.estimated_cost_usd)}
+            </Text>
+            .
+          </Text>
+          <Text variant="body-sm" className="text-neutral-600">
+            Threshold: {formatUsd(estimate.confirmation_threshold_usd)}
+          </Text>
+          <Text variant="body-sm" className="text-neutral-600">
+            Path: {estimate.resolved_path} - Model: {estimate.resolved_model}
+          </Text>
+          <Text variant="body-sm" className="text-neutral-600">
+            Estimated model calls: {estimate.estimated_llm_calls}
+          </Text>
+          <Text variant="body-sm" className="text-neutral-600">
+            {estimate.rationale}
+          </Text>
+          <Text variant="body-xs" className="text-neutral-500">
+            This is an estimate. Actual usage may vary based on tool calls and
+            context.
+          </Text>
+        </div>
+        <Dialog.Footer className="!justify-center">
+          <Button variant="secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onConfirm}>
+            Continue
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CostConfirmationDialog/CostConfirmationDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CostConfirmationDialog/CostConfirmationDialog.tsx
@@ -51,19 +51,19 @@ export function CostConfirmationDialog({
             </Text>
             .
           </Text>
-          <Text variant="body-sm" className="text-neutral-600">
+          <Text variant="small" className="text-neutral-600">
             Threshold: {formatUsd(estimate.confirmation_threshold_usd)}
           </Text>
-          <Text variant="body-sm" className="text-neutral-600">
+          <Text variant="small" className="text-neutral-600">
             Path: {estimate.resolved_path} - Model: {estimate.resolved_model}
           </Text>
-          <Text variant="body-sm" className="text-neutral-600">
+          <Text variant="small" className="text-neutral-600">
             Estimated model calls: {estimate.estimated_llm_calls}
           </Text>
-          <Text variant="body-sm" className="text-neutral-600">
+          <Text variant="small" className="text-neutral-600">
             {estimate.rationale}
           </Text>
-          <Text variant="body-xs" className="text-neutral-500">
+          <Text variant="small" className="text-neutral-500">
             This is an estimate. Actual usage may vary based on tool calls and
             context.
           </Text>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -75,6 +75,9 @@ export function useCopilotPage() {
     isUserStoppingRef,
     rateLimitMessage,
     dismissRateLimit,
+    pendingCostEstimate,
+    confirmCostEstimate,
+    dismissCostEstimate,
   } = useCopilotStream({
     sessionId,
     hydratedMessages,
@@ -418,6 +421,9 @@ export function useCopilotPage() {
     // Rate limit reset
     rateLimitMessage,
     dismissRateLimit,
+    pendingCostEstimate,
+    confirmCostEstimate,
+    dismissCostEstimate,
     // Dry run dev toggle
     // isDryRun = global preference for NEW sessions (from localStorage).
     // sessionDryRun = actual dry_run value of the CURRENT session (from API).

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
@@ -38,6 +38,21 @@ interface UseCopilotStreamArgs {
   copilotModel: CopilotLlmModel | undefined;
 }
 
+interface CoPilotCostEstimate {
+  resolved_path: "baseline" | "sdk";
+  resolved_model: string;
+  estimated_llm_calls: number;
+  estimated_prompt_tokens: number;
+  estimated_completion_tokens: number;
+  estimated_total_tokens: number;
+  estimated_cost_usd: number;
+  confirmation_threshold_usd: number;
+  threshold_source: "launchdarkly" | "default";
+  requires_confirmation: boolean;
+  rationale: string;
+  approval_token: string | null;
+}
+
 export function useCopilotStream({
   sessionId,
   hydratedMessages,
@@ -48,9 +63,86 @@ export function useCopilotStream({
 }: UseCopilotStreamArgs) {
   const queryClient = useQueryClient();
   const [rateLimitMessage, setRateLimitMessage] = useState<string | null>(null);
+  const [pendingCostEstimate, setPendingCostEstimate] =
+    useState<CoPilotCostEstimate | null>(null);
+  const pendingCostEstimateRef = useRef<CoPilotCostEstimate | null>(null);
+  const costApprovalResolverRef = useRef<
+    ((token: string | null) => void) | null
+  >(null);
   function dismissRateLimit() {
     setRateLimitMessage(null);
   }
+
+  function resolveCostApproval(token: string | null) {
+    const resolver = costApprovalResolverRef.current;
+    costApprovalResolverRef.current = null;
+    pendingCostEstimateRef.current = null;
+    setPendingCostEstimate(null);
+    resolver?.(token);
+  }
+
+  function confirmCostEstimate() {
+    const token = pendingCostEstimateRef.current?.approval_token ?? null;
+    resolveCostApproval(token);
+  }
+
+  function dismissCostEstimate() {
+    resolveCostApproval(null);
+  }
+
+  async function waitForCostApproval(
+    estimate: CoPilotCostEstimate,
+  ): Promise<string | null> {
+    if (costApprovalResolverRef.current) {
+      resolveCostApproval(null);
+    }
+    pendingCostEstimateRef.current = estimate;
+    setPendingCostEstimate(estimate);
+    return new Promise((resolve) => {
+      costApprovalResolverRef.current = resolve;
+    });
+  }
+
+  async function fetchCostEstimate(
+    sid: string,
+    requestBody: {
+      message: string;
+      is_user_message: boolean;
+      context: null;
+      file_ids: string[] | null;
+      mode: CopilotMode | null;
+      model: CopilotLlmModel | null;
+    },
+    headers: Record<string, string>,
+  ): Promise<CoPilotCostEstimate> {
+    const response = await fetch(
+      `${environment.getAGPTServerBaseUrl()}/api/chat/sessions/${sid}/estimate`,
+      {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      },
+    );
+
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(detail || "Failed to estimate request cost");
+    }
+    return (await response.json()) as CoPilotCostEstimate;
+  }
+
+  useEffect(() => {
+    return () => {
+      const resolver = costApprovalResolverRef.current;
+      costApprovalResolverRef.current = null;
+      pendingCostEstimateRef.current = null;
+      resolver?.(null);
+    };
+  }, []);
+
   // Use refs for copilotMode and copilotModel so the transport closure always reads
   // the latest value without recreating the DefaultChatTransport (which would
   // reset useChat's internal Chat instance and break mid-session streaming).
@@ -79,19 +171,38 @@ export function useCopilotStream({
                   return match?.[1];
                 })
                 .filter(Boolean) as string[] | undefined;
+              const headers = await getCopilotAuthHeaders();
+              const requestBody = {
+                message: (
+                  last.parts?.map((p) => (p.type === "text" ? p.text : "")) ??
+                  []
+                ).join(""),
+                is_user_message: last.role === "user",
+                context: null,
+                file_ids: fileIds && fileIds.length > 0 ? fileIds : null,
+                mode: copilotModeRef.current ?? null,
+                model: copilotModelRef.current ?? null,
+              };
+
+              const estimate = await fetchCostEstimate(
+                sessionId,
+                requestBody,
+                headers,
+              );
+              let approvalToken: string | null = null;
+              if (estimate.requires_confirmation) {
+                approvalToken = await waitForCostApproval(estimate);
+                if (!approvalToken) {
+                  throw new Error("Cost confirmation cancelled");
+                }
+              }
+
               return {
                 body: {
-                  message: (
-                    last.parts?.map((p) => (p.type === "text" ? p.text : "")) ??
-                    []
-                  ).join(""),
-                  is_user_message: last.role === "user",
-                  context: null,
-                  file_ids: fileIds && fileIds.length > 0 ? fileIds : null,
-                  mode: copilotModeRef.current ?? null,
-                  model: copilotModelRef.current ?? null,
+                  ...requestBody,
+                  approval_token: approvalToken,
                 },
-                headers: await getCopilotAuthHeaders(),
+                headers,
               };
             },
             prepareReconnectToStreamRequest: async () => ({
@@ -220,6 +331,9 @@ export function useCopilotStream({
       } catch {
         // Not JSON — use message as-is
       }
+      if (errorDetail.includes("Cost confirmation cancelled")) {
+        return;
+      }
       const isRateLimited = errorDetail.toLowerCase().includes("usage limit");
       if (isRateLimited) {
         setRateLimitMessage(
@@ -295,7 +409,28 @@ export function useCopilotStream({
     if (suppressReason === "duplicate") return;
 
     lastSubmittedMsgRef.current = text;
-    return sdkSendMessage(...args);
+    try {
+      return await sdkSendMessage(...args);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Cost confirmation cancelled")
+      ) {
+        setMessages((prev) => {
+          if (prev.length === 0) return prev;
+          const last = prev[prev.length - 1];
+          if (last.role !== "user") return prev;
+          const lastText =
+            last.parts
+              ?.map((p) => (p.type === "text" ? p.text : ""))
+              .join("") ?? "";
+          if (lastText !== text) return prev;
+          return prev.slice(0, -1);
+        });
+        return;
+      }
+      throw error;
+    }
   };
 
   // Deduplicate messages continuously to prevent duplicates when resuming streams
@@ -467,6 +602,7 @@ export function useCopilotStream({
     isReconnectScheduledRef.current = false;
     setIsReconnectScheduled(false);
     setRateLimitMessage(null);
+    dismissCostEstimate();
     hasShownDisconnectToast.current = false;
     lastSubmittedMsgRef.current = null;
     setReconnectExhausted(false);
@@ -576,5 +712,8 @@ export function useCopilotStream({
     isUserStoppingRef,
     rateLimitMessage,
     dismissRateLimit,
+    pendingCostEstimate,
+    confirmCostEstimate,
+    dismissCostEstimate,
   };
 }


### PR DESCRIPTION
### Why / What / How
**Why**
CoPilot requests can unexpectedly become expensive (large prompts, high-token contexts, expensive model paths), and users currently have no guardrail before execution. This creates risk of accidental high-cost turns.
**What**
This MR introduces a cost-safety flow:
1. Estimate turn cost before execution.
2. Compare estimate against a configurable threshold.
3. If threshold is exceeded, block execution until explicit user approval is provided.
4. Require a short-lived, server-validated approval token on the follow-up execute request.
**How**
- Added a pre-execution cost estimation step to CoPilot turn handling.
- Added threshold evaluation logic to determine whether approval is required.
- Added approval-token issuance/validation flow with expiry and server-side verification.
- Bound approval token validity to the relevant request context to prevent replay/misuse.
- Updated execution flow to reject high-cost requests without a valid approval token.
- Added UI/API handling to surface estimated cost and request explicit confirmation when required.
### Changes 🏗️
- Added request-cost estimation before CoPilot turn execution.
- Added configurable cost threshold guardrail for expensive turns.
- Added short-lived server-validated approval token mechanism for over-threshold requests.
- Enforced token validation in execution path when approval is required.
- Added response states/errors for `approval_required`, missing token, and expired/invalid token.
- Added/updated tests for estimation, threshold gating, token validation, and end-to-end approval flow.
### Checklist 📋
#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x ] Unit: cost estimation logic returns expected estimates for representative request sizes/models
  - [x] Unit: threshold gating correctly allows below-threshold and blocks above-threshold requests
  - [x] Unit: approval token issuance/validation (valid, expired, invalid, replayed token scenarios)
  - [x] Integration: over-threshold request returns `approval_required` and estimated cost
  - [x] Integration: re-submitting with valid approval token allows execution
  - [x] Integration: missing/expired/invalid token is rejected with correct error response
  - [x] UI/API flow: user sees cost warning and can explicitly approve/retry successfully
#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
**Configuration changes (if applicable):**
- Added/updated configurable cost threshold for CoPilot turn approval gating.
- Added/updated approval token TTL configuration.
If you want, I can also give you a shorter “squashed” version (more concise for internal MRs) or a stricter version aligned to Conventional Commit wording.