### PR TITLE
fix(frontend): prevent Select controlled/uncontrolled switch warning (#11093)

### DIFF
--- a/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
@@ -79,7 +79,11 @@ export function Select({
   );
 
   const select = (
-    <BaseSelect value={value ?? ""} onValueChange={onValueChange} disabled={disabled}>
+    <BaseSelect
+      value={value ?? ""}
+      onValueChange={onValueChange}
+      disabled={disabled}
+    >
       <SelectTrigger
         className={triggerStyles}
         {...(hideLabel ? { "aria-label": label } : {})}

--- a/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Select/Select.tsx
@@ -79,7 +79,7 @@ export function Select({
   );
 
   const select = (
-    <BaseSelect value={value} onValueChange={onValueChange} disabled={disabled}>
+    <BaseSelect value={value ?? ""} onValueChange={onValueChange} disabled={disabled}>
       <SelectTrigger
         className={triggerStyles}
         {...(hideLabel ? { "aria-label": label } : {})}


### PR DESCRIPTION
## Summary

Fixes #11093

Radix UI `Select` warns about switching between controlled and uncontrolled mode when `value` transitions between `undefined` and a string.

## Root Cause

`Select` component in `Select.tsx` passes `value` directly to Radix `<Select value={value}>`. Since `value` is typed as `string | undefined`, when it starts as `undefined` (uncontrolled) and later becomes a string (controlled), React/Radix emits the warning.

## Fix

```tsx
// Before
<BaseSelect value={value} ...>

// After  
<BaseSelect value={value ?? ""} ...>
```

This ensures the component is always in controlled mode with a consistent string value.

## Note

A similar fix was previously submitted in #12449 but was closed without merging. This PR applies the same approach.