### PR TITLE
fix(frontend): fix Unknown Agent in activity dropdown (#11229)

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/helpers.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AgentActivityDropdown/helpers.tsx
@@ -74,7 +74,7 @@ export function enrichExecutionWithAgentInfo(
 
   return {
     ...execution,
-    agent_name: agentInfo?.name ?? "Unknown Agent",
+    agent_name: agentInfo?.name ?? `Agent ${execution.graph_id.slice(0, 8)}`,
     agent_description: agentInfo?.description ?? "",
     library_agent_id: agentInfo?.library_agent_id,
   };

--- a/autogpt_platform/frontend/src/hooks/useLibraryAgents/useLibraryAgents.ts
+++ b/autogpt_platform/frontend/src/hooks/useLibraryAgents/useLibraryAgents.ts
@@ -1,26 +1,38 @@
 import { useGetV2ListLibraryAgentsInfinite } from "@/app/api/__generated__/endpoints/library/library";
 import { getPaginationNextPageNumber, unpaginate } from "@/app/api/helpers";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { buildAgentInfoMap } from "./store";
 
 export function useLibraryAgents() {
-  const { data: agentsQueryData, isLoading: isRefreshing } =
-    useGetV2ListLibraryAgentsInfinite(
-      {
-        page: 1,
-        page_size: 100,
-        is_hidden: false,
+  const {
+    data: agentsQueryData,
+    isLoading: isRefreshing,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useGetV2ListLibraryAgentsInfinite(
+    {
+      page: 1,
+      page_size: 100,
+      is_hidden: false,
+    },
+    {
+      query: {
+        getNextPageParam: getPaginationNextPageNumber,
+        // Don't block rendering - fetch in background
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        staleTime: 5 * 60 * 1000, // 5 minutes
       },
-      {
-        query: {
-          getNextPageParam: getPaginationNextPageNumber,
-          // Don't block rendering - fetch in background
-          refetchOnMount: false,
-          refetchOnWindowFocus: false,
-          staleTime: 5 * 60 * 1000, // 5 minutes
-        },
-      },
-    );
+    },
+  );
+
+  // Auto-fetch all pages so the agentInfoMap is complete (#11229)
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const agents = agentsQueryData ? unpaginate(agentsQueryData, "agents") : [];
 


### PR DESCRIPTION
## Summary

Fixes #11229 — agents not consistently showing up in the Agent Activity dropdown.

## Root Cause

Two issues:

1. **Incomplete agent list**: `useLibraryAgents` uses an infinite query with `page_size: 100` but never calls `fetchNextPage()`. Users with more than 100 agents only get the first page — any agent beyond that shows as 'Unknown Agent'.

2. **Poor fallback**: When an agent's `graph_id` isn't in the library map (e.g. imported via the old hidden method), the fallback was the unhelpful string 'Unknown Agent'.

## Fix

1. **Auto-fetch all pages**: Added a `useEffect` that calls `fetchNextPage()` whenever `hasNextPage` is true, ensuring the complete agent list is loaded progressively.

2. **Better fallback**: Changed from `'Unknown Agent'` to `\`Agent ${graph_id.slice(0, 8)}\`` so users can at least identify which graph is executing.

## Changes

- `hooks/useLibraryAgents/useLibraryAgents.ts`: destructure `fetchNextPage`/`hasNextPage`/`isFetchingNextPage` and auto-paginate
- `AgentActivityDropdown/helpers.tsx`: improve fallback name in `enrichExecutionWithAgentInfo`