### PR TITLE
feat(frontend): creator dashboard page for settings v2 (SECRT-2281)

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/placeholder-pages.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/__tests__/placeholder-pages.test.tsx
@@ -1,11 +1,9 @@
 import { render, screen } from "@/tests/integrations/test-utils";
 import { describe, expect, it } from "vitest";
-import SettingsCreatorDashboardPage from "../creator-dashboard/page";
 import SettingsBillingPage from "../billing/page";
 import SettingsOAuthAppsPage from "../oauth-apps/page";
 
 const pages = [
-  { Component: SettingsCreatorDashboardPage, title: "Creator Dashboard" },
   { Component: SettingsBillingPage, title: "Billing" },
   { Component: SettingsOAuthAppsPage, title: "OAuth Apps" },
 ];

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "vitest";
+
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+
+import {
+  applyFiltersAndSort,
+  computeStats,
+  filterSubmissions,
+  formatRuns,
+  formatSubmittedAt,
+  INITIAL_FILTER_STATE,
+  isFiltered,
+  STATUS_FILTERS,
+  STATUS_OPTIONS,
+  STATUS_VISUAL,
+  type FilterState,
+} from "../helpers";
+
+function makeSubmission(
+  overrides: Partial<StoreSubmission> = {},
+): StoreSubmission {
+  return {
+    listing_id: "listing-1",
+    user_id: "user-1",
+    slug: "agent-slug",
+    listing_version_id: "lv-1",
+    listing_version: 1,
+    graph_id: "graph-1",
+    graph_version: 1,
+    name: "Test Agent",
+    sub_heading: "sub",
+    description: "desc",
+    instructions: null,
+    categories: [],
+    image_urls: [],
+    video_url: null,
+    agent_output_demo_url: null,
+    submitted_at: null,
+    changes_summary: null,
+    status: SubmissionStatus.PENDING,
+    run_count: 0,
+    review_count: 0,
+    review_avg_rating: 0,
+    ...overrides,
+  };
+}
+
+describe("creator-dashboard helpers", () => {
+  describe("INITIAL_FILTER_STATE", () => {
+    test("starts with no filters and descending sort direction", () => {
+      expect(INITIAL_FILTER_STATE).toEqual({
+        statuses: [],
+        nameQuery: "",
+        sortKey: null,
+        sortDir: "desc",
+      });
+    });
+  });
+
+  describe("isFiltered", () => {
+    test("returns false on initial state", () => {
+      expect(isFiltered(INITIAL_FILTER_STATE)).toBe(false);
+    });
+
+    test("returns true if any status selected", () => {
+      const state: FilterState = {
+        ...INITIAL_FILTER_STATE,
+        statuses: [SubmissionStatus.APPROVED],
+      };
+      expect(isFiltered(state)).toBe(true);
+    });
+
+    test("returns true if name query is non-empty after trim", () => {
+      expect(isFiltered({ ...INITIAL_FILTER_STATE, nameQuery: "foo" })).toBe(
+        true,
+      );
+      expect(isFiltered({ ...INITIAL_FILTER_STATE, nameQuery: "   " })).toBe(
+        false,
+      );
+    });
+
+    test("returns true if sortKey is set", () => {
+      expect(isFiltered({ ...INITIAL_FILTER_STATE, sortKey: "runs" })).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("applyFiltersAndSort", () => {
+    const items = [
+      makeSubmission({
+        listing_version_id: "a",
+        name: "Alpha",
+        status: SubmissionStatus.APPROVED,
+        run_count: 100,
+        review_avg_rating: 4.5,
+        submitted_at: new Date("2026-01-10"),
+      }),
+      makeSubmission({
+        listing_version_id: "b",
+        name: "Beta Agent",
+        status: SubmissionStatus.PENDING,
+        run_count: 50,
+        review_avg_rating: 3,
+        submitted_at: new Date("2026-02-10"),
+      }),
+      makeSubmission({
+        listing_version_id: "c",
+        name: "Gamma",
+        status: SubmissionStatus.REJECTED,
+        run_count: 999,
+        review_avg_rating: 5,
+        submitted_at: new Date("2026-03-10"),
+      }),
+    ];
+
+    test("returns same list when no filters or sort applied", () => {
+      const result = applyFiltersAndSort(items, INITIAL_FILTER_STATE);
+      expect(result).toHaveLength(3);
+      expect(result.map((s) => s.listing_version_id)).toEqual(["a", "b", "c"]);
+    });
+
+    test("filters by status set", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        statuses: [SubmissionStatus.APPROVED, SubmissionStatus.REJECTED],
+      });
+      expect(result.map((s) => s.listing_version_id)).toEqual(["a", "c"]);
+    });
+
+    test("filters by case-insensitive name query", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        nameQuery: "BETA",
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].listing_version_id).toBe("b");
+    });
+
+    test("ignores whitespace-only name query", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        nameQuery: "   ",
+      });
+      expect(result).toHaveLength(3);
+    });
+
+    test("sorts by runs descending", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "runs",
+        sortDir: "desc",
+      });
+      expect(result.map((s) => s.listing_version_id)).toEqual(["c", "a", "b"]);
+    });
+
+    test("sorts by runs ascending", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "runs",
+        sortDir: "asc",
+      });
+      expect(result.map((s) => s.listing_version_id)).toEqual(["b", "a", "c"]);
+    });
+
+    test("sorts by rating descending", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "rating",
+        sortDir: "desc",
+      });
+      expect(result.map((s) => s.listing_version_id)).toEqual(["c", "a", "b"]);
+    });
+
+    test("sorts by submitted date descending (newest first)", () => {
+      const result = applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "submitted",
+        sortDir: "desc",
+      });
+      expect(result.map((s) => s.listing_version_id)).toEqual(["c", "b", "a"]);
+    });
+
+    test("treats null submitted_at as 0 when sorting", () => {
+      const withNull = [
+        ...items,
+        makeSubmission({
+          listing_version_id: "d",
+          submitted_at: null,
+        }),
+      ];
+      const result = applyFiltersAndSort(withNull, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "submitted",
+        sortDir: "asc",
+      });
+      expect(result[0].listing_version_id).toBe("d");
+    });
+
+    test("does not mutate original array when sorting", () => {
+      const original = [...items];
+      applyFiltersAndSort(items, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "runs",
+        sortDir: "asc",
+      });
+      expect(items.map((s) => s.listing_version_id)).toEqual(
+        original.map((s) => s.listing_version_id),
+      );
+    });
+  });
+
+  describe("computeStats", () => {
+    test("returns zeroed stats with null average for empty list", () => {
+      expect(computeStats([])).toEqual({
+        total: 0,
+        approved: 0,
+        pending: 0,
+        totalRuns: 0,
+        averageRating: null,
+      });
+    });
+
+    test("aggregates totals, approved, pending, runs, and average rating", () => {
+      const list = [
+        makeSubmission({
+          status: SubmissionStatus.APPROVED,
+          run_count: 100,
+          review_avg_rating: 4,
+        }),
+        makeSubmission({
+          status: SubmissionStatus.APPROVED,
+          run_count: 200,
+          review_avg_rating: 5,
+        }),
+        makeSubmission({
+          status: SubmissionStatus.PENDING,
+          run_count: 50,
+          review_avg_rating: 0,
+        }),
+        makeSubmission({
+          status: SubmissionStatus.REJECTED,
+          run_count: 10,
+        }),
+      ];
+
+      expect(computeStats(list)).toEqual({
+        total: 4,
+        approved: 2,
+        pending: 1,
+        totalRuns: 360,
+        averageRating: 4.5,
+      });
+    });
+
+    test("returns null average when no submission has a positive rating", () => {
+      const list = [
+        makeSubmission({ review_avg_rating: 0 }),
+        makeSubmission({ review_avg_rating: undefined }),
+      ];
+      expect(computeStats(list).averageRating).toBeNull();
+    });
+  });
+
+  describe("filterSubmissions", () => {
+    const list = [
+      makeSubmission({
+        listing_version_id: "a",
+        status: SubmissionStatus.APPROVED,
+      }),
+      makeSubmission({
+        listing_version_id: "b",
+        status: SubmissionStatus.PENDING,
+      }),
+    ];
+
+    test("returns all when filter is 'all'", () => {
+      expect(filterSubmissions(list, "all")).toHaveLength(2);
+    });
+
+    test("returns only matching status", () => {
+      const result = filterSubmissions(list, SubmissionStatus.PENDING);
+      expect(result).toHaveLength(1);
+      expect(result[0].listing_version_id).toBe("b");
+    });
+  });
+
+  describe("formatRuns", () => {
+    test("formats sub-thousand values with locale separators", () => {
+      expect(formatRuns(0)).toBe("0");
+      expect(formatRuns(999)).toBe("999");
+    });
+
+    test("formats thousands with K suffix", () => {
+      expect(formatRuns(1_500)).toBe("1.5K");
+      expect(formatRuns(12_345)).toBe("12.3K");
+    });
+
+    test("formats millions with M suffix", () => {
+      expect(formatRuns(1_500_000)).toBe("1.5M");
+    });
+  });
+
+  describe("formatSubmittedAt", () => {
+    test("returns em dash for null/undefined", () => {
+      expect(formatSubmittedAt(null)).toBe("—");
+      expect(formatSubmittedAt(undefined)).toBe("—");
+    });
+
+    test("returns em dash for invalid date", () => {
+      expect(formatSubmittedAt(new Date("not-a-date"))).toBe("—");
+    });
+
+    test("formats valid Date instance", () => {
+      const formatted = formatSubmittedAt(new Date("2026-04-15T00:00:00Z"));
+      expect(formatted).not.toBe("—");
+      expect(formatted.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("static option lists", () => {
+    test("STATUS_OPTIONS covers all submission statuses except DRAFT visual aside", () => {
+      const values = STATUS_OPTIONS.map((o) => o.value);
+      expect(values).toContain(SubmissionStatus.PENDING);
+      expect(values).toContain(SubmissionStatus.APPROVED);
+      expect(values).toContain(SubmissionStatus.REJECTED);
+      expect(values).toContain(SubmissionStatus.DRAFT);
+    });
+
+    test("STATUS_FILTERS includes 'all' plus every status", () => {
+      const values = STATUS_FILTERS.map((f) => f.value);
+      expect(values[0]).toBe("all");
+      expect(values).toContain(SubmissionStatus.PENDING);
+      expect(values).toContain(SubmissionStatus.APPROVED);
+      expect(values).toContain(SubmissionStatus.REJECTED);
+      expect(values).toContain(SubmissionStatus.DRAFT);
+    });
+
+    test("STATUS_VISUAL has an entry for every SubmissionStatus", () => {
+      for (const status of Object.values(SubmissionStatus)) {
+        expect(STATUS_VISUAL[status]).toBeDefined();
+        expect(STATUS_VISUAL[status].label.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
@@ -301,6 +301,12 @@ describe("creator-dashboard helpers", () => {
       expect(result).toHaveLength(1);
       expect(result[0].listing_version_id).toBe("b");
     });
+
+    test("returns a copy on 'all' so callers can't mutate the input", () => {
+      const result = filterSubmissions(list, "all");
+      expect(result).not.toBe(list);
+      expect(result).toEqual(list);
+    });
   });
 
   describe("formatRuns", () => {
@@ -316,6 +322,11 @@ describe("creator-dashboard helpers", () => {
 
     test("formats millions with M suffix", () => {
       expect(formatRuns(1_500_000)).toBe("1.5M");
+    });
+
+    test("promotes near-million boundary into M (no '1000.0K')", () => {
+      expect(formatRuns(999_950)).toBe("1.0M");
+      expect(formatRuns(999_949)).toBe("999.9K");
     });
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   filterSubmissions,
   formatRuns,
   formatSubmittedAt,
+  getStatusVisual,
   INITIAL_FILTER_STATE,
   isFiltered,
   STATUS_FILTERS,
@@ -182,6 +183,22 @@ describe("creator-dashboard helpers", () => {
       expect(result.map((s) => s.listing_version_id)).toEqual(["c", "b", "a"]);
     });
 
+    test("treats invalid submitted_at strings as 0 (NaN guard)", () => {
+      const withInvalid = [
+        ...items,
+        makeSubmission({
+          listing_version_id: "bad",
+          submitted_at: "not-a-date" as unknown as Date,
+        }),
+      ];
+      const result = applyFiltersAndSort(withInvalid, {
+        ...INITIAL_FILTER_STATE,
+        sortKey: "submitted",
+        sortDir: "asc",
+      });
+      expect(result[0].listing_version_id).toBe("bad");
+    });
+
     test("treats null submitted_at as 0 when sorting", () => {
       const withNull = [
         ...items,
@@ -342,6 +359,24 @@ describe("creator-dashboard helpers", () => {
         expect(STATUS_VISUAL[status]).toBeDefined();
         expect(STATUS_VISUAL[status].label.length).toBeGreaterThan(0);
       }
+    });
+  });
+
+  describe("getStatusVisual", () => {
+    test("returns the matching visual for a known status", () => {
+      expect(getStatusVisual(SubmissionStatus.APPROVED)).toBe(
+        STATUS_VISUAL[SubmissionStatus.APPROVED],
+      );
+      expect(getStatusVisual(SubmissionStatus.PENDING)).toBe(
+        STATUS_VISUAL[SubmissionStatus.PENDING],
+      );
+    });
+
+    test("falls back to DRAFT visual for an unknown status", () => {
+      const unknown = "ARCHIVED" as unknown as SubmissionStatus;
+      expect(getStatusVisual(unknown)).toBe(
+        STATUS_VISUAL[SubmissionStatus.DRAFT],
+      );
     });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  getDeleteV2DeleteStoreSubmissionMockHandler,
+  getGetV2ListMySubmissionsMockHandler,
+  getGetV2ListMySubmissionsMockHandler401,
+} from "@/app/api/__generated__/endpoints/store/store.msw";
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionsResponse } from "@/app/api/__generated__/models/storeSubmissionsResponse";
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import { server } from "@/mocks/mock-server";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+
+import SettingsCreatorDashboardPage from "../page";
+
+const mockUseSupabase = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: mockUseSupabase,
+}));
+
+vi.mock("@/components/contextual/PublishAgentModal/PublishAgentModal", () => ({
+  PublishAgentModal: ({ trigger }: { trigger: React.ReactNode }) => (
+    <>{trigger}</>
+  ),
+}));
+
+vi.mock("@/components/contextual/EditAgentModal/EditAgentModal", () => ({
+  EditAgentModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="edit-agent-modal" /> : null,
+}));
+
+const testUser = {
+  id: "user-1",
+  email: "user@example.com",
+  app_metadata: {},
+  user_metadata: {},
+  aud: "authenticated",
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+function makeSubmission(
+  overrides: Partial<StoreSubmission> = {},
+): StoreSubmission {
+  return {
+    listing_id: "listing-base",
+    user_id: "user-1",
+    slug: "agent-slug",
+    listing_version_id: "lv-base",
+    listing_version: 1,
+    graph_id: "graph-base",
+    graph_version: 1,
+    name: "Base Agent",
+    sub_heading: "sub",
+    description: "desc",
+    instructions: null,
+    categories: [],
+    image_urls: [],
+    video_url: null,
+    agent_output_demo_url: null,
+    submitted_at: new Date("2026-04-01T00:00:00Z"),
+    changes_summary: null,
+    status: SubmissionStatus.PENDING,
+    run_count: 0,
+    review_count: 0,
+    review_avg_rating: 0,
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  submissions: StoreSubmission[],
+): StoreSubmissionsResponse {
+  return {
+    submissions,
+    pagination: {
+      total_items: submissions.length,
+      total_pages: 1,
+      current_page: 1,
+      page_size: submissions.length || 20,
+    },
+  };
+}
+
+describe("SettingsCreatorDashboardPage", () => {
+  beforeEach(() => {
+    mockUseSupabase.mockReturnValue({
+      user: testUser,
+      isLoggedIn: true,
+      isUserLoading: false,
+      supabase: {},
+    });
+  });
+
+  test("renders header, stats, and submission rows from the API", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-1",
+            name: "Approved Agent",
+            status: SubmissionStatus.APPROVED,
+            run_count: 1500,
+            review_avg_rating: 4.2,
+          }),
+          makeSubmission({
+            listing_version_id: "lv-2",
+            name: "Pending Agent",
+            status: SubmissionStatus.PENDING,
+            run_count: 50,
+            review_avg_rating: 0,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: /creator dashboard/i }),
+    ).toBeDefined();
+
+    expect(
+      await screen.findByRole("region", { name: /submission stats/i }),
+    ).toBeDefined();
+
+    expect(screen.getByText("Total submissions")).toBeDefined();
+    expect(screen.getByText("Total runs")).toBeDefined();
+    expect(screen.getAllByText("Approved").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("In review").length).toBeGreaterThan(0);
+
+    expect(
+      (await screen.findAllByText("Approved Agent")).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pending Agent").length).toBeGreaterThan(0);
+
+    expect(screen.getAllByText("1.5K").length).toBeGreaterThan(0);
+  });
+
+  test("renders empty state when API returns no submissions", async () => {
+    server.use(getGetV2ListMySubmissionsMockHandler(makeResponse([])));
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(await screen.findByText(/no submissions yet/i)).toBeDefined();
+
+    expect(
+      screen.queryByRole("region", { name: /submission stats/i }),
+    ).toBeNull();
+    expect(screen.queryByTestId("submissions-list")).toBeNull();
+  });
+
+  test("renders error card when the submissions API fails", async () => {
+    server.use(getGetV2ListMySubmissionsMockHandler401());
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(await screen.findByText(/something went wrong/i)).toBeDefined();
+    expect(
+      screen.queryByRole("heading", { name: /creator dashboard/i }),
+    ).toBeNull();
+  });
+
+  test("error card 'Try again' refetches and recovers", async () => {
+    server.use(getGetV2ListMySubmissionsMockHandler401());
+
+    render(<SettingsCreatorDashboardPage />);
+
+    await screen.findByText(/something went wrong/i);
+
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-recover",
+            name: "Recovered Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(
+      (await screen.findAllByText("Recovered Agent")).length,
+    ).toBeGreaterThan(0);
+  });
+
+  test("filters submissions by name via the dashboard hook state", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-1",
+            name: "Approved Agent",
+            status: SubmissionStatus.APPROVED,
+          }),
+          makeSubmission({
+            listing_version_id: "lv-2",
+            name: "Pending Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(
+      (await screen.findAllByText("Approved Agent")).length,
+    ).toBeGreaterThan(0);
+
+    expect(screen.getAllByText("Pending Agent").length).toBeGreaterThan(0);
+  });
+
+  test("deleting a pending submission via row action calls the delete endpoint", async () => {
+    let deletedId: string | null = null;
+
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-target",
+            name: "Deletable Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+      getDeleteV2DeleteStoreSubmissionMockHandler(async ({ params }) => {
+        deletedId = params.submissionId as string;
+        return true;
+      }),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(
+      (await screen.findAllByText("Deletable Agent")).length,
+    ).toBeGreaterThan(0);
+
+    const actionButtons = screen.getAllByTestId("submission-actions");
+    fireEvent.pointerDown(actionButtons[0], { button: 0 });
+
+    const deleteMenuItem = await screen.findByRole("menuitem", {
+      name: /delete/i,
+    });
+    fireEvent.click(deleteMenuItem);
+
+    const confirmButton = await screen.findByRole("button", {
+      name: /delete submission/i,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(deletedId).toBe("lv-target");
+    });
+  });
+
+  test("approved submissions cannot be selected (no checkbox rendered)", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-approved",
+            name: "Approved Agent",
+            status: SubmissionStatus.APPROVED,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(
+      (await screen.findAllByText("Approved Agent")).length,
+    ).toBeGreaterThan(0);
+
+    expect(
+      screen.queryByRole("checkbox", { name: /select approved agent/i }),
+    ).toBeNull();
+  });
+
+  test("selecting a pending submission shows the bulk selection bar", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-pending",
+            name: "Pending Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    const checkboxes = await screen.findAllByRole("checkbox", {
+      name: /select pending agent/i,
+    });
+    fireEvent.click(checkboxes[0]);
+
+    expect(
+      await screen.findByRole("button", { name: /delete selected/i }),
+    ).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
@@ -521,6 +521,140 @@ describe("SettingsCreatorDashboardPage", () => {
     });
   });
 
+  test("status column filter popover toggles a status and reflects active state", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-1",
+            name: "Pending One",
+            status: SubmissionStatus.PENDING,
+          }),
+          makeSubmission({
+            listing_version_id: "lv-2",
+            name: "Approved One",
+            status: SubmissionStatus.APPROVED,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect((await screen.findAllByText("Pending One")).length).toBeGreaterThan(
+      0,
+    );
+
+    const filterTriggers = screen.getAllByRole("button", {
+      name: /filter status/i,
+    });
+    fireEvent.click(filterTriggers[0]);
+
+    const inReview = await screen.findByRole("button", {
+      name: /in review/i,
+      pressed: false,
+    });
+    fireEvent.click(inReview);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /in review/i, pressed: true }),
+      ).toBeDefined();
+    });
+
+    const clearButton = await screen.findByRole("button", { name: /^clear$/i });
+    fireEvent.click(clearButton);
+  });
+
+  test("sort column filter applies and clears a sort direction", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-a",
+            name: "Alpha",
+            status: SubmissionStatus.APPROVED,
+            run_count: 100,
+          }),
+          makeSubmission({
+            listing_version_id: "lv-b",
+            name: "Beta",
+            status: SubmissionStatus.APPROVED,
+            run_count: 500,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect((await screen.findAllByText("Alpha")).length).toBeGreaterThan(0);
+
+    const sortTriggers = screen.getAllByRole("button", {
+      name: /filter sort/i,
+    });
+    fireEvent.click(sortTriggers[0]);
+
+    const newestFirst = await screen.findByRole("button", {
+      name: /newest first/i,
+    });
+    fireEvent.click(newestFirst);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: /newest first/i,
+          pressed: true,
+        }),
+      ).toBeDefined();
+    });
+
+    const clearButton = await screen.findByRole("button", { name: /^clear$/i });
+    fireEvent.click(clearButton);
+  });
+
+  test("selection bar exposes Select All and Deselect controls", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-p1",
+            name: "Pending One",
+            status: SubmissionStatus.PENDING,
+          }),
+          makeSubmission({
+            listing_version_id: "lv-p2",
+            name: "Pending Two",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    const firstCheckboxes = await screen.findAllByRole("checkbox", {
+      name: /select pending one/i,
+    });
+    fireEvent.click(firstCheckboxes[0]);
+
+    const selectAll = await screen.findByRole("button", {
+      name: /select all/i,
+    });
+    fireEvent.click(selectAll);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /select all/i })).toBeNull();
+    });
+
+    const deselect = screen.getByRole("button", { name: /^deselect$/i });
+    fireEvent.click(deselect);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /^deselect$/i })).toBeNull();
+    });
+  });
+
   test("selecting a pending submission shows the bulk selection bar", async () => {
     server.use(
       getGetV2ListMySubmissionsMockHandler(

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
@@ -472,10 +472,22 @@ describe("SettingsCreatorDashboardPage", () => {
     const actionButtons = screen.getAllByTestId("submission-actions");
     fireEvent.pointerDown(actionButtons[0], { button: 0 });
 
-    expect(
-      await screen.findByRole("menuitem", { name: /view submission/i }),
-    ).toBeDefined();
+    const viewItem = await screen.findByRole("menuitem", {
+      name: /view submission/i,
+    });
     expect(screen.queryByRole("menuitem", { name: /^delete$/i })).toBeNull();
+    fireEvent.click(viewItem);
+  });
+
+  test("clicking Submit agent triggers the publish modal flow", async () => {
+    server.use(getGetV2ListMySubmissionsMockHandler(makeResponse([])));
+
+    render(<SettingsCreatorDashboardPage />);
+
+    const submitButton = await screen.findByTestId("submit-agent-button");
+    fireEvent.click(submitButton);
+
+    expect(submitButton).toBeDefined();
   });
 
   test("mobile dropdown also exposes Delete and triggers the same delete endpoint", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   getDeleteV2DeleteStoreSubmissionMockHandler,
+  getDeleteV2DeleteStoreSubmissionMockHandler422,
   getGetV2ListMySubmissionsMockHandler,
   getGetV2ListMySubmissionsMockHandler401,
 } from "@/app/api/__generated__/endpoints/store/store.msw";
@@ -31,9 +32,56 @@ vi.mock("@/components/contextual/PublishAgentModal/PublishAgentModal", () => ({
 }));
 
 vi.mock("@/components/contextual/EditAgentModal/EditAgentModal", () => ({
-  EditAgentModal: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="edit-agent-modal" /> : null,
+  EditAgentModal: ({
+    isOpen,
+    onSuccess,
+  }: {
+    isOpen: boolean;
+    onSuccess: (s: unknown) => void;
+  }) =>
+    isOpen ? (
+      <button
+        type="button"
+        data-testid="edit-modal-success"
+        onClick={() =>
+          onSuccess({
+            listing_id: "listing-base",
+            user_id: "user-1",
+            slug: "agent-slug",
+            listing_version_id: "lv-edited",
+            listing_version: 2,
+            graph_id: "graph-base",
+            graph_version: 2,
+            name: "Edited Agent",
+            sub_heading: "sub",
+            description: "desc",
+            instructions: null,
+            categories: [],
+            image_urls: [],
+            video_url: null,
+            agent_output_demo_url: null,
+            submitted_at: null,
+            changes_summary: null,
+            status: SubmissionStatus.PENDING,
+          })
+        }
+      >
+        success
+      </button>
+    ) : null,
 }));
+
+const toastSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    toast: (...args: Parameters<typeof actual.toast>) => toastSpy(...args),
+  };
+});
 
 const testUser = {
   id: "user-1",
@@ -89,6 +137,7 @@ function makeResponse(
 
 describe("SettingsCreatorDashboardPage", () => {
   beforeEach(() => {
+    toastSpy.mockClear();
     mockUseSupabase.mockReturnValue({
       user: testUser,
       isLoggedIn: true,
@@ -284,6 +333,149 @@ describe("SettingsCreatorDashboardPage", () => {
     expect(
       screen.queryByRole("checkbox", { name: /select approved agent/i }),
     ).toBeNull();
+  });
+
+  test("delete failure shows a destructive toast and keeps the dialog open", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-fail",
+            name: "Doomed Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+      getDeleteV2DeleteStoreSubmissionMockHandler422(),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect((await screen.findAllByText("Doomed Agent")).length).toBeGreaterThan(
+      0,
+    );
+
+    const actionButtons = screen.getAllByTestId("submission-actions");
+    fireEvent.pointerDown(actionButtons[0], { button: 0 });
+
+    const deleteMenuItem = await screen.findByRole("menuitem", {
+      name: /delete/i,
+    });
+    fireEvent.click(deleteMenuItem);
+
+    const confirmButton = await screen.findByRole("button", {
+      name: /delete submission/i,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Couldn't delete submission",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  test("bulk delete failure shows a partial-success destructive toast", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-bulk",
+            name: "Bulk Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+      getDeleteV2DeleteStoreSubmissionMockHandler422(),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    const checkboxes = await screen.findAllByRole("checkbox", {
+      name: /select bulk agent/i,
+    });
+    fireEvent.click(checkboxes[0]);
+
+    const deleteSelected = await screen.findByRole("button", {
+      name: /delete selected/i,
+    });
+    fireEvent.click(deleteSelected);
+
+    const confirm = await screen.findAllByRole("button", {
+      name: /delete selected/i,
+    });
+    fireEvent.click(confirm[confirm.length - 1]);
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  test("editing a submission via the row dropdown opens and closes the edit modal on success", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-edit",
+            name: "Editable Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(
+      (await screen.findAllByText("Editable Agent")).length,
+    ).toBeGreaterThan(0);
+
+    const actionButtons = screen.getAllByTestId("submission-actions");
+    fireEvent.pointerDown(actionButtons[0], { button: 0 });
+    const editItem = await screen.findByRole("menuitem", { name: /edit/i });
+    fireEvent.click(editItem);
+
+    const successTriggers = await screen.findAllByTestId("edit-modal-success");
+    fireEvent.click(successTriggers[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("edit-modal-success")).toBeNull();
+    });
+  });
+
+  test("approved row dropdown shows a 'View submission' action that calls onView", async () => {
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-view",
+            name: "Viewable Agent",
+            status: SubmissionStatus.APPROVED,
+          }),
+        ]),
+      ),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect(
+      (await screen.findAllByText("Viewable Agent")).length,
+    ).toBeGreaterThan(0);
+
+    const actionButtons = screen.getAllByTestId("submission-actions");
+    fireEvent.pointerDown(actionButtons[0], { button: 0 });
+
+    expect(
+      await screen.findByRole("menuitem", { name: /view submission/i }),
+    ).toBeDefined();
+    expect(screen.queryByRole("menuitem", { name: /^delete$/i })).toBeNull();
   });
 
   test("selecting a pending submission shows the bulk selection bar", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
@@ -478,6 +478,49 @@ describe("SettingsCreatorDashboardPage", () => {
     expect(screen.queryByRole("menuitem", { name: /^delete$/i })).toBeNull();
   });
 
+  test("mobile dropdown also exposes Delete and triggers the same delete endpoint", async () => {
+    let deletedId: string | null = null;
+    server.use(
+      getGetV2ListMySubmissionsMockHandler(
+        makeResponse([
+          makeSubmission({
+            listing_version_id: "lv-mobile",
+            name: "Mobile Agent",
+            status: SubmissionStatus.PENDING,
+          }),
+        ]),
+      ),
+      getDeleteV2DeleteStoreSubmissionMockHandler(async ({ params }) => {
+        deletedId = params.submissionId as string;
+        return true;
+      }),
+    );
+
+    render(<SettingsCreatorDashboardPage />);
+
+    expect((await screen.findAllByText("Mobile Agent")).length).toBeGreaterThan(
+      1,
+    );
+
+    const actionButtons = screen.getAllByTestId("submission-actions");
+    expect(actionButtons.length).toBeGreaterThanOrEqual(2);
+    fireEvent.pointerDown(actionButtons[1], { button: 0 });
+
+    const deleteMenuItem = await screen.findByRole("menuitem", {
+      name: /delete/i,
+    });
+    fireEvent.click(deleteMenuItem);
+
+    const confirmButton = await screen.findByRole("button", {
+      name: /delete submission/i,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(deletedId).toBe("lv-mobile");
+    });
+  });
+
   test("selecting a pending submission shows the bulk selection bar", async () => {
     server.use(
       getGetV2ListMySubmissionsMockHandler(

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/__tests__/main.test.tsx
@@ -192,7 +192,7 @@ describe("SettingsCreatorDashboardPage", () => {
     ).toBeGreaterThan(0);
   });
 
-  test("filters submissions by name via the dashboard hook state", async () => {
+  test("renders both pending and approved submissions in the list", async () => {
     server.use(
       getGetV2ListMySubmissionsMockHandler(
         makeResponse([

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/ColumnFilter/ColumnFilter.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/ColumnFilter/ColumnFilter.tsx
@@ -31,7 +31,7 @@ export function ColumnFilter({
           aria-label={`Filter ${label}`}
           className={cn(
             "inline-flex h-6 w-6 items-center justify-center rounded-full",
-            "transition-[transform,background-color,color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+            "ease-[cubic-bezier(0.16,1,0.3,1)] transition-[transform,background-color,color] duration-150",
             "active:scale-[0.92] motion-reduce:transition-none motion-reduce:active:scale-100",
             active
               ? "bg-violet-100 text-violet-700 hover:bg-violet-200"
@@ -47,10 +47,10 @@ export function ColumnFilter({
         className={cn(
           "w-64 p-3 will-change-transform",
           "origin-[var(--radix-popover-content-transform-origin)]",
-          "data-[state=open]:duration-200 data-[state=closed]:duration-150",
+          "data-[state=closed]:duration-150 data-[state=open]:duration-200",
           "data-[state=open]:ease-[cubic-bezier(0.16,1,0.3,1)]",
           "data-[state=closed]:ease-[cubic-bezier(0.4,0,1,1)]",
-          "motion-reduce:!duration-100 motion-reduce:!animate-none",
+          "motion-reduce:!animate-none motion-reduce:!duration-100",
         )}
         onClick={(e) => e.stopPropagation()}
       >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/ColumnFilter/ColumnFilter.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/ColumnFilter/ColumnFilter.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { FunnelIcon } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/molecules/Popover/Popover";
+
+interface Props {
+  active: boolean;
+  label: string;
+  align?: "start" | "center" | "end";
+  children: ReactNode;
+}
+
+export function ColumnFilter({
+  active,
+  label,
+  align = "start",
+  children,
+}: Props) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Filter ${label}`}
+          className={cn(
+            "inline-flex h-6 w-6 items-center justify-center rounded-full",
+            "transition-[transform,background-color,color] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+            "active:scale-[0.92] motion-reduce:transition-none motion-reduce:active:scale-100",
+            active
+              ? "bg-violet-100 text-violet-700 hover:bg-violet-200"
+              : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700",
+          )}
+        >
+          <FunnelIcon size={12} weight={active ? "fill" : "bold"} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align={align}
+        sideOffset={6}
+        className={cn(
+          "w-64 p-3 will-change-transform",
+          "origin-[var(--radix-popover-content-transform-origin)]",
+          "data-[state=open]:duration-200 data-[state=closed]:duration-150",
+          "data-[state=open]:ease-[cubic-bezier(0.16,1,0.3,1)]",
+          "data-[state=closed]:ease-[cubic-bezier(0.4,0,1,1)]",
+          "motion-reduce:!duration-100 motion-reduce:!animate-none",
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -12,7 +12,9 @@ import { EASE_OUT } from "../../helpers";
 interface PublishState {
   isOpen: boolean;
   step: "select" | "info" | "review";
-  submissionData: import("@/app/api/__generated__/models/storeSubmission").StoreSubmission | null;
+  submissionData:
+    | import("@/app/api/__generated__/models/storeSubmission").StoreSubmission
+    | null;
 }
 
 interface Props {
@@ -33,7 +35,7 @@ export function DashboardHeader({
       initial={reduceMotion ? false : { opacity: 0, y: 8 }}
       animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
       transition={reduceMotion ? undefined : { duration: 0.32, ease: EASE_OUT }}
-      className="flex flex-col gap-5 pl-4 pr-1 pb-2 md:flex-row md:items-end md:justify-between"
+      className="flex flex-col gap-5 pb-2 pl-4 pr-1 md:flex-row md:items-end md:justify-between"
     >
       <div className="flex min-w-0 flex-col">
         <Text variant="h4" as="h1" className="leading-[28px] text-textBlack">

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { PlusIcon } from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "framer-motion";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { PublishAgentModal } from "@/components/contextual/PublishAgentModal/PublishAgentModal";
+
+import { EASE_OUT } from "../../helpers";
+
+interface PublishState {
+  isOpen: boolean;
+  step: "select" | "info" | "review";
+  submissionData: import("@/app/api/__generated__/models/storeSubmission").StoreSubmission | null;
+}
+
+interface Props {
+  publishState: PublishState;
+  onPublishStateChange: (state: PublishState) => void;
+  onOpenSubmit: () => void;
+}
+
+export function DashboardHeader({
+  publishState,
+  onPublishStateChange,
+  onOpenSubmit,
+}: Props) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.header
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={reduceMotion ? undefined : { duration: 0.32, ease: EASE_OUT }}
+      className="flex flex-col gap-5 pl-4 pr-1 pb-2 md:flex-row md:items-end md:justify-between"
+    >
+      <div className="flex min-w-0 flex-col">
+        <Text variant="h4" as="h1" className="leading-[28px] text-textBlack">
+          Creator dashboard
+        </Text>
+        <Text variant="body" className="mt-3 max-w-[640px] text-zinc-700">
+          Track your store submissions, see how they perform, and ship updates
+          for the agents you publish.
+        </Text>
+      </div>
+
+      <PublishAgentModal
+        targetState={publishState}
+        onStateChange={onPublishStateChange}
+        trigger={
+          <Button
+            data-testid="submit-agent-button"
+            size="large"
+            onClick={onOpenSubmit}
+            leftIcon={<PlusIcon size={18} weight="bold" />}
+          >
+            Submit agent
+          </Button>
+        }
+      />
+    </motion.header>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardSkeleton/DashboardSkeleton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/DashboardSkeleton/DashboardSkeleton.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+
+export function DashboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 pb-8" aria-busy="true">
+      <div className="flex flex-col gap-3 pl-4 pr-1 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="mt-1 h-4 w-[420px] max-w-full" />
+        </div>
+        <Skeleton className="h-12 w-36 rounded-full" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="relative flex min-h-[132px] flex-col justify-between gap-3 rounded-[18px] border border-zinc-200 bg-white px-4 py-5"
+          >
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-7 w-16" />
+            <Skeleton className="absolute right-3 top-3 h-7 w-7 rounded-full" />
+          </div>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4 border-b border-zinc-100 px-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="my-2 h-6 w-20" />
+        ))}
+      </div>
+
+      <div className="overflow-hidden rounded-[18px] border border-zinc-200 bg-white">
+        <div className="border-b border-zinc-100 bg-zinc-50/60 px-4 py-3">
+          <Skeleton className="h-4 w-24" />
+        </div>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 border-b border-zinc-100 px-4 py-3 last:border-b-0"
+          >
+            <Skeleton className="aspect-video h-12 w-20 shrink-0 rounded-[8px]" />
+            <div className="flex flex-1 flex-col gap-2">
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+            <Skeleton className="h-6 w-24 rounded-full" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-8 w-8 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/EmptyState/EmptyState.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { RocketLaunchIcon } from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "framer-motion";
+
+import { Text } from "@/components/atoms/Text/Text";
+
+import { EASE_OUT } from "../../helpers";
+
+export function EmptyState() {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={reduceMotion ? undefined : { duration: 0.28, ease: EASE_OUT }}
+      className="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+    >
+      <RocketLaunchIcon size={28} weight="duotone" className="text-zinc-400" />
+      <Text variant="body-medium" className="text-textBlack">
+        No submissions yet
+      </Text>
+      <Text variant="small" className="max-w-[460px] text-zinc-500">
+        Once you submit an agent to the store, it'll show up here with its
+        status, runs, and reviews.
+      </Text>
+    </motion.div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/EmptyState/EmptyState.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/EmptyState/EmptyState.tsx
@@ -22,7 +22,7 @@ export function EmptyState() {
         No submissions yet
       </Text>
       <Text variant="small" className="max-w-[460px] text-zinc-500">
-        Once you submit an agent to the store, it'll show up here with its
+        Once you submit an agent to the store, it&apos;ll show up here with its
         status, runs, and reviews.
       </Text>
     </motion.div>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
@@ -25,11 +25,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
 
-import {
-  STATUS_VISUAL,
-  formatRuns,
-  formatSubmittedAt,
-} from "../../helpers";
+import { STATUS_VISUAL, formatRuns, formatSubmittedAt } from "../../helpers";
 import { useSubmissionItem } from "../SubmissionItem/useSubmissionItem";
 
 interface EditPayload extends StoreSubmissionEditRequest {
@@ -151,7 +147,11 @@ export function MobileSubmissionItem({
               <DotsThreeVerticalIcon size={18} weight="bold" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" sideOffset={6} className="min-w-[160px]">
+          <DropdownMenuContent
+            align="end"
+            sideOffset={6}
+            className="min-w-[160px]"
+          >
             {canModify ? (
               <DropdownMenuItem
                 onSelect={handleEdit}
@@ -195,13 +195,17 @@ export function MobileSubmissionItem({
         <span className="whitespace-nowrap text-xs text-zinc-500">
           {formatSubmittedAt(submission.submitted_at)}
         </span>
-        <span aria-hidden className="text-xs text-zinc-300">·</span>
+        <span aria-hidden className="text-xs text-zinc-300">
+          ·
+        </span>
         <span className="whitespace-nowrap text-xs tabular-nums text-zinc-500">
           {formatRuns(submission.run_count ?? 0)} runs
         </span>
         {hasRating ? (
           <>
-            <span aria-hidden className="text-xs text-zinc-300">·</span>
+            <span aria-hidden className="text-xs text-zinc-300">
+              ·
+            </span>
             <span className="inline-flex items-center gap-1 whitespace-nowrap text-xs tabular-nums text-zinc-500">
               {submission.review_avg_rating!.toFixed(1)}
               <StarIcon size={10} weight="fill" className="text-amber-500" />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import Image from "next/image";
+import {
+  CheckSquareIcon,
+  DotsThreeVerticalIcon,
+  EyeIcon,
+  ImageBrokenIcon,
+  PencilSimpleIcon,
+  SquareIcon,
+  StarIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/molecules/DropdownMenu/DropdownMenu";
+
+import {
+  STATUS_VISUAL,
+  formatRuns,
+  formatSubmittedAt,
+} from "../../helpers";
+import { useSubmissionItem } from "../SubmissionItem/useSubmissionItem";
+
+interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+interface Props {
+  submission: StoreSubmission;
+  selected: boolean;
+  onToggleSelected: () => void;
+  onView: (submission: StoreSubmission) => void;
+  onEdit: (payload: EditPayload) => void;
+  onDelete: (submissionId: string) => Promise<void>;
+}
+
+export function MobileSubmissionItem({
+  submission,
+  selected,
+  onToggleSelected,
+  onView,
+  onEdit,
+  onDelete,
+}: Props) {
+  const {
+    canModify,
+    handleView,
+    handleEdit,
+    confirmDeleteOpen,
+    setConfirmDeleteOpen,
+    isDeleting,
+    handleConfirmDelete,
+  } = useSubmissionItem({ submission, onView, onEdit, onDelete });
+
+  const visual = STATUS_VISUAL[submission.status];
+  const StatusIcon = visual.Icon;
+  const thumbnail = submission.image_urls?.[0];
+  const hasRating =
+    !!submission.review_avg_rating && submission.review_avg_rating > 0;
+
+  return (
+    <article
+      data-testid="submission-card"
+      data-agent-id={submission.graph_id}
+      data-submission-id={submission.listing_version_id}
+      data-selected={selected}
+      className="flex flex-col gap-3 border-b border-zinc-100 px-3 py-3 last:border-b-0 data-[selected=true]:bg-zinc-50"
+    >
+      <div className="flex items-start gap-3">
+        {canModify ? (
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={selected}
+            aria-label={`Select ${submission.name}`}
+            onClick={onToggleSelected}
+            className={`mt-1 shrink-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-800 ${
+              selected
+                ? "text-zinc-800 hover:text-zinc-900"
+                : "text-zinc-500 hover:text-zinc-700"
+            }`}
+          >
+            {selected ? (
+              <CheckSquareIcon size={20} weight="fill" />
+            ) : (
+              <SquareIcon size={20} />
+            )}
+          </button>
+        ) : null}
+
+        <div className="relative aspect-video w-16 shrink-0 overflow-hidden rounded-[8px] bg-zinc-100">
+          {thumbnail ? (
+            <Image
+              src={thumbnail}
+              alt={submission.name}
+              fill
+              sizes="64px"
+              style={{ objectFit: "cover" }}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <ImageBrokenIcon size={18} className="text-zinc-400" />
+            </div>
+          )}
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex min-w-0 items-center gap-2">
+            <Text
+              variant="body-medium"
+              as="span"
+              className="truncate text-textBlack"
+            >
+              {submission.name}
+            </Text>
+            <Text variant="small" as="span" className="shrink-0 text-zinc-600">
+              v{submission.graph_version}
+            </Text>
+          </div>
+          {submission.description ? (
+            <Text
+              variant="small"
+              as="span"
+              className="mt-0.5 line-clamp-2 break-words text-zinc-500"
+            >
+              {submission.description}
+            </Text>
+          ) : null}
+        </div>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Submission actions"
+              data-testid="submission-actions"
+              className="-mr-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 active:scale-[0.92] motion-reduce:active:scale-100"
+            >
+              <DotsThreeVerticalIcon size={18} weight="bold" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" sideOffset={6} className="min-w-[160px]">
+            {canModify ? (
+              <DropdownMenuItem
+                onSelect={handleEdit}
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <PencilSimpleIcon size={14} />
+                Edit details
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                onSelect={handleView}
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <EyeIcon size={14} />
+                View submission
+              </DropdownMenuItem>
+            )}
+            {canModify ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={() => setConfirmDeleteOpen(true)}
+                  className="flex cursor-pointer items-center gap-2 text-rose-600 focus:text-rose-700"
+                >
+                  <TrashIcon size={14} />
+                  Delete
+                </DropdownMenuItem>
+              </>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <span
+          className={`inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium ${visual.pillClass}`}
+        >
+          <StatusIcon size={10} weight="fill" />
+          {visual.label}
+        </span>
+        <span className="whitespace-nowrap text-xs text-zinc-500">
+          {formatSubmittedAt(submission.submitted_at)}
+        </span>
+        <span aria-hidden className="text-xs text-zinc-300">·</span>
+        <span className="whitespace-nowrap text-xs tabular-nums text-zinc-500">
+          {formatRuns(submission.run_count ?? 0)} runs
+        </span>
+        {hasRating ? (
+          <>
+            <span aria-hidden className="text-xs text-zinc-300">·</span>
+            <span className="inline-flex items-center gap-1 whitespace-nowrap text-xs tabular-nums text-zinc-500">
+              {submission.review_avg_rating!.toFixed(1)}
+              <StarIcon size={10} weight="fill" className="text-amber-500" />
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      <Dialog
+        title="Delete submission?"
+        styling={{ maxWidth: "420px" }}
+        controlled={{
+          isOpen: confirmDeleteOpen,
+          set: (open) => setConfirmDeleteOpen(open),
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body" className="text-zinc-700">
+            This will remove <strong>{submission.name}</strong> from the store.
+            This action cannot be undone.
+          </Text>
+          <Dialog.Footer>
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="small"
+              onClick={handleConfirmDelete}
+              loading={isDeleting}
+            >
+              {isDeleting ? "Deleting" : "Delete submission"}
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </article>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionItem/MobileSubmissionItem.tsx
@@ -25,7 +25,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
 
-import { STATUS_VISUAL, formatRuns, formatSubmittedAt } from "../../helpers";
+import { formatRuns, formatSubmittedAt, getStatusVisual } from "../../helpers";
 import { useSubmissionItem } from "../SubmissionItem/useSubmissionItem";
 
 interface EditPayload extends StoreSubmissionEditRequest {
@@ -60,7 +60,7 @@ export function MobileSubmissionItem({
     handleConfirmDelete,
   } = useSubmissionItem({ submission, onView, onEdit, onDelete });
 
-  const visual = STATUS_VISUAL[submission.status];
+  const visual = getStatusVisual(submission.status);
   const StatusIcon = visual.Icon;
   const thumbnail = submission.image_urls?.[0];
   const hasRating =

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSelectionBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSelectionBar.tsx
@@ -1,0 +1,48 @@
+import { TrashIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Props {
+  selectedCount: number;
+  allSelected: boolean;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onDeleteSelected: () => void;
+}
+
+export function MobileSelectionBar({
+  selectedCount,
+  allSelected,
+  onSelectAll,
+  onDeselectAll,
+  onDeleteSelected,
+}: Props) {
+  return (
+    <div className="flex w-full min-w-0 max-w-full flex-col gap-2 rounded-[14px] border border-zinc-200 bg-zinc-100 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <Text variant="body-medium" as="span" className="text-zinc-700">
+          {selectedCount} selected
+        </Text>
+        <Button
+          variant="destructive"
+          size="small"
+          leftIcon={<TrashIcon size={14} />}
+          onClick={onDeleteSelected}
+        >
+          Delete
+        </Button>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        {!allSelected && (
+          <Button variant="ghost" size="small" onClick={onSelectAll}>
+            Select all
+          </Button>
+        )}
+        <Button variant="ghost" size="small" onClick={onDeselectAll}>
+          Deselect
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSelectionBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSelectionBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { TrashIcon } from "@phosphor-icons/react";
 
 import { Button } from "@/components/atoms/Button/Button";

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
@@ -9,6 +10,7 @@ import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatu
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { toast } from "@/components/molecules/Toast/use-toast";
 
 import {
   EASE_OUT,
@@ -74,10 +76,20 @@ export function MobileSubmissionsList({
 
   async function handleBulkDelete() {
     setIsBulkDeleting(true);
+    const ids = [...selection.selectedIds];
     try {
-      const ids = [...selection.selectedIds];
-      for (const id of ids) {
-        await onDelete(id);
+      const results = await Promise.allSettled(ids.map((id) => onDelete(id)));
+      const failed = results.filter((r) => r.status === "rejected").length;
+      const succeeded = ids.length - failed;
+      if (failed > 0) {
+        for (const r of results) {
+          if (r.status === "rejected") Sentry.captureException(r.reason);
+        }
+        toast({
+          title: `Deleted ${succeeded} of ${ids.length} submissions`,
+          description: `${failed} failed to delete. Please try again.`,
+          variant: "destructive",
+        });
       }
       selection.clear();
       setBulkDeleteOpen(false);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/MobileSubmissionsList/MobileSubmissionsList.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+
+import {
+  EASE_OUT,
+  type FilterState,
+  type SortDir,
+  type SortKey,
+} from "../../helpers";
+import { MobileSubmissionItem } from "../MobileSubmissionItem/MobileSubmissionItem";
+import { SortColumnFilter } from "../SubmissionsList/columns/SortColumnFilter";
+import { StatusColumnFilter } from "../SubmissionsList/columns/StatusColumnFilter";
+import { useSubmissionSelection } from "../SubmissionsList/useSubmissionSelection";
+import { MobileSelectionBar } from "./MobileSelectionBar";
+
+interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+interface Props {
+  submissions: StoreSubmission[];
+  totalCount: number;
+  filterState: FilterState;
+  onFilterChange: (next: FilterState) => void;
+  onResetFilters: () => void;
+  onView: (submission: StoreSubmission) => void;
+  onEdit: (payload: EditPayload) => void;
+  onDelete: (submissionId: string) => Promise<void>;
+  index?: number;
+}
+
+export function MobileSubmissionsList({
+  submissions,
+  totalCount,
+  filterState,
+  onFilterChange,
+  onResetFilters,
+  onView,
+  onEdit,
+  onDelete,
+  index = 0,
+}: Props) {
+  const reduceMotion = useReducedMotion();
+
+  const selectableIds = useMemo(
+    () =>
+      submissions
+        .filter((s) => s.status === SubmissionStatus.PENDING)
+        .map((s) => s.listing_version_id),
+    [submissions],
+  );
+
+  const selection = useSubmissionSelection(selectableIds);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
+
+  function setStatuses(statuses: SubmissionStatus[]) {
+    onFilterChange({ ...filterState, statuses });
+  }
+
+  function setSort(sortKey: SortKey | null, sortDir: SortDir) {
+    onFilterChange({ ...filterState, sortKey, sortDir });
+  }
+
+  async function handleBulkDelete() {
+    setIsBulkDeleting(true);
+    try {
+      const ids = [...selection.selectedIds];
+      for (const id of ids) {
+        await onDelete(id);
+      }
+      selection.clear();
+      setBulkDeleteOpen(false);
+    } finally {
+      setIsBulkDeleting(false);
+    }
+  }
+
+  return (
+    <motion.section
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={
+        reduceMotion
+          ? undefined
+          : { duration: 0.28, ease: EASE_OUT, delay: 0.04 + index * 0.05 }
+      }
+      className="flex w-full min-w-0 max-w-full flex-col gap-3"
+      data-testid="mobile-submissions-list"
+    >
+      <div className="flex items-center justify-between gap-3 px-1">
+        <Text variant="body-medium" as="span" className="text-textBlack">
+          Submissions
+        </Text>
+        <Text variant="small" className="text-zinc-500">
+          {submissions.length} of {totalCount}
+        </Text>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 px-1">
+        <FilterChip label="Status">
+          <StatusColumnFilter
+            value={filterState.statuses}
+            onChange={setStatuses}
+          />
+        </FilterChip>
+        <FilterChip label="Date">
+          <SortColumnFilter
+            sortKey="submitted"
+            activeKey={filterState.sortKey}
+            activeDir={filterState.sortDir}
+            onChange={setSort}
+            ascLabel="Oldest first"
+            descLabel="Newest first"
+          />
+        </FilterChip>
+        <FilterChip label="Runs">
+          <SortColumnFilter
+            sortKey="runs"
+            activeKey={filterState.sortKey}
+            activeDir={filterState.sortDir}
+            onChange={setSort}
+            ascLabel="Lowest first"
+            descLabel="Highest first"
+          />
+        </FilterChip>
+        <FilterChip label="Rating">
+          <SortColumnFilter
+            sortKey="rating"
+            activeKey={filterState.sortKey}
+            activeDir={filterState.sortDir}
+            onChange={setSort}
+            ascLabel="Lowest first"
+            descLabel="Highest first"
+          />
+        </FilterChip>
+      </div>
+
+      <AnimatePresence initial={false}>
+        {selection.selectedCount > 0 && (
+          <motion.div
+            key="selection-bar"
+            initial={
+              reduceMotion
+                ? { opacity: 0 }
+                : { opacity: 0, height: 0, marginBottom: -12 }
+            }
+            animate={
+              reduceMotion
+                ? { opacity: 1 }
+                : { opacity: 1, height: "auto", marginBottom: 0 }
+            }
+            exit={
+              reduceMotion
+                ? { opacity: 0 }
+                : { opacity: 0, height: 0, marginBottom: -12 }
+            }
+            transition={{ duration: 0.2, ease: [0, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <MobileSelectionBar
+              selectedCount={selection.selectedCount}
+              allSelected={selection.allSelected}
+              onSelectAll={selection.selectAll}
+              onDeselectAll={selection.clear}
+              onDeleteSelected={() => setBulkDeleteOpen(true)}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        {submissions.length > 0 ? (
+          submissions.map((submission) => (
+            <MobileSubmissionItem
+              key={submission.listing_version_id}
+              submission={submission}
+              selected={selection.isSelected(submission.listing_version_id)}
+              onToggleSelected={() =>
+                selection.toggle(submission.listing_version_id)
+              }
+              onView={onView}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-3 px-4 py-10 text-center">
+            <Text variant="body-medium" className="text-textBlack">
+              No submissions match these filters
+            </Text>
+            <Button variant="secondary" size="small" onClick={onResetFilters}>
+              Clear filters
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <Dialog
+        title="Delete selected submissions?"
+        styling={{ maxWidth: "420px" }}
+        controlled={{
+          isOpen: bulkDeleteOpen,
+          set: (open) => setBulkDeleteOpen(open),
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body" className="text-zinc-700">
+            This will remove {selection.selectedCount} submission
+            {selection.selectedCount === 1 ? "" : "s"} from the store. This
+            action cannot be undone.
+          </Text>
+          <Dialog.Footer>
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={() => setBulkDeleteOpen(false)}
+              disabled={isBulkDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="small"
+              onClick={handleBulkDelete}
+              loading={isBulkDeleting}
+            >
+              {isBulkDeleting ? "Deleting" : "Delete selected"}
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </motion.section>
+  );
+}
+
+function FilterChip({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="inline-flex items-center gap-1 rounded-full border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-600">
+      <span>{label}</span>
+      {children}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/StatsOverview/StatsOverview.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/StatsOverview/StatsOverview.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  PlayIcon,
+  StarIcon,
+  StackIcon,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "framer-motion";
+
+import { Text } from "@/components/atoms/Text/Text";
+
+import { EASE_OUT, formatRuns, type DashboardStats } from "../../helpers";
+
+interface Props {
+  stats: DashboardStats;
+  index?: number;
+}
+
+interface StatTile {
+  label: string;
+  value: string;
+  Icon: PhosphorIcon;
+  iconClass: string;
+}
+
+export function StatsOverview({ stats, index = 0 }: Props) {
+  const reduceMotion = useReducedMotion();
+
+  const tiles: StatTile[] = [
+    {
+      label: "Total submissions",
+      value: stats.total.toLocaleString(),
+      Icon: StackIcon,
+      iconClass: "bg-violet-50 text-violet-700 ring-violet-200",
+    },
+    {
+      label: "Approved",
+      value: stats.approved.toLocaleString(),
+      Icon: CheckCircleIcon,
+      iconClass: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+    },
+    {
+      label: "In review",
+      value: stats.pending.toLocaleString(),
+      Icon: ClockIcon,
+      iconClass: "bg-amber-50 text-amber-700 ring-amber-200",
+    },
+    {
+      label: "Total runs",
+      value: formatRuns(stats.totalRuns),
+      Icon: PlayIcon,
+      iconClass: "bg-sky-50 text-sky-700 ring-sky-200",
+    },
+  ];
+
+  return (
+    <motion.section
+      initial={reduceMotion ? false : { opacity: 0, y: 12 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={
+        reduceMotion
+          ? undefined
+          : {
+              duration: 0.32,
+              ease: EASE_OUT,
+              delay: 0.04 + index * 0.05,
+            }
+      }
+      className="grid w-full grid-cols-2 gap-3 lg:grid-cols-4"
+      aria-label="Submission stats"
+    >
+      {tiles.map((tile) => (
+        <StatTileCard key={tile.label} tile={tile} />
+      ))}
+
+      {stats.averageRating !== null ? (
+        <div className="col-span-2 flex items-center justify-between gap-3 rounded-[18px] border border-zinc-200 bg-gradient-to-br from-amber-50/60 to-white px-4 py-4 shadow-[0_1px_2px_rgba(15,15,20,0.04)] lg:col-span-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-amber-100 text-amber-700 ring-1 ring-inset ring-amber-200">
+              <StarIcon size={18} weight="fill" />
+            </div>
+            <div className="flex flex-col">
+              <Text variant="body-medium" as="span" className="text-textBlack">
+                Average rating
+              </Text>
+              <Text variant="small" className="text-zinc-500">
+                Across all submissions with reviews.
+              </Text>
+            </div>
+          </div>
+          <Text
+            variant="h3"
+            as="span"
+            size="large-medium"
+            className="text-textBlack"
+          >
+            {stats.averageRating.toFixed(1)}
+            <span className="text-zinc-400"> / 5</span>
+          </Text>
+        </div>
+      ) : null}
+    </motion.section>
+  );
+}
+
+function StatTileCard({ tile }: { tile: StatTile }) {
+  const { label, value, Icon, iconClass } = tile;
+  return (
+    <div className="relative flex min-h-[120px] flex-col justify-between gap-2 rounded-[18px] border border-zinc-200 bg-white px-4 py-5 shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+      <div
+        className={`absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full ring-1 ring-inset ${iconClass}`}
+      >
+        <Icon size={14} weight="bold" />
+      </div>
+      <Text variant="body" as="span" className="pr-10 text-zinc-800">
+        {label}
+      </Text>
+      <Text variant="h4" as="span" className="text-textBlack">
+        {value}
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
@@ -25,11 +25,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
 
-import {
-  STATUS_VISUAL,
-  formatRuns,
-  formatSubmittedAt,
-} from "../../helpers";
+import { STATUS_VISUAL, formatRuns, formatSubmittedAt } from "../../helpers";
 import { useSubmissionItem } from "./useSubmissionItem";
 
 interface EditPayload extends StoreSubmissionEditRequest {
@@ -74,7 +70,7 @@ export function SubmissionItem({
       data-agent-id={submission.graph_id}
       data-submission-id={submission.listing_version_id}
       data-selected={selected}
-      className="border-b border-zinc-100 transition-colors duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] last:border-b-0 hover:bg-zinc-50/60 data-[selected=true]:bg-zinc-100"
+      className="ease-[cubic-bezier(0.16,1,0.3,1)] border-b border-zinc-100 transition-colors duration-150 last:border-b-0 data-[selected=true]:bg-zinc-100 hover:bg-zinc-50/60"
     >
       <td className="w-[48px] px-3 py-3 align-middle">
         {canModify ? (
@@ -124,7 +120,11 @@ export function SubmissionItem({
               >
                 {submission.name}
               </Text>
-              <Text variant="small" as="span" className="shrink-0 text-zinc-600">
+              <Text
+                variant="small"
+                as="span"
+                className="shrink-0 text-zinc-600"
+              >
                 v{submission.graph_version}
               </Text>
             </div>
@@ -174,7 +174,7 @@ export function SubmissionItem({
               type="button"
               aria-label="Submission actions"
               data-testid="submission-actions"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full text-zinc-500 transition-[background-color,color,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-zinc-100 hover:text-zinc-900 active:scale-[0.92] motion-reduce:transition-none motion-reduce:active:scale-100"
+              className="ease-[cubic-bezier(0.16,1,0.3,1)] inline-flex h-8 w-8 items-center justify-center rounded-full text-zinc-500 transition-[background-color,color,transform] duration-150 hover:bg-zinc-100 hover:text-zinc-900 active:scale-[0.92] motion-reduce:transition-none motion-reduce:active:scale-100"
             >
               <DotsThreeVerticalIcon size={18} weight="bold" />
             </button>
@@ -182,7 +182,7 @@ export function SubmissionItem({
           <DropdownMenuContent
             align="end"
             sideOffset={6}
-            className="min-w-[160px] origin-[var(--radix-dropdown-menu-content-transform-origin)] data-[state=open]:duration-200 data-[state=closed]:duration-150 data-[state=open]:ease-[cubic-bezier(0.16,1,0.3,1)] data-[state=closed]:ease-[cubic-bezier(0.4,0,1,1)] motion-reduce:!duration-100"
+            className="data-[state=open]:ease-[cubic-bezier(0.16,1,0.3,1)] data-[state=closed]:ease-[cubic-bezier(0.4,0,1,1)] min-w-[160px] origin-[var(--radix-dropdown-menu-content-transform-origin)] data-[state=closed]:duration-150 data-[state=open]:duration-200 motion-reduce:!duration-100"
           >
             {canModify ? (
               <DropdownMenuItem

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import Image from "next/image";
+import {
+  CheckSquareIcon,
+  DotsThreeVerticalIcon,
+  EyeIcon,
+  ImageBrokenIcon,
+  PencilSimpleIcon,
+  SquareIcon,
+  StarIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/molecules/DropdownMenu/DropdownMenu";
+
+import {
+  STATUS_VISUAL,
+  formatRuns,
+  formatSubmittedAt,
+} from "../../helpers";
+import { useSubmissionItem } from "./useSubmissionItem";
+
+interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+interface Props {
+  submission: StoreSubmission;
+  selected: boolean;
+  onToggleSelected: () => void;
+  onView: (submission: StoreSubmission) => void;
+  onEdit: (payload: EditPayload) => void;
+  onDelete: (submissionId: string) => Promise<void>;
+}
+
+export function SubmissionItem({
+  submission,
+  selected,
+  onToggleSelected,
+  onView,
+  onEdit,
+  onDelete,
+}: Props) {
+  const {
+    canModify,
+    handleView,
+    handleEdit,
+    confirmDeleteOpen,
+    setConfirmDeleteOpen,
+    isDeleting,
+    handleConfirmDelete,
+  } = useSubmissionItem({ submission, onView, onEdit, onDelete });
+
+  const visual = STATUS_VISUAL[submission.status];
+  const StatusIcon = visual.Icon;
+  const thumbnail = submission.image_urls?.[0];
+
+  return (
+    <tr
+      data-testid="submission-row"
+      data-agent-id={submission.graph_id}
+      data-submission-id={submission.listing_version_id}
+      data-selected={selected}
+      className="border-b border-zinc-100 transition-colors duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] last:border-b-0 hover:bg-zinc-50/60 data-[selected=true]:bg-zinc-100"
+    >
+      <td className="w-[48px] px-3 py-3 align-middle">
+        {canModify ? (
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={selected}
+            aria-label={`Select ${submission.name}`}
+            onClick={onToggleSelected}
+            className={`shrink-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-800 ${
+              selected
+                ? "text-zinc-800 hover:text-zinc-900"
+                : "text-zinc-500 hover:text-zinc-700"
+            }`}
+          >
+            {selected ? (
+              <CheckSquareIcon size={20} weight="fill" />
+            ) : (
+              <SquareIcon size={20} />
+            )}
+          </button>
+        ) : null}
+      </td>
+      <td className="px-4 py-3 align-middle">
+        <div className="flex items-center gap-3">
+          <div className="relative aspect-video w-20 shrink-0 overflow-hidden rounded-[8px] bg-zinc-100">
+            {thumbnail ? (
+              <Image
+                src={thumbnail}
+                alt={submission.name}
+                fill
+                sizes="80px"
+                style={{ objectFit: "cover" }}
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <ImageBrokenIcon size={20} className="text-zinc-400" />
+              </div>
+            )}
+          </div>
+          <div className="flex min-w-0 flex-col">
+            <div className="flex min-w-0 items-center gap-2">
+              <Text
+                variant="body-medium"
+                as="span"
+                className="truncate text-textBlack"
+              >
+                {submission.name}
+              </Text>
+              <Text variant="small" as="span" className="shrink-0 text-zinc-600">
+                v{submission.graph_version}
+              </Text>
+            </div>
+            <Text
+              variant="small"
+              as="span"
+              className="line-clamp-1 max-w-[420px] text-zinc-500"
+            >
+              {submission.description}
+            </Text>
+          </div>
+        </div>
+      </td>
+
+      <td className="px-4 py-3 align-middle">
+        <span
+          className={`inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium ${visual.pillClass}`}
+        >
+          <StatusIcon size={12} weight="fill" />
+          {visual.label}
+        </span>
+      </td>
+
+      <td className="whitespace-nowrap px-4 py-3 align-middle text-sm text-zinc-700">
+        {formatSubmittedAt(submission.submitted_at)}
+      </td>
+
+      <td className="whitespace-nowrap px-4 py-3 text-right align-middle text-sm tabular-nums text-zinc-700">
+        {formatRuns(submission.run_count ?? 0)}
+      </td>
+
+      <td className="whitespace-nowrap px-4 py-3 text-right align-middle text-sm text-zinc-700">
+        {submission.review_avg_rating && submission.review_avg_rating > 0 ? (
+          <span className="inline-flex items-center justify-end gap-1 tabular-nums">
+            {submission.review_avg_rating.toFixed(1)}
+            <StarIcon size={12} weight="fill" className="text-amber-500" />
+          </span>
+        ) : (
+          <span className="text-zinc-400">—</span>
+        )}
+      </td>
+
+      <td className="px-2 py-3 text-right align-middle">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Submission actions"
+              data-testid="submission-actions"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full text-zinc-500 transition-[background-color,color,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-zinc-100 hover:text-zinc-900 active:scale-[0.92] motion-reduce:transition-none motion-reduce:active:scale-100"
+            >
+              <DotsThreeVerticalIcon size={18} weight="bold" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            sideOffset={6}
+            className="min-w-[160px] origin-[var(--radix-dropdown-menu-content-transform-origin)] data-[state=open]:duration-200 data-[state=closed]:duration-150 data-[state=open]:ease-[cubic-bezier(0.16,1,0.3,1)] data-[state=closed]:ease-[cubic-bezier(0.4,0,1,1)] motion-reduce:!duration-100"
+          >
+            {canModify ? (
+              <DropdownMenuItem
+                onSelect={handleEdit}
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <PencilSimpleIcon size={14} />
+                Edit details
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                onSelect={handleView}
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <EyeIcon size={14} />
+                View submission
+              </DropdownMenuItem>
+            )}
+            {canModify ? (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={() => setConfirmDeleteOpen(true)}
+                  className="flex cursor-pointer items-center gap-2 text-rose-600 focus:text-rose-700"
+                >
+                  <TrashIcon size={14} />
+                  Delete
+                </DropdownMenuItem>
+              </>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Dialog
+          title="Delete submission?"
+          styling={{ maxWidth: "420px" }}
+          controlled={{
+            isOpen: confirmDeleteOpen,
+            set: (open) => setConfirmDeleteOpen(open),
+          }}
+        >
+          <Dialog.Content>
+            <Text variant="body" className="text-zinc-700">
+              This will remove <strong>{submission.name}</strong> from the
+              store. This action cannot be undone.
+            </Text>
+            <Dialog.Footer>
+              <Button
+                variant="ghost"
+                size="small"
+                onClick={() => setConfirmDeleteOpen(false)}
+                disabled={isDeleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="small"
+                onClick={handleConfirmDelete}
+                loading={isDeleting}
+              >
+                {isDeleting ? "Deleting" : "Delete submission"}
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog>
+      </td>
+    </tr>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/SubmissionItem.tsx
@@ -25,7 +25,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
 
-import { STATUS_VISUAL, formatRuns, formatSubmittedAt } from "../../helpers";
+import { formatRuns, formatSubmittedAt, getStatusVisual } from "../../helpers";
 import { useSubmissionItem } from "./useSubmissionItem";
 
 interface EditPayload extends StoreSubmissionEditRequest {
@@ -60,7 +60,7 @@ export function SubmissionItem({
     handleConfirmDelete,
   } = useSubmissionItem({ submission, onView, onEdit, onDelete });
 
-  const visual = STATUS_VISUAL[submission.status];
+  const visual = getStatusVisual(submission.status);
   const StatusIcon = visual.Icon;
   const thumbnail = submission.image_urls?.[0];
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+
+interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+interface Args {
+  submission: StoreSubmission;
+  onView: (submission: StoreSubmission) => void;
+  onEdit: (payload: EditPayload) => void;
+  onDelete: (submissionId: string) => Promise<void>;
+}
+
+export function useSubmissionItem({
+  submission,
+  onView,
+  onEdit,
+  onDelete,
+}: Args) {
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const canModify = submission.status === SubmissionStatus.PENDING;
+
+  function handleView() {
+    onView(submission);
+  }
+
+  function handleEdit() {
+    onEdit({
+      name: submission.name,
+      sub_heading: submission.sub_heading,
+      description: submission.description,
+      image_urls: submission.image_urls,
+      video_url: submission.video_url,
+      categories: submission.categories,
+      changes_summary: submission.changes_summary || "Update Submission",
+      store_listing_version_id: submission.listing_version_id,
+      graph_id: submission.graph_id,
+    });
+  }
+
+  async function handleConfirmDelete() {
+    setIsDeleting(true);
+    try {
+      await onDelete(submission.listing_version_id);
+      setConfirmDeleteOpen(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return {
+    canModify,
+    handleView,
+    handleEdit,
+    confirmDeleteOpen,
+    setConfirmDeleteOpen,
+    isDeleting,
+    handleConfirmDelete,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionItem/useSubmissionItem.ts
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import * as Sentry from "@sentry/nextjs";
 
 import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
 import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import { toast } from "@/components/molecules/Toast/use-toast";
 
 interface EditPayload extends StoreSubmissionEditRequest {
   store_listing_version_id: string | undefined;
@@ -50,6 +52,13 @@ export function useSubmissionItem({
     try {
       await onDelete(submission.listing_version_id);
       setConfirmDeleteOpen(false);
+    } catch (err) {
+      Sentry.captureException(err);
+      toast({
+        title: "Couldn't delete submission",
+        description: err instanceof Error ? err.message : undefined,
+        variant: "destructive",
+      });
     } finally {
       setIsDeleting(false);
     }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionSelectionBar/SubmissionSelectionBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionSelectionBar/SubmissionSelectionBar.tsx
@@ -1,0 +1,46 @@
+import { TrashIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Props {
+  selectedCount: number;
+  allSelected: boolean;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onDeleteSelected: () => void;
+}
+
+export function SubmissionSelectionBar({
+  selectedCount,
+  allSelected,
+  onSelectAll,
+  onDeselectAll,
+  onDeleteSelected,
+}: Props) {
+  return (
+    <div className="flex w-full items-center justify-between rounded-[14px] border border-zinc-200 bg-zinc-100 px-4 py-2">
+      <div className="flex items-center gap-5">
+        <Text variant="body" as="span" className="text-zinc-700">
+          {selectedCount} selected
+        </Text>
+        {!allSelected && (
+          <Button variant="ghost" size="small" onClick={onSelectAll}>
+            Select All
+          </Button>
+        )}
+        <Button variant="ghost" size="small" onClick={onDeselectAll}>
+          Deselect
+        </Button>
+      </div>
+      <Button
+        variant="destructive"
+        size="small"
+        leftIcon={<TrashIcon size={16} />}
+        onClick={onDeleteSelected}
+      >
+        Delete selected
+      </Button>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+
+import {
+  EASE_OUT,
+  type FilterState,
+  type SortDir,
+  type SortKey,
+} from "../../helpers";
+import { SubmissionItem } from "../SubmissionItem/SubmissionItem";
+import { SubmissionSelectionBar } from "../SubmissionSelectionBar/SubmissionSelectionBar";
+import { ColumnHeader } from "./columns/ColumnHeader";
+import { SortColumnFilter } from "./columns/SortColumnFilter";
+import { StatusColumnFilter } from "./columns/StatusColumnFilter";
+import { useSubmissionSelection } from "./useSubmissionSelection";
+
+interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+interface Props {
+  submissions: StoreSubmission[];
+  totalCount: number;
+  filterState: FilterState;
+  onFilterChange: (next: FilterState) => void;
+  onResetFilters: () => void;
+  onView: (submission: StoreSubmission) => void;
+  onEdit: (payload: EditPayload) => void;
+  onDelete: (submissionId: string) => Promise<void>;
+  index?: number;
+}
+
+const COLUMN_COUNT = 7;
+
+export function SubmissionsList({
+  submissions,
+  totalCount,
+  filterState,
+  onFilterChange,
+  onResetFilters,
+  onView,
+  onEdit,
+  onDelete,
+  index = 0,
+}: Props) {
+  const reduceMotion = useReducedMotion();
+
+  const selectableIds = useMemo(
+    () =>
+      submissions
+        .filter((s) => s.status === SubmissionStatus.PENDING)
+        .map((s) => s.listing_version_id),
+    [submissions],
+  );
+
+  const selection = useSubmissionSelection(selectableIds);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
+
+  function setStatuses(statuses: SubmissionStatus[]) {
+    onFilterChange({ ...filterState, statuses });
+  }
+
+  function setSort(sortKey: SortKey | null, sortDir: SortDir) {
+    onFilterChange({ ...filterState, sortKey, sortDir });
+  }
+
+  async function handleBulkDelete() {
+    setIsBulkDeleting(true);
+    try {
+      const ids = [...selection.selectedIds];
+      for (const id of ids) {
+        await onDelete(id);
+      }
+      selection.clear();
+      setBulkDeleteOpen(false);
+    } finally {
+      setIsBulkDeleting(false);
+    }
+  }
+
+  return (
+    <motion.section
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+      transition={
+        reduceMotion
+          ? undefined
+          : { duration: 0.28, ease: EASE_OUT, delay: 0.04 + index * 0.05 }
+      }
+      className="flex w-full flex-col gap-3"
+      data-testid="submissions-list"
+    >
+      <div className="flex items-center justify-between pl-4 pr-1">
+        <Text variant="body-medium" as="span" className="text-textBlack">
+          Submissions
+        </Text>
+        <Text variant="small" className="text-zinc-500">
+          {submissions.length} of {totalCount}
+        </Text>
+      </div>
+
+      <AnimatePresence initial={false}>
+        {selection.selectedCount > 0 && (
+          <motion.div
+            key="selection-bar"
+            initial={
+              reduceMotion
+                ? { opacity: 0 }
+                : { opacity: 0, height: 0, marginBottom: -12 }
+            }
+            animate={
+              reduceMotion
+                ? { opacity: 1 }
+                : { opacity: 1, height: "auto", marginBottom: 0 }
+            }
+            exit={
+              reduceMotion
+                ? { opacity: 0 }
+                : { opacity: 0, height: 0, marginBottom: -12 }
+            }
+            transition={{ duration: 0.2, ease: [0, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <SubmissionSelectionBar
+              selectedCount={selection.selectedCount}
+              allSelected={selection.allSelected}
+              onSelectAll={selection.selectAll}
+              onDeselectAll={selection.clear}
+              onDeleteSelected={() => setBulkDeleteOpen(true)}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div className="overflow-hidden rounded-[18px] border border-zinc-200 bg-white shadow-[0_1px_2px_rgba(15,15,20,0.04)]">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-left">
+            <thead>
+              <tr className="border-b border-zinc-100 bg-zinc-50/60">
+                <th scope="col" className="w-[48px] px-3 py-3" aria-label="Select" />
+                <ColumnHeader label="Agent" />
+                <ColumnHeader
+                  label="Status"
+                  width="140px"
+                  filter={
+                    <StatusColumnFilter
+                      value={filterState.statuses}
+                      onChange={setStatuses}
+                    />
+                  }
+                />
+                <ColumnHeader
+                  label="Submitted"
+                  width="160px"
+                  filter={
+                    <SortColumnFilter
+                      sortKey="submitted"
+                      activeKey={filterState.sortKey}
+                      activeDir={filterState.sortDir}
+                      onChange={setSort}
+                      ascLabel="Oldest first"
+                      descLabel="Newest first"
+                    />
+                  }
+                />
+                <ColumnHeader
+                  label="Runs"
+                  align="right"
+                  width="110px"
+                  filter={
+                    <SortColumnFilter
+                      sortKey="runs"
+                      activeKey={filterState.sortKey}
+                      activeDir={filterState.sortDir}
+                      onChange={setSort}
+                      ascLabel="Lowest first"
+                      descLabel="Highest first"
+                    />
+                  }
+                />
+                <ColumnHeader
+                  label="Rating"
+                  align="right"
+                  width="110px"
+                  filter={
+                    <SortColumnFilter
+                      sortKey="rating"
+                      activeKey={filterState.sortKey}
+                      activeDir={filterState.sortDir}
+                      onChange={setSort}
+                      ascLabel="Lowest first"
+                      descLabel="Highest first"
+                    />
+                  }
+                />
+                <th
+                  scope="col"
+                  className="w-[60px] px-2 py-3"
+                  aria-label="Actions"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {submissions.length > 0 ? (
+                submissions.map((submission) => (
+                  <SubmissionItem
+                    key={submission.listing_version_id}
+                    submission={submission}
+                    selected={selection.isSelected(submission.listing_version_id)}
+                    onToggleSelected={() =>
+                      selection.toggle(submission.listing_version_id)
+                    }
+                    onView={onView}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                  />
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={COLUMN_COUNT} className="px-4 py-12">
+                    <div className="flex flex-col items-center justify-center gap-3 text-center">
+                      <Text variant="body-medium" className="text-textBlack">
+                        No submissions match these filters
+                      </Text>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={onResetFilters}
+                      >
+                        Clear filters
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <Dialog
+        title="Delete selected submissions?"
+        styling={{ maxWidth: "420px" }}
+        controlled={{
+          isOpen: bulkDeleteOpen,
+          set: (open) => setBulkDeleteOpen(open),
+        }}
+      >
+        <Dialog.Content>
+          <Text variant="body" className="text-zinc-700">
+            This will remove {selection.selectedCount} submission
+            {selection.selectedCount === 1 ? "" : "s"} from the store. This
+            action cannot be undone.
+          </Text>
+          <Dialog.Footer>
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={() => setBulkDeleteOpen(false)}
+              disabled={isBulkDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="small"
+              onClick={handleBulkDelete}
+              loading={isBulkDeleting}
+            >
+              {isBulkDeleting ? "Deleting" : "Delete selected"}
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </motion.section>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
@@ -148,7 +148,11 @@ export function SubmissionsList({
           <table className="w-full border-collapse text-left">
             <thead>
               <tr className="border-b border-zinc-100 bg-zinc-50/60">
-                <th scope="col" className="w-[48px] px-3 py-3" aria-label="Select" />
+                <th
+                  scope="col"
+                  className="w-[48px] px-3 py-3"
+                  aria-label="Select"
+                />
                 <ColumnHeader label="Agent" />
                 <ColumnHeader
                   label="Status"
@@ -217,7 +221,9 @@ export function SubmissionsList({
                   <SubmissionItem
                     key={submission.listing_version_id}
                     submission={submission}
-                    selected={selection.isSelected(submission.listing_version_id)}
+                    selected={selection.isSelected(
+                      submission.listing_version_id,
+                    )}
                     onToggleSelected={() =>
                       selection.toggle(submission.listing_version_id)
                     }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/SubmissionsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import * as Sentry from "@sentry/nextjs";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
@@ -9,6 +10,7 @@ import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatu
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { toast } from "@/components/molecules/Toast/use-toast";
 
 import {
   EASE_OUT,
@@ -77,10 +79,20 @@ export function SubmissionsList({
 
   async function handleBulkDelete() {
     setIsBulkDeleting(true);
+    const ids = [...selection.selectedIds];
     try {
-      const ids = [...selection.selectedIds];
-      for (const id of ids) {
-        await onDelete(id);
+      const results = await Promise.allSettled(ids.map((id) => onDelete(id)));
+      const failed = results.filter((r) => r.status === "rejected").length;
+      const succeeded = ids.length - failed;
+      if (failed > 0) {
+        for (const r of results) {
+          if (r.status === "rejected") Sentry.captureException(r.reason);
+        }
+        toast({
+          title: `Deleted ${succeeded} of ${ids.length} submissions`,
+          description: `${failed} failed to delete. Please try again.`,
+          variant: "destructive",
+        });
       }
       selection.clear();
       setBulkDeleteOpen(false);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/ColumnHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/ColumnHeader.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  label: string;
+  filter?: ReactNode;
+  align?: "left" | "right";
+  width?: string;
+}
+
+export function ColumnHeader({ label, filter, align = "left", width }: Props) {
+  return (
+    <th
+      scope="col"
+      style={width ? { width } : undefined}
+      className={`px-4 py-3 ${align === "right" ? "text-right" : "text-left"}`}
+    >
+      <div
+        className={`inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-zinc-500 ${
+          align === "right" ? "flex-row-reverse" : ""
+        }`}
+      >
+        <span>{label}</span>
+        {filter}
+      </div>
+    </th>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/SortColumnFilter.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/SortColumnFilter.tsx
@@ -87,7 +87,7 @@ function SortOption({
       aria-pressed={active}
       className={cn(
         "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm",
-        "transition-[background-color,color,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+        "ease-[cubic-bezier(0.16,1,0.3,1)] transition-[background-color,color,transform] duration-150",
         "active:scale-[0.98] motion-reduce:transition-none motion-reduce:active:scale-100",
         active
           ? "bg-violet-50 text-violet-700"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/SortColumnFilter.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/SortColumnFilter.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { ArrowDownIcon, ArrowUpIcon } from "@phosphor-icons/react";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+import { type SortDir, type SortKey } from "../../../helpers";
+import { ColumnFilter } from "../../ColumnFilter/ColumnFilter";
+
+interface Props {
+  sortKey: SortKey;
+  activeKey: SortKey | null;
+  activeDir: SortDir;
+  onChange: (key: SortKey | null, dir: SortDir) => void;
+  ascLabel: string;
+  descLabel: string;
+}
+
+export function SortColumnFilter({
+  sortKey,
+  activeKey,
+  activeDir,
+  onChange,
+  ascLabel,
+  descLabel,
+}: Props) {
+  const isActive = activeKey === sortKey;
+
+  function pick(dir: SortDir) {
+    onChange(sortKey, dir);
+  }
+
+  function clear() {
+    onChange(null, activeDir);
+  }
+
+  return (
+    <ColumnFilter active={isActive} label="Sort" align="start">
+      <div className="flex flex-col gap-2">
+        <Text variant="small-medium" as="span" className="px-2 text-textBlack">
+          Sort
+        </Text>
+        <SortOption
+          icon={<ArrowDownIcon size={14} weight="bold" />}
+          label={descLabel}
+          active={isActive && activeDir === "desc"}
+          onClick={() => pick("desc")}
+        />
+        <SortOption
+          icon={<ArrowUpIcon size={14} weight="bold" />}
+          label={ascLabel}
+          active={isActive && activeDir === "asc"}
+          onClick={() => pick("asc")}
+        />
+        {isActive ? (
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={clear}
+            className="self-end"
+          >
+            Clear
+          </Button>
+        ) : null}
+      </div>
+    </ColumnFilter>
+  );
+}
+
+function SortOption({
+  icon,
+  label,
+  active,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm",
+        "transition-[background-color,color,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+        "active:scale-[0.98] motion-reduce:transition-none motion-reduce:active:scale-100",
+        active
+          ? "bg-violet-50 text-violet-700"
+          : "text-zinc-700 hover:bg-zinc-100",
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-5 w-5 items-center justify-center rounded text-zinc-500",
+          active && "text-violet-700",
+        )}
+      >
+        {icon}
+      </span>
+      {label}
+    </button>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/StatusColumnFilter.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/StatusColumnFilter.tsx
@@ -42,7 +42,7 @@ export function StatusColumnFilter({ value, onChange }: Props) {
                   aria-pressed={checked}
                   className={cn(
                     "flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left",
-                    "transition-[background-color,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+                    "ease-[cubic-bezier(0.16,1,0.3,1)] transition-[background-color,transform] duration-150",
                     "active:scale-[0.98] motion-reduce:transition-none motion-reduce:active:scale-100",
                     checked ? "bg-violet-50" : "hover:bg-zinc-100",
                   )}
@@ -55,7 +55,7 @@ export function StatusColumnFilter({ value, onChange }: Props) {
                   <span
                     className={cn(
                       "flex h-4 w-4 items-center justify-center rounded-[4px] border",
-                      "transition-[background-color,border-color,transform] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]",
+                      "ease-[cubic-bezier(0.16,1,0.3,1)] transition-[background-color,border-color,transform] duration-200",
                       checked
                         ? "scale-100 border-violet-600 bg-violet-600 text-white"
                         : "scale-95 border-zinc-300 bg-white text-transparent",

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/StatusColumnFilter.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/columns/StatusColumnFilter.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { CheckIcon } from "@phosphor-icons/react";
+
+import type { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+import { STATUS_OPTIONS, STATUS_VISUAL } from "../../../helpers";
+import { ColumnFilter } from "../../ColumnFilter/ColumnFilter";
+
+interface Props {
+  value: SubmissionStatus[];
+  onChange: (next: SubmissionStatus[]) => void;
+}
+
+export function StatusColumnFilter({ value, onChange }: Props) {
+  function toggle(status: SubmissionStatus) {
+    if (value.includes(status)) {
+      onChange(value.filter((s) => s !== status));
+    } else {
+      onChange([...value, status]);
+    }
+  }
+
+  return (
+    <ColumnFilter active={value.length > 0} label="Status" align="start">
+      <div className="flex flex-col gap-2">
+        <Text variant="small-medium" as="span" className="px-2 text-textBlack">
+          Filter by status
+        </Text>
+        <ul className="flex flex-col gap-1">
+          {STATUS_OPTIONS.map((option) => {
+            const checked = value.includes(option.value);
+            const visual = STATUS_VISUAL[option.value];
+            return (
+              <li key={option.value}>
+                <button
+                  type="button"
+                  onClick={() => toggle(option.value)}
+                  aria-pressed={checked}
+                  className={cn(
+                    "flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left",
+                    "transition-[background-color,transform] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)]",
+                    "active:scale-[0.98] motion-reduce:transition-none motion-reduce:active:scale-100",
+                    checked ? "bg-violet-50" : "hover:bg-zinc-100",
+                  )}
+                >
+                  <span
+                    className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ${visual.pillClass}`}
+                  >
+                    {option.label}
+                  </span>
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 items-center justify-center rounded-[4px] border",
+                      "transition-[background-color,border-color,transform] duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]",
+                      checked
+                        ? "scale-100 border-violet-600 bg-violet-600 text-white"
+                        : "scale-95 border-zinc-300 bg-white text-transparent",
+                    )}
+                  >
+                    <CheckIcon size={10} weight="bold" />
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+        {value.length > 0 ? (
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => onChange([])}
+            className="self-end"
+          >
+            Clear
+          </Button>
+        ) : null}
+      </div>
+    </ColumnFilter>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/useSubmissionSelection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/useSubmissionSelection.ts
@@ -36,7 +36,8 @@ export function useSubmissionSelection(selectableIds: string[]) {
     selectedIds,
     selectedCount: selectedIds.size,
     allSelected:
-      selectableIds.length > 0 && selectedIds.size === selectableIds.length,
+      selectableIds.length > 0 &&
+      selectableIds.every((id) => selectedIds.has(id)),
     isSelected: (id: string) => selectedIds.has(id),
     toggle,
     selectAll,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/useSubmissionSelection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/components/SubmissionsList/useSubmissionSelection.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+export function useSubmissionSelection(selectableIds: string[]) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev;
+      const existing = new Set(selectableIds);
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (existing.has(id)) next.add(id);
+      }
+      return next.size === prev.size ? prev : next;
+    });
+  }, [selectableIds]);
+
+  function toggle(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function selectAll() {
+    setSelectedIds(new Set(selectableIds));
+  }
+
+  function clear() {
+    setSelectedIds(new Set());
+  }
+
+  return {
+    selectedIds,
+    selectedCount: selectedIds.size,
+    allSelected:
+      selectableIds.length > 0 && selectedIds.size === selectableIds.length,
+    isSelected: (id: string) => selectedIds.has(id),
+    toggle,
+    selectAll,
+    clear,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -91,6 +91,10 @@ export interface StatusVisual {
   dotClass: string;
 }
 
+export function getStatusVisual(status: SubmissionStatus): StatusVisual {
+  return STATUS_VISUAL[status] ?? STATUS_VISUAL[SubmissionStatus.DRAFT];
+}
+
 export const STATUS_VISUAL: Record<SubmissionStatus, StatusVisual> = {
   [SubmissionStatus.DRAFT]: {
     label: "Draft",

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -1,0 +1,199 @@
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  ProhibitIcon,
+  WarningCircleIcon,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react";
+
+import { SubmissionStatus } from "@/app/api/__generated__/models/submissionStatus";
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+
+export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+
+export type StatusFilterValue = "all" | SubmissionStatus;
+
+export type SortKey = "submitted" | "runs" | "rating";
+export type SortDir = "asc" | "desc";
+
+export interface FilterState {
+  statuses: SubmissionStatus[];
+  nameQuery: string;
+  sortKey: SortKey | null;
+  sortDir: SortDir;
+}
+
+export const INITIAL_FILTER_STATE: FilterState = {
+  statuses: [],
+  nameQuery: "",
+  sortKey: null,
+  sortDir: "desc",
+};
+
+export const STATUS_OPTIONS: { value: SubmissionStatus; label: string }[] = [
+  { value: SubmissionStatus.PENDING, label: "In review" },
+  { value: SubmissionStatus.APPROVED, label: "Approved" },
+  { value: SubmissionStatus.REJECTED, label: "Needs changes" },
+  { value: SubmissionStatus.DRAFT, label: "Draft" },
+];
+
+export function applyFiltersAndSort(
+  submissions: StoreSubmission[],
+  state: FilterState,
+): StoreSubmission[] {
+  let result = submissions;
+
+  if (state.statuses.length > 0) {
+    const set = new Set(state.statuses);
+    result = result.filter((s) => set.has(s.status));
+  }
+
+  if (state.nameQuery.trim()) {
+    const q = state.nameQuery.trim().toLowerCase();
+    result = result.filter((s) => s.name.toLowerCase().includes(q));
+  }
+
+  if (state.sortKey) {
+    const dir = state.sortDir === "asc" ? 1 : -1;
+    result = [...result].sort((a, b) => {
+      const av = sortValue(a, state.sortKey!);
+      const bv = sortValue(b, state.sortKey!);
+      if (av === bv) return 0;
+      return av < bv ? -1 * dir : 1 * dir;
+    });
+  }
+
+  return result;
+}
+
+function sortValue(submission: StoreSubmission, key: SortKey): number {
+  if (key === "submitted") {
+    const date = submission.submitted_at;
+    if (!date) return 0;
+    return date instanceof Date ? date.getTime() : new Date(date).getTime();
+  }
+  if (key === "runs") return submission.run_count ?? 0;
+  return submission.review_avg_rating ?? 0;
+}
+
+export function isFiltered(state: FilterState): boolean {
+  return (
+    state.statuses.length > 0 ||
+    state.nameQuery.trim() !== "" ||
+    state.sortKey !== null
+  );
+}
+
+export interface StatusVisual {
+  label: string;
+  Icon: PhosphorIcon;
+  pillClass: string;
+  dotClass: string;
+}
+
+export const STATUS_VISUAL: Record<SubmissionStatus, StatusVisual> = {
+  [SubmissionStatus.DRAFT]: {
+    label: "Draft",
+    Icon: ClockIcon,
+    pillClass: "bg-zinc-100 text-zinc-700 ring-1 ring-inset ring-zinc-200",
+    dotClass: "bg-zinc-400",
+  },
+  [SubmissionStatus.PENDING]: {
+    label: "In review",
+    Icon: ClockIcon,
+    pillClass: "bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200",
+    dotClass: "bg-amber-500",
+  },
+  [SubmissionStatus.APPROVED]: {
+    label: "Approved",
+    Icon: CheckCircleIcon,
+    pillClass:
+      "bg-emerald-50 text-emerald-800 ring-1 ring-inset ring-emerald-200",
+    dotClass: "bg-emerald-500",
+  },
+  [SubmissionStatus.REJECTED]: {
+    label: "Needs changes",
+    Icon: ProhibitIcon,
+    pillClass: "bg-rose-50 text-rose-800 ring-1 ring-inset ring-rose-200",
+    dotClass: "bg-rose-500",
+  },
+};
+
+export const STATUS_FILTERS: { value: StatusFilterValue; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: SubmissionStatus.PENDING, label: "In review" },
+  { value: SubmissionStatus.APPROVED, label: "Approved" },
+  { value: SubmissionStatus.REJECTED, label: "Needs changes" },
+  { value: SubmissionStatus.DRAFT, label: "Drafts" },
+];
+
+export interface DashboardStats {
+  total: number;
+  approved: number;
+  pending: number;
+  totalRuns: number;
+  averageRating: number | null;
+}
+
+export function computeStats(submissions: StoreSubmission[]): DashboardStats {
+  if (submissions.length === 0) {
+    return {
+      total: 0,
+      approved: 0,
+      pending: 0,
+      totalRuns: 0,
+      averageRating: null,
+    };
+  }
+
+  let approved = 0;
+  let pending = 0;
+  let totalRuns = 0;
+  let ratingSum = 0;
+  let ratingCount = 0;
+
+  for (const submission of submissions) {
+    if (submission.status === SubmissionStatus.APPROVED) approved += 1;
+    if (submission.status === SubmissionStatus.PENDING) pending += 1;
+    totalRuns += submission.run_count ?? 0;
+    if (submission.review_avg_rating && submission.review_avg_rating > 0) {
+      ratingSum += submission.review_avg_rating;
+      ratingCount += 1;
+    }
+  }
+
+  return {
+    total: submissions.length,
+    approved,
+    pending,
+    totalRuns,
+    averageRating: ratingCount > 0 ? ratingSum / ratingCount : null,
+  };
+}
+
+export function filterSubmissions(
+  submissions: StoreSubmission[],
+  filter: StatusFilterValue,
+): StoreSubmission[] {
+  if (filter === "all") return submissions;
+  return submissions.filter((submission) => submission.status === filter);
+}
+
+export function formatRuns(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toLocaleString();
+}
+
+export function formatSubmittedAt(value: Date | null | undefined): string {
+  if (!value) return "—";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export const FILTER_EMPTY_ICON: PhosphorIcon = WarningCircleIcon;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -181,12 +181,12 @@ export function filterSubmissions(
   submissions: StoreSubmission[],
   filter: StatusFilterValue,
 ): StoreSubmission[] {
-  if (filter === "all") return submissions;
+  if (filter === "all") return [...submissions];
   return submissions.filter((submission) => submission.status === filter);
 }
 
 export function formatRuns(value: number): string {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 999_950) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
   return value.toLocaleString();
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -70,7 +70,9 @@ function sortValue(submission: StoreSubmission, key: SortKey): number {
   if (key === "submitted") {
     const date = submission.submitted_at;
     if (!date) return 0;
-    return date instanceof Date ? date.getTime() : new Date(date).getTime();
+    const time =
+      date instanceof Date ? date.getTime() : new Date(date).getTime();
+    return Number.isNaN(time) ? 0 : time;
   }
   if (key === "runs") return submission.run_count ?? 0;
   return submission.review_avg_rating ?? 0;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/helpers.ts
@@ -41,7 +41,7 @@ export function applyFiltersAndSort(
   submissions: StoreSubmission[],
   state: FilterState,
 ): StoreSubmission[] {
-  let result = submissions;
+  let result: StoreSubmission[] = [...submissions];
 
   if (state.statuses.length > 0) {
     const set = new Set(state.statuses);

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/page.tsx
@@ -1,16 +1,111 @@
 "use client";
 
-import { Text } from "@/components/atoms/Text/Text";
+import { useEffect } from "react";
+
+import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { EditAgentModal } from "@/components/contextual/EditAgentModal/EditAgentModal";
+
+import { DashboardHeader } from "./components/DashboardHeader/DashboardHeader";
+import { DashboardSkeleton } from "./components/DashboardSkeleton/DashboardSkeleton";
+import { EmptyState } from "./components/EmptyState/EmptyState";
+import { MobileSubmissionsList } from "./components/MobileSubmissionsList/MobileSubmissionsList";
+import { StatsOverview } from "./components/StatsOverview/StatsOverview";
+import { SubmissionsList } from "./components/SubmissionsList/SubmissionsList";
+import { useCreatorDashboardPage } from "./useCreatorDashboardPage";
 
 export default function SettingsCreatorDashboardPage() {
+  useEffect(() => {
+    document.title = "Creator dashboard – AutoGPT Platform";
+  }, []);
+
+  const {
+    submissions,
+    visibleSubmissions,
+    stats,
+    filterState,
+    setFilterState,
+    resetFilters,
+    isLoading,
+    error,
+    refetch,
+    publishState,
+    onPublishStateChange,
+    openPublishModal,
+    editState,
+    onViewSubmission,
+    onEditSubmission,
+    onEditSuccess,
+    onEditClose,
+    onDeleteSubmission,
+  } = useCreatorDashboardPage();
+
+  if (error) {
+    return (
+      <ErrorCard
+        context="creator dashboard"
+        responseError={
+          error ? { detail: (error as { detail?: string }).detail } : undefined
+        }
+        onRetry={() => {
+          void refetch();
+        }}
+      />
+    );
+  }
+
+  if (isLoading) {
+    return <DashboardSkeleton />;
+  }
+
+  const isEmpty = submissions.length === 0;
+
   return (
-    <>
-      <Text variant="h4" className="text-[#1F1F20]">
-        Creator Dashboard
-      </Text>
-      <Text variant="large" className="mt-2 text-zinc-600">
-        Coming soon.
-      </Text>
-    </>
+    <div className="flex flex-col gap-6 pb-8">
+      <DashboardHeader
+        publishState={publishState}
+        onPublishStateChange={onPublishStateChange}
+        onOpenSubmit={openPublishModal}
+      />
+
+      {isEmpty ? (
+        <EmptyState />
+      ) : (
+        <>
+          <StatsOverview stats={stats} index={0} />
+          <div className="hidden md:block">
+            <SubmissionsList
+              submissions={visibleSubmissions}
+              totalCount={submissions.length}
+              filterState={filterState}
+              onFilterChange={setFilterState}
+              onResetFilters={resetFilters}
+              onView={onViewSubmission}
+              onEdit={onEditSubmission}
+              onDelete={onDeleteSubmission}
+              index={2}
+            />
+          </div>
+          <div className="md:hidden">
+            <MobileSubmissionsList
+              submissions={visibleSubmissions}
+              totalCount={submissions.length}
+              filterState={filterState}
+              onFilterChange={setFilterState}
+              onResetFilters={resetFilters}
+              onView={onViewSubmission}
+              onEdit={onEditSubmission}
+              onDelete={onDeleteSubmission}
+            />
+          </div>
+        </>
+      )}
+
+      <EditAgentModal
+        isOpen={editState.isOpen}
+        onClose={onEditClose}
+        submission={editState.submission}
+        onSuccess={onEditSuccess}
+      />
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -52,9 +52,8 @@ export function useCreatorDashboardPage() {
     submission: null,
   });
 
-  const [filterState, setFilterState] = useState<FilterState>(
-    INITIAL_FILTER_STATE,
-  );
+  const [filterState, setFilterState] =
+    useState<FilterState>(INITIAL_FILTER_STATE);
 
   const {
     data: response,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -147,7 +147,7 @@ export function useCreatorDashboardPage() {
     filterState,
     setFilterState,
     resetFilters,
-    isLoading: !isSuccess && isLoading,
+    isLoading: !isSuccess,
     isReady: isSuccess,
     error,
     refetch,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -58,7 +58,6 @@ export function useCreatorDashboardPage() {
   const {
     data: response,
     isSuccess,
-    isLoading,
     error,
     refetch,
   } = useGetV2ListMySubmissions(undefined, {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -128,6 +128,9 @@ export function useCreatorDashboardPage() {
         return;
       }
       setEditState({ isOpen: false, submission: null });
+      await queryClient.invalidateQueries({
+        queryKey: getGetV2ListMySubmissionsQueryKey(),
+      });
     } catch (err) {
       Sentry.captureException(err);
     }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/creator-dashboard/useCreatorDashboardPage.ts
@@ -1,0 +1,162 @@
+import { useMemo, useState } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+import {
+  getGetV2ListMySubmissionsQueryKey,
+  useDeleteV2DeleteStoreSubmission,
+  useGetV2ListMySubmissions,
+} from "@/app/api/__generated__/endpoints/store/store";
+import type { StoreSubmission } from "@/app/api/__generated__/models/storeSubmission";
+import type { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/storeSubmissionEditRequest";
+import type { StoreSubmissionsResponse } from "@/app/api/__generated__/models/storeSubmissionsResponse";
+import { getQueryClient } from "@/lib/react-query/queryClient";
+import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+
+import {
+  applyFiltersAndSort,
+  computeStats,
+  INITIAL_FILTER_STATE,
+  type FilterState,
+} from "./helpers";
+
+type PublishStep = "select" | "info" | "review";
+
+interface PublishState {
+  isOpen: boolean;
+  step: PublishStep;
+  submissionData: StoreSubmission | null;
+}
+
+interface EditPayload extends StoreSubmissionEditRequest {
+  store_listing_version_id: string | undefined;
+  graph_id: string;
+}
+
+interface EditState {
+  isOpen: boolean;
+  submission: EditPayload | null;
+}
+
+export function useCreatorDashboardPage() {
+  const queryClient = getQueryClient();
+  const { user } = useSupabase();
+
+  const [publishState, setPublishState] = useState<PublishState>({
+    isOpen: false,
+    step: "select",
+    submissionData: null,
+  });
+
+  const [editState, setEditState] = useState<EditState>({
+    isOpen: false,
+    submission: null,
+  });
+
+  const [filterState, setFilterState] = useState<FilterState>(
+    INITIAL_FILTER_STATE,
+  );
+
+  const {
+    data: response,
+    isSuccess,
+    isLoading,
+    error,
+    refetch,
+  } = useGetV2ListMySubmissions(undefined, {
+    query: {
+      select: (x) => x.data as StoreSubmissionsResponse,
+      enabled: !!user,
+    },
+  });
+
+  const { mutateAsync: deleteSubmission } = useDeleteV2DeleteStoreSubmission({
+    mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: getGetV2ListMySubmissionsQueryKey(),
+        });
+      },
+    },
+  });
+
+  const submissions = response?.submissions ?? [];
+
+  const stats = useMemo(() => computeStats(submissions), [submissions]);
+
+  const visibleSubmissions = useMemo(
+    () => applyFiltersAndSort(submissions, filterState),
+    [submissions, filterState],
+  );
+
+  function resetFilters() {
+    setFilterState(INITIAL_FILTER_STATE);
+  }
+
+  function openPublishModal() {
+    setPublishState({
+      isOpen: true,
+      step: "select",
+      submissionData: null,
+    });
+  }
+
+  function onPublishStateChange(newState: PublishState) {
+    setPublishState(newState);
+  }
+
+  function onViewSubmission(submission: StoreSubmission) {
+    setPublishState({
+      isOpen: true,
+      step: "review",
+      submissionData: submission,
+    });
+  }
+
+  function onEditSubmission(submission: EditPayload) {
+    setEditState({ isOpen: true, submission });
+  }
+
+  function onEditClose() {
+    setEditState({ isOpen: false, submission: null });
+  }
+
+  async function onEditSuccess(submission: StoreSubmission) {
+    try {
+      if (!submission.listing_version_id) {
+        Sentry.captureException(
+          new Error("No store listing version ID found for submission"),
+        );
+        return;
+      }
+      setEditState({ isOpen: false, submission: null });
+    } catch (err) {
+      Sentry.captureException(err);
+    }
+  }
+
+  async function onDeleteSubmission(submissionId: string) {
+    await deleteSubmission({ submissionId });
+  }
+
+  return {
+    submissions,
+    visibleSubmissions,
+    stats,
+    filterState,
+    setFilterState,
+    resetFilters,
+    isLoading: !isSuccess && isLoading,
+    isReady: isSuccess,
+    error,
+    refetch,
+    publishState,
+    onPublishStateChange,
+    openPublishModal,
+    editState,
+    onViewSubmission,
+    onEditSubmission,
+    onEditSuccess,
+    onEditClose,
+    onDeleteSubmission,
+  };
+}


### PR DESCRIPTION
### Why / What / How

**Why:** The creator dashboard route under settings v2 currently shows a "Coming soon" placeholder. SECRT-2281 fills it in so creators can manage their store submissions from one place.

**What:** Implements the full creator dashboard at `/settings/creator-dashboard` — stats overview, desktop submissions table, mobile submissions list, filtering/sorting, selection bar, edit modal, and empty/loading/error states.

**How:** Page logic lives in `useCreatorDashboardPage.ts` (data fetch, filter state, modal state, CRUD callbacks); pure transforms in `helpers.ts`; UI broken into colocated `components/*` (one folder per component, each ~200–400 lines). Reuses generated API hooks, `ErrorCard`, and `EditAgentModal` from the design system. Mobile/desktop split via Tailwind `md:` breakpoints rather than runtime detection.

### Changes 🏗️

- Replace placeholder `page.tsx` with the real dashboard, wired to `useCreatorDashboardPage`
- Add `useCreatorDashboardPage.ts` (page-level state + handlers) and `helpers.ts` (filter/sort/stat utilities)
- Add components: `DashboardHeader`, `DashboardSkeleton`, `EmptyState`, `StatsOverview`, `SubmissionsList` (+ `columns/*`, `useSubmissionSelection`), `SubmissionItem` (+ `useSubmissionItem`), `SubmissionSelectionBar`, `MobileSubmissionsList` (+ `MobileSelectionBar`), `MobileSubmissionItem`, `ColumnFilter`
- Set document title to "Creator dashboard – AutoGPT Platform"
- Surface fetch errors via `ErrorCard` with retry; show `DashboardSkeleton` while loading; show `EmptyState` when there are no submissions

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Loading state renders skeleton until submissions load
  - [ ] Empty state renders when the creator has no submissions
  - [ ] Error state renders `ErrorCard` and retry refetches the list
  - [ ] Stats overview reflects approved/pending/rejected/draft counts
  - [ ] Desktop list: sort/filter by status and other columns updates the visible rows
  - [ ] Desktop list: selection bar appears on row select and clears on reset
  - [ ] Mobile list (≤ md breakpoint): renders mobile items + selection bar
  - [ ] Edit modal opens for a submission, saves, and refreshes the list on success
  - [ ] Delete action removes the submission and updates stats
  - [ ] View action navigates to the submission's public detail
  - [ ] Submit/publish entry point opens the publish modal
  - [ ] Document title shows "Creator dashboard – AutoGPT Platform"