### PR TITLE
fix(frontend): prevent prompt value removal when keys share a prefix

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/object/WrapIfAdditionalTemplate.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/base/object/WrapIfAdditionalTemplate.tsx
@@ -54,7 +54,10 @@ export default function WrapIfAdditionalTemplate(
 
   const keyId = `${id}-key`;
   const generateObjectPropertyTitleId = (id: string, label: string) => {
-    return id.replace(`_${label}`, `_#_${label}`);
+    // Use a regex anchored to the end to avoid corrupting IDs when one key
+    // is a prefix of another (e.g. 'PR-Title' vs 'PR-Title-test') (#9884)
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return id.replace(new RegExp(`_${escaped}$`), `_#_${label}`);
   };
   const title_id = generateObjectPropertyTitleId(id, label);
 


### PR DESCRIPTION
## Summary

Fixes #9884 — AI Text Generator Block removes prompt values with similar names.

## Root Cause

In `WrapIfAdditionalTemplate.tsx`, `generateObjectPropertyTitleId` uses `id.replace(\`_${label}\`, ...)` to transform the field ID for the title/handle mapping.

`String.replace` with a plain string only replaces the **first** match. When one dict key is a prefix of another (e.g. `PR-Title` and `PR-Title-test`), the ID for `PR-Title-test` (`root_prompt_values_PR-Title-test`) contains `_PR-Title` as a substring — the replace matches this **wrong** position, corrupting the handle/title ID mapping. This causes RJSF to lose track of the field and effectively remove it.

## Fix

Anchor the replacement to the **end** of the string using a regex with `$`:

```tsx
// Before
return id.replace(\`_${label}\`, \`_#_${label}\`);

// After
const escaped = label.replace(/[.*+?^${}()|[\\]\\]/g, '\\\$&');
return id.replace(new RegExp(\`_${escaped}$\`), \`_#_${label}\`);
```

This ensures only the exact trailing key segment is replaced, even when keys share common prefixes.

## Testing

- Creating dict entries with keys `PR-Title` and `PR-Title-test` should both persist without interference
- Keys with regex special characters (e.g. `key[0]`) are safely escaped