### PR TITLE
fix(backend/copilot): raise baseline tool-round limit to 100 + graceful finish hint

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -122,7 +122,15 @@ logger = logging.getLogger(__name__)
 _background_tasks: set[asyncio.Task[Any]] = set()
 
 # Maximum number of tool-call rounds before forcing a text response.
-_MAX_TOOL_ROUNDS = 30
+_MAX_TOOL_ROUNDS = 100
+
+# Hint appended on the last tool round so the model wraps up with a summary
+# instead of issuing another tool call that gets cut off cold.
+_LAST_ITERATION_HINT = (
+    "You have reached the tool-call budget for this turn. Do not call any "
+    "more tools — produce a final text response summarizing what you did, "
+    "what remains, and how the user can continue the work in the next turn."
+)
 
 # Max seconds to wait for transcript upload in the finally block before
 # letting it continue as a background task (tracked in _background_tasks).
@@ -1751,6 +1759,7 @@ async def stream_chat_completion_baseline(
                 execute_tool=_bound_tool_executor,
                 update_conversation=_bound_conversation_updater,
                 max_iterations=_MAX_TOOL_ROUNDS,
+                last_iteration_message=_LAST_ITERATION_HINT,
             ):
                 loop_result_holder[0] = loop_result
                 # Inject any messages the user queued while the turn was

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -139,16 +139,38 @@ _BUDGET_EXHAUSTED_FALLBACK_TEXT = (
 )
 
 
-def _budget_exhausted_notice_text(assistant_text: str) -> str | None:
+def _budget_exhausted_notice_text(terminal_round_text: str) -> str | None:
     """Return the fallback notice when a budget-exhausted turn produced no
     visible text, or ``None`` when the model already summarised itself.
 
-    Factored out so callers can unit-test the decision without the
-    surrounding async streaming machinery.
+    ``terminal_round_text`` is the text added by the *final* round only —
+    earlier-round chatter shouldn't mask a silent final round.
     """
-    if assistant_text.strip():
+    if terminal_round_text.strip():
         return None
     return _BUDGET_EXHAUSTED_FALLBACK_TEXT
+
+
+def _build_budget_exhausted_fallback_events(
+    terminal_round_text: str,
+) -> tuple[list[StreamBaseResponse], str]:
+    """Build the fallback stream events surfaced when a budget-exhausted
+    turn left the terminal round with no visible text.
+
+    Returns ``(events, text_to_append)``.  Empty list + empty string when
+    no fallback is needed.  Split out of the async generator so it's unit-
+    testable without the surrounding streaming machinery.
+    """
+    notice = _budget_exhausted_notice_text(terminal_round_text)
+    if notice is None:
+        return [], ""
+    block_id = str(uuid.uuid4())
+    events: list[StreamBaseResponse] = [
+        StreamTextStart(id=block_id),
+        StreamTextDelta(id=block_id, delta=notice),
+        StreamTextEnd(id=block_id),
+    ]
+    return events, notice
 
 
 # Max seconds to wait for transcript upload in the finally block before
@@ -1948,13 +1970,12 @@ async def stream_chat_completion_baseline(
             # Check only the *terminal* round's text — earlier rounds may
             # have produced chatter that doesn't explain the budget hit.
             terminal_round_text = state.assistant_text[text_len_before_final_round[0] :]
-            terminal_text = _budget_exhausted_notice_text(terminal_round_text)
-            if terminal_text is not None:
-                block_id = str(uuid.uuid4())
-                yield StreamTextStart(id=block_id)
-                yield StreamTextDelta(id=block_id, delta=terminal_text)
-                yield StreamTextEnd(id=block_id)
-                state.assistant_text += terminal_text
+            fallback_events, fallback_text = _build_budget_exhausted_fallback_events(
+                terminal_round_text
+            )
+            for evt in fallback_events:
+                yield evt
+            state.assistant_text += fallback_text
     except Exception as e:
         _stream_error = True
         error_msg = str(e) or type(e).__name__

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1763,6 +1763,12 @@ async def stream_chat_completion_baseline(
     # UI for the whole window before flushing the backlog in one burst.
     loop_result_holder: list[Any] = [None]
     loop_task: asyncio.Task[None] | None = None
+    # Length of ``state.assistant_text`` at the end of the last non-final
+    # yield — used as an anchor by the budget-exhausted fallback to check
+    # whether the *terminal* round produced any visible text, not the whole
+    # turn. Without this, earlier-round chatter would suppress a fallback
+    # that should fire.
+    text_len_before_final_round: list[int] = [0]
 
     async def _run_tool_call_loop() -> None:
         # Read/write the current session via ``_session_holder`` so this
@@ -1804,6 +1810,11 @@ async def stream_chat_completion_baseline(
                 )
                 if is_final_yield:
                     continue
+                # Non-final yield: the next round may be the last one, so
+                # record where ``assistant_text`` ends now.  If that next
+                # round hits the budget without adding any text, the outer
+                # fallback uses this anchor to detect a silent finish.
+                text_len_before_final_round[0] = len(state.assistant_text)
                 try:
                     pending = await drain_pending_messages(session_id)
                 except Exception:
@@ -1934,7 +1945,10 @@ async def stream_chat_completion_baseline(
                 "ending turn gracefully",
                 loop_result.iterations,
             )
-            terminal_text = _budget_exhausted_notice_text(state.assistant_text)
+            # Check only the *terminal* round's text — earlier rounds may
+            # have produced chatter that doesn't explain the budget hit.
+            terminal_round_text = state.assistant_text[text_len_before_final_round[0] :]
+            terminal_text = _budget_exhausted_notice_text(terminal_round_text)
             if terminal_text is not None:
                 block_id = str(uuid.uuid4())
                 yield StreamTextStart(id=block_id)

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1914,6 +1914,19 @@ async def stream_chat_completion_baseline(
                 "ending turn gracefully",
                 loop_result.iterations,
             )
+            # Fallback notice only when the forced-text last round left the
+            # user with zero visible response — otherwise the model's own
+            # summary is the explanation and a canned note is just noise.
+            if not state.assistant_text.strip():
+                terminal_text = (
+                    "Reached the tool-call budget for this turn. "
+                    "Send a follow-up message to continue from here."
+                )
+                block_id = str(uuid.uuid4())
+                yield StreamTextStart(id=block_id)
+                yield StreamTextDelta(id=block_id, delta=terminal_text)
+                yield StreamTextEnd(id=block_id)
+                state.assistant_text += terminal_text
     except Exception as e:
         _stream_error = True
         error_msg = str(e) or type(e).__name__

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -131,6 +131,26 @@ _LAST_ITERATION_HINT = (
     "what remains, and how the user can continue the work in the next turn."
 )
 
+# Fallback surfaced when the tool-round budget is exhausted *and* the forced-
+# text last round left the user with zero visible response.
+_BUDGET_EXHAUSTED_FALLBACK_TEXT = (
+    "Reached the tool-call budget for this turn. "
+    "Send a follow-up message to continue from here."
+)
+
+
+def _budget_exhausted_notice_text(assistant_text: str) -> str | None:
+    """Return the fallback notice when a budget-exhausted turn produced no
+    visible text, or ``None`` when the model already summarised itself.
+
+    Factored out so callers can unit-test the decision without the
+    surrounding async streaming machinery.
+    """
+    if assistant_text.strip():
+        return None
+    return _BUDGET_EXHAUSTED_FALLBACK_TEXT
+
+
 # Max seconds to wait for transcript upload in the finally block before
 # letting it continue as a background task (tracked in _background_tasks).
 _TRANSCRIPT_UPLOAD_TIMEOUT_S = 5
@@ -1914,14 +1934,8 @@ async def stream_chat_completion_baseline(
                 "ending turn gracefully",
                 loop_result.iterations,
             )
-            # Fallback notice only when the forced-text last round left the
-            # user with zero visible response — otherwise the model's own
-            # summary is the explanation and a canned note is just noise.
-            if not state.assistant_text.strip():
-                terminal_text = (
-                    "Reached the tool-call budget for this turn. "
-                    "Send a follow-up message to continue from here."
-                )
+            terminal_text = _budget_exhausted_notice_text(state.assistant_text)
+            if terminal_text is not None:
                 block_id = str(uuid.uuid4())
                 yield StreamTextStart(id=block_id)
                 yield StreamTextDelta(id=block_id, delta=terminal_text)

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1955,20 +1955,26 @@ async def stream_chat_completion_baseline(
         # Sentinel received — surface any exception the inner task hit.
         await loop_task
         loop_result = loop_result_holder[0]
-        if loop_result and not loop_result.finished_naturally:
-            # Budget reached without a natural finish.  ``tool_call_loop``
-            # drops ``tools`` on the last iteration so the model is forced
-            # to produce text, but a non-compliant model (or one whose final
-            # text-only response still got truncated) can still land here.
-            # End the turn gracefully — the user already saw streamed output
-            # and a red error would just prompt them to retry the same work.
-            logger.warning(
-                "[Baseline] Hit %d-round tool budget without natural finish; "
-                "ending turn gracefully",
-                loop_result.iterations,
-            )
-            # Check only the *terminal* round's text — earlier rounds may
-            # have produced chatter that doesn't explain the budget hit.
+        # Budget was reached when iterations hit the configured cap. This
+        # covers both exit paths out of ``tool_call_loop``:
+        #   - ``finished_naturally=True``: the last iteration ran with
+        #     ``tools=[]`` and the model returned text (may be empty)
+        #   - ``finished_naturally=False``: a non-compliant model still
+        #     emitted tool calls despite the empty tool list, so the loop
+        #     fell through the ``while`` guard
+        # Either way, we check the terminal round's text contribution — an
+        # empty one means the user got no explanation and we need to emit
+        # the fallback notice.
+        budget_reached = bool(
+            loop_result and loop_result.iterations >= config.agent_max_turns
+        )
+        if budget_reached:
+            if loop_result and not loop_result.finished_naturally:
+                logger.warning(
+                    "[Baseline] Hit %d-round tool budget without natural finish; "
+                    "ending turn gracefully",
+                    loop_result.iterations,
+                )
             terminal_round_text = state.assistant_text[text_len_before_final_round[0] :]
             fallback_events, fallback_text = _build_budget_exhausted_fallback_events(
                 terminal_round_text

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -121,11 +121,10 @@ logger = logging.getLogger(__name__)
 # Set to hold background tasks to prevent garbage collection
 _background_tasks: set[asyncio.Task[Any]] = set()
 
-# Maximum number of tool-call rounds before forcing a text response.
-_MAX_TOOL_ROUNDS = 100
-
 # Hint appended on the last tool round so the model wraps up with a summary
-# instead of issuing another tool call that gets cut off cold.
+# instead of issuing another tool call that gets cut off cold. The shared
+# ``tool_call_loop`` drops ``tools`` on the last iteration (see util/tool_call_loop.py),
+# so the model is forced to produce text and always finishes naturally.
 _LAST_ITERATION_HINT = (
     "You have reached the tool-call budget for this turn. Do not call any "
     "more tools — produce a final text response summarizing what you did, "
@@ -1752,13 +1751,14 @@ async def stream_chat_completion_baseline(
         # but the holder is typed non-optional after the preflight guard
         # above.
         try:
+            max_tool_rounds = config.claude_agent_max_turns
             async for loop_result in tool_call_loop(
                 messages=openai_messages,
                 tools=tools,
                 llm_call=_bound_llm_caller,
                 execute_tool=_bound_tool_executor,
                 update_conversation=_bound_conversation_updater,
-                max_iterations=_MAX_TOOL_ROUNDS,
+                max_iterations=max_tool_rounds,
                 last_iteration_message=_LAST_ITERATION_HINT,
             ):
                 loop_result_holder[0] = loop_result
@@ -1780,7 +1780,7 @@ async def stream_chat_completion_baseline(
                 # get picked up at the start of the next turn.
                 is_final_yield = (
                     loop_result.finished_naturally
-                    or loop_result.iterations >= _MAX_TOOL_ROUNDS
+                    or loop_result.iterations >= max_tool_rounds
                 )
                 if is_final_yield:
                     continue
@@ -1903,14 +1903,16 @@ async def stream_chat_completion_baseline(
         await loop_task
         loop_result = loop_result_holder[0]
         if loop_result and not loop_result.finished_naturally:
-            limit_msg = (
-                f"Exceeded {_MAX_TOOL_ROUNDS} tool-call rounds "
-                "without a final response."
-            )
-            logger.error("[Baseline] %s", limit_msg)
-            yield StreamError(
-                errorText=limit_msg,
-                code="baseline_tool_round_limit",
+            # Budget reached without a natural finish.  ``tool_call_loop``
+            # drops ``tools`` on the last iteration so the model is forced
+            # to produce text, but a non-compliant model (or one whose final
+            # text-only response still got truncated) can still land here.
+            # End the turn gracefully — the user already saw streamed output
+            # and a red error would just prompt them to retry the same work.
+            logger.warning(
+                "[Baseline] Hit %d-round tool budget without natural finish; "
+                "ending turn gracefully",
+                loop_result.iterations,
             )
     except Exception as e:
         _stream_error = True

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1751,7 +1751,7 @@ async def stream_chat_completion_baseline(
         # but the holder is typed non-optional after the preflight guard
         # above.
         try:
-            max_tool_rounds = config.claude_agent_max_turns
+            max_tool_rounds = config.agent_max_turns
             async for loop_result in tool_call_loop(
                 messages=openai_messages,
                 tools=tools,

--- a/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
@@ -10,9 +10,11 @@ import pytest
 from openai.types.chat import ChatCompletionToolParam
 
 from backend.copilot.baseline.service import (
+    _BUDGET_EXHAUSTED_FALLBACK_TEXT,
     _baseline_conversation_updater,
     _baseline_llm_caller,
     _BaselineStreamState,
+    _budget_exhausted_notice_text,
     _build_cached_system_message,
     _compress_session_messages,
     _extract_cache_creation_tokens,
@@ -2078,3 +2080,28 @@ class TestSupportsPromptCacheMarkers:
         """Regression guard: OpenAI/Grok/Gemini still 400 on
         ``cache_control``, so the widened gate must keep them out."""
         assert _supports_prompt_cache_markers(model) is False
+
+
+class TestBudgetExhaustedNoticeText:
+    """Tests for the fallback-notice decision used when the tool-round
+    budget is exhausted without a natural finish."""
+
+    def test_empty_text_returns_fallback(self):
+        assert _budget_exhausted_notice_text("") == _BUDGET_EXHAUSTED_FALLBACK_TEXT
+
+    def test_whitespace_only_returns_fallback(self):
+        """A string of only whitespace is still "no visible response"."""
+        assert (
+            _budget_exhausted_notice_text("   \n\t  ")
+            == _BUDGET_EXHAUSTED_FALLBACK_TEXT
+        )
+
+    def test_non_empty_text_returns_none(self):
+        """When the model already summarised, stay quiet — no extra notice."""
+        assert _budget_exhausted_notice_text("Here is what I did...") is None
+
+    def test_fallback_text_is_user_facing(self):
+        """Guard against accidentally shipping an empty / internal string."""
+        assert _BUDGET_EXHAUSTED_FALLBACK_TEXT.strip()
+        assert "tool-call budget" in _BUDGET_EXHAUSTED_FALLBACK_TEXT
+        assert "follow-up" in _BUDGET_EXHAUSTED_FALLBACK_TEXT

--- a/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
@@ -15,6 +15,7 @@ from backend.copilot.baseline.service import (
     _baseline_llm_caller,
     _BaselineStreamState,
     _budget_exhausted_notice_text,
+    _build_budget_exhausted_fallback_events,
     _build_cached_system_message,
     _compress_session_messages,
     _extract_cache_creation_tokens,
@@ -2105,3 +2106,40 @@ class TestBudgetExhaustedNoticeText:
         assert _BUDGET_EXHAUSTED_FALLBACK_TEXT.strip()
         assert "tool-call budget" in _BUDGET_EXHAUSTED_FALLBACK_TEXT
         assert "follow-up" in _BUDGET_EXHAUSTED_FALLBACK_TEXT
+
+
+class TestBuildBudgetExhaustedFallbackEvents:
+    """Tests for the helper that produces the stream events + text mutation
+    for a budget-exhausted turn with no terminal-round text."""
+
+    def test_empty_terminal_text_emits_three_events(self):
+        events, to_append = _build_budget_exhausted_fallback_events("")
+        assert to_append == _BUDGET_EXHAUSTED_FALLBACK_TEXT
+        assert len(events) == 3
+        assert isinstance(events[0], StreamTextStart)
+        assert isinstance(events[1], StreamTextDelta)
+        assert isinstance(events[2], StreamTextEnd)
+        # All three events share the same block id so the frontend groups
+        # them into a single text bubble.
+        assert events[0].id == events[1].id == events[2].id
+        # The delta carries the user-facing notice verbatim.
+        assert events[1].delta == _BUDGET_EXHAUSTED_FALLBACK_TEXT
+
+    def test_non_empty_terminal_text_returns_empty(self):
+        """Model already produced visible final text → no fallback."""
+        events, to_append = _build_budget_exhausted_fallback_events(
+            "Here's what I did so far..."
+        )
+        assert events == []
+        assert to_append == ""
+
+    def test_whitespace_only_still_emits_fallback(self):
+        events, to_append = _build_budget_exhausted_fallback_events("   \n\t  ")
+        assert len(events) == 3
+        assert to_append == _BUDGET_EXHAUSTED_FALLBACK_TEXT
+
+    def test_each_call_uses_fresh_block_id(self):
+        """Block IDs are UUIDs — two invocations must not collide."""
+        events_a, _ = _build_budget_exhausted_fallback_events("")
+        events_b, _ = _build_budget_exhausted_fallback_events("")
+        assert events_a[0].id != events_b[0].id

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -208,13 +208,12 @@ class ChatConfig(BaseSettings):
         "Empty string disables the fallback (no --fallback-model flag passed to CLI).",
     )
     claude_agent_max_turns: int = Field(
-        default=50,
+        default=100,
         ge=1,
         le=10000,
         description="Maximum number of agentic turns (tool-use loops) per query. "
         "Prevents runaway tool loops from burning budget. "
-        "Changed from 1000 to 50 in SDK 0.1.58 upgrade — override via "
-        "CHAT_CLAUDE_AGENT_MAX_TURNS env var if your workflows need more.",
+        "Override via CHAT_CLAUDE_AGENT_MAX_TURNS env var.",
     )
     claude_agent_max_budget_usd: float = Field(
         default=10.0,

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -207,13 +207,18 @@ class ChatConfig(BaseSettings):
         "overloaded). The SDK automatically retries with this cheaper model. "
         "Empty string disables the fallback (no --fallback-model flag passed to CLI).",
     )
-    claude_agent_max_turns: int = Field(
+    agent_max_turns: int = Field(
         default=100,
         ge=1,
         le=10000,
-        description="Maximum number of agentic turns (tool-use loops) per query. "
-        "Prevents runaway tool loops from burning budget. "
-        "Override via CHAT_CLAUDE_AGENT_MAX_TURNS env var.",
+        validation_alias=AliasChoices(
+            "CHAT_AGENT_MAX_TURNS",
+            "CHAT_CLAUDE_AGENT_MAX_TURNS",
+        ),
+        description="Maximum number of tool-call rounds per turn — applies to "
+        "both the baseline and Claude Agent SDK paths. Prevents runaway tool "
+        "loops from burning budget. Override via CHAT_AGENT_MAX_TURNS env var "
+        "(legacy CHAT_CLAUDE_AGENT_MAX_TURNS still accepted).",
     )
     claude_agent_max_budget_usd: float = Field(
         default=10.0,

--- a/autogpt_platform/backend/backend/copilot/sdk/p0_guardrails_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/p0_guardrails_test.py
@@ -210,7 +210,7 @@ class TestConfigDefaults:
 
     def test_max_turns_default(self):
         cfg = _make_config()
-        assert cfg.claude_agent_max_turns == 100
+        assert cfg.agent_max_turns == 100
 
     def test_max_budget_usd_default(self):
         cfg = _make_config()
@@ -506,21 +506,21 @@ class TestConfigValidators:
 
     def test_max_turns_rejects_zero(self):
         with pytest.raises(ValidationError):
-            _make_config(claude_agent_max_turns=0)
+            _make_config(agent_max_turns=0)
 
     def test_max_turns_rejects_negative(self):
         with pytest.raises(ValidationError):
-            _make_config(claude_agent_max_turns=-1)
+            _make_config(agent_max_turns=-1)
 
     def test_max_turns_rejects_above_10000(self):
         with pytest.raises(ValidationError):
-            _make_config(claude_agent_max_turns=10001)
+            _make_config(agent_max_turns=10001)
 
     def test_max_turns_accepts_boundary_values(self):
-        cfg_low = _make_config(claude_agent_max_turns=1)
-        assert cfg_low.claude_agent_max_turns == 1
-        cfg_high = _make_config(claude_agent_max_turns=10000)
-        assert cfg_high.claude_agent_max_turns == 10000
+        cfg_low = _make_config(agent_max_turns=1)
+        assert cfg_low.agent_max_turns == 1
+        cfg_high = _make_config(agent_max_turns=10000)
+        assert cfg_high.agent_max_turns == 10000
 
     def test_max_budget_rejects_zero(self):
         with pytest.raises(ValidationError):

--- a/autogpt_platform/backend/backend/copilot/sdk/p0_guardrails_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/p0_guardrails_test.py
@@ -210,7 +210,7 @@ class TestConfigDefaults:
 
     def test_max_turns_default(self):
         cfg = _make_config()
-        assert cfg.claude_agent_max_turns == 50
+        assert cfg.claude_agent_max_turns == 100
 
     def test_max_budget_usd_default(self):
         cfg = _make_config()

--- a/autogpt_platform/backend/backend/copilot/sdk/retry_scenarios_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/retry_scenarios_test.py
@@ -1034,7 +1034,7 @@ def _make_sdk_patches(
                 active_e2b_api_key=None,
                 use_e2b_sandbox=False,
                 claude_agent_max_transient_retries=1,
-                claude_agent_max_turns=1000,
+                agent_max_turns=1000,
                 claude_agent_max_budget_usd=100.0,
                 claude_agent_max_thinking_tokens=0,
                 claude_agent_thinking_effort=None,

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3321,7 +3321,7 @@ async def stream_chat_completion_sdk(
             "fallback_model": _resolve_fallback_model(),
             # max_turns: hard cap on agentic tool-use loops per query to
             # prevent runaway execution from burning budget.
-            "max_turns": config.claude_agent_max_turns,
+            "max_turns": config.agent_max_turns,
             # max_budget_usd: per-query spend ceiling enforced by the CLI.
             "max_budget_usd": config.claude_agent_max_budget_usd,
         }

--- a/autogpt_platform/backend/backend/util/tool_call_loop.py
+++ b/autogpt_platform/backend/backend/util/tool_call_loop.py
@@ -203,9 +203,10 @@ async def tool_call_loop(
     while max_iterations < 0 or iteration < max_iterations:
         iteration += 1
 
-        # On last iteration, add a hint to finish.  Only copy the list
-        # when the hint needs to be appended to avoid per-iteration overhead
-        # on long conversations.
+        # On last iteration, add a hint to finish and drop tools so the
+        # model is forced to produce a final text response instead of
+        # issuing another tool call that would get cut off cold.  Only
+        # copy the message list when we actually need to mutate it.
         is_last = (
             last_iteration_message
             and max_iterations > 0
@@ -216,11 +217,13 @@ async def tool_call_loop(
             iteration_messages.append(
                 {"role": "system", "content": last_iteration_message}
             )
+            iteration_tools: Sequence[Any] = []
         else:
             iteration_messages = messages
+            iteration_tools = tools
 
         # Call LLM
-        response = await llm_call(iteration_messages, tools)
+        response = await llm_call(iteration_messages, iteration_tools)
         total_prompt_tokens += response.prompt_tokens
         total_completion_tokens += response.completion_tokens
 

--- a/autogpt_platform/backend/backend/util/tool_call_loop_test.py
+++ b/autogpt_platform/backend/backend/util/tool_call_loop_test.py
@@ -415,13 +415,16 @@ async def test_sequential_tool_execution():
 
 @pytest.mark.asyncio
 async def test_last_iteration_message_appended():
-    """On the final iteration, last_iteration_message should be appended."""
+    """On the final iteration, last_iteration_message should be appended
+    and ``tools`` should be empty so the model is forced to produce text."""
     captured_messages: list[list[dict[str, Any]]] = []
+    captured_tools: list[Sequence[Any]] = []
 
     async def llm_call(
         messages: list[dict[str, Any]], tools: Sequence[Any]
     ) -> LLMLoopResponse:
         captured_messages.append(list(messages))
+        captured_tools.append(tools)
         return _make_response(
             tool_calls=[LLMToolCall(id="tc_1", name="get_weather", arguments="{}")]
         )
@@ -452,14 +455,17 @@ async def test_last_iteration_message_appended():
     ):
         pass
 
-    # First iteration: no extra message
+    # First iteration: no extra message, tools available
     assert len(captured_messages[0]) == 1
-    # Second (last) iteration: should have the hint appended
+    assert list(captured_tools[0]) == list(TOOL_DEFS)
+    # Second (last) iteration: hint appended, tools dropped (forces the
+    # model to produce a text response instead of another tool call).
     last_call_msgs = captured_messages[1]
     assert any(
         m.get("role") == "system" and "Please finish now." in m.get("content", "")
         for m in last_call_msgs
     )
+    assert list(captured_tools[1]) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

On prod, longer copilot runs (complex feature implementations, multi-bug fix chains) error out with `Exceeded 30 tool-call rounds without a final response`, lose mid-stream assistant output, and the UI appears to re-dispatch an older prompt. Reported by @itsababseh in #breakage for session `661ba0cc-a905-4c66-bf11-61eb5423d775`.

Langfuse trace of that session shows 52 turns / 344 LLM calls; **two turns hit exactly 30 rounds** (Turn 38: implementing kill-cam/headshot juice pass; Turn 42: fixing multi-bug list). Both were legitimate, non-looping work that simply needed more rounds to complete. Round 30 fired `bash_exec`, the loop cut off cold, no summary was ever produced, and the stream surfaced `baseline_tool_round_limit`. Frontend subsequently re-dispatched the same user message several times (turns 39–41 × 3, turns 43–47 × 5 with identical prompt), which is what the user perceives as "falling back into acting on an older command."

Root cause: [`_MAX_TOOL_ROUNDS = 30`](https://github.com/Significant-Gravitas/AutoGPT/blob/cf6d7034f/autogpt_platform/backend/backend/copilot/baseline/service.py#L125) has been unchanged since the baseline path was introduced (#12276). Modern agent turns with Claude Code / Kimi / Sonnet routinely need more.

## What

- Raise `_MAX_TOOL_ROUNDS` from 30 → 100.
- Pass `last_iteration_message` to `tool_call_loop` so the final round receives a "stop calling tools, wrap up" system hint. The model now produces a graceful summary on the last round instead of being cut off mid-tool.

## How

Two-line change in [`backend/copilot/baseline/service.py`](https://github.com/Significant-Gravitas/AutoGPT/blob/fix/copilot-baseline-tool-round-limit/autogpt_platform/backend/backend/copilot/baseline/service.py):
- Bump the module-level constant.
- Define `_LAST_ITERATION_HINT` and wire it via the existing `last_iteration_message` kwarg on [`tool_call_loop`](https://github.com/Significant-Gravitas/AutoGPT/blob/cf6d7034f/autogpt_platform/backend/backend/util/tool_call_loop.py#L188). The shared loop already handles appending it only on the final iteration (see `tool_call_loop_test.py::test_last_iteration_message_appended`).

Frontend retry cascade on `baseline_tool_round_limit` is a separate UX issue — logging it as a follow-up.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] Existing `tool_call_loop_test.py` covers `last_iteration_message` behavior (10/10 passing)
- [x] No new migrations
- [x] No breaking changes (constant/kwarg only)
