### PR TITLE
feat(backend/copilot): LaunchDarkly per-user model routing

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -45,6 +45,7 @@ from backend.copilot.model import (
     maybe_append_user_message,
     upsert_chat_session,
 )
+from backend.copilot.model_router import resolve_model
 from backend.copilot.pending_message_helpers import (
     combine_pending_with_current,
     drain_pending_safe,
@@ -327,8 +328,6 @@ async def _resolve_baseline_model(
     ``(fast, tier)`` cell is LD-overridable per user.  ``None`` tier
     maps to ``"standard"``.
     """
-    from backend.copilot.model_router import resolve_model
-
     tier_name = "advanced" if tier == "advanced" else "standard"
     return await resolve_model("fast", tier_name, user_id, config=config)
 

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -318,20 +318,19 @@ def _filter_tools_by_permissions(
     ]
 
 
-def _resolve_baseline_model(tier: CopilotLlmModel | None) -> str:
+async def _resolve_baseline_model(
+    tier: CopilotLlmModel | None, user_id: str | None
+) -> str:
     """Pick the model for the baseline path based on the per-request tier.
 
-    Baseline resolves independently of SDK via the ``fast_*_model`` cells
-    of the (path, tier) matrix.  ``'standard'`` / ``None`` picks Kimi
-    K2.6 by default (cheap + OpenRouter ``reasoning`` support);
-    ``'advanced'`` picks Opus by default so the advanced tier is a clean
-    A/B against the SDK advanced tier — same model, different path —
-    isolating reasoning-wire + cache differences from model capability.
-    Both defaults are overridable per ``CHAT_FAST_*_MODEL`` env vars.
+    Delegates to :func:`copilot.model_router.resolve_model` so the
+    ``(fast, tier)`` cell is LD-overridable per user.  ``None`` tier
+    maps to ``"standard"``.
     """
-    if tier == "advanced":
-        return config.fast_advanced_model
-    return config.fast_standard_model
+    from backend.copilot.model_router import resolve_model
+
+    tier_name = "advanced" if tier == "advanced" else "standard"
+    return await resolve_model("fast", tier_name, user_id, config=config)
 
 
 @dataclass
@@ -1358,7 +1357,7 @@ async def stream_chat_completion_baseline(
     # Select model based on the per-request tier toggle (standard / advanced).
     # The path (fast vs extended_thinking) is already decided — we're in the
     # baseline (fast) path; ``mode`` is accepted for logging parity only.
-    active_model = _resolve_baseline_model(model)
+    active_model = await _resolve_baseline_model(model, user_id)
 
     # --- E2B sandbox setup (feature parity with SDK path) ---
     e2b_sandbox = None

--- a/autogpt_platform/backend/backend/copilot/baseline/transcript_integration_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/transcript_integration_test.py
@@ -67,34 +67,40 @@ class TestResolveBaselineModel:
 
     Baseline reads the ``fast_*_model`` cells of the (path, tier) matrix
     and never falls through to the SDK-side ``thinking_*_model`` cells.
-    Default routing:
-    - ``standard`` / ``None`` → ``config.fast_standard_model`` (Kimi K2.6)
-    - ``advanced`` → ``config.fast_advanced_model`` (Opus — same as SDK's
-      advanced tier, so the advanced A/B isolates path differences)
+    Without a user_id (so no LD context) the resolver returns the
+    ``ChatConfig`` static default; per-user overrides are exercised in
+    ``copilot/model_router_test.py``.
     """
 
-    def test_advanced_tier_selects_fast_advanced_model(self):
-        assert _resolve_baseline_model("advanced") == config.fast_advanced_model
+    @pytest.mark.asyncio
+    async def test_advanced_tier_selects_fast_advanced_model(self):
+        assert (
+            await _resolve_baseline_model("advanced", None)
+            == config.fast_advanced_model
+        )
 
-    def test_standard_tier_selects_fast_standard_model(self):
-        assert _resolve_baseline_model("standard") == config.fast_standard_model
+    @pytest.mark.asyncio
+    async def test_standard_tier_selects_fast_standard_model(self):
+        assert (
+            await _resolve_baseline_model("standard", None)
+            == config.fast_standard_model
+        )
 
-    def test_none_tier_selects_fast_standard_model(self):
-        """Baseline users without a tier get the cheap fast-standard default."""
-        assert _resolve_baseline_model(None) == config.fast_standard_model
+    @pytest.mark.asyncio
+    async def test_none_tier_selects_fast_standard_model(self):
+        """Baseline users without a tier get the fast-standard default."""
+        assert await _resolve_baseline_model(None, None) == config.fast_standard_model
 
-    def test_fast_standard_default_is_kimi(self):
-        """Shipped default: Kimi K2.6 on the baseline standard cell.
-
-        Asserts the declared ``Field`` default — env-independent — so a
-        deploy-time ``CHAT_FAST_STANDARD_MODEL`` rollback override
-        doesn't fail CI while still pinning the shipped default.
-        """
+    def test_fast_standard_default_is_sonnet(self):
+        """Shipped default: Sonnet on the baseline standard cell — the
+        non-Anthropic routes ship via the LD flag instead of a config
+        change.  Asserts the declared ``Field`` default so a deploy-time
+        ``CHAT_FAST_STANDARD_MODEL`` override doesn't flake CI."""
         from backend.copilot.config import ChatConfig
 
         assert (
             ChatConfig.model_fields["fast_standard_model"].default
-            == "moonshotai/kimi-k2.6"
+            == "anthropic/claude-sonnet-4-6"
         )
 
     def test_fast_advanced_default_is_opus(self):
@@ -106,18 +112,6 @@ class TestResolveBaselineModel:
         assert (
             ChatConfig.model_fields["fast_advanced_model"].default
             == "anthropic/claude-opus-4.7"
-        )
-
-    def test_standard_cells_diverge_across_paths(self):
-        """The whole point of the split: baseline cheap (Kimi) vs SDK
-        Anthropic-only (Sonnet).  If the shipped standard defaults ever
-        collapse to the same value someone lost the cost savings.
-        Checked against ``Field`` defaults, not the env-backed singleton."""
-        from backend.copilot.config import ChatConfig
-
-        assert (
-            ChatConfig.model_fields["thinking_standard_model"].default
-            != ChatConfig.model_fields["fast_standard_model"].default
         )
 
     def test_standard_and_advanced_cells_differ_on_fast(self):

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -43,20 +43,16 @@ class ChatConfig(BaseSettings):
     # ``CHAT_FAST_MODEL``) are preserved via ``validation_alias`` so
     # existing deployments continue to override the same effective cell.
     fast_standard_model: str = Field(
-        default="moonshotai/kimi-k2.6",
+        default="anthropic/claude-sonnet-4-6",
         validation_alias=AliasChoices(
             "CHAT_FAST_STANDARD_MODEL",
             "CHAT_FAST_MODEL",
         ),
-        description="Baseline path, 'standard' / ``None`` tier.  Kimi K2.6 "
-        "by default: ~5x cheaper input and ~5.4x cheaper output than Sonnet, "
-        "SWE-Bench Verified parity with Opus, and OpenRouter advertises the "
-        "``reasoning`` + ``include_reasoning`` extension params on the "
-        "Moonshot endpoints — so the baseline reasoning plumbing lights up "
-        "without provider-specific code.  Roll back to the Anthropic route "
-        "via ``CHAT_FAST_STANDARD_MODEL=anthropic/claude-sonnet-4-6`` (then "
-        "``cache_control`` breakpoints reactivate via "
-        "``_is_anthropic_model``).",
+        description="Baseline path, 'standard' / ``None`` tier.  Per-user "
+        "overrides flow through the ``copilot-fast-standard-model`` "
+        "LaunchDarkly flag (see ``copilot/model_router.py``); this value "
+        "is the fallback when LD is unset or unavailable.  Override via "
+        "``CHAT_FAST_STANDARD_MODEL``.",
     )
     fast_advanced_model: str = Field(
         default="anthropic/claude-opus-4.7",

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -90,10 +90,15 @@ async def resolve_model(
     if isinstance(value, str) and value.strip():
         return value.strip()
     if value != fallback:
+        reason = (
+            "empty string"
+            if isinstance(value, str)
+            else f"non-string ({type(value).__name__})"
+        )
         logger.warning(
-            "[model_router] LD flag %s returned non-string %r — using config default %s",
+            "[model_router] LD flag %s returned %s — using config default %s",
             flag.value,
-            value,
+            reason,
             fallback,
         )
     return fallback

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -1,0 +1,99 @@
+"""LaunchDarkly-aware model selection for the copilot.
+
+Each cell of the ``(mode, tier)`` matrix has a static default baked into
+``ChatConfig`` (see ``copilot/config.py``) and a matching LaunchDarkly
+string-valued feature flag that can override it per-user.  This module
+centralises the lookup so both the baseline and SDK paths agree on the
+selection rule and so A/B experiments can target a single cell without
+shipping a config change.
+
+Matrix:
+
+    +----------+-------------------------------------+-------------------------------------+
+    |          | standard                            | advanced                            |
+    +----------+-------------------------------------+-------------------------------------+
+    | fast     | copilot-fast-standard-model         | copilot-fast-advanced-model         |
+    | thinking | copilot-thinking-standard-model     | copilot-thinking-advanced-model     |
+    +----------+-------------------------------------+-------------------------------------+
+
+LD flag values are arbitrary strings (model identifiers, e.g.
+``"anthropic/claude-sonnet-4-6"`` or ``"moonshotai/kimi-k2.6"``).  Empty
+or non-string values fall back to the config default.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from backend.copilot.config import ChatConfig
+from backend.util.feature_flag import Flag, get_feature_flag_value
+
+logger = logging.getLogger(__name__)
+
+ModelMode = Literal["fast", "thinking"]
+ModelTier = Literal["standard", "advanced"]
+
+
+_FLAG_BY_CELL: dict[tuple[ModelMode, ModelTier], Flag] = {
+    ("fast", "standard"): Flag.COPILOT_FAST_STANDARD_MODEL,
+    ("fast", "advanced"): Flag.COPILOT_FAST_ADVANCED_MODEL,
+    ("thinking", "standard"): Flag.COPILOT_THINKING_STANDARD_MODEL,
+    ("thinking", "advanced"): Flag.COPILOT_THINKING_ADVANCED_MODEL,
+}
+
+
+def _config_default(config: ChatConfig, mode: ModelMode, tier: ModelTier) -> str:
+    if mode == "fast":
+        return (
+            config.fast_advanced_model
+            if tier == "advanced"
+            else config.fast_standard_model
+        )
+    return (
+        config.thinking_advanced_model
+        if tier == "advanced"
+        else config.thinking_standard_model
+    )
+
+
+async def resolve_model(
+    mode: ModelMode,
+    tier: ModelTier,
+    user_id: str | None,
+    *,
+    config: ChatConfig,
+) -> str:
+    """Return the model identifier for a ``(mode, tier)`` cell.
+
+    Consults the matching LaunchDarkly flag for *user_id* first and
+    falls back to the ``ChatConfig`` default on missing user, missing
+    flag, or non-string flag value.  Passing *config* explicitly keeps
+    the resolver cheap to unit-test.
+    """
+    fallback = _config_default(config, mode, tier)
+    if not user_id:
+        return fallback
+
+    flag = _FLAG_BY_CELL[(mode, tier)]
+    try:
+        value = await get_feature_flag_value(flag.value, user_id, default=fallback)
+    except Exception:
+        logger.warning(
+            "[model_router] LD lookup failed for %s — using config default %s",
+            flag.value,
+            fallback,
+            exc_info=True,
+        )
+        return fallback
+
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if value != fallback:
+        logger.warning(
+            "[model_router] LD flag %s returned non-string %r — using config default %s",
+            flag.value,
+            value,
+            fallback,
+        )
+    return fallback

--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -71,7 +71,7 @@ async def resolve_model(
     flag, or non-string flag value.  Passing *config* explicitly keeps
     the resolver cheap to unit-test.
     """
-    fallback = _config_default(config, mode, tier)
+    fallback = _config_default(config, mode, tier).strip()
     if not user_id:
         return fallback
 

--- a/autogpt_platform/backend/backend/copilot/model_router_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_router_test.py
@@ -72,26 +72,41 @@ class TestResolveModel:
         assert result == "xai/grok-4"
 
     @pytest.mark.asyncio
-    async def test_non_string_value_falls_back(self):
+    async def test_non_string_value_falls_back_with_type_in_warning(self, caplog):
         """LD misconfigured as a boolean flag — don't try to use ``True`` as a
-        model name; return the config default."""
+        model name; return the config default.  Warning must say
+        'non-string' (not 'empty string') so the LD operator knows the
+        flag type is wrong, not just missing a value."""
+        import logging
+
         cfg = _make_config()
-        with patch(
-            "backend.copilot.model_router.get_feature_flag_value",
-            new=AsyncMock(return_value=True),
-        ):
-            result = await resolve_model("fast", "advanced", "user-1", config=cfg)
+        with caplog.at_level(logging.WARNING, logger="backend.copilot.model_router"):
+            with patch(
+                "backend.copilot.model_router.get_feature_flag_value",
+                new=AsyncMock(return_value=True),
+            ):
+                result = await resolve_model("fast", "advanced", "user-1", config=cfg)
         assert result == cfg.fast_advanced_model
+        assert any("non-string" in r.message for r in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_empty_string_falls_back(self):
+    async def test_empty_string_falls_back_with_empty_in_warning(self, caplog):
+        """When LD returns ``""`` the warning must say 'empty string' —
+        not 'non-string' — so the operator doesn't chase a type bug
+        when the flag is simply unset to an empty value."""
+        import logging
+
         cfg = _make_config()
-        with patch(
-            "backend.copilot.model_router.get_feature_flag_value",
-            new=AsyncMock(return_value=""),
-        ):
-            result = await resolve_model("fast", "standard", "user-1", config=cfg)
+        with caplog.at_level(logging.WARNING, logger="backend.copilot.model_router"):
+            with patch(
+                "backend.copilot.model_router.get_feature_flag_value",
+                new=AsyncMock(return_value=""),
+            ):
+                result = await resolve_model("fast", "standard", "user-1", config=cfg)
         assert result == cfg.fast_standard_model
+        messages = [r.message for r in caplog.records]
+        assert any("empty string" in m for m in messages)
+        assert not any("non-string" in m for m in messages)
 
     @pytest.mark.asyncio
     async def test_ld_exception_falls_back(self):

--- a/autogpt_platform/backend/backend/copilot/model_router_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_router_test.py
@@ -1,0 +1,134 @@
+"""Tests for the LD-aware model resolver."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.copilot.config import ChatConfig
+from backend.copilot.model_router import _FLAG_BY_CELL, _config_default, resolve_model
+
+
+def _make_config() -> ChatConfig:
+    """Build a config with the canonical defaults so tests read naturally."""
+    return ChatConfig(
+        fast_standard_model="anthropic/claude-sonnet-4-6",
+        fast_advanced_model="anthropic/claude-opus-4.7",
+        thinking_standard_model="anthropic/claude-sonnet-4-6",
+        thinking_advanced_model="anthropic/claude-opus-4.7",
+    )
+
+
+class TestConfigDefault:
+    def test_fast_standard(self):
+        cfg = _make_config()
+        assert _config_default(cfg, "fast", "standard") == cfg.fast_standard_model
+
+    def test_fast_advanced(self):
+        cfg = _make_config()
+        assert _config_default(cfg, "fast", "advanced") == cfg.fast_advanced_model
+
+    def test_thinking_standard(self):
+        cfg = _make_config()
+        assert (
+            _config_default(cfg, "thinking", "standard") == cfg.thinking_standard_model
+        )
+
+    def test_thinking_advanced(self):
+        cfg = _make_config()
+        assert (
+            _config_default(cfg, "thinking", "advanced") == cfg.thinking_advanced_model
+        )
+
+
+class TestResolveModel:
+    @pytest.mark.asyncio
+    async def test_missing_user_returns_fallback(self):
+        """Without user_id there's no LD context — skip the lookup entirely."""
+        cfg = _make_config()
+        with patch("backend.copilot.model_router.get_feature_flag_value") as mock_flag:
+            result = await resolve_model("fast", "standard", None, config=cfg)
+        assert result == cfg.fast_standard_model
+        mock_flag.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ld_string_override_wins(self):
+        """LD-returned model string replaces the config default."""
+        cfg = _make_config()
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value="moonshotai/kimi-k2.6"),
+        ):
+            result = await resolve_model("fast", "standard", "user-1", config=cfg)
+        assert result == "moonshotai/kimi-k2.6"
+
+    @pytest.mark.asyncio
+    async def test_whitespace_is_stripped(self):
+        cfg = _make_config()
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value="  xai/grok-4  "),
+        ):
+            result = await resolve_model("thinking", "advanced", "user-1", config=cfg)
+        assert result == "xai/grok-4"
+
+    @pytest.mark.asyncio
+    async def test_non_string_value_falls_back(self):
+        """LD misconfigured as a boolean flag — don't try to use ``True`` as a
+        model name; return the config default."""
+        cfg = _make_config()
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=True),
+        ):
+            result = await resolve_model("fast", "advanced", "user-1", config=cfg)
+        assert result == cfg.fast_advanced_model
+
+    @pytest.mark.asyncio
+    async def test_empty_string_falls_back(self):
+        cfg = _make_config()
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(return_value=""),
+        ):
+            result = await resolve_model("fast", "standard", "user-1", config=cfg)
+        assert result == cfg.fast_standard_model
+
+    @pytest.mark.asyncio
+    async def test_ld_exception_falls_back(self):
+        """LD client throws (network blip, SDK init race) — serve the default
+        instead of failing the whole request."""
+        cfg = _make_config()
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(side_effect=RuntimeError("LD down")),
+        ):
+            result = await resolve_model("fast", "standard", "user-1", config=cfg)
+        assert result == cfg.fast_standard_model
+
+    @pytest.mark.asyncio
+    async def test_all_four_cells_hit_distinct_flags(self):
+        """Each (mode, tier) cell must route to its own flag — regression
+        guard against copy-paste bugs in the _FLAG_BY_CELL map."""
+        cfg = _make_config()
+        calls: list[str] = []
+
+        async def _capture(flag_key, user_id, default):
+            calls.append(flag_key)
+            return default
+
+        with patch(
+            "backend.copilot.model_router.get_feature_flag_value",
+            new=AsyncMock(side_effect=_capture),
+        ):
+            await resolve_model("fast", "standard", "u", config=cfg)
+            await resolve_model("fast", "advanced", "u", config=cfg)
+            await resolve_model("thinking", "standard", "u", config=cfg)
+            await resolve_model("thinking", "advanced", "u", config=cfg)
+
+        assert calls == [
+            _FLAG_BY_CELL[("fast", "standard")].value,
+            _FLAG_BY_CELL[("fast", "advanced")].value,
+            _FLAG_BY_CELL[("thinking", "standard")].value,
+            _FLAG_BY_CELL[("thinking", "advanced")].value,
+        ]
+        assert len(set(calls)) == 4

--- a/autogpt_platform/backend/backend/copilot/model_router_test.py
+++ b/autogpt_platform/backend/backend/copilot/model_router_test.py
@@ -51,6 +51,23 @@ class TestResolveModel:
         mock_flag.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_missing_user_strips_whitespace_from_fallback(self):
+        """Sentry MEDIUM: the anonymous-user branch returned an unstripped
+        config value.  If ``CHAT_*_MODEL`` env carries trailing whitespace
+        the downstream ``resolved == tier_default`` check in
+        ``_resolve_sdk_model_for_request`` would diverge from the
+        whitespace-stripped LD side, bypassing subscription mode for
+        every anonymous request.  Strip at the source."""
+        cfg = ChatConfig(
+            fast_standard_model="anthropic/claude-sonnet-4-6  ",  # trailing ws
+            fast_advanced_model="anthropic/claude-opus-4.7",
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            thinking_advanced_model="anthropic/claude-opus-4.7",
+        )
+        result = await resolve_model("fast", "standard", None, config=cfg)
+        assert result == "anthropic/claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
     async def test_ld_string_override_wins(self):
         """LD-returned model string replaces the config default."""
         cfg = _make_config()

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -56,6 +56,7 @@ from ..constants import (
 from ..session_cleanup import prune_orphan_tool_calls
 from ..context import encode_cwd_for_cli, get_workspace_manager
 from ..graphiti.config import is_enabled_for_user
+from ..model_router import resolve_model
 from ..model import (
     ChatMessage,
     ChatSession,
@@ -726,8 +727,6 @@ async def _resolve_thinking_model_for_user(
     Consults ``copilot-thinking-{tier}-model`` and falls back to the
     ``ChatConfig`` default on missing user / missing flag.
     """
-    from backend.copilot.model_router import resolve_model
-
     return await resolve_model("thinking", tier, user_id, config=config)
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -844,7 +844,26 @@ async def _resolve_sdk_model_for_request(
         return None
 
     resolved = await _resolve_thinking_model_for_user(tier_name, user_id)
-    sdk_model = _normalize_model_name(resolved)
+    try:
+        sdk_model = _normalize_model_name(resolved)
+    except ValueError as exc:
+        # The per-user LD value didn't pass ``_normalize_model_name``'s
+        # vendor check (most commonly: a ``moonshotai/kimi-*`` slug on a
+        # direct-Anthropic deployment that has no OpenRouter route).  Fail
+        # soft to the config-default path instead of 500-ing the request —
+        # the LD misconfig is visible in the log + Sentry, but the user
+        # still gets a working turn.
+        fallback = _resolve_sdk_model()
+        logger.warning(
+            "[SDK] [%s] LD model %r rejected for tier=%s (%s); falling "
+            "back to config default %s",
+            session_id[:12] if session_id else "?",
+            resolved,
+            tier_name,
+            exc,
+            fallback,
+        )
+        return fallback
     logger.info(
         "[SDK] [%s] Resolved model for tier=%s: %s",
         session_id[:12] if session_id else "?",

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -699,20 +699,36 @@ def _normalize_model_name(raw_model: str) -> str:
 
 
 def _resolve_sdk_model() -> str | None:
-    """Resolve the model name for the Claude Agent SDK CLI.
+    """Resolve the SDK-CLI model name from static config (no LD lookup).
 
-    Uses `config.claude_agent_model` if set, otherwise derives from
-    `config.thinking_standard_model` via :func:`_normalize_model_name`.
+    ``config.claude_agent_model`` is an explicit override that wins
+    unconditionally.  When the Claude Code subscription is enabled and no
+    override is set, returns ``None`` so the CLI picks the model for the
+    user's subscription plan.  Otherwise derives from
+    ``config.thinking_standard_model``.
 
-    When `use_claude_code_subscription` is enabled and no explicit
-    `claude_agent_model` is set, returns `None` so the CLI uses the
-    default model for the user's subscription plan.
+    For per-user routing (LaunchDarkly overrides), see
+    :func:`_resolve_sdk_model_for_request`.
     """
     if config.claude_agent_model:
         return config.claude_agent_model
     if config.use_claude_code_subscription:
         return None
     return _normalize_model_name(config.thinking_standard_model)
+
+
+async def _resolve_thinking_model_for_user(
+    tier: "CopilotLlmModel",
+    user_id: str | None,
+) -> str:
+    """LD-aware thinking-tier model pick for a specific user.
+
+    Consults ``copilot-thinking-{tier}-model`` and falls back to the
+    ``ChatConfig`` default on missing user / missing flag.
+    """
+    from backend.copilot.model_router import resolve_model
+
+    return await resolve_model("thinking", tier, user_id, config=config)
 
 
 def _resolve_fallback_model() -> str | None:
@@ -729,37 +745,40 @@ def _resolve_fallback_model() -> str | None:
 async def _resolve_sdk_model_for_request(
     model: "CopilotLlmModel | None",
     session_id: str,
+    user_id: str | None = None,
 ) -> str | None:
     """Resolve the SDK model string for a turn.
 
     Priority (highest first):
-    1. Explicit per-request ``model`` tier from the frontend toggle.
-    2. Global config default (``_resolve_sdk_model()``).
-
-    Returns ``None`` when the Claude Code subscription default applies.
-    Rate-limit accounting no longer applies a multiplier — the real turn
-    cost (reported by the SDK) already reflects model-pricing differences.
+    1. ``config.claude_agent_model`` — unconditional override, bypasses LD.
+    2. ``config.use_claude_code_subscription`` on the standard tier — returns
+       ``None`` so the CLI picks the model tied to the user's subscription.
+    3. LaunchDarkly ``copilot-thinking-{tier}-model`` for *user_id*.
+    4. ``ChatConfig`` static default for the tier.
     """
-    if model == "advanced":
-        sdk_model = _normalize_model_name(config.thinking_advanced_model)
-        logger.info(
-            "[SDK] [%s] Per-request model override: advanced (%s)",
-            session_id[:12] if session_id else "?",
-            sdk_model,
-        )
-        return sdk_model
+    if config.claude_agent_model:
+        return config.claude_agent_model
 
-    if model == "standard":
-        # Reset to config default — respects subscription mode (None = CLI default).
-        sdk_model = _resolve_sdk_model()
-        logger.info(
-            "[SDK] [%s] Per-request model override: standard (%s)",
-            session_id[:12] if session_id else "?",
-            sdk_model or "subscription-default",
-        )
-        return sdk_model
+    tier_name: "CopilotLlmModel" = "advanced" if model == "advanced" else "standard"
 
-    return _resolve_sdk_model()
+    # Subscription mode only applies to the standard tier — advanced always
+    # uses an explicit model (Opus).  Preserving the pre-LD behaviour.
+    if tier_name == "standard" and config.use_claude_code_subscription:
+        logger.info(
+            "[SDK] [%s] Subscription default (tier=standard)",
+            session_id[:12] if session_id else "?",
+        )
+        return None
+
+    resolved = await _resolve_thinking_model_for_user(tier_name, user_id)
+    sdk_model = _normalize_model_name(resolved)
+    logger.info(
+        "[SDK] [%s] Resolved model for tier=%s: %s",
+        session_id[:12] if session_id else "?",
+        tier_name,
+        sdk_model,
+    )
+    return sdk_model
 
 
 _MAX_TRANSIENT_BACKOFF_SECONDS = 30
@@ -3059,8 +3078,8 @@ async def stream_chat_completion_sdk(
 
         mcp_server = create_copilot_mcp_server(use_e2b=use_e2b)
 
-        # Resolve model (request tier → config default).
-        sdk_model = await _resolve_sdk_model_for_request(model, session_id)
+        # Resolve model (request tier → LD per-user override → config default).
+        sdk_model = await _resolve_sdk_model_for_request(model, session_id, user_id)
 
         # Track SDK-internal compaction (PreCompact hook → start, next msg → end)
         compaction = CompactionTracker()

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -838,11 +838,17 @@ async def _resolve_sdk_model_for_request(
         return config.claude_agent_model
 
     tier_name: "CopilotLlmModel" = "advanced" if model == "advanced" else "standard"
+    # Strip at read time so a stray trailing space in ``CHAT_*_MODEL`` (a
+    # common ``.env`` pitfall) doesn't make the ``resolved == tier_default``
+    # comparison below spuriously diverge — ``resolve_model`` already strips
+    # the LD side, so both halves must end up whitespace-normalised to stay
+    # equal when they're semantically equal.  Downstream ``_normalize_model_name``
+    # also benefits from the strip.
     tier_default = (
         config.thinking_advanced_model
         if tier_name == "advanced"
         else config.thinking_standard_model
-    )
+    ).strip()
 
     resolved = await _resolve_thinking_model_for_user(tier_name, user_id)
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -824,25 +824,20 @@ async def _resolve_sdk_model_for_request(
 
     Priority (highest first):
     1. ``config.claude_agent_model`` — unconditional override, bypasses LD.
-    2. ``config.use_claude_code_subscription`` on the standard tier — returns
-       ``None`` so the CLI picks the model tied to the user's subscription.
-    3. LaunchDarkly ``copilot-thinking-{tier}-model`` for *user_id*.
+    2. LaunchDarkly ``copilot-thinking-{tier}-model`` if it serves a value
+       different from the config default for *user_id*.  An LD-served
+       override wins over subscription mode so admins can route specific
+       users to a specific model without flipping subscription on/off.
+    3. ``config.use_claude_code_subscription`` on the standard tier —
+       returns ``None`` so the CLI picks the subscription default (this
+       branch fires when LD has no opinion, i.e. the value equals the
+       config default).
     4. ``ChatConfig`` static default for the tier.
     """
     if config.claude_agent_model:
         return config.claude_agent_model
 
     tier_name: "CopilotLlmModel" = "advanced" if model == "advanced" else "standard"
-
-    # Subscription mode only applies to the standard tier — advanced always
-    # uses an explicit model (Opus).  Preserving the pre-LD behaviour.
-    if tier_name == "standard" and config.use_claude_code_subscription:
-        logger.info(
-            "[SDK] [%s] Subscription default (tier=standard)",
-            session_id[:12] if session_id else "?",
-        )
-        return None
-
     tier_default = (
         config.thinking_advanced_model
         if tier_name == "advanced"
@@ -850,6 +845,25 @@ async def _resolve_sdk_model_for_request(
     )
 
     resolved = await _resolve_thinking_model_for_user(tier_name, user_id)
+
+    # Subscription mode on standard tier only wins when LD has no opinion
+    # (value == config default ⇒ admin hasn't explicitly pointed this
+    # user somewhere).  Any LD override — even to the same value with
+    # stripped whitespace normalised — is an explicit admin choice that
+    # must be honoured.  Without this, a subscription-mode deployment
+    # silently ignores the ``copilot-thinking-standard-model`` flag
+    # entirely, which defeats the point of cohort-based routing.
+    ld_overrides_default = resolved != tier_default
+    if (
+        not ld_overrides_default
+        and tier_name == "standard"
+        and config.use_claude_code_subscription
+    ):
+        logger.info(
+            "[SDK] [%s] Subscription default (tier=standard, LD unset)",
+            session_id[:12] if session_id else "?",
+        )
+        return None
     try:
         sdk_model = _normalize_model_name(resolved)
     except ValueError as exc:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -843,6 +843,12 @@ async def _resolve_sdk_model_for_request(
         )
         return None
 
+    tier_default = (
+        config.thinking_advanced_model
+        if tier_name == "advanced"
+        else config.thinking_standard_model
+    )
+
     resolved = await _resolve_thinking_model_for_user(tier_name, user_id)
     try:
         sdk_model = _normalize_model_name(resolved)
@@ -850,20 +856,29 @@ async def _resolve_sdk_model_for_request(
         # The per-user LD value didn't pass ``_normalize_model_name``'s
         # vendor check (most commonly: a ``moonshotai/kimi-*`` slug on a
         # direct-Anthropic deployment that has no OpenRouter route).  Fail
-        # soft to the config-default path instead of 500-ing the request —
-        # the LD misconfig is visible in the log + Sentry, but the user
-        # still gets a working turn.
-        fallback = _resolve_sdk_model()
+        # soft to the TIER-SPECIFIC config default — using the generic
+        # ``_resolve_sdk_model()`` here would pin advanced-tier requests to
+        # ``thinking_standard_model`` (Sonnet) whenever LD misconfigures
+        # the advanced cell, silently downgrading the user's chosen tier.
+        try:
+            sdk_model = _normalize_model_name(tier_default)
+        except ValueError:
+            # Config default is *also* invalid for the active routing
+            # mode — this is a deployment-level misconfig that the
+            # ``model_validator`` should catch at startup.  Re-raise the
+            # original LD error so the issue surfaces loudly rather than
+            # returning something misleading.
+            raise exc
         logger.warning(
             "[SDK] [%s] LD model %r rejected for tier=%s (%s); falling "
-            "back to config default %s",
+            "back to tier default %s",
             session_id[:12] if session_id else "?",
             resolved,
             tier_name,
             exc,
-            fallback,
+            sdk_model,
         )
-        return fallback
+        return sdk_model
     logger.info(
         "[SDK] [%s] Resolved model for tier=%s: %s",
         session_id[:12] if session_id else "?",

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -18,6 +18,7 @@ from .service import (
     _override_cost_for_non_anthropic,
     _prepare_file_attachments,
     _resolve_sdk_model,
+    _resolve_sdk_model_for_request,
     _safe_close_sdk_client,
 )
 
@@ -515,6 +516,66 @@ class TestResolveSdkModel:
         )
         monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
         assert _resolve_sdk_model() == "claude-opus-4-6"
+
+
+class TestResolveSdkModelForRequestLdFallback:
+    """``_resolve_sdk_model_for_request`` must fail soft when the LD value
+    can't be normalised for the active routing mode — flagged as MAJOR by
+    CodeRabbit + HIGH by Sentry when it was a hard ValueError."""
+
+    @pytest.mark.asyncio
+    async def test_direct_anthropic_mode_rejects_kimi_ld_value_and_falls_back(
+        self, monkeypatch, _clean_config_env
+    ):
+        """LD serves ``moonshotai/kimi-k2.6`` but we're on direct-Anthropic
+        (no OpenRouter key).  ``_normalize_model_name`` raises; the
+        resolver must log + return the config-default path instead of
+        500-ing the turn."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            claude_agent_model=None,
+            use_openrouter=False,
+            api_key=None,
+            base_url=None,
+            use_claude_code_subscription=False,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="moonshotai/kimi-k2.6"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="standard", session_id="sess-abc", user_id="user-1"
+            )
+
+        # Fallback == _resolve_sdk_model() on this config = "claude-sonnet-4-6"
+        assert resolved == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_openrouter_mode_accepts_ld_kimi_value(
+        self, monkeypatch, _clean_config_env
+    ):
+        """On OpenRouter the Kimi slug is legitimate — no fallback,
+        value returned as-is."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            claude_agent_model=None,
+            use_openrouter=True,
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            use_claude_code_subscription=False,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="moonshotai/kimi-k2.6"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="standard", session_id="sess-abc", user_id="user-1"
+            )
+        assert resolved == "moonshotai/kimi-k2.6"
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -639,6 +639,37 @@ class TestResolveSdkModelForRequestLdFallback:
         assert resolved == "moonshotai/kimi-k2.6"
 
     @pytest.mark.asyncio
+    async def test_standard_subscription_survives_trailing_whitespace_in_env(
+        self, monkeypatch, _clean_config_env
+    ):
+        """``_resolve_thinking_model_for_user`` strips whitespace from the LD
+        side; the config tier default must be stripped too, otherwise a
+        stray trailing space in ``CHAT_THINKING_STANDARD_MODEL`` makes
+        ``resolved == tier_default`` spuriously False and bypasses
+        subscription-default mode.  Sentry HIGH on L856."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6  ",  # trailing spaces
+            claude_agent_model=None,
+            use_openrouter=False,
+            api_key=None,
+            base_url=None,
+            use_claude_code_subscription=True,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="anthropic/claude-sonnet-4-6"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="standard", session_id="sess-ws", user_id="user-1"
+            )
+        assert resolved is None, (
+            "LD value semantically matches the whitespace-padded config "
+            "default — subscription mode must still win and return None"
+        )
+
+    @pytest.mark.asyncio
     async def test_standard_subscription_default_honoured_when_ld_matches_config(
         self, monkeypatch, _clean_config_env
     ):

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -610,6 +610,62 @@ class TestResolveSdkModelForRequestLdFallback:
         assert resolved == "claude-opus-4-7"
 
     @pytest.mark.asyncio
+    async def test_standard_ld_override_wins_over_subscription(
+        self, monkeypatch, _clean_config_env
+    ):
+        """Bug reported in local test: subscription mode + LD serving Kimi
+        on ``copilot-thinking-standard-model`` returned ``None`` (CLI
+        picked subscription default Opus), silently ignoring the LD
+        override.  An LD value different from the config default is an
+        explicit admin decision and must win."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            claude_agent_model=None,
+            use_openrouter=True,
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            use_claude_code_subscription=True,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="moonshotai/kimi-k2.6"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="standard", session_id="sess-std-sub", user_id="user-1"
+            )
+        # Expect LD-served Kimi, NOT None (the old subscription-default bypass)
+        assert resolved == "moonshotai/kimi-k2.6"
+
+    @pytest.mark.asyncio
+    async def test_standard_subscription_default_honoured_when_ld_matches_config(
+        self, monkeypatch, _clean_config_env
+    ):
+        """When LD serves the SAME value as the config default (i.e. the
+        flag is effectively unset / no override), subscription mode still
+        wins and we return ``None`` so the CLI uses the subscription
+        default model."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            claude_agent_model=None,
+            use_openrouter=False,
+            api_key=None,
+            base_url=None,
+            use_claude_code_subscription=True,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="anthropic/claude-sonnet-4-6"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="standard", session_id="sess-std-nop", user_id="user-1"
+            )
+        assert resolved is None
+
+    @pytest.mark.asyncio
     async def test_advanced_tier_consults_ld_under_subscription(
         self, monkeypatch, _clean_config_env
     ):

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -549,7 +549,8 @@ class TestResolveSdkModelForRequestLdFallback:
                 model="standard", session_id="sess-abc", user_id="user-1"
             )
 
-        # Fallback == _resolve_sdk_model() on this config = "claude-sonnet-4-6"
+        # Fallback == tier-specific config default (thinking_standard_model
+        # normalised to hyphen-form for direct-Anthropic mode).
         assert resolved == "claude-sonnet-4-6"
 
     @pytest.mark.asyncio
@@ -576,6 +577,65 @@ class TestResolveSdkModelForRequestLdFallback:
                 model="standard", session_id="sess-abc", user_id="user-1"
             )
         assert resolved == "moonshotai/kimi-k2.6"
+
+    @pytest.mark.asyncio
+    async def test_advanced_tier_fallback_uses_advanced_default_not_standard(
+        self, monkeypatch, _clean_config_env
+    ):
+        """An LD-rejected ADVANCED slug must fall back to the advanced
+        config default (Opus) — not the standard default (Sonnet).
+        Using ``_resolve_sdk_model()`` as the fallback silently
+        downgraded the user's chosen tier.  Flagged MAJOR by CodeRabbit
+        + HIGH by Sentry on the first fail-soft commit."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            thinking_advanced_model="anthropic/claude-opus-4.7",
+            claude_agent_model=None,
+            use_openrouter=False,
+            api_key=None,
+            base_url=None,
+            use_claude_code_subscription=False,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="moonshotai/kimi-k2.6"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="advanced", session_id="sess-adv", user_id="user-1"
+            )
+
+        # Direct-Anthropic normalises anthropic/claude-opus-4.7 → claude-opus-4-7
+        assert resolved == "claude-opus-4-7"
+
+    @pytest.mark.asyncio
+    async def test_advanced_tier_consults_ld_under_subscription(
+        self, monkeypatch, _clean_config_env
+    ):
+        """Subscription mode bypasses LD only on the standard tier —
+        the advanced tier always consults LD because the user explicitly
+        asked for the premium path.  A subscription + advanced request
+        with LD-served Opus must return Opus (not ``None``)."""
+        cfg = cfg_mod.ChatConfig(
+            thinking_standard_model="anthropic/claude-sonnet-4-6",
+            thinking_advanced_model="anthropic/claude-opus-4.7",
+            claude_agent_model=None,
+            use_openrouter=True,
+            api_key="or-key",
+            base_url="https://openrouter.ai/api/v1",
+            use_claude_code_subscription=True,
+        )
+        monkeypatch.setattr("backend.copilot.sdk.service.config", cfg)
+
+        with patch(
+            "backend.copilot.sdk.service._resolve_thinking_model_for_user",
+            new=AsyncMock(return_value="anthropic/claude-opus-4.7"),
+        ):
+            resolved = await _resolve_sdk_model_for_request(
+                model="advanced", session_id="sess-adv-sub", user_id="user-1"
+            )
+        assert resolved == "anthropic/claude-opus-4.7"
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -48,6 +48,16 @@ class Flag(str, Enum):
     STRIPE_PRICE_BUSINESS = "stripe-price-id-business"
     GRAPHITI_MEMORY = "graphiti-memory"
 
+    # Copilot model routing — string-valued, returns the model identifier
+    # (e.g. ``"anthropic/claude-sonnet-4-6"`` or ``"moonshotai/kimi-k2.6"``)
+    # to use for each cell of the (mode, tier) matrix.  Falls back to the
+    # ``CHAT_*_MODEL`` env/config default when the flag is unset or LD is
+    # unavailable.  Evaluated per user_id so cohorts can be targeted.
+    COPILOT_FAST_STANDARD_MODEL = "copilot-fast-standard-model"
+    COPILOT_FAST_ADVANCED_MODEL = "copilot-fast-advanced-model"
+    COPILOT_THINKING_STANDARD_MODEL = "copilot-thinking-standard-model"
+    COPILOT_THINKING_ADVANCED_MODEL = "copilot-thinking-advanced-model"
+
 
 def is_configured() -> bool:
     """Check if LaunchDarkly is configured with an SDK key."""


### PR DESCRIPTION
## Summary

Per-user model routing for the copilot via LaunchDarkly. Replaces the pure-env-var pick on every `(mode, tier)` cell of the model matrix with an LD-first resolver that falls back to the `ChatConfig` default. Lets us roll out non-default routes (e.g. Kimi K2.6 on baseline standard) to a user cohort without shipping a deploy.

|          | standard                           | advanced                           |
|----------|------------------------------------|------------------------------------|
| fast     | `copilot-fast-standard-model`      | `copilot-fast-advanced-model`      |
| thinking | `copilot-thinking-standard-model`  | `copilot-thinking-advanced-model`  |

All four flags are **string-valued** — the value IS the model identifier (e.g. `"anthropic/claude-sonnet-4-6"` or `"moonshotai/kimi-k2.6"`).

## What ships

- **New module `backend/copilot/model_router.py`** with a single `resolve_model(mode, tier, user_id, *, config)` coroutine. That's the one place both paths consult.
- **4 new `Flag` enum values** in `backend/util/feature_flag.py` (reusing the existing `get_feature_flag_value` helper which already supports arbitrary return types).
- **`baseline/service.py::_resolve_baseline_model`** → async, takes `user_id`.
- **`sdk/service.py::_resolve_sdk_model_for_request`** → takes `user_id`, consults LD for both standard and advanced thinking cells.
- **Default flip**: `fast_standard_model` default goes back to `anthropic/claude-sonnet-4-6`. Non-Anthropic routes now ship via LD targeting — safer rollback, per-user cohort control, no redeploy required to flip.

## Behavior preserved

- `config.claude_agent_model` explicit override still wins unconditionally (existing escape hatch for ops).
- `use_claude_code_subscription=true` on the standard thinking tier still returns `None` so the CLI picks the model tied to the user's Claude Code subscription.
- All legacy env var aliases (`CHAT_MODEL`, `CHAT_ADVANCED_MODEL`, `CHAT_FAST_MODEL`) still bind to their cells.
- LD client exceptions / misconfigured (non-string) flag values fall back silently to config default with a single warning log — never fails the request.

## Files

| File | Change |
|---|---|
| `backend/copilot/model_router.py` | new — `resolve_model` + `_config_default` + `_FLAG_BY_CELL` map |
| `backend/copilot/model_router_test.py` | new — 11 cases |
| `backend/util/feature_flag.py` | add 4 string-valued `Flag` entries |
| `backend/copilot/config.py` | flip `fast_standard_model` default to Sonnet |
| `backend/copilot/baseline/service.py` | `_resolve_baseline_model` → async + LD resolver |
| `backend/copilot/sdk/service.py` | `_resolve_sdk_model_for_request` → LD resolver + user_id |
| `backend/copilot/baseline/transcript_integration_test.py` | update tests for new signature + default |

## Test plan

- [x] `poetry run pytest backend/copilot/model_router_test.py backend/copilot/baseline/transcript_integration_test.py backend/copilot/sdk/service_test.py backend/copilot/config_test.py` — **112 passing**
- [x] 11 resolver cases: missing user → fallback, LD string wins, whitespace stripped, non-string value → fallback, empty string → fallback, LD exception → fallback + warn, each of 4 cells routes to its distinct flag
- [x] Legacy env aliases still bind to their new fields
- [ ] Manual dev-env smoke: flip `copilot-fast-standard-model` LD targeting to `moonshotai/kimi-k2.6` for one user and confirm baseline uses Kimi while other users stay on Sonnet
- [ ] Confirm SDK path still honors subscription mode (LD not consulted when `use_claude_code_subscription=true` + standard tier)

## Rollout

1. Merge this PR → default stays Sonnet / Opus across the matrix, no behavior change.
2. Create the 4 LD flags as string-typed in the LaunchDarkly console (defaults matching config, so no drift if targeting empty).
3. Add per-user / per-cohort targeting in LD for the routes we want to roll out (Kimi on baseline standard for a percentage, etc.).