### PR TITLE
feat(frontend): preferences v2 page (SECRT-2279)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c82c93e3-9c17-4f46-8d35-3b817da472f0","pid":14032,"acquiredAt":1777297402595}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c82c93e3-9c17-4f46-8d35-3b817da472f0","pid":14032,"acquiredAt":1777297402595}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/SettingsMobileNav.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/SettingsMobileNav.test.tsx
@@ -70,7 +70,7 @@ describe("SettingsMobileNav", () => {
       "Creator Dashboard",
       "Billing",
       "Integrations",
-      "Settings",
+      "Preferences",
       "AutoGPT API Keys",
       "OAuth Apps",
     ];

--- a/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/SettingsSidebar.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/SettingsSidebar.test.tsx
@@ -44,7 +44,7 @@ const expectedItems = [
   { label: "Creator Dashboard", href: "/settings/creator-dashboard" },
   { label: "Billing", href: "/settings/billing" },
   { label: "Integrations", href: "/settings/integrations" },
-  { label: "Settings", href: "/settings/preferences" },
+  { label: "Preferences", href: "/settings/preferences" },
   { label: "AutoGPT API Keys", href: "/settings/api-keys" },
   { label: "OAuth Apps", href: "/settings/oauth-apps" },
 ];

--- a/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/placeholder-pages.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/placeholder-pages.test.tsx
@@ -3,14 +3,12 @@ import { describe, expect, it } from "vitest";
 import SettingsProfilePage from "../profile/page";
 import SettingsCreatorDashboardPage from "../creator-dashboard/page";
 import SettingsBillingPage from "../billing/page";
-import SettingsPreferencesPage from "../preferences/page";
 import SettingsOAuthAppsPage from "../oauth-apps/page";
 
 const pages = [
   { Component: SettingsProfilePage, title: "Profile" },
   { Component: SettingsCreatorDashboardPage, title: "Creator Dashboard" },
   { Component: SettingsBillingPage, title: "Billing" },
-  { Component: SettingsPreferencesPage, title: "Settings" },
   { Component: SettingsOAuthAppsPage, title: "OAuth Apps" },
 ];
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/components/SettingsSidebar/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/components/SettingsSidebar/helpers.ts
@@ -1,11 +1,11 @@
 import {
+  ChartLineUpIcon,
   CreditCardIcon,
-  GearIcon,
   IdentificationBadgeIcon,
   KeyIcon,
   PlugsConnectedIcon,
-  SquaresFourIcon,
-  UserCircleIcon,
+  SlidersHorizontalIcon,
+  UserIcon,
   type Icon as PhosphorIcon,
 } from "@phosphor-icons/react";
 
@@ -16,11 +16,11 @@ export interface SettingsNavItem {
 }
 
 export const settingsNavItems: SettingsNavItem[] = [
-  { label: "Profile", href: "/settings/profile", Icon: UserCircleIcon },
+  { label: "Profile", href: "/settings/profile", Icon: UserIcon },
   {
     label: "Creator Dashboard",
     href: "/settings/creator-dashboard",
-    Icon: SquaresFourIcon,
+    Icon: ChartLineUpIcon,
   },
   { label: "Billing", href: "/settings/billing", Icon: CreditCardIcon },
   {
@@ -28,7 +28,11 @@ export const settingsNavItems: SettingsNavItem[] = [
     href: "/settings/integrations",
     Icon: PlugsConnectedIcon,
   },
-  { label: "Settings", href: "/settings/preferences", Icon: GearIcon },
+  {
+    label: "Preferences",
+    href: "/settings/preferences",
+    Icon: SlidersHorizontalIcon,
+  },
   { label: "AutoGPT API Keys", href: "/settings/api-keys", Icon: KeyIcon },
   {
     label: "OAuth Apps",

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
@@ -212,6 +212,103 @@ describe("SettingsPreferencesPage", () => {
     expect(flippedKey).toBeDefined();
   });
 
+  test("saving a timezone change posts the new value", async () => {
+    let submittedTimezone: string | undefined;
+
+    server.use(
+      getGetV1GetNotificationPreferencesMockHandler({
+        user_id: "user-1",
+        email: "user@example.com",
+        preferences: allFalsePreferences,
+        daily_limit: 0,
+        emails_sent_today: 0,
+        last_reset_date: baseDate,
+      }),
+      getGetV1GetUserTimezoneMockHandler({ timezone: "Asia/Kolkata" }),
+      getPostV1UpdateUserEmailMockHandler({}),
+      getPostV1UpdateNotificationPreferencesMockHandler({
+        user_id: "user-1",
+        email: "user@example.com",
+        preferences: {},
+        daily_limit: 0,
+        emails_sent_today: 0,
+        last_reset_date: baseDate,
+      }),
+      getPostV1UpdateUserTimezoneMockHandler(async ({ request }) => {
+        const body = (await request.json()) as { timezone: string };
+        submittedTimezone = body.timezone;
+        return { timezone: body.timezone };
+      }),
+    );
+
+    render(<SettingsPreferencesPage />);
+
+    const select = await screen.findByRole("combobox", { name: "Timezone" });
+    fireEvent.click(select);
+
+    const option = await screen.findByRole("option", {
+      name: /London/i,
+    });
+    fireEvent.click(option);
+
+    const saveButton = screen.getByRole("button", { name: "Save changes" });
+
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(submittedTimezone).toBe("Europe/London");
+    });
+  });
+
+  test("submitting a new email closes the dialog and calls the update endpoint", async () => {
+    const fetchMock = vi.fn(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    setupBaseHandlers();
+
+    render(<SettingsPreferencesPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Edit email" }),
+    );
+
+    const dialogInput = (await screen.findByLabelText(
+      "Email",
+    )) as HTMLInputElement;
+    fireEvent.change(dialogInput, { target: { value: "new@example.com" } });
+
+    const updateButton = screen.getByRole("button", { name: "Update email" });
+    await waitFor(() => {
+      expect((updateButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(updateButton);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/auth/user",
+        expect.objectContaining({ method: "PUT" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Email")).toBeNull();
+    });
+
+    vi.unstubAllGlobals();
+  });
+
   test("Discard reverts unsaved notification toggles", async () => {
     setupBaseHandlers();
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
@@ -1,0 +1,243 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  getGetV1GetNotificationPreferencesMockHandler,
+  getGetV1GetUserTimezoneMockHandler,
+  getPostV1UpdateNotificationPreferencesMockHandler,
+  getPostV1UpdateUserEmailMockHandler,
+  getPostV1UpdateUserTimezoneMockHandler,
+} from "@/app/api/__generated__/endpoints/auth/auth.msw";
+import { server } from "@/mocks/mock-server";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+
+import SettingsPreferencesPage from "../page";
+
+const mockUseSupabase = vi.hoisted(() => vi.fn());
+
+vi.mock("@/providers/onboarding/onboarding-provider", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: mockUseSupabase,
+}));
+
+const testUser = {
+  id: "user-1",
+  email: "user@example.com",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const baseDate = new Date("2026-01-01T00:00:00.000Z");
+
+const allFalsePreferences = {
+  AGENT_RUN: false,
+  ZERO_BALANCE: false,
+  LOW_BALANCE: false,
+  BLOCK_EXECUTION_FAILED: false,
+  CONTINUOUS_AGENT_ERROR: false,
+  DAILY_SUMMARY: false,
+  WEEKLY_SUMMARY: false,
+  MONTHLY_SUMMARY: false,
+  AGENT_APPROVED: false,
+  AGENT_REJECTED: false,
+};
+
+function setupBaseHandlers(
+  options: { timezone?: string; preferences?: Record<string, boolean> } = {},
+) {
+  server.use(
+    getGetV1GetNotificationPreferencesMockHandler({
+      user_id: "user-1",
+      email: "user@example.com",
+      preferences: options.preferences ?? allFalsePreferences,
+      daily_limit: 0,
+      emails_sent_today: 0,
+      last_reset_date: baseDate,
+    }),
+    getGetV1GetUserTimezoneMockHandler({
+      timezone: options.timezone ?? "Asia/Kolkata",
+    }),
+    getPostV1UpdateUserEmailMockHandler({}),
+    getPostV1UpdateNotificationPreferencesMockHandler({
+      user_id: "user-1",
+      email: "user@example.com",
+      preferences: {},
+      daily_limit: 0,
+      emails_sent_today: 0,
+      last_reset_date: baseDate,
+    }),
+    getPostV1UpdateUserTimezoneMockHandler({
+      timezone: "Europe/London",
+    }),
+  );
+}
+
+describe("SettingsPreferencesPage", () => {
+  beforeEach(() => {
+    mockUseSupabase.mockReturnValue({
+      user: testUser,
+      isLoggedIn: true,
+      isUserLoading: false,
+      supabase: {},
+    });
+  });
+
+  test("renders Account card with current email and reset password link", async () => {
+    setupBaseHandlers();
+
+    render(<SettingsPreferencesPage />);
+
+    expect(await screen.findByText("Account")).toBeDefined();
+    expect(screen.getByText("user@example.com")).toBeDefined();
+    expect(screen.getByText("Email")).toBeDefined();
+    expect(screen.getByText("Password")).toBeDefined();
+
+    const resetLink = screen.getByRole("link", { name: "Reset password" });
+    expect(resetLink.getAttribute("href")).toBe("/reset-password");
+  });
+
+  test("opens email update dialog and closes on Cancel", async () => {
+    setupBaseHandlers();
+
+    render(<SettingsPreferencesPage />);
+
+    const editButton = await screen.findByRole("button", {
+      name: "Edit email",
+    });
+    fireEvent.click(editButton);
+
+    const dialogInput = await screen.findByLabelText("Email");
+    expect((dialogInput as HTMLInputElement).value).toBe("user@example.com");
+
+    const updateButton = screen.getByRole("button", { name: "Update email" });
+    expect((updateButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Email")).toBeNull();
+    });
+  });
+
+  test("renders Time zone card with info tooltip trigger", async () => {
+    setupBaseHandlers({ timezone: "Asia/Kolkata" });
+
+    render(<SettingsPreferencesPage />);
+
+    expect(await screen.findByText("Time zone")).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Time zone info" }),
+    ).toBeDefined();
+  });
+
+  test("Save and Discard buttons start disabled when nothing has changed", async () => {
+    setupBaseHandlers();
+
+    render(<SettingsPreferencesPage />);
+
+    const saveButton = await screen.findByRole("button", {
+      name: "Save changes",
+    });
+    const discardButton = screen.getByRole("button", { name: "Discard" });
+
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+    expect((discardButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test("toggling a notification enables Save and persists on click", async () => {
+    let submittedPreferences:
+      | { email: string; preferences: Record<string, boolean> }
+      | undefined;
+
+    server.use(
+      getGetV1GetNotificationPreferencesMockHandler({
+        user_id: "user-1",
+        email: "user@example.com",
+        preferences: allFalsePreferences,
+        daily_limit: 0,
+        emails_sent_today: 0,
+        last_reset_date: baseDate,
+      }),
+      getGetV1GetUserTimezoneMockHandler({ timezone: "Asia/Kolkata" }),
+      getPostV1UpdateUserEmailMockHandler({}),
+      getPostV1UpdateUserTimezoneMockHandler({ timezone: "Asia/Kolkata" }),
+      getPostV1UpdateNotificationPreferencesMockHandler(async ({ request }) => {
+        submittedPreferences = (await request.json()) as {
+          email: string;
+          preferences: Record<string, boolean>;
+        };
+        return {
+          user_id: "user-1",
+          email: submittedPreferences.email,
+          preferences: submittedPreferences.preferences,
+          daily_limit: 0,
+          emails_sent_today: 0,
+          last_reset_date: baseDate,
+        };
+      }),
+    );
+
+    render(<SettingsPreferencesPage />);
+
+    const saveButton = await screen.findByRole("button", {
+      name: "Save changes",
+    });
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+
+    const switches = await screen.findAllByRole("switch");
+    fireEvent.click(switches[0]);
+
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(submittedPreferences).toBeDefined();
+    });
+    const flippedKey = Object.entries(submittedPreferences!.preferences).find(
+      ([, v]) => v === true,
+    )?.[0];
+    expect(flippedKey).toBeDefined();
+  });
+
+  test("Discard reverts unsaved notification toggles", async () => {
+    setupBaseHandlers();
+
+    render(<SettingsPreferencesPage />);
+
+    const saveButton = await screen.findByRole("button", {
+      name: "Save changes",
+    });
+    const discardButton = screen.getByRole("button", { name: "Discard" });
+
+    const switches = await screen.findAllByRole("switch");
+    const targetSwitch = switches[0] as HTMLInputElement;
+    const initialChecked = targetSwitch.getAttribute("aria-checked");
+
+    fireEvent.click(targetSwitch);
+
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+      expect((discardButton as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    fireEvent.click(discardButton);
+
+    await waitFor(() => {
+      expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+      expect(targetSwitch.getAttribute("aria-checked")).toBe(initialChecked);
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/__tests__/main.test.tsx
@@ -279,9 +279,7 @@ describe("SettingsPreferencesPage", () => {
 
     render(<SettingsPreferencesPage />);
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Edit email" }),
-    );
+    fireEvent.click(await screen.findByRole("button", { name: "Edit email" }));
 
     const dialogInput = (await screen.findByLabelText(
       "Email",

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import type { User } from "@supabase/supabase-js";
-import { ShieldCheckIcon } from "@phosphor-icons/react";
+import { PencilSimpleIcon } from "@phosphor-icons/react";
 import { motion, useReducedMotion } from "framer-motion";
+import { useState } from "react";
 
 import { Button } from "@/components/atoms/Button/Button";
 import { Input } from "@/components/atoms/Input/Input";
 import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
 import {
   Form,
   FormControl,
@@ -24,103 +26,142 @@ interface Props {
 
 export function AccountCard({ user, index = 0 }: Props) {
   const reduceMotion = useReducedMotion();
-  const { form, onSubmit, isLoading, currentEmail } = useAccountCard({ user });
+  const [emailDialogOpen, setEmailDialogOpen] = useState(false);
+  const { emailForm, onSubmitEmail, isUpdatingEmail, currentEmail } =
+    useAccountCard({ user });
 
-  const watched = form.watch("email");
-  const hasError = Object.keys(form.formState.errors).length > 0;
-  const isSameEmail = watched === currentEmail;
-  const disableSubmit = hasError || isSameEmail;
+  const watchedEmail = emailForm.watch("email");
+  const emailHasError = Object.keys(emailForm.formState.errors).length > 0;
+  const isSameEmail = watchedEmail === currentEmail;
+  const disableEmailSubmit = emailHasError || isSameEmail;
+
+  async function handleEmailSubmit(values: { email: string }) {
+    await onSubmitEmail(values);
+    if (!emailHasError && !isSameEmail) {
+      setEmailDialogOpen(false);
+    }
+  }
 
   return (
     <motion.section
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
-      className="rounded-[18px] border border-zinc-200 bg-white p-6 shadow-[0_1px_2px_rgba(15,15,20,0.04)] transition-shadow duration-200 ease-out focus-within:shadow-[0_8px_28px_-12px_rgba(15,15,20,0.12)]"
+      className="flex w-full flex-col gap-2"
     >
-      <CardTitle
-        eyebrow="Account & Security"
-        title="How you sign in"
-        description="Update the email tied to your account or rotate your password."
-      />
+      <div className="flex flex-col gap-1 px-4">
+        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          Account
+        </Text>
+        <Text variant="small" className="text-zinc-500">
+          Manage your sign-in details.
+        </Text>
+      </div>
 
-      <Form form={form} onSubmit={onSubmit} className="mt-6 space-y-0">
-        <FormField
-          control={form.control}
-          name="email"
-          render={({ field, fieldState }) => (
-            <FormItem className="space-y-0">
-              <FormControl>
-                <Input
-                  id={field.name}
-                  label="Email"
-                  type="email"
-                  autoComplete="email"
-                  size="medium"
-                  className="w-full"
-                  error={fieldState.error?.message}
-                  {...field}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
+      <div className="flex flex-col divide-y divide-zinc-200 rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+      <div className="flex items-center justify-between gap-4 px-4 py-4">
+        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          Email
+        </Text>
 
-        <div className="-mt-2 flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2 text-zinc-500">
-            <ShieldCheckIcon size={16} weight="duotone" />
-            <Text variant="small" as="span" className="text-zinc-500">
-              We'll send a confirmation link to verify your new address.
-            </Text>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              as="NextLink"
-              href="/reset-password"
-              size="small"
-            >
-              Reset password
-            </Button>
-            <Button
-              type="submit"
-              size="small"
-              disabled={disableSubmit}
-              loading={isLoading}
-            >
-              {isLoading ? "Saving" : "Update email"}
-            </Button>
-          </div>
+        <div className="flex min-w-0 items-center gap-3">
+          <Text
+            variant="body"
+            as="span"
+            className="min-w-0 truncate text-[#1F1F20]"
+          >
+            {currentEmail}
+          </Text>
+
+          <Dialog
+            title="Update email"
+            styling={{ maxWidth: "420px" }}
+            controlled={{
+              isOpen: emailDialogOpen,
+              set: (open) => {
+                setEmailDialogOpen(open);
+                if (open) emailForm.reset({ email: currentEmail });
+              },
+            }}
+          >
+            <Dialog.Trigger>
+              <Button
+                variant="secondary"
+                size="small"
+                aria-label="Edit email"
+                className="h-7 min-w-0 px-1.5 py-0.5"
+              >
+                <PencilSimpleIcon size={14} weight="duotone" />
+              </Button>
+            </Dialog.Trigger>
+            <Dialog.Content>
+              <Form form={emailForm} onSubmit={handleEmailSubmit}>
+                <div className="flex flex-col gap-4">
+                  <Text variant="small" as="span" className="text-zinc-500">
+                    We'll send a confirmation link to verify your new
+                    address.
+                  </Text>
+                  <FormField
+                    control={emailForm.control}
+                    name="email"
+                    render={({ field, fieldState }) => (
+                      <FormItem className="space-y-0">
+                        <FormControl>
+                          <Input
+                            id={field.name}
+                            label="Email"
+                            type="email"
+                            autoComplete="email"
+                            size="medium"
+                            className="w-full"
+                            wrapperClassName="!mb-0"
+                            error={fieldState.error?.message}
+                            {...field}
+                          />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <Dialog.Footer>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="small"
+                    onClick={() => setEmailDialogOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="submit"
+                    size="small"
+                    disabled={disableEmailSubmit}
+                    loading={isUpdatingEmail}
+                  >
+                    {isUpdatingEmail ? "Saving" : "Update email"}
+                  </Button>
+                </Dialog.Footer>
+              </Form>
+            </Dialog.Content>
+          </Dialog>
         </div>
-      </Form>
-    </motion.section>
-  );
-}
+      </div>
 
-function CardTitle({
-  eyebrow,
-  title,
-  description,
-}: {
-  eyebrow: string;
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="flex flex-col gap-1">
-      <Text
-        variant="small-medium"
-        as="span"
-        className="uppercase tracking-[0.08em] text-zinc-400"
-      >
-        {eyebrow}
-      </Text>
-      <Text variant="h4" as="h2" className="text-[#1F1F20]">
-        {title}
-      </Text>
-      <Text variant="small" className="text-zinc-500">
-        {description}
-      </Text>
-    </div>
+      <div className="flex items-center justify-between gap-4 px-4 py-4">
+        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          Password
+        </Text>
+
+        <Button
+          as="NextLink"
+          href="/reset-password"
+          size="small"
+          variant="secondary"
+        >
+          Reset password
+        </Button>
+      </div>
+      </div>
+    </motion.section>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -44,13 +44,17 @@ export function AccountCard({ user, index = 0 }: Props) {
 
   return (
     <motion.section
-      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{
-        duration: 0.32,
-        ease: EASE_OUT,
-        delay: 0.04 + index * 0.05,
-      }}
+      initial={reduceMotion ? false : { opacity: 0, y: 12 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={
+        reduceMotion
+          ? undefined
+          : {
+              duration: 0.32,
+              ease: EASE_OUT,
+              delay: 0.04 + index * 0.05,
+            }
+      }
       className="flex w-full flex-col gap-2"
     >
       <div className="flex flex-col gap-1 px-4">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -54,7 +54,7 @@ export function AccountCard({ user, index = 0 }: Props) {
       className="flex w-full flex-col gap-2"
     >
       <div className="flex flex-col gap-1 px-4">
-        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+        <Text variant="body-medium" as="span" className="text-textBlack">
           Account
         </Text>
         <Text variant="small" className="text-zinc-500">
@@ -64,7 +64,7 @@ export function AccountCard({ user, index = 0 }: Props) {
 
       <div className="flex flex-col divide-y divide-zinc-200 rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
         <div className="flex items-center justify-between gap-4 px-4 py-4">
-          <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          <Text variant="body-medium" as="span" className="text-textBlack">
             Email
           </Text>
 
@@ -72,7 +72,7 @@ export function AccountCard({ user, index = 0 }: Props) {
             <Text
               variant="body"
               as="span"
-              className="min-w-0 truncate text-[#1F1F20]"
+              className="min-w-0 truncate text-textBlack"
             >
               {currentEmail}
             </Text>
@@ -152,7 +152,7 @@ export function AccountCard({ user, index = 0 }: Props) {
         </div>
 
         <div className="flex items-center justify-between gap-4 px-4 py-4">
-          <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          <Text variant="body-medium" as="span" className="text-textBlack">
             Password
           </Text>
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -36,8 +36,8 @@ export function AccountCard({ user, index = 0 }: Props) {
   const disableEmailSubmit = emailHasError || isSameEmail;
 
   async function handleEmailSubmit(values: { email: string }) {
-    await onSubmitEmail(values);
-    if (!emailHasError && !isSameEmail) {
+    const didUpdate = await onSubmitEmail(values);
+    if (didUpdate) {
       setEmailDialogOpen(false);
     }
   }
@@ -98,7 +98,7 @@ export function AccountCard({ user, index = 0 }: Props) {
               <Form form={emailForm} onSubmit={handleEmailSubmit}>
                 <div className="flex flex-col gap-4">
                   <Text variant="small" as="span" className="text-zinc-500">
-                    We'll send a confirmation link to verify your new
+                    We&apos;ll send a confirmation link to verify your new
                     address.
                   </Text>
                   <FormField

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import type { User } from "@supabase/supabase-js";
+import { ShieldCheckIcon } from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "framer-motion";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { Text } from "@/components/atoms/Text/Text";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+} from "@/components/molecules/Form/Form";
+
+import { EASE_OUT } from "../../helpers";
+import { useAccountCard } from "./useAccountCard";
+
+interface Props {
+  user: User;
+  index?: number;
+}
+
+export function AccountCard({ user, index = 0 }: Props) {
+  const reduceMotion = useReducedMotion();
+  const { form, onSubmit, isLoading, currentEmail } = useAccountCard({ user });
+
+  const watched = form.watch("email");
+  const hasError = Object.keys(form.formState.errors).length > 0;
+  const isSameEmail = watched === currentEmail;
+  const disableSubmit = hasError || isSameEmail;
+
+  return (
+    <motion.section
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
+      className="rounded-[18px] border border-zinc-200 bg-white p-6 shadow-[0_1px_2px_rgba(15,15,20,0.04)] transition-shadow duration-200 ease-out focus-within:shadow-[0_8px_28px_-12px_rgba(15,15,20,0.12)]"
+    >
+      <CardTitle
+        eyebrow="Account & Security"
+        title="How you sign in"
+        description="Update the email tied to your account or rotate your password."
+      />
+
+      <Form form={form} onSubmit={onSubmit} className="mt-6 space-y-0">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field, fieldState }) => (
+            <FormItem className="space-y-0">
+              <FormControl>
+                <Input
+                  id={field.name}
+                  label="Email"
+                  type="email"
+                  autoComplete="email"
+                  size="medium"
+                  className="w-full"
+                  error={fieldState.error?.message}
+                  {...field}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <div className="-mt-2 flex flex-col-reverse items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2 text-zinc-500">
+            <ShieldCheckIcon size={16} weight="duotone" />
+            <Text variant="small" as="span" className="text-zinc-500">
+              We'll send a confirmation link to verify your new address.
+            </Text>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              as="NextLink"
+              href="/reset-password"
+              size="small"
+            >
+              Reset password
+            </Button>
+            <Button
+              type="submit"
+              size="small"
+              disabled={disableSubmit}
+              loading={isLoading}
+            >
+              {isLoading ? "Saving" : "Update email"}
+            </Button>
+          </div>
+        </div>
+      </Form>
+    </motion.section>
+  );
+}
+
+function CardTitle({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Text
+        variant="small-medium"
+        as="span"
+        className="uppercase tracking-[0.08em] text-zinc-400"
+      >
+        {eyebrow}
+      </Text>
+      <Text variant="h4" as="h2" className="text-[#1F1F20]">
+        {title}
+      </Text>
+      <Text variant="small" className="text-zinc-500">
+        {description}
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -46,7 +46,11 @@ export function AccountCard({ user, index = 0 }: Props) {
     <motion.section
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
+      transition={{
+        duration: 0.32,
+        ease: EASE_OUT,
+        delay: 0.04 + index * 0.05,
+      }}
       className="flex w-full flex-col gap-2"
     >
       <div className="flex flex-col gap-1 px-4">
@@ -59,108 +63,108 @@ export function AccountCard({ user, index = 0 }: Props) {
       </div>
 
       <div className="flex flex-col divide-y divide-zinc-200 rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
-      <div className="flex items-center justify-between gap-4 px-4 py-4">
-        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
-          Email
-        </Text>
-
-        <div className="flex min-w-0 items-center gap-3">
-          <Text
-            variant="body"
-            as="span"
-            className="min-w-0 truncate text-[#1F1F20]"
-          >
-            {currentEmail}
+        <div className="flex items-center justify-between gap-4 px-4 py-4">
+          <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+            Email
           </Text>
 
-          <Dialog
-            title="Update email"
-            styling={{ maxWidth: "420px" }}
-            controlled={{
-              isOpen: emailDialogOpen,
-              set: (open) => {
-                setEmailDialogOpen(open);
-                if (open) emailForm.reset({ email: currentEmail });
-              },
-            }}
-          >
-            <Dialog.Trigger>
-              <Button
-                variant="secondary"
-                size="small"
-                aria-label="Edit email"
-                className="h-7 min-w-0 px-1.5 py-0.5"
-              >
-                <PencilSimpleIcon size={14} weight="duotone" />
-              </Button>
-            </Dialog.Trigger>
-            <Dialog.Content>
-              <Form form={emailForm} onSubmit={handleEmailSubmit}>
-                <div className="flex flex-col gap-4">
-                  <Text variant="small" as="span" className="text-zinc-500">
-                    We&apos;ll send a confirmation link to verify your new
-                    address.
-                  </Text>
-                  <FormField
-                    control={emailForm.control}
-                    name="email"
-                    render={({ field, fieldState }) => (
-                      <FormItem className="space-y-0">
-                        <FormControl>
-                          <Input
-                            id={field.name}
-                            label="Email"
-                            type="email"
-                            autoComplete="email"
-                            size="medium"
-                            className="w-full"
-                            wrapperClassName="!mb-0"
-                            error={fieldState.error?.message}
-                            {...field}
-                          />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <Dialog.Footer>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="small"
-                    onClick={() => setEmailDialogOpen(false)}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    type="submit"
-                    size="small"
-                    disabled={disableEmailSubmit}
-                    loading={isUpdatingEmail}
-                  >
-                    {isUpdatingEmail ? "Saving" : "Update email"}
-                  </Button>
-                </Dialog.Footer>
-              </Form>
-            </Dialog.Content>
-          </Dialog>
+          <div className="flex min-w-0 items-center gap-3">
+            <Text
+              variant="body"
+              as="span"
+              className="min-w-0 truncate text-[#1F1F20]"
+            >
+              {currentEmail}
+            </Text>
+
+            <Dialog
+              title="Update email"
+              styling={{ maxWidth: "420px" }}
+              controlled={{
+                isOpen: emailDialogOpen,
+                set: (open) => {
+                  setEmailDialogOpen(open);
+                  if (open) emailForm.reset({ email: currentEmail });
+                },
+              }}
+            >
+              <Dialog.Trigger>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  aria-label="Edit email"
+                  className="h-7 min-w-0 px-1.5 py-0.5"
+                >
+                  <PencilSimpleIcon size={14} weight="duotone" />
+                </Button>
+              </Dialog.Trigger>
+              <Dialog.Content>
+                <Form form={emailForm} onSubmit={handleEmailSubmit}>
+                  <div className="flex flex-col gap-4">
+                    <Text variant="small" as="span" className="text-zinc-500">
+                      We&apos;ll send a confirmation link to verify your new
+                      address.
+                    </Text>
+                    <FormField
+                      control={emailForm.control}
+                      name="email"
+                      render={({ field, fieldState }) => (
+                        <FormItem className="space-y-0">
+                          <FormControl>
+                            <Input
+                              id={field.name}
+                              label="Email"
+                              type="email"
+                              autoComplete="email"
+                              size="medium"
+                              className="w-full"
+                              wrapperClassName="!mb-0"
+                              error={fieldState.error?.message}
+                              {...field}
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                  <Dialog.Footer>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="small"
+                      onClick={() => setEmailDialogOpen(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="submit"
+                      size="small"
+                      disabled={disableEmailSubmit}
+                      loading={isUpdatingEmail}
+                    >
+                      {isUpdatingEmail ? "Saving" : "Update email"}
+                    </Button>
+                  </Dialog.Footer>
+                </Form>
+              </Dialog.Content>
+            </Dialog>
+          </div>
         </div>
-      </div>
 
-      <div className="flex items-center justify-between gap-4 px-4 py-4">
-        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
-          Password
-        </Text>
+        <div className="flex items-center justify-between gap-4 px-4 py-4">
+          <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+            Password
+          </Text>
 
-        <Button
-          as="NextLink"
-          href="/reset-password"
-          size="small"
-          variant="secondary"
-        >
-          Reset password
-        </Button>
-      </div>
+          <Button
+            as="NextLink"
+            href="/reset-password"
+            size="small"
+            variant="secondary"
+          >
+            Reset password
+          </Button>
+        </div>
       </div>
     </motion.section>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/AccountCard.tsx
@@ -36,6 +36,7 @@ export function AccountCard({ user, index = 0 }: Props) {
   const disableEmailSubmit = emailHasError || isSameEmail;
 
   async function handleEmailSubmit(values: { email: string }) {
+    if (disableEmailSubmit) return;
     const didUpdate = await onSubmitEmail(values);
     if (didUpdate) {
       setEmailDialogOpen(false);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/useAccountCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/useAccountCard.ts
@@ -35,7 +35,7 @@ async function updateEmailViaSupabase(email: string) {
 export function useAccountCard({ user }: { user: User }) {
   const currentEmail = user.email ?? "";
 
-  const form = useForm<EmailFormValues>({
+  const emailForm = useForm<EmailFormValues>({
     resolver: zodResolver(emailSchema),
     defaultValues: { email: currentEmail },
     mode: "onChange",
@@ -43,7 +43,7 @@ export function useAccountCard({ user }: { user: User }) {
 
   const updateEmailServer = usePostV1UpdateUserEmail();
 
-  async function onSubmit(values: EmailFormValues) {
+  async function onSubmitEmail(values: EmailFormValues) {
     if (values.email === currentEmail) return;
 
     try {
@@ -66,9 +66,9 @@ export function useAccountCard({ user }: { user: User }) {
   }
 
   return {
-    form,
-    onSubmit,
-    isLoading: updateEmailServer.isPending,
+    emailForm,
+    onSubmitEmail,
+    isUpdatingEmail: updateEmailServer.isPending,
     currentEmail,
   };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/useAccountCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/useAccountCard.ts
@@ -43,8 +43,8 @@ export function useAccountCard({ user }: { user: User }) {
 
   const updateEmailServer = usePostV1UpdateUserEmail();
 
-  async function onSubmitEmail(values: EmailFormValues) {
-    if (values.email === currentEmail) return;
+  async function onSubmitEmail(values: EmailFormValues): Promise<boolean> {
+    if (values.email === currentEmail) return false;
 
     try {
       await Promise.all([
@@ -56,12 +56,14 @@ export function useAccountCard({ user }: { user: User }) {
         description: "Check your inbox to confirm the change.",
         variant: "success",
       });
+      return true;
     } catch (err) {
       toast({
         title: "Couldn't update email",
         description: err instanceof Error ? err.message : undefined,
         variant: "destructive",
       });
+      return false;
     }
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/useAccountCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/AccountCard/useAccountCard.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { User } from "@supabase/supabase-js";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { usePostV1UpdateUserEmail } from "@/app/api/__generated__/endpoints/auth/auth";
+import { toast } from "@/components/molecules/Toast/use-toast";
+
+const emailSchema = z.object({
+  email: z
+    .string()
+    .min(1, "Email is required")
+    .email("Enter a valid email address"),
+});
+
+type EmailFormValues = z.infer<typeof emailSchema>;
+
+async function updateEmailViaSupabase(email: string) {
+  const response = await fetch("/api/auth/user", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error ?? "Failed to update email");
+  }
+
+  return response.json();
+}
+
+export function useAccountCard({ user }: { user: User }) {
+  const currentEmail = user.email ?? "";
+
+  const form = useForm<EmailFormValues>({
+    resolver: zodResolver(emailSchema),
+    defaultValues: { email: currentEmail },
+    mode: "onChange",
+  });
+
+  const updateEmailServer = usePostV1UpdateUserEmail();
+
+  async function onSubmit(values: EmailFormValues) {
+    if (values.email === currentEmail) return;
+
+    try {
+      await Promise.all([
+        updateEmailViaSupabase(values.email),
+        updateEmailServer.mutateAsync({ data: values.email }),
+      ]);
+      toast({
+        title: "Email update sent",
+        description: "Check your inbox to confirm the change.",
+        variant: "success",
+      });
+    } catch (err) {
+      toast({
+        title: "Couldn't update email",
+        description: err instanceof Error ? err.message : undefined,
+        variant: "destructive",
+      });
+    }
+  }
+
+  return {
+    form,
+    onSubmit,
+    isLoading: updateEmailServer.isPending,
+    currentEmail,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -48,7 +48,11 @@ export function NotificationsCard({ values, onToggle, index = 0 }: Props) {
     <motion.section
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
+      transition={{
+        duration: 0.32,
+        ease: EASE_OUT,
+        delay: 0.04 + index * 0.05,
+      }}
       className="flex w-full flex-col gap-2 pt-0"
     >
       <div className="flex flex-col gap-1 px-4">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CheckIcon } from "@phosphor-icons/react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import { Switch } from "@/components/atoms/Switch/Switch";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+import {
+  EASE_OUT,
+  NOTIFICATION_GROUPS,
+  type NotificationFlags,
+  type NotificationGroup,
+  type NotificationItem,
+  type NotificationKey,
+} from "../../helpers";
+
+interface Props {
+  values: NotificationFlags;
+  onToggle: (key: NotificationKey, value: boolean) => void;
+  onSetAllInGroup: (keys: NotificationKey[], value: boolean) => void;
+  index?: number;
+}
+
+type TabId = "all" | NotificationGroup["id"];
+
+export function NotificationsCard({
+  values,
+  onToggle,
+  onSetAllInGroup,
+  index = 0,
+}: Props) {
+  const reduceMotion = useReducedMotion();
+  const [activeTab, setActiveTab] = useState<TabId>("all");
+
+  const tabs = useMemo<{ id: TabId; label: string; count: number }[]>(() => {
+    const enabledByGroup = NOTIFICATION_GROUPS.map((group) => {
+      const enabled = group.items.filter((item) => values[item.key]).length;
+      return { id: group.id, label: group.title, count: enabled };
+    });
+    const allEnabled = enabledByGroup.reduce((sum, g) => sum + g.count, 0);
+    return [
+      { id: "all", label: "All", count: allEnabled },
+      ...enabledByGroup,
+    ];
+  }, [values]);
+
+  const visibleGroups = useMemo<NotificationGroup[]>(() => {
+    if (activeTab === "all") return NOTIFICATION_GROUPS;
+    return NOTIFICATION_GROUPS.filter((g) => g.id === activeTab);
+  }, [activeTab]);
+
+  return (
+    <motion.section
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
+      className="overflow-hidden rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)] transition-shadow duration-200 ease-out focus-within:shadow-[0_8px_28px_-12px_rgba(15,15,20,0.12)]"
+    >
+      <div className="flex flex-col gap-4 px-6 pt-6">
+        <div className="flex flex-col gap-1">
+          <Text
+            variant="small-medium"
+            as="span"
+            className="uppercase tracking-[0.08em] text-zinc-400"
+          >
+            Notifications
+          </Text>
+          <Text variant="h4" as="h2" className="text-[#1F1F20]">
+            What should we tell you about?
+          </Text>
+          <Text variant="small" className="text-zinc-500">
+            Filter by category, or scan everything in one place.
+          </Text>
+        </div>
+
+        <CategoryTabs
+          tabs={tabs}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+        />
+      </div>
+
+      <div className="px-2 pb-2 pt-2 sm:px-3">
+        <AnimatePresence initial={false} mode="wait">
+          <motion.div
+            key={activeTab}
+            initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -6 }}
+            transition={{ duration: 0.2, ease: EASE_OUT }}
+            className="flex flex-col gap-1"
+          >
+            {visibleGroups.map((group) => (
+              <NotificationGroupSection
+                key={group.id}
+                group={group}
+                values={values}
+                onToggle={onToggle}
+                onSetAllInGroup={onSetAllInGroup}
+              />
+            ))}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </motion.section>
+  );
+}
+
+function CategoryTabs({
+  tabs,
+  activeTab,
+  onTabChange,
+}: {
+  tabs: { id: TabId; label: string; count: number }[];
+  activeTab: TabId;
+  onTabChange: (id: TabId) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Notification categories"
+      className="-mx-1 flex gap-1 overflow-x-auto pb-1"
+    >
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab.id;
+        return (
+          <button
+            key={tab.id}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            onClick={() => onTabChange(tab.id)}
+            className={cn(
+              "relative flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-zinc-600 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2",
+              isActive ? "text-zinc-900" : "hover:text-zinc-900",
+            )}
+          >
+            {isActive ? (
+              <motion.span
+                layoutId="notif-tab-pill"
+                aria-hidden
+                className="absolute inset-0 rounded-full bg-zinc-900"
+                transition={{ type: "spring", stiffness: 480, damping: 36 }}
+              />
+            ) : null}
+            <span
+              className={cn(
+                "relative z-10 whitespace-nowrap text-[13px] font-medium",
+                isActive && "text-white",
+              )}
+            >
+              {tab.label}
+            </span>
+            <span
+              className={cn(
+                "relative z-10 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-[11px] font-medium tabular-nums",
+                isActive ? "bg-white/20 text-white" : "bg-zinc-100 text-zinc-500",
+              )}
+            >
+              {tab.count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function NotificationGroupSection({
+  group,
+  values,
+  onToggle,
+  onSetAllInGroup,
+}: {
+  group: NotificationGroup;
+  values: NotificationFlags;
+  onToggle: (key: NotificationKey, value: boolean) => void;
+  onSetAllInGroup: (keys: NotificationKey[], value: boolean) => void;
+}) {
+  const Icon = group.icon;
+  const itemKeys = group.items.map((i) => i.key);
+  const allOn = itemKeys.every((k) => values[k]);
+  const anyOn = itemKeys.some((k) => values[k]);
+
+  return (
+    <div className="rounded-[14px]">
+      <div className="flex items-center gap-3 px-4 pb-2 pt-4">
+        <span
+          className={cn(
+            "inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br",
+            group.accent,
+          )}
+        >
+          <Icon size={18} weight="duotone" />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <Text variant="large-medium" as="h3" className="text-[#1F1F20]">
+            {group.title}
+          </Text>
+          <Text variant="small" className="text-zinc-500">
+            {group.caption}
+          </Text>
+        </div>
+        <button
+          type="button"
+          onClick={() => onSetAllInGroup(itemKeys, !allOn)}
+          aria-pressed={allOn}
+          className={cn(
+            "flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-[12px] font-medium transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2",
+            allOn
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100"
+              : anyOn
+                ? "border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50"
+                : "border-zinc-200 bg-white text-zinc-500 hover:bg-zinc-50",
+          )}
+        >
+          {allOn ? (
+            <>
+              <CheckIcon size={12} weight="bold" /> All on
+            </>
+          ) : (
+            "Enable all"
+          )}
+        </button>
+      </div>
+
+      <div className="flex flex-col">
+        {group.items.map((item, i) => (
+          <NotificationRow
+            key={item.key}
+            item={item}
+            value={values[item.key]}
+            onChange={(checked) => onToggle(item.key, checked)}
+            isLast={i === group.items.length - 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function NotificationRow({
+  item,
+  value,
+  onChange,
+  isLast,
+}: {
+  item: NotificationItem;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  isLast: boolean;
+}) {
+  const id = `notif-${item.key}`;
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "group flex cursor-pointer items-center justify-between gap-4 rounded-[12px] px-4 py-3 transition-colors duration-150 ease-out hover:bg-zinc-50",
+        !isLast && "mb-0.5",
+      )}
+    >
+      <div className="flex min-w-0 flex-col">
+        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          {item.title}
+        </Text>
+        <Text variant="small" as="span" className="text-zinc-500">
+          {item.description}
+        </Text>
+      </div>
+      <Switch
+        id={id}
+        aria-label={item.title}
+        checked={value}
+        onCheckedChange={onChange}
+      />
+    </label>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -56,7 +56,7 @@ export function NotificationsCard({ values, onToggle, index = 0 }: Props) {
       className="flex w-full flex-col gap-2 pt-0"
     >
       <div className="flex flex-col gap-1 px-4">
-        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+        <Text variant="body-medium" as="span" className="text-textBlack">
           Notifications
         </Text>
         <Text variant="small" className="text-zinc-500">
@@ -150,7 +150,7 @@ function NotificationRow({
       )}
     >
       <div className="flex min-w-0 flex-col">
-        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+        <Text variant="body-medium" as="span" className="text-textBlack">
           {item.title}
         </Text>
         <Text variant="small" as="span" className="text-zinc-500">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -88,10 +88,12 @@ export function NotificationsCard({ values, onToggle, index = 0 }: Props) {
         <AnimatePresence initial={false} mode="wait">
           <motion.div
             key={activeTab}
-            initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -6 }}
-            transition={{ duration: 0.2, ease: EASE_OUT }}
+            initial={reduceMotion ? false : { opacity: 0, y: 6 }}
+            animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+            exit={reduceMotion ? undefined : { opacity: 0, y: -6 }}
+            transition={
+              reduceMotion ? undefined : { duration: 0.2, ease: EASE_OUT }
+            }
             className="flex flex-col gap-1"
           >
             {visibleGroups.map((group) => (

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { CheckIcon } from "@phosphor-icons/react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import { Switch } from "@/components/atoms/Switch/Switch";
 import { Text } from "@/components/atoms/Text/Text";
+import {
+  TabsLine,
+  TabsLineList,
+  TabsLineTrigger,
+} from "@/components/molecules/TabsLine/TabsLine";
 import { cn } from "@/lib/utils";
 
 import {
@@ -20,70 +24,61 @@ import {
 interface Props {
   values: NotificationFlags;
   onToggle: (key: NotificationKey, value: boolean) => void;
-  onSetAllInGroup: (keys: NotificationKey[], value: boolean) => void;
   index?: number;
 }
 
-type TabId = "all" | NotificationGroup["id"];
+type TabId = NotificationGroup["id"];
 
-export function NotificationsCard({
-  values,
-  onToggle,
-  onSetAllInGroup,
-  index = 0,
-}: Props) {
+export function NotificationsCard({ values, onToggle, index = 0 }: Props) {
   const reduceMotion = useReducedMotion();
-  const [activeTab, setActiveTab] = useState<TabId>("all");
+  const [activeTab, setActiveTab] = useState<TabId>(NOTIFICATION_GROUPS[0].id);
 
   const tabs = useMemo<{ id: TabId; label: string; count: number }[]>(() => {
-    const enabledByGroup = NOTIFICATION_GROUPS.map((group) => {
-      const enabled = group.items.filter((item) => values[item.key]).length;
-      return { id: group.id, label: group.title, count: enabled };
-    });
-    const allEnabled = enabledByGroup.reduce((sum, g) => sum + g.count, 0);
-    return [
-      { id: "all", label: "All", count: allEnabled },
-      ...enabledByGroup,
-    ];
+    return NOTIFICATION_GROUPS.map((group) => ({
+      id: group.id,
+      label: group.title,
+      count: group.items.filter((item) => values[item.key]).length,
+    }));
   }, [values]);
 
-  const visibleGroups = useMemo<NotificationGroup[]>(() => {
-    if (activeTab === "all") return NOTIFICATION_GROUPS;
-    return NOTIFICATION_GROUPS.filter((g) => g.id === activeTab);
-  }, [activeTab]);
+  const visibleGroups = useMemo<NotificationGroup[]>(
+    () => NOTIFICATION_GROUPS.filter((g) => g.id === activeTab),
+    [activeTab],
+  );
 
   return (
     <motion.section
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
-      className="overflow-hidden rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)] transition-shadow duration-200 ease-out focus-within:shadow-[0_8px_28px_-12px_rgba(15,15,20,0.12)]"
+      className="flex w-full flex-col gap-2 pt-0"
     >
-      <div className="flex flex-col gap-4 px-6 pt-6">
-        <div className="flex flex-col gap-1">
-          <Text
-            variant="small-medium"
-            as="span"
-            className="uppercase tracking-[0.08em] text-zinc-400"
-          >
-            Notifications
-          </Text>
-          <Text variant="h4" as="h2" className="text-[#1F1F20]">
-            What should we tell you about?
-          </Text>
-          <Text variant="small" className="text-zinc-500">
-            Filter by category, or scan everything in one place.
-          </Text>
-        </div>
-
-        <CategoryTabs
-          tabs={tabs}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-        />
+      <div className="flex flex-col gap-1 px-4">
+        <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+          Notifications
+        </Text>
+        <Text variant="small" className="text-zinc-500">
+          Filter by category, or scan everything in one place.
+        </Text>
       </div>
 
-      <div className="px-2 pb-2 pt-2 sm:px-3">
+      <div className="flex flex-col gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 pb-4 pt-0 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        <TabsLine
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as TabId)}
+        >
+          <TabsLineList>
+            {tabs.map((tab) => (
+              <TabsLineTrigger key={tab.id} value={tab.id}>
+                {tab.label}
+                <span className="ml-2 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-zinc-100 px-1 text-[11px] font-medium tabular-nums text-zinc-500">
+                  {tab.count}
+                </span>
+              </TabsLineTrigger>
+            ))}
+          </TabsLineList>
+        </TabsLine>
+
         <AnimatePresence initial={false} mode="wait">
           <motion.div
             key={activeTab}
@@ -99,7 +94,6 @@ export function NotificationsCard({
                 group={group}
                 values={values}
                 onToggle={onToggle}
-                onSetAllInGroup={onSetAllInGroup}
               />
             ))}
           </motion.div>
@@ -109,135 +103,26 @@ export function NotificationsCard({
   );
 }
 
-function CategoryTabs({
-  tabs,
-  activeTab,
-  onTabChange,
-}: {
-  tabs: { id: TabId; label: string; count: number }[];
-  activeTab: TabId;
-  onTabChange: (id: TabId) => void;
-}) {
-  return (
-    <div
-      role="tablist"
-      aria-label="Notification categories"
-      className="-mx-1 flex gap-1 overflow-x-auto pb-1"
-    >
-      {tabs.map((tab) => {
-        const isActive = activeTab === tab.id;
-        return (
-          <button
-            key={tab.id}
-            role="tab"
-            type="button"
-            aria-selected={isActive}
-            onClick={() => onTabChange(tab.id)}
-            className={cn(
-              "relative flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-zinc-600 transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2",
-              isActive ? "text-zinc-900" : "hover:text-zinc-900",
-            )}
-          >
-            {isActive ? (
-              <motion.span
-                layoutId="notif-tab-pill"
-                aria-hidden
-                className="absolute inset-0 rounded-full bg-zinc-900"
-                transition={{ type: "spring", stiffness: 480, damping: 36 }}
-              />
-            ) : null}
-            <span
-              className={cn(
-                "relative z-10 whitespace-nowrap text-[13px] font-medium",
-                isActive && "text-white",
-              )}
-            >
-              {tab.label}
-            </span>
-            <span
-              className={cn(
-                "relative z-10 inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-[11px] font-medium tabular-nums",
-                isActive ? "bg-white/20 text-white" : "bg-zinc-100 text-zinc-500",
-              )}
-            >
-              {tab.count}
-            </span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 function NotificationGroupSection({
   group,
   values,
   onToggle,
-  onSetAllInGroup,
 }: {
   group: NotificationGroup;
   values: NotificationFlags;
   onToggle: (key: NotificationKey, value: boolean) => void;
-  onSetAllInGroup: (keys: NotificationKey[], value: boolean) => void;
 }) {
-  const Icon = group.icon;
-  const itemKeys = group.items.map((i) => i.key);
-  const allOn = itemKeys.every((k) => values[k]);
-  const anyOn = itemKeys.some((k) => values[k]);
-
   return (
-    <div className="rounded-[14px]">
-      <div className="flex items-center gap-3 px-4 pb-2 pt-4">
-        <span
-          className={cn(
-            "inline-flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br",
-            group.accent,
-          )}
-        >
-          <Icon size={18} weight="duotone" />
-        </span>
-        <div className="flex min-w-0 flex-1 flex-col">
-          <Text variant="large-medium" as="h3" className="text-[#1F1F20]">
-            {group.title}
-          </Text>
-          <Text variant="small" className="text-zinc-500">
-            {group.caption}
-          </Text>
-        </div>
-        <button
-          type="button"
-          onClick={() => onSetAllInGroup(itemKeys, !allOn)}
-          aria-pressed={allOn}
-          className={cn(
-            "flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-1 text-[12px] font-medium transition-colors duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2",
-            allOn
-              ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100"
-              : anyOn
-                ? "border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50"
-                : "border-zinc-200 bg-white text-zinc-500 hover:bg-zinc-50",
-          )}
-        >
-          {allOn ? (
-            <>
-              <CheckIcon size={12} weight="bold" /> All on
-            </>
-          ) : (
-            "Enable all"
-          )}
-        </button>
-      </div>
-
-      <div className="flex flex-col">
-        {group.items.map((item, i) => (
-          <NotificationRow
-            key={item.key}
-            item={item}
-            value={values[item.key]}
-            onChange={(checked) => onToggle(item.key, checked)}
-            isLast={i === group.items.length - 1}
-          />
-        ))}
-      </div>
+    <div className="flex flex-col">
+      {group.items.map((item, i) => (
+        <NotificationRow
+          key={item.key}
+          item={item}
+          value={values[item.key]}
+          onChange={(checked) => onToggle(item.key, checked)}
+          isLast={i === group.items.length - 1}
+        />
+      ))}
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -46,13 +46,17 @@ export function NotificationsCard({ values, onToggle, index = 0 }: Props) {
 
   return (
     <motion.section
-      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{
-        duration: 0.32,
-        ease: EASE_OUT,
-        delay: 0.04 + index * 0.05,
-      }}
+      initial={reduceMotion ? false : { opacity: 0, y: 12 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={
+        reduceMotion
+          ? undefined
+          : {
+              duration: 0.32,
+              ease: EASE_OUT,
+              delay: 0.04 + index * 0.05,
+            }
+      }
       className="flex w-full flex-col gap-2 pt-0"
     >
       <div className="flex flex-col gap-1 px-4">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/NotificationsCard/NotificationsCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import { Switch } from "@/components/atoms/Switch/Switch";
@@ -33,17 +33,15 @@ export function NotificationsCard({ values, onToggle, index = 0 }: Props) {
   const reduceMotion = useReducedMotion();
   const [activeTab, setActiveTab] = useState<TabId>(NOTIFICATION_GROUPS[0].id);
 
-  const tabs = useMemo<{ id: TabId; label: string; count: number }[]>(() => {
-    return NOTIFICATION_GROUPS.map((group) => ({
+  const tabs: { id: TabId; label: string; count: number }[] =
+    NOTIFICATION_GROUPS.map((group) => ({
       id: group.id,
       label: group.title,
       count: group.items.filter((item) => values[item.key]).length,
     }));
-  }, [values]);
 
-  const visibleGroups = useMemo<NotificationGroup[]>(
-    () => NOTIFICATION_GROUPS.filter((g) => g.id === activeTab),
-    [activeTab],
+  const visibleGroups: NotificationGroup[] = NOTIFICATION_GROUPS.filter(
+    (g) => g.id === activeTab,
   );
 
   return (

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
@@ -14,16 +14,12 @@ export function PreferencesHeader() {
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.32, ease: EASE_OUT }}
-      className="flex flex-col gap-2"
+      className="flex min-w-0 flex-col pb-2 pl-4"
     >
-      <Text
-        variant="h3"
-        as="h1"
-        className="bg-gradient-to-br from-[#1F1F20] via-[#3a3a3f] to-[#7a4dff] bg-clip-text text-transparent"
-      >
+      <Text variant="h4" as="h1" className="leading-[28px] text-textBlack">
         Settings
       </Text>
-      <Text variant="large" className="text-zinc-500">
+      <Text variant="body" className="mt-4 max-w-[600px] text-zinc-700">
         Tune your account, time zone, and which notifications reach you.
       </Text>
     </motion.header>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
@@ -17,7 +17,7 @@ export function PreferencesHeader() {
       className="flex min-w-0 flex-col pb-2 pl-4"
     >
       <Text variant="h4" as="h1" className="leading-[28px] text-textBlack">
-        Settings
+        Preferences
       </Text>
       <Text variant="body" className="mt-4 max-w-[600px] text-zinc-700">
         Tune your account, time zone, and which notifications reach you.

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
@@ -11,9 +11,9 @@ export function PreferencesHeader() {
 
   return (
     <motion.header
-      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.32, ease: EASE_OUT }}
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={reduceMotion ? undefined : { duration: 0.32, ease: EASE_OUT }}
       className="flex min-w-0 flex-col pb-2 pl-4"
     >
       <Text variant="h4" as="h1" className="leading-[28px] text-textBlack">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesHeader/PreferencesHeader.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+import { Text } from "@/components/atoms/Text/Text";
+
+import { EASE_OUT } from "../../helpers";
+
+export function PreferencesHeader() {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.header
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.32, ease: EASE_OUT }}
+      className="flex flex-col gap-2"
+    >
+      <Text
+        variant="h3"
+        as="h1"
+        className="bg-gradient-to-br from-[#1F1F20] via-[#3a3a3f] to-[#7a4dff] bg-clip-text text-transparent"
+      >
+        Settings
+      </Text>
+      <Text variant="large" className="text-zinc-500">
+        Tune your account, time zone, and which notifications reach you.
+      </Text>
+    </motion.header>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesSkeleton/PreferencesSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesSkeleton/PreferencesSkeleton.tsx
@@ -17,7 +17,7 @@ export function PreferencesSkeleton() {
 
 function SectionSkeleton({ rows }: { rows: number }) {
   return (
-    <div className="flex flex-col gap-4 rounded-[16px] border border-zinc-200 bg-white p-6">
+    <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
         <Skeleton className="h-5 w-40" />
         <Skeleton className="h-3.5 w-56" />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesSkeleton/PreferencesSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesSkeleton/PreferencesSkeleton.tsx
@@ -2,36 +2,94 @@ import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 
 export function PreferencesSkeleton() {
   return (
-    <div className="flex flex-col gap-6 pb-28" aria-busy="true">
-      <div className="flex flex-col gap-3">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-4 w-72" />
+    <div className="flex flex-col gap-6 pb-8" aria-busy="true">
+      <div className="flex min-w-0 flex-col gap-3 pb-2 pl-4">
+        <Skeleton className="h-7 w-32" />
+        <Skeleton className="mt-2 h-4 w-[420px] max-w-full" />
       </div>
 
-      <SectionSkeleton rows={2} />
-      <SectionSkeleton rows={1} />
-      <SectionSkeleton rows={6} />
+      <AccountSkeleton />
+      <TimezoneSkeleton />
+      <NotificationsSkeleton />
+
+      <div className="flex items-center justify-end gap-2 px-4">
+        <Skeleton className="h-12 w-32 rounded-full" />
+        <Skeleton className="h-12 w-28 rounded-full" />
+      </div>
     </div>
   );
 }
 
-function SectionSkeleton({ rows }: { rows: number }) {
+function AccountSkeleton() {
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2">
-        <Skeleton className="h-5 w-40" />
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex flex-col gap-1 px-4">
+        <Skeleton className="h-5 w-24" />
         <Skeleton className="h-3.5 w-56" />
       </div>
-      <div className="flex flex-col gap-3">
-        {Array.from({ length: rows }).map((_, i) => (
-          <div key={i} className="flex items-center justify-between gap-4">
-            <div className="flex flex-col gap-2">
-              <Skeleton className="h-4 w-44" />
-              <Skeleton className="h-3 w-64" />
-            </div>
-            <Skeleton className="h-5 w-9 rounded-full" />
+      <div className="flex flex-col divide-y divide-zinc-200 rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        <div className="flex items-center justify-between gap-4 px-4 py-4">
+          <Skeleton className="h-4 w-14" />
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-7 w-7 rounded-full" />
           </div>
-        ))}
+        </div>
+        <div className="flex items-center justify-between gap-4 px-4 py-4">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-9 w-32 rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TimezoneSkeleton() {
+  return (
+    <div className="flex w-full flex-col">
+      <div className="flex flex-col gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 py-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-4 rounded-full" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-9 w-40 rounded-full" />
+            <Skeleton className="h-7 w-20 rounded-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NotificationsSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <div className="flex flex-col gap-1 px-4">
+        <Skeleton className="h-5 w-32" />
+        <Skeleton className="h-3.5 w-72" />
+      </div>
+      <div className="flex flex-col gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 pb-4 pt-0 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        <div className="flex items-center gap-6 border-b border-zinc-100 pb-3 pt-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-28" />
+          ))}
+        </div>
+        <div className="flex flex-col">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between gap-4 rounded-[12px] px-4 py-3"
+            >
+              <div className="flex min-w-0 flex-col gap-2">
+                <Skeleton className="h-4 w-56" />
+                <Skeleton className="h-3 w-72" />
+              </div>
+              <Skeleton className="h-5 w-9 rounded-full" />
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesSkeleton/PreferencesSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/PreferencesSkeleton/PreferencesSkeleton.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+
+export function PreferencesSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 pb-28" aria-busy="true">
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+
+      <SectionSkeleton rows={2} />
+      <SectionSkeleton rows={1} />
+      <SectionSkeleton rows={6} />
+    </div>
+  );
+}
+
+function SectionSkeleton({ rows }: { rows: number }) {
+  return (
+    <div className="flex flex-col gap-4 rounded-[16px] border border-zinc-200 bg-white p-6">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3.5 w-56" />
+      </div>
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-4 w-44" />
+              <Skeleton className="h-3 w-64" />
+            </div>
+            <Skeleton className="h-5 w-9 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/SaveBar/SaveBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/SaveBar/SaveBar.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-
 import { Button } from "@/components/atoms/Button/Button";
-import { Text } from "@/components/atoms/Text/Text";
-
-import { EASE_IOS } from "../../helpers";
 
 interface Props {
   visible: boolean;
@@ -15,54 +10,25 @@ interface Props {
 }
 
 export function SaveBar({ visible, saving, onDiscard, onSave }: Props) {
-  const reduceMotion = useReducedMotion();
-
   return (
-    <AnimatePresence initial={false}>
-      {visible ? (
-        <motion.div
-          key="preferences-save-bar"
-          initial={
-            reduceMotion ? { opacity: 0 } : { opacity: 0, y: 28, scale: 0.98 }
-          }
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          exit={
-            reduceMotion ? { opacity: 0 } : { opacity: 0, y: 28, scale: 0.98 }
-          }
-          transition={{ duration: 0.28, ease: EASE_IOS }}
-          className="pointer-events-none fixed inset-x-0 bottom-4 z-30 flex justify-center px-4"
-        >
-          <div className="pointer-events-auto flex w-full max-w-[640px] items-center justify-between gap-4 rounded-[14px] border border-zinc-200 bg-white/95 px-4 py-3 shadow-[0_12px_30px_-10px_rgba(15,15,20,0.18)] backdrop-blur-md">
-            <div className="flex min-w-0 flex-col">
-              <Text variant="large-medium" className="text-[#1F1F20]">
-                Unsaved changes
-              </Text>
-              <Text variant="small" className="text-zinc-500">
-                Review your time zone or notifications, then save.
-              </Text>
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <Button
-                variant="ghost"
-                size="small"
-                onClick={onDiscard}
-                disabled={saving}
-              >
-                Discard
-              </Button>
-              <Button
-                variant="primary"
-                size="small"
-                onClick={onSave}
-                loading={saving}
-                disabled={saving}
-              >
-                Save changes
-              </Button>
-            </div>
-          </div>
-        </motion.div>
-      ) : null}
-    </AnimatePresence>
+    <div className="flex items-center justify-end gap-2 px-4">
+      <Button
+        variant="primary"
+        size="large"
+        onClick={onSave}
+        loading={saving}
+        disabled={saving || !visible}
+      >
+        Save changes
+      </Button>
+      <Button
+        variant="secondary"
+        size="large"
+        onClick={onDiscard}
+        disabled={saving || !visible}
+      >
+        Discard
+      </Button>
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/SaveBar/SaveBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/SaveBar/SaveBar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+
+import { EASE_IOS } from "../../helpers";
+
+interface Props {
+  visible: boolean;
+  saving: boolean;
+  onDiscard: () => void;
+  onSave: () => void;
+}
+
+export function SaveBar({ visible, saving, onDiscard, onSave }: Props) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <AnimatePresence initial={false}>
+      {visible ? (
+        <motion.div
+          key="preferences-save-bar"
+          initial={
+            reduceMotion ? { opacity: 0 } : { opacity: 0, y: 28, scale: 0.98 }
+          }
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={
+            reduceMotion ? { opacity: 0 } : { opacity: 0, y: 28, scale: 0.98 }
+          }
+          transition={{ duration: 0.28, ease: EASE_IOS }}
+          className="pointer-events-none fixed inset-x-0 bottom-4 z-30 flex justify-center px-4"
+        >
+          <div className="pointer-events-auto flex w-full max-w-[640px] items-center justify-between gap-4 rounded-[14px] border border-zinc-200 bg-white/95 px-4 py-3 shadow-[0_12px_30px_-10px_rgba(15,15,20,0.18)] backdrop-blur-md">
+            <div className="flex min-w-0 flex-col">
+              <Text variant="large-medium" className="text-[#1F1F20]">
+                Unsaved changes
+              </Text>
+              <Text variant="small" className="text-zinc-500">
+                Review your time zone or notifications, then save.
+              </Text>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                variant="ghost"
+                size="small"
+                onClick={onDiscard}
+                disabled={saving}
+              >
+                Discard
+              </Button>
+              <Button
+                variant="primary"
+                size="small"
+                onClick={onSave}
+                loading={saving}
+                disabled={saving}
+              >
+                Save changes
+              </Button>
+            </div>
+          </div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -113,14 +113,14 @@ export function TimezoneCard({
               key="autodetect"
               type="button"
               onClick={() => onChange(browserTz)}
-              initial={
-                reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
+              initial={reduceMotion ? false : { opacity: 0, y: -4, height: 0 }}
+              animate={
+                reduceMotion ? undefined : { opacity: 1, y: 0, height: "auto" }
               }
-              animate={{ opacity: 1, y: 0, height: "auto" }}
-              exit={
-                reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
+              exit={reduceMotion ? undefined : { opacity: 0, y: -4, height: 0 }}
+              transition={
+                reduceMotion ? undefined : { duration: 0.22, ease: EASE_OUT }
               }
-              transition={{ duration: 0.22, ease: EASE_OUT }}
               className="flex w-fit items-center gap-2 self-end overflow-hidden rounded-full border border-violet-300 bg-violet-50/60 px-3 py-1.5 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
             >
               <GlobeIcon size={16} weight="duotone" />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { useMemo } from "react";
-import { ClockIcon, GlobeIcon } from "@phosphor-icons/react";
+import { ClockIcon, GlobeIcon, InfoIcon } from "@phosphor-icons/react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import { Select } from "@/components/atoms/Select/Select";
 import { Text } from "@/components/atoms/Text/Text";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/atoms/Tooltip/BaseTooltip";
 
 import {
   EASE_OUT,
@@ -37,7 +42,6 @@ export function TimezoneCard({
   );
 
   const showAutoDetect = initialValue !== browserTz && value !== browserTz;
-  const isDirty = value !== initialValue;
 
   const options = useMemo(() => {
     if (TIMEZONES.some((t) => t.value === value)) return TIMEZONES;
@@ -49,100 +53,87 @@ export function TimezoneCard({
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
-      className="rounded-[18px] border border-zinc-200 bg-white p-6 shadow-[0_1px_2px_rgba(15,15,20,0.04)] transition-shadow duration-200 ease-out focus-within:shadow-[0_8px_28px_-12px_rgba(15,15,20,0.12)]"
+      className="flex w-full flex-col"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1">
-          <Text
-            variant="small-medium"
-            as="span"
-            className="uppercase tracking-[0.08em] text-zinc-400"
-          >
-            Time & Locale
-          </Text>
-          <Text variant="h4" as="h2" className="text-[#1F1F20]">
-            Time zone
-          </Text>
-          <Text variant="small" className="text-zinc-500">
-            We'll use this for run schedules, summaries, and timestamps you see.
-          </Text>
+      <div className="flex h-fit flex-col justify-center gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 py-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+              Time zone
+            </Text>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="Time zone info"
+                  className="flex items-center text-zinc-400 transition-colors hover:text-zinc-600 focus-visible:text-zinc-600 focus-visible:outline-none"
+                >
+                  <InfoIcon size={16} weight="duotone" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Used for run schedules, summaries, and timestamps.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
+          <div className="flex h-fit items-center gap-2">
+            <Select
+              id="timezone"
+              label="Timezone"
+              hideLabel
+              value={value}
+              onValueChange={onChange}
+              options={options}
+              placeholder="Select your timezone"
+              size="small"
+              wrapperClassName="!mb-0 w-fit"
+            />
+            {offset ? (
+              <div className="flex h-fit shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 tabular-nums text-zinc-600">
+                <ClockIcon size={14} weight="duotone" />
+                <Text
+                  variant="small-medium"
+                  as="span"
+                  className="text-zinc-600"
+                >
+                  {offset}
+                </Text>
+              </div>
+            ) : null}
+          </div>
         </div>
 
-        <motion.div
-          initial={false}
-          animate={{
-            opacity: offset ? 1 : 0,
-            scale: offset ? 1 : 0.96,
-          }}
-          transition={{ duration: 0.18, ease: EASE_OUT }}
-          aria-hidden={!offset}
-          className="flex shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 tabular-nums text-zinc-600"
-        >
-          <ClockIcon size={14} weight="duotone" />
-          <Text variant="small-medium" as="span" className="text-zinc-600">
-            {offset ?? ""}
-          </Text>
-        </motion.div>
+        <AnimatePresence initial={false}>
+          {showAutoDetect ? (
+            <motion.button
+              key="autodetect"
+              type="button"
+              onClick={() => onChange(browserTz)}
+              initial={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: -4, height: 0 }
+              }
+              animate={{ opacity: 1, y: 0, height: "auto" }}
+              exit={
+                reduceMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: -4, height: 0 }
+              }
+              transition={{ duration: 0.22, ease: EASE_OUT }}
+              className="flex w-full items-center gap-2 overflow-hidden rounded-xl border border-dashed border-violet-300 bg-violet-50/60 px-3 py-2 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
+            >
+              <GlobeIcon size={16} weight="duotone" />
+              <Text variant="small" as="span" className="text-violet-800">
+                Looks like you're in{" "}
+                <span className="font-medium">{browserLabel}</span>. Use that?
+              </Text>
+            </motion.button>
+          ) : null}
+        </AnimatePresence>
+
       </div>
-
-      <div className="mt-5">
-        <Select
-          id="timezone"
-          label="Timezone"
-          hideLabel
-          value={value}
-          onValueChange={onChange}
-          options={options}
-          placeholder="Select your timezone"
-          size="medium"
-        />
-      </div>
-
-      <AnimatePresence initial={false}>
-        {showAutoDetect ? (
-          <motion.button
-            key="autodetect"
-            type="button"
-            onClick={() => onChange(browserTz)}
-            initial={
-              reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
-            }
-            animate={{ opacity: 1, y: 0, height: "auto" }}
-            exit={
-              reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
-            }
-            transition={{ duration: 0.22, ease: EASE_OUT }}
-            className="mt-1 flex w-full items-center gap-2 overflow-hidden rounded-xl border border-dashed border-violet-300 bg-violet-50/60 px-3 py-2 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
-          >
-            <GlobeIcon size={16} weight="duotone" />
-            <Text variant="small" as="span" className="text-violet-800">
-              Looks like you're in{" "}
-              <span className="font-medium">{browserLabel}</span>. Use that?
-            </Text>
-          </motion.button>
-        ) : null}
-      </AnimatePresence>
-
-      <AnimatePresence initial={false}>
-        {isDirty ? (
-          <motion.div
-            key="changed"
-            initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
-            transition={{ duration: 0.18, ease: EASE_OUT }}
-            className="mt-3 flex items-center gap-2"
-          >
-            <span
-              aria-hidden
-              className="h-1.5 w-1.5 rounded-full bg-amber-500"
-            />
-            <Text variant="small" as="span" className="text-zinc-500">
-              Unsaved change — review and hit save below.
-            </Text>
-          </motion.div>
-        ) : null}
-      </AnimatePresence>
     </motion.section>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -45,13 +45,17 @@ export function TimezoneCard({
 
   return (
     <motion.section
-      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{
-        duration: 0.32,
-        ease: EASE_OUT,
-        delay: 0.04 + index * 0.05,
-      }}
+      initial={reduceMotion ? false : { opacity: 0, y: 12 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={
+        reduceMotion
+          ? undefined
+          : {
+              duration: 0.32,
+              ease: EASE_OUT,
+              delay: 0.04 + index * 0.05,
+            }
+      }
       className="flex w-full flex-col"
     >
       <div className="flex h-fit flex-col justify-center gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 py-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { ClockIcon, GlobeIcon, InfoIcon } from "@phosphor-icons/react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
@@ -34,19 +33,15 @@ export function TimezoneCard({
   index = 0,
 }: Props) {
   const reduceMotion = useReducedMotion();
-  const browserTz = useMemo(detectBrowserTimezone, []);
-  const offset = useMemo(() => formatGmtOffset(value), [value]);
-  const browserLabel = useMemo(
-    () => findTimezoneLabel(browserTz),
-    [browserTz],
-  );
+  const browserTz = detectBrowserTimezone();
+  const offset = formatGmtOffset(value);
+  const browserLabel = findTimezoneLabel(browserTz);
 
   const showAutoDetect = initialValue !== browserTz && value !== browserTz;
 
-  const options = useMemo(() => {
-    if (TIMEZONES.some((t) => t.value === value)) return TIMEZONES;
-    return [{ value, label: findTimezoneLabel(value) }, ...TIMEZONES];
-  }, [value]);
+  const options = TIMEZONES.some((t) => t.value === value)
+    ? TIMEZONES
+    : [{ value, label: findTimezoneLabel(value) }, ...TIMEZONES];
 
   return (
     <motion.section
@@ -126,7 +121,7 @@ export function TimezoneCard({
             >
               <GlobeIcon size={16} weight="duotone" />
               <Text variant="small" as="span" className="text-violet-800">
-                Looks like you're in{" "}
+                Looks like you&apos;re in{" "}
                 <span className="font-medium">{browserLabel}</span>. Use that?
               </Text>
             </motion.button>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo } from "react";
+import { ClockIcon, GlobeIcon } from "@phosphor-icons/react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import { Select } from "@/components/atoms/Select/Select";
+import { Text } from "@/components/atoms/Text/Text";
+
+import {
+  EASE_OUT,
+  TIMEZONES,
+  detectBrowserTimezone,
+  findTimezoneLabel,
+  formatGmtOffset,
+} from "../../helpers";
+
+interface Props {
+  value: string;
+  initialValue: string;
+  onChange: (timezone: string) => void;
+  index?: number;
+}
+
+export function TimezoneCard({
+  value,
+  initialValue,
+  onChange,
+  index = 0,
+}: Props) {
+  const reduceMotion = useReducedMotion();
+  const browserTz = useMemo(detectBrowserTimezone, []);
+  const offset = useMemo(() => formatGmtOffset(value), [value]);
+  const browserLabel = useMemo(
+    () => findTimezoneLabel(browserTz),
+    [browserTz],
+  );
+
+  const showAutoDetect = initialValue !== browserTz && value !== browserTz;
+  const isDirty = value !== initialValue;
+
+  const options = useMemo(() => {
+    if (TIMEZONES.some((t) => t.value === value)) return TIMEZONES;
+    return [{ value, label: findTimezoneLabel(value) }, ...TIMEZONES];
+  }, [value]);
+
+  return (
+    <motion.section
+      initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
+      className="rounded-[18px] border border-zinc-200 bg-white p-6 shadow-[0_1px_2px_rgba(15,15,20,0.04)] transition-shadow duration-200 ease-out focus-within:shadow-[0_8px_28px_-12px_rgba(15,15,20,0.12)]"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <Text
+            variant="small-medium"
+            as="span"
+            className="uppercase tracking-[0.08em] text-zinc-400"
+          >
+            Time & Locale
+          </Text>
+          <Text variant="h4" as="h2" className="text-[#1F1F20]">
+            Time zone
+          </Text>
+          <Text variant="small" className="text-zinc-500">
+            We'll use this for run schedules, summaries, and timestamps you see.
+          </Text>
+        </div>
+
+        <motion.div
+          initial={false}
+          animate={{
+            opacity: offset ? 1 : 0,
+            scale: offset ? 1 : 0.96,
+          }}
+          transition={{ duration: 0.18, ease: EASE_OUT }}
+          aria-hidden={!offset}
+          className="flex shrink-0 items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1.5 tabular-nums text-zinc-600"
+        >
+          <ClockIcon size={14} weight="duotone" />
+          <Text variant="small-medium" as="span" className="text-zinc-600">
+            {offset ?? ""}
+          </Text>
+        </motion.div>
+      </div>
+
+      <div className="mt-5">
+        <Select
+          id="timezone"
+          label="Timezone"
+          hideLabel
+          value={value}
+          onValueChange={onChange}
+          options={options}
+          placeholder="Select your timezone"
+          size="medium"
+        />
+      </div>
+
+      <AnimatePresence initial={false}>
+        {showAutoDetect ? (
+          <motion.button
+            key="autodetect"
+            type="button"
+            onClick={() => onChange(browserTz)}
+            initial={
+              reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
+            }
+            animate={{ opacity: 1, y: 0, height: "auto" }}
+            exit={
+              reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
+            }
+            transition={{ duration: 0.22, ease: EASE_OUT }}
+            className="mt-1 flex w-full items-center gap-2 overflow-hidden rounded-xl border border-dashed border-violet-300 bg-violet-50/60 px-3 py-2 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
+          >
+            <GlobeIcon size={16} weight="duotone" />
+            <Text variant="small" as="span" className="text-violet-800">
+              Looks like you're in{" "}
+              <span className="font-medium">{browserLabel}</span>. Use that?
+            </Text>
+          </motion.button>
+        ) : null}
+      </AnimatePresence>
+
+      <AnimatePresence initial={false}>
+        {isDirty ? (
+          <motion.div
+            key="changed"
+            initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+            transition={{ duration: 0.18, ease: EASE_OUT }}
+            className="mt-3 flex items-center gap-2"
+          >
+            <span
+              aria-hidden
+              className="h-1.5 w-1.5 rounded-full bg-amber-500"
+            />
+            <Text variant="small" as="span" className="text-zinc-500">
+              Unsaved change — review and hit save below.
+            </Text>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </motion.section>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -122,7 +122,7 @@ export function TimezoneCard({
                   : { opacity: 0, y: -4, height: 0 }
               }
               transition={{ duration: 0.22, ease: EASE_OUT }}
-              className="flex w-full items-center gap-2 overflow-hidden rounded-xl border border-dashed border-violet-300 bg-violet-50/60 px-3 py-2 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
+              className="flex w-fit items-center gap-2 self-end overflow-hidden rounded-full border border-violet-300 bg-violet-50/60 px-3 py-1.5 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
             >
               <GlobeIcon size={16} weight="duotone" />
               <Text variant="small" as="span" className="text-violet-800">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -47,7 +47,11 @@ export function TimezoneCard({
     <motion.section
       initial={reduceMotion ? { opacity: 0 } : { opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.32, ease: EASE_OUT, delay: 0.04 + index * 0.05 }}
+      transition={{
+        duration: 0.32,
+        ease: EASE_OUT,
+        delay: 0.04 + index * 0.05,
+      }}
       className="flex w-full flex-col"
     >
       <div className="flex h-fit flex-col justify-center gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 py-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
@@ -106,15 +110,11 @@ export function TimezoneCard({
               type="button"
               onClick={() => onChange(browserTz)}
               initial={
-                reduceMotion
-                  ? { opacity: 0 }
-                  : { opacity: 0, y: -4, height: 0 }
+                reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
               }
               animate={{ opacity: 1, y: 0, height: "auto" }}
               exit={
-                reduceMotion
-                  ? { opacity: 0 }
-                  : { opacity: 0, y: -4, height: 0 }
+                reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4, height: 0 }
               }
               transition={{ duration: 0.22, ease: EASE_OUT }}
               className="flex w-fit items-center gap-2 self-end overflow-hidden rounded-full border border-violet-300 bg-violet-50/60 px-3 py-1.5 text-left text-violet-800 transition-colors duration-150 ease-out hover:bg-violet-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2"
@@ -127,7 +127,6 @@ export function TimezoneCard({
             </motion.button>
           ) : null}
         </AnimatePresence>
-
       </div>
     </motion.section>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/components/TimezoneCard/TimezoneCard.tsx
@@ -57,7 +57,7 @@ export function TimezoneCard({
       <div className="flex h-fit flex-col justify-center gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 py-3 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
-            <Text variant="body-medium" as="span" className="text-[#1F1F20]">
+            <Text variant="body-medium" as="span" className="text-textBlack">
               Time zone
             </Text>
             <Tooltip>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/helpers.ts
@@ -1,0 +1,291 @@
+import {
+  BellSimpleRingingIcon,
+  ChartLineUpIcon,
+  CoinsIcon,
+  RobotIcon,
+  StorefrontIcon,
+} from "@phosphor-icons/react";
+import type { Icon } from "@phosphor-icons/react";
+
+import type { NotificationPreference } from "@/app/api/__generated__/models/notificationPreference";
+
+export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+export const EASE_IOS = [0.32, 0.72, 0, 1] as const;
+export const EASE_IN_OUT = [0.4, 0, 0.2, 1] as const;
+
+export type NotificationKey =
+  | "notifyOnAgentRun"
+  | "notifyOnBlockExecutionFailed"
+  | "notifyOnContinuousAgentError"
+  | "notifyOnAgentApproved"
+  | "notifyOnAgentRejected"
+  | "notifyOnZeroBalance"
+  | "notifyOnLowBalance"
+  | "notifyOnDailySummary"
+  | "notifyOnWeeklySummary"
+  | "notifyOnMonthlySummary";
+
+export type NotificationFlags = Record<NotificationKey, boolean>;
+
+export interface PreferencesFormState {
+  timezone: string;
+  notifications: NotificationFlags;
+}
+
+export interface NotificationItem {
+  key: NotificationKey;
+  title: string;
+  description: string;
+}
+
+export interface NotificationGroup {
+  id: "agents" | "store" | "balance" | "summary";
+  title: string;
+  caption: string;
+  icon: Icon;
+  accent: string;
+  items: NotificationItem[];
+}
+
+export const NOTIFICATION_GROUPS: NotificationGroup[] = [
+  {
+    id: "agents",
+    title: "Agent activity",
+    caption: "Heads-up when your agents do something — or stop doing it.",
+    icon: RobotIcon,
+    accent: "from-violet-500/15 to-violet-500/0 text-violet-700",
+    items: [
+      {
+        key: "notifyOnAgentRun",
+        title: "Run started or completed",
+        description:
+          "Hear from us when an agent kicks off or finishes a run.",
+      },
+      {
+        key: "notifyOnBlockExecutionFailed",
+        title: "Block execution failed",
+        description: "Get notified the moment a block fails mid-run.",
+      },
+      {
+        key: "notifyOnContinuousAgentError",
+        title: "Continuous errors",
+        description:
+          "Alert me when an agent runs into the same error repeatedly.",
+      },
+    ],
+  },
+  {
+    id: "store",
+    title: "Marketplace",
+    caption: "Updates on agents you've published to the store.",
+    icon: StorefrontIcon,
+    accent: "from-amber-400/15 to-amber-500/0 text-amber-700",
+    items: [
+      {
+        key: "notifyOnAgentApproved",
+        title: "Agent approved",
+        description: "Your submission is live in the store.",
+      },
+      {
+        key: "notifyOnAgentRejected",
+        title: "Agent needs changes",
+        description:
+          "Reviewers have feedback before your agent can go live.",
+      },
+    ],
+  },
+  {
+    id: "balance",
+    title: "Credits & balance",
+    caption: "Stay ahead of an empty tank.",
+    icon: CoinsIcon,
+    accent: "from-emerald-400/15 to-emerald-500/0 text-emerald-700",
+    items: [
+      {
+        key: "notifyOnLowBalance",
+        title: "Running low",
+        description: "Warn me before I run out of credits.",
+      },
+      {
+        key: "notifyOnZeroBalance",
+        title: "Empty balance",
+        description: "Let me know when my balance hits zero.",
+      },
+    ],
+  },
+  {
+    id: "summary",
+    title: "Summaries",
+    caption: "Recap emails to keep tabs on your account at a glance.",
+    icon: ChartLineUpIcon,
+    accent: "from-sky-400/15 to-sky-500/0 text-sky-700",
+    items: [
+      {
+        key: "notifyOnDailySummary",
+        title: "Daily summary",
+        description: "A short daily digest of activity.",
+      },
+      {
+        key: "notifyOnWeeklySummary",
+        title: "Weekly summary",
+        description: "A weekly overview of performance.",
+      },
+      {
+        key: "notifyOnMonthlySummary",
+        title: "Monthly summary",
+        description: "A comprehensive monthly report.",
+      },
+    ],
+  },
+];
+
+export const NOTIFICATIONS_FALLBACK_ICON = BellSimpleRingingIcon;
+
+const PREFERENCE_API_KEYS: Record<NotificationKey, string> = {
+  notifyOnAgentRun: "AGENT_RUN",
+  notifyOnBlockExecutionFailed: "BLOCK_EXECUTION_FAILED",
+  notifyOnContinuousAgentError: "CONTINUOUS_AGENT_ERROR",
+  notifyOnAgentApproved: "AGENT_APPROVED",
+  notifyOnAgentRejected: "AGENT_REJECTED",
+  notifyOnZeroBalance: "ZERO_BALANCE",
+  notifyOnLowBalance: "LOW_BALANCE",
+  notifyOnDailySummary: "DAILY_SUMMARY",
+  notifyOnWeeklySummary: "WEEKLY_SUMMARY",
+  notifyOnMonthlySummary: "MONTHLY_SUMMARY",
+};
+
+export function preferencesToFlags(
+  preferences: NotificationPreference,
+): NotificationFlags {
+  const raw = preferences.preferences ?? {};
+  return Object.fromEntries(
+    (Object.keys(PREFERENCE_API_KEYS) as NotificationKey[]).map((key) => [
+      key,
+      Boolean(raw[PREFERENCE_API_KEYS[key]]),
+    ]),
+  ) as NotificationFlags;
+}
+
+export function flagsToPreferenceMap(
+  flags: NotificationFlags,
+): Record<string, boolean> {
+  return Object.fromEntries(
+    (Object.keys(PREFERENCE_API_KEYS) as NotificationKey[]).map((key) => [
+      PREFERENCE_API_KEYS[key],
+      flags[key],
+    ]),
+  );
+}
+
+export function detectBrowserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+export function isFormDirty(
+  initial: PreferencesFormState,
+  current: PreferencesFormState,
+): boolean {
+  if (initial.timezone !== current.timezone) return true;
+  for (const key of Object.keys(initial.notifications) as NotificationKey[]) {
+    if (initial.notifications[key] !== current.notifications[key]) return true;
+  }
+  return false;
+}
+
+export function dirtyKinds(
+  initial: PreferencesFormState,
+  current: PreferencesFormState,
+): { timezone: boolean; notifications: boolean } {
+  const timezone = initial.timezone !== current.timezone;
+  let notifications = false;
+  for (const key of Object.keys(initial.notifications) as NotificationKey[]) {
+    if (initial.notifications[key] !== current.notifications[key]) {
+      notifications = true;
+      break;
+    }
+  }
+  return { timezone, notifications };
+}
+
+const TIMEZONE_LIST: { value: string; label: string }[] = [
+  { value: "UTC", label: "UTC (Coordinated Universal Time)" },
+  { value: "America/Los_Angeles", label: "Los Angeles (US - Pacific)" },
+  { value: "America/Denver", label: "Denver (US - Mountain)" },
+  { value: "America/Chicago", label: "Chicago (US - Central)" },
+  { value: "America/New_York", label: "New York (US - Eastern)" },
+  { value: "America/Toronto", label: "Toronto (Canada - Eastern)" },
+  { value: "America/Mexico_City", label: "Mexico City (Mexico)" },
+  { value: "America/Sao_Paulo", label: "São Paulo (Brazil)" },
+  { value: "America/Buenos_Aires", label: "Buenos Aires (Argentina)" },
+  { value: "America/Bogota", label: "Bogotá (Colombia)" },
+  { value: "America/Lima", label: "Lima (Peru)" },
+  { value: "America/Santiago", label: "Santiago (Chile)" },
+  { value: "Europe/London", label: "London (UK)" },
+  { value: "Europe/Dublin", label: "Dublin (Ireland)" },
+  { value: "Europe/Lisbon", label: "Lisbon (Portugal)" },
+  { value: "Europe/Madrid", label: "Madrid (Spain)" },
+  { value: "Europe/Paris", label: "Paris (France)" },
+  { value: "Europe/Amsterdam", label: "Amsterdam (Netherlands)" },
+  { value: "Europe/Brussels", label: "Brussels (Belgium)" },
+  { value: "Europe/Berlin", label: "Berlin (Germany)" },
+  { value: "Europe/Zurich", label: "Zurich (Switzerland)" },
+  { value: "Europe/Rome", label: "Rome (Italy)" },
+  { value: "Europe/Vienna", label: "Vienna (Austria)" },
+  { value: "Europe/Prague", label: "Prague (Czechia)" },
+  { value: "Europe/Warsaw", label: "Warsaw (Poland)" },
+  { value: "Europe/Stockholm", label: "Stockholm (Sweden)" },
+  { value: "Europe/Oslo", label: "Oslo (Norway)" },
+  { value: "Europe/Copenhagen", label: "Copenhagen (Denmark)" },
+  { value: "Europe/Helsinki", label: "Helsinki (Finland)" },
+  { value: "Europe/Athens", label: "Athens (Greece)" },
+  { value: "Europe/Istanbul", label: "Istanbul (Türkiye)" },
+  { value: "Europe/Moscow", label: "Moscow (Russia)" },
+  { value: "Africa/Cairo", label: "Cairo (Egypt)" },
+  { value: "Africa/Lagos", label: "Lagos (Nigeria)" },
+  { value: "Africa/Nairobi", label: "Nairobi (Kenya)" },
+  { value: "Africa/Johannesburg", label: "Johannesburg (South Africa)" },
+  { value: "Asia/Dubai", label: "Dubai (UAE)" },
+  { value: "Asia/Tehran", label: "Tehran (Iran)" },
+  { value: "Asia/Karachi", label: "Karachi (Pakistan)" },
+  { value: "Asia/Kolkata", label: "Kolkata (India)" },
+  { value: "Asia/Dhaka", label: "Dhaka (Bangladesh)" },
+  { value: "Asia/Bangkok", label: "Bangkok (Thailand)" },
+  { value: "Asia/Jakarta", label: "Jakarta (Indonesia)" },
+  { value: "Asia/Singapore", label: "Singapore" },
+  { value: "Asia/Manila", label: "Manila (Philippines)" },
+  { value: "Asia/Hong_Kong", label: "Hong Kong" },
+  { value: "Asia/Shanghai", label: "Shanghai (China)" },
+  { value: "Asia/Taipei", label: "Taipei (Taiwan)" },
+  { value: "Asia/Seoul", label: "Seoul (South Korea)" },
+  { value: "Asia/Tokyo", label: "Tokyo (Japan)" },
+  { value: "Australia/Perth", label: "Perth (Australia - West)" },
+  { value: "Australia/Adelaide", label: "Adelaide (Australia - Central)" },
+  { value: "Australia/Brisbane", label: "Brisbane (Australia - East)" },
+  { value: "Australia/Sydney", label: "Sydney (Australia - East)" },
+  { value: "Pacific/Auckland", label: "Auckland (New Zealand)" },
+  { value: "Pacific/Honolulu", label: "Honolulu (US - Hawaii)" },
+];
+
+export const TIMEZONES = TIMEZONE_LIST;
+
+export function findTimezoneLabel(value: string): string {
+  return TIMEZONES.find((t) => t.value === value)?.label ?? value;
+}
+
+export function formatGmtOffset(timezone: string): string | null {
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    });
+    const parts = formatter.formatToParts(new Date());
+    const offset = parts.find((p) => p.type === "timeZoneName")?.value;
+    return offset ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/helpers.ts
@@ -58,8 +58,7 @@ export const NOTIFICATION_GROUPS: NotificationGroup[] = [
       {
         key: "notifyOnAgentRun",
         title: "Run started or completed",
-        description:
-          "Hear from us when an agent kicks off or finishes a run.",
+        description: "Hear from us when an agent kicks off or finishes a run.",
       },
       {
         key: "notifyOnBlockExecutionFailed",
@@ -89,8 +88,7 @@ export const NOTIFICATION_GROUPS: NotificationGroup[] = [
       {
         key: "notifyOnAgentRejected",
         title: "Agent needs changes",
-        description:
-          "Reviewers have feedback before your agent can go live.",
+        description: "Reviewers have feedback before your agent can go live.",
       },
     ],
   },

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -31,7 +31,6 @@ export default function SettingsPreferencesPage() {
     isSaving,
     setTimezone,
     toggleNotification,
-    setAllInGroup,
     discardChanges,
     savePreferences,
   } = usePreferencesPage();
@@ -59,7 +58,7 @@ export default function SettingsPreferencesPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6 pb-28">
+    <div className="flex flex-col gap-6 pb-8">
       <PreferencesHeader />
 
       <AccountCard user={user} index={0} />
@@ -74,7 +73,6 @@ export default function SettingsPreferencesPage() {
       <NotificationsCard
         values={formState.notifications}
         onToggle={toggleNotification}
-        onSetAllInGroup={setAllInGroup}
         index={2}
       />
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -10,7 +10,6 @@ import { PreferencesHeader } from "./components/PreferencesHeader/PreferencesHea
 import { PreferencesSkeleton } from "./components/PreferencesSkeleton/PreferencesSkeleton";
 import { SaveBar } from "./components/SaveBar/SaveBar";
 import { TimezoneCard } from "./components/TimezoneCard/TimezoneCard";
-import { useTimezoneDetection } from "@/app/(platform)/profile/(user)/settings/useTimezoneDetection";
 import { usePreferencesPage } from "./usePreferencesPage";
 
 export default function SettingsPreferencesPage() {
@@ -26,7 +25,6 @@ export default function SettingsPreferencesPage() {
     refetch,
     formState,
     savedState,
-    rawTimezone,
     dirty,
     isSaving,
     setTimezone,
@@ -34,8 +32,6 @@ export default function SettingsPreferencesPage() {
     discardChanges,
     savePreferences,
   } = usePreferencesPage();
-
-  useTimezoneDetection(rawTimezone);
 
   if (isError) {
     return (

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -15,7 +15,7 @@ import { usePreferencesPage } from "./usePreferencesPage";
 
 export default function SettingsPreferencesPage() {
   useEffect(() => {
-    document.title = "Settings – AutoGPT Platform";
+    document.title = "Preferences – AutoGPT Platform";
   }, []);
 
   const {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -25,7 +25,7 @@ export default function SettingsPreferencesPage() {
     error,
     refetch,
     formState,
-    initialState,
+    savedState,
     rawTimezone,
     dirty,
     isSaving,
@@ -65,7 +65,7 @@ export default function SettingsPreferencesPage() {
 
       <TimezoneCard
         value={formState.timezone}
-        initialValue={initialState.timezone}
+        initialValue={savedState.timezone}
         onChange={setTimezone}
         index={1}
       />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -42,9 +42,7 @@ export default function SettingsPreferencesPage() {
       <ErrorCard
         context="settings"
         responseError={
-          error
-            ? { detail: (error as { detail?: string }).detail }
-            : undefined
+          error ? { detail: (error as { detail?: string }).detail } : undefined
         }
         onRetry={() => {
           void refetch();

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/page.tsx
@@ -1,16 +1,89 @@
 "use client";
 
-import { Text } from "@/components/atoms/Text/Text";
+import { useEffect } from "react";
+
+import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+
+import { AccountCard } from "./components/AccountCard/AccountCard";
+import { NotificationsCard } from "./components/NotificationsCard/NotificationsCard";
+import { PreferencesHeader } from "./components/PreferencesHeader/PreferencesHeader";
+import { PreferencesSkeleton } from "./components/PreferencesSkeleton/PreferencesSkeleton";
+import { SaveBar } from "./components/SaveBar/SaveBar";
+import { TimezoneCard } from "./components/TimezoneCard/TimezoneCard";
+import { useTimezoneDetection } from "@/app/(platform)/profile/(user)/settings/useTimezoneDetection";
+import { usePreferencesPage } from "./usePreferencesPage";
 
 export default function SettingsPreferencesPage() {
+  useEffect(() => {
+    document.title = "Settings – AutoGPT Platform";
+  }, []);
+
+  const {
+    user,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    formState,
+    initialState,
+    rawTimezone,
+    dirty,
+    isSaving,
+    setTimezone,
+    toggleNotification,
+    setAllInGroup,
+    discardChanges,
+    savePreferences,
+  } = usePreferencesPage();
+
+  useTimezoneDetection(rawTimezone);
+
+  if (isError) {
+    return (
+      <ErrorCard
+        context="settings"
+        responseError={
+          error
+            ? { detail: (error as { detail?: string }).detail }
+            : undefined
+        }
+        onRetry={() => {
+          void refetch();
+        }}
+      />
+    );
+  }
+
+  if (isLoading || !user) {
+    return <PreferencesSkeleton />;
+  }
+
   return (
-    <>
-      <Text variant="h4" className="text-[#1F1F20]">
-        Settings
-      </Text>
-      <Text variant="large" className="mt-2 text-zinc-600">
-        Coming soon.
-      </Text>
-    </>
+    <div className="flex flex-col gap-6 pb-28">
+      <PreferencesHeader />
+
+      <AccountCard user={user} index={0} />
+
+      <TimezoneCard
+        value={formState.timezone}
+        initialValue={initialState.timezone}
+        onChange={setTimezone}
+        index={1}
+      />
+
+      <NotificationsCard
+        values={formState.notifications}
+        onToggle={toggleNotification}
+        onSetAllInGroup={setAllInGroup}
+        index={2}
+      />
+
+      <SaveBar
+        visible={dirty}
+        saving={isSaving}
+        onDiscard={discardChanges}
+        onSave={savePreferences}
+      />
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -157,6 +157,25 @@ export function usePreferencesPage() {
 
       await Promise.all(tasks);
 
+      if (dirtyParts.timezone) {
+        queryClient.setQueryData(
+          getGetV1GetUserTimezoneQueryKey(),
+          (prev: unknown) => {
+            if (
+              prev &&
+              typeof prev === "object" &&
+              "data" in (prev as Record<string, unknown>)
+            ) {
+              return {
+                ...(prev as Record<string, unknown>),
+                data: { timezone: formState.timezone },
+              };
+            }
+            return { status: 200, data: { timezone: formState.timezone } };
+          },
+        );
+      }
+
       await Promise.all([
         dirtyParts.timezone
           ? queryClient.invalidateQueries({

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -91,11 +91,12 @@ export function usePreferencesPage() {
     function syncFormStateOnce() {
       if (hasInitializedFormState.current) return;
       if (!preferencesQuery.data) return;
+      if (timezoneQuery.isLoading) return;
       setFormState(initialState);
       setSavedState(initialState);
       hasInitializedFormState.current = true;
     },
-    [initialState, preferencesQuery.data],
+    [initialState, preferencesQuery.data, timezoneQuery.isLoading],
   );
 
   const dirty = isFormDirty(savedState, formState);
@@ -202,7 +203,10 @@ export function usePreferencesPage() {
     isLoading,
     isError: preferencesQuery.isError || timezoneQuery.isError,
     error: preferencesQuery.error ?? timezoneQuery.error,
-    refetch: preferencesQuery.refetch,
+    refetch: () => {
+      void preferencesQuery.refetch();
+      void timezoneQuery.refetch();
+    },
     formState,
     savedState,
     rawTimezone: timezoneQuery.data,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -132,34 +132,18 @@ export function usePreferencesPage() {
     if (!dirty || isSaving || !user) return;
 
     setIsSaving(true);
-    try {
-      const tasks: Promise<unknown>[] = [];
 
-      if (dirtyParts.timezone) {
-        tasks.push(
-          updateTimezone.mutateAsync({
-            data: {
-              timezone: formState.timezone as UpdateTimezoneRequestTimezone,
-            },
-          }),
-        );
-      }
+    let timezoneSaved = !dirtyParts.timezone;
+    let notificationsSaved = !dirtyParts.notifications;
+    const failures: string[] = [];
 
-      if (dirtyParts.notifications) {
-        tasks.push(
-          updateNotifications.mutateAsync({
-            data: {
-              email: user.email ?? "",
-              preferences: flagsToPreferenceMap(formState.notifications),
-              daily_limit: 0,
-            },
-          }),
-        );
-      }
-
-      await Promise.all(tasks);
-
-      if (dirtyParts.timezone) {
+    if (dirtyParts.timezone) {
+      try {
+        await updateTimezone.mutateAsync({
+          data: {
+            timezone: formState.timezone as UpdateTimezoneRequestTimezone,
+          },
+        });
         queryClient.setQueryData(
           getGetV1GetUserTimezoneQueryKey(),
           (prev: unknown) => {
@@ -176,25 +160,55 @@ export function usePreferencesPage() {
             return { status: 200, data: { timezone: formState.timezone } };
           },
         );
+        setSavedState((prev) => ({ ...prev, timezone: formState.timezone }));
+        timezoneSaved = true;
+      } catch (err) {
+        failures.push(
+          `Time zone: ${err instanceof Error ? err.message : "unknown error"}`,
+        );
       }
+    }
 
-      if (dirtyParts.notifications) {
+    if (dirtyParts.notifications) {
+      try {
+        await updateNotifications.mutateAsync({
+          data: {
+            email: user.email ?? "",
+            preferences: flagsToPreferenceMap(formState.notifications),
+            daily_limit: 0,
+          },
+        });
         await queryClient.invalidateQueries({
           queryKey: getGetV1GetNotificationPreferencesQueryKey(),
         });
+        setSavedState((prev) => ({
+          ...prev,
+          notifications: formState.notifications,
+        }));
+        notificationsSaved = true;
+      } catch (err) {
+        failures.push(
+          `Notifications: ${err instanceof Error ? err.message : "unknown error"}`,
+        );
       }
+    }
 
-      setSavedState(formState);
+    setIsSaving(false);
 
+    if (failures.length === 0) {
       toast({ title: "Preferences saved", variant: "success" });
-    } catch (err) {
+    } else if (timezoneSaved || notificationsSaved) {
       toast({
-        title: "Couldn't save preferences",
-        description: err instanceof Error ? err.message : undefined,
+        title: "Preferences partially saved",
+        description: failures.join("; "),
         variant: "destructive",
       });
-    } finally {
-      setIsSaving(false);
+    } else {
+      toast({
+        title: "Couldn't save preferences",
+        description: failures.join("; "),
+        variant: "destructive",
+      });
     }
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -80,13 +80,16 @@ export function usePreferencesPage() {
     notifications: EMPTY_FLAGS,
   });
   const [isSaving, setIsSaving] = useState(false);
+  const hasInitializedFormState = useRef(false);
 
   useEffect(
-    function syncFormStateOnLoad() {
-      if (!preferencesQuery.data) return;
+    function syncFormStateOnce() {
+      if (hasInitializedFormState.current) return;
+      if (!preferencesQuery.data || timezoneQuery.data === undefined) return;
       setFormState(initialState);
+      hasInitializedFormState.current = true;
     },
-    [initialState, preferencesQuery.data],
+    [initialState, preferencesQuery.data, timezoneQuery.data],
   );
 
   const dirty = useMemo(

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -131,17 +131,20 @@ export function usePreferencesPage() {
   async function savePreferences() {
     if (!dirty || isSaving || !user) return;
 
+    const snapshot = formState;
+    const partsAtSubmit = dirtyParts;
+
     setIsSaving(true);
 
-    let timezoneSaved = !dirtyParts.timezone;
-    let notificationsSaved = !dirtyParts.notifications;
+    let timezoneSaved = !partsAtSubmit.timezone;
+    let notificationsSaved = !partsAtSubmit.notifications;
     const failures: string[] = [];
 
-    if (dirtyParts.timezone) {
+    if (partsAtSubmit.timezone) {
       try {
         await updateTimezone.mutateAsync({
           data: {
-            timezone: formState.timezone as UpdateTimezoneRequestTimezone,
+            timezone: snapshot.timezone as UpdateTimezoneRequestTimezone,
           },
         });
         queryClient.setQueryData(
@@ -154,13 +157,13 @@ export function usePreferencesPage() {
             ) {
               return {
                 ...(prev as Record<string, unknown>),
-                data: { timezone: formState.timezone },
+                data: { timezone: snapshot.timezone },
               };
             }
-            return { status: 200, data: { timezone: formState.timezone } };
+            return { status: 200, data: { timezone: snapshot.timezone } };
           },
         );
-        setSavedState((prev) => ({ ...prev, timezone: formState.timezone }));
+        setSavedState((prev) => ({ ...prev, timezone: snapshot.timezone }));
         timezoneSaved = true;
       } catch (err) {
         failures.push(
@@ -169,12 +172,12 @@ export function usePreferencesPage() {
       }
     }
 
-    if (dirtyParts.notifications) {
+    if (partsAtSubmit.notifications) {
       try {
         await updateNotifications.mutateAsync({
           data: {
             email: user.email ?? "",
-            preferences: flagsToPreferenceMap(formState.notifications),
+            preferences: flagsToPreferenceMap(snapshot.notifications),
             daily_limit: 0,
           },
         });
@@ -183,7 +186,7 @@ export function usePreferencesPage() {
         });
         setSavedState((prev) => ({
           ...prev,
-          notifications: formState.notifications,
+          notifications: snapshot.notifications,
         }));
         notificationsSaved = true;
       } catch (err) {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -90,13 +90,13 @@ export function usePreferencesPage() {
   useEffect(
     function syncFormStateOnce() {
       if (hasInitializedFormState.current) return;
-      if (!preferencesQuery.data) return;
-      if (timezoneQuery.isLoading) return;
+      if (!preferencesQuery.isSuccess) return;
+      if (!timezoneQuery.isSuccess) return;
       setFormState(initialState);
       setSavedState(initialState);
       hasInitializedFormState.current = true;
     },
-    [initialState, preferencesQuery.data, timezoneQuery.isLoading],
+    [initialState, preferencesQuery.isSuccess, timezoneQuery.isSuccess],
   );
 
   const dirty = isFormDirty(savedState, formState);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -138,8 +138,7 @@ export function usePreferencesPage() {
         tasks.push(
           updateTimezone.mutateAsync({
             data: {
-              timezone:
-                formState.timezone as UpdateTimezoneRequestTimezone,
+              timezone: formState.timezone as UpdateTimezoneRequestTimezone,
             },
           }),
         );

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -64,16 +64,17 @@ export function usePreferencesPage() {
     timezoneQuery.isLoading ||
     !preferencesQuery.data;
 
-  const initialState = useMemo<PreferencesFormState>(() => {
-    const tz =
-      timezoneQuery.data && timezoneQuery.data !== "not-set"
-        ? timezoneQuery.data
-        : detectBrowserTimezone();
-    const flags = preferencesQuery.data
-      ? preferencesToFlags(preferencesQuery.data)
-      : EMPTY_FLAGS;
-    return { timezone: tz, notifications: flags };
-  }, [preferencesQuery.data, timezoneQuery.data]);
+  const initialTimezone =
+    timezoneQuery.data && timezoneQuery.data !== "not-set"
+      ? timezoneQuery.data
+      : detectBrowserTimezone();
+  const initialFlags = preferencesQuery.data
+    ? preferencesToFlags(preferencesQuery.data)
+    : EMPTY_FLAGS;
+  const initialState: PreferencesFormState = {
+    timezone: initialTimezone,
+    notifications: initialFlags,
+  };
 
   const [formState, setFormState] = useState<PreferencesFormState>({
     timezone: detectBrowserTimezone(),
@@ -89,23 +90,16 @@ export function usePreferencesPage() {
   useEffect(
     function syncFormStateOnce() {
       if (hasInitializedFormState.current) return;
-      if (!preferencesQuery.data || timezoneQuery.data === undefined) return;
+      if (!preferencesQuery.data) return;
       setFormState(initialState);
       setSavedState(initialState);
       hasInitializedFormState.current = true;
     },
-    [initialState, preferencesQuery.data, timezoneQuery.data],
+    [initialState, preferencesQuery.data],
   );
 
-  const dirty = useMemo(
-    () => isFormDirty(savedState, formState),
-    [savedState, formState],
-  );
-
-  const dirtyParts = useMemo(
-    () => dirtyKinds(savedState, formState),
-    [savedState, formState],
-  );
+  const dirty = isFormDirty(savedState, formState);
+  const dirtyParts = dirtyKinds(savedState, formState);
 
   function setTimezone(value: string) {
     setFormState((prev) => ({ ...prev, timezone: value }));
@@ -207,8 +201,8 @@ export function usePreferencesPage() {
   return {
     user,
     isLoading,
-    isError: preferencesQuery.isError,
-    error: preferencesQuery.error,
+    isError: preferencesQuery.isError || timezoneQuery.isError,
+    error: preferencesQuery.error ?? timezoneQuery.error,
     refetch: preferencesQuery.refetch,
     formState,
     savedState,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGetV1GetNotificationPreferencesQueryKey,
+  getGetV1GetUserTimezoneQueryKey,
+  useGetV1GetNotificationPreferences,
+  useGetV1GetUserTimezone,
+  usePostV1UpdateNotificationPreferences,
+  usePostV1UpdateUserTimezone,
+} from "@/app/api/__generated__/endpoints/auth/auth";
+import type { UpdateTimezoneRequestTimezone } from "@/app/api/__generated__/models/updateTimezoneRequestTimezone";
+import { okData } from "@/app/api/helpers";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+
+import {
+  detectBrowserTimezone,
+  dirtyKinds,
+  flagsToPreferenceMap,
+  isFormDirty,
+  preferencesToFlags,
+  type NotificationFlags,
+  type NotificationKey,
+  type PreferencesFormState,
+} from "./helpers";
+
+const EMPTY_FLAGS: NotificationFlags = {
+  notifyOnAgentRun: false,
+  notifyOnBlockExecutionFailed: false,
+  notifyOnContinuousAgentError: false,
+  notifyOnAgentApproved: false,
+  notifyOnAgentRejected: false,
+  notifyOnZeroBalance: false,
+  notifyOnLowBalance: false,
+  notifyOnDailySummary: false,
+  notifyOnWeeklySummary: false,
+  notifyOnMonthlySummary: false,
+};
+
+export function usePreferencesPage() {
+  const { user } = useSupabase();
+  const queryClient = useQueryClient();
+
+  const preferencesQuery = useGetV1GetNotificationPreferences({
+    query: {
+      enabled: !!user,
+      select: okData,
+    },
+  });
+
+  const timezoneQuery = useGetV1GetUserTimezone({
+    query: {
+      enabled: !!user,
+      select: (res) => okData(res)?.timezone ?? "not-set",
+    },
+  });
+
+  const isLoading =
+    !user ||
+    preferencesQuery.isLoading ||
+    timezoneQuery.isLoading ||
+    !preferencesQuery.data;
+
+  const initialState = useMemo<PreferencesFormState>(() => {
+    const tz =
+      timezoneQuery.data && timezoneQuery.data !== "not-set"
+        ? timezoneQuery.data
+        : detectBrowserTimezone();
+    const flags = preferencesQuery.data
+      ? preferencesToFlags(preferencesQuery.data)
+      : EMPTY_FLAGS;
+    return { timezone: tz, notifications: flags };
+  }, [preferencesQuery.data, timezoneQuery.data]);
+
+  const [formState, setFormState] = useState<PreferencesFormState>({
+    timezone: detectBrowserTimezone(),
+    notifications: EMPTY_FLAGS,
+  });
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(
+    function syncFormStateOnLoad() {
+      if (!preferencesQuery.data) return;
+      setFormState(initialState);
+    },
+    [initialState, preferencesQuery.data],
+  );
+
+  const dirty = useMemo(
+    () => isFormDirty(initialState, formState),
+    [initialState, formState],
+  );
+
+  const dirtyParts = useMemo(
+    () => dirtyKinds(initialState, formState),
+    [initialState, formState],
+  );
+
+  function setTimezone(value: string) {
+    setFormState((prev) => ({ ...prev, timezone: value }));
+  }
+
+  function toggleNotification(key: NotificationKey, value: boolean) {
+    setFormState((prev) => ({
+      ...prev,
+      notifications: { ...prev.notifications, [key]: value },
+    }));
+  }
+
+  function setAllInGroup(keys: NotificationKey[], value: boolean) {
+    setFormState((prev) => {
+      const next = { ...prev.notifications };
+      for (const key of keys) next[key] = value;
+      return { ...prev, notifications: next };
+    });
+  }
+
+  function discardChanges() {
+    setFormState(initialState);
+  }
+
+  const updateTimezone = usePostV1UpdateUserTimezone();
+  const updateNotifications = usePostV1UpdateNotificationPreferences();
+
+  async function savePreferences() {
+    if (!dirty || isSaving || !user) return;
+
+    setIsSaving(true);
+    try {
+      const tasks: Promise<unknown>[] = [];
+
+      if (dirtyParts.timezone) {
+        tasks.push(
+          updateTimezone.mutateAsync({
+            data: {
+              timezone:
+                formState.timezone as UpdateTimezoneRequestTimezone,
+            },
+          }),
+        );
+      }
+
+      if (dirtyParts.notifications) {
+        tasks.push(
+          updateNotifications.mutateAsync({
+            data: {
+              email: user.email ?? "",
+              preferences: flagsToPreferenceMap(formState.notifications),
+              daily_limit: 0,
+            },
+          }),
+        );
+      }
+
+      await Promise.all(tasks);
+
+      await Promise.all([
+        dirtyParts.timezone
+          ? queryClient.invalidateQueries({
+              queryKey: getGetV1GetUserTimezoneQueryKey(),
+            })
+          : null,
+        dirtyParts.notifications
+          ? queryClient.invalidateQueries({
+              queryKey: getGetV1GetNotificationPreferencesQueryKey(),
+            })
+          : null,
+      ]);
+
+      toast({ title: "Preferences saved", variant: "success" });
+    } catch (err) {
+      toast({
+        title: "Couldn't save preferences",
+        description: err instanceof Error ? err.message : undefined,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return {
+    user,
+    isLoading,
+    isError: preferencesQuery.isError,
+    error: preferencesQuery.error,
+    refetch: preferencesQuery.refetch,
+    formState,
+    initialState,
+    rawTimezone: timezoneQuery.data,
+    dirty,
+    isSaving,
+    setTimezone,
+    toggleNotification,
+    setAllInGroup,
+    discardChanges,
+    savePreferences,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -79,6 +79,10 @@ export function usePreferencesPage() {
     timezone: detectBrowserTimezone(),
     notifications: EMPTY_FLAGS,
   });
+  const [savedState, setSavedState] = useState<PreferencesFormState>({
+    timezone: detectBrowserTimezone(),
+    notifications: EMPTY_FLAGS,
+  });
   const [isSaving, setIsSaving] = useState(false);
   const hasInitializedFormState = useRef(false);
 
@@ -87,19 +91,20 @@ export function usePreferencesPage() {
       if (hasInitializedFormState.current) return;
       if (!preferencesQuery.data || timezoneQuery.data === undefined) return;
       setFormState(initialState);
+      setSavedState(initialState);
       hasInitializedFormState.current = true;
     },
     [initialState, preferencesQuery.data, timezoneQuery.data],
   );
 
   const dirty = useMemo(
-    () => isFormDirty(initialState, formState),
-    [initialState, formState],
+    () => isFormDirty(savedState, formState),
+    [savedState, formState],
   );
 
   const dirtyParts = useMemo(
-    () => dirtyKinds(initialState, formState),
-    [initialState, formState],
+    () => dirtyKinds(savedState, formState),
+    [savedState, formState],
   );
 
   function setTimezone(value: string) {
@@ -122,7 +127,7 @@ export function usePreferencesPage() {
   }
 
   function discardChanges() {
-    setFormState(initialState);
+    setFormState(savedState);
   }
 
   const updateTimezone = usePostV1UpdateUserTimezone();
@@ -185,6 +190,8 @@ export function usePreferencesPage() {
         });
       }
 
+      setSavedState(formState);
+
       toast({ title: "Preferences saved", variant: "success" });
     } catch (err) {
       toast({
@@ -204,7 +211,7 @@ export function usePreferencesPage() {
     error: preferencesQuery.error,
     refetch: preferencesQuery.refetch,
     formState,
-    initialState,
+    savedState,
     rawTimezone: timezoneQuery.data,
     dirty,
     isSaving,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/preferences/usePreferencesPage.ts
@@ -176,18 +176,11 @@ export function usePreferencesPage() {
         );
       }
 
-      await Promise.all([
-        dirtyParts.timezone
-          ? queryClient.invalidateQueries({
-              queryKey: getGetV1GetUserTimezoneQueryKey(),
-            })
-          : null,
-        dirtyParts.notifications
-          ? queryClient.invalidateQueries({
-              queryKey: getGetV1GetNotificationPreferencesQueryKey(),
-            })
-          : null,
-      ]);
+      if (dirtyParts.notifications) {
+        await queryClient.invalidateQueries({
+          queryKey: getGetV1GetNotificationPreferencesQueryKey(),
+        });
+      }
 
       toast({ title: "Preferences saved", variant: "success" });
     } catch (err) {


### PR DESCRIPTION
### Why / What / How

**Why** — Settings v2 needs a dedicated Preferences page covering account info (email, password reset), time zone, and notification preferences with a single, predictable save flow. The existing legacy page at `/profile/(user)/settings` mixes concerns and uses `__legacy__` UI primitives we are migrating away from. SECRT-2279.

**What** — A new preferences page at `/settings/preferences` built from atomic / molecular design-system components. Three cards (Account, Time zone, Notifications) share one inline Save / Discard bar at the bottom. The page replaces the legacy settings page from a UX standpoint while keeping the same backend mutations.

<img width="1511" height="899" alt="Screenshot 2026-04-27 at 6 43 09 PM" src="https://github.com/user-attachments/assets/5762fc41-1654-4764-8fbf-d5dd262e031a" />

**How**
- **Page composition (`page.tsx`)** uses a single `usePreferencesPage` hook that owns dirty/saved/form state. Renders `PreferencesHeader`, `AccountCard`, `TimezoneCard`, `NotificationsCard`, and the inline `SaveBar` below the cards.
- **Account card** — Email row shows the current address with a compact pencil button that opens a width-constrained `Dialog` for editing (Cancel / Update). Password row is a `NextLink` button that routes to `/reset-password`.
- **Time zone card** — Single row inside a card: label + info-icon tooltip on the left; small-size `Select` and the GMT offset chip on the right. The "auto-detect" prompt shows up only when the saved tz differs from the browser tz, rendered as a pill on the right side of the card.
- **Notifications card** — Tabs for Agents / Marketplace / Credits; toggling a switch flips a flag in formState and enables Save.
- **Save flow** — `usePreferencesPage` keeps a `savedState` snapshot (mirrors the old `react-hook-form` `defaultValues` capture-once semantics) so the dirty check is fully decoupled from any backend GET refetch. After a successful mutation, `savedState ← formState`, and the timezone query cache gets an optimistic `setQueryData` write so the value isn't snapped back by the (cached) GET endpoint.
- **Skeleton** — `PreferencesSkeleton` mirrors the real layout — header, Account card with the two row shapes, Time zone single row, Notifications tabs + toggle rows, and the Save / Discard buttons.
- **Sidebar** — Renames the entry "Settings" → "Preferences" with `SlidersHorizontalIcon`. Profile and Creator Dashboard get clearer affordances (`UserIcon`, `ChartLineUpIcon`).

### Changes 🏗️

- New page: `src/app/(platform)/settings/preferences/page.tsx` and `usePreferencesPage.ts`
- New components: `AccountCard`, `TimezoneCard`, `NotificationsCard`, `PreferencesHeader`, `PreferencesSkeleton`, `SaveBar`
- Helpers: `helpers.ts` (timezones list, GMT-offset formatter, dirty utilities, notification-group definitions)
- Sidebar: rename "Settings" → "Preferences", swap to `SlidersHorizontalIcon` + cleaner Profile / Creator Dashboard icons (`SettingsSidebar/helpers.ts`)
- Tests:
  - `preferences/__tests__/main.test.tsx` — page render, edit-email dialog open/cancel, time zone info trigger, Save/Discard disabled-on-clean, notification toggle → save submission, discard revert
  - Updated `SettingsSidebar.test.tsx` and `SettingsMobileNav.test.tsx` for the "Preferences" label

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Sidebar shows "Preferences" with the new icon; clicking routes to `/settings/preferences`
  - [ ] Account card: pencil button opens a 420px-wide dialog; Update button stays disabled until the email differs and is valid; Cancel closes the dialog
  - [ ] Password row: "Reset password" button navigates to `/reset-password`
  - [ ] Time zone: changing the select enables Save; clicking Save persists the value and the form keeps showing the saved value (does not snap back), the inline GMT offset chip updates, info tooltip appears on hover
  - [ ] Auto-detect prompt appears only when saved tz ≠ browser tz; clicking it sets the select to the browser tz
  - [ ] Notifications: toggling any switch enables Save; saving flips the flag in the request body; switching tabs preserves toggles; Discard reverts unsaved toggles
  - [ ] Save / Discard render below the cards on the right and stay disabled until any field is dirty
  - [ ] Loading state shows the new skeleton that mirrors the layout
  - [ ] `pnpm test:unit` passes (covers the page-level integration tests above)

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
