### PR TITLE
feat(platform): add MAX tier + LD-configurable pricing + hide unconfigured tiers

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes_test.py
@@ -57,7 +57,7 @@ def _patch_rate_limit_deps(
     mocker.patch(
         f"{_MOCK_MODULE}.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(2_500_000, 12_500_000, SubscriptionTier.FREE),
+        return_value=(2_500_000, 12_500_000, SubscriptionTier.BASIC),
     )
     mocker.patch(
         f"{_MOCK_MODULE}.get_usage_status",
@@ -89,7 +89,7 @@ def test_get_rate_limit(
     assert data["weekly_cost_limit_microdollars"] == 12_500_000
     assert data["daily_cost_used_microdollars"] == 500_000
     assert data["weekly_cost_used_microdollars"] == 3_000_000
-    assert data["tier"] == "FREE"
+    assert data["tier"] == "BASIC"
 
     configured_snapshot.assert_match(
         json.dumps(data, indent=2, sort_keys=True) + "\n",
@@ -163,7 +163,7 @@ def test_reset_user_usage_daily_only(
     assert data["daily_cost_used_microdollars"] == 0
     # Weekly is untouched
     assert data["weekly_cost_used_microdollars"] == 3_000_000
-    assert data["tier"] == "FREE"
+    assert data["tier"] == "BASIC"
 
     mock_reset.assert_awaited_once_with(target_user_id, reset_weekly=False)
 
@@ -194,7 +194,7 @@ def test_reset_user_usage_daily_and_weekly(
     data = response.json()
     assert data["daily_cost_used_microdollars"] == 0
     assert data["weekly_cost_used_microdollars"] == 0
-    assert data["tier"] == "FREE"
+    assert data["tier"] == "BASIC"
 
     mock_reset.assert_awaited_once_with(target_user_id, reset_weekly=True)
 
@@ -231,7 +231,7 @@ def test_get_rate_limit_email_lookup_failure(
     mocker.patch(
         f"{_MOCK_MODULE}.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(2_500_000, 12_500_000, SubscriptionTier.FREE),
+        return_value=(2_500_000, 12_500_000, SubscriptionTier.BASIC),
     )
     mocker.patch(
         f"{_MOCK_MODULE}.get_usage_status",
@@ -324,7 +324,7 @@ def test_set_user_tier(
     mocker.patch(
         f"{_MOCK_MODULE}.get_user_tier",
         new_callable=AsyncMock,
-        return_value=SubscriptionTier.FREE,
+        return_value=SubscriptionTier.BASIC,
     )
     mock_set = mocker.patch(
         f"{_MOCK_MODULE}.set_user_tier",
@@ -347,7 +347,7 @@ def test_set_user_tier_downgrade(
     mocker: pytest_mock.MockerFixture,
     target_user_id: str,
 ) -> None:
-    """Test downgrading a user's tier from PRO to FREE."""
+    """Test downgrading a user's tier from PRO to BASIC."""
     mocker.patch(
         f"{_MOCK_MODULE}.get_user_email_by_id",
         new_callable=AsyncMock,
@@ -365,14 +365,14 @@ def test_set_user_tier_downgrade(
 
     response = client.post(
         "/admin/rate_limit/tier",
-        json={"user_id": target_user_id, "tier": "FREE"},
+        json={"user_id": target_user_id, "tier": "BASIC"},
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["user_id"] == target_user_id
-    assert data["tier"] == "FREE"
-    mock_set.assert_awaited_once_with(target_user_id, SubscriptionTier.FREE)
+    assert data["tier"] == "BASIC"
+    mock_set.assert_awaited_once_with(target_user_id, SubscriptionTier.BASIC)
 
 
 def test_set_user_tier_invalid_tier(
@@ -456,7 +456,7 @@ def test_set_user_tier_db_failure(
     mocker.patch(
         f"{_MOCK_MODULE}.get_user_tier",
         new_callable=AsyncMock,
-        return_value=SubscriptionTier.FREE,
+        return_value=SubscriptionTier.BASIC,
     )
     mocker.patch(
         f"{_MOCK_MODULE}.set_user_tier",

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -380,7 +380,7 @@ def _mock_usage(
     weekly_used: int = 2000,
     daily_limit: int = 10000,
     weekly_limit: int = 50000,
-    tier: "SubscriptionTier" = SubscriptionTier.FREE,
+    tier: "SubscriptionTier" = SubscriptionTier.BASIC,
 ) -> AsyncMock:
     """Mock get_usage_status and get_global_rate_limits for usage endpoint tests.
 
@@ -440,7 +440,7 @@ def test_usage_returns_daily_and_weekly(
         daily_cost_limit=10000,
         weekly_cost_limit=50000,
         rate_limit_reset_cost=chat_routes.config.rate_limit_reset_cost,
-        tier=SubscriptionTier.FREE,
+        tier=SubscriptionTier.BASIC,
     )
 
 
@@ -461,7 +461,7 @@ def test_usage_uses_config_limits(
         daily_cost_limit=99999,
         weekly_cost_limit=77777,
         rate_limit_reset_cost=500,
-        tier=SubscriptionTier.FREE,
+        tier=SubscriptionTier.BASIC,
     )
 
 
@@ -996,7 +996,7 @@ def test_stream_chat_accepts_exactly_max_length_message(
     mocker.patch(
         "backend.api.features.chat.routes.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(0, 0, SubscriptionTier.FREE),
+        return_value=(0, 0, SubscriptionTier.BASIC),
     )
 
     response = client.post(
@@ -1267,7 +1267,7 @@ def _mock_reset_internals(
     enable_credit: bool = True,
     daily_limit: int = 10_000,
     weekly_limit: int = 50_000,
-    tier: "SubscriptionTier" = SubscriptionTier.FREE,
+    tier: "SubscriptionTier" = SubscriptionTier.BASIC,
     daily_used: int = 10_001,
     weekly_used: int = 1_000,
     reset_count: int | None = 0,
@@ -1366,7 +1366,7 @@ def test_reset_usage_returns_400_when_no_daily_limit(
     mocker.patch(
         "backend.api.features.chat.routes.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(0, 50_000, SubscriptionTier.FREE),
+        return_value=(0, 50_000, SubscriptionTier.BASIC),
     )
     mocker.patch(
         "backend.api.features.chat.routes.get_daily_reset_count",
@@ -1389,7 +1389,7 @@ def test_reset_usage_returns_503_when_redis_unavailable(
     mocker.patch(
         "backend.api.features.chat.routes.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(10_000, 50_000, SubscriptionTier.FREE),
+        return_value=(10_000, 50_000, SubscriptionTier.BASIC),
     )
     mocker.patch(
         "backend.api.features.chat.routes.get_daily_reset_count",
@@ -1412,7 +1412,7 @@ def test_reset_usage_returns_429_when_max_resets_reached(
     mocker.patch(
         "backend.api.features.chat.routes.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(10_000, 50_000, SubscriptionTier.FREE),
+        return_value=(10_000, 50_000, SubscriptionTier.BASIC),
     )
     mocker.patch(
         "backend.api.features.chat.routes.get_daily_reset_count",
@@ -1436,7 +1436,7 @@ def test_reset_usage_returns_429_when_lock_not_acquired(
     mocker.patch(
         "backend.api.features.chat.routes.get_global_rate_limits",
         new_callable=AsyncMock,
-        return_value=(10_000, 50_000, SubscriptionTier.FREE),
+        return_value=(10_000, 50_000, SubscriptionTier.BASIC),
     )
     mocker.patch(
         "backend.api.features.chat.routes.get_daily_reset_count",

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -189,7 +189,7 @@ async def test_create_store_submission(mocker):
         notifyOnAgentApproved=True,
         notifyOnAgentRejected=True,
         timezone="Europe/Delft",
-        subscriptionTier=prisma.enums.SubscriptionTier.FREE,  # type: ignore[reportCallIssue,reportAttributeAccessIssue]
+        subscriptionTier=prisma.enums.SubscriptionTier.BASIC,  # type: ignore[reportCallIssue,reportAttributeAccessIssue]
     )
     mock_agent = prisma.models.AgentGraph(
         id="agent-id",

--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -929,6 +929,61 @@ def test_update_subscription_tier_priced_free_no_sub_falls_through_to_checkout(
     modify_mock.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.PRO)
 
 
+def test_update_subscription_tier_target_without_ld_price_returns_422(
+    client: fastapi.testclient.TestClient,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Paid target with no LD-configured Stripe price must fail fast with 422.
+
+    Matches the UI hiding: if `stripe-price-id-pro` resolves to None we can't
+    start a Checkout Session anyway, and we don't want to surface an opaque
+    Stripe error mid-flow. The handler rejects the request before touching
+    Stripe at all.
+    """
+    mock_user = Mock()
+    mock_user.subscription_tier = SubscriptionTier.FREE
+
+    async def mock_price_id(tier: SubscriptionTier) -> str | None:
+        return None  # Neither FREE nor PRO have an LD price.
+
+    mocker.patch(
+        "backend.api.features.v1.get_user_by_id",
+        new_callable=AsyncMock,
+        return_value=mock_user,
+    )
+    mocker.patch(
+        "backend.api.features.v1.get_subscription_price_id",
+        side_effect=mock_price_id,
+    )
+    mocker.patch(
+        "backend.api.features.v1.is_feature_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    checkout_mock = mocker.patch(
+        "backend.api.features.v1.create_subscription_checkout",
+        new_callable=AsyncMock,
+    )
+    modify_mock = mocker.patch(
+        "backend.api.features.v1.modify_stripe_subscription_for_tier",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post(
+        "/credits/subscription",
+        json={
+            "tier": "PRO",
+            "success_url": f"{TEST_FRONTEND_ORIGIN}/success",
+            "cancel_url": f"{TEST_FRONTEND_ORIGIN}/cancel",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "not available" in response.json()["detail"].lower()
+    checkout_mock.assert_not_awaited()
+    modify_mock.assert_not_awaited()
+
+
 def test_update_subscription_tier_paid_to_paid_stripe_error_returns_502(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,

--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -193,11 +193,7 @@ def test_get_subscription_status_defaults_to_basic(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """When all LD price IDs are unset, tier_costs still includes the current tier.
-
-    Safety net: we always include the current tier (if not ENTERPRISE) so the UI
-    has something to render even when LaunchDarkly is unconfigured.
-    """
+    """When all LD price IDs are unset, tier_costs is empty and the caller sees cost=0."""
     mock_user = Mock()
     mock_user.subscription_tier = None
 
@@ -223,7 +219,7 @@ def test_get_subscription_status_defaults_to_basic(
     data = response.json()
     assert data["tier"] == SubscriptionTier.BASIC.value
     assert data["monthly_cost"] == 0
-    assert data["tier_costs"] == {"BASIC": 0}
+    assert data["tier_costs"] == {}
     assert data["proration_credit_cents"] == 0
 
 

--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -60,6 +60,13 @@ def _stub_pending_subscription_change(mocker: pytest_mock.MockFixture) -> None:
     )
 
 
+_DEFAULT_TIER_PRICES: dict[SubscriptionTier, str | None] = {
+    SubscriptionTier.FREE: None,  # Legacy: stripe-price-id-basic unset by default.
+    SubscriptionTier.PRO: "price_pro",
+    SubscriptionTier.BUSINESS: "price_max",
+}
+
+
 @pytest.fixture(autouse=True)
 def _stub_subscription_status_lookups(mocker: pytest_mock.MockFixture) -> None:
     """Stub Stripe price + proration lookups used by get_subscription_status.
@@ -69,10 +76,13 @@ def _stub_subscription_status_lookups(mocker: pytest_mock.MockFixture) -> None:
     modify, checkout creation), so every POST test implicitly hits these
     helpers.  Individual tests can override via their own mocker.patch call.
     """
+
+    async def default_price_id(tier: SubscriptionTier) -> str | None:
+        return _DEFAULT_TIER_PRICES.get(tier)
+
     mocker.patch(
         "backend.api.features.v1.get_subscription_price_id",
-        new_callable=AsyncMock,
-        return_value=None,
+        side_effect=default_price_id,
     )
     mocker.patch(
         "backend.api.features.v1.get_proration_credit_cents",
@@ -122,15 +132,22 @@ def test_get_subscription_status_pro(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """GET /credits/subscription returns PRO tier with Stripe price for a PRO user."""
+    """GET /credits/subscription returns PRO tier with Stripe prices for all priced tiers."""
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
+    prices = {
+        SubscriptionTier.FREE: "price_basic",
+        SubscriptionTier.PRO: "price_pro",
+        SubscriptionTier.BUSINESS: "price_max",
+    }
+    amounts = {"price_basic": 0, "price_pro": 1999, "price_max": 4999}
+
     async def mock_price_id(tier: SubscriptionTier) -> str | None:
-        return "price_pro" if tier == SubscriptionTier.PRO else None
+        return prices.get(tier)
 
     async def mock_stripe_price_amount(price_id: str) -> int:
-        return 1999 if price_id == "price_pro" else 0
+        return amounts.get(price_id, 0)
 
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
@@ -158,8 +175,9 @@ def test_get_subscription_status_pro(
     assert data["tier"] == "PRO"
     assert data["monthly_cost"] == 1999
     assert data["tier_costs"]["PRO"] == 1999
-    assert data["tier_costs"]["BUSINESS"] == 0
+    assert data["tier_costs"]["BUSINESS"] == 4999
     assert data["tier_costs"]["FREE"] == 0
+    assert "ENTERPRISE" not in data["tier_costs"]
     assert data["proration_credit_cents"] == 500
 
 
@@ -167,7 +185,11 @@ def test_get_subscription_status_defaults_to_free(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """GET /credits/subscription when subscription_tier is None defaults to FREE."""
+    """When all LD price IDs are unset, tier_costs still includes the current tier.
+
+    Safety net: we always include the current tier (if not ENTERPRISE) so the UI
+    has something to render even when LaunchDarkly is unconfigured.
+    """
     mock_user = Mock()
     mock_user.subscription_tier = None
 
@@ -193,12 +215,7 @@ def test_get_subscription_status_defaults_to_free(
     data = response.json()
     assert data["tier"] == SubscriptionTier.FREE.value
     assert data["monthly_cost"] == 0
-    assert data["tier_costs"] == {
-        "FREE": 0,
-        "PRO": 0,
-        "BUSINESS": 0,
-        "ENTERPRISE": 0,
-    }
+    assert data["tier_costs"] == {"FREE": 0}
     assert data["proration_credit_cents"] == 0
 
 
@@ -844,6 +861,72 @@ def test_update_subscription_tier_admin_granted_paid_to_paid_updates_db_directly
     # DB tier updated directly — no Stripe Checkout Session created
     set_tier_mock.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.BUSINESS)
     checkout_mock.assert_not_awaited()
+
+
+def test_update_subscription_tier_priced_free_no_sub_falls_through_to_checkout(
+    client: fastapi.testclient.TestClient,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Once stripe-price-id-basic is configured, a FREE user without an active sub
+    must hit Stripe Checkout rather than being silently set_subscription_tier'd."""
+    mock_user = Mock()
+    mock_user.subscription_tier = SubscriptionTier.FREE
+
+    async def mock_price_id(tier: SubscriptionTier) -> str | None:
+        return {
+            SubscriptionTier.FREE: "price_basic",
+            SubscriptionTier.PRO: "price_pro",
+            SubscriptionTier.BUSINESS: "price_max",
+        }.get(tier)
+
+    mocker.patch(
+        "backend.api.features.v1.get_user_by_id",
+        new_callable=AsyncMock,
+        return_value=mock_user,
+    )
+    mocker.patch(
+        "backend.api.features.v1.get_subscription_price_id",
+        side_effect=mock_price_id,
+    )
+    mocker.patch(
+        "backend.api.features.v1.is_feature_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    modify_mock = mocker.patch(
+        "backend.api.features.v1.modify_stripe_subscription_for_tier",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
+    set_tier_mock = mocker.patch(
+        "backend.api.features.v1.set_subscription_tier",
+        new_callable=AsyncMock,
+    )
+    checkout_mock = mocker.patch(
+        "backend.api.features.v1.create_subscription_checkout",
+        new_callable=AsyncMock,
+        return_value="https://checkout.stripe.com/pay/cs_test_priced_free",
+    )
+
+    response = client.post(
+        "/credits/subscription",
+        json={
+            "tier": "PRO",
+            "success_url": f"{TEST_FRONTEND_ORIGIN}/success",
+            "cancel_url": f"{TEST_FRONTEND_ORIGIN}/cancel",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["url"] == "https://checkout.stripe.com/pay/cs_test_priced_free"
+    )
+    # Priced-FREE user without an active sub: must NOT silently flip DB tier —
+    # they need to set up payment via Checkout.
+    set_tier_mock.assert_not_awaited()
+    checkout_mock.assert_awaited_once()
+    # modify is still called first; returning False just means "no active sub".
+    modify_mock.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.PRO)
 
 
 def test_update_subscription_tier_paid_to_paid_stripe_error_returns_502(

--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -61,7 +61,7 @@ def _stub_pending_subscription_change(mocker: pytest_mock.MockFixture) -> None:
 
 
 _DEFAULT_TIER_PRICES: dict[SubscriptionTier, str | None] = {
-    SubscriptionTier.FREE: None,  # Legacy: stripe-price-id-basic unset by default.
+    SubscriptionTier.BASIC: None,  # Legacy: stripe-price-id-basic unset by default.
     SubscriptionTier.PRO: "price_pro",
     SubscriptionTier.MAX: "price_max",
     SubscriptionTier.BUSINESS: None,  # Reserved: Business card hidden by default.
@@ -73,7 +73,7 @@ def _stub_subscription_status_lookups(mocker: pytest_mock.MockFixture) -> None:
     """Stub Stripe price + proration lookups used by get_subscription_status.
 
     The POST /credits/subscription handler now returns the full subscription
-    status payload from every branch (same-tier, FREE downgrade, paid→paid
+    status payload from every branch (same-tier, BASIC downgrade, paid→paid
     modify, checkout creation), so every POST test implicitly hits these
     helpers.  Individual tests can override via their own mocker.patch call.
     """
@@ -138,7 +138,7 @@ def test_get_subscription_status_pro(
     mock_user.subscription_tier = SubscriptionTier.PRO
 
     prices = {
-        SubscriptionTier.FREE: "price_basic",
+        SubscriptionTier.BASIC: "price_basic",
         SubscriptionTier.PRO: "price_pro",
         SubscriptionTier.MAX: "price_max",
         SubscriptionTier.BUSINESS: "price_business",
@@ -184,12 +184,12 @@ def test_get_subscription_status_pro(
     assert data["tier_costs"]["PRO"] == 1999
     assert data["tier_costs"]["MAX"] == 4999
     assert data["tier_costs"]["BUSINESS"] == 14999
-    assert data["tier_costs"]["FREE"] == 0
+    assert data["tier_costs"]["BASIC"] == 0
     assert "ENTERPRISE" not in data["tier_costs"]
     assert data["proration_credit_cents"] == 500
 
 
-def test_get_subscription_status_defaults_to_free(
+def test_get_subscription_status_defaults_to_basic(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
@@ -221,9 +221,9 @@ def test_get_subscription_status_defaults_to_free(
 
     assert response.status_code == 200
     data = response.json()
-    assert data["tier"] == SubscriptionTier.FREE.value
+    assert data["tier"] == SubscriptionTier.BASIC.value
     assert data["monthly_cost"] == 0
-    assert data["tier_costs"] == {"FREE": 0}
+    assert data["tier_costs"] == {"BASIC": 0}
     assert data["proration_credit_cents"] == 0
 
 
@@ -274,11 +274,11 @@ def test_get_subscription_status_stripe_error_falls_back_to_zero(
     assert data["tier_costs"]["PRO"] == 0
 
 
-def test_update_subscription_tier_free_no_payment(
+def test_update_subscription_tier_basic_no_payment(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """POST /credits/subscription to FREE tier when payment disabled skips Stripe."""
+    """POST /credits/subscription to BASIC tier when payment disabled skips Stripe."""
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
@@ -299,7 +299,7 @@ def test_update_subscription_tier_free_no_payment(
         new_callable=AsyncMock,
     )
 
-    response = client.post("/credits/subscription", json={"tier": "FREE"})
+    response = client.post("/credits/subscription", json={"tier": "BASIC"})
 
     assert response.status_code == 200
     assert response.json()["url"] == ""
@@ -311,7 +311,7 @@ def test_update_subscription_tier_paid_beta_user(
 ) -> None:
     """POST /credits/subscription for paid tier when payment disabled returns 422."""
     mock_user = Mock()
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     async def mock_feature_disabled(*args, **kwargs):
         return False
@@ -338,7 +338,7 @@ def test_update_subscription_tier_paid_requires_urls(
 ) -> None:
     """POST /credits/subscription for paid tier without success/cancel URLs returns 422."""
     mock_user = Mock()
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     async def mock_feature_enabled(*args, **kwargs):
         return True
@@ -364,7 +364,7 @@ def test_update_subscription_tier_creates_checkout(
 ) -> None:
     """POST /credits/subscription creates Stripe Checkout Session for paid upgrade."""
     mock_user = Mock()
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     async def mock_feature_enabled(*args, **kwargs):
         return True
@@ -403,7 +403,7 @@ def test_update_subscription_tier_rejects_open_redirect(
 ) -> None:
     """POST /credits/subscription rejects success/cancel URLs outside the frontend origin."""
     mock_user = Mock()
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     async def mock_feature_enabled(*args, **kwargs):
         return True
@@ -597,14 +597,14 @@ def test_update_subscription_tier_same_tier_stripe_error_returns_502(
     assert "contact support" in response.json()["detail"].lower()
 
 
-def test_update_subscription_tier_free_with_payment_schedules_cancel_and_does_not_update_db(
+def test_update_subscription_tier_basic_with_payment_schedules_cancel_and_does_not_update_db(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """Downgrading to FREE schedules Stripe cancellation at period end.
+    """Downgrading to BASIC schedules Stripe cancellation at period end.
 
     The DB tier must NOT be updated immediately — the customer.subscription.deleted
-    webhook fires at period end and downgrades to FREE then.
+    webhook fires at period end and downgrades to BASIC then.
     """
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
@@ -630,18 +630,18 @@ def test_update_subscription_tier_free_with_payment_schedules_cancel_and_does_no
         side_effect=mock_feature_enabled,
     )
 
-    response = client.post("/credits/subscription", json={"tier": "FREE"})
+    response = client.post("/credits/subscription", json={"tier": "BASIC"})
 
     assert response.status_code == 200
     mock_cancel.assert_awaited_once()
     mock_set_tier.assert_not_awaited()
 
 
-def test_update_subscription_tier_free_cancel_failure_returns_502(
+def test_update_subscription_tier_basic_cancel_failure_returns_502(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """Downgrading to FREE returns 502 with a generic error (no Stripe detail leakage)."""
+    """Downgrading to BASIC returns 502 with a generic error (no Stripe detail leakage)."""
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
@@ -664,7 +664,7 @@ def test_update_subscription_tier_free_cancel_failure_returns_502(
         side_effect=mock_feature_enabled,
     )
 
-    response = client.post("/credits/subscription", json={"tier": "FREE"})
+    response = client.post("/credits/subscription", json={"tier": "BASIC"})
 
     assert response.status_code == 502
     detail = response.json()["detail"]
@@ -934,18 +934,18 @@ def test_update_subscription_tier_admin_granted_paid_to_paid_updates_db_directly
     checkout_mock.assert_not_awaited()
 
 
-def test_update_subscription_tier_priced_free_no_sub_falls_through_to_checkout(
+def test_update_subscription_tier_priced_basic_no_sub_falls_through_to_checkout(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """Once stripe-price-id-basic is configured, a FREE user without an active sub
+    """Once stripe-price-id-basic is configured, a BASIC user without an active sub
     must hit Stripe Checkout rather than being silently set_subscription_tier'd."""
     mock_user = Mock()
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     async def mock_price_id(tier: SubscriptionTier) -> str | None:
         return {
-            SubscriptionTier.FREE: "price_basic",
+            SubscriptionTier.BASIC: "price_basic",
             SubscriptionTier.PRO: "price_pro",
             SubscriptionTier.MAX: "price_max",
             SubscriptionTier.BUSINESS: "price_business",
@@ -977,7 +977,7 @@ def test_update_subscription_tier_priced_free_no_sub_falls_through_to_checkout(
     checkout_mock = mocker.patch(
         "backend.api.features.v1.create_subscription_checkout",
         new_callable=AsyncMock,
-        return_value="https://checkout.stripe.com/pay/cs_test_priced_free",
+        return_value="https://checkout.stripe.com/pay/cs_test_priced_basic",
     )
 
     response = client.post(
@@ -991,9 +991,9 @@ def test_update_subscription_tier_priced_free_no_sub_falls_through_to_checkout(
 
     assert response.status_code == 200
     assert (
-        response.json()["url"] == "https://checkout.stripe.com/pay/cs_test_priced_free"
+        response.json()["url"] == "https://checkout.stripe.com/pay/cs_test_priced_basic"
     )
-    # Priced-FREE user without an active sub: must NOT silently flip DB tier —
+    # Priced-BASIC user without an active sub: must NOT silently flip DB tier —
     # they need to set up payment via Checkout.
     set_tier_mock.assert_not_awaited()
     checkout_mock.assert_awaited_once()
@@ -1013,10 +1013,10 @@ def test_update_subscription_tier_target_without_ld_price_returns_422(
     Stripe at all.
     """
     mock_user = Mock()
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     async def mock_price_id(tier: SubscriptionTier) -> str | None:
-        return None  # Neither FREE nor PRO have an LD price.
+        return None  # Neither BASIC nor PRO have an LD price.
 
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
@@ -1102,11 +1102,11 @@ def test_update_subscription_tier_paid_to_paid_stripe_error_returns_502(
     assert response.status_code == 502
 
 
-def test_update_subscription_tier_free_no_stripe_subscription(
+def test_update_subscription_tier_basic_no_stripe_subscription(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    """Downgrading to FREE when no Stripe subscription exists updates DB tier directly.
+    """Downgrading to BASIC when no Stripe subscription exists updates DB tier directly.
 
     Admin-granted paid tiers have no associated Stripe subscription.  When such a
     user requests a self-service downgrade, cancel_stripe_subscription returns False
@@ -1137,13 +1137,13 @@ def test_update_subscription_tier_free_no_stripe_subscription(
         new_callable=AsyncMock,
     )
 
-    response = client.post("/credits/subscription", json={"tier": "FREE"})
+    response = client.post("/credits/subscription", json={"tier": "BASIC"})
 
     assert response.status_code == 200
     assert response.json()["url"] == ""
     cancel_mock.assert_awaited_once_with(TEST_USER_ID)
     # DB tier must be updated immediately — no webhook will fire for a missing sub
-    set_tier_mock.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.FREE)
+    set_tier_mock.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.BASIC)
 
 
 def test_get_subscription_status_includes_pending_tier(

--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -63,7 +63,8 @@ def _stub_pending_subscription_change(mocker: pytest_mock.MockFixture) -> None:
 _DEFAULT_TIER_PRICES: dict[SubscriptionTier, str | None] = {
     SubscriptionTier.FREE: None,  # Legacy: stripe-price-id-basic unset by default.
     SubscriptionTier.PRO: "price_pro",
-    SubscriptionTier.BUSINESS: "price_max",
+    SubscriptionTier.MAX: "price_max",
+    SubscriptionTier.BUSINESS: None,  # Reserved: Business card hidden by default.
 }
 
 
@@ -139,9 +140,15 @@ def test_get_subscription_status_pro(
     prices = {
         SubscriptionTier.FREE: "price_basic",
         SubscriptionTier.PRO: "price_pro",
-        SubscriptionTier.BUSINESS: "price_max",
+        SubscriptionTier.MAX: "price_max",
+        SubscriptionTier.BUSINESS: "price_business",
     }
-    amounts = {"price_basic": 0, "price_pro": 1999, "price_max": 4999}
+    amounts = {
+        "price_basic": 0,
+        "price_pro": 1999,
+        "price_max": 4999,
+        "price_business": 14999,
+    }
 
     async def mock_price_id(tier: SubscriptionTier) -> str | None:
         return prices.get(tier)
@@ -175,7 +182,8 @@ def test_get_subscription_status_pro(
     assert data["tier"] == "PRO"
     assert data["monthly_cost"] == 1999
     assert data["tier_costs"]["PRO"] == 1999
-    assert data["tier_costs"]["BUSINESS"] == 4999
+    assert data["tier_costs"]["MAX"] == 4999
+    assert data["tier_costs"]["BUSINESS"] == 14999
     assert data["tier_costs"]["FREE"] == 0
     assert "ENTERPRISE" not in data["tier_costs"]
     assert data["proration_credit_cents"] == 500
@@ -773,6 +781,16 @@ def test_update_subscription_tier_paid_to_paid_modifies_subscription(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
+    async def price_id_with_business(tier: SubscriptionTier) -> str | None:
+        return {
+            **_DEFAULT_TIER_PRICES,
+            SubscriptionTier.BUSINESS: "price_business",
+        }.get(tier)
+
+    mocker.patch(
+        "backend.api.features.v1.get_subscription_price_id",
+        side_effect=price_id_with_business,
+    )
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
@@ -808,6 +826,49 @@ def test_update_subscription_tier_paid_to_paid_modifies_subscription(
     checkout_mock.assert_not_awaited()
 
 
+def test_update_subscription_tier_max_checkout(
+    client: fastapi.testclient.TestClient,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """POST /credits/subscription from PRO→MAX modifies the existing subscription."""
+    mock_user = Mock()
+    mock_user.subscription_tier = SubscriptionTier.PRO
+
+    mocker.patch(
+        "backend.api.features.v1.get_user_by_id",
+        new_callable=AsyncMock,
+        return_value=mock_user,
+    )
+    mocker.patch(
+        "backend.api.features.v1.is_feature_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    modify_mock = mocker.patch(
+        "backend.api.features.v1.modify_stripe_subscription_for_tier",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    checkout_mock = mocker.patch(
+        "backend.api.features.v1.create_subscription_checkout",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post(
+        "/credits/subscription",
+        json={
+            "tier": "MAX",
+            "success_url": f"{TEST_FRONTEND_ORIGIN}/success",
+            "cancel_url": f"{TEST_FRONTEND_ORIGIN}/cancel",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["url"] == ""
+    modify_mock.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.MAX)
+    checkout_mock.assert_not_awaited()
+
+
 def test_update_subscription_tier_admin_granted_paid_to_paid_updates_db_directly(
     client: fastapi.testclient.TestClient,
     mocker: pytest_mock.MockFixture,
@@ -821,6 +882,16 @@ def test_update_subscription_tier_admin_granted_paid_to_paid_updates_db_directly
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
+    async def price_id_with_business(tier: SubscriptionTier) -> str | None:
+        return {
+            **_DEFAULT_TIER_PRICES,
+            SubscriptionTier.BUSINESS: "price_business",
+        }.get(tier)
+
+    mocker.patch(
+        "backend.api.features.v1.get_subscription_price_id",
+        side_effect=price_id_with_business,
+    )
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
@@ -876,7 +947,8 @@ def test_update_subscription_tier_priced_free_no_sub_falls_through_to_checkout(
         return {
             SubscriptionTier.FREE: "price_basic",
             SubscriptionTier.PRO: "price_pro",
-            SubscriptionTier.BUSINESS: "price_max",
+            SubscriptionTier.MAX: "price_max",
+            SubscriptionTier.BUSINESS: "price_business",
         }.get(tier)
 
     mocker.patch(
@@ -992,6 +1064,16 @@ def test_update_subscription_tier_paid_to_paid_stripe_error_returns_502(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
+    async def price_id_with_business(tier: SubscriptionTier) -> str | None:
+        return {
+            **_DEFAULT_TIER_PRICES,
+            SubscriptionTier.BUSINESS: "price_business",
+        }.get(tier)
+
+    mocker.patch(
+        "backend.api.features.v1.get_subscription_price_id",
+        side_effect=price_id_with_business,
+    )
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
@@ -1152,6 +1234,16 @@ def test_update_subscription_tier_downgrade_paid_to_paid_schedules(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BUSINESS
 
+    async def price_id_with_business(tier: SubscriptionTier) -> str | None:
+        return {
+            **_DEFAULT_TIER_PRICES,
+            SubscriptionTier.BUSINESS: "price_business",
+        }.get(tier)
+
+    mocker.patch(
+        "backend.api.features.v1.get_subscription_price_id",
+        side_effect=price_id_with_business,
+    )
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -699,23 +699,23 @@ async def get_user_auto_top_up(
 
 
 class SubscriptionTierRequest(BaseModel):
-    tier: Literal["FREE", "PRO", "MAX", "BUSINESS"]
+    tier: Literal["BASIC", "PRO", "MAX", "BUSINESS"]
     success_url: str = ""
     cancel_url: str = ""
 
 
 class SubscriptionStatusResponse(BaseModel):
-    tier: Literal["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"]
+    tier: Literal["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"]
     monthly_cost: int  # amount in cents (Stripe convention)
     tier_costs: dict[str, int]  # tier name -> amount in cents
     proration_credit_cents: int  # unused portion of current sub to convert on upgrade
-    pending_tier: Optional[Literal["FREE", "PRO", "MAX", "BUSINESS"]] = None
+    pending_tier: Optional[Literal["BASIC", "PRO", "MAX", "BUSINESS"]] = None
     pending_tier_effective_at: Optional[datetime] = None
     url: str = Field(
         default="",
         description=(
             "Populated only when POST /credits/subscription starts a Stripe Checkout"
-            " Session (FREE → paid upgrade). Empty string in all other branches —"
+            " Session (BASIC → paid upgrade). Empty string in all other branches —"
             " the client redirects to this URL when non-empty."
         ),
     )
@@ -794,10 +794,10 @@ async def get_subscription_status(
     user_id: Annotated[str, Security(get_user_id)],
 ) -> SubscriptionStatusResponse:
     user = await get_user_by_id(user_id)
-    tier = user.subscription_tier or SubscriptionTier.FREE
+    tier = user.subscription_tier or SubscriptionTier.BASIC
 
     priceable_tiers = [
-        SubscriptionTier.FREE,
+        SubscriptionTier.BASIC,
         SubscriptionTier.PRO,
         SubscriptionTier.MAX,
         SubscriptionTier.BUSINESS,
@@ -845,7 +845,7 @@ async def get_subscription_status(
     if pending is not None:
         pending_tier_enum, pending_effective_at = pending
         if pending_tier_enum in (
-            SubscriptionTier.FREE,
+            SubscriptionTier.BASIC,
             SubscriptionTier.PRO,
             SubscriptionTier.MAX,
             SubscriptionTier.BUSINESS,
@@ -866,23 +866,25 @@ async def update_subscription_tier(
     request: SubscriptionTierRequest,
     user_id: Annotated[str, Security(get_user_id)],
 ) -> SubscriptionStatusResponse:
-    # Pydantic validates tier is one of FREE/PRO/MAX/BUSINESS via Literal type.
+    # Pydantic validates tier is one of BASIC/PRO/MAX/BUSINESS via Literal type.
     tier = SubscriptionTier(request.tier)
 
     # ENTERPRISE tier is admin-managed — block self-service changes from ENTERPRISE users.
     user = await get_user_by_id(user_id)
-    if (user.subscription_tier or SubscriptionTier.FREE) == SubscriptionTier.ENTERPRISE:
+    if (
+        user.subscription_tier or SubscriptionTier.BASIC
+    ) == SubscriptionTier.ENTERPRISE:
         raise HTTPException(
             status_code=403,
             detail="ENTERPRISE subscription changes must be managed by an administrator",
         )
 
     # Same-tier request = "stay on my current tier" = cancel any pending
-    # scheduled change (paid→paid downgrade or paid→FREE cancel). This is the
+    # scheduled change (paid→paid downgrade or paid→BASIC cancel). This is the
     # collapsed behaviour that replaces the old /credits/subscription/cancel-pending
     # route. Safe when no pending change exists: release_pending_subscription_schedule
     # returns False and we simply return the current status.
-    if (user.subscription_tier or SubscriptionTier.FREE) == tier:
+    if (user.subscription_tier or SubscriptionTier.BASIC) == tier:
         try:
             await release_pending_subscription_schedule(user_id)
         except stripe.StripeError as e:
@@ -904,18 +906,18 @@ async def update_subscription_tier(
         Flag.ENABLE_PLATFORM_PAYMENT, user_id, default=False
     )
 
-    current_tier = user.subscription_tier or SubscriptionTier.FREE
+    current_tier = user.subscription_tier or SubscriptionTier.BASIC
     target_price_id, current_tier_price_id = await asyncio.gather(
         get_subscription_price_id(tier),
         get_subscription_price_id(current_tier),
     )
 
-    # Legacy cancel: target FREE + stripe-price-id-basic unset. Schedule Stripe
+    # Legacy cancel: target BASIC + stripe-price-id-basic unset. Schedule Stripe
     # cancellation at period end; cancel_at_period_end=True lets the webhook flip
     # the DB tier. No active sub (admin-granted) or payment disabled → DB flip.
-    # Once stripe-price-id-basic is configured, FREE becomes a real sub and falls
+    # Once stripe-price-id-basic is configured, BASIC becomes a real sub and falls
     # through to the modify/checkout flow below.
-    if tier == SubscriptionTier.FREE and target_price_id is None:
+    if tier == SubscriptionTier.BASIC and target_price_id is None:
         if payment_enabled:
             try:
                 had_subscription = await cancel_stripe_subscription(user_id)
@@ -954,14 +956,14 @@ async def update_subscription_tier(
     # User has an active Stripe subscription (current tier has an LD price):
     # modify it in-place. modify_stripe_subscription_for_tier returns False when no
     # active sub exists — that's only a "DB-only flip is OK" signal for admin-granted
-    # paid tiers (PRO/BUSINESS with no Stripe record). Priced-FREE users without a
+    # paid tiers (PRO/BUSINESS with no Stripe record). Priced-BASIC users without a
     # sub must still go through Checkout so they set up payment.
     if current_tier_price_id is not None:
         try:
             modified = await modify_stripe_subscription_for_tier(user_id, tier)
             if modified:
                 return await get_subscription_status(user_id)
-            if current_tier != SubscriptionTier.FREE:
+            if current_tier != SubscriptionTier.BASIC:
                 await set_subscription_tier(user_id, tier)
                 return await get_subscription_status(user_id)
         except ValueError as e:

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -815,9 +815,6 @@ async def get_subscription_status(
     for t, pid, cost in zip(priceable_tiers, price_ids, costs):
         if pid:
             tier_costs[t.value] = cost
-    # Always include the current tier so users can see what they're on.
-    if tier.value not in tier_costs and tier != SubscriptionTier.ENTERPRISE:
-        tier_costs[tier.value] = 0
 
     current_monthly_cost = tier_costs.get(tier.value, 0)
     proration_credit = await get_proration_credit_cents(user_id, current_monthly_cost)

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -796,22 +796,27 @@ async def get_subscription_status(
     user = await get_user_by_id(user_id)
     tier = user.subscription_tier or SubscriptionTier.FREE
 
-    paid_tiers = [SubscriptionTier.PRO, SubscriptionTier.BUSINESS]
+    priceable_tiers = [
+        SubscriptionTier.FREE,
+        SubscriptionTier.PRO,
+        SubscriptionTier.BUSINESS,
+    ]
     price_ids = await asyncio.gather(
-        *[get_subscription_price_id(t) for t in paid_tiers]
+        *[get_subscription_price_id(t) for t in priceable_tiers]
     )
-
-    tier_costs: dict[str, int] = {
-        SubscriptionTier.FREE.value: 0,
-        SubscriptionTier.ENTERPRISE.value: 0,
-    }
 
     async def _cost(pid: str | None) -> int:
         return (await _get_stripe_price_amount(pid) or 0) if pid else 0
 
     costs = await asyncio.gather(*[_cost(pid) for pid in price_ids])
-    for t, cost in zip(paid_tiers, costs):
-        tier_costs[t.value] = cost
+
+    tier_costs: dict[str, int] = {}
+    for t, pid, cost in zip(priceable_tiers, price_ids, costs):
+        if pid:
+            tier_costs[t.value] = cost
+    # Always include the current tier so users can see what they're on.
+    if tier.value not in tier_costs and tier != SubscriptionTier.ENTERPRISE:
+        tier_costs[tier.value] = 0
 
     current_monthly_cost = tier_costs.get(tier.value, 0)
     proration_credit = await get_proration_credit_cents(user_id, current_monthly_cost)
@@ -838,13 +843,12 @@ async def get_subscription_status(
     )
     if pending is not None:
         pending_tier_enum, pending_effective_at = pending
-        if pending_tier_enum == SubscriptionTier.FREE:
-            response.pending_tier = "FREE"
-        elif pending_tier_enum == SubscriptionTier.PRO:
-            response.pending_tier = "PRO"
-        elif pending_tier_enum == SubscriptionTier.BUSINESS:
-            response.pending_tier = "BUSINESS"
-        if response.pending_tier is not None:
+        if pending_tier_enum in (
+            SubscriptionTier.FREE,
+            SubscriptionTier.PRO,
+            SubscriptionTier.BUSINESS,
+        ):
+            response.pending_tier = pending_tier_enum.value
             response.pending_tier_effective_at = pending_effective_at
     return response
 
@@ -898,22 +902,22 @@ async def update_subscription_tier(
         Flag.ENABLE_PLATFORM_PAYMENT, user_id, default=False
     )
 
-    # Downgrade to FREE: schedule Stripe cancellation at period end so the user
-    # keeps their tier for the time they already paid for. The DB tier is NOT
-    # updated here when a subscription exists — the customer.subscription.deleted
-    # webhook fires at period end and downgrades to FREE then.
-    # Exception: if the user has no active Stripe subscription (e.g. admin-granted
-    # tier), cancel_stripe_subscription returns False and we update the DB tier
-    # immediately since no webhook will ever fire.
-    # When payment is disabled entirely, update the DB tier directly.
-    if tier == SubscriptionTier.FREE:
+    current_tier = user.subscription_tier or SubscriptionTier.FREE
+    target_price_id, current_tier_price_id = await asyncio.gather(
+        get_subscription_price_id(tier),
+        get_subscription_price_id(current_tier),
+    )
+
+    # Legacy cancel: target FREE + stripe-price-id-basic unset. Schedule Stripe
+    # cancellation at period end; cancel_at_period_end=True lets the webhook flip
+    # the DB tier. No active sub (admin-granted) or payment disabled → DB flip.
+    # Once stripe-price-id-basic is configured, FREE becomes a real sub and falls
+    # through to the modify/checkout flow below.
+    if tier == SubscriptionTier.FREE and target_price_id is None:
         if payment_enabled:
             try:
                 had_subscription = await cancel_stripe_subscription(user_id)
             except stripe.StripeError as e:
-                # Log full Stripe error server-side but return a generic message
-                # to the client — raw Stripe errors can leak customer/sub IDs and
-                # infrastructure config details.
                 logger.exception(
                     "Stripe error cancelling subscription for user %s: %s",
                     user_id,
@@ -927,39 +931,37 @@ async def update_subscription_tier(
                     ),
                 )
             if not had_subscription:
-                # No active Stripe subscription found — the user was on an
-                # admin-granted tier. Update DB immediately since the
-                # subscription.deleted webhook will never fire.
                 await set_subscription_tier(user_id, tier)
             return await get_subscription_status(user_id)
         await set_subscription_tier(user_id, tier)
         return await get_subscription_status(user_id)
 
-    # Paid tier changes require payment to be enabled — block self-service upgrades
-    # when the flag is off.  Admins use the /api/admin/ routes to set tiers directly.
     if not payment_enabled:
         raise HTTPException(
             status_code=422,
-            detail=f"Subscription not available for tier {tier}",
+            detail=f"Subscription not available for tier {tier.value}",
         )
 
-    # Paid→paid tier change: if the user already has a Stripe subscription,
-    # modify it in-place with proration instead of creating a new Checkout
-    # Session. This preserves remaining paid time and avoids double-charging.
-    # The customer.subscription.updated webhook fires and updates the DB tier.
-    current_tier = user.subscription_tier or SubscriptionTier.FREE
-    if current_tier in (SubscriptionTier.PRO, SubscriptionTier.BUSINESS):
+    # Target has no LD price — not provisionable (matches the GET hiding).
+    if target_price_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Subscription not available for tier {tier.value}",
+        )
+
+    # User has an active Stripe subscription (current tier has an LD price):
+    # modify it in-place. modify_stripe_subscription_for_tier returns False when no
+    # active sub exists — that's only a "DB-only flip is OK" signal for admin-granted
+    # paid tiers (PRO/BUSINESS with no Stripe record). Priced-FREE users without a
+    # sub must still go through Checkout so they set up payment.
+    if current_tier_price_id is not None:
         try:
             modified = await modify_stripe_subscription_for_tier(user_id, tier)
             if modified:
                 return await get_subscription_status(user_id)
-            # modify_stripe_subscription_for_tier returns False when no active
-            # Stripe subscription exists — i.e. the user has an admin-granted
-            # paid tier with no Stripe record.  In that case, update the DB
-            # tier directly (same as the FREE-downgrade path for admin-granted
-            # users) rather than sending them through a new Checkout Session.
-            await set_subscription_tier(user_id, tier)
-            return await get_subscription_status(user_id)
+            if current_tier != SubscriptionTier.FREE:
+                await set_subscription_tier(user_id, tier)
+                return await get_subscription_status(user_id)
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
         except stripe.StripeError as e:
@@ -974,7 +976,7 @@ async def update_subscription_tier(
                 ),
             )
 
-    # Paid upgrade from FREE → create Stripe Checkout Session.
+    # No active Stripe subscription → create Stripe Checkout Session.
     if not request.success_url or not request.cancel_url:
         raise HTTPException(
             status_code=422,

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -699,17 +699,17 @@ async def get_user_auto_top_up(
 
 
 class SubscriptionTierRequest(BaseModel):
-    tier: Literal["FREE", "PRO", "BUSINESS"]
+    tier: Literal["FREE", "PRO", "MAX", "BUSINESS"]
     success_url: str = ""
     cancel_url: str = ""
 
 
 class SubscriptionStatusResponse(BaseModel):
-    tier: Literal["FREE", "PRO", "BUSINESS", "ENTERPRISE"]
+    tier: Literal["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"]
     monthly_cost: int  # amount in cents (Stripe convention)
     tier_costs: dict[str, int]  # tier name -> amount in cents
     proration_credit_cents: int  # unused portion of current sub to convert on upgrade
-    pending_tier: Optional[Literal["FREE", "PRO", "BUSINESS"]] = None
+    pending_tier: Optional[Literal["FREE", "PRO", "MAX", "BUSINESS"]] = None
     pending_tier_effective_at: Optional[datetime] = None
     url: str = Field(
         default="",
@@ -799,6 +799,7 @@ async def get_subscription_status(
     priceable_tiers = [
         SubscriptionTier.FREE,
         SubscriptionTier.PRO,
+        SubscriptionTier.MAX,
         SubscriptionTier.BUSINESS,
     ]
     price_ids = await asyncio.gather(
@@ -846,6 +847,7 @@ async def get_subscription_status(
         if pending_tier_enum in (
             SubscriptionTier.FREE,
             SubscriptionTier.PRO,
+            SubscriptionTier.MAX,
             SubscriptionTier.BUSINESS,
         ):
             response.pending_tier = pending_tier_enum.value
@@ -864,7 +866,7 @@ async def update_subscription_tier(
     request: SubscriptionTierRequest,
     user_id: Annotated[str, Security(get_user_id)],
 ) -> SubscriptionStatusResponse:
-    # Pydantic validates tier is one of FREE/PRO/BUSINESS via Literal type.
+    # Pydantic validates tier is one of FREE/PRO/MAX/BUSINESS via Literal type.
     tier = SubscriptionTier(request.tier)
 
     # ENTERPRISE tier is admin-managed — block self-service changes from ENTERPRISE users.

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -83,10 +83,11 @@ class SubscriptionTier(str, Enum):
 # Intentionally int (not float): keeps limits as whole microdollars and avoids
 # floating-point rounding. If fractional multipliers are ever needed, change
 # the type and round the result in get_global_rate_limits().
+# BUSINESS matches ENTERPRISE's 60x: same capacity, self-service vs admin-managed.
 TIER_MULTIPLIERS: dict[SubscriptionTier, int] = {
     SubscriptionTier.FREE: 1,
     SubscriptionTier.PRO: 5,
-    SubscriptionTier.BUSINESS: 20,
+    SubscriptionTier.BUSINESS: 60,
     SubscriptionTier.ENTERPRISE: 60,
 }
 

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -73,7 +73,7 @@ class SubscriptionTier(str, Enum):
         from prisma.enums import SubscriptionTier
     """
 
-    FREE = "FREE"
+    BASIC = "BASIC"
     PRO = "PRO"
     MAX = "MAX"
     BUSINESS = "BUSINESS"
@@ -86,14 +86,14 @@ class SubscriptionTier(str, Enum):
 # the type and round the result in get_global_rate_limits().
 # BUSINESS matches ENTERPRISE (60x); MAX sits at 20x as the self-service $320 tier.
 TIER_MULTIPLIERS: dict[SubscriptionTier, int] = {
-    SubscriptionTier.FREE: 1,
+    SubscriptionTier.BASIC: 1,
     SubscriptionTier.PRO: 5,
     SubscriptionTier.MAX: 20,
     SubscriptionTier.BUSINESS: 60,
     SubscriptionTier.ENTERPRISE: 60,
 }
 
-DEFAULT_TIER = SubscriptionTier.FREE
+DEFAULT_TIER = SubscriptionTier.BASIC
 
 
 class UsageWindow(BaseModel):

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -75,6 +75,7 @@ class SubscriptionTier(str, Enum):
 
     FREE = "FREE"
     PRO = "PRO"
+    MAX = "MAX"
     BUSINESS = "BUSINESS"
     ENTERPRISE = "ENTERPRISE"
 
@@ -83,10 +84,11 @@ class SubscriptionTier(str, Enum):
 # Intentionally int (not float): keeps limits as whole microdollars and avoids
 # floating-point rounding. If fractional multipliers are ever needed, change
 # the type and round the result in get_global_rate_limits().
-# BUSINESS matches ENTERPRISE's 60x: same capacity, self-service vs admin-managed.
+# BUSINESS matches ENTERPRISE (60x); MAX sits at 20x as the self-service $320 tier.
 TIER_MULTIPLIERS: dict[SubscriptionTier, int] = {
     SubscriptionTier.FREE: 1,
     SubscriptionTier.PRO: 5,
+    SubscriptionTier.MAX: 20,
     SubscriptionTier.BUSINESS: 60,
     SubscriptionTier.ENTERPRISE: 60,
 }

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -346,21 +346,21 @@ class TestRecordCostUsage:
 
 class TestSubscriptionTier:
     def test_tier_values(self):
-        assert SubscriptionTier.FREE.value == "FREE"
+        assert SubscriptionTier.BASIC.value == "BASIC"
         assert SubscriptionTier.PRO.value == "PRO"
         assert SubscriptionTier.MAX.value == "MAX"
         assert SubscriptionTier.BUSINESS.value == "BUSINESS"
         assert SubscriptionTier.ENTERPRISE.value == "ENTERPRISE"
 
     def test_tier_multipliers(self):
-        assert TIER_MULTIPLIERS[SubscriptionTier.FREE] == 1
+        assert TIER_MULTIPLIERS[SubscriptionTier.BASIC] == 1
         assert TIER_MULTIPLIERS[SubscriptionTier.PRO] == 5
         assert TIER_MULTIPLIERS[SubscriptionTier.MAX] == 20
         assert TIER_MULTIPLIERS[SubscriptionTier.BUSINESS] == 60
         assert TIER_MULTIPLIERS[SubscriptionTier.ENTERPRISE] == 60
 
-    def test_default_tier_is_free(self):
-        assert DEFAULT_TIER == SubscriptionTier.FREE
+    def test_default_tier_is_basic(self):
+        assert DEFAULT_TIER == SubscriptionTier.BASIC
 
     def test_usage_status_includes_tier(self):
         now = datetime.now(UTC)
@@ -368,7 +368,7 @@ class TestSubscriptionTier:
             daily=UsageWindow(used=0, limit=100, resets_at=now + timedelta(hours=1)),
             weekly=UsageWindow(used=0, limit=500, resets_at=now + timedelta(days=1)),
         )
-        assert status.tier == SubscriptionTier.FREE
+        assert status.tier == SubscriptionTier.BASIC
 
     def test_usage_status_with_custom_tier(self):
         now = datetime.now(UTC)
@@ -471,7 +471,7 @@ class TestGetUserTier:
         Regression test: when ``get_user_tier`` is called before a user record
         exists, the DEFAULT_TIER fallback must not be cached.  Otherwise, a
         newly created user with a higher tier (e.g. PRO) would receive the
-        stale cached FREE tier for up to 5 minutes.
+        stale cached BASIC tier for up to 5 minutes.
         """
         # First call: user does not exist yet
         missing_db = self._mock_user_db(raises=Exception("not found"))
@@ -672,7 +672,7 @@ class TestGetGlobalRateLimitsWithTiers:
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
                 new_callable=AsyncMock,
-                return_value=SubscriptionTier.FREE,
+                return_value=SubscriptionTier.BASIC,
             ),
             patch(
                 "backend.util.feature_flag.get_feature_flag_value",
@@ -685,7 +685,7 @@ class TestGetGlobalRateLimitsWithTiers:
 
         assert daily == 2_500_000
         assert weekly == 12_500_000
-        assert tier == SubscriptionTier.FREE
+        assert tier == SubscriptionTier.BASIC
 
     @pytest.mark.asyncio
     async def test_pro_tier_5x_multiplier(self):
@@ -802,9 +802,9 @@ class TestTierLimitsRespected:
         return _side_effect
 
     @pytest.mark.asyncio
-    async def test_pro_user_allowed_above_free_limit(self):
-        """A PRO user with usage above the FREE limit should be allowed."""
-        # Usage: 3M tokens (above FREE limit of 2.5M, below PRO limit of 12.5M)
+    async def test_pro_user_allowed_above_basic_limit(self):
+        """A PRO user with usage above the BASIC limit should be allowed."""
+        # Usage: 3M tokens (above BASIC limit of 2.5M, below PRO limit of 12.5M)
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(side_effect=["3000000", "3000000"])
 
@@ -835,9 +835,9 @@ class TestTierLimitsRespected:
             )
 
     @pytest.mark.asyncio
-    async def test_free_user_blocked_at_free_limit(self):
-        """A FREE user at or above the base limit should be blocked."""
-        # Usage: 2.5M tokens (at FREE limit of 2.5M)
+    async def test_basic_user_blocked_at_basic_limit(self):
+        """A BASIC user at or above the base limit should be blocked."""
+        # Usage: 2.5M tokens (at BASIC limit of 2.5M)
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(side_effect=["2500000", "2500000"])
 
@@ -845,7 +845,7 @@ class TestTierLimitsRespected:
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
                 new_callable=AsyncMock,
-                return_value=SubscriptionTier.FREE,
+                return_value=SubscriptionTier.BASIC,
             ),
             patch(
                 "backend.util.feature_flag.get_feature_flag_value",
@@ -859,9 +859,9 @@ class TestTierLimitsRespected:
             daily, weekly, tier = await get_global_rate_limits(
                 _USER, self._BASE_DAILY, self._BASE_WEEKLY
             )
-            # FREE: 1x multiplier
+            # BASIC: 1x multiplier
             assert daily == 2_500_000
-            assert tier == SubscriptionTier.FREE
+            assert tier == SubscriptionTier.BASIC
             # Should raise — 2.5M >= 2.5M
             with pytest.raises(RateLimitExceeded):
                 await check_rate_limit(
@@ -1150,7 +1150,7 @@ class TestTierLimitsEnforced:
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
                 new_callable=AsyncMock,
-                return_value=SubscriptionTier.FREE,
+                return_value=SubscriptionTier.BASIC,
             ),
             patch(
                 "backend.util.feature_flag.get_feature_flag_value",
@@ -1169,18 +1169,18 @@ class TestTierLimitsEnforced:
                 await check_rate_limit(_USER, daily, weekly)
 
     @pytest.mark.asyncio
-    async def test_free_tier_cannot_bypass_pro_limit(self):
-        """A FREE-tier user whose usage is within PRO limits but over FREE
+    async def test_basic_tier_cannot_bypass_pro_limit(self):
+        """A BASIC-tier user whose usage is within PRO limits but over BASIC
         limits must still be rejected.
 
         Negative test: ensures the tier multiplier is applied *before* the
         rate-limit check, so a lower-tier user cannot 'bypass' limits that
         would be acceptable for a higher tier.
         """
-        free_daily = self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.FREE]
+        basic_daily = self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.BASIC]
         pro_daily = self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.PRO]
-        # Usage above FREE limit but below PRO limit
-        usage = free_daily + 500_000
+        # Usage above BASIC limit but below PRO limit
+        usage = basic_daily + 500_000
         assert usage < pro_daily, "test sanity: usage must be under PRO limit"
 
         mock_redis = AsyncMock()
@@ -1190,7 +1190,7 @@ class TestTierLimitsEnforced:
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
                 new_callable=AsyncMock,
-                return_value=SubscriptionTier.FREE,
+                return_value=SubscriptionTier.BASIC,
             ),
             patch(
                 "backend.util.feature_flag.get_feature_flag_value",
@@ -1204,25 +1204,25 @@ class TestTierLimitsEnforced:
             daily, weekly, tier = await get_global_rate_limits(
                 _USER, self._BASE_DAILY, self._BASE_WEEKLY
             )
-            assert tier == SubscriptionTier.FREE
-            assert daily == free_daily  # 1x, not 5x
+            assert tier == SubscriptionTier.BASIC
+            assert daily == basic_daily  # 1x, not 5x
             with pytest.raises(RateLimitExceeded) as exc_info:
                 await check_rate_limit(_USER, daily, weekly)
             assert exc_info.value.window == "daily"
 
     @pytest.mark.asyncio
     async def test_tier_change_updates_effective_limits(self):
-        """After upgrading from FREE to BUSINESS, the effective limits must
+        """After upgrading from BASIC to BUSINESS, the effective limits must
         increase accordingly.
 
         Verifies that the tier multiplier is correctly applied after a tier
-        change, and that usage that was over the FREE limit is within the new
+        change, and that usage that was over the BASIC limit is within the new
         BUSINESS limit.
         """
-        free_daily = self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.FREE]
+        basic_daily = self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.BASIC]
         biz_daily = self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.BUSINESS]
-        # Usage above FREE limit but below BUSINESS limit
-        usage = free_daily + 500_000
+        # Usage above BASIC limit but below BUSINESS limit
+        usage = basic_daily + 500_000
         assert usage < biz_daily, "test sanity: usage must be under BUSINESS limit"
 
         mock_redis = AsyncMock()

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -354,7 +354,7 @@ class TestSubscriptionTier:
     def test_tier_multipliers(self):
         assert TIER_MULTIPLIERS[SubscriptionTier.FREE] == 1
         assert TIER_MULTIPLIERS[SubscriptionTier.PRO] == 5
-        assert TIER_MULTIPLIERS[SubscriptionTier.BUSINESS] == 20
+        assert TIER_MULTIPLIERS[SubscriptionTier.BUSINESS] == 60
         assert TIER_MULTIPLIERS[SubscriptionTier.ENTERPRISE] == 60
 
     def test_default_tier_is_free(self):
@@ -708,8 +708,8 @@ class TestGetGlobalRateLimitsWithTiers:
         assert tier == SubscriptionTier.PRO
 
     @pytest.mark.asyncio
-    async def test_business_tier_20x_multiplier(self):
-        """Business tier should multiply limits by 20."""
+    async def test_business_tier_60x_multiplier(self):
+        """Business tier should multiply limits by 60 (matches Enterprise capacity)."""
         with (
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
@@ -725,8 +725,8 @@ class TestGetGlobalRateLimitsWithTiers:
                 _USER, 2_500_000, 12_500_000
             )
 
-        assert daily == 50_000_000
-        assert weekly == 250_000_000
+        assert daily == 150_000_000
+        assert weekly == 750_000_000
         assert tier == SubscriptionTier.BUSINESS
 
     @pytest.mark.asyncio
@@ -1224,7 +1224,7 @@ class TestTierLimitsEnforced:
                 _USER, self._BASE_DAILY, self._BASE_WEEKLY
             )
             assert tier == SubscriptionTier.BUSINESS
-            assert daily == biz_daily  # 20x
+            assert daily == biz_daily  # 60x
             # Should NOT raise — usage is within the BUSINESS tier allowance
             await check_rate_limit(_USER, daily, weekly)
 

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -348,12 +348,14 @@ class TestSubscriptionTier:
     def test_tier_values(self):
         assert SubscriptionTier.FREE.value == "FREE"
         assert SubscriptionTier.PRO.value == "PRO"
+        assert SubscriptionTier.MAX.value == "MAX"
         assert SubscriptionTier.BUSINESS.value == "BUSINESS"
         assert SubscriptionTier.ENTERPRISE.value == "ENTERPRISE"
 
     def test_tier_multipliers(self):
         assert TIER_MULTIPLIERS[SubscriptionTier.FREE] == 1
         assert TIER_MULTIPLIERS[SubscriptionTier.PRO] == 5
+        assert TIER_MULTIPLIERS[SubscriptionTier.MAX] == 20
         assert TIER_MULTIPLIERS[SubscriptionTier.BUSINESS] == 60
         assert TIER_MULTIPLIERS[SubscriptionTier.ENTERPRISE] == 60
 
@@ -706,6 +708,28 @@ class TestGetGlobalRateLimitsWithTiers:
         assert daily == 12_500_000
         assert weekly == 62_500_000
         assert tier == SubscriptionTier.PRO
+
+    @pytest.mark.asyncio
+    async def test_max_tier_20x_multiplier(self):
+        """Max tier should multiply limits by 20 (self-service $320 tier)."""
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_tier",
+                new_callable=AsyncMock,
+                return_value=SubscriptionTier.MAX,
+            ),
+            patch(
+                "backend.util.feature_flag.get_feature_flag_value",
+                side_effect=self._ld_side_effect(2_500_000, 12_500_000),
+            ),
+        ):
+            daily, weekly, tier = await get_global_rate_limits(
+                _USER, 2_500_000, 12_500_000
+            )
+
+        assert daily == 50_000_000
+        assert weekly == 250_000_000
+        assert tier == SubscriptionTier.MAX
 
     @pytest.mark.asyncio
     async def test_business_tier_60x_multiplier(self):

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1444,6 +1444,7 @@ async def get_proration_credit_cents(user_id: str, monthly_cost_cents: int) -> i
 _TIER_ORDER: tuple[SubscriptionTier, ...] = (
     SubscriptionTier.FREE,
     SubscriptionTier.PRO,
+    SubscriptionTier.MAX,
     SubscriptionTier.BUSINESS,
     SubscriptionTier.ENTERPRISE,
 )
@@ -1857,9 +1858,10 @@ async def get_pending_subscription_change(
         # FREE-only users): skip the Stripe API calls entirely.
         return None
 
-    free_price, pro_price, max_price = await asyncio.gather(
+    free_price, pro_price, max_price, business_price = await asyncio.gather(
         get_subscription_price_id(SubscriptionTier.FREE),
         get_subscription_price_id(SubscriptionTier.PRO),
+        get_subscription_price_id(SubscriptionTier.MAX),
         get_subscription_price_id(SubscriptionTier.BUSINESS),
     )
     price_to_tier: dict[str, SubscriptionTier] = {}
@@ -1868,11 +1870,13 @@ async def get_pending_subscription_change(
     if pro_price:
         price_to_tier[pro_price] = SubscriptionTier.PRO
     if max_price:
-        price_to_tier[max_price] = SubscriptionTier.BUSINESS
+        price_to_tier[max_price] = SubscriptionTier.MAX
+    if business_price:
+        price_to_tier[business_price] = SubscriptionTier.BUSINESS
     if not price_to_tier:
         logger.warning(
             "get_pending_subscription_change: no Stripe price IDs resolvable for"
-            " FREE/PRO/BUSINESS (LaunchDarkly fetch failed?); raising to bypass"
+            " FREE/PRO/MAX/BUSINESS (LaunchDarkly fetch failed?); raising to bypass"
             " the None cache so the next request retries fresh"
         )
         raise PendingChangeUnknown(
@@ -1952,7 +1956,8 @@ async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
     flag_map = {
         SubscriptionTier.FREE: Flag.STRIPE_PRICE_BASIC,
         SubscriptionTier.PRO: Flag.STRIPE_PRICE_PRO,
-        SubscriptionTier.BUSINESS: Flag.STRIPE_PRICE_MAX,
+        SubscriptionTier.MAX: Flag.STRIPE_PRICE_MAX,
+        SubscriptionTier.BUSINESS: Flag.STRIPE_PRICE_BUSINESS,
     }
     flag = flag_map.get(tier)
     if flag is None:
@@ -2082,9 +2087,10 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         items = stripe_subscription.get("items", {}).get("data", [])
         if items:
             price_id = items[0].get("price", {}).get("id", "")
-        free_price, pro_price, max_price = await asyncio.gather(
+        free_price, pro_price, max_price, business_price = await asyncio.gather(
             get_subscription_price_id(SubscriptionTier.FREE),
             get_subscription_price_id(SubscriptionTier.PRO),
+            get_subscription_price_id(SubscriptionTier.MAX),
             get_subscription_price_id(SubscriptionTier.BUSINESS),
         )
         if price_id and free_price and price_id == free_price:
@@ -2092,6 +2098,8 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         elif price_id and pro_price and price_id == pro_price:
             tier = SubscriptionTier.PRO
         elif price_id and max_price and price_id == max_price:
+            tier = SubscriptionTier.MAX
+        elif price_id and business_price and price_id == business_price:
             tier = SubscriptionTier.BUSINESS
         else:
             # Unknown or unconfigured price ID — preserve the user's current tier

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1302,7 +1302,7 @@ async def _cancel_customer_subscriptions(
     When ``at_period_end=True``, schedules cancellation at the end of the current
     billing period instead of cancelling immediately — the user keeps their tier
     until the period ends, then ``customer.subscription.deleted`` fires and the
-    webhook downgrades them to FREE.
+    webhook downgrades them to BASIC.
 
     Wraps every synchronous Stripe SDK call with run_in_threadpool so the async event
     loop is never blocked. Raises stripe.StripeError on list/cancel failure so callers
@@ -1364,7 +1364,7 @@ async def cancel_stripe_subscription(user_id: str) -> bool:
 
     The subscription stays active until the end of the billing period so the user
     keeps their tier for the time they already paid for. The ``customer.subscription.deleted``
-    webhook fires at period end and downgrades the DB tier to FREE.
+    webhook fires at period end and downgrades the DB tier to BASIC.
 
     Returns True if at least one subscription was found and scheduled for cancellation,
     False if the customer had no active/trialing subscriptions (e.g., admin-granted tier
@@ -1403,7 +1403,7 @@ async def get_proration_credit_cents(user_id: str, monthly_cost_cents: int) -> i
 
     Fetches the user's active Stripe subscription to determine how many seconds
     remain in the current billing period, then calculates the unused portion of
-    the monthly cost. Returns 0 for FREE/ENTERPRISE users or when no active sub
+    the monthly cost. Returns 0 for BASIC/ENTERPRISE users or when no active sub
     is found.
     """
     if monthly_cost_cents <= 0:
@@ -1442,7 +1442,7 @@ async def get_proration_credit_cents(user_id: str, monthly_cost_cents: int) -> i
 # (move right) from downgrades (move left); ENTERPRISE is admin-managed and
 # never reached via self-service flows.
 _TIER_ORDER: tuple[SubscriptionTier, ...] = (
-    SubscriptionTier.FREE,
+    SubscriptionTier.BASIC,
     SubscriptionTier.PRO,
     SubscriptionTier.MAX,
     SubscriptionTier.BUSINESS,
@@ -1552,7 +1552,7 @@ async def _schedule_downgrade_at_period_end(
     ``SubscriptionSchedule.create`` if either (a) a schedule is already
     attached to the subscription or (b) ``cancel_at_period_end=True`` is set.
     Both conditions mean the user is overwriting a pending change they made
-    earlier (e.g. BUSINESS→FREE cancel, now switching to BUSINESS→PRO
+    earlier (e.g. BUSINESS→BASIC cancel, now switching to BUSINESS→PRO
     downgrade). We clear the conflicting state first so the new schedule can
     be created. These defensive reads serialize through Stripe's own atomic
     operations — by the time modify/release returns, the subscription is in a
@@ -1670,7 +1670,7 @@ async def modify_stripe_subscription_for_tier(
     user = await get_user_by_id(user_id)
     if not user.stripe_customer_id:
         return False
-    current_tier = user.subscription_tier or SubscriptionTier.FREE
+    current_tier = user.subscription_tier or SubscriptionTier.BASIC
 
     sub = await _get_active_subscription(user.stripe_customer_id)
     if sub is None:
@@ -1702,7 +1702,7 @@ async def modify_stripe_subscription_for_tier(
                 existing_schedule_id, "modify_stripe_subscription_for_tier"
             )
 
-        # If a paid→FREE cancel is pending (cancel_at_period_end=True), clear it
+        # If a paid→BASIC cancel is pending (cancel_at_period_end=True), clear it
         # as part of the upgrade — the user is explicitly choosing to stay on a
         # paid tier. Without this, the sub would be upgraded AND still cancelled
         # at period end, leaving a confusing dual state.
@@ -1758,7 +1758,7 @@ async def release_pending_subscription_schedule(user_id: str) -> bool:
     - **Subscription Schedule** (paid→paid downgrade): ``stripe.SubscriptionSchedule.release``
       detaches the schedule and lets the subscription continue on its current
       phase's price.
-    - **cancel_at_period_end=True** (paid→FREE cancel): clearing that flag via
+    - **cancel_at_period_end=True** (paid→BASIC cancel): clearing that flag via
       ``stripe.Subscription.modify`` keeps the subscription active indefinitely.
 
     Returns True if a pending change was found and reverted, False otherwise.
@@ -1827,7 +1827,7 @@ async def get_pending_subscription_change(
     """Return ``(pending_tier, effective_at)`` when a change is queued, else ``None``.
 
     Reflects both Subscription Schedule phase transitions (paid→paid downgrade)
-    and ``cancel_at_period_end=True`` (paid→FREE cancel).
+    and ``cancel_at_period_end=True`` (paid→BASIC cancel).
 
     Cached for 30 seconds per user_id. *Why the cache exists:* this function
     runs on every dashboard/home fetch and would otherwise fire
@@ -1855,18 +1855,18 @@ async def get_pending_subscription_change(
     user = await get_user_by_id(user_id)
     if not user.stripe_customer_id:
         # Short-circuit for users with no Stripe customer (admin-granted tiers,
-        # FREE-only users): skip the Stripe API calls entirely.
+        # BASIC-only users): skip the Stripe API calls entirely.
         return None
 
-    free_price, pro_price, max_price, business_price = await asyncio.gather(
-        get_subscription_price_id(SubscriptionTier.FREE),
+    basic_price, pro_price, max_price, business_price = await asyncio.gather(
+        get_subscription_price_id(SubscriptionTier.BASIC),
         get_subscription_price_id(SubscriptionTier.PRO),
         get_subscription_price_id(SubscriptionTier.MAX),
         get_subscription_price_id(SubscriptionTier.BUSINESS),
     )
     price_to_tier: dict[str, SubscriptionTier] = {}
-    if free_price:
-        price_to_tier[free_price] = SubscriptionTier.FREE
+    if basic_price:
+        price_to_tier[basic_price] = SubscriptionTier.BASIC
     if pro_price:
         price_to_tier[pro_price] = SubscriptionTier.PRO
     if max_price:
@@ -1876,7 +1876,7 @@ async def get_pending_subscription_change(
     if not price_to_tier:
         logger.warning(
             "get_pending_subscription_change: no Stripe price IDs resolvable for"
-            " FREE/PRO/MAX/BUSINESS (LaunchDarkly fetch failed?); raising to bypass"
+            " BASIC/PRO/MAX/BUSINESS (LaunchDarkly fetch failed?); raising to bypass"
             " the None cache so the next request retries fresh"
         )
         raise PendingChangeUnknown(
@@ -1891,7 +1891,7 @@ async def get_pending_subscription_change(
         return None
     effective_at = datetime.fromtimestamp(period_end, tz=timezone.utc)
     if sub.cancel_at_period_end:
-        return SubscriptionTier.FREE, effective_at
+        return SubscriptionTier.BASIC, effective_at
     if not sub.schedule:
         return None
     schedule_id = sub.schedule if isinstance(sub.schedule, str) else sub.schedule.id
@@ -1954,7 +1954,7 @@ async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
     hitting LD, so the extra LD call is never made.
     """
     flag_map = {
-        SubscriptionTier.FREE: Flag.STRIPE_PRICE_BASIC,
+        SubscriptionTier.BASIC: Flag.STRIPE_PRICE_BASIC,
         SubscriptionTier.PRO: Flag.STRIPE_PRICE_PRO,
         SubscriptionTier.MAX: Flag.STRIPE_PRICE_MAX,
         SubscriptionTier.BUSINESS: Flag.STRIPE_PRICE_BUSINESS,
@@ -2070,7 +2070,7 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
     # ENTERPRISE user to a different tier — if a user on ENTERPRISE somehow has
     # a self-service Stripe sub, it's a data-consistency issue for an operator,
     # not something the webhook should automatically "fix".
-    current_tier = user.subscriptionTier or SubscriptionTier.FREE
+    current_tier = user.subscriptionTier or SubscriptionTier.BASIC
     if current_tier == SubscriptionTier.ENTERPRISE:
         logger.warning(
             "sync_subscription_from_stripe: refusing to overwrite ENTERPRISE tier"
@@ -2087,14 +2087,14 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         items = stripe_subscription.get("items", {}).get("data", [])
         if items:
             price_id = items[0].get("price", {}).get("id", "")
-        free_price, pro_price, max_price, business_price = await asyncio.gather(
-            get_subscription_price_id(SubscriptionTier.FREE),
+        basic_price, pro_price, max_price, business_price = await asyncio.gather(
+            get_subscription_price_id(SubscriptionTier.BASIC),
             get_subscription_price_id(SubscriptionTier.PRO),
             get_subscription_price_id(SubscriptionTier.MAX),
             get_subscription_price_id(SubscriptionTier.BUSINESS),
         )
-        if price_id and free_price and price_id == free_price:
-            tier = SubscriptionTier.FREE
+        if price_id and basic_price and price_id == basic_price:
+            tier = SubscriptionTier.BASIC
         elif price_id and pro_price and price_id == pro_price:
             tier = SubscriptionTier.PRO
         elif price_id and max_price and price_id == max_price:
@@ -2103,7 +2103,7 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
             tier = SubscriptionTier.BUSINESS
         else:
             # Unknown or unconfigured price ID — preserve the user's current tier
-            # rather than defaulting to FREE. This prevents accidental downgrades
+            # rather than defaulting to BASIC. This prevents accidental downgrades
             # during a price migration or when LD flags are not yet configured.
             logger.warning(
                 "sync_subscription_from_stripe: unknown price %s for customer %s,"
@@ -2114,7 +2114,7 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
             return
     else:
         # A subscription was cancelled or ended. DO NOT unconditionally downgrade
-        # to FREE — Stripe does not guarantee webhook delivery order, so a
+        # to BASIC — Stripe does not guarantee webhook delivery order, so a
         # `customer.subscription.deleted` for the OLD sub can arrive after we've
         # already processed `customer.subscription.created` for a new paid sub.
         # Ask Stripe whether any OTHER active/trialing subs exist for this
@@ -2169,7 +2169,7 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
                 current_tier.value,
             )
             return
-        tier = SubscriptionTier.FREE
+        tier = SubscriptionTier.BASIC
     # Idempotency: Stripe retries webhooks on delivery failure, and several event
     # types map to the same final tier. Skip the DB write + cache invalidation
     # when the tier is already correct to avoid redundant writes on replay.
@@ -2190,7 +2190,7 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         # set_subscription_tier writes BUSINESS to the DB.  If Stripe delivers
         # the PRO `customer.subscription.deleted` event concurrently and it
         # processes after the PRO cancel but before set_subscription_tier
-        # commits, the user could momentarily appear as FREE in the DB.
+        # commits, the user could momentarily appear as BASIC in the DB.
         # This window is very short in practice (two sequential awaits),
         # but is a known limitation of the current webhook-driven approach.
         # A future improvement would be to write the new tier first, then
@@ -2250,7 +2250,7 @@ async def handle_subscription_payment_failure(invoice: dict) -> None:
 
     - Balance sufficient  → deduct from balance, then pay the Stripe invoice so
       Stripe stops retrying it. The sub stays intact and the user keeps their tier.
-    - Balance insufficient → cancel Stripe sub immediately, downgrade to FREE.
+    - Balance insufficient → cancel Stripe sub immediately, downgrade to BASIC.
       Cancelling here avoids further Stripe retries on an invoice we cannot cover.
     """
     customer_id = invoice.get("customer")
@@ -2268,7 +2268,7 @@ async def handle_subscription_payment_failure(invoice: dict) -> None:
         )
         return
 
-    current_tier = user.subscriptionTier or SubscriptionTier.FREE
+    current_tier = user.subscriptionTier or SubscriptionTier.BASIC
     if current_tier == SubscriptionTier.ENTERPRISE:
         logger.warning(
             "handle_subscription_payment_failure: skipping ENTERPRISE user %s"
@@ -2333,12 +2333,12 @@ async def handle_subscription_payment_failure(invoice: dict) -> None:
     except InsufficientBalanceError:
         # Balance insufficient — cancel Stripe subscription first, then downgrade DB.
         # Order matters: if we downgrade the DB first and the Stripe cancel fails, the
-        # user is permanently stuck on FREE while Stripe continues billing them.
+        # user is permanently stuck on BASIC while Stripe continues billing them.
         # Cancelling Stripe first is safe: if the DB write then fails, the webhook
         # customer.subscription.deleted will fire and correct the tier eventually.
         logger.info(
             "handle_subscription_payment_failure: insufficient balance for user %s;"
-            " cancelling Stripe sub %s then downgrading to FREE",
+            " cancelling Stripe sub %s then downgrading to BASIC",
             user.id,
             sub_id,
         )
@@ -2354,7 +2354,7 @@ async def handle_subscription_payment_failure(invoice: dict) -> None:
                 customer_id,
             )
             return
-        await set_subscription_tier(user.id, SubscriptionTier.FREE)
+        await set_subscription_tier(user.id, SubscriptionTier.BASIC)
 
 
 async def admin_get_user_history(

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1857,20 +1857,23 @@ async def get_pending_subscription_change(
         # FREE-only users): skip the Stripe API calls entirely.
         return None
 
-    pro_price, biz_price = await asyncio.gather(
+    free_price, pro_price, max_price = await asyncio.gather(
+        get_subscription_price_id(SubscriptionTier.FREE),
         get_subscription_price_id(SubscriptionTier.PRO),
         get_subscription_price_id(SubscriptionTier.BUSINESS),
     )
     price_to_tier: dict[str, SubscriptionTier] = {}
+    if free_price:
+        price_to_tier[free_price] = SubscriptionTier.FREE
     if pro_price:
         price_to_tier[pro_price] = SubscriptionTier.PRO
-    if biz_price:
-        price_to_tier[biz_price] = SubscriptionTier.BUSINESS
+    if max_price:
+        price_to_tier[max_price] = SubscriptionTier.BUSINESS
     if not price_to_tier:
         logger.warning(
             "get_pending_subscription_change: no Stripe price IDs resolvable for"
-            " PRO/BUSINESS (LaunchDarkly fetch failed?); raising to bypass the"
-            " None cache so the next request retries fresh"
+            " FREE/PRO/BUSINESS (LaunchDarkly fetch failed?); raising to bypass"
+            " the None cache so the next request retries fresh"
         )
         raise PendingChangeUnknown(
             "Stripe price lookup failed; pending-change state cannot be determined"
@@ -1943,12 +1946,13 @@ async def get_subscription_price_id(tier: SubscriptionTier) -> str | None:
 
     ``cache_none=False`` prevents a transient LD failure from caching ``None``
     and blocking subscription upgrades for the full 60-second TTL window.
-    A tier with no configured flag (FREE, ENTERPRISE) returns ``None`` from an
-    O(1) dict lookup before hitting LD, so the extra LD call is never made.
+    ENTERPRISE has no LD flag and returns None from an O(1) dict lookup before
+    hitting LD, so the extra LD call is never made.
     """
     flag_map = {
+        SubscriptionTier.FREE: Flag.STRIPE_PRICE_BASIC,
         SubscriptionTier.PRO: Flag.STRIPE_PRICE_PRO,
-        SubscriptionTier.BUSINESS: Flag.STRIPE_PRICE_BUSINESS,
+        SubscriptionTier.BUSINESS: Flag.STRIPE_PRICE_MAX,
     }
     flag = flag_map.get(tier)
     if flag is None:
@@ -2078,13 +2082,16 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         items = stripe_subscription.get("items", {}).get("data", [])
         if items:
             price_id = items[0].get("price", {}).get("id", "")
-        pro_price, biz_price = await asyncio.gather(
+        free_price, pro_price, max_price = await asyncio.gather(
+            get_subscription_price_id(SubscriptionTier.FREE),
             get_subscription_price_id(SubscriptionTier.PRO),
             get_subscription_price_id(SubscriptionTier.BUSINESS),
         )
-        if price_id and pro_price and price_id == pro_price:
+        if price_id and free_price and price_id == free_price:
+            tier = SubscriptionTier.FREE
+        elif price_id and pro_price and price_id == pro_price:
             tier = SubscriptionTier.PRO
-        elif price_id and biz_price and price_id == biz_price:
+        elif price_id and max_price and price_id == max_price:
             tier = SubscriptionTier.BUSINESS
         else:
             # Unknown or unconfigured price ID — preserve the user's current tier

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -910,11 +910,26 @@ async def test_get_subscription_price_id_pro():
 
 
 @pytest.mark.asyncio
-async def test_get_subscription_price_id_free_returns_none():
+async def test_get_subscription_price_id_free_returns_ld_flag():
     from backend.data.credit import get_subscription_price_id
 
-    # FREE tier bypasses the LD flag lookup entirely (returns None before fetch).
-    price_id = await get_subscription_price_id(SubscriptionTier.FREE)
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value="price_basic_monthly",
+    ):
+        price_id = await get_subscription_price_id(SubscriptionTier.FREE)
+        assert price_id == "price_basic_monthly"
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_get_subscription_price_id_enterprise_returns_none():
+    from backend.data.credit import get_subscription_price_id
+
+    # ENTERPRISE bypasses the LD flag lookup entirely (returns None before fetch).
+    price_id = await get_subscription_price_id(SubscriptionTier.ENTERPRISE)
     assert price_id is None
 
 

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -791,6 +791,56 @@ async def test_sync_subscription_from_stripe_business_tier():
 
 
 @pytest.mark.asyncio
+async def test_sync_subscription_from_stripe_free_tier_via_ld_price():
+    """BASIC (FREE) price_id via LD should reconcile the user to FREE.
+
+    Protects the new stripe-price-id-basic reconciliation path — webhooks for a
+    priced-FREE sub must flip the DB tier back to FREE when the active Stripe
+    item matches the configured basic price.
+    """
+    mock_user = _make_user(tier=SubscriptionTier.PRO)
+    stripe_sub = {
+        "id": "sub_new",
+        "customer": "cus_123",
+        "status": "active",
+        "items": {"data": [{"price": {"id": "price_basic_monthly"}}]},
+    }
+
+    async def mock_price_id(tier: SubscriptionTier) -> str | None:
+        if tier == SubscriptionTier.FREE:
+            return "price_basic_monthly"
+        if tier == SubscriptionTier.PRO:
+            return "price_pro_monthly"
+        if tier == SubscriptionTier.BUSINESS:
+            return "price_biz_monthly"
+        return None
+
+    empty_list = MagicMock()
+    empty_list.data = []
+    empty_list.has_more = False
+
+    with (
+        patch(
+            "backend.data.credit.User.prisma",
+            return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
+        ),
+        patch(
+            "backend.data.credit.get_subscription_price_id",
+            side_effect=mock_price_id,
+        ),
+        patch(
+            "backend.data.credit.stripe.Subscription.list",
+            return_value=empty_list,
+        ),
+        patch(
+            "backend.data.credit.set_subscription_tier", new_callable=AsyncMock
+        ) as mock_set,
+    ):
+        await sync_subscription_from_stripe(stripe_sub)
+        mock_set.assert_awaited_once_with("user-1", SubscriptionTier.FREE)
+
+
+@pytest.mark.asyncio
 async def test_sync_subscription_from_stripe_cancels_stale_subs():
     """When a new subscription becomes active, older active subs are cancelled.
 
@@ -1805,6 +1855,86 @@ async def test_get_pending_subscription_change_from_schedule():
     assert result is not None
     pending_tier, effective_at = result
     assert pending_tier == SubscriptionTier.PRO
+    assert int(effective_at.timestamp()) == period_end
+
+
+@pytest.mark.asyncio
+async def test_get_pending_subscription_change_from_schedule_to_free():
+    """A schedule whose next phase uses the BASIC price maps to pending_tier=FREE."""
+    import time as time_mod
+
+    get_pending_subscription_change.cache_clear()  # type: ignore[attr-defined]
+
+    now = int(time_mod.time())
+    period_end = now + 10 * 24 * 3600
+    mock_sub = stripe.Subscription.construct_from(
+        {
+            "id": "sub_pro",
+            "current_period_end": period_end,
+            "cancel_at_period_end": False,
+            "schedule": "sub_sched_2",
+        },
+        "k",
+    )
+    mock_list = MagicMock()
+    mock_list.data = [mock_sub]
+
+    mock_schedule = stripe.SubscriptionSchedule.construct_from(
+        {
+            "id": "sub_sched_2",
+            "phases": [
+                {
+                    "start_date": now - 3 * 24 * 3600,
+                    "end_date": period_end,
+                    "items": [{"price": "price_pro_monthly"}],
+                },
+                {
+                    "start_date": period_end,
+                    "items": [{"price": "price_basic_monthly"}],
+                },
+            ],
+        },
+        "k",
+    )
+
+    mock_user = MagicMock()
+    mock_user.stripe_customer_id = "cus_abc"
+
+    async def mock_price_id(tier: SubscriptionTier) -> str | None:
+        if tier == SubscriptionTier.FREE:
+            return "price_basic_monthly"
+        if tier == SubscriptionTier.PRO:
+            return "price_pro_monthly"
+        if tier == SubscriptionTier.BUSINESS:
+            return "price_biz_monthly"
+        return None
+
+    with (
+        patch(
+            "backend.data.credit.get_user_by_id",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+        patch(
+            "backend.data.credit.get_subscription_price_id",
+            side_effect=mock_price_id,
+        ),
+        patch(
+            "backend.data.credit.stripe.Subscription.list_async",
+            new_callable=AsyncMock,
+            return_value=mock_list,
+        ),
+        patch(
+            "backend.data.credit.stripe.SubscriptionSchedule.retrieve_async",
+            new_callable=AsyncMock,
+            return_value=mock_schedule,
+        ),
+    ):
+        result = await get_pending_subscription_change("user-1")
+
+    assert result is not None
+    pending_tier, effective_at = result
+    assert pending_tier == SubscriptionTier.FREE
     assert int(effective_at.timestamp()) == period_end
 
 

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -975,6 +975,21 @@ async def test_get_subscription_price_id_free_returns_ld_flag():
 
 
 @pytest.mark.asyncio
+async def test_get_subscription_price_id_max():
+    from backend.data.credit import get_subscription_price_id
+
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+    with patch(
+        "backend.data.credit.get_feature_flag_value",
+        new_callable=AsyncMock,
+        return_value="price_max_monthly",
+    ):
+        price_id = await get_subscription_price_id(SubscriptionTier.MAX)
+        assert price_id == "price_max_monthly"
+    get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_get_subscription_price_id_enterprise_returns_none():
     from backend.data.credit import get_subscription_price_id
 

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -50,11 +50,13 @@ async def test_set_subscription_tier_downgrade():
         ),
         patch("backend.data.credit.get_user_by_id"),
     ):
-        # Downgrade to FREE should not raise
-        await set_subscription_tier("user-1", SubscriptionTier.FREE)
+        # Downgrade to BASIC should not raise
+        await set_subscription_tier("user-1", SubscriptionTier.BASIC)
 
 
-def _make_user(user_id: str = "user-1", tier: SubscriptionTier = SubscriptionTier.FREE):
+def _make_user(
+    user_id: str = "user-1", tier: SubscriptionTier = SubscriptionTier.BASIC
+):
     mock_user = MagicMock(spec=User)
     mock_user.id = user_id
     mock_user.subscriptionTier = tier
@@ -172,7 +174,7 @@ async def test_sync_subscription_from_stripe_enterprise_not_overwritten():
 
 @pytest.mark.asyncio
 async def test_sync_subscription_from_stripe_cancelled():
-    """When the only active sub is cancelled, the user is downgraded to FREE."""
+    """When the only active sub is cancelled, the user is downgraded to BASIC."""
     mock_user = _make_user(tier=SubscriptionTier.PRO)
     stripe_sub = {
         "id": "sub_old",
@@ -197,7 +199,7 @@ async def test_sync_subscription_from_stripe_cancelled():
         ) as mock_set,
     ):
         await sync_subscription_from_stripe(stripe_sub)
-        mock_set.assert_awaited_once_with("user-1", SubscriptionTier.FREE)
+        mock_set.assert_awaited_once_with("user-1", SubscriptionTier.BASIC)
 
 
 @pytest.mark.asyncio
@@ -206,7 +208,7 @@ async def test_sync_subscription_from_stripe_cancelled_but_other_active_sub_exis
 
     This covers the race condition where `customer.subscription.deleted` for
     the old sub arrives after `customer.subscription.created` for the new sub
-    was already processed. Unconditionally downgrading to FREE here would
+    was already processed. Unconditionally downgrading to BASIC here would
     immediately undo the user's upgrade.
     """
     mock_user = _make_user(tier=SubscriptionTier.BUSINESS)
@@ -243,7 +245,7 @@ async def test_sync_subscription_from_stripe_cancelled_but_other_active_sub_exis
         ) as mock_set,
     ):
         await sync_subscription_from_stripe(stripe_sub)
-        # Must NOT write FREE — another active sub is still present.
+        # Must NOT write BASIC — another active sub is still present.
         mock_set.assert_not_awaited()
 
 
@@ -514,7 +516,7 @@ async def test_cancel_stripe_subscription_releases_attached_schedule_first():
 
     Stripe rejects ``modify(cancel_at_period_end=True)`` with HTTP 400 when the
     subscription has an attached schedule (e.g. user queued a BUSINESS→PRO
-    downgrade and now clicks "Downgrade to FREE"). Without the pre-release,
+    downgrade and now clicks "Downgrade to BASIC"). Without the pre-release,
     the API handler would surface a 502 to the user.
     """
     mock_subscriptions = MagicMock()
@@ -579,7 +581,7 @@ async def test_get_proration_credit_cents_no_stripe_customer_returns_zero():
 
 @pytest.mark.asyncio
 async def test_get_proration_credit_cents_zero_cost_returns_zero():
-    """FREE tier users (cost=0) return 0 without calling get_user_by_id."""
+    """BASIC tier users (cost=0) return 0 without calling get_user_by_id."""
     with patch(
         "backend.data.credit.get_user_by_id", new_callable=AsyncMock
     ) as mock_get_user:
@@ -689,7 +691,7 @@ async def test_sync_subscription_from_stripe_missing_customer_key_returns_early(
 
 @pytest.mark.asyncio
 async def test_sync_subscription_from_stripe_unknown_price_id_preserves_current_tier():
-    """Unknown price_id should preserve the current tier, not default to FREE (no DB write)."""
+    """Unknown price_id should preserve the current tier, not default to BASIC (no DB write)."""
     mock_user = _make_user(tier=SubscriptionTier.PRO)
     stripe_sub = {
         "customer": "cus_123",
@@ -720,7 +722,7 @@ async def test_sync_subscription_from_stripe_unknown_price_id_preserves_current_
 
 @pytest.mark.asyncio
 async def test_sync_subscription_from_stripe_unconfigured_ld_price_preserves_current_tier():
-    """When LD flags are unconfigured (None price IDs), the current tier should be preserved, not defaulted to FREE."""
+    """When LD flags are unconfigured (None price IDs), the current tier should be preserved, not defaulted to BASIC."""
     mock_user = _make_user(tier=SubscriptionTier.PRO)
     stripe_sub = {
         "customer": "cus_123",
@@ -791,11 +793,11 @@ async def test_sync_subscription_from_stripe_business_tier():
 
 
 @pytest.mark.asyncio
-async def test_sync_subscription_from_stripe_free_tier_via_ld_price():
-    """BASIC (FREE) price_id via LD should reconcile the user to FREE.
+async def test_sync_subscription_from_stripe_basic_tier_via_ld_price():
+    """BASIC price_id via LD should reconcile the user to BASIC.
 
     Protects the new stripe-price-id-basic reconciliation path — webhooks for a
-    priced-FREE sub must flip the DB tier back to FREE when the active Stripe
+    priced-BASIC sub must flip the DB tier back to BASIC when the active Stripe
     item matches the configured basic price.
     """
     mock_user = _make_user(tier=SubscriptionTier.PRO)
@@ -807,7 +809,7 @@ async def test_sync_subscription_from_stripe_free_tier_via_ld_price():
     }
 
     async def mock_price_id(tier: SubscriptionTier) -> str | None:
-        if tier == SubscriptionTier.FREE:
+        if tier == SubscriptionTier.BASIC:
             return "price_basic_monthly"
         if tier == SubscriptionTier.PRO:
             return "price_pro_monthly"
@@ -837,7 +839,7 @@ async def test_sync_subscription_from_stripe_free_tier_via_ld_price():
         ) as mock_set,
     ):
         await sync_subscription_from_stripe(stripe_sub)
-        mock_set.assert_awaited_once_with("user-1", SubscriptionTier.FREE)
+        mock_set.assert_awaited_once_with("user-1", SubscriptionTier.BASIC)
 
 
 @pytest.mark.asyncio
@@ -960,7 +962,7 @@ async def test_get_subscription_price_id_pro():
 
 
 @pytest.mark.asyncio
-async def test_get_subscription_price_id_free_returns_ld_flag():
+async def test_get_subscription_price_id_basic_returns_ld_flag():
     from backend.data.credit import get_subscription_price_id
 
     get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
@@ -969,7 +971,7 @@ async def test_get_subscription_price_id_free_returns_ld_flag():
         new_callable=AsyncMock,
         return_value="price_basic_monthly",
     ):
-        price_id = await get_subscription_price_id(SubscriptionTier.FREE)
+        price_id = await get_subscription_price_id(SubscriptionTier.BASIC)
         assert price_id == "price_basic_monthly"
     get_subscription_price_id.cache_clear()  # type: ignore[attr-defined]
 
@@ -1071,7 +1073,7 @@ async def test_cancel_stripe_subscription_raises_on_cancel_error():
 @pytest.mark.asyncio
 async def test_sync_subscription_from_stripe_metadata_user_id_matches():
     """metadata.user_id matching the DB user is accepted and the tier is updated normally."""
-    mock_user = _make_user(user_id="user-1", tier=SubscriptionTier.FREE)
+    mock_user = _make_user(user_id="user-1", tier=SubscriptionTier.BASIC)
     stripe_sub = {
         "id": "sub_new",
         "customer": "cus_123",
@@ -1115,7 +1117,7 @@ async def test_sync_subscription_from_stripe_metadata_user_id_mismatch_blocked()
     A customer↔user mapping inconsistency (e.g. a customer ID reassigned or
     a corrupted DB row) must never silently update the wrong user's tier.
     """
-    mock_user = _make_user(user_id="user-1", tier=SubscriptionTier.FREE)
+    mock_user = _make_user(user_id="user-1", tier=SubscriptionTier.BASIC)
     stripe_sub = {
         "id": "sub_new",
         "customer": "cus_123",
@@ -1141,7 +1143,7 @@ async def test_sync_subscription_from_stripe_metadata_user_id_mismatch_blocked()
 @pytest.mark.asyncio
 async def test_sync_subscription_from_stripe_no_metadata_user_id_skips_check():
     """Absence of metadata.user_id (e.g. subs created outside Checkout) skips the cross-check."""
-    mock_user = _make_user(user_id="user-1", tier=SubscriptionTier.FREE)
+    mock_user = _make_user(user_id="user-1", tier=SubscriptionTier.BASIC)
     stripe_sub = {
         "id": "sub_new",
         "customer": "cus_123",
@@ -1281,7 +1283,7 @@ async def test_modify_stripe_subscription_for_tier_modifies_existing_sub():
 
     mock_user = MagicMock(spec=User)
     mock_user.stripe_customer_id = "cus_abc"
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     with (
         patch(
@@ -1418,7 +1420,7 @@ async def test_modify_stripe_subscription_for_tier_returns_false_when_no_sub():
 
     mock_user = MagicMock(spec=User)
     mock_user.stripe_customer_id = "cus_abc"
-    mock_user.subscription_tier = SubscriptionTier.FREE
+    mock_user.subscription_tier = SubscriptionTier.BASIC
 
     with (
         patch(
@@ -1457,11 +1459,11 @@ async def test_modify_stripe_subscription_for_tier_raises_on_missing_price_id():
 
 
 def test_tier_order_helpers():
-    assert is_tier_upgrade(SubscriptionTier.FREE, SubscriptionTier.PRO) is True
+    assert is_tier_upgrade(SubscriptionTier.BASIC, SubscriptionTier.PRO) is True
     assert is_tier_upgrade(SubscriptionTier.PRO, SubscriptionTier.BUSINESS) is True
     assert is_tier_upgrade(SubscriptionTier.BUSINESS, SubscriptionTier.PRO) is False
     assert is_tier_downgrade(SubscriptionTier.BUSINESS, SubscriptionTier.PRO) is True
-    assert is_tier_downgrade(SubscriptionTier.PRO, SubscriptionTier.FREE) is True
+    assert is_tier_downgrade(SubscriptionTier.PRO, SubscriptionTier.BASIC) is True
     assert is_tier_downgrade(SubscriptionTier.PRO, SubscriptionTier.BUSINESS) is False
 
 
@@ -1649,7 +1651,7 @@ async def test_release_pending_subscription_schedule_releases_downgrade_schedule
 
 @pytest.mark.asyncio
 async def test_release_pending_subscription_schedule_clears_cancel_at_period_end():
-    """release_pending_subscription_schedule reverts a pending paid→FREE cancel."""
+    """release_pending_subscription_schedule reverts a pending paid→BASIC cancel."""
     mock_sub = stripe.Subscription.construct_from(
         {
             "id": "sub_pro",
@@ -1742,7 +1744,7 @@ async def test_release_pending_subscription_schedule_no_stripe_customer_returns_
 
 @pytest.mark.asyncio
 async def test_get_pending_subscription_change_cancel_at_period_end():
-    """cancel_at_period_end=True maps to pending FREE at current_period_end."""
+    """cancel_at_period_end=True maps to pending BASIC at current_period_end."""
     import time as time_mod
 
     get_pending_subscription_change.cache_clear()  # type: ignore[attr-defined]
@@ -1791,7 +1793,7 @@ async def test_get_pending_subscription_change_cancel_at_period_end():
 
     assert result is not None
     pending_tier, effective_at = result
-    assert pending_tier == SubscriptionTier.FREE
+    assert pending_tier == SubscriptionTier.BASIC
     assert int(effective_at.timestamp()) == period_end
 
 
@@ -1874,8 +1876,8 @@ async def test_get_pending_subscription_change_from_schedule():
 
 
 @pytest.mark.asyncio
-async def test_get_pending_subscription_change_from_schedule_to_free():
-    """A schedule whose next phase uses the BASIC price maps to pending_tier=FREE."""
+async def test_get_pending_subscription_change_from_schedule_to_basic():
+    """A schedule whose next phase uses the BASIC price maps to pending_tier=BASIC."""
     import time as time_mod
 
     get_pending_subscription_change.cache_clear()  # type: ignore[attr-defined]
@@ -1916,7 +1918,7 @@ async def test_get_pending_subscription_change_from_schedule_to_free():
     mock_user.stripe_customer_id = "cus_abc"
 
     async def mock_price_id(tier: SubscriptionTier) -> str | None:
-        if tier == SubscriptionTier.FREE:
+        if tier == SubscriptionTier.BASIC:
             return "price_basic_monthly"
         if tier == SubscriptionTier.PRO:
             return "price_pro_monthly"
@@ -1949,7 +1951,7 @@ async def test_get_pending_subscription_change_from_schedule_to_free():
 
     assert result is not None
     pending_tier, effective_at = result
-    assert pending_tier == SubscriptionTier.FREE
+    assert pending_tier == SubscriptionTier.BASIC
     assert int(effective_at.timestamp()) == period_end
 
 

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -72,7 +72,7 @@ class User(BaseModel):
         None, description="Top up configuration"
     )
     subscription_tier: SubscriptionTier = Field(
-        default=SubscriptionTier.FREE, description="User subscription tier"
+        default=SubscriptionTier.BASIC, description="User subscription tier"
     )
 
     # Notification preferences
@@ -148,7 +148,7 @@ class User(BaseModel):
             integrations=prisma_user.integrations or "",
             stripe_customer_id=prisma_user.stripeCustomerId,
             top_up_config=top_up_config,
-            subscription_tier=prisma_user.subscriptionTier or SubscriptionTier.FREE,
+            subscription_tier=prisma_user.subscriptionTier or SubscriptionTier.BASIC,
             max_emails_per_day=prisma_user.maxEmailsPerDay or 3,
             notify_on_agent_run=prisma_user.notifyOnAgentRun or True,
             notify_on_zero_balance=prisma_user.notifyOnZeroBalance or True,

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -44,8 +44,9 @@ class Flag(str, Enum):
     COPILOT_SDK = "copilot-sdk"
     COPILOT_DAILY_COST_LIMIT = "copilot-daily-cost-limit-microdollars"
     COPILOT_WEEKLY_COST_LIMIT = "copilot-weekly-cost-limit-microdollars"
+    STRIPE_PRICE_BASIC = "stripe-price-id-basic"
     STRIPE_PRICE_PRO = "stripe-price-id-pro"
-    STRIPE_PRICE_BUSINESS = "stripe-price-id-business"
+    STRIPE_PRICE_MAX = "stripe-price-id-max"
     GRAPHITI_MEMORY = "graphiti-memory"
 
     # Copilot model routing — string-valued, returns the model identifier

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -47,6 +47,7 @@ class Flag(str, Enum):
     STRIPE_PRICE_BASIC = "stripe-price-id-basic"
     STRIPE_PRICE_PRO = "stripe-price-id-pro"
     STRIPE_PRICE_MAX = "stripe-price-id-max"
+    STRIPE_PRICE_BUSINESS = "stripe-price-id-business"
     GRAPHITI_MEMORY = "graphiti-memory"
 
     # Copilot model routing — string-valued, returns the model identifier

--- a/autogpt_platform/backend/migrations/20260424091957_add_max_tier_and_rename_free_to_basic/migration.sql
+++ b/autogpt_platform/backend/migrations/20260424091957_add_max_tier_and_rename_free_to_basic/migration.sql
@@ -1,0 +1,5 @@
+-- Add MAX between PRO and BUSINESS and rename FREE → BASIC. ADD VALUE BEFORE
+-- preserves existing rows on BUSINESS/ENTERPRISE; RENAME VALUE updates the
+-- label in place so existing FREE rows (the common case) remain valid.
+ALTER TYPE "SubscriptionTier" ADD VALUE IF NOT EXISTS 'MAX' BEFORE 'BUSINESS';
+ALTER TYPE "SubscriptionTier" RENAME VALUE 'FREE' TO 'BASIC';

--- a/autogpt_platform/backend/migrations/20260424091957_add_subscription_tier_max/migration.sql
+++ b/autogpt_platform/backend/migrations/20260424091957_add_subscription_tier_max/migration.sql
@@ -1,0 +1,3 @@
+-- Add MAX between PRO and BUSINESS. ADD VALUE ... BEFORE preserves existing rows
+-- (nothing currently on BUSINESS/ENTERPRISE via self-service flows).
+ALTER TYPE "SubscriptionTier" ADD VALUE IF NOT EXISTS 'MAX' BEFORE 'BUSINESS';

--- a/autogpt_platform/backend/migrations/20260424091957_add_subscription_tier_max/migration.sql
+++ b/autogpt_platform/backend/migrations/20260424091957_add_subscription_tier_max/migration.sql
@@ -1,3 +1,0 @@
--- Add MAX between PRO and BUSINESS. ADD VALUE ... BEFORE preserves existing rows
--- (nothing currently on BUSINESS/ENTERPRISE via self-service flows).
-ALTER TYPE "SubscriptionTier" ADD VALUE IF NOT EXISTS 'MAX' BEFORE 'BUSINESS';

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -41,7 +41,7 @@ model User {
   timezone String @default("not-set")
 
   // CoPilot subscription tier — controls rate-limit multipliers.
-  // Multipliers applied in get_global_rate_limits(): FREE=1x, PRO=5x, BUSINESS=20x, ENTERPRISE=60x.
+  // Multipliers applied in get_global_rate_limits(): FREE=1x, PRO=5x, BUSINESS=60x, ENTERPRISE=60x.
   // NOTE: @default(PRO) is intentional for the beta period — all existing and new
   // users receive PRO-level (5x) rate limits by default. The Python-level constant
   // DEFAULT_TIER=FREE (in copilot/rate_limit.py) acts as a code-level fallback when

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -41,7 +41,7 @@ model User {
   timezone String @default("not-set")
 
   // CoPilot subscription tier — controls rate-limit multipliers.
-  // Multipliers applied in get_global_rate_limits(): FREE=1x, PRO=5x, BUSINESS=60x, ENTERPRISE=60x.
+  // Multipliers applied in get_global_rate_limits(): FREE=1x, PRO=5x, MAX=20x, BUSINESS=60x, ENTERPRISE=60x.
   // NOTE: @default(PRO) is intentional for the beta period — all existing and new
   // users receive PRO-level (5x) rate limits by default. The Python-level constant
   // DEFAULT_TIER=FREE (in copilot/rate_limit.py) acts as a code-level fallback when
@@ -90,6 +90,7 @@ model User {
 enum SubscriptionTier {
   FREE
   PRO
+  MAX
   BUSINESS
   ENTERPRISE
 }

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -41,12 +41,12 @@ model User {
   timezone String @default("not-set")
 
   // CoPilot subscription tier — controls rate-limit multipliers.
-  // Multipliers applied in get_global_rate_limits(): FREE=1x, PRO=5x, MAX=20x, BUSINESS=60x, ENTERPRISE=60x.
+  // Multipliers applied in get_global_rate_limits(): BASIC=1x, PRO=5x, MAX=20x, BUSINESS=60x, ENTERPRISE=60x.
   // NOTE: @default(PRO) is intentional for the beta period — all existing and new
   // users receive PRO-level (5x) rate limits by default. The Python-level constant
-  // DEFAULT_TIER=FREE (in copilot/rate_limit.py) acts as a code-level fallback when
+  // DEFAULT_TIER=BASIC (in copilot/rate_limit.py) acts as a code-level fallback when
   // the DB value is NULL or unrecognised. At GA, a migration will flip the column
-  // default to FREE and batch-update users to their billing-derived tiers.
+  // default to BASIC and batch-update users to their billing-derived tiers.
   subscriptionTier SubscriptionTier @default(PRO)
 
   // Relations
@@ -88,7 +88,7 @@ model User {
 }
 
 enum SubscriptionTier {
-  FREE
+  BASIC
   PRO
   MAX
   BUSINESS

--- a/autogpt_platform/backend/snapshots/get_rate_limit
+++ b/autogpt_platform/backend/snapshots/get_rate_limit
@@ -1,7 +1,7 @@
 {
   "daily_cost_limit_microdollars": 2500000,
   "daily_cost_used_microdollars": 500000,
-  "tier": "FREE",
+  "tier": "BASIC",
   "user_email": "target@example.com",
   "user_id": "5e53486c-cf57-477e-ba2a-cb02dc828e1c",
   "weekly_cost_limit_microdollars": 12500000,

--- a/autogpt_platform/backend/snapshots/reset_user_usage_daily_and_weekly
+++ b/autogpt_platform/backend/snapshots/reset_user_usage_daily_and_weekly
@@ -1,7 +1,7 @@
 {
   "daily_cost_limit_microdollars": 2500000,
   "daily_cost_used_microdollars": 0,
-  "tier": "FREE",
+  "tier": "BASIC",
   "user_email": "target@example.com",
   "user_id": "5e53486c-cf57-477e-ba2a-cb02dc828e1c",
   "weekly_cost_limit_microdollars": 12500000,

--- a/autogpt_platform/backend/snapshots/reset_user_usage_daily_only
+++ b/autogpt_platform/backend/snapshots/reset_user_usage_daily_only
@@ -1,7 +1,7 @@
 {
   "daily_cost_limit_microdollars": 2500000,
   "daily_cost_used_microdollars": 0,
-  "tier": "FREE",
+  "tier": "BASIC",
   "user_email": "target@example.com",
   "user_id": "5e53486c-cf57-477e-ba2a-cb02dc828e1c",
   "weekly_cost_limit_microdollars": 12500000,

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
@@ -12,7 +12,7 @@ type Tier = (typeof TIERS)[number];
 const TIER_MULTIPLIERS: Record<Tier, string> = {
   FREE: "1x base limits",
   PRO: "5x base limits",
-  BUSINESS: "20x base limits",
+  BUSINESS: "60x base limits",
   ENTERPRISE: "60x base limits",
 };
 

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
@@ -6,11 +6,11 @@ import type { UserRateLimitResponse } from "@/app/api/__generated__/models/userR
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { UsageBar } from "../../components/UsageBar";
 
-const TIERS = ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"] as const;
+const TIERS = ["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"] as const;
 type Tier = (typeof TIERS)[number];
 
 const TIER_MULTIPLIERS: Record<Tier, string> = {
-  FREE: "1x base limits",
+  BASIC: "1x base limits",
   PRO: "5x base limits",
   MAX: "20x base limits",
   BUSINESS: "60x base limits",
@@ -18,7 +18,7 @@ const TIER_MULTIPLIERS: Record<Tier, string> = {
 };
 
 const TIER_COLORS: Record<Tier, string> = {
-  FREE: "bg-gray-100 text-gray-700",
+  BASIC: "bg-gray-100 text-gray-700",
   PRO: "bg-blue-100 text-blue-700",
   MAX: "bg-indigo-100 text-indigo-700",
   BUSINESS: "bg-purple-100 text-purple-700",
@@ -46,7 +46,7 @@ export function RateLimitDisplay({
 
   const currentTier = TIERS.includes(data.tier as Tier)
     ? (data.tier as Tier)
-    : "FREE";
+    : "BASIC";
 
   async function handleReset() {
     const msg = resetWeekly

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/RateLimitDisplay.tsx
@@ -6,12 +6,13 @@ import type { UserRateLimitResponse } from "@/app/api/__generated__/models/userR
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { UsageBar } from "../../components/UsageBar";
 
-const TIERS = ["FREE", "PRO", "BUSINESS", "ENTERPRISE"] as const;
+const TIERS = ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"] as const;
 type Tier = (typeof TIERS)[number];
 
 const TIER_MULTIPLIERS: Record<Tier, string> = {
   FREE: "1x base limits",
   PRO: "5x base limits",
+  MAX: "20x base limits",
   BUSINESS: "60x base limits",
   ENTERPRISE: "60x base limits",
 };
@@ -19,6 +20,7 @@ const TIER_MULTIPLIERS: Record<Tier, string> = {
 const TIER_COLORS: Record<Tier, string> = {
   FREE: "bg-gray-100 text-gray-700",
   PRO: "bg-blue-100 text-blue-700",
+  MAX: "bg-indigo-100 text-indigo-700",
   BUSINESS: "bg-purple-100 text-purple-700",
   ENTERPRISE: "bg-amber-100 text-amber-700",
 };

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
@@ -86,7 +86,7 @@ describe("RateLimitDisplay", () => {
     render(<RateLimitDisplay data={makeData()} onReset={vi.fn()} />);
     const select = screen.getByLabelText("Subscription tier");
     expect(select).toBeDefined();
-    expect(select.querySelectorAll("option").length).toBe(4);
+    expect(select.querySelectorAll("option").length).toBe(5);
   });
 
   it("disables tier dropdown when onTierChange is not provided", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitDisplay.test.tsx
@@ -34,7 +34,7 @@ function makeData(
     weekly_cost_limit_microdollars: 50_000_000,
     daily_cost_used_microdollars: 2_500_000,
     weekly_cost_used_microdollars: 10_000_000,
-    tier: "FREE",
+    tier: "BASIC",
     ...overrides,
   };
 }
@@ -71,14 +71,14 @@ describe("RateLimitDisplay", () => {
     expect(badge.className).toContain("bg-blue-100");
   });
 
-  it("defaults unknown tier to FREE", () => {
+  it("defaults unknown tier to BASIC", () => {
     render(
       <RateLimitDisplay
         data={makeData({ tier: "UNKNOWN" as UserRateLimitResponse["tier"] })}
         onReset={vi.fn()}
       />,
     );
-    const badge = screen.getByText("FREE");
+    const badge = screen.getByText("BASIC");
     expect(badge).toBeDefined();
   });
 
@@ -195,7 +195,7 @@ describe("RateLimitDisplay", () => {
 
     render(
       <RateLimitDisplay
-        data={makeData({ tier: "FREE" })}
+        data={makeData({ tier: "BASIC" })}
         onReset={vi.fn()}
         onTierChange={onTierChange}
       />,
@@ -215,14 +215,14 @@ describe("RateLimitDisplay", () => {
 
     render(
       <RateLimitDisplay
-        data={makeData({ tier: "FREE" })}
+        data={makeData({ tier: "BASIC" })}
         onReset={vi.fn()}
         onTierChange={onTierChange}
       />,
     );
 
     fireEvent.change(screen.getByLabelText("Subscription tier"), {
-      target: { value: "FREE" },
+      target: { value: "BASIC" },
     });
 
     expect(onTierChange).not.toHaveBeenCalled();
@@ -234,7 +234,7 @@ describe("RateLimitDisplay", () => {
 
     render(
       <RateLimitDisplay
-        data={makeData({ tier: "FREE" })}
+        data={makeData({ tier: "BASIC" })}
         onReset={vi.fn()}
         onTierChange={onTierChange}
       />,
@@ -253,7 +253,7 @@ describe("RateLimitDisplay", () => {
 
     render(
       <RateLimitDisplay
-        data={makeData({ tier: "FREE" })}
+        data={makeData({ tier: "BASIC" })}
         onReset={vi.fn()}
         onTierChange={onTierChange}
       />,

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitManager.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/RateLimitManager.test.tsx
@@ -178,7 +178,7 @@ describe("RateLimitManager", () => {
         weekly_cost_limit_microdollars: 50_000_000,
         daily_cost_used_microdollars: 2_500_000,
         weekly_cost_used_microdollars: 10_000_000,
-        tier: "FREE",
+        tier: "BASIC",
       },
     });
 
@@ -201,7 +201,7 @@ describe("RateLimitManager", () => {
         weekly_cost_limit_microdollars: 50_000_000,
         daily_cost_used_microdollars: 2_500_000,
         weekly_cost_used_microdollars: 10_000_000,
-        tier: "FREE",
+        tier: "BASIC",
       },
     });
 

--- a/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/useRateLimitManager.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/rate-limits/components/__tests__/useRateLimitManager.test.ts
@@ -32,7 +32,7 @@ function makeRateLimitResponse(overrides = {}) {
     weekly_cost_limit_microdollars: 50_000_000,
     daily_cost_used_microdollars: 2_500_000,
     weekly_cost_used_microdollars: 10_000_000,
-    tier: "FREE",
+    tier: "BASIC",
     ...overrides,
   };
 }
@@ -304,7 +304,7 @@ describe("useRateLimitManager", () => {
   });
 
   it("handleTierChange calls set tier and re-fetches", async () => {
-    const initial = makeRateLimitResponse({ tier: "FREE" });
+    const initial = makeRateLimitResponse({ tier: "BASIC" });
     const updated = makeRateLimitResponse({ tier: "PRO" });
     mockGetV2GetUserRateLimit
       .mockResolvedValueOnce({ status: 200, data: initial })
@@ -371,7 +371,7 @@ describe("useRateLimitManager", () => {
   });
 
   it("handleTierChange throws when set-tier endpoint returns non-200", async () => {
-    const initial = makeRateLimitResponse({ tier: "FREE" });
+    const initial = makeRateLimitResponse({ tier: "BASIC" });
     mockGetV2GetUserRateLimit.mockResolvedValue({ status: 200, data: initial });
     mockPostV2SetUserRateLimitTier.mockResolvedValue({ status: 500 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/CopilotPage.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/CopilotPage.test.tsx
@@ -48,7 +48,7 @@ vi.mock("@/app/api/__generated__/endpoints/chat/chat", () => ({
     const data = {
       daily: null,
       weekly: null,
-      tier: "FREE",
+      tier: "BASIC",
       reset_cost: 0,
     };
     if (typeof opts?.query?.select === "function") {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsageLimits.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsageLimits.test.tsx
@@ -38,7 +38,7 @@ afterEach(() => {
 function makeUsage({
   dailyPercent = 5,
   weeklyPercent = 4,
-  tier = "FREE",
+  tier = "BASIC",
 }: {
   dailyPercent?: number | null;
   weeklyPercent?: number | null;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsagePanelContentRender.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/UsageLimits/__tests__/UsagePanelContentRender.test.tsx
@@ -29,7 +29,7 @@ function makeUsage(
   const {
     dailyPercent = 5,
     weeklyPercent = 4,
-    tier = "FREE",
+    tier = "BASIC",
     resetCost = 100,
   } = overrides;
   const future = new Date(Date.now() + 3600 * 1000).toISOString();

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
@@ -51,7 +51,7 @@ afterEach(() => {
 function makeUsage({
   dailyPercent = 5,
   weeklyPercent = 4,
-  tier = "FREE",
+  tier = "BASIC",
   resetCost = 500,
 }: {
   dailyPercent?: number | null;

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/SubscriptionTierSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/SubscriptionTierSection.tsx
@@ -211,7 +211,7 @@ export function SubscriptionTierSection() {
         })}
       </div>
 
-      {currentTier !== "FREE" && isPaymentEnabled && (
+      {currentTier !== "BASIC" && isPaymentEnabled && (
         <p className="text-sm text-neutral-500">
           Your subscription is managed through Stripe. Upgrades take effect
           immediately. Downgrades take effect at the end of your current billing
@@ -230,8 +230,8 @@ export function SubscriptionTierSection() {
       >
         <Dialog.Content>
           <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            {confirmDowngradeTo === "FREE"
-              ? "Downgrading to Free will schedule your subscription to cancel at the end of your current billing period. You keep your current plan until then."
+            {confirmDowngradeTo === "BASIC"
+              ? "Downgrading to Basic will schedule your subscription to cancel at the end of your current billing period. You keep your current plan until then."
               : `Switching to ${TIERS.find((t) => t.key === confirmDowngradeTo)?.label ?? confirmDowngradeTo} will take effect at the end of your current billing period. You keep your current plan until then.`}{" "}
             Are you sure?
           </p>

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/SubscriptionTierSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/SubscriptionTierSection.tsx
@@ -144,10 +144,7 @@ export function SubscriptionTierSection() {
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         {TIERS.filter(
-          // Hide tiers without a configured LD price; keep current tier visible.
-          (tier) =>
-            subscription.tier_costs[tier.key] !== undefined ||
-            tier.key === currentTier,
+          (tier) => subscription.tier_costs[tier.key] !== undefined,
         ).map((tier) => {
           const isCurrent = currentTier === tier.key;
           const cost = subscription.tier_costs[tier.key] ?? 0;

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/SubscriptionTierSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/SubscriptionTierSection.tsx
@@ -143,7 +143,12 @@ export function SubscriptionTierSection() {
       ) : null}
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        {TIERS.map((tier) => {
+        {TIERS.filter(
+          // Hide tiers without a configured LD price; keep current tier visible.
+          (tier) =>
+            subscription.tier_costs[tier.key] !== undefined ||
+            tier.key === currentTier,
+        ).map((tier) => {
           const isCurrent = currentTier === tier.key;
           const cost = subscription.tier_costs[tier.key] ?? 0;
           const currentIdx = TIER_ORDER.indexOf(currentTier);

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
@@ -334,6 +334,35 @@ describe("SubscriptionTierSection", () => {
     expect(screen.queryByRole("button", { name: /downgrade/i })).toBeNull();
   });
 
+  it("hides tiers that are missing from tier_costs (no LD price configured)", () => {
+    // LD only has stripe-price-id-basic → only FREE appears; PRO/Max cards must hide.
+    setupMocks({
+      subscription: makeSubscription({
+        tier: "FREE",
+        tierCosts: { FREE: 0 },
+      }),
+    });
+    render(<SubscriptionTierSection />);
+    expect(screen.getByText("Basic")).toBeDefined();
+    expect(screen.queryByText("Pro")).toBeNull();
+    expect(screen.queryByText("Max")).toBeNull();
+  });
+
+  it("always renders the current tier card as a safety net, even when tier_costs omits it", () => {
+    // BUSINESS user but LD dropped stripe-price-id-max → Max must still render.
+    setupMocks({
+      subscription: makeSubscription({
+        tier: "BUSINESS",
+        tierCosts: { PRO: 1999 },
+      }),
+    });
+    render(<SubscriptionTierSection />);
+    expect(screen.getByText("Max")).toBeDefined();
+    expect(screen.getByText("Pro")).toBeDefined();
+    // FREE has no price AND isn't the current tier → hidden.
+    expect(screen.queryByText("Basic")).toBeNull();
+  });
+
   it("shows ENTERPRISE message for ENTERPRISE tier users", () => {
     setupMocks({ subscription: makeSubscription({ tier: "ENTERPRISE" }) });
     render(<SubscriptionTierSection />);

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
@@ -365,8 +365,7 @@ describe("SubscriptionTierSection", () => {
     expect(screen.queryByText("Business")).toBeNull();
   });
 
-  it("always renders the current tier card as a safety net, even when tier_costs omits it", () => {
-    // MAX user but LD dropped stripe-price-id-max → Max must still render.
+  it("hides the current tier when its LD price is unset — no safety-net rendering", () => {
     setupMocks({
       subscription: makeSubscription({
         tier: "MAX",
@@ -374,9 +373,8 @@ describe("SubscriptionTierSection", () => {
       }),
     });
     render(<SubscriptionTierSection />);
-    expect(screen.getByText("Max")).toBeDefined();
     expect(screen.getByText("Pro")).toBeDefined();
-    // BASIC has no price AND isn't the current tier → hidden.
+    expect(screen.queryByText("Max")).toBeNull();
     expect(screen.queryByText("Basic")).toBeNull();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
@@ -67,9 +67,9 @@ vi.mock("@/components/molecules/Dialog/Dialog", () => ({
 }));
 
 function makeSubscription({
-  tier = "FREE",
+  tier = "BASIC",
   monthlyCost = 0,
-  tierCosts = { FREE: 0, PRO: 1999, MAX: 32000, ENTERPRISE: 0 },
+  tierCosts = { BASIC: 0, PRO: 1999, MAX: 32000, ENTERPRISE: 0 },
   prorationCreditCents = 0,
   pendingTier = null as string | null,
   pendingTierEffectiveAt = null as Date | string | null,
@@ -153,10 +153,10 @@ describe("SubscriptionTierSection", () => {
     expect(screen.getByText(/failed to load subscription info/i)).toBeDefined();
   });
 
-  it("renders all three tier cards for FREE user", () => {
+  it("renders all three tier cards for BASIC user", () => {
     setupMocks();
     render(<SubscriptionTierSection />);
-    // FREE tier card is labelled "Basic"; cost displays "Free" for FREE@$0.
+    // BASIC tier card is labelled "Basic"; cost displays "Free" for BASIC@$0.
     expect(screen.getByText("Basic")).toBeDefined();
     expect(screen.getByText("Free")).toBeDefined();
     expect(screen.getByText("Pro")).toBeDefined();
@@ -182,14 +182,14 @@ describe("SubscriptionTierSection", () => {
   it("displays tier costs from the API", () => {
     setupMocks({
       subscription: makeSubscription({
-        tier: "FREE",
-        tierCosts: { FREE: 0, PRO: 1999, MAX: 32000, ENTERPRISE: 0 },
+        tier: "BASIC",
+        tierCosts: { BASIC: 0, PRO: 1999, MAX: 32000, ENTERPRISE: 0 },
       }),
     });
     render(<SubscriptionTierSection />);
     expect(screen.getByText("$19.99/mo")).toBeDefined();
     expect(screen.getByText("$320.00/mo")).toBeDefined();
-    // FREE tier card label is "Basic"; its $0 cost renders "Free".
+    // BASIC tier card label is "Basic"; its $0 cost renders "Free".
     expect(screen.getByText("Basic")).toBeDefined();
     expect(screen.getByText("Free")).toBeDefined();
   });
@@ -197,8 +197,8 @@ describe("SubscriptionTierSection", () => {
   it("shows 'Pricing available soon' when tier cost is 0 for a paid tier", () => {
     setupMocks({
       subscription: makeSubscription({
-        tier: "FREE",
-        tierCosts: { FREE: 0, PRO: 0, MAX: 0, ENTERPRISE: 0 },
+        tier: "BASIC",
+        tierCosts: { BASIC: 0, PRO: 0, MAX: 0, ENTERPRISE: 0 },
       }),
     });
     render(<SubscriptionTierSection />);
@@ -260,7 +260,7 @@ describe("SubscriptionTierSection", () => {
     await waitFor(() => {
       expect(mutateFn).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ tier: "FREE" }),
+          data: expect.objectContaining({ tier: "BASIC" }),
         }),
       );
     });
@@ -324,7 +324,7 @@ describe("SubscriptionTierSection", () => {
 
   it("hides action buttons when payment flag is disabled", () => {
     mockPaymentEnabled = false;
-    setupMocks({ subscription: makeSubscription({ tier: "FREE" }) });
+    setupMocks({ subscription: makeSubscription({ tier: "BASIC" }) });
     render(<SubscriptionTierSection />);
     // Tier cards still visible
     expect(screen.getByText("Pro")).toBeDefined();
@@ -335,12 +335,12 @@ describe("SubscriptionTierSection", () => {
   });
 
   it("hides tiers that are missing from tier_costs (no LD price configured)", () => {
-    // LD only has stripe-price-id-basic → only FREE appears; PRO/Max/Business
+    // LD only has stripe-price-id-basic → only BASIC appears; PRO/Max/Business
     // cards must hide.
     setupMocks({
       subscription: makeSubscription({
-        tier: "FREE",
-        tierCosts: { FREE: 0 },
+        tier: "BASIC",
+        tierCosts: { BASIC: 0 },
       }),
     });
     render(<SubscriptionTierSection />);
@@ -355,8 +355,8 @@ describe("SubscriptionTierSection", () => {
     // (stripe-price-id-business unset) and must not render.
     setupMocks({
       subscription: makeSubscription({
-        tier: "FREE",
-        tierCosts: { FREE: 0, PRO: 1999, MAX: 32000 },
+        tier: "BASIC",
+        tierCosts: { BASIC: 0, PRO: 1999, MAX: 32000 },
       }),
     });
     render(<SubscriptionTierSection />);
@@ -376,7 +376,7 @@ describe("SubscriptionTierSection", () => {
     render(<SubscriptionTierSection />);
     expect(screen.getByText("Max")).toBeDefined();
     expect(screen.getByText("Pro")).toBeDefined();
-    // FREE has no price AND isn't the current tier → hidden.
+    // BASIC has no price AND isn't the current tier → hidden.
     expect(screen.queryByText("Basic")).toBeNull();
   });
 
@@ -537,7 +537,7 @@ describe("SubscriptionTierSection", () => {
   it("disables the tier button that matches the pending tier so users can't overwrite their own scheduled change by mis-click", () => {
     // User is on MAX and has a pending downgrade to PRO. The "Downgrade
     // to Pro" button must be disabled + labelled "Scheduled" so the primary
-    // cancel path stays the banner. Other tier buttons (FREE here) remain
+    // cancel path stays the banner. Other tier buttons (BASIC here) remain
     // clickable — the user can still overwrite their pending change by
     // picking a different target; backend handles that.
     setupMocks({
@@ -553,17 +553,19 @@ describe("SubscriptionTierSection", () => {
     expect(scheduledBtn).toBeDefined();
     expect((scheduledBtn as HTMLButtonElement).disabled).toBe(true);
 
-    // The non-pending tier (FREE) button is still clickable.
-    const freeBtn = screen.getByRole("button", { name: /downgrade to basic/i });
-    expect((freeBtn as HTMLButtonElement).disabled).toBe(false);
+    // The non-pending tier (BASIC) button is still clickable.
+    const basicBtn = screen.getByRole("button", {
+      name: /downgrade to basic/i,
+    });
+    expect((basicBtn as HTMLButtonElement).disabled).toBe(false);
   });
 
   it("shows replace-pending dialog when clicking a non-pending tier while a pending change exists, and fires the mutation after confirm", async () => {
-    // User is on MAX with a pending downgrade to PRO. Clicking FREE (a
+    // User is on MAX with a pending downgrade to PRO. Clicking BASIC (a
     // tier that is neither current nor the pending target) must NOT silently
     // overwrite the pending schedule — it must open a confirmation dialog.
     // Only after the user explicitly confirms should changeTier (→ its own
-    // downgrade confirm for paid→FREE) fire.
+    // downgrade confirm for paid→BASIC) fire.
     const mutateFn = vi
       .fn()
       .mockResolvedValue({ status: 200, data: { url: "" } });
@@ -577,7 +579,7 @@ describe("SubscriptionTierSection", () => {
     });
     render(<SubscriptionTierSection />);
 
-    // Clicking FREE while PRO is pending surfaces the replace-pending dialog
+    // Clicking BASIC while PRO is pending surfaces the replace-pending dialog
     // before anything mutates.
     fireEvent.click(
       screen.getByRole("button", { name: /downgrade to basic/i }),
@@ -587,7 +589,7 @@ describe("SubscriptionTierSection", () => {
     expect(mutateFn).not.toHaveBeenCalled();
 
     // Confirm the replace: the replace-pending dialog closes and the
-    // downgrade-to-FREE dialog takes over (because FREE is a downgrade).
+    // downgrade-to-BASIC dialog takes over (because BASIC is a downgrade).
     fireEvent.click(
       screen.getByRole("button", { name: /replace pending change/i }),
     );
@@ -599,7 +601,7 @@ describe("SubscriptionTierSection", () => {
     await waitFor(() => {
       expect(mutateFn).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ tier: "FREE" }),
+          data: expect.objectContaining({ tier: "BASIC" }),
         }),
       );
     });
@@ -629,11 +631,11 @@ describe("SubscriptionTierSection", () => {
     expect(mutateFn).not.toHaveBeenCalled();
   });
 
-  it("renders FREE cancellation copy in banner when pending_tier is FREE", () => {
+  it("renders BASIC cancellation copy in banner when pending_tier is BASIC", () => {
     setupMocks({
       subscription: makeSubscription({
         tier: "MAX",
-        pendingTier: "FREE",
+        pendingTier: "BASIC",
         // Noon UTC so the local-formatted date lands on the same day
         // regardless of the runner's timezone (midnight UTC drifts to
         // the prior day in any timezone west of UTC).
@@ -646,7 +648,7 @@ describe("SubscriptionTierSection", () => {
       screen.getByText(/scheduled to cancel your subscription on/i),
     ).toBeDefined();
     expect(screen.getByText(/May 15, 2026/)).toBeDefined();
-    // Must NOT render the "downgrade to" phrasing on FREE cancellation.
+    // Must NOT render the "downgrade to" phrasing on BASIC cancellation.
     expect(screen.queryByText(/scheduled to downgrade to/i)).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
@@ -69,7 +69,7 @@ vi.mock("@/components/molecules/Dialog/Dialog", () => ({
 function makeSubscription({
   tier = "FREE",
   monthlyCost = 0,
-  tierCosts = { FREE: 0, PRO: 1999, BUSINESS: 4999, ENTERPRISE: 0 },
+  tierCosts = { FREE: 0, PRO: 1999, MAX: 32000, ENTERPRISE: 0 },
   prorationCreditCents = 0,
   pendingTier = null as string | null,
   pendingTierEffectiveAt = null as Date | string | null,
@@ -183,12 +183,12 @@ describe("SubscriptionTierSection", () => {
     setupMocks({
       subscription: makeSubscription({
         tier: "FREE",
-        tierCosts: { FREE: 0, PRO: 1999, BUSINESS: 4999, ENTERPRISE: 0 },
+        tierCosts: { FREE: 0, PRO: 1999, MAX: 32000, ENTERPRISE: 0 },
       }),
     });
     render(<SubscriptionTierSection />);
     expect(screen.getByText("$19.99/mo")).toBeDefined();
-    expect(screen.getByText("$49.99/mo")).toBeDefined();
+    expect(screen.getByText("$320.00/mo")).toBeDefined();
     // FREE tier card label is "Basic"; its $0 cost renders "Free".
     expect(screen.getByText("Basic")).toBeDefined();
     expect(screen.getByText("Free")).toBeDefined();
@@ -198,11 +198,11 @@ describe("SubscriptionTierSection", () => {
     setupMocks({
       subscription: makeSubscription({
         tier: "FREE",
-        tierCosts: { FREE: 0, PRO: 0, BUSINESS: 0, ENTERPRISE: 0 },
+        tierCosts: { FREE: 0, PRO: 0, MAX: 0, ENTERPRISE: 0 },
       }),
     });
     render(<SubscriptionTierSection />);
-    // PRO and BUSINESS with cost=0 should show "Pricing available soon"
+    // PRO and MAX with cost=0 should show "Pricing available soon"
     expect(screen.getAllByText("Pricing available soon")).toHaveLength(2);
   });
 
@@ -335,7 +335,8 @@ describe("SubscriptionTierSection", () => {
   });
 
   it("hides tiers that are missing from tier_costs (no LD price configured)", () => {
-    // LD only has stripe-price-id-basic → only FREE appears; PRO/Max cards must hide.
+    // LD only has stripe-price-id-basic → only FREE appears; PRO/Max/Business
+    // cards must hide.
     setupMocks({
       subscription: makeSubscription({
         tier: "FREE",
@@ -346,13 +347,29 @@ describe("SubscriptionTierSection", () => {
     expect(screen.getByText("Basic")).toBeDefined();
     expect(screen.queryByText("Pro")).toBeNull();
     expect(screen.queryByText("Max")).toBeNull();
+    expect(screen.queryByText("Business")).toBeNull();
+  });
+
+  it("renders Max card when tier_costs includes MAX and hides BUSINESS when its flag is unset", () => {
+    // MAX is priced by default (stripe-price-id-max); BUSINESS stays reserved
+    // (stripe-price-id-business unset) and must not render.
+    setupMocks({
+      subscription: makeSubscription({
+        tier: "FREE",
+        tierCosts: { FREE: 0, PRO: 1999, MAX: 32000 },
+      }),
+    });
+    render(<SubscriptionTierSection />);
+    expect(screen.getByText("Max")).toBeDefined();
+    expect(screen.getByText("$320.00/mo")).toBeDefined();
+    expect(screen.queryByText("Business")).toBeNull();
   });
 
   it("always renders the current tier card as a safety net, even when tier_costs omits it", () => {
-    // BUSINESS user but LD dropped stripe-price-id-max → Max must still render.
+    // MAX user but LD dropped stripe-price-id-max → Max must still render.
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         tierCosts: { PRO: 1999 },
       }),
     });
@@ -404,7 +421,7 @@ describe("SubscriptionTierSection", () => {
   it("renders pending-change banner when pending_tier is set", () => {
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "PRO",
         pendingTierEffectiveAt: new Date("2026-11-15T00:00:00Z"),
       }),
@@ -420,7 +437,7 @@ describe("SubscriptionTierSection", () => {
 
   it("does not render pending-change banner when pending_tier is null", () => {
     setupMocks({
-      subscription: makeSubscription({ tier: "BUSINESS", pendingTier: null }),
+      subscription: makeSubscription({ tier: "MAX", pendingTier: null }),
     });
     render(<SubscriptionTierSection />);
     expect(screen.queryByText(/scheduled to downgrade/i)).toBeNull();
@@ -429,15 +446,15 @@ describe("SubscriptionTierSection", () => {
 
   it("clicking Keep [CurrentTier] in banner submits a same-tier update and refetches", async () => {
     // The cancel-pending route was collapsed into POST /credits/subscription as
-    // a same-tier request. Clicking "Keep BUSINESS" calls useUpdateSubscriptionTier
+    // a same-tier request. Clicking "Keep MAX" calls useUpdateSubscriptionTier
     // with tier === current tier so the backend releases any pending schedule.
     const mutateFn = vi
       .fn()
-      .mockResolvedValue({ status: 200, data: { url: "", tier: "BUSINESS" } });
+      .mockResolvedValue({ status: 200, data: { url: "", tier: "MAX" } });
     const refetchFn = vi.fn();
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "PRO",
         pendingTierEffectiveAt: new Date("2026-11-15T00:00:00Z"),
       }),
@@ -451,7 +468,7 @@ describe("SubscriptionTierSection", () => {
     await waitFor(() => {
       expect(mutateFn).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ tier: "BUSINESS" }),
+          data: expect.objectContaining({ tier: "MAX" }),
         }),
       );
       expect(refetchFn).toHaveBeenCalled();
@@ -464,7 +481,7 @@ describe("SubscriptionTierSection", () => {
   });
 
   it("uses end-of-period copy for paid→paid downgrade confirmation", () => {
-    setupMocks({ subscription: makeSubscription({ tier: "BUSINESS" }) });
+    setupMocks({ subscription: makeSubscription({ tier: "MAX" }) });
     render(<SubscriptionTierSection />);
 
     fireEvent.click(screen.getByRole("button", { name: /downgrade to pro/i }));
@@ -490,7 +507,7 @@ describe("SubscriptionTierSection", () => {
     const refetchFn = vi.fn();
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "PRO",
         pendingTierEffectiveAt: new Date("2026-11-15T00:00:00Z"),
       }),
@@ -518,14 +535,14 @@ describe("SubscriptionTierSection", () => {
   });
 
   it("disables the tier button that matches the pending tier so users can't overwrite their own scheduled change by mis-click", () => {
-    // User is on BUSINESS and has a pending downgrade to PRO. The "Downgrade
+    // User is on MAX and has a pending downgrade to PRO. The "Downgrade
     // to Pro" button must be disabled + labelled "Scheduled" so the primary
     // cancel path stays the banner. Other tier buttons (FREE here) remain
     // clickable — the user can still overwrite their pending change by
     // picking a different target; backend handles that.
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "PRO",
         pendingTierEffectiveAt: new Date("2026-11-15T00:00:00Z"),
       }),
@@ -542,7 +559,7 @@ describe("SubscriptionTierSection", () => {
   });
 
   it("shows replace-pending dialog when clicking a non-pending tier while a pending change exists, and fires the mutation after confirm", async () => {
-    // User is on BUSINESS with a pending downgrade to PRO. Clicking FREE (a
+    // User is on MAX with a pending downgrade to PRO. Clicking FREE (a
     // tier that is neither current nor the pending target) must NOT silently
     // overwrite the pending schedule — it must open a confirmation dialog.
     // Only after the user explicitly confirms should changeTier (→ its own
@@ -552,7 +569,7 @@ describe("SubscriptionTierSection", () => {
       .mockResolvedValue({ status: 200, data: { url: "" } });
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "PRO",
         pendingTierEffectiveAt: new Date("2026-11-15T00:00:00Z"),
       }),
@@ -594,7 +611,7 @@ describe("SubscriptionTierSection", () => {
       .mockResolvedValue({ status: 200, data: { url: "" } });
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "PRO",
         pendingTierEffectiveAt: new Date("2026-11-15T00:00:00Z"),
       }),
@@ -615,7 +632,7 @@ describe("SubscriptionTierSection", () => {
   it("renders FREE cancellation copy in banner when pending_tier is FREE", () => {
     setupMocks({
       subscription: makeSubscription({
-        tier: "BUSINESS",
+        tier: "MAX",
         pendingTier: "FREE",
         // Noon UTC so the local-formatted date lands on the same day
         // regardless of the runner's timezone (midnight UTC drifts to

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/__tests__/SubscriptionTierSection.test.tsx
@@ -133,7 +133,7 @@ describe("SubscriptionTierSection", () => {
     render(<SubscriptionTierSection />);
     // Just verify we're rendering something (not null) and no tier cards
     expect(screen.queryByText("Pro")).toBeNull();
-    expect(screen.queryByText("Business")).toBeNull();
+    expect(screen.queryByText("Max")).toBeNull();
   });
 
   it("renders error message when subscription fetch fails", () => {
@@ -156,25 +156,26 @@ describe("SubscriptionTierSection", () => {
   it("renders all three tier cards for FREE user", () => {
     setupMocks();
     render(<SubscriptionTierSection />);
-    // Use getAllByText to account for the tier label AND cost display both containing "Free"
-    expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
+    // FREE tier card is labelled "Basic"; cost displays "Free" for FREE@$0.
+    expect(screen.getByText("Basic")).toBeDefined();
+    expect(screen.getByText("Free")).toBeDefined();
     expect(screen.getByText("Pro")).toBeDefined();
-    expect(screen.getByText("Business")).toBeDefined();
+    expect(screen.getByText("Max")).toBeDefined();
   });
 
   it("shows Current badge on the active tier", () => {
     setupMocks({ subscription: makeSubscription({ tier: "PRO" }) });
     render(<SubscriptionTierSection />);
     expect(screen.getByText("Current")).toBeDefined();
-    // Upgrade to PRO button should NOT exist; Upgrade to BUSINESS and Downgrade to Free should
+    // Upgrade to PRO button should NOT exist; Upgrade to Max and Downgrade to Basic should
     expect(
       screen.queryByRole("button", { name: /upgrade to pro/i }),
     ).toBeNull();
     expect(
-      screen.getByRole("button", { name: /upgrade to business/i }),
+      screen.getByRole("button", { name: /upgrade to max/i }),
     ).toBeDefined();
     expect(
-      screen.getByRole("button", { name: /downgrade to free/i }),
+      screen.getByRole("button", { name: /downgrade to basic/i }),
     ).toBeDefined();
   });
 
@@ -188,8 +189,9 @@ describe("SubscriptionTierSection", () => {
     render(<SubscriptionTierSection />);
     expect(screen.getByText("$19.99/mo")).toBeDefined();
     expect(screen.getByText("$49.99/mo")).toBeDefined();
-    // FREE tier label should still be visible (there may be multiple "Free" elements)
-    expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
+    // FREE tier card label is "Basic"; its $0 cost renders "Free".
+    expect(screen.getByText("Basic")).toBeDefined();
+    expect(screen.getByText("Free")).toBeDefined();
   });
 
   it("shows 'Pricing available soon' when tier cost is 0 for a paid tier", () => {
@@ -231,7 +233,9 @@ describe("SubscriptionTierSection", () => {
     setupMocks({ subscription: makeSubscription({ tier: "PRO" }) });
     render(<SubscriptionTierSection />);
 
-    fireEvent.click(screen.getByRole("button", { name: /downgrade to free/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /downgrade to basic/i }),
+    );
 
     expect(screen.getByRole("dialog")).toBeDefined();
     // The dialog title text appears in both a div and a button — just check the dialog is open
@@ -248,7 +252,9 @@ describe("SubscriptionTierSection", () => {
     });
     render(<SubscriptionTierSection />);
 
-    fireEvent.click(screen.getByRole("button", { name: /downgrade to free/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /downgrade to basic/i }),
+    );
     fireEvent.click(screen.getByRole("button", { name: /confirm downgrade/i }));
 
     await waitFor(() => {
@@ -264,7 +270,9 @@ describe("SubscriptionTierSection", () => {
     setupMocks({ subscription: makeSubscription({ tier: "PRO" }) });
     render(<SubscriptionTierSection />);
 
-    fireEvent.click(screen.getByRole("button", { name: /downgrade to free/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /downgrade to basic/i }),
+    );
     expect(screen.getByRole("dialog")).toBeDefined();
 
     fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
@@ -320,7 +328,7 @@ describe("SubscriptionTierSection", () => {
     render(<SubscriptionTierSection />);
     // Tier cards still visible
     expect(screen.getByText("Pro")).toBeDefined();
-    expect(screen.getByText("Business")).toBeDefined();
+    expect(screen.getByText("Max")).toBeDefined();
     // No upgrade/downgrade buttons
     expect(screen.queryByRole("button", { name: /upgrade/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /downgrade/i })).toBeNull();
@@ -334,7 +342,7 @@ describe("SubscriptionTierSection", () => {
     expect(screen.getByText(/managed by your administrator/i)).toBeDefined();
     // No standard tier cards should be rendered
     expect(screen.queryByText("Pro")).toBeNull();
-    expect(screen.queryByText("Business")).toBeNull();
+    expect(screen.queryByText("Max")).toBeNull();
   });
 
   it("shows success toast and clears URL param when ?subscription=success is present", async () => {
@@ -374,11 +382,11 @@ describe("SubscriptionTierSection", () => {
     });
     render(<SubscriptionTierSection />);
     expect(screen.getByText(/scheduled to downgrade to/i)).toBeDefined();
-    // Banner "Keep Business" button — the only Keep button, since the on-card
+    // Banner "Keep Max" button — the only Keep button, since the on-card
     // duplicate was removed in favour of the banner.
-    expect(
-      screen.getAllByRole("button", { name: /keep business/i }),
-    ).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: /keep max/i })).toHaveLength(
+      1,
+    );
   });
 
   it("does not render pending-change banner when pending_tier is null", () => {
@@ -387,7 +395,7 @@ describe("SubscriptionTierSection", () => {
     });
     render(<SubscriptionTierSection />);
     expect(screen.queryByText(/scheduled to downgrade/i)).toBeNull();
-    expect(screen.queryByRole("button", { name: /keep business/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /keep max/i })).toBeNull();
   });
 
   it("clicking Keep [CurrentTier] in banner submits a same-tier update and refetches", async () => {
@@ -409,7 +417,7 @@ describe("SubscriptionTierSection", () => {
     });
     render(<SubscriptionTierSection />);
 
-    fireEvent.click(screen.getByRole("button", { name: /keep business/i }));
+    fireEvent.click(screen.getByRole("button", { name: /keep max/i }));
 
     await waitFor(() => {
       expect(mutateFn).toHaveBeenCalledWith(
@@ -463,7 +471,7 @@ describe("SubscriptionTierSection", () => {
     render(<SubscriptionTierSection />);
 
     const keepButtons = screen.getAllByRole("button", {
-      name: /keep business/i,
+      name: /keep max/i,
     });
     fireEvent.click(keepButtons[0]);
 
@@ -500,7 +508,7 @@ describe("SubscriptionTierSection", () => {
     expect((scheduledBtn as HTMLButtonElement).disabled).toBe(true);
 
     // The non-pending tier (FREE) button is still clickable.
-    const freeBtn = screen.getByRole("button", { name: /downgrade to free/i });
+    const freeBtn = screen.getByRole("button", { name: /downgrade to basic/i });
     expect((freeBtn as HTMLButtonElement).disabled).toBe(false);
   });
 
@@ -525,7 +533,9 @@ describe("SubscriptionTierSection", () => {
 
     // Clicking FREE while PRO is pending surfaces the replace-pending dialog
     // before anything mutates.
-    fireEvent.click(screen.getByRole("button", { name: /downgrade to free/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /downgrade to basic/i }),
+    );
     expect(screen.getByRole("dialog")).toBeDefined();
     expect(screen.getByText(/replace pending change/i)).toBeDefined();
     expect(mutateFn).not.toHaveBeenCalled();
@@ -563,7 +573,9 @@ describe("SubscriptionTierSection", () => {
     });
     render(<SubscriptionTierSection />);
 
-    fireEvent.click(screen.getByRole("button", { name: /downgrade to free/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /downgrade to basic/i }),
+    );
     expect(screen.getByRole("dialog")).toBeDefined();
 
     fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/PendingChangeBanner.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/PendingChangeBanner.tsx
@@ -25,7 +25,7 @@ export function PendingChangeBanner({
   const currentLabel = getTierLabel(currentTier);
   const dateText = formatPendingDate(pendingEffectiveAt);
 
-  const isCancellation = pendingTier === "FREE";
+  const isCancellation = pendingTier === "BASIC";
 
   return (
     <div

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
@@ -43,9 +43,7 @@ describe("PendingChangeBanner", () => {
     );
     expect(screen.getByText(/downgrade to/i)).toBeDefined();
     expect(screen.getByText("Pro")).toBeDefined();
-    expect(
-      screen.getByRole("button", { name: /keep max/i }),
-    ).toBeDefined();
+    expect(screen.getByRole("button", { name: /keep max/i })).toBeDefined();
   });
 
   it("invokes onKeepCurrent when the button is clicked", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
@@ -37,7 +37,7 @@ describe("PendingChangeBanner", () => {
     render(
       <PendingChangeBanner
         {...baseProps}
-        currentTier="BUSINESS"
+        currentTier="MAX"
         pendingTier="PRO"
       />,
     );

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
@@ -44,7 +44,7 @@ describe("PendingChangeBanner", () => {
     expect(screen.getByText(/downgrade to/i)).toBeDefined();
     expect(screen.getByText("Pro")).toBeDefined();
     expect(
-      screen.getByRole("button", { name: /keep business/i }),
+      screen.getByRole("button", { name: /keep max/i }),
     ).toBeDefined();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/components/PendingChangeBanner/__tests__/PendingChangeBanner.test.tsx
@@ -7,7 +7,7 @@ import { PendingChangeBanner } from "../PendingChangeBanner";
 describe("PendingChangeBanner", () => {
   const baseProps = {
     currentTier: "PRO",
-    pendingTier: "FREE",
+    pendingTier: "BASIC",
     // Use noon UTC so the formatted local date lands on the same day
     // regardless of the host timezone (important for CI runners).
     pendingEffectiveAt: "2026-05-01T12:00:00Z",
@@ -25,7 +25,7 @@ describe("PendingChangeBanner", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("shows cancellation copy when pending tier is FREE", () => {
+  it("shows cancellation copy when pending tier is BASIC", () => {
     render(<PendingChangeBanner {...baseProps} />);
     expect(screen.getByText(/cancel your subscription on/i)).toBeDefined();
     expect(screen.getByText("May 1, 2026")).toBeDefined();

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.test.ts
@@ -9,9 +9,12 @@ import {
 } from "./helpers";
 
 describe("formatCost", () => {
-  it("returns 'Free' for the FREE tier regardless of cents", () => {
+  it("returns 'Free' only when FREE actually costs $0", () => {
     expect(formatCost(0, "FREE")).toBe("Free");
-    expect(formatCost(999, "FREE")).toBe("Free");
+  });
+
+  it("formats FREE to a dollars-per-month string when LD sets a non-zero price", () => {
+    expect(formatCost(999, "FREE")).toBe("$9.99/mo");
   });
 
   it("returns a placeholder when paid tier has no price yet", () => {
@@ -27,9 +30,9 @@ describe("formatCost", () => {
 
 describe("getTierLabel", () => {
   it("returns the canonical label for known tiers", () => {
-    expect(getTierLabel("FREE")).toBe("Free");
+    expect(getTierLabel("FREE")).toBe("Basic");
     expect(getTierLabel("PRO")).toBe("Pro");
-    expect(getTierLabel("BUSINESS")).toBe("Business");
+    expect(getTierLabel("BUSINESS")).toBe("Max");
   });
 
   it("title-cases unknown tier keys as a fallback", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.test.ts
@@ -19,11 +19,13 @@ describe("formatCost", () => {
 
   it("returns a placeholder when paid tier has no price yet", () => {
     expect(formatCost(0, "PRO")).toBe("Pricing available soon");
+    expect(formatCost(0, "MAX")).toBe("Pricing available soon");
     expect(formatCost(0, "BUSINESS")).toBe("Pricing available soon");
   });
 
   it("formats cents to a dollars-per-month string for paid tiers", () => {
     expect(formatCost(999, "PRO")).toBe("$9.99/mo");
+    expect(formatCost(32000, "MAX")).toBe("$320.00/mo");
     expect(formatCost(4900, "BUSINESS")).toBe("$49.00/mo");
   });
 });
@@ -32,7 +34,8 @@ describe("getTierLabel", () => {
   it("returns the canonical label for known tiers", () => {
     expect(getTierLabel("FREE")).toBe("Basic");
     expect(getTierLabel("PRO")).toBe("Pro");
-    expect(getTierLabel("BUSINESS")).toBe("Max");
+    expect(getTierLabel("MAX")).toBe("Max");
+    expect(getTierLabel("BUSINESS")).toBe("Business");
   });
 
   it("title-cases unknown tier keys as a fallback", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.test.ts
@@ -9,12 +9,12 @@ import {
 } from "./helpers";
 
 describe("formatCost", () => {
-  it("returns 'Free' only when FREE actually costs $0", () => {
-    expect(formatCost(0, "FREE")).toBe("Free");
+  it("returns 'Free' only when BASIC actually costs $0", () => {
+    expect(formatCost(0, "BASIC")).toBe("Free");
   });
 
-  it("formats FREE to a dollars-per-month string when LD sets a non-zero price", () => {
-    expect(formatCost(999, "FREE")).toBe("$9.99/mo");
+  it("formats BASIC to a dollars-per-month string when LD sets a non-zero price", () => {
+    expect(formatCost(999, "BASIC")).toBe("$9.99/mo");
   });
 
   it("returns a placeholder when paid tier has no price yet", () => {
@@ -32,7 +32,7 @@ describe("formatCost", () => {
 
 describe("getTierLabel", () => {
   it("returns the canonical label for known tiers", () => {
-    expect(getTierLabel("FREE")).toBe("Basic");
+    expect(getTierLabel("BASIC")).toBe("Basic");
     expect(getTierLabel("PRO")).toBe("Pro");
     expect(getTierLabel("MAX")).toBe("Max");
     expect(getTierLabel("BUSINESS")).toBe("Business");

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
@@ -8,7 +8,7 @@ export interface TierInfo {
 export const TIERS: TierInfo[] = [
   {
     key: "FREE",
-    label: "Free",
+    label: "Basic",
     multiplier: "1x",
     description: "Base AutoPilot capacity with standard rate limits",
   },
@@ -20,7 +20,7 @@ export const TIERS: TierInfo[] = [
   },
   {
     key: "BUSINESS",
-    label: "Business",
+    label: "Max",
     multiplier: "20x",
     description: "20x AutoPilot capacity — ideal for teams and heavy workloads",
   },
@@ -29,8 +29,8 @@ export const TIERS: TierInfo[] = [
 export const TIER_ORDER = ["FREE", "PRO", "BUSINESS", "ENTERPRISE"];
 
 export function formatCost(cents: number, tierKey: string): string {
-  if (tierKey === "FREE") return "Free";
-  if (cents === 0) return "Pricing available soon";
+  if (cents === 0)
+    return tierKey === "FREE" ? "Free" : "Pricing available soon";
   return `$${(cents / 100).toFixed(2)}/mo`;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
@@ -19,14 +19,20 @@ export const TIERS: TierInfo[] = [
     description: "5x AutoPilot capacity — run 5× more tasks per day/week",
   },
   {
-    key: "BUSINESS",
+    key: "MAX",
     label: "Max",
+    multiplier: "20x",
+    description: "20x AutoPilot capacity — ideal for power users",
+  },
+  {
+    key: "BUSINESS",
+    label: "Business",
     multiplier: "60x",
     description: "60x AutoPilot capacity — ideal for teams and heavy workloads",
   },
 ];
 
-export const TIER_ORDER = ["FREE", "PRO", "BUSINESS", "ENTERPRISE"];
+export const TIER_ORDER = ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
 
 export function formatCost(cents: number, tierKey: string): string {
   if (cents === 0)

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
@@ -7,7 +7,7 @@ export interface TierInfo {
 
 export const TIERS: TierInfo[] = [
   {
-    key: "FREE",
+    key: "BASIC",
     label: "Basic",
     multiplier: "1x",
     description: "Base AutoPilot capacity with standard rate limits",
@@ -32,11 +32,11 @@ export const TIERS: TierInfo[] = [
   },
 ];
 
-export const TIER_ORDER = ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
+export const TIER_ORDER = ["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
 
 export function formatCost(cents: number, tierKey: string): string {
   if (cents === 0)
-    return tierKey === "FREE" ? "Free" : "Pricing available soon";
+    return tierKey === "BASIC" ? "Free" : "Pricing available soon";
   return `$${(cents / 100).toFixed(2)}/mo`;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/helpers.ts
@@ -21,8 +21,8 @@ export const TIERS: TierInfo[] = [
   {
     key: "BUSINESS",
     label: "Max",
-    multiplier: "20x",
-    description: "20x AutoPilot capacity — ideal for teams and heavy workloads",
+    multiplier: "60x",
+    description: "60x AutoPilot capacity — ideal for teams and heavy workloads",
   },
 ];
 

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/useSubscriptionTierSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/useSubscriptionTierSection.ts
@@ -11,7 +11,7 @@ import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 
 export type SubscriptionStatus = SubscriptionStatusResponse;
 
-const TIER_ORDER = ["FREE", "PRO", "BUSINESS", "ENTERPRISE"];
+const TIER_ORDER = ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
 
 export function useSubscriptionTierSection() {
   const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/useSubscriptionTierSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/useSubscriptionTierSection.ts
@@ -11,7 +11,7 @@ import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 
 export type SubscriptionStatus = SubscriptionStatusResponse;
 
-const TIER_ORDER = ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
+const TIER_ORDER = ["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"];
 
 export function useSubscriptionTierSection() {
   const isPaymentEnabled = useGetFlag(Flag.ENABLE_PLATFORM_PAYMENT);
@@ -85,8 +85,8 @@ export function useSubscriptionTierSection() {
       toast({
         title: "Subscription updated",
         description:
-          tier === "FREE"
-            ? "Your plan will be downgraded to Free at the end of your current billing period."
+          tier === "BASIC"
+            ? "Your plan will be downgraded to Basic at the end of your current billing period."
             : "Your subscription has been updated.",
       });
     } catch (e: unknown) {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -15982,7 +15982,7 @@
         "properties": {
           "tier": {
             "type": "string",
-            "enum": ["FREE", "PRO", "BUSINESS", "ENTERPRISE"],
+            "enum": ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
             "title": "Tier"
           },
           "monthly_cost": { "type": "integer", "title": "Monthly Cost" },
@@ -15997,7 +15997,7 @@
           },
           "pending_tier": {
             "anyOf": [
-              { "type": "string", "enum": ["FREE", "PRO", "BUSINESS"] },
+              { "type": "string", "enum": ["FREE", "PRO", "MAX", "BUSINESS"] },
               { "type": "null" }
             ],
             "title": "Pending Tier"
@@ -16027,7 +16027,7 @@
       },
       "SubscriptionTier": {
         "type": "string",
-        "enum": ["FREE", "PRO", "BUSINESS", "ENTERPRISE"],
+        "enum": ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
         "title": "SubscriptionTier",
         "description": "Subscription tiers with increasing cost allowances.\n\nMirrors the ``SubscriptionTier`` enum in ``schema.prisma``.\nOnce ``prisma generate`` is run, this can be replaced with::\n\n    from prisma.enums import SubscriptionTier"
       },
@@ -16035,7 +16035,7 @@
         "properties": {
           "tier": {
             "type": "string",
-            "enum": ["FREE", "PRO", "BUSINESS"],
+            "enum": ["FREE", "PRO", "MAX", "BUSINESS"],
             "title": "Tier"
           },
           "success_url": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -10377,7 +10377,7 @@
           },
           "tier": {
             "$ref": "#/components/schemas/SubscriptionTier",
-            "default": "FREE"
+            "default": "BASIC"
           },
           "reset_cost": {
             "type": "integer",
@@ -15982,7 +15982,7 @@
         "properties": {
           "tier": {
             "type": "string",
-            "enum": ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
+            "enum": ["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
             "title": "Tier"
           },
           "monthly_cost": { "type": "integer", "title": "Monthly Cost" },
@@ -15997,7 +15997,7 @@
           },
           "pending_tier": {
             "anyOf": [
-              { "type": "string", "enum": ["FREE", "PRO", "MAX", "BUSINESS"] },
+              { "type": "string", "enum": ["BASIC", "PRO", "MAX", "BUSINESS"] },
               { "type": "null" }
             ],
             "title": "Pending Tier"
@@ -16012,7 +16012,7 @@
           "url": {
             "type": "string",
             "title": "Url",
-            "description": "Populated only when POST /credits/subscription starts a Stripe Checkout Session (FREE → paid upgrade). Empty string in all other branches — the client redirects to this URL when non-empty.",
+            "description": "Populated only when POST /credits/subscription starts a Stripe Checkout Session (BASIC → paid upgrade). Empty string in all other branches — the client redirects to this URL when non-empty.",
             "default": ""
           }
         },
@@ -16027,7 +16027,7 @@
       },
       "SubscriptionTier": {
         "type": "string",
-        "enum": ["FREE", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
+        "enum": ["BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
         "title": "SubscriptionTier",
         "description": "Subscription tiers with increasing cost allowances.\n\nMirrors the ``SubscriptionTier`` enum in ``schema.prisma``.\nOnce ``prisma generate`` is run, this can be replaced with::\n\n    from prisma.enums import SubscriptionTier"
       },
@@ -16035,7 +16035,7 @@
         "properties": {
           "tier": {
             "type": "string",
-            "enum": ["FREE", "PRO", "MAX", "BUSINESS"],
+            "enum": ["BASIC", "PRO", "MAX", "BUSINESS"],
             "title": "Tier"
           },
           "success_url": {


### PR DESCRIPTION
## What

Introduces a new `MAX` tier slot between `PRO` and `BUSINESS` (self-service $320/mo at 20× capacity), routes every self-service tier's Stripe price ID through LaunchDarkly, and hides tiers from the UI when their price isn't configured. `BUSINESS` stays in the enum at 60× as a reserved/future self-service slot (hidden by default until its LD price flag is set). ENTERPRISE stays admin-managed.

## Tier shape after this PR

| Enum | UI label | Multiplier | LD price flag | Surfaced in UI by default |
|---|---|---|---|---|
| `FREE` | Basic | 1× | `stripe-price-id-basic` | no (flag unset) |
| `PRO` | Pro | 5× | `stripe-price-id-pro` | yes (already live) |
| `MAX` **(new)** | Max | 20× | `stripe-price-id-max` | no (flag unset until $320 price ready) |
| `BUSINESS` | Business | 60× | `stripe-price-id-business` | no (reserved / future) |
| `ENTERPRISE` | — | 60× | — (admin-managed) | no (Contact-Us only) |

## Prisma

- Added `MAX` between `PRO` and `BUSINESS` in `SubscriptionTier`.
- Migration `add_subscription_tier_max/migration.sql` uses `ALTER TYPE ... ADD VALUE IF NOT EXISTS 'MAX' BEFORE 'BUSINESS'` (transactional since PG 12). No data migration — no rows currently on BUSINESS via self-service flows.

## Backend

- `get_subscription_price_id` flag map covers `FREE`/`PRO`/`MAX`/`BUSINESS`. ENTERPRISE returns `None`.
- `GET /credits/subscription.tier_costs` only includes tiers whose LD price ID is set. Current tier always present as a safety net.
- `POST /credits/subscription` routes by LD-resolved prices instead of hard-coding `tier == FREE`:
  - Target `FREE` + `stripe-price-id-basic` unset → legacy cancel-at-period-end (unchanged behaviour).
  - Target has LD price → modify in-place when user has an active sub, else Checkout Session.
  - Priced-FREE users with no sub fall through to Checkout (admin-granted DB-flip shortcut gated on `current_tier != FREE`).
- `sync_subscription_from_stripe` + `get_pending_subscription_change` cover FREE/PRO/MAX/BUSINESS in the price-to-tier map so every tier's Stripe webhook reconciles cleanly.
- Pending-tier mapping collapsed into a single membership check.
- `TIER_MULTIPLIERS`: `FREE=1, PRO=5, MAX=20, BUSINESS=60, ENTERPRISE=60`.

## Frontend

- UI labels: FREE→"Basic", MAX→"Max", BUSINESS→"Business" (PRO unchanged). `TIER_ORDER` now `[FREE, PRO, MAX, BUSINESS, ENTERPRISE]`.
- `SubscriptionTierSection` filters by `tier_costs` — any tier without a backend-provided price is hidden (current tier always visible).
- `formatCost` surfaces "Free" only when `FREE` is actually `$0`; non-zero `stripe-price-id-basic` renders `$X.XX/mo`.
- Admin rate-limit display lists all five tiers with multiplier badges.

## LaunchDarkly flag actions (operator)

- **New:** `stripe-price-id-basic` → FREE tier. Set to `""` or a `$0` Stripe price.
- **New:** `stripe-price-id-max` → MAX tier. Point at the `$320` Stripe price when you launch the Max tier.
- **Unchanged:** `stripe-price-id-pro` (PRO), `stripe-price-id-business` (BUSINESS — leave unset until you're ready for the 60× Business tier).
- Base rate limits stay on `copilot-daily-cost-limit-microdollars` / `copilot-weekly-cost-limit-microdollars` (Basic's limit; everything else = × tier multiplier).

## Out of scope

- Subscription-required onboarding screen / middleware gating (separate PR).
- "Pricing available soon" vs Stripe-failure disambiguation in the UI (follow-up).

## Testing

- Backend: 213 tests across `subscription_routes_test.py`, `credit_subscription_test.py`, `rate_limit_test.py`, `admin/rate_limit_admin_routes_test.py` — all passing.
- Frontend: 91 tests across `credits/` + `admin/rate-limits/` — all passing.
- Fresh-backend manual E2E on the pre-MAX commit confirmed tier-hiding works (`tier_costs` returns only the current tier when LD flags are unset).

## Checklist

- [x] I have read the project's contributing guide.
- [x] I have clearly described what this PR changes and why.
- [x] My code follows the style guidelines of this project.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes (CI will confirm).