### PR TITLE
feat(platform): admin CSV exports — credit transactions + copilot weekly usage

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
@@ -1,6 +1,6 @@
 import logging
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 
 from autogpt_libs.auth import get_user_id, requires_admin_user
 from fastapi import APIRouter, Body, HTTPException, Query, Security
@@ -129,6 +129,13 @@ async def export_credit_transactions(
         raise HTTPException(
             status_code=400, detail="start and end query params are required"
         )
+    # Coerce naive datetimes to UTC at the boundary so neither the data layer
+    # nor the response builder hits a TypeError on (end - start) when callers
+    # send mixed naive/aware shapes.
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
     logger.info(
         "Admin %s exporting credit transactions [%s..%s] type=%s user=%s incl_inactive=%s",
         admin_user_id,
@@ -187,6 +194,13 @@ async def export_copilot_weekly_usage(
         raise HTTPException(
             status_code=400, detail="start and end query params are required"
         )
+    # Coerce naive datetimes to UTC at the boundary so neither the data layer
+    # nor the response builder hits a TypeError on (end - start) when callers
+    # send mixed naive/aware shapes.
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
     logger.info(
         "Admin %s exporting copilot weekly usage [%s..%s]",
         admin_user_id,

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
@@ -1,11 +1,24 @@
 import logging
 import typing
+from datetime import datetime
 
 from autogpt_libs.auth import get_user_id, requires_admin_user
-from fastapi import APIRouter, Body, Security
+from fastapi import APIRouter, Body, HTTPException, Query, Security
 from prisma.enums import CreditTransactionType
+from pydantic import BaseModel
 
-from backend.data.credit import admin_get_user_history, get_user_credit_model
+from backend.data.credit import (
+    CREDIT_EXPORT_MAX_DAYS,
+    admin_export_user_history,
+    admin_get_user_history,
+    get_user_credit_model,
+)
+from backend.data.model import UserTransaction
+from backend.data.platform_cost import (
+    COPILOT_USAGE_EXPORT_MAX_DAYS,
+    CopilotWeeklyUsageRow,
+    get_copilot_weekly_usage_for_export,
+)
 from backend.util.json import SafeJson
 
 from .model import AddUserCreditsResponse, UserHistoryResponse
@@ -72,3 +85,112 @@ async def admin_get_all_user_history(
     except Exception as e:
         logger.exception(f"Error getting grant history: {e}")
         raise e
+
+
+class CreditTransactionsExportResponse(BaseModel):
+    transactions: list[UserTransaction]
+    total_rows: int
+    window_days: int
+    max_window_days: int
+
+
+@router.get(
+    "/transactions/export",
+    response_model=CreditTransactionsExportResponse,
+    summary="Export Credit Transactions",
+)
+async def export_credit_transactions(
+    # Typed Optional so orval generates `Date | null` and the URL builder
+    # handles the union correctly.  Both are validated as required below.
+    start: typing.Optional[datetime] = Query(
+        None, description="ISO timestamp (inclusive)"
+    ),
+    end: typing.Optional[datetime] = Query(
+        None, description="ISO timestamp (inclusive)"
+    ),
+    transaction_type: typing.Optional[CreditTransactionType] = Query(None),
+    user_id: typing.Optional[str] = Query(None),
+    admin_user_id: str = Security(get_user_id),
+) -> CreditTransactionsExportResponse:
+    """Export CreditTransaction rows in [start, end] for finance reporting.
+
+    Capped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;
+    over-cap requests fail fast with 400 so callers narrow the window
+    instead of receiving silently truncated data.
+    """
+    if start is None or end is None:
+        raise HTTPException(
+            status_code=400, detail="start and end query params are required"
+        )
+    logger.info(
+        "Admin %s exporting credit transactions [%s..%s] type=%s user=%s",
+        admin_user_id,
+        start.isoformat(),
+        end.isoformat(),
+        transaction_type.value if transaction_type else None,
+        user_id,
+    )
+    try:
+        history = await admin_export_user_history(
+            start=start,
+            end=end,
+            transaction_type=transaction_type,
+            user_id=user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return CreditTransactionsExportResponse(
+        transactions=history,
+        total_rows=len(history),
+        window_days=(end - start).days,
+        max_window_days=CREDIT_EXPORT_MAX_DAYS,
+    )
+
+
+class CopilotUsageExportResponse(BaseModel):
+    rows: list[CopilotWeeklyUsageRow]
+    total_rows: int
+    window_days: int
+    max_window_days: int
+
+
+@router.get(
+    "/copilot-usage/export",
+    response_model=CopilotUsageExportResponse,
+    summary="Export Copilot Weekly Usage vs Rate Limit",
+)
+async def export_copilot_weekly_usage(
+    # Typed Optional so orval generates `Date | null` and the URL builder
+    # handles the union correctly.  Both are validated as required below.
+    start: typing.Optional[datetime] = Query(
+        None, description="ISO timestamp (inclusive)"
+    ),
+    end: typing.Optional[datetime] = Query(
+        None, description="ISO timestamp (inclusive)"
+    ),
+    admin_user_id: str = Security(get_user_id),
+) -> CopilotUsageExportResponse:
+    """Export per-(user, ISO week) copilot spend with the user's tier limit.
+
+    Uses the same 90-day window cap and 100k row cap as the credit export.
+    """
+    if start is None or end is None:
+        raise HTTPException(
+            status_code=400, detail="start and end query params are required"
+        )
+    logger.info(
+        "Admin %s exporting copilot weekly usage [%s..%s]",
+        admin_user_id,
+        start.isoformat(),
+        end.isoformat(),
+    )
+    try:
+        rows = await get_copilot_weekly_usage_for_export(start=start, end=end)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return CopilotUsageExportResponse(
+        rows=rows,
+        total_rows=len(rows),
+        window_days=(end - start).days,
+        max_window_days=COPILOT_USAGE_EXPORT_MAX_DAYS,
+    )

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
@@ -110,6 +110,13 @@ async def export_credit_transactions(
     ),
     transaction_type: typing.Optional[CreditTransactionType] = Query(None),
     user_id: typing.Optional[str] = Query(None),
+    include_inactive: bool = Query(
+        False,
+        description=(
+            "Include inactive rows (e.g. abandoned Stripe checkouts). "
+            "Off by default so phantom rows aren't surfaced in normal exports."
+        ),
+    ),
     admin_user_id: str = Security(get_user_id),
 ) -> CreditTransactionsExportResponse:
     """Export CreditTransaction rows in [start, end] for finance reporting.
@@ -123,12 +130,13 @@ async def export_credit_transactions(
             status_code=400, detail="start and end query params are required"
         )
     logger.info(
-        "Admin %s exporting credit transactions [%s..%s] type=%s user=%s",
+        "Admin %s exporting credit transactions [%s..%s] type=%s user=%s incl_inactive=%s",
         admin_user_id,
         start.isoformat(),
         end.isoformat(),
         transaction_type.value if transaction_type else None,
         user_id,
+        include_inactive,
     )
     try:
         history = await admin_export_user_history(
@@ -136,6 +144,7 @@ async def export_credit_transactions(
             end=end,
             transaction_type=transaction_type,
             user_id=user_id,
+            include_inactive=include_inactive,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes_test.py
@@ -313,3 +313,150 @@ def test_admin_endpoints_require_admin_role(mock_jwt_user) -> None:
     # Test users_history endpoint
     response = client.get("/admin/users_history")
     assert response.status_code == 403
+
+    # Test new export endpoints
+    response = client.get(
+        "/admin/transactions/export",
+        params={"start": "2026-01-01T00:00:00", "end": "2026-01-31T00:00:00"},
+    )
+    assert response.status_code == 403
+    response = client.get(
+        "/admin/copilot-usage/export",
+        params={"start": "2026-01-01T00:00:00", "end": "2026-01-31T00:00:00"},
+    )
+    assert response.status_code == 403
+
+
+def test_export_credit_transactions_success(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mock_export = AsyncMock(
+        return_value=[
+            UserTransaction(
+                user_id="user-1",
+                user_email="user1@example.com",
+                amount=1000,
+                running_balance=2500,
+                reason="Initial grant",
+                admin_email="admin@example.com",
+                transaction_type=prisma.enums.CreditTransactionType.GRANT,
+            ),
+            UserTransaction(
+                user_id="user-2",
+                user_email="user2@example.com",
+                amount=-50,
+                running_balance=4500,
+                reason="",
+                transaction_type=prisma.enums.CreditTransactionType.USAGE,
+            ),
+        ]
+    )
+    mocker.patch(
+        "backend.api.features.admin.credit_admin_routes.admin_export_user_history",
+        mock_export,
+    )
+
+    response = client.get(
+        "/admin/transactions/export",
+        params={
+            "start": "2026-01-01T00:00:00",
+            "end": "2026-01-31T00:00:00",
+            "transaction_type": "GRANT",
+            "user_id": "user-1",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_rows"] == 2
+    assert body["window_days"] == 30
+    assert body["max_window_days"] == 90
+    assert body["transactions"][0]["user_email"] == "user1@example.com"
+
+    call_kwargs = mock_export.call_args.kwargs
+    assert call_kwargs["transaction_type"] == prisma.enums.CreditTransactionType.GRANT
+    assert call_kwargs["user_id"] == "user-1"
+
+
+def test_export_credit_transactions_window_too_wide_returns_400(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.admin.credit_admin_routes.admin_export_user_history",
+        AsyncMock(side_effect=ValueError("Export window must be <= 90 days")),
+    )
+    response = client.get(
+        "/admin/transactions/export",
+        params={
+            "start": "2025-01-01T00:00:00",
+            "end": "2026-01-01T00:00:00",
+        },
+    )
+    assert response.status_code == 400
+    assert "90 days" in response.json()["detail"]
+
+
+def test_export_credit_transactions_missing_window_is_400() -> None:
+    response = client.get("/admin/transactions/export")
+    assert response.status_code == 400
+
+
+def test_export_copilot_weekly_usage_success(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    from datetime import datetime, timezone
+
+    from backend.data.platform_cost import CopilotWeeklyUsageRow
+
+    rows = [
+        CopilotWeeklyUsageRow(
+            user_id="user-1",
+            user_email="user1@example.com",
+            week_start=datetime(2026, 1, 5, tzinfo=timezone.utc),
+            week_end=datetime(2026, 1, 12, tzinfo=timezone.utc),
+            copilot_cost_microdollars=2_500_000,
+            tier="PRO",
+            weekly_limit_microdollars=25_000_000,
+            percent_used=10.0,
+        ),
+    ]
+    mock_export = AsyncMock(return_value=rows)
+    mocker.patch(
+        "backend.api.features.admin.credit_admin_routes.get_copilot_weekly_usage_for_export",
+        mock_export,
+    )
+
+    response = client.get(
+        "/admin/copilot-usage/export",
+        params={
+            "start": "2026-01-01T00:00:00",
+            "end": "2026-01-31T00:00:00",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_rows"] == 1
+    assert body["max_window_days"] == 90
+    row = body["rows"][0]
+    assert row["user_id"] == "user-1"
+    assert row["tier"] == "PRO"
+    assert row["weekly_limit_microdollars"] == 25_000_000
+    assert row["percent_used"] == 10.0
+
+
+def test_export_copilot_weekly_usage_window_too_wide_returns_400(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.admin.credit_admin_routes.get_copilot_weekly_usage_for_export",
+        AsyncMock(side_effect=ValueError("Export window must be <= 90 days")),
+    )
+    response = client.get(
+        "/admin/copilot-usage/export",
+        params={
+            "start": "2025-01-01T00:00:00",
+            "end": "2026-01-01T00:00:00",
+        },
+    )
+    assert response.status_code == 400

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2682,6 +2682,13 @@ async def admin_export_user_history(
     balance).  Pass `include_inactive=True` to surface them when debugging
     why a checkout never completed.
     """
+    # Normalize naive datetimes to UTC so direct API callers that send
+    # `2026-01-01T00:00:00` (no tz) don't trip a TypeError when subtracted
+    # against an aware `2026-01-31T00:00:00Z` partner.
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
     if end < start:
         raise ValueError("end must be >= start")
     # Compare timedeltas directly so 90d + any sub-day remainder still trips

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2577,3 +2577,83 @@ async def admin_get_user_history(
             page_size=page_size,
         ),
     )
+
+
+# Limits for credit-transaction CSV export. Window cap matches a typical
+# finance-month query; row cap protects the API from accidental wide pulls
+# (one big tenant can easily exceed 100k rows in 90 days).
+CREDIT_EXPORT_MAX_DAYS = 90
+CREDIT_EXPORT_MAX_ROWS = 100_000
+
+
+async def admin_export_user_history(
+    start: datetime,
+    end: datetime,
+    transaction_type: CreditTransactionType | None = None,
+    user_id: str | None = None,
+) -> list[UserTransaction]:
+    """Return all CreditTransactions in the [start, end] window for export.
+
+    Caps the window at CREDIT_EXPORT_MAX_DAYS and the row count at
+    CREDIT_EXPORT_MAX_ROWS — callers should validate the window before calling
+    so the user sees a 4xx instead of a silently truncated CSV.
+    """
+    if end < start:
+        raise ValueError("end must be >= start")
+    if (end - start).days > CREDIT_EXPORT_MAX_DAYS:
+        raise ValueError(
+            f"Export window must be <= {CREDIT_EXPORT_MAX_DAYS} days "
+            f"(got {(end - start).days} days)"
+        )
+
+    where: CreditTransactionWhereInput = {
+        "createdAt": {"gte": start, "lte": end},
+    }
+    if transaction_type:
+        where["type"] = transaction_type
+    if user_id:
+        where["userId"] = user_id
+
+    total = await CreditTransaction.prisma().count(where=where)
+    if total > CREDIT_EXPORT_MAX_ROWS:
+        raise ValueError(
+            f"Export would return {total} rows (cap is {CREDIT_EXPORT_MAX_ROWS}); "
+            "narrow the window or add filters."
+        )
+
+    transactions = await CreditTransaction.prisma().find_many(
+        where=where,
+        include={"User": True},
+        order={"createdAt": "desc"},
+        take=CREDIT_EXPORT_MAX_ROWS,
+    )
+
+    admin_id_to_email: dict[str, str] = {}
+
+    async def _resolve_admin_email(admin_id: str) -> str:
+        if admin_id in admin_id_to_email:
+            return admin_id_to_email[admin_id]
+        email = await get_user_email_by_id(admin_id) or f"Unknown Admin: {admin_id}"
+        admin_id_to_email[admin_id] = email
+        return email
+
+    history: list[UserTransaction] = []
+    for tx in transactions:
+        metadata: dict = cast(dict, tx.metadata) or {}
+        admin_id = metadata.get("admin_id") or ""
+        admin_email = await _resolve_admin_email(admin_id) if admin_id else ""
+        reason = metadata.get("reason", "") if metadata else ""
+        history.append(
+            UserTransaction(
+                transaction_key=tx.transactionKey,
+                transaction_time=tx.createdAt,
+                transaction_type=tx.type,
+                amount=tx.amount,
+                running_balance=tx.runningBalance or 0,
+                user_id=tx.userId,
+                user_email=tx.User.email if tx.User else None,
+                reason=reason,
+                admin_email=admin_email,
+            )
+        )
+    return history

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2591,12 +2591,18 @@ async def admin_export_user_history(
     end: datetime,
     transaction_type: CreditTransactionType | None = None,
     user_id: str | None = None,
+    include_inactive: bool = False,
 ) -> list[UserTransaction]:
     """Return all CreditTransactions in the [start, end] window for export.
 
     Caps the window at CREDIT_EXPORT_MAX_DAYS and the row count at
     CREDIT_EXPORT_MAX_ROWS — callers should validate the window before calling
     so the user sees a 4xx instead of a silently truncated CSV.
+
+    By default filters out `isActive=False` rows (e.g. abandoned Stripe
+    checkouts whose `runningBalance` snapshot never advanced the user's real
+    balance).  Pass `include_inactive=True` to surface them when debugging
+    why a checkout never completed.
     """
     if end < start:
         raise ValueError("end must be >= start")
@@ -2615,6 +2621,8 @@ async def admin_export_user_history(
         where["type"] = transaction_type
     if user_id:
         where["userId"] = user_id
+    if not include_inactive:
+        where["isActive"] = True
 
     # Fetch one over the cap and reject — avoids the TOCTOU race a separate
     # count() + take=cap pair would have if rows land between the two queries.

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2633,7 +2633,7 @@ async def admin_export_user_history(
     async def _resolve_admin_email(admin_id: str) -> str:
         if admin_id in admin_id_to_email:
             return admin_id_to_email[admin_id]
-        email = await get_user_email_by_id(admin_id) or f"Unknown Admin: {admin_id}"
+        email = await get_user_email_by_id(admin_id) or ""
         admin_id_to_email[admin_id] = email
         return email
 

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2614,19 +2614,19 @@ async def admin_export_user_history(
     if user_id:
         where["userId"] = user_id
 
-    total = await CreditTransaction.prisma().count(where=where)
-    if total > CREDIT_EXPORT_MAX_ROWS:
-        raise ValueError(
-            f"Export would return {total} rows (cap is {CREDIT_EXPORT_MAX_ROWS}); "
-            "narrow the window or add filters."
-        )
-
+    # Fetch one over the cap and reject — avoids the TOCTOU race a separate
+    # count() + take=cap pair would have if rows land between the two queries.
     transactions = await CreditTransaction.prisma().find_many(
         where=where,
         include={"User": True},
         order={"createdAt": "desc"},
-        take=CREDIT_EXPORT_MAX_ROWS,
+        take=CREDIT_EXPORT_MAX_ROWS + 1,
     )
+    if len(transactions) > CREDIT_EXPORT_MAX_ROWS:
+        raise ValueError(
+            f"Export would return more than {CREDIT_EXPORT_MAX_ROWS} rows; "
+            "narrow the window or add filters."
+        )
 
     admin_id_to_email: dict[str, str] = {}
 

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2644,7 +2644,12 @@ async def admin_export_user_history(
         metadata: dict = cast(dict, tx.metadata) or {}
         admin_id = metadata.get("admin_id") or ""
         admin_email = await _resolve_admin_email(admin_id) if admin_id else ""
-        reason = metadata.get("reason", "") if metadata else ""
+        # _top_up_credits writes reason as {"reason": "..."}; unwrap so the CSV
+        # column carries a plain string regardless of source.
+        raw_reason = metadata.get("reason", "") if metadata else ""
+        if isinstance(raw_reason, dict):
+            raw_reason = raw_reason.get("reason", "")
+        reason = str(raw_reason) if raw_reason is not None else ""
         history.append(
             UserTransaction(
                 transaction_key=tx.transactionKey,

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -3,7 +3,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 import stripe
@@ -2600,10 +2600,12 @@ async def admin_export_user_history(
     """
     if end < start:
         raise ValueError("end must be >= start")
-    if (end - start).days > CREDIT_EXPORT_MAX_DAYS:
+    # Compare timedeltas directly so 90d + any sub-day remainder still trips
+    # the cap (.days truncates fractional days and was letting ~91d through).
+    if (end - start) > timedelta(days=CREDIT_EXPORT_MAX_DAYS):
         raise ValueError(
             f"Export window must be <= {CREDIT_EXPORT_MAX_DAYS} days "
-            f"(got {(end - start).days} days)"
+            f"(got {(end - start).total_seconds() / 86400:.2f} days)"
         )
 
     where: CreditTransactionWhereInput = {

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -720,8 +720,8 @@ async def get_platform_cost_logs(
 EXPORT_MAX_ROWS = 100_000
 
 # Caps for the copilot weekly-usage CSV export.  Window cap matches the credit
-# transactions export so finance has a consistent shape; row cap protects the
-# API from a wildcard query that would scan an entire production cohort.
+# transactions export (CREDIT_EXPORT_MAX_DAYS in backend/data/credit.py) so
+# finance has a consistent shape across both exports — keep them in sync.
 COPILOT_USAGE_EXPORT_MAX_DAYS = 90
 COPILOT_USAGE_EXPORT_MAX_ROWS = 100_000
 
@@ -786,12 +786,15 @@ async def get_copilot_weekly_usage_for_export(
     # transitively imports back into this module at startup.
     from backend.copilot.config import ChatConfig
     from backend.copilot.rate_limit import (
-        _DEFAULT_TIER_MULTIPLIERS,
         DEFAULT_TIER,
         SubscriptionTier,
+        get_tier_multipliers,
     )
 
     base_weekly = ChatConfig().weekly_cost_limit_microdollars
+    # Use the LD-aware multipliers so percent_used reflects the limit that's
+    # actually enforced for each user, not the static default.
+    tier_multipliers = await get_tier_multipliers()
 
     out: list[CopilotWeeklyUsageRow] = []
     for r in rows:
@@ -805,7 +808,7 @@ async def get_copilot_weekly_usage_for_export(
             tier_enum = SubscriptionTier(tier_str)
         except ValueError:
             tier_enum = DEFAULT_TIER
-        multiplier = _DEFAULT_TIER_MULTIPLIERS.get(tier_enum, 1.0)
+        multiplier = tier_multipliers.get(tier_enum.value, 1.0)
         weekly_limit = int(base_weekly * multiplier)
         if weekly_limit > 0:
             percent_used = round(100.0 * cost / weekly_limit, 2)

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -755,6 +755,13 @@ async def get_copilot_weekly_usage_for_export(
     - `NO_TIER` users have no enforced rate limit; their `percent_used` will
       report `0.0` (no denominator) — interpret these rows as "unmetered".
     """
+    # Normalize naive datetimes to UTC so direct API callers that send
+    # `2026-01-01T00:00:00` (no tz) don't trip a TypeError when subtracted
+    # against an aware `2026-01-31T00:00:00Z` partner.
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
     if end < start:
         raise ValueError("end must be >= start")
     # Compare timedeltas directly so 90d + any sub-day remainder still trips

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -719,6 +719,112 @@ async def get_platform_cost_logs(
 
 EXPORT_MAX_ROWS = 100_000
 
+# Caps for the copilot weekly-usage CSV export.  Window cap matches the credit
+# transactions export so finance has a consistent shape; row cap protects the
+# API from a wildcard query that would scan an entire production cohort.
+COPILOT_USAGE_EXPORT_MAX_DAYS = 90
+COPILOT_USAGE_EXPORT_MAX_ROWS = 100_000
+
+
+class CopilotWeeklyUsageRow(BaseModel):
+    user_id: str
+    user_email: str | None = None
+    week_start: datetime
+    week_end: datetime
+    copilot_cost_microdollars: int
+    tier: str
+    weekly_limit_microdollars: int
+    percent_used: float
+
+
+async def get_copilot_weekly_usage_for_export(
+    start: datetime,
+    end: datetime,
+) -> list[CopilotWeeklyUsageRow]:
+    """Aggregate copilot:* PlatformCostLog rows by (user, ISO week) for export.
+
+    Joins User to surface the email and subscription tier in a single query,
+    then computes the per-tier weekly limit using the same defaults
+    `get_global_rate_limits` falls back to (LaunchDarkly overrides aren't
+    materialised here — finance pulls the **steady-state** allowance, which
+    is what they need to size limits against).
+    """
+    if end < start:
+        raise ValueError("end must be >= start")
+    if (end - start).days > COPILOT_USAGE_EXPORT_MAX_DAYS:
+        raise ValueError(
+            f"Export window must be <= {COPILOT_USAGE_EXPORT_MAX_DAYS} days "
+            f"(got {(end - start).days} days)"
+        )
+
+    rows = await query_raw_with_schema(
+        'SELECT log."userId" AS user_id,'
+        '  u."email" AS user_email,'
+        '  u."subscriptionTier" AS tier,'
+        "  date_trunc('week', log.\"createdAt\") AS week_start,"
+        '  SUM(COALESCE(log."costMicrodollars", 0))::bigint AS cost_microdollars'
+        ' FROM {schema_prefix}"PlatformCostLog" log'
+        ' LEFT JOIN {schema_prefix}"User" u ON u."id" = log."userId"'
+        ' WHERE log."createdAt" >= $1::timestamptz'
+        '   AND log."createdAt" <= $2::timestamptz'
+        "   AND log.\"blockName\" ILIKE 'copilot:%'"
+        ' GROUP BY log."userId", u."email", u."subscriptionTier",'
+        "   date_trunc('week', log.\"createdAt\")"
+        " ORDER BY week_start ASC, cost_microdollars DESC"
+        f" LIMIT {COPILOT_USAGE_EXPORT_MAX_ROWS + 1}",
+        start,
+        end,
+    )
+
+    if len(rows) > COPILOT_USAGE_EXPORT_MAX_ROWS:
+        raise ValueError(
+            f"Export would return {len(rows)} rows (cap is "
+            f"{COPILOT_USAGE_EXPORT_MAX_ROWS}); narrow the window."
+        )
+
+    # Lazy import: backend.copilot.config and rate_limit pull settings which
+    # transitively imports back into this module at startup.
+    from backend.copilot.config import ChatConfig
+    from backend.copilot.rate_limit import (
+        _DEFAULT_TIER_MULTIPLIERS,
+        DEFAULT_TIER,
+        SubscriptionTier,
+    )
+
+    base_weekly = ChatConfig().weekly_cost_limit_microdollars
+
+    out: list[CopilotWeeklyUsageRow] = []
+    for r in rows:
+        week_start: datetime = r["week_start"]
+        if week_start.tzinfo is None:
+            week_start = week_start.replace(tzinfo=timezone.utc)
+        week_end = week_start + timedelta(days=7)
+        cost = int(r.get("cost_microdollars") or 0)
+        tier_str = r.get("tier") or DEFAULT_TIER.value
+        try:
+            tier_enum = SubscriptionTier(tier_str)
+        except ValueError:
+            tier_enum = DEFAULT_TIER
+        multiplier = _DEFAULT_TIER_MULTIPLIERS.get(tier_enum, 1.0)
+        weekly_limit = int(base_weekly * multiplier)
+        if weekly_limit > 0:
+            percent_used = round(100.0 * cost / weekly_limit, 2)
+        else:
+            percent_used = 0.0
+        out.append(
+            CopilotWeeklyUsageRow(
+                user_id=r["user_id"],
+                user_email=r.get("user_email"),
+                week_start=week_start,
+                week_end=week_end,
+                copilot_cost_microdollars=cost,
+                tier=tier_enum.value,
+                weekly_limit_microdollars=weekly_limit,
+                percent_used=percent_used,
+            )
+        )
+    return out
+
 
 async def get_platform_cost_logs_for_export(
     start: datetime | None = None,

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -765,11 +765,16 @@ async def get_copilot_weekly_usage_for_export(
             f"(got {(end - start).total_seconds() / 86400:.2f} days)"
         )
 
+    # date_trunc('week', timestamptz) uses the session time zone by default,
+    # which makes the per-week buckets non-deterministic across replicas in
+    # different time zones.  Convert to UTC explicitly via AT TIME ZONE so
+    # the boundary is always Monday 00:00 UTC.
     rows = await query_raw_with_schema(
         'SELECT log."userId" AS user_id,'
         '  u."email" AS user_email,'
         '  u."subscriptionTier" AS tier,'
-        "  date_trunc('week', log.\"createdAt\") AS week_start,"
+        "  (date_trunc('week', log.\"createdAt\" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')"
+        " AS week_start,"
         '  SUM(COALESCE(log."costMicrodollars", 0))::bigint AS cost_microdollars'
         ' FROM {schema_prefix}"PlatformCostLog" log'
         ' LEFT JOIN {schema_prefix}"User" u ON u."id" = log."userId"'
@@ -777,7 +782,7 @@ async def get_copilot_weekly_usage_for_export(
         '   AND log."createdAt" <= $2::timestamptz'
         "   AND log.\"blockName\" ILIKE 'copilot:%'"
         ' GROUP BY log."userId", u."email", u."subscriptionTier",'
-        "   date_trunc('week', log.\"createdAt\")"
+        "   (date_trunc('week', log.\"createdAt\" AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')"
         " ORDER BY week_start ASC, cost_microdollars DESC"
         f" LIMIT {COPILOT_USAGE_EXPORT_MAX_ROWS + 1}",
         start,
@@ -809,7 +814,9 @@ async def get_copilot_weekly_usage_for_export(
         week_start: datetime = r["week_start"]
         if week_start.tzinfo is None:
             week_start = week_start.replace(tzinfo=timezone.utc)
-        week_end = week_start + timedelta(days=7)
+        # Inclusive end-of-week (Sunday 23:59:59.999999 UTC) — matches finance
+        # conventions where "the week" is Mon–Sun, not Mon–next Mon.
+        week_end = week_start + timedelta(days=7, microseconds=-1)
         cost = int(r.get("cost_microdollars") or 0)
         tier_str = r.get("tier") or DEFAULT_TIER.value
         try:

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -744,10 +744,16 @@ async def get_copilot_weekly_usage_for_export(
     """Aggregate copilot:* PlatformCostLog rows by (user, ISO week) for export.
 
     Joins User to surface the email and subscription tier in a single query,
-    then computes the per-tier weekly limit using the same defaults
-    `get_global_rate_limits` falls back to (LaunchDarkly overrides aren't
-    materialised here — finance pulls the **steady-state** allowance, which
-    is what they need to size limits against).
+    then computes the per-tier weekly limit from `get_tier_multipliers()` so
+    `percent_used` reflects what's actually enforced (LD overrides included).
+
+    Caveats:
+    - Tier is the user's **current** tier — `PlatformCostLog` has no historical
+      tier snapshot, so a recent upgrade/downgrade will retroactively reweight
+      old weeks' `percent_used`. Filter by `week_start` and join with billing
+      events outside this CSV if you need historically-correct attribution.
+    - `NO_TIER` users have no enforced rate limit; their `percent_used` will
+      report `0.0` (no denominator) — interpret these rows as "unmetered".
     """
     if end < start:
         raise ValueError("end must be >= start")

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -824,7 +824,9 @@ async def get_copilot_weekly_usage_for_export(
         except ValueError:
             tier_enum = DEFAULT_TIER
         multiplier = tier_multipliers.get(tier_enum.value, 1.0)
-        weekly_limit = int(base_weekly * multiplier)
+        # Clamp to >= 0 so a misconfigured/negative multiplier never emits
+        # negative limits in the CSV.
+        weekly_limit = max(0, int(base_weekly * multiplier))
         if weekly_limit > 0:
             percent_used = round(100.0 * cost / weekly_limit, 2)
         else:

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -751,10 +751,12 @@ async def get_copilot_weekly_usage_for_export(
     """
     if end < start:
         raise ValueError("end must be >= start")
-    if (end - start).days > COPILOT_USAGE_EXPORT_MAX_DAYS:
+    # Compare timedeltas directly so 90d + any sub-day remainder still trips
+    # the cap (.days truncates fractional days and was letting ~91d through).
+    if (end - start) > timedelta(days=COPILOT_USAGE_EXPORT_MAX_DAYS):
         raise ValueError(
             f"Export window must be <= {COPILOT_USAGE_EXPORT_MAX_DAYS} days "
-            f"(got {(end - start).days} days)"
+            f"(got {(end - start).total_seconds() / 86400:.2f} days)"
         )
 
     rows = await query_raw_with_schema(

--- a/autogpt_platform/backend/backend/data/spending_export_test.py
+++ b/autogpt_platform/backend/backend/data/spending_export_test.py
@@ -1,0 +1,357 @@
+"""Unit tests for the admin CSV export functions on credit + platform_cost.
+
+Mocks prisma + raw-SQL helpers so these run fast without the docker postgres.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prisma.enums import CreditTransactionType
+
+from backend.data.credit import (
+    CREDIT_EXPORT_MAX_DAYS,
+    CREDIT_EXPORT_MAX_ROWS,
+    admin_export_user_history,
+)
+from backend.data.platform_cost import (
+    COPILOT_USAGE_EXPORT_MAX_DAYS,
+    get_copilot_weekly_usage_for_export,
+)
+
+
+def _make_tx(
+    *,
+    user_id: str = "u1",
+    amount: int = 100,
+    running_balance: int = 1000,
+    metadata: dict | None = None,
+    user_email: str | None = "u1@example.com",
+    tx_type: CreditTransactionType = CreditTransactionType.GRANT,
+    created_at: datetime | None = None,
+) -> MagicMock:
+    tx = MagicMock()
+    tx.transactionKey = "tx-key"
+    tx.createdAt = created_at or datetime(2026, 4, 1, tzinfo=timezone.utc)
+    tx.type = tx_type
+    tx.amount = amount
+    tx.runningBalance = running_balance
+    tx.userId = user_id
+    tx.metadata = metadata or {}
+    user = MagicMock()
+    user.email = user_email
+    tx.User = user if user_email is not None else None
+    return tx
+
+
+class TestAdminExportUserHistory:
+    @pytest.mark.asyncio
+    async def test_rejects_inverted_window(self):
+        with pytest.raises(ValueError, match="end must be >= start"):
+            await admin_export_user_history(
+                start=datetime(2026, 4, 30, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_window_exceeding_cap_by_subday_remainder(self):
+        # 90 days + 1 second — `.days` would round to 90 and pass; timedelta
+        # comparison must still reject this.
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = start + timedelta(days=CREDIT_EXPORT_MAX_DAYS, seconds=1)
+        with pytest.raises(ValueError, match="must be <="):
+            await admin_export_user_history(start=start, end=end)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_rows(self):
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = AsyncMock(return_value=[])
+            result = await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_maps_basic_row(self):
+        tx = _make_tx(metadata={"reason": "Initial grant"})
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = AsyncMock(return_value=[tx])
+            result = await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert len(result) == 1
+        assert result[0].user_id == "u1"
+        assert result[0].user_email == "u1@example.com"
+        assert result[0].amount == 100
+        assert result[0].running_balance == 1000
+        assert result[0].reason == "Initial grant"
+        assert result[0].admin_email == ""
+
+    @pytest.mark.asyncio
+    async def test_unwraps_nested_reason_from_top_up_credits_metadata(self):
+        # _top_up_credits writes reason as {"reason": "..."} — the export
+        # must flatten this for the CSV column.
+        tx = _make_tx(
+            tx_type=CreditTransactionType.TOP_UP,
+            metadata={"reason": {"reason": "Auto top up"}},
+        )
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = AsyncMock(return_value=[tx])
+            result = await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert result[0].reason == "Auto top up"
+
+    @pytest.mark.asyncio
+    async def test_resolves_admin_email_once_per_unique_admin(self):
+        # Two rows from same admin → email lookup hits cache on second.
+        tx_a = _make_tx(user_id="u1", metadata={"admin_id": "admin-1"})
+        tx_b = _make_tx(user_id="u2", metadata={"admin_id": "admin-1"})
+        email_lookup = AsyncMock(return_value="admin1@example.com")
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            email_lookup,
+        ):
+            ct.prisma.return_value.find_many = AsyncMock(return_value=[tx_a, tx_b])
+            result = await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert email_lookup.call_count == 1
+        assert all(r.admin_email == "admin1@example.com" for r in result)
+
+    @pytest.mark.asyncio
+    async def test_admin_email_empty_when_lookup_misses(self):
+        # When get_user_email_by_id returns None, admin_email is "" not "Unknown
+        # Admin: <uuid>" so the column doesn't mix email + UUID formats.
+        tx = _make_tx(metadata={"admin_id": "deleted-admin"})
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            AsyncMock(return_value=None),
+        ):
+            ct.prisma.return_value.find_many = AsyncMock(return_value=[tx])
+            result = await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert result[0].admin_email == ""
+
+    @pytest.mark.asyncio
+    async def test_passes_filters_to_prisma_where_clause(self):
+        find_many = AsyncMock(return_value=[])
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = find_many
+            await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+                transaction_type=CreditTransactionType.TOP_UP,
+                user_id="u1",
+            )
+        where = find_many.call_args.kwargs["where"]
+        assert where["type"] == CreditTransactionType.TOP_UP
+        assert where["userId"] == "u1"
+        assert "createdAt" in where
+        # take must be cap+1 to detect over-cap rowsets without a separate count.
+        assert find_many.call_args.kwargs["take"] == CREDIT_EXPORT_MAX_ROWS + 1
+
+    @pytest.mark.asyncio
+    async def test_filters_inactive_rows_by_default(self):
+        find_many = AsyncMock(return_value=[])
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = find_many
+            await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert find_many.call_args.kwargs["where"]["isActive"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_inactive_drops_isactive_filter(self):
+        find_many = AsyncMock(return_value=[])
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = find_many
+            await admin_export_user_history(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+                include_inactive=True,
+            )
+        assert "isActive" not in find_many.call_args.kwargs["where"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_fetched_rowset_exceeds_cap(self):
+        oversize = [_make_tx() for _ in range(CREDIT_EXPORT_MAX_ROWS + 1)]
+        with patch("backend.data.credit.CreditTransaction") as ct, patch(
+            "backend.data.credit.get_user_email_by_id",
+            new_callable=AsyncMock,
+        ):
+            ct.prisma.return_value.find_many = AsyncMock(return_value=oversize)
+            with pytest.raises(ValueError, match="more than"):
+                await admin_export_user_history(
+                    start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                    end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+                )
+
+
+class TestGetCopilotWeeklyUsageForExport:
+    @pytest.mark.asyncio
+    async def test_rejects_inverted_window(self):
+        with pytest.raises(ValueError, match="end must be >= start"):
+            await get_copilot_weekly_usage_for_export(
+                start=datetime(2026, 4, 30, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_window_exceeding_cap_by_subday_remainder(self):
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = start + timedelta(days=COPILOT_USAGE_EXPORT_MAX_DAYS, hours=2)
+        with pytest.raises(ValueError, match="must be <="):
+            await get_copilot_weekly_usage_for_export(start=start, end=end)
+
+    @pytest.mark.asyncio
+    async def test_empty_result_when_no_copilot_usage(self):
+        with patch(
+            "backend.data.platform_cost.query_raw_with_schema",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await get_copilot_weekly_usage_for_export(
+                start=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_computes_inclusive_week_end_and_percent_used(self):
+        rows = [
+            {
+                "user_id": "u1",
+                "user_email": "u1@example.com",
+                "tier": "PRO",
+                "week_start": datetime(2026, 3, 30, tzinfo=timezone.utc),
+                "cost_microdollars": 5_000_000,
+            }
+        ]
+        with patch(
+            "backend.data.platform_cost.query_raw_with_schema",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ), patch(
+            "backend.copilot.rate_limit.get_tier_multipliers",
+            new_callable=AsyncMock,
+            return_value={"PRO": 5.0, "BETA": 1.0, "NO_TIER": 0.0},
+        ):
+            result = await get_copilot_weekly_usage_for_export(
+                start=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert len(result) == 1
+        row = result[0]
+        assert row.user_id == "u1"
+        assert row.tier == "PRO"
+        # week_end is inclusive end-of-Sunday, NOT next Monday.
+        assert row.week_end == datetime(
+            2026, 4, 5, 23, 59, 59, 999999, tzinfo=timezone.utc
+        )
+        assert row.copilot_cost_microdollars == 5_000_000
+
+    @pytest.mark.asyncio
+    async def test_no_tier_user_gets_zero_percent(self):
+        rows = [
+            {
+                "user_id": "u1",
+                "user_email": "u1@example.com",
+                "tier": "NO_TIER",
+                "week_start": datetime(2026, 3, 30, tzinfo=timezone.utc),
+                "cost_microdollars": 1_000_000,
+            }
+        ]
+        with patch(
+            "backend.data.platform_cost.query_raw_with_schema",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ), patch(
+            "backend.copilot.rate_limit.get_tier_multipliers",
+            new_callable=AsyncMock,
+            return_value={"PRO": 5.0, "BETA": 1.0, "NO_TIER": 0.0},
+        ):
+            result = await get_copilot_weekly_usage_for_export(
+                start=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert result[0].weekly_limit_microdollars == 0
+        assert result[0].percent_used == 0.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_tier_falls_back_to_default(self):
+        rows = [
+            {
+                "user_id": "u1",
+                "user_email": "u1@example.com",
+                "tier": "MARS",  # not a real SubscriptionTier value
+                "week_start": datetime(2026, 3, 30, tzinfo=timezone.utc),
+                "cost_microdollars": 100_000,
+            }
+        ]
+        with patch(
+            "backend.data.platform_cost.query_raw_with_schema",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ), patch(
+            "backend.copilot.rate_limit.get_tier_multipliers",
+            new_callable=AsyncMock,
+            return_value={"PRO": 5.0, "BETA": 1.0, "NO_TIER": 0.0},
+        ):
+            result = await get_copilot_weekly_usage_for_export(
+                start=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        # Falls back to DEFAULT_TIER (NO_TIER)
+        assert result[0].tier == "NO_TIER"
+
+    @pytest.mark.asyncio
+    async def test_naive_week_start_gets_utc_tzinfo(self):
+        rows = [
+            {
+                "user_id": "u1",
+                "user_email": "u1@example.com",
+                "tier": "PRO",
+                "week_start": datetime(2026, 3, 30),  # naive
+                "cost_microdollars": 1,
+            }
+        ]
+        with patch(
+            "backend.data.platform_cost.query_raw_with_schema",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ), patch(
+            "backend.copilot.rate_limit.get_tier_multipliers",
+            new_callable=AsyncMock,
+            return_value={"PRO": 5.0},
+        ):
+            result = await get_copilot_weekly_usage_for_export(
+                start=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 30, tzinfo=timezone.utc),
+            )
+        assert result[0].week_start.tzinfo == timezone.utc

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCopilotUsageButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCopilotUsageButton.test.tsx
@@ -6,6 +6,7 @@ import {
   cleanup,
 } from "@/tests/integrations/test-utils";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import { ExportCopilotUsageButton } from "../components/ExportCopilotUsageButton";
 
 const toastSpy = vi.fn();
@@ -94,10 +95,11 @@ describe("ExportCopilotUsageButton", () => {
   });
 
   test("surfaces 400 detail as a toast when the window is too large", async () => {
-    exportSpy.mockResolvedValue({
-      status: 400,
-      data: { detail: "Export window must be <= 90 days (got 200.00 days)" },
-    });
+    exportSpy.mockRejectedValue(
+      new ApiError("Export window must be <= 90 days (got 200.00 days)", 400, {
+        detail: "Export window must be <= 90 days (got 200.00 days)",
+      }),
+    );
     render(<ExportCopilotUsageButton />);
     fireEvent.click(screen.getByRole("button", { name: /Copilot Usage CSV/i }));
     await waitFor(() => screen.getByLabelText(/Start date/i));

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCopilotUsageButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCopilotUsageButton.test.tsx
@@ -1,0 +1,115 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@/tests/integrations/test-utils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ExportCopilotUsageButton } from "../components/ExportCopilotUsageButton";
+
+const toastSpy = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+const exportSpy = vi.fn();
+vi.mock("@/app/api/__generated__/endpoints/admin/admin", () => ({
+  getV2ExportCopilotWeeklyUsageVsRateLimit: (
+    ...args: Parameters<typeof exportSpy>
+  ): ReturnType<typeof exportSpy> => exportSpy(...args),
+}));
+
+beforeEach(() => {
+  toastSpy.mockReset();
+  exportSpy.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ExportCopilotUsageButton", () => {
+  test("renders the trigger button", () => {
+    render(<ExportCopilotUsageButton />);
+    expect(
+      screen.getByRole("button", { name: /Copilot Usage CSV/i }),
+    ).toBeDefined();
+  });
+
+  test("opens a dialog with date inputs when clicked", async () => {
+    render(<ExportCopilotUsageButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Copilot Usage CSV/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Start date/i)).toBeDefined();
+      expect(screen.getByLabelText(/End date/i)).toBeDefined();
+    });
+  });
+
+  test("triggers a CSV download on success", async () => {
+    exportSpy.mockResolvedValue({
+      status: 200,
+      data: {
+        rows: [
+          {
+            user_id: "u1",
+            user_email: "u1@example.com",
+            week_start: "2026-03-30T00:00:00Z",
+            week_end: "2026-04-05T23:59:59.999Z",
+            copilot_cost_microdollars: 1_500_000,
+            tier: "PRO",
+            weekly_limit_microdollars: 25_000_000,
+            percent_used: 6.0,
+          },
+        ],
+        total_rows: 1,
+        window_days: 30,
+        max_window_days: 90,
+      },
+    });
+    const createUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:mock");
+    const revokeUrl = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    render(<ExportCopilotUsageButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Copilot Usage CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+
+    await waitFor(() => expect(click).toHaveBeenCalledTimes(1));
+    expect(createUrl).toHaveBeenCalledTimes(1);
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Export ready" }),
+    );
+
+    createUrl.mockRestore();
+    revokeUrl.mockRestore();
+    click.mockRestore();
+  });
+
+  test("surfaces 400 detail as a toast when the window is too large", async () => {
+    exportSpy.mockResolvedValue({
+      status: 400,
+      data: { detail: "Export window must be <= 90 days (got 200.00 days)" },
+    });
+    render(<ExportCopilotUsageButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Copilot Usage CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Window too large",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCopilotUsageButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCopilotUsageButton.test.tsx
@@ -114,4 +114,38 @@ describe("ExportCopilotUsageButton", () => {
       ),
     );
   });
+
+  test("falls back to a generic toast when the API throws a non-ApiError", async () => {
+    exportSpy.mockRejectedValue(new Error("network blip"));
+    render(<ExportCopilotUsageButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Copilot Usage CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Export failed",
+          description: "network blip",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
+
+  test("warns when the response is missing the expected success shape", async () => {
+    exportSpy.mockResolvedValue({ status: 204, data: null });
+    render(<ExportCopilotUsageButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Copilot Usage CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Export failed",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCreditTransactionsButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCreditTransactionsButton.test.tsx
@@ -6,6 +6,7 @@ import {
   cleanup,
 } from "@/tests/integrations/test-utils";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import { ExportCreditTransactionsButton } from "../components/ExportCreditTransactionsButton";
 
 const toastSpy = vi.fn();
@@ -46,10 +47,11 @@ describe("ExportCreditTransactionsButton", () => {
   });
 
   test("surfaces a 400 detail in the toast when the API rejects the window", async () => {
-    exportSpy.mockResolvedValue({
-      status: 400,
-      data: { detail: "Export window must be <= 90 days (got 200.00 days)" },
-    });
+    exportSpy.mockRejectedValue(
+      new ApiError("Export window must be <= 90 days (got 200.00 days)", 400, {
+        detail: "Export window must be <= 90 days (got 200.00 days)",
+      }),
+    );
     render(<ExportCreditTransactionsButton />);
     fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
     await waitFor(() => screen.getByLabelText(/Start date/i));

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCreditTransactionsButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCreditTransactionsButton.test.tsx
@@ -1,0 +1,116 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@/tests/integrations/test-utils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ExportCreditTransactionsButton } from "../components/ExportCreditTransactionsButton";
+
+const toastSpy = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+const exportSpy = vi.fn();
+vi.mock("@/app/api/__generated__/endpoints/admin/admin", () => ({
+  getV2ExportCreditTransactions: (
+    ...args: Parameters<typeof exportSpy>
+  ): ReturnType<typeof exportSpy> => exportSpy(...args),
+}));
+
+beforeEach(() => {
+  toastSpy.mockReset();
+  exportSpy.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ExportCreditTransactionsButton", () => {
+  test("renders the trigger button", () => {
+    render(<ExportCreditTransactionsButton />);
+    expect(screen.getByRole("button", { name: /Export CSV/i })).toBeDefined();
+  });
+
+  test("opens a dialog with date inputs and a type filter when clicked", async () => {
+    render(<ExportCreditTransactionsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Start date/i)).toBeDefined();
+      expect(screen.getByLabelText(/End date/i)).toBeDefined();
+      expect(screen.getByLabelText(/User ID/i)).toBeDefined();
+    });
+  });
+
+  test("surfaces a 400 detail in the toast when the API rejects the window", async () => {
+    exportSpy.mockResolvedValue({
+      status: 400,
+      data: { detail: "Export window must be <= 90 days (got 200.00 days)" },
+    });
+    render(<ExportCreditTransactionsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Window too large",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
+
+  test("triggers a CSV download on success", async () => {
+    exportSpy.mockResolvedValue({
+      status: 200,
+      data: {
+        transactions: [
+          {
+            transaction_key: "tx-1",
+            user_id: "u1",
+            user_email: "u1@example.com",
+            transaction_time: "2026-04-01T00:00:00Z",
+            transaction_type: "GRANT",
+            amount: 1000,
+            running_balance: 5000,
+            current_balance: 5000,
+            reason: "Initial grant",
+            admin_email: "admin@example.com",
+          },
+        ],
+        total_rows: 1,
+        window_days: 30,
+        max_window_days: 90,
+      },
+    });
+    const createUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:mock");
+    const revokeUrl = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    render(<ExportCreditTransactionsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+
+    await waitFor(() => expect(click).toHaveBeenCalledTimes(1));
+    expect(createUrl).toHaveBeenCalledTimes(1);
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Export ready" }),
+    );
+
+    createUrl.mockRestore();
+    revokeUrl.mockRestore();
+    click.mockRestore();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCreditTransactionsButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/ExportCreditTransactionsButton.test.tsx
@@ -115,4 +115,40 @@ describe("ExportCreditTransactionsButton", () => {
     revokeUrl.mockRestore();
     click.mockRestore();
   });
+
+  test("falls back to a generic toast when the API throws a non-ApiError", async () => {
+    exportSpy.mockRejectedValue(new Error("network blip"));
+    render(<ExportCreditTransactionsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    await waitFor(() => expect(exportSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Export failed",
+          description: "network blip",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
+
+  test("warns when the response is missing the expected success shape", async () => {
+    // Simulate an unexpected non-200 that didn't throw — okData() returns
+    // undefined and the operator should see a clear error instead of a crash.
+    exportSpy.mockResolvedValue({ status: 204, data: null });
+    render(<ExportCreditTransactionsButton />);
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+    await waitFor(() => screen.getByLabelText(/Start date/i));
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    await waitFor(() =>
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Export failed",
+          variant: "destructive",
+        }),
+      ),
+    );
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/helpers.test.ts
@@ -140,14 +140,11 @@ describe("dateInputToUtcIso / dateInputToUtcIsoEnd", () => {
   });
 
   test("anchors start to UTC midnight of the input date", () => {
-    const d = dateInputToUtcIso("2026-03-15");
-    expect(d).toBeInstanceOf(Date);
-    expect(d?.toISOString()).toBe("2026-03-15T00:00:00.000Z");
+    expect(dateInputToUtcIso("2026-03-15")).toBe("2026-03-15T00:00:00.000Z");
   });
 
   test("anchors end to UTC end-of-day so the inclusive filter covers the day", () => {
-    const d = dateInputToUtcIsoEnd("2026-03-15");
-    expect(d?.toISOString()).toBe("2026-03-15T23:59:59.999Z");
+    expect(dateInputToUtcIsoEnd("2026-03-15")).toBe("2026-03-15T23:59:59.999Z");
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/__tests__/helpers.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import type { CopilotWeeklyUsageRow } from "@/app/api/__generated__/models/copilotWeeklyUsageRow";
+import type { UserTransaction } from "@/app/api/__generated__/models/userTransaction";
+
+import {
+  buildCopilotUsageCsv,
+  buildCreditTransactionsCsv,
+  dateInputToUtcIso,
+  dateInputToUtcIsoEnd,
+  defaultEndDate,
+  defaultStartDate,
+  downloadCsv,
+} from "../helpers";
+
+function makeTx(overrides: Partial<UserTransaction> = {}): UserTransaction {
+  return {
+    transaction_key: "tx-1",
+    transaction_time: "2026-04-01T10:00:00Z",
+    transaction_type: "TOP_UP",
+    amount: 5000,
+    running_balance: 12500,
+    current_balance: 12500,
+    user_id: "user-1",
+    user_email: "alice@example.com",
+    reason: "Stripe checkout",
+    admin_email: null,
+    ...overrides,
+  } as UserTransaction;
+}
+
+function makeUsage(
+  overrides: Partial<CopilotWeeklyUsageRow> = {},
+): CopilotWeeklyUsageRow {
+  return {
+    user_id: "user-1",
+    user_email: "alice@example.com",
+    week_start: "2026-03-30T00:00:00Z",
+    week_end: "2026-04-05T23:59:59.999Z",
+    copilot_cost_microdollars: 1_500_000,
+    tier: "PRO",
+    weekly_limit_microdollars: 25_000_000,
+    percent_used: 6.0,
+    ...overrides,
+  } as CopilotWeeklyUsageRow;
+}
+
+describe("buildCreditTransactionsCsv", () => {
+  test("emits header followed by one CRLF-terminated row per transaction", () => {
+    const csv = buildCreditTransactionsCsv([makeTx()]);
+    const lines = csv.split("\r\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(
+      [
+        '"transaction_id"',
+        '"user_id"',
+        '"user_email"',
+        '"created_at"',
+        '"type"',
+        '"amount_usd"',
+        '"running_balance_usd"',
+        '"admin_email"',
+        '"reason"',
+      ].join(","),
+    );
+  });
+
+  test("converts cents to USD with two decimals", () => {
+    const csv = buildCreditTransactionsCsv([
+      makeTx({ amount: 12345, running_balance: -678 }),
+    ]);
+    const row = csv.split("\r\n")[1];
+    expect(row).toContain('"123.45"');
+    expect(row).toContain('"-6.78"');
+  });
+
+  test("escapes embedded quotes by doubling them", () => {
+    const csv = buildCreditTransactionsCsv([
+      makeTx({ reason: 'has "quotes" inside' }),
+    ]);
+    expect(csv).toContain('"has ""quotes"" inside"');
+  });
+
+  test("emits empty string for null fields without breaking row shape", () => {
+    const csv = buildCreditTransactionsCsv([
+      makeTx({ user_email: null, admin_email: null, reason: null }),
+    ]);
+    const row = csv.split("\r\n")[1];
+    expect(row.split(",")).toHaveLength(9);
+    expect(row).toContain('""');
+  });
+
+  test("renders each transaction as its own row", () => {
+    const csv = buildCreditTransactionsCsv([
+      makeTx({ transaction_key: "tx-a" }),
+      makeTx({ transaction_key: "tx-b" }),
+    ]);
+    expect(csv.split("\r\n")).toHaveLength(3);
+  });
+});
+
+describe("buildCopilotUsageCsv", () => {
+  test("converts microdollars to USD (6dp for cost, 2dp for limit)", () => {
+    const csv = buildCopilotUsageCsv([
+      makeUsage({
+        copilot_cost_microdollars: 2_500_000,
+        weekly_limit_microdollars: 25_000_000,
+      }),
+    ]);
+    const row = csv.split("\r\n")[1];
+    expect(row).toContain('"2.500000"');
+    expect(row).toContain('"25.00"');
+  });
+
+  test("formats percent_used with two decimal places", () => {
+    const csv = buildCopilotUsageCsv([makeUsage({ percent_used: 33.7 })]);
+    expect(csv.split("\r\n")[1]).toContain('"33.70"');
+  });
+
+  test("emits the expected header row", () => {
+    const csv = buildCopilotUsageCsv([]);
+    expect(csv).toBe(
+      [
+        '"user_id"',
+        '"user_email"',
+        '"week_start"',
+        '"week_end"',
+        '"copilot_cost_usd"',
+        '"tier"',
+        '"weekly_limit_usd"',
+        '"percent_used"',
+      ].join(","),
+    );
+  });
+});
+
+describe("dateInputToUtcIso / dateInputToUtcIsoEnd", () => {
+  test("returns null for an empty string", () => {
+    expect(dateInputToUtcIso("")).toBeNull();
+    expect(dateInputToUtcIsoEnd("")).toBeNull();
+  });
+
+  test("anchors start to UTC midnight of the input date", () => {
+    const d = dateInputToUtcIso("2026-03-15");
+    expect(d).toBeInstanceOf(Date);
+    expect(d?.toISOString()).toBe("2026-03-15T00:00:00.000Z");
+  });
+
+  test("anchors end to UTC end-of-day so the inclusive filter covers the day", () => {
+    const d = dateInputToUtcIsoEnd("2026-03-15");
+    expect(d?.toISOString()).toBe("2026-03-15T23:59:59.999Z");
+  });
+});
+
+describe("defaultStartDate / defaultEndDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("defaultStartDate returns 30 UTC days before now", () => {
+    vi.setSystemTime(new Date("2026-04-30T12:34:56Z"));
+    expect(defaultStartDate()).toBe("2026-03-31");
+  });
+
+  test("defaultEndDate returns today's UTC date string", () => {
+    vi.setSystemTime(new Date("2026-04-30T23:59:00Z"));
+    expect(defaultEndDate()).toBe("2026-04-30");
+  });
+
+  test("UTC arithmetic — late-night-PST viewer still gets correct UTC date", () => {
+    // 2026-04-30 23:30 PST ⇒ 2026-05-01 06:30 UTC
+    vi.setSystemTime(new Date("2026-05-01T06:30:00Z"));
+    expect(defaultEndDate()).toBe("2026-05-01");
+    expect(defaultStartDate()).toBe("2026-04-01");
+  });
+});
+
+describe("downloadCsv", () => {
+  test("clicks an anchor and defers URL.revokeObjectURL via setTimeout", () => {
+    const createUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:mock");
+    const revokeUrl = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const anchorClick = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    vi.useFakeTimers();
+    downloadCsv("col1\r\nval1", "out.csv");
+    expect(createUrl).toHaveBeenCalledTimes(1);
+    expect(anchorClick).toHaveBeenCalledTimes(1);
+    // revoke is deferred via setTimeout so the download stream gets to start
+    expect(revokeUrl).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(revokeUrl).toHaveBeenCalledWith("blob:mock");
+
+    createUrl.mockRestore();
+    revokeUrl.mockRestore();
+    anchorClick.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { ChartLineIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/atoms/Button/Button";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { getV2ExportCopilotWeeklyUsageVsRateLimit } from "@/app/api/__generated__/endpoints/admin/admin";
+import { okData } from "@/app/api/helpers";
+import {
+  buildCopilotUsageCsv,
+  dateInputToUtcIso,
+  dateInputToUtcIsoEnd,
+  defaultEndDate,
+  defaultStartDate,
+  downloadCsv,
+} from "../helpers";
+
+export function ExportCopilotUsageButton() {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState(defaultStartDate);
+  const [end, setEnd] = useState(defaultEndDate);
+  const [exporting, setExporting] = useState(false);
+
+  async function handleExport() {
+    if (!start || !end) {
+      toast({
+        title: "Pick a date range",
+        description: "Both start and end dates are required.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setExporting(true);
+    try {
+      const response = await getV2ExportCopilotWeeklyUsageVsRateLimit({
+        start: dateInputToUtcIso(start) as unknown as Date,
+        end: dateInputToUtcIsoEnd(end) as unknown as Date,
+      });
+      const data = okData(response);
+      if (!data) {
+        const status = (response as { status?: number }).status;
+        const detail =
+          (response as { data?: { detail?: string } }).data?.detail ??
+          "Export failed";
+        toast({
+          title: status === 400 ? "Window too large" : "Export failed",
+          description: detail,
+          variant: "destructive",
+        });
+        return;
+      }
+      const csv = buildCopilotUsageCsv(data.rows);
+      downloadCsv(csv, `copilot_weekly_usage_${start}_${end}.csv`);
+      toast({
+        title: "Export ready",
+        description: `${data.total_rows} (user, week) rows downloaded.`,
+      });
+      setOpen(false);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      title="Export copilot weekly usage"
+      styling={{ maxWidth: "30rem" }}
+      controlled={{ isOpen: open, set: setOpen }}
+    >
+      <Dialog.Trigger>
+        <Button
+          variant="secondary"
+          size="small"
+          leftIcon={<ChartLineIcon weight="bold" />}
+        >
+          Copilot Usage CSV
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">
+            Aggregates copilot:* spend by user and ISO week and joins each row
+            against the user&apos;s tier-derived weekly limit.
+          </p>
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="copilot-export-start" className="text-sm">
+                Start date (UTC)
+              </label>
+              <input
+                id="copilot-export-start"
+                type="date"
+                className="rounded border px-3 py-1.5 text-sm"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="copilot-export-end" className="text-sm">
+                End date (UTC)
+              </label>
+              <input
+                id="copilot-export-end"
+                type="date"
+                className="rounded border px-3 py-1.5 text-sm"
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+              />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Window is capped at 90 days and 100k rows.
+          </p>
+        </div>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => setOpen(false)}
+            disabled={exporting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            onClick={handleExport}
+            loading={exporting}
+          >
+            Download CSV
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/atoms/Button/Button";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { getV2ExportCopilotWeeklyUsageVsRateLimit } from "@/app/api/__generated__/endpoints/admin/admin";
-import { okData } from "@/app/api/helpers";
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import {
   buildCopilotUsageCsv,
   dateInputToUtcIso,
@@ -44,26 +44,16 @@ export function ExportCopilotUsageButton() {
     }
     setExporting(true);
     try {
-      const startDate = dateInputToUtcIso(start);
-      const endDate = dateInputToUtcIsoEnd(end);
-      if (!startDate || !endDate) return;
+      const startIso = dateInputToUtcIso(start);
+      const endIso = dateInputToUtcIsoEnd(end);
+      if (!startIso || !endIso) return;
+      // Pass ISO strings as-is — orval calls .toString() on Date params, which
+      // produces a localised string FastAPI rejects (422). Strings round-trip.
       const response = await getV2ExportCopilotWeeklyUsageVsRateLimit({
-        start: startDate,
-        end: endDate,
+        start: startIso as unknown as Date,
+        end: endIso as unknown as Date,
       });
-      const data = okData(response);
-      if (!data) {
-        const status = (response as { status?: number }).status;
-        const detail =
-          (response as { data?: { detail?: string } }).data?.detail ??
-          "Export failed";
-        toast({
-          title: status === 400 ? "Window too large" : "Export failed",
-          description: detail,
-          variant: "destructive",
-        });
-        return;
-      }
+      const data = response.data;
       const csv = buildCopilotUsageCsv(data.rows);
       downloadCsv(csv, `copilot_weekly_usage_${start}_${end}.csv`);
       toast({
@@ -71,6 +61,25 @@ export function ExportCopilotUsageButton() {
         description: `${data.total_rows} (user, week) rows downloaded.`,
       });
       setOpen(false);
+    } catch (err) {
+      // customMutator throws ApiError on non-2xx. Surface backend cap-exceed
+      // detail (400) so the operator can narrow their range without a refresh.
+      if (err instanceof ApiError) {
+        const detail =
+          (err.response as { detail?: string } | undefined)?.detail ??
+          err.message;
+        toast({
+          title: err.status === 400 ? "Window too large" : "Export failed",
+          description: detail,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Export failed",
+          description: err instanceof Error ? err.message : "Unknown error",
+          variant: "destructive",
+        });
+      }
     } finally {
       setExporting(false);
     }

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
@@ -34,9 +34,12 @@ export function ExportCopilotUsageButton() {
     }
     setExporting(true);
     try {
+      const startDate = dateInputToUtcIso(start);
+      const endDate = dateInputToUtcIsoEnd(end);
+      if (!startDate || !endDate) return;
       const response = await getV2ExportCopilotWeeklyUsageVsRateLimit({
-        start: dateInputToUtcIso(start) as unknown as Date,
-        end: dateInputToUtcIsoEnd(end) as unknown as Date,
+        start: startDate,
+        end: endDate,
       });
       const data = okData(response);
       if (!data) {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChartLineIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
@@ -22,6 +22,16 @@ export function ExportCopilotUsageButton() {
   const [start, setStart] = useState(defaultStartDate);
   const [end, setEnd] = useState(defaultEndDate);
   const [exporting, setExporting] = useState(false);
+
+  // Refresh the default window each time the dialog opens — the lazy useState
+  // initializer only runs once on mount, so without this the dates would
+  // freeze at component-mount time and drift on a long-lived page.
+  useEffect(() => {
+    if (open) {
+      setStart(defaultStartDate());
+      setEnd(defaultEndDate());
+    }
+  }, [open]);
 
   async function handleExport() {
     if (!start || !end) {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCopilotUsageButton.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/atoms/Button/Button";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { getV2ExportCopilotWeeklyUsageVsRateLimit } from "@/app/api/__generated__/endpoints/admin/admin";
+import { okData } from "@/app/api/helpers";
 import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import {
   buildCopilotUsageCsv,
@@ -53,7 +54,15 @@ export function ExportCopilotUsageButton() {
         start: startIso as unknown as Date,
         end: endIso as unknown as Date,
       });
-      const data = response.data;
+      const data = okData(response);
+      if (!data) {
+        toast({
+          title: "Export failed",
+          description: "Unexpected response shape from the export endpoint.",
+          variant: "destructive",
+        });
+        return;
+      }
       const csv = buildCopilotUsageCsv(data.rows);
       downloadCsv(csv, `copilot_weekly_usage_${start}_${end}.csv`);
       toast({

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { DownloadSimpleIcon } from "@phosphor-icons/react";
+import { Button } from "@/components/atoms/Button/Button";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/__legacy__/ui/select";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { getV2ExportCreditTransactions } from "@/app/api/__generated__/endpoints/admin/admin";
+import { okData } from "@/app/api/helpers";
+import { CreditTransactionType } from "@/app/api/__generated__/models/creditTransactionType";
+import {
+  buildCreditTransactionsCsv,
+  dateInputToUtcIso,
+  dateInputToUtcIsoEnd,
+  defaultEndDate,
+  defaultStartDate,
+  downloadCsv,
+} from "../helpers";
+
+type TypeFilter = "ALL" | CreditTransactionType;
+
+const TYPE_OPTIONS: { value: TypeFilter; label: string }[] = [
+  { value: "ALL", label: "All types" },
+  { value: CreditTransactionType.TOP_UP, label: "Top up" },
+  { value: CreditTransactionType.USAGE, label: "Usage" },
+  { value: CreditTransactionType.GRANT, label: "Grant" },
+  { value: CreditTransactionType.REFUND, label: "Refund" },
+  { value: CreditTransactionType.CARD_CHECK, label: "Card check" },
+  { value: CreditTransactionType.SUBSCRIPTION, label: "Subscription" },
+];
+
+export function ExportCreditTransactionsButton() {
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [start, setStart] = useState(defaultStartDate);
+  const [end, setEnd] = useState(defaultEndDate);
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("ALL");
+  const [userId, setUserId] = useState("");
+  const [exporting, setExporting] = useState(false);
+
+  async function handleExport() {
+    if (!start || !end) {
+      toast({
+        title: "Pick a date range",
+        description: "Both start and end dates are required.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setExporting(true);
+    try {
+      const response = await getV2ExportCreditTransactions({
+        start: dateInputToUtcIso(start) as unknown as Date,
+        end: dateInputToUtcIsoEnd(end) as unknown as Date,
+        transaction_type:
+          typeFilter === "ALL"
+            ? undefined
+            : (typeFilter as CreditTransactionType),
+        user_id: userId.trim() || undefined,
+      });
+      const data = okData(response);
+      if (!data) {
+        const status = (response as { status?: number }).status;
+        const detail =
+          (response as { data?: { detail?: string } }).data?.detail ??
+          "Export failed";
+        toast({
+          title: status === 400 ? "Window too large" : "Export failed",
+          description: detail,
+          variant: "destructive",
+        });
+        return;
+      }
+      const csv = buildCreditTransactionsCsv(data.transactions);
+      downloadCsv(csv, `credit_transactions_${start}_${end}.csv`);
+      toast({
+        title: "Export ready",
+        description: `${data.total_rows} transactions downloaded.`,
+      });
+      setOpen(false);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      title="Export credit transactions"
+      styling={{ maxWidth: "30rem" }}
+      controlled={{ isOpen: open, set: setOpen }}
+    >
+      <Dialog.Trigger>
+        <Button
+          variant="secondary"
+          size="small"
+          leftIcon={<DownloadSimpleIcon weight="bold" />}
+        >
+          Export CSV
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <div className="flex flex-col gap-4">
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="credit-export-start" className="text-sm">
+                Start date (UTC)
+              </label>
+              <input
+                id="credit-export-start"
+                type="date"
+                className="rounded border px-3 py-1.5 text-sm"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="credit-export-end" className="text-sm">
+                End date (UTC)
+              </label>
+              <input
+                id="credit-export-end"
+                type="date"
+                className="rounded border px-3 py-1.5 text-sm"
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-sm" htmlFor="credit-export-type">
+              Transaction type
+            </label>
+            <Select
+              value={typeFilter}
+              onValueChange={(v) => setTypeFilter(v as TypeFilter)}
+            >
+              <SelectTrigger id="credit-export-type" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TYPE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-sm" htmlFor="credit-export-user-id">
+              User ID (optional)
+            </label>
+            <input
+              id="credit-export-user-id"
+              type="text"
+              placeholder="Filter by a single user ID"
+              className="rounded border px-3 py-1.5 text-sm"
+              value={userId}
+              onChange={(e) => setUserId(e.target.value)}
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Window is capped at 90 days and 100k rows. Narrow the range if the
+            backend returns a 400.
+          </p>
+        </div>
+        <Dialog.Footer>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => setOpen(false)}
+            disabled={exporting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            onClick={handleExport}
+            loading={exporting}
+          >
+            Download CSV
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/__legacy__/ui/select";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { getV2ExportCreditTransactions } from "@/app/api/__generated__/endpoints/admin/admin";
-import { okData } from "@/app/api/helpers";
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import { CreditTransactionType } from "@/app/api/__generated__/models/creditTransactionType";
 import {
   buildCreditTransactionsCsv,
@@ -66,31 +66,21 @@ export function ExportCreditTransactionsButton() {
     }
     setExporting(true);
     try {
-      const startDate = dateInputToUtcIso(start);
-      const endDate = dateInputToUtcIsoEnd(end);
-      if (!startDate || !endDate) return;
+      const startIso = dateInputToUtcIso(start);
+      const endIso = dateInputToUtcIsoEnd(end);
+      if (!startIso || !endIso) return;
+      // Pass ISO strings as-is — orval calls .toString() on Date params, which
+      // produces a localised string FastAPI rejects (422). Strings round-trip.
       const response = await getV2ExportCreditTransactions({
-        start: startDate,
-        end: endDate,
+        start: startIso as unknown as Date,
+        end: endIso as unknown as Date,
         transaction_type:
           typeFilter === "ALL"
             ? undefined
             : (typeFilter as CreditTransactionType),
         user_id: userId.trim() || undefined,
       });
-      const data = okData(response);
-      if (!data) {
-        const status = (response as { status?: number }).status;
-        const detail =
-          (response as { data?: { detail?: string } }).data?.detail ??
-          "Export failed";
-        toast({
-          title: status === 400 ? "Window too large" : "Export failed",
-          description: detail,
-          variant: "destructive",
-        });
-        return;
-      }
+      const data = response.data;
       const csv = buildCreditTransactionsCsv(data.transactions);
       downloadCsv(csv, `credit_transactions_${start}_${end}.csv`);
       toast({
@@ -98,6 +88,25 @@ export function ExportCreditTransactionsButton() {
         description: `${data.total_rows} transactions downloaded.`,
       });
       setOpen(false);
+    } catch (err) {
+      // customMutator throws ApiError on non-2xx. Surface backend cap-exceed
+      // detail (400) so the operator can narrow their range without a refresh.
+      if (err instanceof ApiError) {
+        const detail =
+          (err.response as { detail?: string } | undefined)?.detail ??
+          err.message;
+        toast({
+          title: err.status === 400 ? "Window too large" : "Export failed",
+          description: detail,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "Export failed",
+          description: err instanceof Error ? err.message : "Unknown error",
+          variant: "destructive",
+        });
+      }
     } finally {
       setExporting(false);
     }

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
@@ -56,9 +56,12 @@ export function ExportCreditTransactionsButton() {
     }
     setExporting(true);
     try {
+      const startDate = dateInputToUtcIso(start);
+      const endDate = dateInputToUtcIsoEnd(end);
+      if (!startDate || !endDate) return;
       const response = await getV2ExportCreditTransactions({
-        start: dateInputToUtcIso(start) as unknown as Date,
-        end: dateInputToUtcIsoEnd(end) as unknown as Date,
+        start: startDate,
+        end: endDate,
         transaction_type:
           typeFilter === "ALL"
             ? undefined

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DownloadSimpleIcon } from "@phosphor-icons/react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
@@ -44,6 +44,16 @@ export function ExportCreditTransactionsButton() {
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("ALL");
   const [userId, setUserId] = useState("");
   const [exporting, setExporting] = useState(false);
+
+  // Refresh the default window each time the dialog opens — the lazy useState
+  // initializer only runs once on mount, so without this the dates would
+  // freeze at component-mount time and drift on a long-lived page.
+  useEffect(() => {
+    if (open) {
+      setStart(defaultStartDate());
+      setEnd(defaultEndDate());
+    }
+  }, [open]);
 
   async function handleExport() {
     if (!start || !end) {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/ExportCreditTransactionsButton.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/__legacy__/ui/select";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { getV2ExportCreditTransactions } from "@/app/api/__generated__/endpoints/admin/admin";
+import { okData } from "@/app/api/helpers";
 import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import { CreditTransactionType } from "@/app/api/__generated__/models/creditTransactionType";
 import {
@@ -80,7 +81,15 @@ export function ExportCreditTransactionsButton() {
             : (typeFilter as CreditTransactionType),
         user_id: userId.trim() || undefined,
       });
-      const data = response.data;
+      const data = okData(response);
+      if (!data) {
+        toast({
+          title: "Export failed",
+          description: "Unexpected response shape from the export endpoint.",
+          variant: "destructive",
+        });
+        return;
+      }
       const csv = buildCreditTransactionsCsv(data.transactions);
       downloadCsv(csv, `credit_transactions_${start}_${end}.csv`);
       toast({

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
@@ -1,0 +1,111 @@
+import type { CopilotWeeklyUsageRow } from "@/app/api/__generated__/models/copilotWeeklyUsageRow";
+import type { UserTransaction } from "@/app/api/__generated__/models/userTransaction";
+
+const MICRODOLLARS_PER_USD = 1_000_000;
+const CREDIT_CENTS_PER_USD = 100;
+
+function csvEscape(val: unknown): string {
+  const s = val == null ? "" : String(val);
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+const CREDIT_CSV_HEADERS = [
+  "transaction_id",
+  "user_id",
+  "user_email",
+  "created_at",
+  "type",
+  "amount_usd",
+  "running_balance_usd",
+  "admin_user_id",
+  "admin_email",
+  "reason",
+];
+
+export function buildCreditTransactionsCsv(rows: UserTransaction[]): string {
+  const header = CREDIT_CSV_HEADERS.map(csvEscape).join(",");
+  const body = rows.map((tx) =>
+    [
+      tx.transaction_key,
+      tx.user_id,
+      tx.user_email,
+      tx.transaction_time,
+      tx.transaction_type,
+      ((tx.amount ?? 0) / CREDIT_CENTS_PER_USD).toFixed(2),
+      ((tx.running_balance ?? 0) / CREDIT_CENTS_PER_USD).toFixed(2),
+      // admin_user_id is not surfaced separately; admin_email already encodes the
+      // identity, so leave the column blank rather than duplicating data.
+      "",
+      tx.admin_email,
+      tx.reason,
+    ]
+      .map(csvEscape)
+      .join(","),
+  );
+  return [header, ...body].join("\r\n");
+}
+
+const COPILOT_CSV_HEADERS = [
+  "user_id",
+  "user_email",
+  "week_start",
+  "week_end",
+  "copilot_cost_usd",
+  "tier",
+  "weekly_limit_usd",
+  "percent_used",
+];
+
+export function buildCopilotUsageCsv(rows: CopilotWeeklyUsageRow[]): string {
+  const header = COPILOT_CSV_HEADERS.map(csvEscape).join(",");
+  const body = rows.map((row) =>
+    [
+      row.user_id,
+      row.user_email,
+      row.week_start,
+      row.week_end,
+      (row.copilot_cost_microdollars / MICRODOLLARS_PER_USD).toFixed(6),
+      row.tier,
+      (row.weekly_limit_microdollars / MICRODOLLARS_PER_USD).toFixed(2),
+      row.percent_used.toFixed(2),
+    ]
+      .map(csvEscape)
+      .join(","),
+  );
+  return [header, ...body].join("\r\n");
+}
+
+export function downloadCsv(csv: string, filename: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+// "YYYY-MM-DD" -> ISO timestamp at UTC midnight.
+export function dateInputToUtcIso(input: string): string {
+  if (!input) return "";
+  return new Date(`${input}T00:00:00Z`).toISOString();
+}
+
+// Same conversion but pinned to end-of-day so the inclusive `end` filter
+// covers the entire selected day.
+export function dateInputToUtcIsoEnd(input: string): string {
+  if (!input) return "";
+  return new Date(`${input}T23:59:59.999Z`).toISOString();
+}
+
+export function defaultStartDate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString().slice(0, 10);
+}
+
+export function defaultEndDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
@@ -86,18 +86,19 @@ export function downloadCsv(csv: string, filename: string): void {
   setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
-// "YYYY-MM-DD" -> Date at UTC midnight.  Returning a real Date lets orval's
-// generated client serialize via toISOString() in the URL builder.
-export function dateInputToUtcIso(input: string): Date | null {
+// "YYYY-MM-DD" -> ISO 8601 UTC string. The orval URL builder calls .toString()
+// on params, which on a Date produces a localised string FastAPI rejects (422);
+// returning a string keeps .toString() a no-op and the ISO format intact.
+export function dateInputToUtcIso(input: string): string | null {
   if (!input) return null;
-  return new Date(`${input}T00:00:00Z`);
+  return new Date(`${input}T00:00:00Z`).toISOString();
 }
 
 // Same conversion but pinned to end-of-day so the inclusive `end` filter
 // covers the entire selected day.
-export function dateInputToUtcIsoEnd(input: string): Date | null {
+export function dateInputToUtcIsoEnd(input: string): string | null {
   if (!input) return null;
-  return new Date(`${input}T23:59:59.999Z`);
+  return new Date(`${input}T23:59:59.999Z`).toISOString();
 }
 
 // Use UTC arithmetic so the default 30-day window matches the UI's UTC label

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
@@ -17,7 +17,6 @@ const CREDIT_CSV_HEADERS = [
   "type",
   "amount_usd",
   "running_balance_usd",
-  "admin_user_id",
   "admin_email",
   "reason",
 ];
@@ -33,9 +32,6 @@ export function buildCreditTransactionsCsv(rows: UserTransaction[]): string {
       tx.transaction_type,
       ((tx.amount ?? 0) / CREDIT_CENTS_PER_USD).toFixed(2),
       ((tx.running_balance ?? 0) / CREDIT_CENTS_PER_USD).toFixed(2),
-      // admin_user_id is not surfaced separately; admin_email already encodes the
-      // identity, so leave the column blank rather than duplicating data.
-      "",
       tx.admin_email,
       tx.reason,
     ]

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
@@ -84,20 +84,24 @@ export function downloadCsv(csv: string, filename: string): void {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Defer revoke so the browser has time to start the download stream —
+  // some browsers (older Firefox/Edge, mobile WebViews) cancel the download
+  // if the object URL is revoked synchronously after click().
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
-// "YYYY-MM-DD" -> ISO timestamp at UTC midnight.
-export function dateInputToUtcIso(input: string): string {
-  if (!input) return "";
-  return new Date(`${input}T00:00:00Z`).toISOString();
+// "YYYY-MM-DD" -> Date at UTC midnight.  Returning a real Date lets orval's
+// generated client serialize via toISOString() in the URL builder.
+export function dateInputToUtcIso(input: string): Date | null {
+  if (!input) return null;
+  return new Date(`${input}T00:00:00Z`);
 }
 
 // Same conversion but pinned to end-of-day so the inclusive `end` filter
 // covers the entire selected day.
-export function dateInputToUtcIsoEnd(input: string): string {
-  if (!input) return "";
-  return new Date(`${input}T23:59:59.999Z`).toISOString();
+export function dateInputToUtcIsoEnd(input: string): Date | null {
+  if (!input) return null;
+  return new Date(`${input}T23:59:59.999Z`);
 }
 
 export function defaultStartDate(): string {

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/helpers.ts
@@ -100,9 +100,11 @@ export function dateInputToUtcIsoEnd(input: string): Date | null {
   return new Date(`${input}T23:59:59.999Z`);
 }
 
+// Use UTC arithmetic so the default 30-day window matches the UI's UTC label
+// regardless of the viewer's local timezone.
 export function defaultStartDate(): string {
   const d = new Date();
-  d.setDate(d.getDate() - 30);
+  d.setUTCDate(d.getUTCDate() - 30);
   return d.toISOString().slice(0, 10);
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/page.tsx
@@ -2,6 +2,8 @@ import type { CreditTransactionType } from "@/lib/autogpt-server-api";
 import { withRoleAccess } from "@/lib/withRoleAccess";
 import { Suspense } from "react";
 import { AdminUserGrantHistory } from "./components/AdminUserGrantHistory";
+import { ExportCopilotUsageButton } from "./components/ExportCopilotUsageButton";
+import { ExportCreditTransactionsButton } from "./components/ExportCreditTransactionsButton";
 
 type SpendingDashboardPageSearchParams = {
   page?: string;
@@ -25,6 +27,10 @@ function SpendingDashboard({
           <div>
             <h1 className="text-3xl font-bold">User Spending</h1>
             <p className="text-gray-500">Manage user spending balances</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <ExportCreditTransactionsButton />
+            <ExportCopilotUsageButton />
           </div>
         </div>
 

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -3183,6 +3183,18 @@
               "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
+          },
+          {
+            "name": "include_inactive",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Include inactive rows (e.g. abandoned Stripe checkouts). Off by default so phantom rows aren't surfaced in normal exports.",
+              "default": false,
+              "title": "Include Inactive"
+            },
+            "description": "Include inactive rows (e.g. abandoned Stripe checkouts). Off by default so phantom rows aren't surfaced in normal exports."
           }
         ],
         "responses": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -9,7 +9,12 @@
   "paths": {
     "/api/admin/diagnostics/agents": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Get Agent Diagnostics",
         "description": "Get diagnostic information about agents.\n\nReturns:\n    - agents_with_active_executions: Number of unique agents with running/queued executions\n    - timestamp: Current timestamp",
         "operationId": "getV2Get agent diagnostics",
@@ -28,12 +33,21 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Get Execution Diagnostics",
         "description": "Get comprehensive diagnostic information about execution status.\n\nReturns all execution metrics including:\n- Current state (running, queued)\n- Orphaned executions (>24h old, likely not in executor)\n- Failure metrics (1h, 24h, rate)\n- Long-running detection (stuck >1h, >24h)\n- Stuck queued detection\n- Throughput metrics (completions/hour)\n- RabbitMQ queue depths",
         "operationId": "getV2Get execution diagnostics",
@@ -52,12 +66,21 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-orphaned": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Cleanup ALL Orphaned Executions",
         "description": "Cleanup ALL orphaned executions (>24h old) by directly updating DB status.\nOperates on all executions, not just paginated results.\n\nReturns:\n    Number of executions cleaned up and success message",
         "operationId": "postV2Cleanup all orphaned executions",
@@ -76,12 +99,21 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-stuck-queued": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Cleanup ALL Stuck Queued Executions",
         "description": "Cleanup ALL stuck queued executions (QUEUED >1h) by updating DB status (admin only).\nOperates on entire dataset, not limited to pagination.\n\nReturns:\n    Number of executions cleaned up and success message",
         "operationId": "postV2Cleanup all stuck queued executions",
@@ -100,19 +132,30 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-orphaned": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Cleanup Orphaned Executions",
         "description": "Cleanup orphaned executions by directly updating DB status (admin only).\nFor executions in DB but not actually running in executor (old/stale records).\n\nArgs:\n    request: Contains list of execution_ids to cleanup\n\nReturns:\n    Number of executions cleaned up and success message",
         "operationId": "postV2Cleanup orphaned executions",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionsRequest"
+              }
             }
           },
           "required": true
@@ -135,39 +178,66 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/failed": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Failed Executions",
         "description": "Get detailed list of failed executions.\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n    hours: Number of hours to look back (default 24)\n\nReturns:\n    List of failed executions with error details",
         "operationId": "getV2List failed executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           },
           {
             "name": "hours",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 24, "title": "Hours" }
+            "schema": {
+              "type": "integer",
+              "default": 24,
+              "title": "Hours"
+            }
           }
         ],
         "responses": {
@@ -188,7 +258,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -197,23 +269,40 @@
     },
     "/api/admin/diagnostics/executions/invalid": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Invalid Executions",
         "description": "Get detailed list of executions in invalid states (READ-ONLY).\n\nInvalid states indicate data corruption and require manual investigation:\n- QUEUED but has startedAt (impossible - can't start while queued)\n- RUNNING but no startedAt (impossible - can't run without starting)\n\n⚠️ NO BULK ACTIONS PROVIDED - These need case-by-case investigation.\n\nEach invalid execution likely has a different root cause (crashes, race conditions,\nDB corruption). Investigate the execution history and logs to determine appropriate\naction (manual cleanup, status fix, or leave as-is if system recovered).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of invalid state executions with details",
         "operationId": "getV2List invalid executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -234,7 +323,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -243,23 +334,40 @@
     },
     "/api/admin/diagnostics/executions/long-running": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Long-Running Executions",
         "description": "Get detailed list of long-running executions (RUNNING status >24h).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of long-running executions with details",
         "operationId": "getV2List long-running executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -280,7 +388,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -289,23 +399,40 @@
     },
     "/api/admin/diagnostics/executions/orphaned": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Orphaned Executions",
         "description": "Get detailed list of orphaned executions (>24h old, likely not in executor).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of orphaned executions with details",
         "operationId": "getV2List orphaned executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -326,7 +453,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -335,14 +464,21 @@
     },
     "/api/admin/diagnostics/executions/requeue": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Requeue Stuck Execution",
         "description": "Requeue a stuck QUEUED execution (admin only).\n\nUses add_graph_execution with existing graph_exec_id to requeue.\n\n⚠️ WARNING: Only use for stuck executions. This will re-execute and may cost credits.\n\nArgs:\n    request: Contains execution_id to requeue\n\nReturns:\n    Success status and message",
         "operationId": "postV2Requeue stuck execution",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionRequest"
+              }
             }
           },
           "required": true
@@ -365,17 +501,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/requeue-all-stuck": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Requeue ALL Stuck Queued Executions",
         "description": "Requeue ALL stuck queued executions (QUEUED >1h) by publishing to RabbitMQ.\nOperates on all executions, not just paginated results.\n\nUses add_graph_execution with existing graph_exec_id to requeue.\n\n⚠️ WARNING: This will re-execute ALL stuck executions and may cost significant credits.\n\nReturns:\n    Number of executions requeued and success message",
         "operationId": "postV2Requeue all stuck queued executions",
@@ -394,19 +541,30 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/requeue-bulk": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Requeue Multiple Stuck Executions",
         "description": "Requeue multiple stuck QUEUED executions (admin only).\n\nUses add_graph_execution with existing graph_exec_id to requeue.\n\n⚠️ WARNING: Only use for stuck executions. This will re-execute and may cost credits.\n\nArgs:\n    request: Contains list of execution_ids to requeue\n\nReturns:\n    Number of executions requeued and success message",
         "operationId": "postV2Requeue multiple stuck executions",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionsRequest"
+              }
             }
           },
           "required": true
@@ -429,33 +587,56 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/running": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Running Executions",
         "description": "Get detailed list of running and queued executions (recent, likely active).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of running executions with details",
         "operationId": "getV2List running executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -476,7 +657,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -485,14 +668,21 @@
     },
     "/api/admin/diagnostics/executions/stop": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Stop Single Execution",
         "description": "Stop a single execution (admin only).\n\nUses robust stop_graph_execution which cascades to children and waits for termination.\n\nArgs:\n    request: Contains execution_id to stop\n\nReturns:\n    Success status and message",
         "operationId": "postV2Stop single execution",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionRequest"
+              }
             }
           },
           "required": true
@@ -515,17 +705,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/stop-all-long-running": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Stop ALL Long-Running Executions",
         "description": "Stop ALL long-running executions (RUNNING >24h) by sending cancel signals (admin only).\nOperates on entire dataset, not limited to pagination.\n\nReturns:\n    Number of executions stopped and success message",
         "operationId": "postV2Stop all long-running executions",
@@ -544,19 +745,30 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/stop-bulk": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Stop Multiple Executions",
         "description": "Stop multiple active executions (admin only).\n\nUses robust stop_graph_execution which cascades to children and waits for termination.\n\nArgs:\n    request: Contains list of execution_ids to stop\n\nReturns:\n    Number of executions stopped and success message",
         "operationId": "postV2Stop multiple executions",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StopExecutionsRequest"
+              }
             }
           },
           "required": true
@@ -579,33 +791,56 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/executions/stuck-queued": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Stuck Queued Executions",
         "description": "Get detailed list of stuck queued executions (QUEUED >1h, never started).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of stuck queued executions with details",
         "operationId": "getV2List stuck queued executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -626,7 +861,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -635,7 +872,12 @@
     },
     "/api/admin/diagnostics/schedules": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Get Schedule Diagnostics",
         "description": "Get comprehensive diagnostic information about schedule health.\n\nReturns schedule metrics including:\n- Total schedules (user vs system)\n- Orphaned schedules by category\n- Upcoming executions",
         "operationId": "getV2Get schedule diagnostics",
@@ -654,28 +896,49 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/schedules/all": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List All User Schedules",
         "description": "Get detailed list of all user schedules (excludes system monitoring jobs).\n\nArgs:\n    limit: Maximum number of schedules to return (default 100)\n    offset: Number of schedules to skip (default 0)\n\nReturns:\n    List of schedules with details",
         "operationId": "getV2List all user schedules",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 100, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 0, "title": "Offset" }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Offset"
+            }
           }
         ],
         "responses": {
@@ -696,7 +959,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -705,7 +970,12 @@
     },
     "/api/admin/diagnostics/schedules/cleanup-orphaned": {
       "post": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "Cleanup Orphaned Schedules",
         "description": "Cleanup orphaned schedules by deleting from scheduler (admin only).\n\nArgs:\n    request: Contains list of schedule_ids to delete\n\nReturns:\n    Number of schedules deleted and success message",
         "operationId": "postV2Cleanup orphaned schedules",
@@ -737,17 +1007,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/diagnostics/schedules/orphaned": {
       "get": {
-        "tags": ["v2", "admin", "diagnostics", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "diagnostics",
+          "admin"
+        ],
         "summary": "List Orphaned Schedules",
         "description": "Get detailed list of orphaned schedules with orphan reasons.\n\nReturns:\n    List of orphaned schedules categorized by orphan type",
         "operationId": "getV2List orphaned schedules",
@@ -766,15 +1047,28 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/admin/platform-costs/dashboard": {
       "get": {
-        "tags": ["v2", "admin", "platform-cost", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "platform-cost",
+          "admin"
+        ],
         "summary": "Get Platform Cost Dashboard",
         "operationId": "getV2Get platform cost dashboard",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -782,8 +1076,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Start"
             }
@@ -794,8 +1093,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "End"
             }
@@ -805,7 +1109,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Provider"
             }
           },
@@ -814,7 +1125,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -823,7 +1141,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Model"
             }
           },
@@ -832,7 +1157,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Block Name"
             }
           },
@@ -841,7 +1173,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Tracking Type"
             }
           },
@@ -850,7 +1189,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Exec Id"
             }
           }
@@ -873,7 +1219,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -882,10 +1230,19 @@
     },
     "/api/admin/platform-costs/logs": {
       "get": {
-        "tags": ["v2", "admin", "platform-cost", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "platform-cost",
+          "admin"
+        ],
         "summary": "Get Platform Cost Logs",
         "operationId": "getV2Get platform cost logs",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -893,8 +1250,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Start"
             }
@@ -905,8 +1267,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "End"
             }
@@ -916,7 +1283,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Provider"
             }
           },
@@ -925,7 +1299,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -957,7 +1338,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Model"
             }
           },
@@ -966,7 +1354,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Block Name"
             }
           },
@@ -975,7 +1370,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Tracking Type"
             }
           },
@@ -984,7 +1386,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Exec Id"
             }
           }
@@ -1007,7 +1416,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1016,10 +1427,19 @@
     },
     "/api/admin/platform-costs/logs/export": {
       "get": {
-        "tags": ["v2", "admin", "platform-cost", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "platform-cost",
+          "admin"
+        ],
         "summary": "Export Platform Cost Logs",
         "operationId": "getV2Export platform cost logs",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "start",
@@ -1027,8 +1447,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Start"
             }
@@ -1039,8 +1464,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "End"
             }
@@ -1050,7 +1480,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Provider"
             }
           },
@@ -1059,7 +1496,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -1068,7 +1512,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Model"
             }
           },
@@ -1077,7 +1528,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Block Name"
             }
           },
@@ -1086,7 +1544,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Tracking Type"
             }
           },
@@ -1095,7 +1560,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Exec Id"
             }
           }
@@ -1118,7 +1590,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1127,7 +1601,9 @@
     },
     "/api/analytics/log_raw_analytics": {
       "post": {
-        "tags": ["analytics"],
+        "tags": [
+          "analytics"
+        ],
         "summary": "Log Raw Analytics",
         "operationId": "postAnalyticsLogRawAnalytics",
         "requestBody": {
@@ -1143,7 +1619,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1152,23 +1632,33 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/analytics/log_raw_metric": {
       "post": {
-        "tags": ["analytics"],
+        "tags": [
+          "analytics"
+        ],
         "summary": "Log Raw Metric",
         "operationId": "postAnalyticsLogRawMetric",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/LogRawMetricRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/LogRawMetricRequest"
+              }
             }
           },
           "required": true
@@ -1176,7 +1666,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1185,17 +1679,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/api-keys": {
       "get": {
-        "tags": ["v1", "api-keys"],
+        "tags": [
+          "v1",
+          "api-keys"
+        ],
         "summary": "List user API keys",
         "description": "List all API keys for the user",
         "operationId": "getV1List user api keys",
@@ -1205,7 +1708,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/APIKeyInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/APIKeyInfo"
+                  },
                   "type": "array",
                   "title": "Response Getv1List User Api Keys"
                 }
@@ -1216,17 +1721,26 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "api-keys"],
+        "tags": [
+          "v1",
+          "api-keys"
+        ],
         "summary": "Create new API key",
         "description": "Create a new API key",
         "operationId": "postV1Create new api key",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateAPIKeyRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateAPIKeyRequest"
+              }
             }
           },
           "required": true
@@ -1249,27 +1763,43 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/api-keys/{key_id}": {
       "delete": {
-        "tags": ["v1", "api-keys"],
+        "tags": [
+          "v1",
+          "api-keys"
+        ],
         "summary": "Revoke API key",
         "description": "Revoke an API key",
         "operationId": "deleteV1Revoke api key",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "responses": {
@@ -1277,7 +1807,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1288,24 +1820,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v1", "api-keys"],
+        "tags": [
+          "v1",
+          "api-keys"
+        ],
         "summary": "Get specific API key",
         "description": "Get a specific API key",
         "operationId": "getV1Get specific api key",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "responses": {
@@ -1313,7 +1857,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1324,7 +1870,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1333,17 +1881,27 @@
     },
     "/api/api-keys/{key_id}/permissions": {
       "put": {
-        "tags": ["v1", "api-keys"],
+        "tags": [
+          "v1",
+          "api-keys"
+        ],
         "summary": "Update key permissions",
         "description": "Update API key permissions",
         "operationId": "putV1Update key permissions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "requestBody": {
@@ -1361,7 +1919,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1372,7 +1932,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1381,17 +1943,27 @@
     },
     "/api/api-keys/{key_id}/suspend": {
       "post": {
-        "tags": ["v1", "api-keys"],
+        "tags": [
+          "v1",
+          "api-keys"
+        ],
         "summary": "Suspend API key",
         "description": "Suspend an API key",
         "operationId": "postV1Suspend api key",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Key Id" }
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
           }
         ],
         "responses": {
@@ -1399,7 +1971,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
+                "schema": {
+                  "$ref": "#/components/schemas/APIKeyInfo"
+                }
               }
             }
           },
@@ -1410,7 +1984,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1419,30 +1995,47 @@
     },
     "/api/auth/user": {
       "post": {
-        "tags": ["v1", "auth"],
+        "tags": [
+          "v1",
+          "auth"
+        ],
         "summary": "Get or create user",
         "operationId": "postV1Get or create user",
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/auth/user/email": {
       "post": {
-        "tags": ["v1", "auth"],
+        "tags": [
+          "v1",
+          "auth"
+        ],
         "summary": "Update user email",
         "operationId": "postV1Update user email",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "type": "string", "title": "Email" }
+              "schema": {
+                "type": "string",
+                "title": "Email"
+              }
             }
           },
           "required": true
@@ -1453,7 +2046,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
                   "title": "Response Postv1Update User Email"
                 }
@@ -1467,17 +2062,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/auth/user/preferences": {
       "get": {
-        "tags": ["v1", "auth"],
+        "tags": [
+          "v1",
+          "auth"
+        ],
         "summary": "Get notification preferences",
         "operationId": "getV1Get notification preferences",
         "responses": {
@@ -1495,10 +2099,17 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "auth"],
+        "tags": [
+          "v1",
+          "auth"
+        ],
         "summary": "Update notification preferences",
         "operationId": "postV1Update notification preferences",
         "requestBody": {
@@ -1529,17 +2140,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/auth/user/timezone": {
       "get": {
-        "tags": ["v1", "auth"],
+        "tags": [
+          "v1",
+          "auth"
+        ],
         "summary": "Get user timezone",
         "description": "Get user timezone setting.",
         "operationId": "getV1Get user timezone",
@@ -1548,7 +2168,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/TimezoneResponse"
+                }
               }
             }
           },
@@ -1556,17 +2178,26 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "auth"],
+        "tags": [
+          "v1",
+          "auth"
+        ],
         "summary": "Update user timezone",
         "description": "Update user timezone. The timezone should be a valid IANA timezone identifier.",
         "operationId": "postV1Update user timezone",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateTimezoneRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTimezoneRequest"
+              }
             }
           },
           "required": true
@@ -1576,7 +2207,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/TimezoneResponse"
+                }
               }
             }
           },
@@ -1587,17 +2220,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/blocks": {
       "get": {
-        "tags": ["v1", "blocks"],
+        "tags": [
+          "v1",
+          "blocks"
+        ],
         "summary": "List available blocks",
         "operationId": "getV1List available blocks",
         "responses": {
@@ -1606,7 +2248,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "additionalProperties": true, "type": "object" },
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
                   "type": "array",
                   "title": "Response Getv1List Available Blocks"
                 }
@@ -1617,21 +2262,35 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/blocks/{block_id}/execute": {
       "post": {
-        "tags": ["v1", "blocks"],
+        "tags": [
+          "v1",
+          "blocks"
+        ],
         "summary": "Execute graph block",
         "operationId": "postV1Execute graph block",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "block_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Block Id" }
+            "schema": {
+              "type": "string",
+              "title": "Block Id"
+            }
           }
         ],
         "requestBody": {
@@ -1653,7 +2312,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": { "type": "array", "items": {} },
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {}
+                  },
                   "title": "Response Postv1Execute Graph Block"
                 }
               }
@@ -1666,7 +2328,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1675,18 +2339,31 @@
     },
     "/api/builder/blocks": {
       "get": {
-        "tags": ["v2"],
+        "tags": [
+          "v2"
+        ],
         "summary": "Get Builder blocks",
         "description": "Get blocks based on either category, type, or provider.",
         "operationId": "getV2Get builder blocks",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "category",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Category"
             }
           },
@@ -1697,10 +2374,17 @@
             "schema": {
               "anyOf": [
                 {
-                  "enum": ["all", "input", "action", "output"],
+                  "enum": [
+                    "all",
+                    "input",
+                    "action",
+                    "output"
+                  ],
                   "type": "string"
                 },
-                { "type": "null" }
+                {
+                  "type": "null"
+                }
               ],
               "title": "Type"
             }
@@ -1715,7 +2399,9 @@
                   "type": "string",
                   "description": "Provider name for integrations. Can be any string value, including custom provider names."
                 },
-                { "type": "null" }
+                {
+                  "type": "null"
+                }
               ],
               "title": "Provider"
             }
@@ -1724,13 +2410,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -1738,7 +2432,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BlockResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/BlockResponse"
+                }
               }
             }
           },
@@ -1749,7 +2445,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1758,11 +2456,17 @@
     },
     "/api/builder/blocks/batch": {
       "get": {
-        "tags": ["v2"],
+        "tags": [
+          "v2"
+        ],
         "summary": "Get specific blocks",
         "description": "Get specific blocks by their IDs.",
         "operationId": "getV2Get specific blocks",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "block_ids",
@@ -1770,7 +2474,9 @@
             "required": true,
             "schema": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "title": "Block Ids"
             }
           }
@@ -1782,7 +2488,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/BlockInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/BlockInfo"
+                  },
                   "title": "Response Getv2Get Specific Blocks"
                 }
               }
@@ -1795,7 +2503,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1804,11 +2514,17 @@
     },
     "/api/builder/categories": {
       "get": {
-        "tags": ["v2"],
+        "tags": [
+          "v2"
+        ],
         "summary": "Get Builder block categories",
         "description": "Get all block categories with a specified number of blocks per category.",
         "operationId": "getV2Get builder block categories",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "blocks_per_category",
@@ -1843,7 +2559,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1852,7 +2570,9 @@
     },
     "/api/builder/counts": {
       "get": {
-        "tags": ["v2"],
+        "tags": [
+          "v2"
+        ],
         "summary": "Get Builder item counts",
         "description": "Get item counts for the menu categories in the Blocks Menu.",
         "operationId": "getV2Get builder item counts",
@@ -1861,7 +2581,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CountResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CountResponse"
+                }
               }
             }
           },
@@ -1869,28 +2591,46 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/builder/providers": {
       "get": {
-        "tags": ["v2"],
+        "tags": [
+          "v2"
+        ],
         "summary": "Get Builder integration providers",
         "description": "Get all integration providers with their block counts.",
         "operationId": "getV2Get builder integration providers",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -1898,7 +2638,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProviderResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderResponse"
+                }
               }
             }
           },
@@ -1909,7 +2651,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -1918,18 +2662,33 @@
     },
     "/api/builder/search": {
       "get": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Builder search",
         "description": "Search for blocks (including integrations), marketplace agents, and user library agents.",
         "operationId": "getV2Builder search",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "search_query",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search Query"
             }
           },
@@ -1938,7 +2697,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Filter"
             }
           },
@@ -1947,7 +2713,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search Id"
             }
           },
@@ -1957,8 +2730,15 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "array", "items": { "type": "string" } },
-                { "type": "null" }
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "By Creator"
             }
@@ -1967,13 +2747,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -1981,7 +2769,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
               }
             }
           },
@@ -1992,7 +2782,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2001,7 +2793,9 @@
     },
     "/api/builder/suggestions": {
       "get": {
-        "tags": ["v2"],
+        "tags": [
+          "v2"
+        ],
         "summary": "Get Builder suggestions",
         "description": "Get all suggestions for the Blocks Menu.",
         "operationId": "getV2Get builder suggestions",
@@ -2010,7 +2804,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SuggestionsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestionsResponse"
+                }
               }
             }
           },
@@ -2018,12 +2814,20 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/chat/config/ttl": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Get Ttl Config",
         "description": "Get the stream TTL configuration.\n\nReturns the Time-To-Live settings for chat streams, which determines\nhow long clients can reconnect to an active stream.\n\nReturns:\n    dict: TTL configuration with seconds and milliseconds values.",
         "operationId": "getV2GetTtlConfig",
@@ -2045,7 +2849,11 @@
     },
     "/api/chat/health": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Health Check",
         "description": "Health check endpoint for the chat service.\n\nPerforms a full cycle test of session creation and retrieval. Should always return healthy\nif the service and data layer are operational.\n\nReturns:\n    dict: A status dictionary indicating health, service name, and API version.",
         "operationId": "getV2HealthCheck",
@@ -2067,7 +2875,11 @@
     },
     "/api/chat/schema/tool-responses": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "[Dummy] Tool response type export for codegen",
         "description": "This endpoint is not meant to be called. It exists solely to expose tool response models in the OpenAPI schema for frontend codegen.",
         "operationId": "getV2[dummy] tool response type export for codegen",
@@ -2078,46 +2890,84 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/AgentsFoundResponse" },
-                    { "$ref": "#/components/schemas/NoResultsResponse" },
-                    { "$ref": "#/components/schemas/AgentDetailsResponse" },
+                    {
+                      "$ref": "#/components/schemas/AgentsFoundResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NoResultsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AgentDetailsResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/SetupRequirementsResponse"
                     },
-                    { "$ref": "#/components/schemas/ExecutionStartedResponse" },
-                    { "$ref": "#/components/schemas/NeedLoginResponse" },
-                    { "$ref": "#/components/schemas/ErrorResponse" },
+                    {
+                      "$ref": "#/components/schemas/ExecutionStartedResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NeedLoginResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ErrorResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/InputValidationErrorResponse"
                     },
-                    { "$ref": "#/components/schemas/AgentOutputResponse" },
+                    {
+                      "$ref": "#/components/schemas/AgentOutputResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/UnderstandingUpdatedResponse"
                     },
-                    { "$ref": "#/components/schemas/AgentPreviewResponse" },
-                    { "$ref": "#/components/schemas/AgentSavedResponse" },
+                    {
+                      "$ref": "#/components/schemas/AgentPreviewResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AgentSavedResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/ClarificationNeededResponse"
                     },
-                    { "$ref": "#/components/schemas/SuggestedGoalResponse" },
-                    { "$ref": "#/components/schemas/BlockListResponse" },
-                    { "$ref": "#/components/schemas/BlockDetailsResponse" },
-                    { "$ref": "#/components/schemas/BlockOutputResponse" },
-                    { "$ref": "#/components/schemas/DocSearchResultsResponse" },
-                    { "$ref": "#/components/schemas/DocPageResponse" },
+                    {
+                      "$ref": "#/components/schemas/SuggestedGoalResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockListResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockDetailsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockOutputResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DocSearchResultsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DocPageResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/MCPToolsDiscoveredResponse"
                     },
-                    { "$ref": "#/components/schemas/MCPToolOutputResponse" },
-                    { "$ref": "#/components/schemas/MemoryStoreResponse" },
-                    { "$ref": "#/components/schemas/MemorySearchResponse" },
+                    {
+                      "$ref": "#/components/schemas/MCPToolOutputResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MemoryStoreResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MemorySearchResponse"
+                    },
                     {
                       "$ref": "#/components/schemas/MemoryForgetCandidatesResponse"
                     },
                     {
                       "$ref": "#/components/schemas/MemoryForgetConfirmResponse"
                     },
-                    { "$ref": "#/components/schemas/TodoWriteResponse" }
+                    {
+                      "$ref": "#/components/schemas/TodoWriteResponse"
+                    }
                   ],
                   "title": "Response Getv2[Dummy] Tool Response Type Export For Codegen"
                 }
@@ -2129,11 +2979,19 @@
     },
     "/api/chat/sessions": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "List Sessions",
         "description": "List chat sessions for the authenticated user.\n\nReturns a paginated list of chat sessions belonging to the current user,\nordered by most recently updated.\n\nArgs:\n    user_id: The authenticated user's ID.\n    limit: Maximum number of sessions to return (1-100).\n    offset: Number of sessions to skip for pagination.\n\nReturns:\n    ListSessionsResponse: List of session summaries and total count.",
         "operationId": "getV2ListSessions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -2177,25 +3035,39 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Create Session",
         "description": "Create (or get-or-create) a chat session.\n\nTwo modes, selected by the request body:\n\n- Default: create a fresh session for the user. ``dry_run=True`` forces\n  run_block and run_agent calls to use dry-run simulation.\n- Builder-bound: when ``builder_graph_id`` is set, get-or-create keyed\n  on ``(user_id, builder_graph_id)``. Returns the existing session for\n  that graph or creates one locked to it.  Graph ownership is validated\n  inside :func:`get_or_create_builder_session`; raises 404 on\n  unauthorized access.  Write-side scope is enforced per-tool\n  (``edit_agent`` / ``run_agent`` reject any ``agent_id`` other than\n  the bound graph) and a small blacklist hides tools that conflict\n  with the panel's scope (see :data:`BUILDER_BLOCKED_TOOLS`).\n\nArgs:\n    user_id: The authenticated user ID parsed from the JWT (required).\n    request: Optional request body with ``dry_run`` and/or\n        ``builder_graph_id``.\n\nReturns:\n    CreateSessionResponse: Details of the resulting session.",
         "operationId": "postV2CreateSession",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "anyOf": [
-                  { "$ref": "#/components/schemas/CreateSessionRequest" },
-                  { "type": "null" }
+                  {
+                    "$ref": "#/components/schemas/CreateSessionRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ],
                 "title": "Request"
               }
@@ -2220,7 +3092,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2229,47 +3103,75 @@
     },
     "/api/chat/sessions/{session_id}": {
       "delete": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Delete Session",
         "description": "Delete a chat session.\n\nPermanently removes a chat session and all its messages.\nOnly the owner can delete their sessions.\n\nArgs:\n    session_id: The session ID to delete.\n    user_id: The authenticated user's ID.\n\nReturns:\n    204 No Content on success.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "deleteV2DeleteSession",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Get Session",
         "description": "Retrieve the details of a specific chat session.\n\nSupports cursor-based pagination via ``limit`` and ``before_sequence``.\nWhen no pagination params are provided, returns the most recent messages.",
         "operationId": "getV2GetSession",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           },
           {
             "name": "limit",
@@ -2289,8 +3191,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "integer", "minimum": 0 },
-                { "type": "null" }
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Before Sequence"
             }
@@ -2314,7 +3221,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2323,17 +3232,28 @@
     },
     "/api/chat/sessions/{session_id}/assign-user": {
       "patch": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Session Assign User",
         "description": "Assign an authenticated user to a chat session.\n\nUsed (typically post-login) to claim an existing anonymous session as the current authenticated user.\n\nArgs:\n    session_id: The identifier for the (previously anonymous) session.\n    user_id: The authenticated user's ID to associate with the session.\n\nReturns:\n    dict: Status of the assignment.",
         "operationId": "patchV2SessionAssignUser",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
@@ -2356,7 +3276,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2365,17 +3287,28 @@
     },
     "/api/chat/sessions/{session_id}/cancel": {
       "post": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Cancel Session Task",
         "description": "Cancel the active streaming task for a session.\n\nPublishes a cancel event to the executor via RabbitMQ FANOUT, then\npolls Redis until the task status flips from ``running`` or a timeout\n(5 s) is reached.  Returns only after the cancellation is confirmed.",
         "operationId": "postV2CancelSessionTask",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
@@ -2396,7 +3329,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2405,17 +3340,28 @@
     },
     "/api/chat/sessions/{session_id}/messages/pending": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Get Pending Messages",
         "description": "Peek at the pending-message buffer without consuming it.\n\nReturns the current contents of the session's pending message buffer\nso the frontend can restore the queued-message indicator after a page\nrefresh and clear it correctly once a turn drains the buffer.",
         "operationId": "getV2GetPendingMessages",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
@@ -2432,29 +3378,44 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Queue Pending Message",
         "description": "Queue a follow-up message while the session has an active turn.",
         "operationId": "postV2QueuePendingMessage",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "requestBody": {
@@ -2481,7 +3442,9 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "409": {
             "description": "Session has no active turn to receive pending messages"
           },
@@ -2489,31 +3452,48 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "429": { "description": "Call-frequency cap exceeded" }
+          "429": {
+            "description": "Call-frequency cap exceeded"
+          }
         }
       }
     },
     "/api/chat/sessions/{session_id}/stream": {
       "delete": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Disconnect Session Stream",
         "description": "Disconnect all active SSE listeners for a session.\n\nCalled by the frontend when the user switches away from a chat so the\nbackend releases XREAD listeners immediately rather than waiting for\nthe 5-10 s timeout.",
         "operationId": "deleteV2DisconnectSessionStream",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -2521,30 +3501,47 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Resume Session Stream",
         "description": "Resume an active stream for a session.\n\nCalled by the AI SDK's ``useChat(resume: true)`` on page load.\nChecks for an active (in-progress) task on the session and either replays\nthe full SSE stream or returns 204 No Content if nothing is running.\n\nAlways replays the active turn from ``0-0``. The AI SDK UI-message parser\nkeeps text/reasoning part state inside a single parser instance; resuming\nfrom a Redis cursor can skip the ``*-start`` events required by later\n``*-delta`` chunks.",
         "operationId": "getV2ResumeSessionStream",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -2553,48 +3550,71 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Stream Chat Post",
         "description": "Start a new turn and return an AI SDK UI message stream.\n\nReturns an SSE stream (``text/event-stream``) with Vercel AI SDK chunks\n(text fragments, tool-call UI, tool results). The generation runs in a\nbackground task that survives client disconnects; reconnect via\n``GET /sessions/{session_id}/stream`` to resume.\n\nFollow-up messages typed while a turn is already running should use\n``POST /sessions/{session_id}/messages/pending``. If an older client still\nposts that follow-up here, we queue it defensively but still return a valid\nempty UI-message stream so AI SDK transports never receive a JSON body from\nthe stream endpoint.\n\nArgs:\n    session_id: The chat session identifier.\n    request: Request body with message, is_user_message, and optional context.\n    user_id: Authenticated user ID.",
         "operationId": "postV2StreamChatPost",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StreamChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/StreamChatRequest"
+              }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
@@ -2606,17 +3626,28 @@
     },
     "/api/chat/sessions/{session_id}/title": {
       "patch": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Update session title",
         "description": "Update the title of a chat session.\n\nAllows the user to rename their chat session.\n\nArgs:\n    session_id: The session ID to update.\n    request: Request body containing the new title.\n    user_id: The authenticated user's ID.\n\nReturns:\n    dict: Status of the update.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "patchV2Update session title",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Session Id" }
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
           }
         ],
         "requestBody": {
@@ -2645,12 +3676,16 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Session not found or access denied" },
+          "404": {
+            "description": "Session not found or access denied"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2659,7 +3694,11 @@
     },
     "/api/chat/suggested-prompts": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Get Suggested Prompts",
         "description": "Get LLM-generated suggested prompts grouped by theme.\n\nReturns personalized quick-action prompts based on the user's\nbusiness understanding. Returns empty themes list if no custom\nprompts are available.",
         "operationId": "getV2GetSuggestedPrompts",
@@ -2678,12 +3717,20 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/chat/usage": {
       "get": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Get Copilot Usage",
         "description": "Get CoPilot usage status for the authenticated user.\n\nReturns the percentage of the daily/weekly allowance used — not the\nraw spend or cap — so clients cannot derive per-turn cost or platform\nmargins. Global defaults sourced from LaunchDarkly (falling back to\nconfig). Includes the user's rate-limit tier.",
         "operationId": "getV2GetCopilotUsage",
@@ -2692,7 +3739,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CoPilotUsagePublic" }
+                "schema": {
+                  "$ref": "#/components/schemas/CoPilotUsagePublic"
+                }
               }
             }
           },
@@ -2700,12 +3749,20 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/chat/usage/reset": {
       "post": {
-        "tags": ["v2", "chat", "chat"],
+        "tags": [
+          "v2",
+          "chat",
+          "chat"
+        ],
         "summary": "Reset Copilot Usage",
         "description": "Reset the daily CoPilot rate limit by spending credits.\n\nAllows users who have hit their daily cost limit to spend credits\nto reset their daily usage counter and continue working.\nReturns 400 if the feature is disabled or the user is not over the limit.\nReturns 402 if the user has insufficient credits.",
         "operationId": "postV2ResetCopilotUsage",
@@ -2726,7 +3783,9 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "402": { "description": "Payment Required (insufficient credits)" },
+          "402": {
+            "description": "Payment Required (insufficient credits)"
+          },
           "429": {
             "description": "Too Many Requests (max daily resets exceeded or reset in progress)"
           },
@@ -2734,23 +3793,43 @@
             "description": "Service Unavailable (Redis reset failed; credits refunded or support needed)"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/copilot/admin/rate_limit": {
       "get": {
-        "tags": ["v2", "admin", "copilot", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "copilot",
+          "admin"
+        ],
         "summary": "Get User Rate Limit",
         "description": "Get a user's current usage and effective rate limits. Admin-only.\n\nAccepts either ``user_id`` or ``email`` as a query parameter.\nWhen ``email`` is provided the user is looked up by email first.",
         "operationId": "getV2Get user rate limit",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -2759,7 +3838,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Email"
             }
           }
@@ -2782,7 +3868,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2791,7 +3879,12 @@
     },
     "/api/copilot/admin/rate_limit/reset": {
       "post": {
-        "tags": ["v2", "admin", "copilot", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "copilot",
+          "admin"
+        ],
         "summary": "Reset User Rate Limit Usage",
         "description": "Reset a user's daily usage counter (and optionally weekly). Admin-only.",
         "operationId": "postV2Reset user rate limit usage",
@@ -2823,33 +3916,55 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/copilot/admin/rate_limit/search_users": {
       "get": {
-        "tags": ["v2", "admin", "copilot", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "copilot",
+          "admin"
+        ],
         "summary": "Search Users by Name or Email",
         "description": "Search users by partial email or name. Admin-only.\n\nQueries the User table directly — returns results even for users\nwithout credit transaction history.",
         "operationId": "getV2Search users by name or email",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Query" }
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 20, "title": "Limit" }
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Limit"
+            }
           }
         ],
         "responses": {
@@ -2859,7 +3974,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/UserSearchResult" },
+                  "items": {
+                    "$ref": "#/components/schemas/UserSearchResult"
+                  },
                   "title": "Response Getv2Search Users By Name Or Email"
                 }
               }
@@ -2872,7 +3989,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2881,17 +4000,29 @@
     },
     "/api/copilot/admin/rate_limit/tier": {
       "get": {
-        "tags": ["v2", "admin", "copilot", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "copilot",
+          "admin"
+        ],
         "summary": "Get User Rate Limit Tier",
         "description": "Get a user's current rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "getV2Get user rate limit tier",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "User Id" }
+            "schema": {
+              "type": "string",
+              "title": "User Id"
+            }
           }
         ],
         "responses": {
@@ -2899,7 +4030,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserTierResponse"
+                }
               }
             }
           },
@@ -2910,23 +4043,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "admin", "copilot", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "copilot",
+          "admin"
+        ],
         "summary": "Set User Rate Limit Tier",
         "description": "Set a user's rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "postV2Set user rate limit tier",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetUserTierRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/SetUserTierRequest"
+              }
             }
           }
         },
@@ -2935,7 +4081,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserTierResponse"
+                }
               }
             }
           },
@@ -2946,7 +4094,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -2955,7 +4105,10 @@
     },
     "/api/credits": {
       "get": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Get user credits",
         "operationId": "getV1Get user credits",
         "responses": {
@@ -2964,7 +4117,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "integer" },
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
                   "type": "object",
                   "title": "Response Getv1Get User Credits"
                 }
@@ -2975,31 +4130,51 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "patch": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Fulfill checkout session",
         "operationId": "patchV1Fulfill checkout session",
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Request credit top up",
         "operationId": "postV1Request credit top up",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/RequestTopUp" }
+              "schema": {
+                "$ref": "#/components/schemas/RequestTopUp"
+              }
             }
           },
           "required": true
@@ -3007,7 +4182,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -3016,17 +4195,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/admin/add_credits": {
       "post": {
-        "tags": ["v2", "admin", "credits", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "credits",
+          "admin"
+        ],
         "summary": "Add Credits to User",
         "operationId": "postV2Add credits to user",
         "requestBody": {
@@ -3057,53 +4247,74 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
-    "/api/credits/admin/users_history": {
+    "/api/credits/admin/copilot-usage/export": {
       "get": {
-        "tags": ["v2", "admin", "credits", "admin"],
-        "summary": "Get All Users History",
-        "operationId": "getV2Get all users history",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "tags": [
+          "v2",
+          "admin",
+          "credits",
+          "admin"
+        ],
+        "summary": "Export Copilot Weekly Usage vs Rate Limit",
+        "description": "Export per-(user, ISO week) copilot spend with the user's tier limit.\n\nUses the same 90-day window cap and 100k row cap as the credit export.",
+        "operationId": "getV2Export copilot weekly usage vs rate limit",
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
-            "name": "search",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
-              "title": "Search"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
-          },
-          {
-            "name": "transaction_filter",
+            "name": "start",
             "in": "query",
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/CreditTransactionType" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
-              "title": "Transaction Filter"
-            }
+              "description": "ISO timestamp (inclusive)",
+              "title": "Start"
+            },
+            "description": "ISO timestamp (inclusive)"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO timestamp (inclusive)",
+              "title": "End"
+            },
+            "description": "ISO timestamp (inclusive)"
           }
         ],
         "responses": {
@@ -3111,7 +4322,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserHistoryResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CopilotUsageExportResponse"
+                }
               }
             }
           },
@@ -3122,7 +4335,220 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credits/admin/transactions/export": {
+      "get": {
+        "tags": [
+          "v2",
+          "admin",
+          "credits",
+          "admin"
+        ],
+        "summary": "Export Credit Transactions",
+        "description": "Export CreditTransaction rows in [start, end] for finance reporting.\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
+        "operationId": "getV2Export credit transactions",
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO timestamp (inclusive)",
+              "title": "Start"
+            },
+            "description": "ISO timestamp (inclusive)"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO timestamp (inclusive)",
+              "title": "End"
+            },
+            "description": "ISO timestamp (inclusive)"
+          },
+          {
+            "name": "transaction_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/CreditTransactionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Transaction Type"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreditTransactionsExportResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/credits/admin/users_history": {
+      "get": {
+        "tags": [
+          "v2",
+          "admin",
+          "credits",
+          "admin"
+        ],
+        "summary": "Get All Users History",
+        "operationId": "getV2Get all users history",
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "transaction_filter",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/CreditTransactionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Transaction Filter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3131,7 +4557,10 @@
     },
     "/api/credits/auto-top-up": {
       "get": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Get auto top up",
         "operationId": "getV1Get auto top up",
         "responses": {
@@ -3139,7 +4568,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTopUpConfig"
+                }
               }
             }
           },
@@ -3147,17 +4578,26 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Configure auto top up",
         "description": "Configure auto top-up settings and perform an immediate top-up if needed.\n\nRaises HTTPException(422) if the request parameters are invalid or if\nthe credit top-up fails.",
         "operationId": "postV1Configure auto top up",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
+              "schema": {
+                "$ref": "#/components/schemas/AutoTopUpConfig"
+              }
             }
           },
           "required": true
@@ -3181,17 +4621,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/manage": {
       "get": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Manage payment methods",
         "operationId": "getV1Manage payment methods",
         "responses": {
@@ -3200,7 +4649,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": { "type": "string" },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
                   "type": "object",
                   "title": "Response Getv1Manage Payment Methods"
                 }
@@ -3211,12 +4662,19 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/refunds": {
       "get": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Get refund requests",
         "operationId": "getV1Get refund requests",
         "responses": {
@@ -3225,7 +4683,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/RefundRequest" },
+                  "items": {
+                    "$ref": "#/components/schemas/RefundRequest"
+                  },
                   "type": "array",
                   "title": "Response Getv1Get Refund Requests"
                 }
@@ -3236,25 +4696,39 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/stripe_webhook": {
       "post": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Handle Stripe webhooks",
         "operationId": "postV1Handle stripe webhooks",
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           }
         }
       }
     },
     "/api/credits/subscription": {
       "get": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Get subscription tier, current cost, and all tier costs",
         "operationId": "getSubscriptionStatus",
         "responses": {
@@ -3272,10 +4746,17 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Update subscription tier or start a Stripe Checkout session",
         "operationId": "updateSubscriptionTier",
         "requestBody": {
@@ -3306,20 +4787,33 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/credits/transactions": {
       "get": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Get credit history",
         "operationId": "getV1Get credit history",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "transaction_time",
@@ -3327,8 +4821,13 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "type": "string", "format": "date-time" },
-                { "type": "null" }
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Transaction Time"
             }
@@ -3338,7 +4837,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Transaction Type"
             }
           },
@@ -3358,7 +4864,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TransactionHistory" }
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionHistory"
+                }
               }
             }
           },
@@ -3369,7 +4877,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3378,16 +4888,26 @@
     },
     "/api/credits/{transaction_key}/refund": {
       "post": {
-        "tags": ["v1", "credits"],
+        "tags": [
+          "v1",
+          "credits"
+        ],
         "summary": "Refund credit transaction",
         "operationId": "postV1Refund credit transaction",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "transaction_key",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Transaction Key" }
+            "schema": {
+              "type": "string",
+              "title": "Transaction Key"
+            }
           }
         ],
         "requestBody": {
@@ -3396,7 +4916,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "title": "Metadata"
               }
             }
@@ -3421,7 +4943,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3430,7 +4954,10 @@
     },
     "/api/email/": {
       "post": {
-        "tags": ["v1", "email"],
+        "tags": [
+          "v1",
+          "email"
+        ],
         "summary": "Handle Postmark Email Webhooks",
         "operationId": "postV1Handle postmark email webhooks",
         "requestBody": {
@@ -3438,13 +4965,21 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  { "$ref": "#/components/schemas/PostmarkDeliveryWebhook" },
-                  { "$ref": "#/components/schemas/PostmarkBounceWebhook" },
+                  {
+                    "$ref": "#/components/schemas/PostmarkDeliveryWebhook"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PostmarkBounceWebhook"
+                  },
                   {
                     "$ref": "#/components/schemas/PostmarkSpamComplaintWebhook"
                   },
-                  { "$ref": "#/components/schemas/PostmarkOpenWebhook" },
-                  { "$ref": "#/components/schemas/PostmarkClickWebhook" },
+                  {
+                    "$ref": "#/components/schemas/PostmarkOpenWebhook"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PostmarkClickWebhook"
+                  },
                   {
                     "$ref": "#/components/schemas/PostmarkSubscriptionChangeWebhook"
                   }
@@ -3469,23 +5004,36 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "APIKeyAuthenticator-X-Postmark-Webhook-Token": [] }]
+        "security": [
+          {
+            "APIKeyAuthenticator-X-Postmark-Webhook-Token": []
+          }
+        ]
       }
     },
     "/api/email/unsubscribe": {
       "post": {
-        "tags": ["v1", "email"],
+        "tags": [
+          "v1",
+          "email"
+        ],
         "summary": "One Click Email Unsubscribe",
         "operationId": "postV1One click email unsubscribe",
         "parameters": [
@@ -3493,19 +5041,28 @@
             "name": "token",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Token" }
+            "schema": {
+              "type": "string",
+              "title": "Token"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3514,7 +5071,10 @@
     },
     "/api/executions": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "List all executions",
         "operationId": "getV1List all executions",
         "responses": {
@@ -3536,29 +5096,52 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/executions/admin/execution_accuracy_trends": {
       "get": {
-        "tags": ["v2", "admin", "admin", "execution_analytics"],
+        "tags": [
+          "v2",
+          "admin",
+          "admin",
+          "execution_analytics"
+        ],
         "summary": "Get Execution Accuracy Trends and Alerts",
         "description": "Get execution accuracy trends with moving averages and alert detection.\nSimple single-query approach.",
         "operationId": "getV2Get execution accuracy trends and alerts",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "User Id"
             }
           },
@@ -3566,7 +5149,11 @@
             "name": "days_back",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 30, "title": "Days Back" }
+            "schema": {
+              "type": "integer",
+              "default": 30,
+              "title": "Days Back"
+            }
           },
           {
             "name": "drop_threshold",
@@ -3607,7 +5194,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3616,7 +5205,12 @@
     },
     "/api/executions/admin/execution_analytics": {
       "post": {
-        "tags": ["v2", "admin", "admin", "execution_analytics"],
+        "tags": [
+          "v2",
+          "admin",
+          "admin",
+          "execution_analytics"
+        ],
         "summary": "Generate Execution Analytics",
         "description": "Generate activity summaries and correctness scores for graph executions.\n\nThis endpoint:\n1. Fetches all completed executions matching the criteria\n2. Identifies executions missing activity_status or correctness_score\n3. Generates missing data using AI in batches\n4. Updates the database with new stats\n5. Returns a detailed report of the analytics operation",
         "operationId": "postV2Generate execution analytics",
@@ -3648,17 +5242,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/executions/admin/execution_analytics/config": {
       "get": {
-        "tags": ["v2", "admin", "admin", "execution_analytics"],
+        "tags": [
+          "v2",
+          "admin",
+          "admin",
+          "execution_analytics"
+        ],
         "summary": "Get Execution Analytics Configuration",
         "description": "Get the configuration for execution analytics including:\n- Available AI models with metadata\n- Default system and user prompts\n- Recommended model selection",
         "operationId": "getV2Get execution analytics configuration",
@@ -3677,25 +5282,41 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/executions/{graph_exec_id}": {
       "delete": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Delete graph execution",
         "operationId": "deleteV1Delete graph execution",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -3703,7 +5324,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3712,11 +5335,18 @@
     },
     "/api/files/upload": {
       "post": {
-        "tags": ["v1", "files"],
+        "tags": [
+          "v1",
+          "files"
+        ],
         "summary": "Upload file to cloud storage",
         "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    provider: Cloud storage provider (\"gcs\", \"s3\", \"azure\")\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    Dict containing the cloud storage path and signed URL",
         "operationId": "postV1Upload file to cloud storage",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "expiration_hours",
@@ -3757,7 +5387,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3766,7 +5398,10 @@
     },
     "/api/graphs": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "List user graphs",
         "operationId": "getV1List user graphs",
         "responses": {
@@ -3775,7 +5410,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/GraphMeta" },
+                  "items": {
+                    "$ref": "#/components/schemas/GraphMeta"
+                  },
                   "type": "array",
                   "title": "Response Getv1List User Graphs"
                 }
@@ -3786,16 +5423,25 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Create new graph",
         "operationId": "postV1Create new graph",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateGraph" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateGraph"
+              }
             }
           },
           "required": true
@@ -3805,7 +5451,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -3816,26 +5464,42 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/graphs/{graph_id}": {
       "delete": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Delete graph permanently",
         "operationId": "deleteV1Delete graph permanently",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -3843,7 +5507,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteGraphResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteGraphResponse"
+                }
               }
             }
           },
@@ -3854,30 +5520,49 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Get specific graph",
         "operationId": "getV1Get specific graph",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Version"
             }
           },
@@ -3897,7 +5582,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -3908,30 +5595,44 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "put": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Update graph version",
         "operationId": "putV1Update graph version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Graph" }
+              "schema": {
+                "$ref": "#/components/schemas/Graph"
+              }
             }
           }
         },
@@ -3940,7 +5641,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -3951,7 +5654,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3960,23 +5665,40 @@
     },
     "/api/graphs/{graph_id}/execute/{graph_version}": {
       "post": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Execute graph agent",
         "operationId": "postV1Execute graph agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Graph Version"
             }
           },
@@ -3985,7 +5707,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Preset Id"
             }
           }
@@ -4004,7 +5733,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphExecutionMeta"
+                }
               }
             }
           },
@@ -4015,7 +5746,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4024,16 +5757,26 @@
     },
     "/api/graphs/{graph_id}/executions": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "List graph executions",
         "operationId": "getV1List graph executions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "page",
@@ -4081,7 +5824,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4090,22 +5835,35 @@
     },
     "/api/graphs/{graph_id}/executions/{graph_exec_id}": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Get execution details",
         "operationId": "getV1Get execution details",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
@@ -4115,8 +5873,12 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/GraphExecution" },
-                    { "$ref": "#/components/schemas/GraphExecutionWithNodes" }
+                    {
+                      "$ref": "#/components/schemas/GraphExecution"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GraphExecutionWithNodes"
+                    }
                   ],
                   "title": "Response Getv1Get Execution Details"
                 }
@@ -4130,7 +5892,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4139,27 +5903,41 @@
     },
     "/api/graphs/{graph_id}/executions/{graph_exec_id}/share": {
       "delete": {
-        "tags": ["v1"],
+        "tags": [
+          "v1"
+        ],
         "summary": "Disable Execution Sharing",
         "description": "Disable sharing for a graph execution.",
         "operationId": "deleteV1DisableExecutionSharing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -4167,30 +5945,44 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v1"],
+        "tags": [
+          "v1"
+        ],
         "summary": "Enable Execution Sharing",
         "description": "Enable sharing for a graph execution.",
         "operationId": "postV1EnableExecutionSharing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "requestBody": {
@@ -4208,7 +6000,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ShareResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponse"
+                }
               }
             }
           },
@@ -4219,7 +6013,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4228,22 +6024,35 @@
     },
     "/api/graphs/{graph_id}/executions/{graph_exec_id}/stop": {
       "post": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Stop graph execution",
         "operationId": "postV1Stop graph execution",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
@@ -4253,8 +6062,12 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/GraphExecutionMeta" },
-                    { "type": "null" }
+                    {
+                      "$ref": "#/components/schemas/GraphExecutionMeta"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ],
                   "title": "Response Postv1Stop Graph Execution"
                 }
@@ -4268,7 +6081,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4277,16 +6092,26 @@
     },
     "/api/graphs/{graph_id}/schedules": {
       "get": {
-        "tags": ["v1", "schedules"],
+        "tags": [
+          "v1",
+          "schedules"
+        ],
         "summary": "List execution schedules for a graph",
         "operationId": "getV1List execution schedules for a graph",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -4311,17 +6136,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v1", "schedules"],
+        "tags": [
+          "v1",
+          "schedules"
+        ],
         "summary": "Create execution schedule",
         "operationId": "postV1Create execution schedule",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
@@ -4363,7 +6197,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4372,24 +6208,36 @@
     },
     "/api/graphs/{graph_id}/settings": {
       "patch": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Update graph settings",
         "description": "Update graph settings for the user's library agent.",
         "operationId": "patchV1Update graph settings",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/GraphSettings" }
+              "schema": {
+                "$ref": "#/components/schemas/GraphSettings"
+              }
             }
           }
         },
@@ -4398,7 +6246,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphSettings" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphSettings"
+                }
               }
             }
           },
@@ -4409,7 +6259,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4418,16 +6270,26 @@
     },
     "/api/graphs/{graph_id}/versions": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Get all graph versions",
         "operationId": "getV1Get all graph versions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -4437,7 +6299,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/GraphModel" },
+                  "items": {
+                    "$ref": "#/components/schemas/GraphModel"
+                  },
                   "title": "Response Getv1Get All Graph Versions"
                 }
               }
@@ -4450,7 +6314,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4459,30 +6325,46 @@
     },
     "/api/graphs/{graph_id}/versions/active": {
       "put": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Set active graph version",
         "operationId": "putV1Set active graph version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SetGraphActiveVersion" }
+              "schema": {
+                "$ref": "#/components/schemas/SetGraphActiveVersion"
+              }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -4491,7 +6373,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4500,23 +6384,40 @@
     },
     "/api/graphs/{graph_id}/versions/{version}": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Get graph version",
         "operationId": "getV1Get graph version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Version"
             }
           },
@@ -4536,7 +6437,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphModel" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphModel"
+                }
               }
             }
           },
@@ -4547,7 +6450,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4556,7 +6461,10 @@
     },
     "/api/integrations/ayrshare/sso_url": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Get Ayrshare Sso Url",
         "description": "Generate a JWT SSO URL so the user can link their social accounts.\n\nThe per-user Ayrshare profile key is provisioned and persisted as a\nstandard ``is_managed=True`` credential by\n:class:`~backend.integrations.managed_providers.ayrshare.AyrshareManagedProvider`.\nThis endpoint only signs a short-lived JWT pointing at the Ayrshare-\nhosted social-linking page; all profile lifecycle logic lives with the\nmanaged provider.",
         "operationId": "getV1GetAyrshareSsoUrl",
@@ -4565,7 +6473,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AyrshareSSOResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AyrshareSSOResponse"
+                }
               }
             }
           },
@@ -4573,12 +6483,19 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/integrations/credentials": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "List Credentials",
         "operationId": "getV1List credentials",
         "responses": {
@@ -4600,12 +6517,19 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/integrations/providers": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "List Providers",
         "description": "Get metadata for every available provider.\n\nReturns both statically defined providers (from ``ProviderName`` enum) and\ndynamically registered providers (from SDK decorators). Each entry includes\na ``description`` declared via ``ProviderBuilder.with_description(...)`` in\nthe provider's ``_config.py``.\n\nNote: The complete list of provider names is also available as a constant\nin the generated TypeScript client via PROVIDER_NAMES.",
         "operationId": "getV1ListProviders",
@@ -4615,7 +6539,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/ProviderMetadata" },
+                  "items": {
+                    "$ref": "#/components/schemas/ProviderMetadata"
+                  },
                   "type": "array",
                   "title": "Response Getv1Listproviders"
                 }
@@ -4627,7 +6553,10 @@
     },
     "/api/integrations/providers/constants": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Get Provider Constants",
         "description": "Get provider names as constants.\n\nThis endpoint returns a model with provider names as constants,\nspecifically designed for OpenAPI code generation tools to create\nTypeScript constants.",
         "operationId": "getV1GetProviderConstants",
@@ -4636,7 +6565,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProviderConstants" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderConstants"
+                }
               }
             }
           }
@@ -4645,7 +6576,10 @@
     },
     "/api/integrations/providers/enum-example": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Get Provider Enum Example",
         "description": "Example endpoint that uses the CompleteProviderNames enum.\n\nThis endpoint exists to ensure that the CompleteProviderNames enum is included\nin the OpenAPI schema, which will cause Orval to generate it as a\nTypeScript enum/constant.",
         "operationId": "getV1GetProviderEnumExample",
@@ -4665,7 +6599,10 @@
     },
     "/api/integrations/providers/names": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Get Provider Names",
         "description": "Get all provider names in a structured format.\n\nThis endpoint is specifically designed to expose the provider names\nin the OpenAPI schema so that code generators like Orval can create\nappropriate TypeScript constants.",
         "operationId": "getV1GetProviderNames",
@@ -4685,7 +6622,10 @@
     },
     "/api/integrations/providers/system": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "List System Providers",
         "description": "Get a list of providers that have platform credits (system credentials) available.\n\nThese providers can be used without the user providing their own API keys.",
         "operationId": "getV1ListSystemProviders",
@@ -4695,7 +6635,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "type": "string" },
+                  "items": {
+                    "type": "string"
+                  },
                   "type": "array",
                   "title": "Response Getv1Listsystemproviders"
                 }
@@ -4707,22 +6649,36 @@
     },
     "/api/integrations/webhooks/{webhook_id}/ping": {
       "post": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Webhook Ping",
         "operationId": "postV1WebhookPing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Our ID for the webhook" }
+            "schema": {
+              "type": "string",
+              "title": "Our ID for the webhook"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -4731,7 +6687,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4740,10 +6698,17 @@
     },
     "/api/integrations/{provider}/callback": {
       "post": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Exchange OAuth code for tokens",
         "operationId": "postV1Exchange oauth code for tokens",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -4784,7 +6749,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4793,10 +6760,17 @@
     },
     "/api/integrations/{provider}/credentials": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "List Credentials By Provider",
         "operationId": "getV1ListCredentialsByProvider",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -4831,17 +6805,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Create Credentials",
         "operationId": "postV1Create credentials",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -4860,10 +6843,18 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  { "$ref": "#/components/schemas/OAuth2Credentials" },
-                  { "$ref": "#/components/schemas/APIKeyCredentials" },
-                  { "$ref": "#/components/schemas/UserPasswordCredentials" },
-                  { "$ref": "#/components/schemas/HostScopedCredentials" }
+                  {
+                    "$ref": "#/components/schemas/OAuth2Credentials"
+                  },
+                  {
+                    "$ref": "#/components/schemas/APIKeyCredentials"
+                  },
+                  {
+                    "$ref": "#/components/schemas/UserPasswordCredentials"
+                  },
+                  {
+                    "$ref": "#/components/schemas/HostScopedCredentials"
+                  }
                 ],
                 "discriminator": {
                   "propertyName": "type",
@@ -4897,7 +6888,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -4906,10 +6899,17 @@
     },
     "/api/integrations/{provider}/credentials/{cred_id}": {
       "delete": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Delete Credentials",
         "operationId": "deleteV1DeleteCredentials",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -4967,17 +6967,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Get Specific Credential By ID",
         "operationId": "getV1Get specific credential by id",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5017,7 +7026,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5026,11 +7037,18 @@
     },
     "/api/integrations/{provider}/credentials/{cred_id}/picker-token": {
       "post": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Issue a short-lived access token for a provider-hosted picker",
         "description": "Return the raw access token for an OAuth2 credential so the frontend\ncan initialize a provider-hosted picker (e.g. Google Drive Picker).\n\n`GET /{provider}/credentials/{cred_id}` deliberately strips secrets (see\n`CredentialsMetaResponse` + `TestGetCredentialReturnsMetaOnly` in\n`router_test.py`). That hardening broke the Drive picker, which needs the\nraw access token to call `google.picker.Builder.setOAuthToken(...)`. This\nendpoint carves a narrow, explicit hole: the caller must own the\ncredential, it must be OAuth2, and the endpoint returns only the access\ntoken + its expiry — nothing else about the credential. SDK-default\ncredentials are excluded for the same reason as `get_credential`.",
         "operationId": "postV1GetPickerToken",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5057,7 +7075,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/PickerTokenResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/PickerTokenResponse"
+                }
               }
             }
           },
@@ -5068,7 +7088,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5077,10 +7099,17 @@
     },
     "/api/integrations/{provider}/login": {
       "get": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Initiate OAuth flow",
         "operationId": "getV1Initiate oauth flow",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -5107,7 +7136,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "ID of existing credential to upgrade scopes for"
             }
           }
@@ -5117,7 +7153,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LoginResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
               }
             }
           },
@@ -5128,7 +7166,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5137,7 +7177,10 @@
     },
     "/api/integrations/{provider}/webhooks/{webhook_id}/ingress": {
       "post": {
-        "tags": ["v1", "integrations"],
+        "tags": [
+          "v1",
+          "integrations"
+        ],
         "summary": "Webhook Ingress Generic",
         "operationId": "postV1WebhookIngressGeneric",
         "parameters": [
@@ -5155,19 +7198,28 @@
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Our ID for the webhook" }
+            "schema": {
+              "type": "string",
+              "title": "Our ID for the webhook"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5176,18 +7228,33 @@
     },
     "/api/library/agents": {
       "get": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "List Library Agents",
         "description": "Get all agents in the user's library (both created and saved).",
         "operationId": "getV2List library agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "search_term",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Search term to filter agents",
               "title": "Search Term"
             },
@@ -5235,7 +7302,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter by folder ID",
               "title": "Folder Id"
             },
@@ -5272,18 +7346,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "Add Marketplace Agent",
         "description": "Add an agent from the marketplace to the user's library.",
         "operationId": "postV2Add marketplace agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -5299,7 +7383,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5310,7 +7396,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5319,23 +7407,41 @@
     },
     "/api/library/agents/by-graph/{graph_id}": {
       "get": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "Get Library Agent By Graph Id",
         "operationId": "getV2GetLibraryAgentByGraphId",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "integer" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Version"
             }
           }
@@ -5345,7 +7451,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5356,7 +7464,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5365,11 +7475,19 @@
     },
     "/api/library/agents/favorites": {
       "get": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "List Favorite Library Agents",
         "description": "Get all favorite agents in the user's library.",
         "operationId": "getV2List favorite library agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -5416,7 +7534,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5425,17 +7545,30 @@
     },
     "/api/library/agents/marketplace/{store_listing_version_id}": {
       "get": {
-        "tags": ["v2", "library", "private", "store", "library"],
+        "tags": [
+          "v2",
+          "library",
+          "private",
+          "store",
+          "library"
+        ],
         "summary": "Get Agent By Store ID",
         "description": "Get Library Agent from Store Listing Version ID.",
         "operationId": "getV2Get agent by store id",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -5445,8 +7578,12 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    { "$ref": "#/components/schemas/LibraryAgent" },
-                    { "type": "null" }
+                    {
+                      "$ref": "#/components/schemas/LibraryAgent"
+                    },
+                    {
+                      "type": "null"
+                    }
                   ],
                   "title": "Response Getv2Get Agent By Store Id"
                 }
@@ -5460,7 +7597,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5469,23 +7608,38 @@
     },
     "/api/library/agents/{library_agent_id}": {
       "delete": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "Delete Library Agent",
         "description": "Soft-delete the specified library agent.",
         "operationId": "deleteV2Delete library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -5494,23 +7648,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "Get Library Agent",
         "operationId": "getV2Get library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
@@ -5518,7 +7685,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5529,24 +7698,37 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "patch": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "Update Library Agent",
         "description": "Update the library agent with the given fields.",
         "operationId": "patchV2Update library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "requestBody": {
@@ -5564,7 +7746,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5575,7 +7759,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5584,16 +7770,27 @@
     },
     "/api/library/agents/{library_agent_id}/fork": {
       "post": {
-        "tags": ["v2", "library", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "private"
+        ],
         "summary": "Fork Library Agent",
         "operationId": "postV2Fork library agent",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Library Agent Id" }
+            "schema": {
+              "type": "string",
+              "title": "Library Agent Id"
+            }
           }
         ],
         "responses": {
@@ -5601,7 +7798,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -5612,7 +7811,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -5621,18 +7822,34 @@
     },
     "/api/library/folders": {
       "get": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "List Library Folders",
         "description": "List folders for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n    parent_id: Optional parent folder ID to filter by.\n    include_relations: Whether to include agent and subfolder relations for counts.\n\nReturns:\n    A FolderListResponse containing folders.",
         "operationId": "getV2List library folders",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "parent_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter by parent folder ID. If not provided, returns root-level folders.",
               "title": "Parent Id"
             },
@@ -5656,7 +7873,9 @@
             "description": "List of folders",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/FolderListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/FolderListResponse"
+                }
               }
             }
           },
@@ -5667,24 +7886,39 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       },
       "post": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Create Folder",
         "description": "Create a new folder.\n\nArgs:\n    payload: The folder creation request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The created LibraryFolder.",
         "operationId": "postV2Create folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FolderCreateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/FolderCreateRequest"
+              }
             }
           }
         },
@@ -5693,38 +7927,57 @@
             "description": "Folder created successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
-          "400": { "description": "Validation error" },
+          "400": {
+            "description": "Validation error"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Parent folder not found" },
-          "409": { "description": "Folder name conflict" },
+          "404": {
+            "description": "Parent folder not found"
+          },
+          "409": {
+            "description": "Folder name conflict"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       }
     },
     "/api/library/folders/agents/bulk-move": {
       "post": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Bulk Move Agents",
         "description": "Move multiple agents to a folder.\n\nArgs:\n    payload: The bulk move request with agent IDs and target folder.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryAgents.",
         "operationId": "postV2Bulk move agents",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/BulkMoveAgentsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/BulkMoveAgentsRequest"
+              }
             }
           },
           "required": true
@@ -5735,7 +7988,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/LibraryAgent" },
+                  "items": {
+                    "$ref": "#/components/schemas/LibraryAgent"
+                  },
                   "type": "array",
                   "title": "Response Postv2Bulk Move Agents"
                 }
@@ -5745,23 +8000,38 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
+          "404": {
+            "description": "Folder not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/library/folders/tree": {
       "get": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Get Folder Tree",
         "description": "Get the full folder tree for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n\nReturns:\n    A FolderTreeResponse containing the nested folder structure.",
         "operationId": "getV2Get folder tree",
@@ -5770,62 +8040,102 @@
             "description": "Folder tree structure",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/FolderTreeResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/FolderTreeResponse"
+                }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/library/folders/{folder_id}": {
       "delete": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Delete Folder",
         "description": "Soft-delete a folder and all its contents.\n\nArgs:\n    folder_id: ID of the folder to delete.\n    user_id: ID of the authenticated user.\n\nReturns:\n    204 No Content if successful.",
         "operationId": "deleteV2Delete folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Folder deleted successfully" },
+          "204": {
+            "description": "Folder deleted successfully"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
+          "404": {
+            "description": "Folder not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       },
       "get": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Get Folder",
         "description": "Get a specific folder.\n\nArgs:\n    folder_id: ID of the folder to retrieve.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The requested LibraryFolder.",
         "operationId": "getV2Get folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {
@@ -5833,44 +8143,66 @@
             "description": "Folder details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
+          "404": {
+            "description": "Folder not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       },
       "patch": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Update Folder",
         "description": "Update a folder's properties.\n\nArgs:\n    folder_id: ID of the folder to update.\n    payload: The folder update request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryFolder.",
         "operationId": "patchV2Update folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FolderUpdateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/FolderUpdateRequest"
+              }
             }
           }
         },
@@ -5879,48 +8211,74 @@
             "description": "Folder updated successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
-          "400": { "description": "Validation error" },
+          "400": {
+            "description": "Validation error"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder not found" },
-          "409": { "description": "Folder name conflict" },
+          "404": {
+            "description": "Folder not found"
+          },
+          "409": {
+            "description": "Folder name conflict"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       }
     },
     "/api/library/folders/{folder_id}/move": {
       "post": {
-        "tags": ["v2", "library", "folders", "private"],
+        "tags": [
+          "v2",
+          "library",
+          "folders",
+          "private"
+        ],
         "summary": "Move Folder",
         "description": "Move a folder to a new parent.\n\nArgs:\n    folder_id: ID of the folder to move.\n    payload: The move request with target parent.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The moved LibraryFolder.",
         "operationId": "postV2Move folder",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Folder Id" }
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/FolderMoveRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/FolderMoveRequest"
+              }
             }
           }
         },
@@ -5929,35 +8287,54 @@
             "description": "Folder moved successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryFolder"
+                }
               }
             }
           },
-          "400": { "description": "Validation error (circular reference)" },
+          "400": {
+            "description": "Validation error (circular reference)"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Folder or target parent not found" },
-          "409": { "description": "Folder name conflict in target location" },
+          "404": {
+            "description": "Folder or target parent not found"
+          },
+          "409": {
+            "description": "Folder name conflict in target location"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
-          "500": { "description": "Server error" }
+          "500": {
+            "description": "Server error"
+          }
         }
       }
     },
     "/api/library/presets": {
       "get": {
-        "tags": ["v2", "presets"],
+        "tags": [
+          "v2",
+          "presets"
+        ],
         "summary": "List presets",
         "description": "Retrieve a paginated list of presets for the current user.",
         "operationId": "getV2List presets",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -5986,7 +8363,14 @@
             "in": "query",
             "required": true,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Allows to filter presets by a specific agent graph",
               "title": "Graph Id"
             },
@@ -6011,18 +8395,27 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "presets"],
+        "tags": [
+          "v2",
+          "presets"
+        ],
         "summary": "Create a new preset",
         "description": "Create a new preset for the current user.",
         "operationId": "postV2Create a new preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -6046,7 +8439,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6057,7 +8452,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6066,7 +8463,10 @@
     },
     "/api/library/presets/setup-trigger": {
       "post": {
-        "tags": ["v2", "presets"],
+        "tags": [
+          "v2",
+          "presets"
+        ],
         "summary": "Setup Trigger",
         "description": "Sets up a webhook-triggered `LibraryAgentPreset` for a `LibraryAgent`.\nReturns the correspondingly created `LibraryAgentPreset` with `webhook_id` set.",
         "operationId": "postV2SetupTrigger",
@@ -6085,7 +8485,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6096,31 +8498,49 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/library/presets/{preset_id}": {
       "delete": {
-        "tags": ["v2", "presets"],
+        "tags": [
+          "v2",
+          "presets"
+        ],
         "summary": "Delete a preset",
         "description": "Delete an existing preset by its ID.",
         "operationId": "deleteV2Delete a preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -6128,24 +8548,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "get": {
-        "tags": ["v2", "presets"],
+        "tags": [
+          "v2",
+          "presets"
+        ],
         "summary": "Get a specific preset",
         "description": "Retrieve details for a specific preset by its ID.",
         "operationId": "getV2Get a specific preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "responses": {
@@ -6153,7 +8585,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6164,24 +8598,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "patch": {
-        "tags": ["v2", "presets"],
+        "tags": [
+          "v2",
+          "presets"
+        ],
         "summary": "Update an existing preset",
         "description": "Update an existing preset by its ID.",
         "operationId": "patchV2Update an existing preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "requestBody": {
@@ -6199,7 +8645,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgentPreset"
+                }
               }
             }
           },
@@ -6210,7 +8658,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6219,17 +8669,28 @@
     },
     "/api/library/presets/{preset_id}/execute": {
       "post": {
-        "tags": ["v2", "presets", "presets"],
+        "tags": [
+          "v2",
+          "presets",
+          "presets"
+        ],
         "summary": "Execute a preset",
         "description": "Execute a preset with the given graph and node input for the current user.",
         "operationId": "postV2Execute a preset",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Preset Id" }
+            "schema": {
+              "type": "string",
+              "title": "Preset Id"
+            }
           }
         ],
         "requestBody": {
@@ -6246,7 +8707,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
+                "schema": {
+                  "$ref": "#/components/schemas/GraphExecutionMeta"
+                }
               }
             }
           },
@@ -6257,7 +8720,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6266,14 +8731,20 @@
     },
     "/api/mcp/discover-tools": {
       "post": {
-        "tags": ["v2", "mcp", "mcp"],
+        "tags": [
+          "v2",
+          "mcp",
+          "mcp"
+        ],
         "summary": "Discover available tools on an MCP server",
         "description": "Connect to an MCP server and return its available tools.\n\nIf the user has a stored MCP credential for this server URL, it will be\nused automatically — no need to pass an explicit auth token.",
         "operationId": "postV2Discover available tools on an mcp server",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/DiscoverToolsRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverToolsRequest"
+              }
             }
           },
           "required": true
@@ -6296,17 +8767,27 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/mcp/oauth/callback": {
       "post": {
-        "tags": ["v2", "mcp", "mcp"],
+        "tags": [
+          "v2",
+          "mcp",
+          "mcp"
+        ],
         "summary": "Exchange OAuth code for MCP tokens",
         "description": "Exchange the authorization code for tokens and store the credential.\n\nThe frontend calls this after receiving the OAuth code from the popup.\nOn success, subsequent ``/discover-tools`` calls for the same server URL\nwill automatically use the stored credential.",
         "operationId": "postV2Exchange oauth code for mcp tokens",
@@ -6338,24 +8819,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/mcp/oauth/login": {
       "post": {
-        "tags": ["v2", "mcp", "mcp"],
+        "tags": [
+          "v2",
+          "mcp",
+          "mcp"
+        ],
         "summary": "Initiate OAuth login for an MCP server",
         "description": "Discover OAuth metadata from the MCP server and return a login URL.\n\n1. Discovers the protected-resource metadata (RFC 9728)\n2. Fetches the authorization server metadata (RFC 8414)\n3. Performs Dynamic Client Registration (RFC 7591) if available\n4. Returns the authorization URL for the frontend to open in a popup",
         "operationId": "postV2Initiate oauth login for an mcp server",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPOAuthLoginRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/MCPOAuthLoginRequest"
+              }
             }
           },
           "required": true
@@ -6378,24 +8871,36 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/mcp/token": {
       "post": {
-        "tags": ["v2", "mcp", "mcp"],
+        "tags": [
+          "v2",
+          "mcp",
+          "mcp"
+        ],
         "summary": "Store a bearer token for an MCP server",
         "description": "Store a manually provided bearer token as an MCP credential.\n\nUsed by the Copilot MCPSetupCard when the server doesn't support the MCP\nOAuth discovery flow (returns 400 from /oauth/login).  Subsequent\n``run_mcp_tool`` calls will automatically pick up the token via\n``_auto_lookup_credential``.",
         "operationId": "postV2Store a bearer token for an mcp server",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPStoreTokenRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/MCPStoreTokenRequest"
+              }
             }
           },
           "required": true
@@ -6418,27 +8923,42 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/oauth/app/{client_id}": {
       "get": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Get Oauth App Info",
         "description": "Get public information about an OAuth application.\n\nThis endpoint is used by the consent screen to display application details\nto the user before they authorize access.\n\nReturns:\n- name: Application name\n- description: Application description (if provided)\n- scopes: List of scopes the application is allowed to request",
         "operationId": "getOauthGetOauthAppInfo",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "client_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Client Id" }
+            "schema": {
+              "type": "string",
+              "title": "Client Id"
+            }
           }
         ],
         "responses": {
@@ -6455,12 +8975,16 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Application not found or disabled" },
+          "404": {
+            "description": "Application not found or disabled"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6469,7 +8993,9 @@
     },
     "/api/oauth/apps/mine": {
       "get": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "List My Oauth Apps",
         "description": "List all OAuth applications owned by the current user.\n\nReturns a list of OAuth applications with their details including:\n- id, name, description, logo_url\n- client_id (public identifier)\n- redirect_uris, grant_types, scopes\n- is_active status\n- created_at, updated_at timestamps\n\nNote: client_secret is never returned for security reasons.",
         "operationId": "getOauthListMyOauthApps",
@@ -6492,29 +9018,44 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/oauth/apps/{app_id}/logo": {
       "patch": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Update App Logo",
         "description": "Update the logo URL for an OAuth application.\n\nOnly the application owner can update the logo.\nThe logo should be uploaded first using the media upload endpoint,\nthen this endpoint is called with the resulting URL.\n\nLogo requirements:\n- Must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppLogo",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "App Id" }
+            "schema": {
+              "type": "string",
+              "title": "App Id"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateAppLogoRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAppLogoRequest"
+              }
             }
           }
         },
@@ -6536,7 +9077,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6545,17 +9088,26 @@
     },
     "/api/oauth/apps/{app_id}/logo/upload": {
       "post": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Upload App Logo",
         "description": "Upload a logo image for an OAuth application.\n\nRequirements:\n- Image must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n- Allowed formats: JPEG, PNG, WebP\n- Maximum file size: 3MB\n\nThe image is uploaded to cloud storage and the app's logoUrl is updated.\nReturns the updated application info.",
         "operationId": "postOauthUploadAppLogo",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "App Id" }
+            "schema": {
+              "type": "string",
+              "title": "App Id"
+            }
           }
         ],
         "requestBody": {
@@ -6586,7 +9138,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6595,17 +9149,26 @@
     },
     "/api/oauth/apps/{app_id}/status": {
       "patch": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Update App Status",
         "description": "Enable or disable an OAuth application.\n\nOnly the application owner can update the status.\nWhen disabled, the application cannot be used for new authorizations\nand existing access tokens will fail validation.\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppStatus",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "App Id" }
+            "schema": {
+              "type": "string",
+              "title": "App Id"
+            }
           }
         ],
         "requestBody": {
@@ -6636,7 +9199,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6645,14 +9210,18 @@
     },
     "/api/oauth/authorize": {
       "post": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Authorize",
         "description": "OAuth 2.0 Authorization Endpoint\n\nUser must be logged in (authenticated with Supabase JWT).\nThis endpoint creates an authorization code and returns a redirect URL.\n\nPKCE (Proof Key for Code Exchange) is REQUIRED for all authorization requests.\n\nThe frontend consent screen should call this endpoint after the user approves,\nthen redirect the user to the returned `redirect_url`.\n\nRequest Body:\n- client_id: The OAuth application's client ID\n- redirect_uri: Where to redirect after authorization (must match registered URI)\n- scopes: List of permissions (e.g., \"EXECUTE_GRAPH READ_GRAPH\")\n- state: Anti-CSRF token provided by client (will be returned in redirect)\n- response_type: Must be \"code\" (for authorization code flow)\n- code_challenge: PKCE code challenge (required)\n- code_challenge_method: \"S256\" (recommended) or \"plain\"\n\nReturns:\n- redirect_url: The URL to redirect the user to (includes authorization code)\n\nError cases return a redirect_url with error parameters, or raise HTTPException\nfor critical errors (like invalid redirect_uri).",
         "operationId": "postOauthAuthorize",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AuthorizeRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/AuthorizeRequest"
+              }
             }
           },
           "required": true
@@ -6662,7 +9231,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AuthorizeResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizeResponse"
+                }
               }
             }
           },
@@ -6673,17 +9244,25 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/oauth/introspect": {
       "post": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Introspect",
         "description": "OAuth 2.0 Token Introspection Endpoint (RFC 7662)\n\nAllows clients to check if a token is valid and get its metadata.\n\nReturns:\n- active: Whether the token is currently active\n- scopes: List of authorized scopes (if active)\n- client_id: The client the token was issued to (if active)\n- user_id: The user the token represents (if active)\n- exp: Expiration timestamp (if active)\n- token_type: \"access_token\" or \"refresh_token\" (if active)",
         "operationId": "postOauthIntrospect",
@@ -6712,7 +9291,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6721,14 +9302,18 @@
     },
     "/api/oauth/revoke": {
       "post": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Revoke",
         "description": "OAuth 2.0 Token Revocation Endpoint (RFC 7009)\n\nAllows clients to revoke an access or refresh token.\n\nNote: Revoking a refresh token does NOT revoke associated access tokens.\nRevoking an access token does NOT revoke the associated refresh token.",
         "operationId": "postOauthRevoke",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Body_postOauthRevoke" }
+              "schema": {
+                "$ref": "#/components/schemas/Body_postOauthRevoke"
+              }
             }
           },
           "required": true
@@ -6736,13 +9321,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6751,7 +9342,9 @@
     },
     "/api/oauth/token": {
       "post": {
-        "tags": ["oauth"],
+        "tags": [
+          "oauth"
+        ],
         "summary": "Token",
         "description": "OAuth 2.0 Token Endpoint\n\nExchanges authorization code or refresh token for access token.\n\nGrant Types:\n1. authorization_code: Exchange authorization code for tokens\n   - Required: grant_type, code, redirect_uri, client_id, client_secret\n   - Optional: code_verifier (required if PKCE was used)\n\n2. refresh_token: Exchange refresh token for new access token\n   - Required: grant_type, refresh_token, client_id, client_secret\n\nReturns:\n- access_token: Bearer token for API access (1 hour TTL)\n- token_type: \"Bearer\"\n- expires_in: Seconds until access token expires\n- refresh_token: Token for refreshing access (30 days TTL)\n- scopes: List of scopes",
         "operationId": "postOauthToken",
@@ -6760,8 +9353,12 @@
             "application/json": {
               "schema": {
                 "anyOf": [
-                  { "$ref": "#/components/schemas/TokenRequestByCode" },
-                  { "$ref": "#/components/schemas/TokenRequestByRefreshToken" }
+                  {
+                    "$ref": "#/components/schemas/TokenRequestByCode"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TokenRequestByRefreshToken"
+                  }
                 ],
                 "title": "Request"
               }
@@ -6774,7 +9371,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/TokenResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
               }
             }
           },
@@ -6782,7 +9381,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6791,7 +9392,10 @@
     },
     "/api/onboarding": {
       "get": {
-        "tags": ["v1", "onboarding"],
+        "tags": [
+          "v1",
+          "onboarding"
+        ],
         "summary": "Onboarding state",
         "operationId": "getV1Onboarding state",
         "responses": {
@@ -6799,7 +9403,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboarding"
+                }
               }
             }
           },
@@ -6807,16 +9413,25 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "patch": {
-        "tags": ["v1", "onboarding"],
+        "tags": [
+          "v1",
+          "onboarding"
+        ],
         "summary": "Update onboarding state",
         "operationId": "patchV1Update onboarding state",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UserOnboardingUpdate" }
+              "schema": {
+                "$ref": "#/components/schemas/UserOnboardingUpdate"
+              }
             }
           },
           "required": true
@@ -6826,7 +9441,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboarding"
+                }
               }
             }
           },
@@ -6837,17 +9454,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/agents": {
       "get": {
-        "tags": ["v1", "onboarding"],
+        "tags": [
+          "v1",
+          "onboarding"
+        ],
         "summary": "Recommended onboarding agents",
         "operationId": "getV1Recommended onboarding agents",
         "responses": {
@@ -6856,7 +9482,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/StoreAgentDetails" },
+                  "items": {
+                    "$ref": "#/components/schemas/StoreAgentDetails"
+                  },
                   "type": "array",
                   "title": "Response Getv1Recommended Onboarding Agents"
                 }
@@ -6867,12 +9495,20 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/completed": {
       "get": {
-        "tags": ["v1", "onboarding", "public"],
+        "tags": [
+          "v1",
+          "onboarding",
+          "public"
+        ],
         "summary": "Check if onboarding is completed",
         "operationId": "getV1Check if onboarding is completed",
         "responses": {
@@ -6890,12 +9526,19 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/profile": {
       "post": {
-        "tags": ["v1", "onboarding"],
+        "tags": [
+          "v1",
+          "onboarding"
+        ],
         "summary": "Submit onboarding profile",
         "operationId": "postV1Submit onboarding profile",
         "requestBody": {
@@ -6911,7 +9554,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -6920,17 +9567,26 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/reset": {
       "post": {
-        "tags": ["v1", "onboarding"],
+        "tags": [
+          "v1",
+          "onboarding"
+        ],
         "summary": "Reset onboarding progress",
         "operationId": "postV1Reset onboarding progress",
         "responses": {
@@ -6938,7 +9594,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
+                "schema": {
+                  "$ref": "#/components/schemas/UserOnboarding"
+                }
               }
             }
           },
@@ -6946,15 +9604,26 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/onboarding/step": {
       "post": {
-        "tags": ["v1", "onboarding"],
+        "tags": [
+          "v1",
+          "onboarding"
+        ],
         "summary": "Complete onboarding step",
         "operationId": "postV1Complete onboarding step",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "step",
@@ -6981,7 +9650,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -6990,7 +9663,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -6999,14 +9674,19 @@
     },
     "/api/otto/ask": {
       "post": {
-        "tags": ["v2", "otto"],
+        "tags": [
+          "v2",
+          "otto"
+        ],
         "summary": "Proxy Otto Chat Request",
         "description": "Proxy requests to Otto API while adding necessary security headers and logging.\nRequires an authenticated user.",
         "operationId": "postV2Proxy otto chat request",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ChatRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
             }
           },
           "required": true
@@ -7016,7 +9696,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
               }
             }
           },
@@ -7027,17 +9709,25 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/links": {
       "get": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "List all platform servers linked to the authenticated user",
         "operationId": "getPlatform-linkingList all platform servers linked to the authenticated user",
         "responses": {
@@ -7046,7 +9736,9 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": { "$ref": "#/components/schemas/PlatformLinkInfo" },
+                  "items": {
+                    "$ref": "#/components/schemas/PlatformLinkInfo"
+                  },
                   "type": "array",
                   "title": "Response Getplatform-Linkinglist All Platform Servers Linked To The Authenticated User"
                 }
@@ -7057,21 +9749,34 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/links/{link_id}": {
       "delete": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "Unlink a platform server",
         "operationId": "deletePlatform-linkingUnlink a platform server",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Link Id" }
+            "schema": {
+              "type": "string",
+              "title": "Link Id"
+            }
           }
         ],
         "responses": {
@@ -7079,7 +9784,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteLinkResponse"
+                }
               }
             }
           },
@@ -7090,7 +9797,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7099,10 +9808,16 @@
     },
     "/api/platform-linking/tokens/{token}/confirm": {
       "post": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "Confirm a SERVER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a server link token (user must be authenticated)",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "token",
@@ -7121,7 +9836,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ConfirmLinkResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ConfirmLinkResponse"
+                }
               }
             }
           },
@@ -7132,7 +9849,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7141,10 +9860,16 @@
     },
     "/api/platform-linking/tokens/{token}/info": {
       "get": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "Get display info for a link token",
         "operationId": "getPlatform-linkingGet display info for a link token",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "token",
@@ -7176,7 +9901,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7185,7 +9912,9 @@
     },
     "/api/platform-linking/user-links": {
       "get": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "List all DM links for the authenticated user",
         "operationId": "getPlatform-linkingList all dm links for the authenticated user",
         "responses": {
@@ -7207,21 +9936,34 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/platform-linking/user-links/{link_id}": {
       "delete": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "Unlink a DM / user link",
         "operationId": "deletePlatform-linkingUnlink a dm / user link",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Link Id" }
+            "schema": {
+              "type": "string",
+              "title": "Link Id"
+            }
           }
         ],
         "responses": {
@@ -7229,7 +9971,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteLinkResponse"
+                }
               }
             }
           },
@@ -7240,7 +9984,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7249,10 +9995,16 @@
     },
     "/api/platform-linking/user-tokens/{token}/confirm": {
       "post": {
-        "tags": ["platform-linking"],
+        "tags": [
+          "platform-linking"
+        ],
         "summary": "Confirm a USER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a user link token (user must be authenticated)",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "token",
@@ -7284,7 +10036,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7293,7 +10047,9 @@
     },
     "/api/public/shared/{share_token}": {
       "get": {
-        "tags": ["v1"],
+        "tags": [
+          "v1"
+        ],
         "summary": "Get Shared Execution",
         "description": "Get a shared graph execution by share token (no auth required).",
         "operationId": "getV1GetSharedExecution",
@@ -7324,7 +10080,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7333,7 +10091,10 @@
     },
     "/api/public/shared/{share_token}/files/{file_id}/download": {
       "get": {
-        "tags": ["v1", "graphs"],
+        "tags": [
+          "v1",
+          "graphs"
+        ],
         "summary": "Download a file from a shared execution",
         "description": "Download a workspace file from a shared execution (no auth required).\n\nValidates that the file was explicitly exposed when sharing was enabled.\nReturns a uniform 404 for all failure modes to prevent enumeration attacks.",
         "operationId": "download_shared_file",
@@ -7362,13 +10123,19 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7377,19 +10144,25 @@
     },
     "/api/push/subscribe": {
       "post": {
-        "tags": ["push"],
+        "tags": [
+          "push"
+        ],
         "summary": "Register a push subscription for the current user",
         "operationId": "postPushRegister a push subscription for the current user",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/PushSubscribeRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/PushSubscribeRequest"
+              }
             }
           },
           "required": true
         },
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -7397,17 +10170,25 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/push/unsubscribe": {
       "post": {
-        "tags": ["push"],
+        "tags": [
+          "push"
+        ],
         "summary": "Remove a push subscription",
         "operationId": "postPushRemove a push subscription",
         "requestBody": {
@@ -7421,7 +10202,9 @@
           "required": true
         },
         "responses": {
-          "204": { "description": "Successful Response" },
+          "204": {
+            "description": "Successful Response"
+          },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -7429,17 +10212,25 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/push/vapid-key": {
       "get": {
-        "tags": ["push"],
+        "tags": [
+          "push"
+        ],
         "summary": "Get VAPID public key for push subscription",
         "operationId": "getPushGet vapid public key for push subscription",
         "responses": {
@@ -7458,14 +10249,23 @@
     },
     "/api/review/action": {
       "post": {
-        "tags": ["v2", "executions", "review", "v2", "executions", "review"],
+        "tags": [
+          "v2",
+          "executions",
+          "review",
+          "v2",
+          "executions",
+          "review"
+        ],
         "summary": "Process Review Action",
         "description": "Process reviews with approve or reject actions.",
         "operationId": "postV2ProcessReviewAction",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ReviewRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/ReviewRequest"
+              }
             }
           },
           "required": true
@@ -7475,7 +10275,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ReviewResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewResponse"
+                }
               }
             }
           },
@@ -7486,27 +10288,47 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/review/execution/{graph_exec_id}": {
       "get": {
-        "tags": ["v2", "executions", "review", "v2", "executions", "review"],
+        "tags": [
+          "v2",
+          "executions",
+          "review",
+          "v2",
+          "executions",
+          "review"
+        ],
         "summary": "Get Pending Reviews for Execution",
         "description": "Get all pending reviews for a specific graph execution.\n\nRetrieves all reviews with status \"WAITING\" for the specified graph execution\nthat belong to the authenticated user. Results are ordered by creation time\n(oldest first) to preserve review order within the execution.\n\nArgs:\n    graph_exec_id: ID of the graph execution to get reviews for\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects for the specified execution\n\nRaises:\n    HTTPException:\n        - 404: If the graph execution doesn't exist or isn't owned by this user\n        - 500: If authentication fails or database error occurs\n\nNote:\n    Only returns reviews owned by the authenticated user for security.\n    Reviews with invalid status are excluded with warning logs.",
         "operationId": "getV2Get pending reviews for execution",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Exec Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Exec Id"
+            }
           }
         ],
         "responses": {
@@ -7527,29 +10349,46 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": { "description": "Graph execution not found" },
+          "404": {
+            "description": "Graph execution not found"
+          },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
     },
     "/api/review/pending": {
       "get": {
-        "tags": ["v2", "executions", "review", "v2", "executions", "review"],
+        "tags": [
+          "v2",
+          "executions",
+          "review",
+          "v2",
+          "executions",
+          "review"
+        ],
         "summary": "Get Pending Reviews",
         "description": "Get all pending reviews for the current user.\n\nRetrieves all reviews with status \"WAITING\" that belong to the authenticated user.\nResults are ordered by creation time (newest first).\n\nArgs:\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects with status converted to typed literals\n\nRaises:\n    HTTPException: If authentication fails or database error occurs\n\nNote:\n    Reviews with invalid status values are logged as warnings but excluded\n    from results rather than failing the entire request.",
         "operationId": "getV2Get pending reviews",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -7601,20 +10440,27 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": { "application/json": {} }
+            "content": {
+              "application/json": {}
+            }
           }
         }
       }
     },
     "/api/schedules": {
       "get": {
-        "tags": ["v1", "schedules"],
+        "tags": [
+          "v1",
+          "schedules"
+        ],
         "summary": "List execution schedules for a user",
         "operationId": "getV1List execution schedules for a user",
         "responses": {
@@ -7636,15 +10482,26 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/schedules/{schedule_id}": {
       "delete": {
-        "tags": ["v1", "schedules"],
+        "tags": [
+          "v1",
+          "schedules"
+        ],
         "summary": "Delete execution schedule",
         "operationId": "deleteV1Delete execution schedule",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "schedule_id",
@@ -7678,7 +10535,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7687,11 +10546,20 @@
     },
     "/api/store/admin/listings": {
       "get": {
-        "tags": ["v2", "admin", "store", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "store",
+          "admin"
+        ],
         "summary": "Get Admin Listings History",
         "description": "Get store listings with their version history for admins.\n\nThis provides a consolidated view of listings with their versions,\nallowing for an expandable UI in the admin dashboard.\n\nArgs:\n    status: Filter by submission status (PENDING, APPROVED, REJECTED)\n    search: Search by name, description, or user email\n    page: Page number for pagination\n    page_size: Number of items per page\n\nReturns:\n    Paginated listings with their versions",
         "operationId": "getV2Get admin listings history",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "status",
@@ -7699,8 +10567,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/SubmissionStatus" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/SubmissionStatus"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Status"
             }
@@ -7710,7 +10582,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Search"
             }
           },
@@ -7718,13 +10597,21 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 1, "title": "Page" }
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Page Size"
+            }
           }
         ],
         "responses": {
@@ -7745,7 +10632,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7754,11 +10643,22 @@
     },
     "/api/store/admin/submissions/download/{store_listing_version_id}": {
       "get": {
-        "tags": ["v2", "admin", "store", "admin", "store", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "store",
+          "admin",
+          "store",
+          "admin"
+        ],
         "summary": "Admin Download Agent File",
         "description": "Download the agent file by streaming its content.\n\nArgs:\n    store_listing_version_id (str): The ID of the agent to download\n\nReturns:\n    StreamingResponse: A streaming response containing the agent's graph data.\n\nRaises:\n    HTTPException: If the agent is not found or an unexpected error occurs.",
         "operationId": "getV2Admin download agent file",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
@@ -7775,7 +10675,11 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -7784,7 +10688,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7793,17 +10699,29 @@
     },
     "/api/store/admin/submissions/{store_listing_version_id}/add-to-library": {
       "post": {
-        "tags": ["v2", "admin", "store", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "store",
+          "admin"
+        ],
         "summary": "Admin Add Pending Agent to Library",
         "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can load the graph because get_graph() checks library\nmembership as a fallback: \"you added it, you keep it.\"",
         "operationId": "postV2Admin add pending agent to library",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -7811,7 +10729,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
+                "schema": {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                }
               }
             }
           },
@@ -7822,7 +10742,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7831,17 +10753,29 @@
     },
     "/api/store/admin/submissions/{store_listing_version_id}/preview": {
       "get": {
-        "tags": ["v2", "admin", "store", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "store",
+          "admin"
+        ],
         "summary": "Admin Preview Submission Listing",
         "description": "Preview a marketplace submission as it would appear on the listing page.\nBypasses the APPROVED-only StoreAgent view so admins can preview pending\nsubmissions before approving.",
         "operationId": "getV2Admin preview submission listing",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -7849,7 +10783,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentDetails"
+                }
               }
             }
           },
@@ -7860,7 +10796,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7869,17 +10807,29 @@
     },
     "/api/store/admin/submissions/{store_listing_version_id}/review": {
       "post": {
-        "tags": ["v2", "admin", "store", "admin"],
+        "tags": [
+          "v2",
+          "admin",
+          "store",
+          "admin"
+        ],
         "summary": "Review Store Submission",
         "description": "Review a store listing submission.\n\nArgs:\n    store_listing_version_id: ID of the submission to review\n    request: Review details including approval status and comments\n    user_id: Authenticated admin user performing the review\n\nReturns:\n    StoreSubmissionAdminView with updated review information",
         "operationId": "postV2Review store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "requestBody": {
@@ -7910,7 +10860,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -7919,7 +10871,11 @@
     },
     "/api/store/agents": {
       "get": {
-        "tags": ["v2", "store", "public"],
+        "tags": [
+          "v2",
+          "store",
+          "public"
+        ],
         "summary": "List store agents",
         "description": "Get a paginated list of agents from the marketplace,\nwith optional filtering and sorting.\n\nUsed for:\n- Home Page Featured Agents\n- Home Page Top Agents\n- Search Results\n- Agent Details - Other Agents By Creator\n- Agent Details - Similar Agents\n- Creator Details - Agents By Creator",
         "operationId": "getV2List store agents",
@@ -7941,7 +10897,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter agents by creator username",
               "title": "Creator"
             },
@@ -7952,7 +10915,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Filter agents by category",
               "title": "Category"
             },
@@ -7963,7 +10933,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -7975,8 +10952,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/StoreAgentsSortOptions" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/StoreAgentsSortOptions"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "description": "Property to sort results by. Ignored if search_query is provided.",
               "title": "Sorted By"
@@ -8011,7 +10992,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentsResponse"
+                }
               }
             }
           },
@@ -8019,7 +11002,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8028,7 +11013,11 @@
     },
     "/api/store/agents/{username}/{agent_name}": {
       "get": {
-        "tags": ["v2", "store", "public"],
+        "tags": [
+          "v2",
+          "store",
+          "public"
+        ],
         "summary": "Get specific agent",
         "description": "Get details of a marketplace agent",
         "operationId": "getV2Get specific agent",
@@ -8037,13 +11026,19 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Username" }
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Agent Name" }
+            "schema": {
+              "type": "string",
+              "title": "Agent Name"
+            }
           },
           {
             "name": "include_changelog",
@@ -8061,7 +11056,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentDetails"
+                }
               }
             }
           },
@@ -8069,7 +11066,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8078,30 +11077,45 @@
     },
     "/api/store/agents/{username}/{agent_name}/review": {
       "post": {
-        "tags": ["v2", "store"],
+        "tags": [
+          "v2",
+          "store"
+        ],
         "summary": "Create agent review",
         "description": "Post a user review on a marketplace agent listing",
         "operationId": "postV2Create agent review",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Username" }
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Agent Name" }
+            "schema": {
+              "type": "string",
+              "title": "Agent Name"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/StoreReviewCreate" }
+              "schema": {
+                "$ref": "#/components/schemas/StoreReviewCreate"
+              }
             }
           }
         },
@@ -8110,7 +11124,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreReview" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreReview"
+                }
               }
             }
           },
@@ -8121,7 +11137,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8130,7 +11148,11 @@
     },
     "/api/store/creators": {
       "get": {
-        "tags": ["v2", "store", "public"],
+        "tags": [
+          "v2",
+          "store",
+          "public"
+        ],
         "summary": "List store creators",
         "description": "List or search marketplace creators",
         "operationId": "getV2List store creators",
@@ -8152,7 +11174,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -8164,8 +11193,12 @@
             "required": false,
             "schema": {
               "anyOf": [
-                { "$ref": "#/components/schemas/StoreCreatorsSortOptions" },
-                { "type": "null" }
+                {
+                  "$ref": "#/components/schemas/StoreCreatorsSortOptions"
+                },
+                {
+                  "type": "null"
+                }
               ],
               "title": "Sorted By"
             }
@@ -8198,7 +11231,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreatorsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CreatorsResponse"
+                }
               }
             }
           },
@@ -8206,7 +11241,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8215,7 +11252,11 @@
     },
     "/api/store/creators/{username}": {
       "get": {
-        "tags": ["v2", "store", "public"],
+        "tags": [
+          "v2",
+          "store",
+          "public"
+        ],
         "summary": "Get creator details",
         "description": "Get details on a marketplace creator",
         "operationId": "getV2Get creator details",
@@ -8224,7 +11265,10 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Username" }
+            "schema": {
+              "type": "string",
+              "title": "Username"
+            }
           }
         ],
         "responses": {
@@ -8232,7 +11276,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CreatorDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/CreatorDetails"
+                }
               }
             }
           },
@@ -8240,7 +11286,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8249,16 +11297,26 @@
     },
     "/api/store/listings/versions/{store_listing_version_id}": {
       "get": {
-        "tags": ["v2", "store"],
+        "tags": [
+          "v2",
+          "store"
+        ],
         "summary": "Get agent by version",
         "operationId": "getV2Get agent by version",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -8266,7 +11324,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreAgentDetails"
+                }
               }
             }
           },
@@ -8277,7 +11337,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8286,17 +11348,27 @@
     },
     "/api/store/listings/versions/{store_listing_version_id}/graph": {
       "get": {
-        "tags": ["v2", "store"],
+        "tags": [
+          "v2",
+          "store"
+        ],
         "summary": "Get agent graph",
         "description": "Get outline of graph belonging to a specific marketplace listing version",
         "operationId": "getV2Get agent graph",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
@@ -8317,7 +11389,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8326,7 +11400,11 @@
     },
     "/api/store/listings/versions/{store_listing_version_id}/graph/download": {
       "get": {
-        "tags": ["v2", "store", "public"],
+        "tags": [
+          "v2",
+          "store",
+          "public"
+        ],
         "summary": "Download agent file",
         "description": "Download agent graph file for a specific marketplace listing version",
         "operationId": "getV2Download agent file",
@@ -8335,19 +11413,28 @@
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8356,25 +11443,43 @@
     },
     "/api/store/metrics/cache": {
       "get": {
-        "tags": ["v2", "store", "metrics"],
+        "tags": [
+          "v2",
+          "store",
+          "metrics"
+        ],
         "summary": "Get cache metrics in Prometheus format",
         "description": "Get cache metrics in Prometheus text format.\n\nReturns Prometheus-compatible metrics for monitoring cache performance.\nMetrics include size, maxsize, TTL, and hit rate for each cache.\n\nReturns:\n    str: Prometheus-formatted metrics text",
         "operationId": "getV2Get cache metrics in prometheus format",
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "text/plain": { "schema": { "type": "string" } } }
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/store/my-unpublished-agents": {
       "get": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Get my agents",
         "description": "List the authenticated user's unpublished agents",
         "operationId": "getV2Get my agents",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -8417,7 +11522,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8426,7 +11533,11 @@
     },
     "/api/store/profile": {
       "get": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Get user profile",
         "description": "Get the profile details for the authenticated user.",
         "operationId": "getV2Get user profile",
@@ -8435,7 +11546,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileDetails"
+                }
               }
             }
           },
@@ -8443,17 +11556,27 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       },
       "post": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Update user profile",
         "description": "Update the store profile for the authenticated user.",
         "operationId": "postV2Update user profile",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/Profile" }
+              "schema": {
+                "$ref": "#/components/schemas/Profile"
+              }
             }
           },
           "required": true
@@ -8463,7 +11586,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileDetails"
+                }
               }
             }
           },
@@ -8474,27 +11599,44 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/store/search": {
       "get": {
-        "tags": ["v2", "store", "public"],
+        "tags": [
+          "v2",
+          "store",
+          "public"
+        ],
         "summary": "Unified search across all content types",
         "description": "Search across all content types (marketplace agents, blocks, documentation)\nusing hybrid search.\n\nCombines semantic (embedding-based) and lexical (text-based) search for best results.",
         "operationId": "getV2Unified search across all content types",
-        "security": [{ "HTTPBearer": [] }],
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Query" }
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
           },
           {
             "name": "content_types",
@@ -8504,9 +11646,13 @@
               "anyOf": [
                 {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ContentType" }
+                  "items": {
+                    "$ref": "#/components/schemas/ContentType"
+                  }
                 },
-                { "type": "null" }
+                {
+                  "type": "null"
+                }
               ],
               "description": "Content types to search. If not specified, searches all.",
               "title": "Content Types"
@@ -8551,7 +11697,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8560,11 +11708,19 @@
     },
     "/api/store/submissions": {
       "get": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "List my submissions",
         "description": "List the authenticated user's marketplace listing submissions",
         "operationId": "getV2List my submissions",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "page",
@@ -8607,18 +11763,28 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Create store submission",
         "description": "Submit a new marketplace listing for review",
         "operationId": "postV2Create store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -8634,7 +11800,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreSubmission"
+                }
               }
             }
           },
@@ -8645,7 +11813,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8654,17 +11824,28 @@
     },
     "/api/store/submissions/generate_image": {
       "post": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Generate submission image",
         "description": "Generate an image for a marketplace listing submission based on the properties\nof a given graph.",
         "operationId": "postV2Generate submission image",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "title": "Graph Id" }
+            "schema": {
+              "type": "string",
+              "title": "Graph Id"
+            }
           }
         ],
         "responses": {
@@ -8672,7 +11853,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ImageURLResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ImageURLResponse"
+                }
               }
             }
           },
@@ -8683,7 +11866,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8692,7 +11877,11 @@
     },
     "/api/store/submissions/media": {
       "post": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Upload submission media",
         "description": "Upload media for a marketplace listing submission",
         "operationId": "postV2Upload submission media",
@@ -8725,27 +11914,44 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/api/store/submissions/{store_listing_version_id}": {
       "put": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Edit store submission",
         "description": "Update a pending marketplace listing submission",
         "operationId": "putV2Edit store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Store Listing Version Id" }
+            "schema": {
+              "type": "string",
+              "title": "Store Listing Version Id"
+            }
           }
         ],
         "requestBody": {
@@ -8763,7 +11969,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
+                "schema": {
+                  "$ref": "#/components/schemas/StoreSubmission"
+                }
               }
             }
           },
@@ -8774,7 +11982,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8783,17 +11993,28 @@
     },
     "/api/store/submissions/{submission_id}": {
       "delete": {
-        "tags": ["v2", "store", "private"],
+        "tags": [
+          "v2",
+          "store",
+          "private"
+        ],
         "summary": "Delete store submission",
         "description": "Delete a marketplace listing submission",
         "operationId": "deleteV2Delete store submission",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "submission_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "Submission Id" }
+            "schema": {
+              "type": "string",
+              "title": "Submission Id"
+            }
           }
         ],
         "responses": {
@@ -8815,7 +12036,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8824,18 +12047,31 @@
     },
     "/api/workspace/files": {
       "get": {
-        "tags": ["workspace"],
+        "tags": [
+          "workspace"
+        ],
         "summary": "List workspace files",
         "description": "List files in the user's workspace.\n\nWhen session_id is provided, only files for that session are returned.\nOtherwise, all files across sessions are listed. Results are paginated\nvia `limit`/`offset`; `has_more` indicates whether additional pages exist.",
         "operationId": "listWorkspaceFiles",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Session Id"
             }
           },
@@ -8868,7 +12104,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ListFilesResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ListFilesResponse"
+                }
               }
             }
           },
@@ -8879,7 +12117,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8888,18 +12128,31 @@
     },
     "/api/workspace/files/upload": {
       "post": {
-        "tags": ["workspace"],
+        "tags": [
+          "workspace"
+        ],
         "summary": "Upload file to workspace",
         "description": "Upload a file to the user's workspace.\n\nFiles are stored in session-scoped paths when session_id is provided,\nso the agent's session-scoped tools can discover them automatically.",
         "operationId": "uploadWorkspaceFile",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Session Id"
             }
           },
@@ -8942,7 +12195,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8951,17 +12206,26 @@
     },
     "/api/workspace/files/{file_id}": {
       "delete": {
-        "tags": ["workspace"],
+        "tags": [
+          "workspace"
+        ],
         "summary": "Delete a workspace file",
         "description": "Soft-delete a workspace file and attempt to remove it from storage.\n\nUsed when a user clears a file input in the builder.",
         "operationId": "deleteWorkspaceFile",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "File Id" }
+            "schema": {
+              "type": "string",
+              "title": "File Id"
+            }
           }
         ],
         "responses": {
@@ -8969,7 +12233,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DeleteFileResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteFileResponse"
+                }
               }
             }
           },
@@ -8980,7 +12246,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -8989,23 +12257,36 @@
     },
     "/api/workspace/files/{file_id}/download": {
       "get": {
-        "tags": ["workspace"],
+        "tags": [
+          "workspace"
+        ],
         "summary": "Download file by ID",
         "description": "Download a file by its ID.\n\nReturns the file content directly or redirects to a signed URL for GCS.",
         "operationId": "getWorkspaceDownloadFileById",
-        "security": [{ "HTTPBearerJWT": [] }],
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "title": "File Id" }
+            "schema": {
+              "type": "string",
+              "title": "File Id"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -9014,7 +12295,9 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -9023,7 +12306,9 @@
     },
     "/api/workspace/storage/usage": {
       "get": {
-        "tags": ["workspace"],
+        "tags": [
+          "workspace"
+        ],
         "summary": "Get workspace storage usage",
         "description": "Get storage usage information for the user's workspace.",
         "operationId": "getWorkspaceStorageUsage",
@@ -9042,18 +12327,28 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [{ "HTTPBearerJWT": [] }]
+        "security": [
+          {
+            "HTTPBearerJWT": []
+          }
+        ]
       }
     },
     "/health": {
       "get": {
-        "tags": ["health"],
+        "tags": [
+          "health"
+        ],
         "summary": "Health",
         "operationId": "getHealthHealth",
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": { "application/json": { "schema": {} } }
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           }
         }
       }
@@ -9063,10 +12358,23 @@
     "schemas": {
       "APIKeyCredentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -9092,20 +12400,35 @@
             "writeOnly": true
           },
           "expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Expires At",
             "description": "Unix timestamp (seconds) indicating when the API key expires (if at all)"
           }
         },
         "type": "object",
-        "required": ["provider", "api_key"],
+        "required": [
+          "provider",
+          "api_key"
+        ],
         "title": "APIKeyCredentials"
       },
       "APIKeyInfo": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "scopes": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Scopes"
           },
@@ -9122,27 +12445,48 @@
           },
           "expires_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Expires At"
           },
           "last_used_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Last Used At"
           },
           "revoked_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Revoked At"
           },
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "head": {
             "type": "string",
             "title": "Head",
@@ -9153,9 +12497,18 @@
             "title": "Tail",
             "description": "The last 8 characters of the key"
           },
-          "status": { "$ref": "#/components/schemas/APIKeyStatus" },
+          "status": {
+            "$ref": "#/components/schemas/APIKeyStatus"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           }
         },
@@ -9192,19 +12545,42 @@
       },
       "APIKeyStatus": {
         "type": "string",
-        "enum": ["ACTIVE", "REVOKED", "SUSPENDED"],
+        "enum": [
+          "ACTIVE",
+          "REVOKED",
+          "SUSPENDED"
+        ],
         "title": "APIKeyStatus"
       },
       "AccuracyAlertData": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
-          "drop_percent": { "type": "number", "title": "Drop Percent" },
-          "three_day_avg": { "type": "number", "title": "Three Day Avg" },
-          "seven_day_avg": { "type": "number", "title": "Seven Day Avg" },
+          "drop_percent": {
+            "type": "number",
+            "title": "Drop Percent"
+          },
+          "three_day_avg": {
+            "type": "number",
+            "title": "Three Day Avg"
+          },
+          "seven_day_avg": {
+            "type": "number",
+            "title": "Seven Day Avg"
+          },
           "detected_at": {
             "type": "string",
             "format": "date-time",
@@ -9225,21 +12601,53 @@
       },
       "AccuracyLatestData": {
         "properties": {
-          "date": { "type": "string", "format": "date-time", "title": "Date" },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Date"
+          },
           "daily_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Daily Score"
           },
           "three_day_avg": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Three Day Avg"
           },
           "seven_day_avg": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Seven Day Avg"
           },
           "fourteen_day_avg": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Fourteen Day Avg"
           }
         },
@@ -9256,57 +12664,104 @@
       },
       "AccuracyTrendsResponse": {
         "properties": {
-          "latest_data": { "$ref": "#/components/schemas/AccuracyLatestData" },
+          "latest_data": {
+            "$ref": "#/components/schemas/AccuracyLatestData"
+          },
           "alert": {
             "anyOf": [
-              { "$ref": "#/components/schemas/AccuracyAlertData" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/AccuracyAlertData"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "historical_data": {
             "anyOf": [
               {
-                "items": { "$ref": "#/components/schemas/AccuracyLatestData" },
+                "items": {
+                  "$ref": "#/components/schemas/AccuracyLatestData"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Historical Data"
           }
         },
         "type": "object",
-        "required": ["latest_data", "alert"],
+        "required": [
+          "latest_data",
+          "alert"
+        ],
         "title": "AccuracyTrendsResponse",
         "description": "Response model for accuracy trends and alerts."
       },
       "ActiveStreamInfo": {
         "properties": {
-          "turn_id": { "type": "string", "title": "Turn Id" },
-          "last_message_id": { "type": "string", "title": "Last Message Id" },
+          "turn_id": {
+            "type": "string",
+            "title": "Turn Id"
+          },
+          "last_message_id": {
+            "type": "string",
+            "title": "Last Message Id"
+          },
           "started_at": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Started At"
           }
         },
         "type": "object",
-        "required": ["turn_id", "last_message_id"],
+        "required": [
+          "turn_id",
+          "last_message_id"
+        ],
         "title": "ActiveStreamInfo",
         "description": "Information about an active stream for reconnection."
       },
       "AddUserCreditsResponse": {
         "properties": {
-          "new_balance": { "type": "integer", "title": "New Balance" },
-          "transaction_key": { "type": "string", "title": "Transaction Key" }
+          "new_balance": {
+            "type": "integer",
+            "title": "New Balance"
+          },
+          "transaction_key": {
+            "type": "string",
+            "title": "Transaction Key"
+          }
         },
         "type": "object",
-        "required": ["new_balance", "transaction_key"],
+        "required": [
+          "new_balance",
+          "transaction_key"
+        ],
         "title": "AddUserCreditsResponse"
       },
       "AgentDetails": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "in_library": {
             "type": "boolean",
             "title": "In Library",
@@ -9319,7 +12774,9 @@
             "default": {}
           },
           "credentials": {
-            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
+            "items": {
+              "$ref": "#/components/schemas/CredentialsMetaInput"
+            },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -9329,14 +12786,23 @@
           },
           "trigger_info": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Trigger Info"
           }
         },
         "type": "object",
-        "required": ["id", "name", "description"],
+        "required": [
+          "id",
+          "name",
+          "description"
+        ],
         "title": "AgentDetails",
         "description": "Detailed agent information."
       },
@@ -9346,28 +12812,57 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_details"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "agent": { "$ref": "#/components/schemas/AgentDetails" },
+          "agent": {
+            "$ref": "#/components/schemas/AgentDetails"
+          },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
             "default": false
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           }
         },
         "type": "object",
-        "required": ["message", "agent"],
+        "required": [
+          "message",
+          "agent"
+        ],
         "title": "AgentDetailsResponse",
         "description": "Response for get_details action."
       },
@@ -9377,10 +12872,16 @@
             "type": "integer",
             "title": "Agents With Active Executions"
           },
-          "timestamp": { "type": "string", "title": "Timestamp" }
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          }
         },
         "type": "object",
-        "required": ["agents_with_active_executions", "timestamp"],
+        "required": [
+          "agents_with_active_executions",
+          "timestamp"
+        ],
         "title": "AgentDiagnosticsResponse",
         "description": "Response model for agent diagnostics"
       },
@@ -9399,9 +12900,18 @@
       },
       "AgentInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "source": {
             "type": "string",
             "title": "Source",
@@ -9413,83 +12923,184 @@
             "default": false
           },
           "creator": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Creator"
           },
           "category": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Category"
           },
           "rating": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Rating"
           },
           "runs": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Runs"
           },
           "is_featured": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Featured"
           },
           "status": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Status"
           },
           "can_access_graph": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Can Access Graph"
           },
           "has_external_trigger": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Has External Trigger"
           },
           "new_output": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "New Output"
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
           "input_schema": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Input Schema",
             "description": "JSON Schema for the agent's inputs (for AgentExecutorBlock)"
           },
           "output_schema": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Output Schema",
             "description": "JSON Schema for the agent's outputs (for AgentExecutorBlock)"
           },
           "inputs": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs",
             "description": "Input schema for the agent, including field names, types, and defaults"
           },
           "graph": {
             "anyOf": [
-              { "$ref": "#/components/schemas/BaseGraph-Output" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/BaseGraph-Output"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Full graph structure (nodes + links) when include_graph is requested"
           }
         },
         "type": "object",
-        "required": ["id", "name", "description", "source"],
+        "required": [
+          "id",
+          "name",
+          "description",
+          "source"
+        ],
         "title": "AgentInfo",
         "description": "Information about an agent."
       },
@@ -9499,34 +13110,73 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_output"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
           "library_agent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Link"
           },
           "execution": {
             "anyOf": [
-              { "$ref": "#/components/schemas/ExecutionOutputInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/ExecutionOutputInfo"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "available_executions": {
             "anyOf": [
               {
-                "items": { "additionalProperties": true, "type": "object" },
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Available Executions"
           },
@@ -9537,7 +13187,11 @@
           }
         },
         "type": "object",
-        "required": ["message", "agent_name", "agent_id"],
+        "required": [
+          "message",
+          "agent_name",
+          "agent_id"
+        ],
         "title": "AgentOutputResponse",
         "description": "Response for agent_output tool."
       },
@@ -9547,9 +13201,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_preview"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "agent_json": {
@@ -9557,9 +13221,18 @@
             "type": "object",
             "title": "Agent Json"
           },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "description": { "type": "string", "title": "Description" },
-          "node_count": { "type": "integer", "title": "Node Count" },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "node_count": {
+            "type": "integer",
+            "title": "Node Count"
+          },
           "link_count": {
             "type": "integer",
             "title": "Link Count",
@@ -9583,23 +13256,52 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_saved"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "agent_id": { "type": "string", "title": "Agent Id" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
-          "library_agent_id": { "type": "string", "title": "Library Agent Id" },
+          "library_agent_id": {
+            "type": "string",
+            "title": "Library Agent Id"
+          },
           "library_agent_link": {
             "type": "string",
             "title": "Library Agent Link"
           },
-          "agent_page_link": { "type": "string", "title": "Agent Page Link" }
+          "agent_page_link": {
+            "type": "string",
+            "title": "Agent Page Link"
+          }
         },
         "type": "object",
         "required": [
@@ -9619,9 +13321,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agents_found"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "title": {
@@ -9630,11 +13342,16 @@
             "default": "Available Agents"
           },
           "agents": {
-            "items": { "$ref": "#/components/schemas/AgentInfo" },
+            "items": {
+              "$ref": "#/components/schemas/AgentInfo"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "count": { "type": "integer", "title": "Count" },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
           "name": {
             "type": "string",
             "title": "Name",
@@ -9642,22 +13359,38 @@
           }
         },
         "type": "object",
-        "required": ["message", "agents", "count"],
+        "required": [
+          "message",
+          "agents",
+          "count"
+        ],
         "title": "AgentsFoundResponse",
         "description": "Response for find_agent tool."
       },
       "ApiResponse": {
         "properties": {
-          "answer": { "type": "string", "title": "Answer" },
+          "answer": {
+            "type": "string",
+            "title": "Answer"
+          },
           "documents": {
-            "items": { "$ref": "#/components/schemas/Document" },
+            "items": {
+              "$ref": "#/components/schemas/Document"
+            },
             "type": "array",
             "title": "Documents"
           },
-          "success": { "type": "boolean", "title": "Success" }
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          }
         },
         "type": "object",
-        "required": ["answer", "documents", "success"],
+        "required": [
+          "answer",
+          "documents",
+          "success"
+        ],
         "title": "ApiResponse"
       },
       "AuthorizeRequest": {
@@ -9673,7 +13406,9 @@
             "description": "Redirect URI"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes",
             "description": "List of scopes"
@@ -9696,7 +13431,10 @@
           },
           "code_challenge_method": {
             "type": "string",
-            "enum": ["S256", "plain"],
+            "enum": [
+              "S256",
+              "plain"
+            ],
             "title": "Code Challenge Method",
             "description": "PKCE code challenge method (S256 recommended)",
             "default": "S256"
@@ -9722,17 +13460,28 @@
           }
         },
         "type": "object",
-        "required": ["redirect_url"],
+        "required": [
+          "redirect_url"
+        ],
         "title": "AuthorizeResponse",
         "description": "OAuth 2.0 authorization response with redirect URL"
       },
       "AutoTopUpConfig": {
         "properties": {
-          "amount": { "type": "integer", "title": "Amount" },
-          "threshold": { "type": "integer", "title": "Threshold" }
+          "amount": {
+            "type": "integer",
+            "title": "Amount"
+          },
+          "threshold": {
+            "type": "integer",
+            "title": "Threshold"
+          }
         },
         "type": "object",
-        "required": ["amount", "threshold"],
+        "required": [
+          "amount",
+          "threshold"
+        ],
         "title": "AutoTopUpConfig"
       },
       "AyrshareSSOResponse": {
@@ -9750,86 +13499,182 @@
           }
         },
         "type": "object",
-        "required": ["sso_url", "expires_at"],
+        "required": [
+          "sso_url",
+          "expires_at"
+        ],
         "title": "AyrshareSSOResponse"
       },
       "BaseGraph-Input": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/Node" },
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           }
         },
         "type": "object",
-        "required": ["name", "description"],
+        "required": [
+          "name",
+          "description"
+        ],
         "title": "BaseGraph",
         "description": "Graph with nodes, links, and computed I/O schema fields.\n\nUsed to represent sub-graphs within a `Graph`. Contains the full graph\nstructure including nodes and links, plus computed fields for schemas\nand trigger info. Does NOT include user_id or created_at (see GraphModel)."
       },
       "BaseGraph-Output": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/Node" },
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           },
@@ -9862,8 +13707,12 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ],
             "readOnly": true
           }
@@ -9884,27 +13733,44 @@
       },
       "BlockCategoryResponse": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "total_blocks": { "type": "integer", "title": "Total Blocks" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "total_blocks": {
+            "type": "integer",
+            "title": "Total Blocks"
+          },
           "blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfo"
+            },
             "type": "array",
             "title": "Blocks"
           }
         },
         "type": "object",
-        "required": ["name", "total_blocks", "blocks"],
+        "required": [
+          "name",
+          "total_blocks",
+          "blocks"
+        ],
         "title": "BlockCategoryResponse"
       },
       "BlockCost": {
         "properties": {
-          "cost_amount": { "type": "integer", "title": "Cost Amount" },
+          "cost_amount": {
+            "type": "integer",
+            "title": "Cost Amount"
+          },
           "cost_filter": {
             "additionalProperties": true,
             "type": "object",
             "title": "Cost Filter"
           },
-          "cost_type": { "$ref": "#/components/schemas/BlockCostType" },
+          "cost_type": {
+            "$ref": "#/components/schemas/BlockCostType"
+          },
           "cost_divisor": {
             "type": "integer",
             "title": "Cost Divisor",
@@ -9912,19 +13778,39 @@
           }
         },
         "type": "object",
-        "required": ["cost_amount", "cost_filter", "cost_type"],
+        "required": [
+          "cost_amount",
+          "cost_filter",
+          "cost_type"
+        ],
         "title": "BlockCost"
       },
       "BlockCostType": {
         "type": "string",
-        "enum": ["run", "byte", "second", "items", "cost_usd", "tokens"],
+        "enum": [
+          "run",
+          "byte",
+          "second",
+          "items",
+          "cost_usd",
+          "tokens"
+        ],
         "title": "BlockCostType"
       },
       "BlockDetails": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -9938,14 +13824,20 @@
             "default": {}
           },
           "credentials": {
-            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
+            "items": {
+              "$ref": "#/components/schemas/CredentialsMetaInput"
+            },
             "type": "array",
             "title": "Credentials",
             "default": []
           }
         },
         "type": "object",
-        "required": ["id", "name", "description"],
+        "required": [
+          "id",
+          "name",
+          "description"
+        ],
         "title": "BlockDetails",
         "description": "Detailed block information."
       },
@@ -9955,12 +13847,24 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_details"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "block": { "$ref": "#/components/schemas/BlockDetails" },
+          "block": {
+            "$ref": "#/components/schemas/BlockDetails"
+          },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
@@ -9968,14 +13872,23 @@
           }
         },
         "type": "object",
-        "required": ["message", "block"],
+        "required": [
+          "message",
+          "block"
+        ],
         "title": "BlockDetailsResponse",
         "description": "Response for block details (first run_block attempt)."
       },
       "BlockInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "inputSchema": {
             "additionalProperties": true,
             "type": "object",
@@ -9987,26 +13900,42 @@
             "title": "Outputschema"
           },
           "costs": {
-            "items": { "$ref": "#/components/schemas/BlockCost" },
+            "items": {
+              "$ref": "#/components/schemas/BlockCost"
+            },
             "type": "array",
             "title": "Costs"
           },
-          "description": { "type": "string", "title": "Description" },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "categories": {
             "items": {
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "type": "string"
+              },
               "type": "object"
             },
             "type": "array",
             "title": "Categories"
           },
           "contributors": {
-            "items": { "additionalProperties": true, "type": "object" },
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array",
             "title": "Contributors"
           },
-          "staticOutput": { "type": "boolean", "title": "Staticoutput" },
-          "uiType": { "type": "string", "title": "Uitype" }
+          "staticOutput": {
+            "type": "boolean",
+            "title": "Staticoutput"
+          },
+          "uiType": {
+            "type": "string",
+            "title": "Uitype"
+          }
         },
         "type": "object",
         "required": [
@@ -10025,11 +13954,22 @@
       },
       "BlockInfoSummary": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
@@ -10052,21 +13992,34 @@
             "default": false
           },
           "required_inputs": {
-            "items": { "$ref": "#/components/schemas/BlockInputFieldInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInputFieldInfo"
+            },
             "type": "array",
             "title": "Required Inputs",
             "description": "List of input fields for this block"
           }
         },
         "type": "object",
-        "required": ["id", "name", "description", "categories"],
+        "required": [
+          "id",
+          "name",
+          "description",
+          "categories"
+        ],
         "title": "BlockInfoSummary",
         "description": "Summary of a block for search results."
       },
       "BlockInputFieldInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "type": { "type": "string", "title": "Type" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
           "description": {
             "type": "string",
             "title": "Description",
@@ -10077,10 +14030,21 @@
             "title": "Required",
             "default": false
           },
-          "default": { "anyOf": [{}, { "type": "null" }], "title": "Default" }
+          "default": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default"
+          }
         },
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "title": "BlockInputFieldInfo",
         "description": "Information about a block input field."
       },
@@ -10090,18 +14054,36 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_list"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfoSummary" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfoSummary"
+            },
             "type": "array",
             "title": "Blocks"
           },
-          "count": { "type": "integer", "title": "Count" },
-          "query": { "type": "string", "title": "Query" },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
           "usage_hint": {
             "type": "string",
             "title": "Usage Hint",
@@ -10109,7 +14091,12 @@
           }
         },
         "type": "object",
-        "required": ["message", "blocks", "count", "query"],
+        "required": [
+          "message",
+          "blocks",
+          "count",
+          "query"
+        ],
         "title": "BlockListResponse",
         "description": "Response for find_block tool."
       },
@@ -10119,40 +14106,82 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_output"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "block_id": { "type": "string", "title": "Block Id" },
-          "block_name": { "type": "string", "title": "Block Name" },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
+          "block_name": {
+            "type": "string",
+            "title": "Block Name"
+          },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           },
-          "success": { "type": "boolean", "title": "Success", "default": true },
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": true
+          },
           "is_dry_run": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Dry Run"
           }
         },
         "type": "object",
-        "required": ["message", "block_id", "block_name", "outputs"],
+        "required": [
+          "message",
+          "block_id",
+          "block_name",
+          "outputs"
+        ],
         "title": "BlockOutputResponse",
         "description": "Response for run_block tool."
       },
       "BlockResponse": {
         "properties": {
           "blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfo"
+            },
             "type": "array",
             "title": "Blocks"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["blocks", "pagination"],
+        "required": [
+          "blocks",
+          "pagination"
+        ],
         "title": "BlockResponse"
       },
       "Body_patchOauthUpdateAppStatus": {
@@ -10164,12 +14193,17 @@
           }
         },
         "type": "object",
-        "required": ["is_active"],
+        "required": [
+          "is_active"
+        ],
         "title": "Body_patchOauthUpdateAppStatus"
       },
       "Body_postAnalyticsLogRawAnalytics": {
         "properties": {
-          "type": { "type": "string", "title": "Type" },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
           "data": {
             "additionalProperties": true,
             "type": "object",
@@ -10183,7 +14217,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "data", "data_index"],
+        "required": [
+          "type",
+          "data",
+          "data_index"
+        ],
         "title": "Body_postAnalyticsLogRawAnalytics"
       },
       "Body_postOauthIntrospect": {
@@ -10195,8 +14233,16 @@
           },
           "token_type_hint": {
             "anyOf": [
-              { "type": "string", "enum": ["access_token", "refresh_token"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": [
+                  "access_token",
+                  "refresh_token"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -10213,7 +14259,11 @@
           }
         },
         "type": "object",
-        "required": ["token", "client_id", "client_secret"],
+        "required": [
+          "token",
+          "client_id",
+          "client_secret"
+        ],
         "title": "Body_postOauthIntrospect"
       },
       "Body_postOauthRevoke": {
@@ -10225,8 +14275,16 @@
           },
           "token_type_hint": {
             "anyOf": [
-              { "type": "string", "enum": ["access_token", "refresh_token"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": [
+                  "access_token",
+                  "refresh_token"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -10243,15 +14301,25 @@
           }
         },
         "type": "object",
-        "required": ["token", "client_id", "client_secret"],
+        "required": [
+          "token",
+          "client_id",
+          "client_secret"
+        ],
         "title": "Body_postOauthRevoke"
       },
       "Body_postOauthUploadAppLogo": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
-        "required": ["file"],
+        "required": [
+          "file"
+        ],
         "title": "Body_postOauthUploadAppLogo"
       },
       "Body_postV1Exchange_oauth_code_for_tokens": {
@@ -10260,10 +14328,16 @@
             "type": "string",
             "title": "Authorization code acquired by user login"
           },
-          "state_token": { "type": "string", "title": "Anti-CSRF nonce" }
+          "state_token": {
+            "type": "string",
+            "title": "Anti-CSRF nonce"
+          }
         },
         "type": "object",
-        "required": ["code", "state_token"],
+        "required": [
+          "code",
+          "state_token"
+        ],
         "title": "Body_postV1Exchange oauth code for tokens"
       },
       "Body_postV1Execute_graph_agent": {
@@ -10284,33 +14358,62 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": ["builder", "library", "onboarding"]
+                "enum": [
+                  "builder",
+                  "library",
+                  "onboarding"
+                ]
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Source"
           },
-          "dry_run": { "type": "boolean", "title": "Dry Run", "default": false }
+          "dry_run": {
+            "type": "boolean",
+            "title": "Dry Run",
+            "default": false
+          }
         },
         "type": "object",
         "title": "Body_postV1Execute graph agent"
       },
       "Body_postV1Upload_file_to_cloud_storage": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
-        "required": ["file"],
+        "required": [
+          "file"
+        ],
         "title": "Body_postV1Upload file to cloud storage"
       },
       "Body_postV2Add_credits_to_user": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "amount": { "type": "integer", "title": "Amount" },
-          "comments": { "type": "string", "title": "Comments" }
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "amount": {
+            "type": "integer",
+            "title": "Amount"
+          },
+          "comments": {
+            "type": "string",
+            "title": "Comments"
+          }
         },
         "type": "object",
-        "required": ["user_id", "amount", "comments"],
+        "required": [
+          "user_id",
+          "amount",
+          "comments"
+        ],
         "title": "Body_postV2Add credits to user"
       },
       "Body_postV2Add_marketplace_agent": {
@@ -10321,13 +14424,18 @@
           },
           "source": {
             "type": "string",
-            "enum": ["onboarding", "marketplace"],
+            "enum": [
+              "onboarding",
+              "marketplace"
+            ],
             "title": "Source",
             "default": "marketplace"
           }
         },
         "type": "object",
-        "required": ["store_listing_version_id"],
+        "required": [
+          "store_listing_version_id"
+        ],
         "title": "Body_postV2Add marketplace agent"
       },
       "Body_postV2Execute_a_preset": {
@@ -10350,7 +14458,10 @@
       },
       "Body_postV2Reset_user_rate_limit_usage": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "reset_weekly": {
             "type": "boolean",
             "title": "Reset Weekly",
@@ -10358,86 +14469,156 @@
           }
         },
         "type": "object",
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "title": "Body_postV2Reset user rate limit usage"
       },
       "Body_postV2Upload_submission_media": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
-        "required": ["file"],
+        "required": [
+          "file"
+        ],
         "title": "Body_postV2Upload submission media"
       },
       "Body_uploadWorkspaceFile": {
         "properties": {
-          "file": { "type": "string", "format": "binary", "title": "File" }
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
-        "required": ["file"],
+        "required": [
+          "file"
+        ],
         "title": "Body_uploadWorkspaceFile"
       },
       "BulkMoveAgentsRequest": {
         "properties": {
           "agent_ids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Agent Ids"
           },
           "folder_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Id"
           }
         },
         "type": "object",
-        "required": ["agent_ids"],
+        "required": [
+          "agent_ids"
+        ],
         "title": "BulkMoveAgentsRequest",
         "description": "Request model for moving multiple agents to a folder."
       },
       "CancelSessionResponse": {
         "properties": {
-          "cancelled": { "type": "boolean", "title": "Cancelled" },
+          "cancelled": {
+            "type": "boolean",
+            "title": "Cancelled"
+          },
           "reason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reason"
           }
         },
         "type": "object",
-        "required": ["cancelled"],
+        "required": [
+          "cancelled"
+        ],
         "title": "CancelSessionResponse",
         "description": "Response model for the cancel session endpoint."
       },
       "ChangelogEntry": {
         "properties": {
-          "version": { "type": "string", "title": "Version" },
-          "changes_summary": { "type": "string", "title": "Changes Summary" },
-          "date": { "type": "string", "format": "date-time", "title": "Date" }
+          "version": {
+            "type": "string",
+            "title": "Version"
+          },
+          "changes_summary": {
+            "type": "string",
+            "title": "Changes Summary"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Date"
+          }
         },
         "type": "object",
-        "required": ["version", "changes_summary", "date"],
+        "required": [
+          "version",
+          "changes_summary",
+          "date"
+        ],
         "title": "ChangelogEntry"
       },
       "ChatRequest": {
         "properties": {
-          "query": { "type": "string", "title": "Query" },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
           "conversation_history": {
-            "items": { "$ref": "#/components/schemas/Message" },
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            },
             "type": "array",
             "title": "Conversation History"
           },
-          "message_id": { "type": "string", "title": "Message Id" },
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
           "include_graph_data": {
             "type": "boolean",
             "title": "Include Graph Data",
             "default": false
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           }
         },
         "type": "object",
-        "required": ["query", "conversation_history", "message_id"],
+        "required": [
+          "query",
+          "conversation_history",
+          "message_id"
+        ],
         "title": "ChatRequest"
       },
       "ChatSessionMetadata": {
@@ -10448,7 +14629,14 @@
             "default": false
           },
           "builder_graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Builder Graph Id"
           }
         },
@@ -10462,33 +14650,63 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_clarification_needed"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "questions": {
-            "items": { "$ref": "#/components/schemas/ClarifyingQuestion" },
+            "items": {
+              "$ref": "#/components/schemas/ClarifyingQuestion"
+            },
             "type": "array",
             "title": "Questions"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "ClarificationNeededResponse",
         "description": "Response when the LLM needs more information from the user."
       },
       "ClarifyingQuestion": {
         "properties": {
-          "question": { "type": "string", "title": "Question" },
-          "keyword": { "type": "string", "title": "Keyword" },
+          "question": {
+            "type": "string",
+            "title": "Question"
+          },
+          "keyword": {
+            "type": "string",
+            "title": "Keyword"
+          },
           "example": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Example"
           }
         },
         "type": "object",
-        "required": ["question", "keyword"],
+        "required": [
+          "question",
+          "keyword"
+        ],
         "title": "ClarifyingQuestion",
         "description": "A question that needs user clarification."
       },
@@ -10496,15 +14714,23 @@
         "properties": {
           "daily": {
             "anyOf": [
-              { "$ref": "#/components/schemas/UsageWindowPublic" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/UsageWindowPublic"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Null when no daily cap is configured (unlimited)."
           },
           "weekly": {
             "anyOf": [
-              { "$ref": "#/components/schemas/UsageWindowPublic" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/UsageWindowPublic"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Null when no weekly cap is configured (unlimited)."
           },
@@ -10525,18 +14751,31 @@
       },
       "ConfirmLinkResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "SERVER"
           },
-          "platform": { "type": "string", "title": "Platform" },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
           },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           }
         },
@@ -10551,16 +14790,29 @@
       },
       "ConfirmUserLinkResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "USER"
           },
-          "platform": { "type": "string", "title": "Platform" },
-          "platform_user_id": { "type": "string", "title": "Platform User Id" }
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "platform_user_id": {
+            "type": "string",
+            "title": "Platform User Id"
+          }
         },
         "type": "object",
-        "required": ["success", "platform", "platform_user_id"],
+        "required": [
+          "success",
+          "platform",
+          "platform_user_id"
+        ],
         "title": "ConfirmUserLinkResponse"
       },
       "ContentType": {
@@ -10574,90 +14826,302 @@
         ],
         "title": "ContentType"
       },
-      "CostBucket": {
+      "CopilotUsageExportResponse": {
         "properties": {
-          "bucket": { "type": "string", "title": "Bucket" },
-          "count": { "type": "integer", "title": "Count" }
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/CopilotWeeklyUsageRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "window_days": {
+            "type": "integer",
+            "title": "Window Days"
+          },
+          "max_window_days": {
+            "type": "integer",
+            "title": "Max Window Days"
+          }
         },
         "type": "object",
-        "required": ["bucket", "count"],
+        "required": [
+          "rows",
+          "total_rows",
+          "window_days",
+          "max_window_days"
+        ],
+        "title": "CopilotUsageExportResponse"
+      },
+      "CopilotWeeklyUsageRow": {
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "user_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Email"
+          },
+          "week_start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Week Start"
+          },
+          "week_end": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Week End"
+          },
+          "copilot_cost_microdollars": {
+            "type": "integer",
+            "title": "Copilot Cost Microdollars"
+          },
+          "tier": {
+            "type": "string",
+            "title": "Tier"
+          },
+          "weekly_limit_microdollars": {
+            "type": "integer",
+            "title": "Weekly Limit Microdollars"
+          },
+          "percent_used": {
+            "type": "number",
+            "title": "Percent Used"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id",
+          "week_start",
+          "week_end",
+          "copilot_cost_microdollars",
+          "tier",
+          "weekly_limit_microdollars",
+          "percent_used"
+        ],
+        "title": "CopilotWeeklyUsageRow"
+      },
+      "CostBucket": {
+        "properties": {
+          "bucket": {
+            "type": "string",
+            "title": "Bucket"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "bucket",
+          "count"
+        ],
         "title": "CostBucket"
       },
       "CostLogRow": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Email"
           },
           "graph_exec_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Exec Id"
           },
           "node_exec_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Node Exec Id"
           },
-          "block_name": { "type": "string", "title": "Block Name" },
-          "provider": { "type": "string", "title": "Provider" },
+          "block_name": {
+            "type": "string",
+            "title": "Block Name"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "tracking_type": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Tracking Type"
           },
           "cost_microdollars": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cost Microdollars"
           },
           "input_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Input Tokens"
           },
           "output_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Output Tokens"
           },
           "duration": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Duration"
           },
           "model": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Model"
           },
           "cache_read_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cache Read Tokens"
           },
           "cache_creation_tokens": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Cache Creation Tokens"
           }
         },
         "type": "object",
-        "required": ["id", "created_at", "block_name", "provider"],
+        "required": [
+          "id",
+          "created_at",
+          "block_name",
+          "provider"
+        ],
         "title": "CostLogRow"
       },
       "CountResponse": {
         "properties": {
-          "all_blocks": { "type": "integer", "title": "All Blocks" },
-          "input_blocks": { "type": "integer", "title": "Input Blocks" },
-          "action_blocks": { "type": "integer", "title": "Action Blocks" },
-          "output_blocks": { "type": "integer", "title": "Output Blocks" },
-          "integrations": { "type": "integer", "title": "Integrations" },
+          "all_blocks": {
+            "type": "integer",
+            "title": "All Blocks"
+          },
+          "input_blocks": {
+            "type": "integer",
+            "title": "Input Blocks"
+          },
+          "action_blocks": {
+            "type": "integer",
+            "title": "Action Blocks"
+          },
+          "output_blocks": {
+            "type": "integer",
+            "title": "Output Blocks"
+          },
+          "integrations": {
+            "type": "integer",
+            "title": "Integrations"
+          },
           "marketplace_agents": {
             "type": "integer",
             "title": "Marketplace Agents"
           },
-          "my_agents": { "type": "integer", "title": "My Agents" }
+          "my_agents": {
+            "type": "integer",
+            "title": "My Agents"
+          }
         },
         "type": "object",
         "required": [
@@ -10673,43 +15137,78 @@
       },
       "CreateAPIKeyRequest": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "permissions": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Permissions"
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           }
         },
         "type": "object",
-        "required": ["name", "permissions"],
+        "required": [
+          "name",
+          "permissions"
+        ],
         "title": "CreateAPIKeyRequest"
       },
       "CreateAPIKeyResponse": {
         "properties": {
-          "api_key": { "$ref": "#/components/schemas/APIKeyInfo" },
-          "plain_text_key": { "type": "string", "title": "Plain Text Key" }
+          "api_key": {
+            "$ref": "#/components/schemas/APIKeyInfo"
+          },
+          "plain_text_key": {
+            "type": "string",
+            "title": "Plain Text Key"
+          }
         },
         "type": "object",
-        "required": ["api_key", "plain_text_key"],
+        "required": [
+          "api_key",
+          "plain_text_key"
+        ],
         "title": "CreateAPIKeyResponse"
       },
       "CreateGraph": {
         "properties": {
-          "graph": { "$ref": "#/components/schemas/Graph" },
+          "graph": {
+            "$ref": "#/components/schemas/Graph"
+          },
           "source": {
             "anyOf": [
-              { "type": "string", "enum": ["builder", "upload"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": [
+                  "builder",
+                  "upload"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Source"
           }
         },
         "type": "object",
-        "required": ["graph"],
+        "required": [
+          "graph"
+        ],
         "title": "CreateGraph"
       },
       "CreateSessionRequest": {
@@ -10721,8 +15220,13 @@
           },
           "builder_graph_id": {
             "anyOf": [
-              { "type": "string", "maxLength": 128 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Builder Graph Id"
           }
@@ -10734,42 +15238,93 @@
       },
       "CreateSessionResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "created_at": { "type": "string", "title": "Created At" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": { "dry_run": false }
+            "default": {
+              "dry_run": false
+            }
           }
         },
         "type": "object",
-        "required": ["id", "created_at", "user_id"],
+        "required": [
+          "id",
+          "created_at",
+          "user_id"
+        ],
         "title": "CreateSessionResponse",
         "description": "Response model containing information on a newly created chat session."
       },
       "CreatorDetails": {
         "properties": {
-          "username": { "type": "string", "title": "Username" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "avatar_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avatar Url"
           },
           "links": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": { "type": "boolean", "title": "Is Featured" },
-          "num_agents": { "type": "integer", "title": "Num Agents" },
-          "agent_runs": { "type": "integer", "title": "Agent Runs" },
-          "agent_rating": { "type": "number", "title": "Agent Rating" },
+          "is_featured": {
+            "type": "boolean",
+            "title": "Is Featured"
+          },
+          "num_agents": {
+            "type": "integer",
+            "title": "Num Agents"
+          },
+          "agent_runs": {
+            "type": "integer",
+            "title": "Agent Runs"
+          },
+          "agent_rating": {
+            "type": "number",
+            "title": "Agent Rating"
+          },
           "top_categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Top Categories"
           }
@@ -10793,14 +15348,21 @@
       "CreatorsResponse": {
         "properties": {
           "creators": {
-            "items": { "$ref": "#/components/schemas/CreatorDetails" },
+            "items": {
+              "$ref": "#/components/schemas/CreatorDetails"
+            },
             "type": "array",
             "title": "Creators"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["creators", "pagination"],
+        "required": [
+          "creators",
+          "pagination"
+        ],
         "title": "CreatorsResponse"
       },
       "CredentialsDeletionNeedsConfirmationResponse": {
@@ -10817,10 +15379,15 @@
             "title": "Need Confirmation",
             "default": true
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "CredentialsDeletionNeedsConfirmationResponse"
       },
       "CredentialsDeletionResponse": {
@@ -10832,20 +15399,39 @@
             "default": true
           },
           "revoked": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Revoked",
             "description": "Indicates whether the credentials were also revoked by their provider. `None`/`null` if not applicable, e.g. when deleting non-revocable credentials such as API keys."
           }
         },
         "type": "object",
-        "required": ["revoked"],
+        "required": [
+          "revoked"
+        ],
         "title": "CredentialsDeletionResponse"
       },
       "CredentialsMetaInput": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "provider": {
@@ -10855,42 +15441,90 @@
           },
           "type": {
             "type": "string",
-            "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
+            "enum": [
+              "api_key",
+              "oauth2",
+              "user_password",
+              "host_scoped"
+            ],
             "title": "Type"
           }
         },
         "type": "object",
-        "required": ["id", "provider", "type"],
+        "required": [
+          "id",
+          "provider",
+          "type"
+        ],
         "title": "CredentialsMetaInput",
         "credentials_provider": [],
         "credentials_types": []
       },
       "CredentialsMetaResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "type": {
             "type": "string",
-            "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
+            "enum": [
+              "api_key",
+              "oauth2",
+              "user_password",
+              "host_scoped"
+            ],
             "title": "Type"
           },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "scopes": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Scopes"
           },
           "username": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Username"
           },
           "host": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Host",
             "description": "Host pattern for host-scoped or MCP server URL for MCP credentials"
           },
@@ -10901,7 +15535,14 @@
           }
         },
         "type": "object",
-        "required": ["id", "provider", "type", "title", "scopes", "username"],
+        "required": [
+          "id",
+          "provider",
+          "type",
+          "title",
+          "scopes",
+          "username"
+        ],
         "title": "CredentialsMetaResponse"
       },
       "CreditTransactionType": {
@@ -10916,24 +15557,74 @@
         ],
         "title": "CreditTransactionType"
       },
-      "DeleteFileResponse": {
-        "properties": { "deleted": { "type": "boolean", "title": "Deleted" } },
+      "CreditTransactionsExportResponse": {
+        "properties": {
+          "transactions": {
+            "items": {
+              "$ref": "#/components/schemas/UserTransaction"
+            },
+            "type": "array",
+            "title": "Transactions"
+          },
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "window_days": {
+            "type": "integer",
+            "title": "Window Days"
+          },
+          "max_window_days": {
+            "type": "integer",
+            "title": "Max Window Days"
+          }
+        },
         "type": "object",
-        "required": ["deleted"],
+        "required": [
+          "transactions",
+          "total_rows",
+          "window_days",
+          "max_window_days"
+        ],
+        "title": "CreditTransactionsExportResponse"
+      },
+      "DeleteFileResponse": {
+        "properties": {
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted"
+          }
+        },
+        "type": "object",
+        "required": [
+          "deleted"
+        ],
         "title": "DeleteFileResponse"
       },
       "DeleteGraphResponse": {
         "properties": {
-          "version_counts": { "type": "integer", "title": "Version Counts" }
+          "version_counts": {
+            "type": "integer",
+            "title": "Version Counts"
+          }
         },
         "type": "object",
-        "required": ["version_counts"],
+        "required": [
+          "version_counts"
+        ],
         "title": "DeleteGraphResponse"
       },
       "DeleteLinkResponse": {
-        "properties": { "success": { "type": "boolean", "title": "Success" } },
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          }
+        },
         "type": "object",
-        "required": ["success"],
+        "required": [
+          "success"
+        ],
         "title": "DeleteLinkResponse"
       },
       "DiscoverToolsRequest": {
@@ -10944,34 +15635,61 @@
             "description": "URL of the MCP server"
           },
           "auth_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Auth Token",
             "description": "Optional Bearer token for authenticated MCP servers"
           }
         },
         "type": "object",
-        "required": ["server_url"],
+        "required": [
+          "server_url"
+        ],
         "title": "DiscoverToolsRequest",
         "description": "Request to discover tools on an MCP server."
       },
       "DiscoverToolsResponse": {
         "properties": {
           "tools": {
-            "items": { "$ref": "#/components/schemas/MCPToolResponse" },
+            "items": {
+              "$ref": "#/components/schemas/MCPToolResponse"
+            },
             "type": "array",
             "title": "Tools"
           },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           },
           "protocol_version": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Protocol Version"
           }
         },
         "type": "object",
-        "required": ["tools"],
+        "required": [
+          "tools"
+        ],
         "title": "DiscoverToolsResponse",
         "description": "Response containing the list of tools available on an MCP server."
       },
@@ -10981,38 +15699,97 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_page"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "title": { "type": "string", "title": "Title" },
-          "path": { "type": "string", "title": "Path" },
-          "content": { "type": "string", "title": "Content" },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
           "doc_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Doc Url"
           }
         },
         "type": "object",
-        "required": ["message", "title", "path", "content"],
+        "required": [
+          "message",
+          "title",
+          "path",
+          "content"
+        ],
         "title": "DocPageResponse",
         "description": "Response for get_doc_page tool."
       },
       "DocSearchResult": {
         "properties": {
-          "title": { "type": "string", "title": "Title" },
-          "path": { "type": "string", "title": "Path" },
-          "section": { "type": "string", "title": "Section" },
-          "snippet": { "type": "string", "title": "Snippet" },
-          "score": { "type": "number", "title": "Score" },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "section": {
+            "type": "string",
+            "title": "Section"
+          },
+          "snippet": {
+            "type": "string",
+            "title": "Snippet"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          },
           "doc_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Doc Url"
           }
         },
         "type": "object",
-        "required": ["title", "path", "section", "snippet", "score"],
+        "required": [
+          "title",
+          "path",
+          "section",
+          "snippet",
+          "score"
+        ],
         "title": "DocSearchResult",
         "description": "A single documentation search result."
       },
@@ -11022,31 +15799,63 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_search_results"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "results": {
-            "items": { "$ref": "#/components/schemas/DocSearchResult" },
+            "items": {
+              "$ref": "#/components/schemas/DocSearchResult"
+            },
             "type": "array",
             "title": "Results"
           },
-          "count": { "type": "integer", "title": "Count" },
-          "query": { "type": "string", "title": "Query" }
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          }
         },
         "type": "object",
-        "required": ["message", "results", "count", "query"],
+        "required": [
+          "message",
+          "results",
+          "count",
+          "query"
+        ],
         "title": "DocSearchResultsResponse",
         "description": "Response for search_docs tool."
       },
       "Document": {
         "properties": {
-          "url": { "type": "string", "title": "Url" },
-          "relevance_score": { "type": "number", "title": "Relevance Score" }
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "relevance_score": {
+            "type": "number",
+            "title": "Relevance Score"
+          }
         },
         "type": "object",
-        "required": ["url", "relevance_score"],
+        "required": [
+          "url",
+          "relevance_score"
+        ],
         "title": "Document"
       },
       "ErrorResponse": {
@@ -11055,32 +15864,58 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "error"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "error": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error"
           },
           "details": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Details"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "ErrorResponse",
         "description": "Response for errors."
       },
       "ExecutionAnalyticsConfig": {
         "properties": {
           "available_models": {
-            "items": { "$ref": "#/components/schemas/ModelInfo" },
+            "items": {
+              "$ref": "#/components/schemas/ModelInfo"
+            },
             "type": "array",
             "title": "Available Models"
           },
@@ -11114,19 +15949,38 @@
             "description": "Graph ID to analyze"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version",
             "description": "Optional graph version"
           },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id",
             "description": "Optional user ID filter"
           },
           "created_after": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Created After",
             "description": "Optional created date lower bound"
@@ -11146,12 +16000,26 @@
             "default": 10
           },
           "system_prompt": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "System Prompt",
             "description": "Custom system prompt (default: built-in prompt)"
           },
           "user_prompt": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Prompt",
             "description": "Custom user prompt with {{GRAPH_NAME}} and {{EXECUTION_DATA}} placeholders (default: built-in prompt)"
           },
@@ -11163,7 +16031,9 @@
           }
         },
         "type": "object",
-        "required": ["graph_id"],
+        "required": [
+          "graph_id"
+        ],
         "title": "ExecutionAnalyticsRequest"
       },
       "ExecutionAnalyticsResponse": {
@@ -11209,34 +16079,80 @@
       },
       "ExecutionAnalyticsResult": {
         "properties": {
-          "agent_id": { "type": "string", "title": "Agent Id" },
-          "version_id": { "type": "integer", "title": "Version Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "exec_id": { "type": "string", "title": "Exec Id" },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "version_id": {
+            "type": "integer",
+            "title": "Version Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "exec_id": {
+            "type": "string",
+            "title": "Exec Id"
+          },
           "summary_text": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Summary Text"
           },
           "score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Score"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "error_message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error Message"
           },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At"
           }
@@ -11275,13 +16191,22 @@
             "type": "integer",
             "title": "Orphaned Running"
           },
-          "orphaned_queued": { "type": "integer", "title": "Orphaned Queued" },
-          "failed_count_1h": { "type": "integer", "title": "Failed Count 1H" },
+          "orphaned_queued": {
+            "type": "integer",
+            "title": "Orphaned Queued"
+          },
+          "failed_count_1h": {
+            "type": "integer",
+            "title": "Failed Count 1H"
+          },
           "failed_count_24h": {
             "type": "integer",
             "title": "Failed Count 24H"
           },
-          "failure_rate_24h": { "type": "number", "title": "Failure Rate 24H" },
+          "failure_rate_24h": {
+            "type": "number",
+            "title": "Failure Rate 24H"
+          },
           "stuck_running_24h": {
             "type": "integer",
             "title": "Stuck Running 24H"
@@ -11291,10 +16216,20 @@
             "title": "Stuck Running 1H"
           },
           "oldest_running_hours": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Oldest Running Hours"
           },
-          "stuck_queued_1h": { "type": "integer", "title": "Stuck Queued 1H" },
+          "stuck_queued_1h": {
+            "type": "integer",
+            "title": "Stuck Queued 1H"
+          },
           "queued_never_started": {
             "type": "integer",
             "title": "Queued Never Started"
@@ -11307,13 +16242,22 @@
             "type": "integer",
             "title": "Invalid Running Without Start"
           },
-          "completed_1h": { "type": "integer", "title": "Completed 1H" },
-          "completed_24h": { "type": "integer", "title": "Completed 24H" },
+          "completed_1h": {
+            "type": "integer",
+            "title": "Completed 1H"
+          },
+          "completed_24h": {
+            "type": "integer",
+            "title": "Completed 24H"
+          },
           "throughput_per_hour": {
             "type": "number",
             "title": "Throughput Per Hour"
           },
-          "timestamp": { "type": "string", "title": "Timestamp" }
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          }
         },
         "type": "object",
         "required": [
@@ -11343,13 +16287,21 @@
       },
       "ExecutionOptions": {
         "properties": {
-          "manual": { "type": "boolean", "title": "Manual", "default": true },
+          "manual": {
+            "type": "boolean",
+            "title": "Manual",
+            "default": true
+          },
           "scheduled": {
             "type": "boolean",
             "title": "Scheduled",
             "default": true
           },
-          "webhook": { "type": "boolean", "title": "Webhook", "default": false }
+          "webhook": {
+            "type": "boolean",
+            "title": "Webhook",
+            "default": false
+          }
         },
         "type": "object",
         "title": "ExecutionOptions",
@@ -11357,47 +16309,80 @@
       },
       "ExecutionOutputInfo": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "status": { "type": "string", "title": "Status" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At"
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           },
           "inputs_summary": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs Summary"
           },
           "node_executions": {
             "anyOf": [
               {
-                "items": { "additionalProperties": true, "type": "object" },
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Node Executions"
           }
         },
         "type": "object",
-        "required": ["execution_id", "status", "outputs"],
+        "required": [
+          "execution_id",
+          "status",
+          "outputs"
+        ],
         "title": "ExecutionOutputInfo",
         "description": "Summary of a single execution's outputs."
       },
@@ -11407,41 +16392,108 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "execution_started"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
           "library_agent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Library Agent Link"
           },
-          "status": { "type": "string", "title": "Status", "default": "QUEUED" }
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "QUEUED"
+          }
         },
         "type": "object",
-        "required": ["message", "execution_id", "graph_id", "graph_name"],
+        "required": [
+          "message",
+          "execution_id",
+          "graph_id",
+          "graph_name"
+        ],
         "title": "ExecutionStartedResponse",
         "description": "Response for run/schedule actions."
       },
       "FailedExecutionDetail": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -11449,20 +16501,37 @@
           },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "failed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Failed At"
           },
           "error_message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error Message"
           }
         },
@@ -11486,14 +16555,22 @@
       "FailedExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": { "$ref": "#/components/schemas/FailedExecutionDetail" },
+            "items": {
+              "$ref": "#/components/schemas/FailedExecutionDetail"
+            },
             "type": "array",
             "title": "Executions"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
-        "required": ["executions", "total"],
+        "required": [
+          "executions",
+          "total"
+        ],
         "title": "FailedExecutionsListResponse",
         "description": "Response model for list of failed executions"
       },
@@ -11506,45 +16583,80 @@
             "title": "Name"
           },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
             "anyOf": [
-              { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "pattern": "^#[0-9A-Fa-f]{6}$"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Color",
             "description": "Hex color code (#RRGGBB)"
           },
           "parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
           }
         },
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "FolderCreateRequest",
         "description": "Request model for creating a folder."
       },
       "FolderListResponse": {
         "properties": {
           "folders": {
-            "items": { "$ref": "#/components/schemas/LibraryFolder" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryFolder"
+            },
             "type": "array",
             "title": "Folders"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["folders", "pagination"],
+        "required": [
+          "folders",
+          "pagination"
+        ],
         "title": "FolderListResponse",
         "description": "Response schema for a list of folders."
       },
       "FolderMoveRequest": {
         "properties": {
           "target_parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Target Parent Id"
           }
         },
@@ -11555,13 +16667,17 @@
       "FolderTreeResponse": {
         "properties": {
           "tree": {
-            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryFolderTree"
+            },
             "type": "array",
             "title": "Tree"
           }
         },
         "type": "object",
-        "required": ["tree"],
+        "required": [
+          "tree"
+        ],
         "title": "FolderTreeResponse",
         "description": "Response schema for folder tree structure."
       },
@@ -11569,17 +16685,37 @@
         "properties": {
           "name": {
             "anyOf": [
-              { "type": "string", "maxLength": 100, "minLength": 1 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 100,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Name"
           },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Color"
           }
         },
@@ -11589,58 +16725,120 @@
       },
       "Graph": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/Node" },
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": { "$ref": "#/components/schemas/BaseGraph-Input" },
+            "items": {
+              "$ref": "#/components/schemas/BaseGraph-Input"
+            },
             "type": "array",
             "title": "Sub Graphs"
           }
         },
         "type": "object",
-        "required": ["name", "description"],
+        "required": [
+          "name",
+          "description"
+        ],
         "title": "Graph",
         "description": "Creatable graph model used in API create/update endpoints."
       },
       "GraphExecution": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -11654,7 +16852,9 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credential Inputs"
           },
@@ -11667,27 +16867,48 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Preset Id"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -11698,7 +16919,14 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -11708,12 +16936,19 @@
           },
           "stats": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Stats" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Stats"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           }
@@ -11737,17 +16972,43 @@
       "GraphExecutionJobInfo": {
         "properties": {
           "schedule_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Schedule Id"
           },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "agent_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Name"
           },
-          "cron": { "type": "string", "title": "Cron" },
+          "cron": {
+            "type": "string",
+            "title": "Cron"
+          },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
@@ -11760,9 +17021,18 @@
             "type": "object",
             "title": "Input Credentials"
           },
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          },
           "timezone": {
             "type": "string",
             "title": "Timezone",
@@ -11785,14 +17055,31 @@
       },
       "GraphExecutionMeta": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs"
           },
@@ -11804,7 +17091,9 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credential Inputs"
           },
@@ -11817,27 +17106,48 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Preset Id"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -11848,7 +17158,14 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -11858,8 +17175,12 @@
           },
           "stats": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Stats" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Stats"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -11880,10 +17201,22 @@
       },
       "GraphExecutionWithNodes": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -11897,7 +17230,9 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credential Inputs"
           },
@@ -11910,27 +17245,48 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Preset Id"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -11941,7 +17297,14 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -11951,17 +17314,26 @@
           },
           "stats": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Stats" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Stats"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           },
           "node_executions": {
-            "items": { "$ref": "#/components/schemas/NodeExecutionResult" },
+            "items": {
+              "$ref": "#/components/schemas/NodeExecutionResult"
+            },
             "type": "array",
             "title": "Node Executions"
           }
@@ -11986,45 +17358,95 @@
       "GraphExecutionsPaginated": {
         "properties": {
           "executions": {
-            "items": { "$ref": "#/components/schemas/GraphExecutionMeta" },
+            "items": {
+              "$ref": "#/components/schemas/GraphExecutionMeta"
+            },
             "type": "array",
             "title": "Executions"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["executions", "pagination"],
+        "required": [
+          "executions",
+          "pagination"
+        ],
         "title": "GraphExecutionsPaginated",
         "description": "Response schema for paginated graph executions."
       },
       "GraphMeta": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12045,49 +17467,99 @@
       },
       "GraphModel": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "nodes": {
-            "items": { "$ref": "#/components/schemas/NodeModel" },
+            "items": {
+              "$ref": "#/components/schemas/NodeModel"
+            },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": { "$ref": "#/components/schemas/BaseGraph-Output" },
+            "items": {
+              "$ref": "#/components/schemas/BaseGraph-Output"
+            },
             "type": "array",
             "title": "Sub Graphs"
           },
@@ -12120,8 +17592,12 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ],
             "readOnly": true
           },
@@ -12151,32 +17627,76 @@
       },
       "GraphModelWithoutNodes": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "version": { "type": "integer", "title": "Version", "default": 1 },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version",
+            "default": 1
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Forked From Version"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12211,8 +17731,12 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ],
             "readOnly": true
           },
@@ -12253,7 +17777,14 @@
             "default": false
           },
           "builder_chat_session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Builder Chat Session Id"
           }
         },
@@ -12274,18 +17805,31 @@
             "description": "Input schema for the trigger block"
           },
           "credentials_input_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Credentials Input Name"
           }
         },
         "type": "object",
-        "required": ["provider", "config_schema", "credentials_input_name"],
+        "required": [
+          "provider",
+          "config_schema",
+          "credentials_input_name"
+        ],
         "title": "GraphTriggerInfo"
       },
       "HTTPValidationError": {
         "properties": {
           "detail": {
-            "items": { "$ref": "#/components/schemas/ValidationError" },
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
             "type": "array",
             "title": "Detail"
           }
@@ -12295,10 +17839,23 @@
       },
       "HostScopedCredentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -12334,15 +17891,23 @@
           }
         },
         "type": "object",
-        "required": ["provider", "host"],
+        "required": [
+          "provider",
+          "host"
+        ],
         "title": "HostScopedCredentials"
       },
       "ImageURLResponse": {
         "properties": {
-          "image_url": { "type": "string", "title": "Image Url" }
+          "image_url": {
+            "type": "string",
+            "title": "Image Url"
+          }
         },
         "type": "object",
-        "required": ["image_url"],
+        "required": [
+          "image_url"
+        ],
         "title": "ImageURLResponse"
       },
       "InputValidationErrorResponse": {
@@ -12351,13 +17916,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "input_validation_error"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "unrecognized_fields": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Unrecognized Fields",
             "description": "List of input field names that were not recognized"
@@ -12369,34 +17946,73 @@
             "description": "The agent's valid input schema for reference"
           },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           }
         },
         "type": "object",
-        "required": ["message", "unrecognized_fields", "inputs"],
+        "required": [
+          "message",
+          "unrecognized_fields",
+          "inputs"
+        ],
         "title": "InputValidationErrorResponse",
         "description": "Response when run_agent receives unknown input fields."
       },
       "LibraryAgent": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "image_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Image Url"
           },
-          "creator_name": { "type": "string", "title": "Creator Name" },
+          "creator_name": {
+            "type": "string",
+            "title": "Creator Name"
+          },
           "creator_image_url": {
             "type": "string",
             "title": "Creator Image Url"
           },
-          "status": { "$ref": "#/components/schemas/LibraryAgentStatus" },
+          "status": {
+            "$ref": "#/components/schemas/LibraryAgentStatus"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12407,10 +18023,23 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "input_schema": {
@@ -12425,8 +18054,13 @@
           },
           "credentials_input_schema": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Credentials Input Schema",
             "description": "Input schema for credentials required by the agent"
@@ -12448,26 +18082,49 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphTriggerInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphTriggerInfo"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
-          "new_output": { "type": "boolean", "title": "New Output" },
+          "new_output": {
+            "type": "boolean",
+            "title": "New Output"
+          },
           "execution_count": {
             "type": "integer",
             "title": "Execution Count",
             "default": 0
           },
           "success_rate": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Success Rate"
           },
           "avg_correctness_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avg Correctness Score"
           },
           "recent_executions": {
-            "items": { "$ref": "#/components/schemas/RecentExecution" },
+            "items": {
+              "$ref": "#/components/schemas/RecentExecution"
+            },
             "type": "array",
             "title": "Recent Executions",
             "description": "List of recent executions with status, score, and summary"
@@ -12481,17 +18138,41 @@
             "type": "boolean",
             "title": "Is Latest Version"
           },
-          "is_favorite": { "type": "boolean", "title": "Is Favorite" },
+          "is_favorite": {
+            "type": "boolean",
+            "title": "Is Favorite"
+          },
           "folder_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Id"
           },
           "folder_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Name"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "is_scheduled": {
@@ -12501,15 +18182,28 @@
             "default": false
           },
           "next_scheduled_run": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Next Scheduled Run",
             "description": "ISO 8601 timestamp of the next scheduled run, if any"
           },
-          "settings": { "$ref": "#/components/schemas/GraphSettings" },
+          "settings": {
+            "$ref": "#/components/schemas/GraphSettings"
+          },
           "marketplace_listing": {
             "anyOf": [
-              { "$ref": "#/components/schemas/MarketplaceListing" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/MarketplaceListing"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -12542,8 +18236,14 @@
       },
       "LibraryAgentPreset": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -12556,19 +18256,38 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Webhook Id"
           },
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -12581,8 +18300,12 @@
           },
           "webhook": {
             "anyOf": [
-              { "$ref": "#/components/schemas/Webhook" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/Webhook"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -12605,8 +18328,14 @@
       },
       "LibraryAgentPresetCreatable": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -12619,15 +18348,28 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Webhook Id"
           }
         },
@@ -12649,8 +18391,14 @@
             "type": "string",
             "title": "Graph Execution Id"
           },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
@@ -12658,21 +18406,32 @@
           }
         },
         "type": "object",
-        "required": ["graph_execution_id", "name", "description"],
+        "required": [
+          "graph_execution_id",
+          "name",
+          "description"
+        ],
         "title": "LibraryAgentPresetCreatableFromGraphExecution",
         "description": "Request model used when creating a new preset for a library agent."
       },
       "LibraryAgentPresetResponse": {
         "properties": {
           "presets": {
-            "items": { "$ref": "#/components/schemas/LibraryAgentPreset" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryAgentPreset"
+            },
             "type": "array",
             "title": "Presets"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["presets", "pagination"],
+        "required": [
+          "presets",
+          "pagination"
+        ],
         "title": "LibraryAgentPresetResponse",
         "description": "Response schema for a list of agent presets and pagination info."
       },
@@ -12680,8 +18439,13 @@
         "properties": {
           "inputs": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Inputs"
           },
@@ -12693,20 +18457,43 @@
                 },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Credentials"
           },
           "name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Name"
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "is_active": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Active"
           }
         },
@@ -12717,59 +18504,113 @@
       "LibraryAgentResponse": {
         "properties": {
           "agents": {
-            "items": { "$ref": "#/components/schemas/LibraryAgent" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryAgent"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["agents", "pagination"],
+        "required": [
+          "agents",
+          "pagination"
+        ],
         "title": "LibraryAgentResponse",
         "description": "Response schema for a list of library agents and pagination info."
       },
       "LibraryAgentSort": {
         "type": "string",
-        "enum": ["createdAt", "updatedAt"],
+        "enum": [
+          "createdAt",
+          "updatedAt"
+        ],
         "title": "LibraryAgentSort",
         "description": "Possible sort options for sorting library agents."
       },
       "LibraryAgentStatus": {
         "type": "string",
-        "enum": ["COMPLETED", "HEALTHY", "WAITING", "ERROR"],
+        "enum": [
+          "COMPLETED",
+          "HEALTHY",
+          "WAITING",
+          "ERROR"
+        ],
         "title": "LibraryAgentStatus"
       },
       "LibraryAgentUpdateRequest": {
         "properties": {
           "auto_update_version": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Auto Update Version",
             "description": "Auto-update the agent version"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version",
             "description": "Specific graph version to update to"
           },
           "is_favorite": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Favorite",
             "description": "Mark the agent as a favorite"
           },
           "is_archived": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Archived",
             "description": "Archive the agent"
           },
           "settings": {
             "anyOf": [
-              { "$ref": "#/components/schemas/GraphSettings" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/GraphSettings"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "User-specific settings for this library agent"
           },
           "folder_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Folder Id",
             "description": "Folder ID to move agent to (None to move to root)"
           }
@@ -12780,19 +18621,49 @@
       },
       "LibraryFolder": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
           },
           "created_at": {
@@ -12817,25 +18688,61 @@
           }
         },
         "type": "object",
-        "required": ["id", "user_id", "name", "created_at", "updated_at"],
+        "required": [
+          "id",
+          "user_id",
+          "name",
+          "created_at",
+          "updated_at"
+        ],
         "title": "LibraryFolder",
         "description": "Represents a folder for organizing library agents."
       },
       "LibraryFolderTree": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "icon": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
           },
           "created_at": {
@@ -12859,24 +18766,47 @@
             "default": 0
           },
           "children": {
-            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
+            "items": {
+              "$ref": "#/components/schemas/LibraryFolderTree"
+            },
             "type": "array",
             "title": "Children",
             "default": []
           }
         },
         "type": "object",
-        "required": ["id", "user_id", "name", "created_at", "updated_at"],
+        "required": [
+          "id",
+          "user_id",
+          "name",
+          "created_at",
+          "updated_at"
+        ],
         "title": "LibraryFolderTree",
         "description": "Folder with nested children for tree view."
       },
       "Link": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "source_id": { "type": "string", "title": "Source Id" },
-          "sink_id": { "type": "string", "title": "Sink Id" },
-          "source_name": { "type": "string", "title": "Source Name" },
-          "sink_name": { "type": "string", "title": "Sink Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "source_id": {
+            "type": "string",
+            "title": "Source Id"
+          },
+          "sink_id": {
+            "type": "string",
+            "title": "Sink Id"
+          },
+          "source_name": {
+            "type": "string",
+            "title": "Source Name"
+          },
+          "sink_name": {
+            "type": "string",
+            "title": "Sink Name"
+          },
           "is_static": {
             "type": "boolean",
             "title": "Is Static",
@@ -12884,35 +18814,64 @@
           }
         },
         "type": "object",
-        "required": ["source_id", "sink_id", "source_name", "sink_name"],
+        "required": [
+          "source_id",
+          "sink_id",
+          "source_name",
+          "sink_name"
+        ],
         "title": "Link"
       },
       "LinkTokenInfoResponse": {
         "properties": {
-          "platform": { "type": "string", "title": "Platform" },
-          "link_type": { "$ref": "#/components/schemas/LinkType" },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "link_type": {
+            "$ref": "#/components/schemas/LinkType"
+          },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           }
         },
         "type": "object",
-        "required": ["platform", "link_type"],
+        "required": [
+          "platform",
+          "link_type"
+        ],
         "title": "LinkTokenInfoResponse"
       },
       "LinkType": {
         "type": "string",
-        "enum": ["SERVER", "USER"],
+        "enum": [
+          "SERVER",
+          "USER"
+        ],
         "title": "LinkType"
       },
       "ListFilesResponse": {
         "properties": {
           "files": {
-            "items": { "$ref": "#/components/schemas/WorkspaceFileItem" },
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceFileItem"
+            },
             "type": "array",
             "title": "Files"
           },
-          "offset": { "type": "integer", "title": "Offset", "default": 0 },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "default": 0
+          },
           "has_more": {
             "type": "boolean",
             "title": "Has More",
@@ -12920,20 +18879,30 @@
           }
         },
         "type": "object",
-        "required": ["files"],
+        "required": [
+          "files"
+        ],
         "title": "ListFilesResponse"
       },
       "ListSessionsResponse": {
         "properties": {
           "sessions": {
-            "items": { "$ref": "#/components/schemas/SessionSummaryResponse" },
+            "items": {
+              "$ref": "#/components/schemas/SessionSummaryResponse"
+            },
             "type": "array",
             "title": "Sessions"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
-        "required": ["sessions", "total"],
+        "required": [
+          "sessions",
+          "total"
+        ],
         "title": "ListSessionsResponse",
         "description": "Response model for listing chat sessions."
       },
@@ -12944,7 +18913,10 @@
             "minLength": 1,
             "title": "Metric Name"
           },
-          "metric_value": { "type": "number", "title": "Metric Value" },
+          "metric_value": {
+            "type": "number",
+            "title": "Metric Value"
+          },
           "data_string": {
             "type": "string",
             "minLength": 1,
@@ -12952,16 +18924,29 @@
           }
         },
         "type": "object",
-        "required": ["metric_name", "metric_value", "data_string"],
+        "required": [
+          "metric_name",
+          "metric_value",
+          "data_string"
+        ],
         "title": "LogRawMetricRequest"
       },
       "LoginResponse": {
         "properties": {
-          "login_url": { "type": "string", "title": "Login Url" },
-          "state_token": { "type": "string", "title": "State Token" }
+          "login_url": {
+            "type": "string",
+            "title": "Login Url"
+          },
+          "state_token": {
+            "type": "string",
+            "title": "State Token"
+          }
         },
         "type": "object",
-        "required": ["login_url", "state_token"],
+        "required": [
+          "login_url",
+          "state_token"
+        ],
         "title": "LoginResponse"
       },
       "MCPOAuthCallbackRequest": {
@@ -12978,7 +18963,10 @@
           }
         },
         "type": "object",
-        "required": ["code", "state_token"],
+        "required": [
+          "code",
+          "state_token"
+        ],
         "title": "MCPOAuthCallbackRequest",
         "description": "Request to exchange an OAuth code for tokens."
       },
@@ -12991,17 +18979,28 @@
           }
         },
         "type": "object",
-        "required": ["server_url"],
+        "required": [
+          "server_url"
+        ],
         "title": "MCPOAuthLoginRequest",
         "description": "Request to start an OAuth flow for an MCP server."
       },
       "MCPOAuthLoginResponse": {
         "properties": {
-          "login_url": { "type": "string", "title": "Login Url" },
-          "state_token": { "type": "string", "title": "State Token" }
+          "login_url": {
+            "type": "string",
+            "title": "Login Url"
+          },
+          "state_token": {
+            "type": "string",
+            "title": "State Token"
+          }
         },
         "type": "object",
-        "required": ["login_url", "state_token"],
+        "required": [
+          "login_url",
+          "state_token"
+        ],
         "title": "MCPOAuthLoginResponse",
         "description": "Response with the OAuth login URL for the user to authenticate."
       },
@@ -13022,14 +19021,23 @@
           }
         },
         "type": "object",
-        "required": ["server_url", "token"],
+        "required": [
+          "server_url",
+          "token"
+        ],
         "title": "MCPStoreTokenRequest",
         "description": "Request to store a bearer token for an MCP server that doesn't support OAuth."
       },
       "MCPToolInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -13037,7 +19045,11 @@
           }
         },
         "type": "object",
-        "required": ["name", "description", "input_schema"],
+        "required": [
+          "name",
+          "description",
+          "input_schema"
+        ],
         "title": "MCPToolInfo",
         "description": "Information about a single MCP tool discovered from a server."
       },
@@ -13047,25 +19059,57 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tool_output"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "server_url": { "type": "string", "title": "Server Url" },
-          "tool_name": { "type": "string", "title": "Tool Name" },
-          "result": { "title": "Result" },
-          "success": { "type": "boolean", "title": "Success", "default": true }
+          "server_url": {
+            "type": "string",
+            "title": "Server Url"
+          },
+          "tool_name": {
+            "type": "string",
+            "title": "Tool Name"
+          },
+          "result": {
+            "title": "Result"
+          },
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": true
+          }
         },
         "type": "object",
-        "required": ["message", "server_url", "tool_name"],
+        "required": [
+          "message",
+          "server_url",
+          "tool_name"
+        ],
         "title": "MCPToolOutputResponse",
         "description": "Response after executing an MCP tool."
       },
       "MCPToolResponse": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -13073,7 +19117,11 @@
           }
         },
         "type": "object",
-        "required": ["name", "description", "input_schema"],
+        "required": [
+          "name",
+          "description",
+          "input_schema"
+        ],
         "title": "MCPToolResponse",
         "description": "A single MCP tool returned by discovery."
       },
@@ -13083,45 +19131,91 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tools_discovered"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "server_url": { "type": "string", "title": "Server Url" },
+          "server_url": {
+            "type": "string",
+            "title": "Server Url"
+          },
           "tools": {
-            "items": { "$ref": "#/components/schemas/MCPToolInfo" },
+            "items": {
+              "$ref": "#/components/schemas/MCPToolInfo"
+            },
             "type": "array",
             "title": "Tools"
           }
         },
         "type": "object",
-        "required": ["message", "server_url", "tools"],
+        "required": [
+          "message",
+          "server_url",
+          "tools"
+        ],
         "title": "MCPToolsDiscoveredResponse",
         "description": "Response when MCP tools are discovered from a server (agent-internal)."
       },
       "MarketplaceListing": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "slug": { "type": "string", "title": "Slug" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "creator": {
             "$ref": "#/components/schemas/MarketplaceListingCreator"
           }
         },
         "type": "object",
-        "required": ["id", "name", "slug", "creator"],
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "creator"
+        ],
         "title": "MarketplaceListing",
         "description": "Marketplace listing information for a library agent."
       },
       "MarketplaceListingCreator": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "id": { "type": "string", "title": "Id" },
-          "slug": { "type": "string", "title": "Slug" }
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          }
         },
         "type": "object",
-        "required": ["name", "id", "slug"],
+        "required": [
+          "name",
+          "id",
+          "slug"
+        ],
         "title": "MarketplaceListingCreator",
         "description": "Creator information for a marketplace listing."
       },
@@ -13131,14 +19225,26 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_candidates"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "candidates": {
             "items": {
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "type": "string"
+              },
               "type": "object"
             },
             "type": "array",
@@ -13146,7 +19252,9 @@
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "MemoryForgetCandidatesResponse",
         "description": "Response with candidate memories to forget."
       },
@@ -13156,24 +19264,40 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_confirm"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "deleted_uuids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Deleted Uuids"
           },
           "failed_uuids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Failed Uuids"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "MemoryForgetConfirmResponse",
         "description": "Response after deleting specific memory edges."
       },
@@ -13183,24 +19307,40 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_search"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "facts": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Facts"
           },
           "recent_episodes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Recent Episodes"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "MemorySearchResponse",
         "description": "Response when memories are searched."
       },
@@ -13210,54 +19350,118 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_store"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "memory_name": { "type": "string", "title": "Memory Name" }
+          "memory_name": {
+            "type": "string",
+            "title": "Memory Name"
+          }
         },
         "type": "object",
-        "required": ["message", "memory_name"],
+        "required": [
+          "message",
+          "memory_name"
+        ],
         "title": "MemoryStoreResponse",
         "description": "Response when a memory is stored."
       },
       "Message": {
         "properties": {
-          "query": { "type": "string", "title": "Query" },
-          "response": { "type": "string", "title": "Response" }
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
+          "response": {
+            "type": "string",
+            "title": "Response"
+          }
         },
         "type": "object",
-        "required": ["query", "response"],
+        "required": [
+          "query",
+          "response"
+        ],
         "title": "Message"
       },
       "ModelInfo": {
         "properties": {
-          "value": { "type": "string", "title": "Value" },
-          "label": { "type": "string", "title": "Label" },
-          "provider": { "type": "string", "title": "Provider" }
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          }
         },
         "type": "object",
-        "required": ["value", "label", "provider"],
+        "required": [
+          "value",
+          "label",
+          "provider"
+        ],
         "title": "ModelInfo"
       },
       "MyUnpublishedAgent": {
         "properties": {
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
           "agent_image": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Image"
           },
-          "description": { "type": "string", "title": "Description" },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "last_edited": {
             "type": "string",
             "format": "date-time",
             "title": "Last Edited"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -13274,14 +19478,21 @@
       "MyUnpublishedAgentsResponse": {
         "properties": {
           "agents": {
-            "items": { "$ref": "#/components/schemas/MyUnpublishedAgent" },
+            "items": {
+              "$ref": "#/components/schemas/MyUnpublishedAgent"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["agents", "pagination"],
+        "required": [
+          "agents",
+          "pagination"
+        ],
         "title": "MyUnpublishedAgentsResponse"
       },
       "NeedLoginResponse": {
@@ -13290,21 +19501,38 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "need_login"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "agent_info": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Agent Info"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "NeedLoginResponse",
         "description": "Response when login is needed."
       },
@@ -13314,28 +19542,52 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "no_results"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "suggestions": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Suggestions",
             "default": []
           },
-          "name": { "type": "string", "title": "Name", "default": "no_results" }
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "default": "no_results"
+          }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "NoResultsResponse",
         "description": "Response when no agents found."
       },
       "Node": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "block_id": { "type": "string", "title": "Block Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -13347,37 +19599,69 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Output Links"
           }
         },
         "type": "object",
-        "required": ["block_id"],
+        "required": [
+          "block_id"
+        ],
         "title": "Node"
       },
       "NodeExecutionResult": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "graph_exec_id": { "type": "string", "title": "Graph Exec Id" },
-          "node_exec_id": { "type": "string", "title": "Node Exec Id" },
-          "node_id": { "type": "string", "title": "Node Id" },
-          "block_id": { "type": "string", "title": "Block Id" },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "graph_exec_id": {
+            "type": "string",
+            "title": "Graph Exec Id"
+          },
+          "node_exec_id": {
+            "type": "string",
+            "title": "Node Exec Id"
+          },
+          "node_id": {
+            "type": "string",
+            "title": "Node Id"
+          },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
             "title": "Input Data"
           },
           "output_data": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Output Data"
           },
@@ -13388,22 +19672,37 @@
           },
           "queue_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Queue Time"
           },
           "start_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Start Time"
           },
           "end_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "End Time"
           }
@@ -13429,8 +19728,14 @@
       },
       "NodeModel": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "block_id": { "type": "string", "title": "Block Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "block_id": {
+            "type": "string",
+            "title": "Block Id"
+          },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -13442,32 +19747,62 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": { "$ref": "#/components/schemas/Link" },
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
             "type": "array",
             "title": "Output Links"
           },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "webhook_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Webhook Id"
           }
         },
         "type": "object",
-        "required": ["block_id", "graph_id", "graph_version"],
+        "required": [
+          "block_id",
+          "graph_id",
+          "graph_version"
+        ],
         "title": "NodeModel"
       },
       "NotificationPreference": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "email": { "type": "string", "format": "email", "title": "Email" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
           "preferences": {
-            "additionalProperties": { "type": "boolean" },
+            "additionalProperties": {
+              "type": "boolean"
+            },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -13492,7 +19827,10 @@
           }
         },
         "type": "object",
-        "required": ["user_id", "email"],
+        "required": [
+          "user_id",
+          "email"
+        ],
         "title": "NotificationPreference"
       },
       "NotificationPreferenceDTO": {
@@ -13504,7 +19842,9 @@
             "description": "User's email address"
           },
           "preferences": {
-            "additionalProperties": { "type": "boolean" },
+            "additionalProperties": {
+              "type": "boolean"
+            },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -13519,7 +19859,11 @@
           }
         },
         "type": "object",
-        "required": ["email", "preferences", "daily_limit"],
+        "required": [
+          "email",
+          "preferences",
+          "daily_limit"
+        ],
         "title": "NotificationPreferenceDTO"
       },
       "NotificationType": {
@@ -13542,10 +19886,23 @@
       },
       "OAuth2Credentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -13565,7 +19922,14 @@
             "default": "oauth2"
           },
           "username": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Username"
           },
           "access_token": {
@@ -13575,60 +19939,121 @@
             "writeOnly": true
           },
           "access_token_expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Access Token Expires At"
           },
           "refresh_token": {
             "anyOf": [
-              { "type": "string", "format": "password", "writeOnly": true },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Refresh Token"
           },
           "refresh_token_expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes"
           }
         },
         "type": "object",
-        "required": ["provider", "access_token", "scopes"],
+        "required": [
+          "provider",
+          "access_token",
+          "scopes"
+        ],
         "title": "OAuth2Credentials"
       },
       "OAuthApplicationInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Logo Url"
           },
-          "client_id": { "type": "string", "title": "Client Id" },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
           "redirect_uris": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Redirect Uris"
           },
           "grant_types": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Grant Types"
           },
           "scopes": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Scopes"
           },
-          "owner_id": { "type": "string", "title": "Owner Id" },
-          "is_active": { "type": "boolean", "title": "Is Active" },
+          "owner_id": {
+            "type": "string",
+            "title": "Owner Id"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -13658,23 +20083,45 @@
       },
       "OAuthApplicationPublicInfo": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Logo Url"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes"
           }
         },
         "type": "object",
-        "required": ["name", "scopes"],
+        "required": [
+          "name",
+          "scopes"
+        ],
         "title": "OAuthApplicationPublicInfo",
         "description": "Public information about an OAuth application (for consent screen)"
       },
@@ -13693,23 +20140,33 @@
             "title": "User Role"
           },
           "pain_points": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "maxItems": 20,
             "title": "Pain Points"
           }
         },
         "type": "object",
-        "required": ["user_name", "user_role"],
+        "required": [
+          "user_name",
+          "user_role"
+        ],
         "title": "OnboardingProfileRequest",
         "description": "Request body for onboarding profile submission."
       },
       "OnboardingStatusResponse": {
         "properties": {
-          "is_completed": { "type": "boolean", "title": "Is Completed" }
+          "is_completed": {
+            "type": "boolean",
+            "title": "Is Completed"
+          }
         },
         "type": "object",
-        "required": ["is_completed"],
+        "required": [
+          "is_completed"
+        ],
         "title": "OnboardingStatusResponse",
         "description": "Response for onboarding completion check."
       },
@@ -13743,17 +20200,45 @@
       },
       "OrphanedScheduleDetail": {
         "properties": {
-          "schedule_id": { "type": "string", "title": "Schedule Id" },
-          "schedule_name": { "type": "string", "title": "Schedule Name" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "orphan_reason": { "type": "string", "title": "Orphan Reason" },
+          "schedule_id": {
+            "type": "string",
+            "title": "Schedule Id"
+          },
+          "schedule_name": {
+            "type": "string",
+            "title": "Schedule Name"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "orphan_reason": {
+            "type": "string",
+            "title": "Orphan Reason"
+          },
           "error_detail": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error Detail"
           },
-          "next_run_time": { "type": "string", "title": "Next Run Time" }
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          }
         },
         "type": "object",
         "required": [
@@ -13772,14 +20257,22 @@
       "OrphanedSchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": { "$ref": "#/components/schemas/OrphanedScheduleDetail" },
+            "items": {
+              "$ref": "#/components/schemas/OrphanedScheduleDetail"
+            },
             "type": "array",
             "title": "Schedules"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
-        "required": ["schedules", "total"],
+        "required": [
+          "schedules",
+          "total"
+        ],
         "title": "OrphanedSchedulesListResponse",
         "description": "Response model for list of orphaned schedules"
       },
@@ -13789,42 +20282,63 @@
             "type": "integer",
             "title": "Total Items",
             "description": "Total number of items.",
-            "examples": [42]
+            "examples": [
+              42
+            ]
           },
           "total_pages": {
             "type": "integer",
             "title": "Total Pages",
             "description": "Total number of pages.",
-            "examples": [2]
+            "examples": [
+              2
+            ]
           },
           "current_page": {
             "type": "integer",
             "title": "Current Page",
             "description": "Current_page page number.",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           },
           "page_size": {
             "type": "integer",
             "title": "Page Size",
             "description": "Number of items per page.",
-            "examples": [25]
+            "examples": [
+              25
+            ]
           }
         },
         "type": "object",
-        "required": ["total_items", "total_pages", "current_page", "page_size"],
+        "required": [
+          "total_items",
+          "total_pages",
+          "current_page",
+          "page_size"
+        ],
         "title": "Pagination"
       },
       "PeekPendingMessagesResponse": {
         "properties": {
           "messages": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Messages"
           },
-          "count": { "type": "integer", "title": "Count" }
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
         },
         "type": "object",
-        "required": ["messages", "count"],
+        "required": [
+          "messages",
+          "count"
+        ],
         "title": "PeekPendingMessagesResponse",
         "description": "Response for the pending-message peek (GET) endpoint.\n\nReturns a read-only view of the pending buffer — messages are NOT\nconsumed.  The frontend uses this to restore the queued-message\nindicator after a page refresh and to decide when to clear it once\na turn has ended."
       },
@@ -13863,19 +20377,42 @@
           },
           "payload": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "items": {}, "type": "array" },
-              { "type": "string" },
-              { "type": "integer" },
-              { "type": "number" },
-              { "type": "boolean" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Payload",
             "description": "The actual data payload awaiting review"
           },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions",
             "description": "Instructions or message for the reviewer"
           },
@@ -13889,12 +20426,26 @@
             "description": "Review status"
           },
           "review_message": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Review Message",
             "description": "Optional message from the reviewer"
           },
           "was_edited": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Was Edited",
             "description": "Whether the data was modified during review"
           },
@@ -13912,16 +20463,26 @@
           },
           "updated_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Updated At",
             "description": "When the review was last updated"
           },
           "reviewed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed At",
             "description": "When the review was completed"
@@ -13950,25 +20511,38 @@
             "description": "OAuth access token suitable for the picker SDK call."
           },
           "access_token_expires_at": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Access Token Expires At",
             "description": "Unix timestamp at which the access token expires, if known."
           }
         },
         "type": "object",
-        "required": ["access_token"],
+        "required": [
+          "access_token"
+        ],
         "title": "PickerTokenResponse",
         "description": "Short-lived OAuth access token shipped to the browser for rendering a\nprovider-hosted picker UI (e.g. Google Drive Picker). Deliberately narrow:\nonly the fields the client needs to initialize the picker widget. Issued\nfrom the user's own stored credential so ownership and scope gating are\nenforced by the credential lookup."
       },
       "PlatformCostDashboard": {
         "properties": {
           "by_provider": {
-            "items": { "$ref": "#/components/schemas/ProviderCostSummary" },
+            "items": {
+              "$ref": "#/components/schemas/ProviderCostSummary"
+            },
             "type": "array",
             "title": "By Provider"
           },
           "by_user": {
-            "items": { "$ref": "#/components/schemas/UserCostSummary" },
+            "items": {
+              "$ref": "#/components/schemas/UserCostSummary"
+            },
             "type": "array",
             "title": "By User"
           },
@@ -13976,8 +20550,14 @@
             "type": "integer",
             "title": "Total Cost Microdollars"
           },
-          "total_requests": { "type": "integer", "title": "Total Requests" },
-          "total_users": { "type": "integer", "title": "Total Users" },
+          "total_requests": {
+            "type": "integer",
+            "title": "Total Requests"
+          },
+          "total_users": {
+            "type": "integer",
+            "title": "Total Users"
+          },
           "total_input_tokens": {
             "type": "integer",
             "title": "Total Input Tokens",
@@ -14024,7 +20604,9 @@
             "default": 0.0
           },
           "cost_buckets": {
-            "items": { "$ref": "#/components/schemas/CostBucket" },
+            "items": {
+              "$ref": "#/components/schemas/CostBucket"
+            },
             "type": "array",
             "title": "Cost Buckets",
             "default": []
@@ -14043,34 +20625,59 @@
       "PlatformCostExportResponse": {
         "properties": {
           "logs": {
-            "items": { "$ref": "#/components/schemas/CostLogRow" },
+            "items": {
+              "$ref": "#/components/schemas/CostLogRow"
+            },
             "type": "array",
             "title": "Logs"
           },
-          "total_rows": { "type": "integer", "title": "Total Rows" },
-          "truncated": { "type": "boolean", "title": "Truncated" }
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "truncated": {
+            "type": "boolean",
+            "title": "Truncated"
+          }
         },
         "type": "object",
-        "required": ["logs", "total_rows", "truncated"],
+        "required": [
+          "logs",
+          "total_rows",
+          "truncated"
+        ],
         "title": "PlatformCostExportResponse"
       },
       "PlatformCostLogsResponse": {
         "properties": {
           "logs": {
-            "items": { "$ref": "#/components/schemas/CostLogRow" },
+            "items": {
+              "$ref": "#/components/schemas/CostLogRow"
+            },
             "type": "array",
             "title": "Logs"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["logs", "pagination"],
+        "required": [
+          "logs",
+          "pagination"
+        ],
         "title": "PlatformCostLogsResponse"
       },
       "PlatformLinkInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "platform": { "type": "string", "title": "Platform" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
@@ -14080,7 +20687,14 @@
             "title": "Owner Platform User Id"
           },
           "server_name": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Server Name"
           },
           "linked_at": {
@@ -14102,11 +20716,27 @@
       },
       "PlatformUserLinkInfo": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "platform": { "type": "string", "title": "Platform" },
-          "platform_user_id": { "type": "string", "title": "Platform User Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "platform_user_id": {
+            "type": "string",
+            "title": "Platform User Id"
+          },
           "platform_username": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Platform Username"
           },
           "linked_at": {
@@ -14128,8 +20758,28 @@
       "PostmarkBounceEnum": {
         "type": "integer",
         "enum": [
-          1, 2, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
-          100000, 100001, 100002, 100003, 100006, 100007, 100008, 100009, 100010
+          1,
+          2,
+          16,
+          32,
+          64,
+          128,
+          256,
+          512,
+          1024,
+          2048,
+          4096,
+          8192,
+          16384,
+          100000,
+          100001,
+          100002,
+          100003,
+          100006,
+          100007,
+          100008,
+          100009,
+          100010
         ],
         "title": "PostmarkBounceEnum"
       },
@@ -14141,26 +20791,81 @@
             "title": "Recordtype",
             "default": "Bounce"
           },
-          "ID": { "type": "integer", "title": "Id" },
-          "Type": { "type": "string", "title": "Type" },
-          "TypeCode": { "$ref": "#/components/schemas/PostmarkBounceEnum" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "Details": { "type": "string", "title": "Details" },
-          "Email": { "type": "string", "title": "Email" },
-          "From": { "type": "string", "title": "From" },
-          "BouncedAt": { "type": "string", "title": "Bouncedat" },
-          "Inactive": { "type": "boolean", "title": "Inactive" },
-          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
-          "CanActivate": { "type": "boolean", "title": "Canactivate" },
-          "Subject": { "type": "string", "title": "Subject" },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "Content": { "type": "string", "title": "Content" },
-          "Name": { "type": "string", "title": "Name" },
-          "Description": { "type": "string", "title": "Description" },
+          "ID": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "Type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "TypeCode": {
+            "$ref": "#/components/schemas/PostmarkBounceEnum"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "Details": {
+            "type": "string",
+            "title": "Details"
+          },
+          "Email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "From": {
+            "type": "string",
+            "title": "From"
+          },
+          "BouncedAt": {
+            "type": "string",
+            "title": "Bouncedat"
+          },
+          "Inactive": {
+            "type": "boolean",
+            "title": "Inactive"
+          },
+          "DumpAvailable": {
+            "type": "boolean",
+            "title": "Dumpavailable"
+          },
+          "CanActivate": {
+            "type": "boolean",
+            "title": "Canactivate"
+          },
+          "Subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "Content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "Name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -14197,32 +20902,67 @@
             "title": "Recordtype",
             "default": "Click"
           },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "ReceivedAt": { "type": "string", "title": "Receivedat" },
-          "Platform": { "type": "string", "title": "Platform" },
-          "ClickLocation": { "type": "string", "title": "Clicklocation" },
-          "OriginalLink": { "type": "string", "title": "Originallink" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "UserAgent": { "type": "string", "title": "Useragent" },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "ReceivedAt": {
+            "type": "string",
+            "title": "Receivedat"
+          },
+          "Platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "ClickLocation": {
+            "type": "string",
+            "title": "Clicklocation"
+          },
+          "OriginalLink": {
+            "type": "string",
+            "title": "Originallink"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "UserAgent": {
+            "type": "string",
+            "title": "Useragent"
+          },
           "OS": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Geo"
           }
@@ -14253,15 +20993,38 @@
             "title": "Recordtype",
             "default": "Delivery"
           },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "DeliveredAt": { "type": "string", "title": "Deliveredat" },
-          "Details": { "type": "string", "title": "Details" },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "DeliveredAt": {
+            "type": "string",
+            "title": "Deliveredat"
+          },
+          "Details": {
+            "type": "string",
+            "title": "Details"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -14287,32 +21050,67 @@
             "title": "Recordtype",
             "default": "Open"
           },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           },
-          "FirstOpen": { "type": "boolean", "title": "Firstopen" },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "ReceivedAt": { "type": "string", "title": "Receivedat" },
-          "Platform": { "type": "string", "title": "Platform" },
-          "ReadSeconds": { "type": "integer", "title": "Readseconds" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "UserAgent": { "type": "string", "title": "Useragent" },
+          "FirstOpen": {
+            "type": "boolean",
+            "title": "Firstopen"
+          },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "ReceivedAt": {
+            "type": "string",
+            "title": "Receivedat"
+          },
+          "Platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "ReadSeconds": {
+            "type": "integer",
+            "title": "Readseconds"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "UserAgent": {
+            "type": "string",
+            "title": "Useragent"
+          },
           "OS": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Geo"
           }
@@ -14343,26 +21141,82 @@
             "title": "Recordtype",
             "default": "SpamComplaint"
           },
-          "ID": { "type": "integer", "title": "Id" },
-          "Type": { "type": "string", "title": "Type" },
-          "TypeCode": { "type": "integer", "title": "Typecode" },
-          "Tag": { "type": "string", "title": "Tag" },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "Details": { "type": "string", "title": "Details" },
-          "Email": { "type": "string", "title": "Email" },
-          "From": { "type": "string", "title": "From" },
-          "BouncedAt": { "type": "string", "title": "Bouncedat" },
-          "Inactive": { "type": "boolean", "title": "Inactive" },
-          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
-          "CanActivate": { "type": "boolean", "title": "Canactivate" },
-          "Subject": { "type": "string", "title": "Subject" },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "Content": { "type": "string", "title": "Content" },
-          "Name": { "type": "string", "title": "Name" },
-          "Description": { "type": "string", "title": "Description" },
+          "ID": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "Type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "TypeCode": {
+            "type": "integer",
+            "title": "Typecode"
+          },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "Details": {
+            "type": "string",
+            "title": "Details"
+          },
+          "Email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "From": {
+            "type": "string",
+            "title": "From"
+          },
+          "BouncedAt": {
+            "type": "string",
+            "title": "Bouncedat"
+          },
+          "Inactive": {
+            "type": "boolean",
+            "title": "Inactive"
+          },
+          "DumpAvailable": {
+            "type": "boolean",
+            "title": "Dumpavailable"
+          },
+          "CanActivate": {
+            "type": "boolean",
+            "title": "Canactivate"
+          },
+          "Subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "Content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "Name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "Description": {
+            "type": "string",
+            "title": "Description"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -14399,20 +21253,46 @@
             "title": "Recordtype",
             "default": "SubscriptionChange"
           },
-          "MessageID": { "type": "string", "title": "Messageid" },
-          "ServerID": { "type": "integer", "title": "Serverid" },
-          "MessageStream": { "type": "string", "title": "Messagestream" },
-          "ChangedAt": { "type": "string", "title": "Changedat" },
-          "Recipient": { "type": "string", "title": "Recipient" },
-          "Origin": { "type": "string", "title": "Origin" },
-          "SuppressSending": { "type": "boolean", "title": "Suppresssending" },
+          "MessageID": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "ServerID": {
+            "type": "integer",
+            "title": "Serverid"
+          },
+          "MessageStream": {
+            "type": "string",
+            "title": "Messagestream"
+          },
+          "ChangedAt": {
+            "type": "string",
+            "title": "Changedat"
+          },
+          "Recipient": {
+            "type": "string",
+            "title": "Recipient"
+          },
+          "Origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "SuppressSending": {
+            "type": "boolean",
+            "title": "Suppresssending"
+          },
           "SuppressionReason": {
             "type": "string",
             "title": "Suppressionreason"
           },
-          "Tag": { "type": "string", "title": "Tag" },
+          "Tag": {
+            "type": "string",
+            "title": "Tag"
+          },
           "Metadata": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Metadata"
           }
@@ -14434,39 +21314,84 @@
       },
       "Profile": {
         "properties": {
-          "username": { "type": "string", "title": "Username" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "avatar_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avatar Url"
           },
           "links": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Links"
           }
         },
         "type": "object",
-        "required": ["username", "name", "description", "avatar_url", "links"],
+        "required": [
+          "username",
+          "name",
+          "description",
+          "avatar_url",
+          "links"
+        ],
         "title": "Profile",
         "description": "Marketplace user profile (only attributes that the user can update)"
       },
       "ProfileDetails": {
         "properties": {
-          "username": { "type": "string", "title": "Username" },
-          "name": { "type": "string", "title": "Name" },
-          "description": { "type": "string", "title": "Description" },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "avatar_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Avatar Url"
           },
           "links": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": { "type": "boolean", "title": "Is Featured" }
+          "is_featured": {
+            "type": "boolean",
+            "title": "Is Featured"
+          }
         },
         "type": "object",
         "required": [
@@ -14487,20 +21412,29 @@
             "title": "Name",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "description": { "type": "string", "title": "Description" },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "integration_count": {
             "type": "integer",
             "title": "Integration Count"
           }
         },
         "type": "object",
-        "required": ["name", "description", "integration_count"],
+        "required": [
+          "name",
+          "description",
+          "integration_count"
+        ],
         "title": "Provider"
       },
       "ProviderConstants": {
         "properties": {
           "PROVIDER_NAMES": {
-            "additionalProperties": { "type": "string" },
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object",
             "title": "Provider Names",
             "description": "All available provider names as a constant mapping",
@@ -14521,13 +21455,30 @@
       },
       "ProviderCostSummary": {
         "properties": {
-          "provider": { "type": "string", "title": "Provider" },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "tracking_type": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Tracking Type"
           },
           "model": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Model"
           },
           "total_cost_microdollars": {
@@ -14562,7 +21513,10 @@
             "title": "Total Tracking Amount",
             "default": 0.0
           },
-          "request_count": { "type": "integer", "title": "Request Count" }
+          "request_count": {
+            "type": "integer",
+            "title": "Request Count"
+          }
         },
         "type": "object",
         "required": [
@@ -14583,7 +21537,9 @@
           }
         },
         "type": "object",
-        "required": ["provider"],
+        "required": [
+          "provider"
+        ],
         "title": "ProviderEnumResponse",
         "description": "Response containing a provider from the enum."
       },
@@ -14595,14 +21551,26 @@
             "description": "Provider slug (e.g. ``github``)"
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description",
             "description": "One-line human-readable summary of what the provider does. Declared via ``ProviderBuilder.with_description(...)`` in the provider's ``_config.py``. ``None`` if not set."
           },
           "supported_auth_types": {
             "items": {
               "type": "string",
-              "enum": ["api_key", "oauth2", "user_password", "host_scoped"]
+              "enum": [
+                "api_key",
+                "oauth2",
+                "user_password",
+                "host_scoped"
+              ]
             },
             "type": "array",
             "title": "Supported Auth Types",
@@ -14610,14 +21578,18 @@
           }
         },
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "title": "ProviderMetadata",
         "description": "Display metadata for a provider, shown in the settings integrations UI."
       },
       "ProviderNamesResponse": {
         "properties": {
           "providers": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Providers",
             "description": "List of all available provider names"
@@ -14630,14 +21602,21 @@
       "ProviderResponse": {
         "properties": {
           "providers": {
-            "items": { "$ref": "#/components/schemas/Provider" },
+            "items": {
+              "$ref": "#/components/schemas/Provider"
+            },
             "type": "array",
             "title": "Providers"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["providers", "pagination"],
+        "required": [
+          "providers",
+          "pagination"
+        ],
         "title": "ProviderResponse"
       },
       "PushSubscribeRequest": {
@@ -14648,17 +21627,27 @@
             "minLength": 1,
             "title": "Endpoint"
           },
-          "keys": { "$ref": "#/components/schemas/PushSubscriptionKeys" },
+          "keys": {
+            "$ref": "#/components/schemas/PushSubscriptionKeys"
+          },
           "user_agent": {
             "anyOf": [
-              { "type": "string", "maxLength": 512 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 512
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "User Agent"
           }
         },
         "type": "object",
-        "required": ["endpoint", "keys"],
+        "required": [
+          "endpoint",
+          "keys"
+        ],
         "title": "PushSubscribeRequest"
       },
       "PushSubscriptionKeys": {
@@ -14677,7 +21666,10 @@
           }
         },
         "type": "object",
-        "required": ["p256dh", "auth"],
+        "required": [
+          "p256dh",
+          "auth"
+        ],
         "title": "PushSubscriptionKeys"
       },
       "PushUnsubscribeRequest": {
@@ -14690,7 +21682,9 @@
           }
         },
         "type": "object",
-        "required": ["endpoint"],
+        "required": [
+          "endpoint"
+        ],
         "title": "PushUnsubscribeRequest"
       },
       "QueuePendingMessageRequest": {
@@ -14703,47 +21697,70 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "type": "array",
                 "maxItems": 20
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "File Ids"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "QueuePendingMessageRequest",
         "description": "Request model for queueing a follow-up while a turn is running."
       },
       "QueuePendingMessageResponse": {
         "properties": {
-          "buffer_length": { "type": "integer", "title": "Buffer Length" },
+          "buffer_length": {
+            "type": "integer",
+            "title": "Buffer Length"
+          },
           "max_buffer_length": {
             "type": "integer",
             "title": "Max Buffer Length"
           },
-          "turn_in_flight": { "type": "boolean", "title": "Turn In Flight" }
+          "turn_in_flight": {
+            "type": "boolean",
+            "title": "Turn In Flight"
+          }
         },
         "type": "object",
-        "required": ["buffer_length", "max_buffer_length", "turn_in_flight"],
+        "required": [
+          "buffer_length",
+          "max_buffer_length",
+          "turn_in_flight"
+        ],
         "title": "QueuePendingMessageResponse",
         "description": "Response returned when a message is queued because the session already\nhas a turn in flight.\n\n- ``buffer_length``: how many messages are now in the session's\n  pending buffer (after this push)\n- ``max_buffer_length``: the per-session cap (server-side constant)\n- ``turn_in_flight``: ``True`` if a copilot turn was running when\n  we checked — purely informational for UX feedback."
       },
       "RateLimitResetResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "credits_charged": {
             "type": "integer",
             "title": "Credits Charged",
@@ -14771,33 +21788,77 @@
       },
       "RecentExecution": {
         "properties": {
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "correctness_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Correctness Score"
           },
           "activity_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Activity Summary"
           }
         },
         "type": "object",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "title": "RecentExecution",
         "description": "Summary of a recent execution for quality assessment.\n\nUsed by the LLM to understand the agent's recent performance with specific examples\nrather than just aggregate statistics."
       },
       "RefundRequest": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "transaction_key": { "type": "string", "title": "Transaction Key" },
-          "amount": { "type": "integer", "title": "Amount" },
-          "reason": { "type": "string", "title": "Reason" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "transaction_key": {
+            "type": "string",
+            "title": "Transaction Key"
+          },
+          "amount": {
+            "type": "integer",
+            "title": "Amount"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason"
+          },
           "result": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Result"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -14824,24 +21885,38 @@
       },
       "RequestTopUp": {
         "properties": {
-          "credit_amount": { "type": "integer", "title": "Credit Amount" }
+          "credit_amount": {
+            "type": "integer",
+            "title": "Credit Amount"
+          }
         },
         "type": "object",
-        "required": ["credit_amount"],
+        "required": [
+          "credit_amount"
+        ],
         "title": "RequestTopUp"
       },
       "RequeueExecutionResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "requeued_count": {
             "type": "integer",
             "title": "Requeued Count",
             "default": 0
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
-        "required": ["success", "message"],
+        "required": [
+          "success",
+          "message"
+        ],
         "title": "RequeueExecutionResponse",
         "description": "Response model for requeue execution operations"
       },
@@ -14916,21 +21991,42 @@
           },
           "message": {
             "anyOf": [
-              { "type": "string", "maxLength": 2000 },
-              { "type": "null" }
+              {
+                "type": "string",
+                "maxLength": 2000
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Message",
             "description": "Optional review message"
           },
           "reviewed_data": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "items": {}, "type": "array" },
-              { "type": "string" },
-              { "type": "integer" },
-              { "type": "number" },
-              { "type": "boolean" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed Data",
             "description": "Optional edited data (ignored if approved=False)"
@@ -14943,21 +22039,28 @@
           }
         },
         "type": "object",
-        "required": ["node_exec_id", "approved"],
+        "required": [
+          "node_exec_id",
+          "approved"
+        ],
         "title": "ReviewItem",
         "description": "Single review item for processing."
       },
       "ReviewRequest": {
         "properties": {
           "reviews": {
-            "items": { "$ref": "#/components/schemas/ReviewItem" },
+            "items": {
+              "$ref": "#/components/schemas/ReviewItem"
+            },
             "type": "array",
             "title": "Reviews",
             "description": "All reviews with their approval status, data, and messages"
           }
         },
         "type": "object",
-        "required": ["reviews"],
+        "required": [
+          "reviews"
+        ],
         "title": "ReviewRequest",
         "description": "Request model for processing ALL pending reviews for an execution.\n\nThis request must include ALL pending reviews for a graph execution.\nEach review will be either approved (with optional data modifications)\nor rejected (data ignored). The execution will resume only after ALL reviews are processed.\n\nEach review item can individually specify whether to auto-approve future executions\nof the same block via the `auto_approve_future` field on ReviewItem."
       },
@@ -14979,19 +22082,34 @@
             "description": "Number of reviews that failed processing"
           },
           "error": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error",
             "description": "Error message if operation failed"
           }
         },
         "type": "object",
-        "required": ["approved_count", "rejected_count", "failed_count"],
+        "required": [
+          "approved_count",
+          "rejected_count",
+          "failed_count"
+        ],
         "title": "ReviewResponse",
         "description": "Response from review endpoint."
       },
       "ReviewStatus": {
         "type": "string",
-        "enum": ["WAITING", "APPROVED", "REJECTED"],
+        "enum": [
+          "WAITING",
+          "APPROVED",
+          "REJECTED"
+        ],
         "title": "ReviewStatus"
       },
       "ReviewSubmissionRequest": {
@@ -15000,29 +22118,71 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "is_approved": { "type": "boolean", "title": "Is Approved" },
-          "comments": { "type": "string", "title": "Comments" },
+          "is_approved": {
+            "type": "boolean",
+            "title": "Is Approved"
+          },
+          "comments": {
+            "type": "string",
+            "title": "Comments"
+          },
           "internal_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Internal Comments"
           }
         },
         "type": "object",
-        "required": ["store_listing_version_id", "is_approved", "comments"],
+        "required": [
+          "store_listing_version_id",
+          "is_approved",
+          "comments"
+        ],
         "title": "ReviewSubmissionRequest"
       },
       "RunningExecutionDetail": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
-          "status": { "type": "string", "title": "Status" },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15030,13 +22190,25 @@
           },
           "started_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Started At"
           },
           "queue_status": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Queue Status"
           }
         },
@@ -15058,53 +22230,87 @@
       "RunningExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": { "$ref": "#/components/schemas/RunningExecutionDetail" },
+            "items": {
+              "$ref": "#/components/schemas/RunningExecutionDetail"
+            },
             "type": "array",
             "title": "Executions"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
-        "required": ["executions", "total"],
+        "required": [
+          "executions",
+          "total"
+        ],
         "title": "RunningExecutionsListResponse",
         "description": "Response model for list of running executions"
       },
       "ScheduleCleanupRequest": {
         "properties": {
           "schedule_ids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Schedule Ids"
           }
         },
         "type": "object",
-        "required": ["schedule_ids"],
+        "required": [
+          "schedule_ids"
+        ],
         "title": "ScheduleCleanupRequest",
         "description": "Request model for cleaning up schedules"
       },
       "ScheduleCleanupResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "deleted_count": {
             "type": "integer",
             "title": "Deleted Count",
             "default": 0
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
-        "required": ["success", "message"],
+        "required": [
+          "success",
+          "message"
+        ],
         "title": "ScheduleCleanupResponse",
         "description": "Response model for schedule cleanup operations"
       },
       "ScheduleCreationRequest": {
         "properties": {
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           },
-          "name": { "type": "string", "title": "Name" },
-          "cron": { "type": "string", "title": "Cron" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "cron": {
+            "type": "string",
+            "title": "Cron"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -15118,34 +22324,84 @@
             "title": "Credentials"
           },
           "timezone": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Timezone",
             "description": "User's timezone for scheduling (e.g., 'America/New_York'). If not provided, will use user's saved timezone or UTC."
           }
         },
         "type": "object",
-        "required": ["name", "cron", "inputs"],
+        "required": [
+          "name",
+          "cron",
+          "inputs"
+        ],
         "title": "ScheduleCreationRequest"
       },
       "ScheduleDetail": {
         "properties": {
-          "schedule_id": { "type": "string", "title": "Schedule Id" },
-          "schedule_name": { "type": "string", "title": "Schedule Name" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "schedule_id": {
+            "type": "string",
+            "title": "Schedule Id"
+          },
+          "schedule_name": {
+            "type": "string",
+            "title": "Schedule Name"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
-          "cron": { "type": "string", "title": "Cron" },
-          "timezone": { "type": "string", "title": "Timezone" },
-          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "cron": {
+            "type": "string",
+            "title": "Cron"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone"
+          },
+          "next_run_time": {
+            "type": "string",
+            "title": "Next Run Time"
+          },
           "created_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Created At"
           }
@@ -15168,8 +22424,14 @@
       },
       "ScheduleHealthMetrics": {
         "properties": {
-          "total_schedules": { "type": "integer", "title": "Total Schedules" },
-          "user_schedules": { "type": "integer", "title": "User Schedules" },
+          "total_schedules": {
+            "type": "integer",
+            "title": "Total Schedules"
+          },
+          "user_schedules": {
+            "type": "integer",
+            "title": "User Schedules"
+          },
           "system_schedules": {
             "type": "integer",
             "title": "System Schedules"
@@ -15190,7 +22452,10 @@
             "type": "integer",
             "title": "Orphaned Validation Failed"
           },
-          "total_orphaned": { "type": "integer", "title": "Total Orphaned" },
+          "total_orphaned": {
+            "type": "integer",
+            "title": "Total Orphaned"
+          },
           "schedules_next_hour": {
             "type": "integer",
             "title": "Schedules Next Hour"
@@ -15207,7 +22472,10 @@
             "type": "integer",
             "title": "Total Runs Next 24H"
           },
-          "timestamp": { "type": "string", "title": "Timestamp" }
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          }
         },
         "type": "object",
         "required": [
@@ -15231,21 +22499,36 @@
       "SchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": { "$ref": "#/components/schemas/ScheduleDetail" },
+            "items": {
+              "$ref": "#/components/schemas/ScheduleDetail"
+            },
             "type": "array",
             "title": "Schedules"
           },
-          "total": { "type": "integer", "title": "Total" }
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
         },
         "type": "object",
-        "required": ["schedules", "total"],
+        "required": [
+          "schedules",
+          "total"
+        ],
         "title": "SchedulesListResponse",
         "description": "Response model for list of schedules"
       },
       "SearchEntry": {
         "properties": {
           "search_query": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Search Query"
           },
           "filter": {
@@ -15262,19 +22545,35 @@
                 },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Filter"
           },
           "by_creator": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "By Creator"
           },
           "search_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Search Id"
           }
         },
@@ -15286,17 +22585,28 @@
           "items": {
             "items": {
               "anyOf": [
-                { "$ref": "#/components/schemas/BlockInfo" },
-                { "$ref": "#/components/schemas/LibraryAgent" },
-                { "$ref": "#/components/schemas/StoreAgent" }
+                {
+                  "$ref": "#/components/schemas/BlockInfo"
+                },
+                {
+                  "$ref": "#/components/schemas/LibraryAgent"
+                },
+                {
+                  "$ref": "#/components/schemas/StoreAgent"
+                }
               ]
             },
             "type": "array",
             "title": "Items"
           },
-          "search_id": { "type": "string", "title": "Search Id" },
+          "search_id": {
+            "type": "string",
+            "title": "Search Id"
+          },
           "total_items": {
-            "additionalProperties": { "type": "integer" },
+            "additionalProperties": {
+              "type": "integer"
+            },
             "propertyNames": {
               "enum": [
                 "blocks",
@@ -15308,30 +22618,60 @@
             "type": "object",
             "title": "Total Items"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["items", "search_id", "total_items", "pagination"],
+        "required": [
+          "items",
+          "search_id",
+          "total_items",
+          "pagination"
+        ],
         "title": "SearchResponse"
       },
       "SessionDetailResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "created_at": { "type": "string", "title": "Created At" },
-          "updated_at": { "type": "string", "title": "Updated At" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "messages": {
-            "items": { "additionalProperties": true, "type": "object" },
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array",
             "title": "Messages"
           },
           "active_stream": {
             "anyOf": [
-              { "$ref": "#/components/schemas/ActiveStreamInfo" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/ActiveStreamInfo"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "has_more_messages": {
@@ -15340,7 +22680,14 @@
             "default": false
           },
           "oldest_sequence": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Oldest Sequence"
           },
           "total_prompt_tokens": {
@@ -15355,27 +22702,59 @@
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": { "dry_run": false }
+            "default": {
+              "dry_run": false
+            }
           }
         },
         "type": "object",
-        "required": ["id", "created_at", "updated_at", "user_id", "messages"],
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "user_id",
+          "messages"
+        ],
         "title": "SessionDetailResponse",
         "description": "Response model providing complete details for a chat session, including messages."
       },
       "SessionSummaryResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "created_at": { "type": "string", "title": "Created At" },
-          "updated_at": { "type": "string", "title": "Updated At" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
-          "is_processing": { "type": "boolean", "title": "Is Processing" }
+          "is_processing": {
+            "type": "boolean",
+            "title": "Is Processing"
+          }
         },
         "type": "object",
-        "required": ["id", "created_at", "updated_at", "is_processing"],
+        "required": [
+          "id",
+          "created_at",
+          "updated_at",
+          "is_processing"
+        ],
         "title": "SessionSummaryResponse",
         "description": "Response model for a session summary (without messages)."
       },
@@ -15387,31 +22766,55 @@
           }
         },
         "type": "object",
-        "required": ["active_graph_version"],
+        "required": [
+          "active_graph_version"
+        ],
         "title": "SetGraphActiveVersion"
       },
       "SetUserTierRequest": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/SubscriptionTier"
+          }
         },
         "type": "object",
-        "required": ["user_id", "tier"],
+        "required": [
+          "user_id",
+          "tier"
+        ],
         "title": "SetUserTierRequest"
       },
       "SetupInfo": {
         "properties": {
-          "agent_id": { "type": "string", "title": "Agent Id" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_id": {
+            "type": "string",
+            "title": "Agent Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
           "requirements": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Requirements"
           },
-          "user_readiness": { "$ref": "#/components/schemas/UserReadiness" }
+          "user_readiness": {
+            "$ref": "#/components/schemas/UserReadiness"
+          }
         },
         "type": "object",
-        "required": ["agent_id", "agent_name"],
+        "required": [
+          "agent_id",
+          "agent_name"
+        ],
         "title": "SetupInfo",
         "description": "Complete setup information."
       },
@@ -15421,23 +22824,52 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "setup_requirements"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
-          "setup_info": { "$ref": "#/components/schemas/SetupInfo" },
+          "setup_info": {
+            "$ref": "#/components/schemas/SetupInfo"
+          },
           "graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Version"
           }
         },
         "type": "object",
-        "required": ["message", "setup_info"],
+        "required": [
+          "message",
+          "setup_info"
+        ],
         "title": "SetupRequirementsResponse",
         "description": "Response for validate action."
       },
@@ -15449,30 +22881,57 @@
       },
       "ShareResponse": {
         "properties": {
-          "share_url": { "type": "string", "title": "Share Url" },
-          "share_token": { "type": "string", "title": "Share Token" }
+          "share_url": {
+            "type": "string",
+            "title": "Share Url"
+          },
+          "share_token": {
+            "type": "string",
+            "title": "Share Token"
+          }
         },
         "type": "object",
-        "required": ["share_url", "share_token"],
+        "required": [
+          "share_url",
+          "share_token"
+        ],
         "title": "ShareResponse",
         "description": "Response from share endpoints."
       },
       "SharedExecutionResponse": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "graph_name": { "type": "string", "title": "Graph Name" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "graph_name": {
+            "type": "string",
+            "title": "Graph Name"
+          },
           "graph_description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Description"
           },
-          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/AgentExecutionStatus"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "outputs": {
-            "additionalProperties": { "items": {}, "type": "array" },
+            "additionalProperties": {
+              "items": {},
+              "type": "array"
+            },
             "type": "object",
             "title": "Outputs"
           }
@@ -15534,17 +22993,38 @@
             "default": 0
           },
           "error": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Error",
             "description": "Error message if any"
           },
           "activity_status": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Activity Status",
             "description": "AI-generated summary of what the agent did"
           },
           "correctness_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Correctness Score",
             "description": "AI-generated score (0.0-1.0) indicating how well the execution achieved its intended purpose"
           }
@@ -15555,64 +23035,129 @@
       },
       "StopExecutionRequest": {
         "properties": {
-          "execution_id": { "type": "string", "title": "Execution Id" }
+          "execution_id": {
+            "type": "string",
+            "title": "Execution Id"
+          }
         },
         "type": "object",
-        "required": ["execution_id"],
+        "required": [
+          "execution_id"
+        ],
         "title": "StopExecutionRequest",
         "description": "Request model for stopping a single execution"
       },
       "StopExecutionResponse": {
         "properties": {
-          "success": { "type": "boolean", "title": "Success" },
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
           "stopped_count": {
             "type": "integer",
             "title": "Stopped Count",
             "default": 0
           },
-          "message": { "type": "string", "title": "Message" }
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
         },
         "type": "object",
-        "required": ["success", "message"],
+        "required": [
+          "success",
+          "message"
+        ],
         "title": "StopExecutionResponse",
         "description": "Response model for stop execution operations"
       },
       "StopExecutionsRequest": {
         "properties": {
           "execution_ids": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Execution Ids"
           }
         },
         "type": "object",
-        "required": ["execution_ids"],
+        "required": [
+          "execution_ids"
+        ],
         "title": "StopExecutionsRequest",
         "description": "Request model for stopping multiple executions"
       },
       "StorageUsageResponse": {
         "properties": {
-          "used_bytes": { "type": "integer", "title": "Used Bytes" },
-          "limit_bytes": { "type": "integer", "title": "Limit Bytes" },
-          "used_percent": { "type": "number", "title": "Used Percent" },
-          "file_count": { "type": "integer", "title": "File Count" }
+          "used_bytes": {
+            "type": "integer",
+            "title": "Used Bytes"
+          },
+          "limit_bytes": {
+            "type": "integer",
+            "title": "Limit Bytes"
+          },
+          "used_percent": {
+            "type": "number",
+            "title": "Used Percent"
+          },
+          "file_count": {
+            "type": "integer",
+            "title": "File Count"
+          }
         },
         "type": "object",
-        "required": ["used_bytes", "limit_bytes", "used_percent", "file_count"],
+        "required": [
+          "used_bytes",
+          "limit_bytes",
+          "used_percent",
+          "file_count"
+        ],
         "title": "StorageUsageResponse"
       },
       "StoreAgent": {
         "properties": {
-          "slug": { "type": "string", "title": "Slug" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "agent_image": { "type": "string", "title": "Agent Image" },
-          "creator": { "type": "string", "title": "Creator" },
-          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
-          "runs": { "type": "integer", "title": "Runs" },
-          "rating": { "type": "number", "title": "Rating" },
-          "agent_graph_id": { "type": "string", "title": "Agent Graph Id" }
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_image": {
+            "type": "string",
+            "title": "Agent Image"
+          },
+          "creator": {
+            "type": "string",
+            "title": "Creator"
+          },
+          "creator_avatar": {
+            "type": "string",
+            "title": "Creator Avatar"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "runs": {
+            "type": "integer",
+            "title": "Runs"
+          },
+          "rating": {
+            "type": "number",
+            "title": "Rating"
+          },
+          "agent_graph_id": {
+            "type": "string",
+            "title": "Agent Graph Id"
+          }
         },
         "type": "object",
         "required": [
@@ -15635,41 +23180,86 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "slug": { "type": "string", "title": "Slug" },
-          "agent_name": { "type": "string", "title": "Agent Name" },
-          "agent_video": { "type": "string", "title": "Agent Video" },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "agent_video": {
+            "type": "string",
+            "title": "Agent Video"
+          },
           "agent_output_demo": {
             "type": "string",
             "title": "Agent Output Demo"
           },
           "agent_image": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Agent Image"
           },
-          "creator": { "type": "string", "title": "Creator" },
-          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
+          "creator": {
+            "type": "string",
+            "title": "Creator"
+          },
+          "creator_avatar": {
+            "type": "string",
+            "title": "Creator Avatar"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
-          "runs": { "type": "integer", "title": "Runs" },
-          "rating": { "type": "number", "title": "Rating" },
+          "runs": {
+            "type": "integer",
+            "title": "Runs"
+          },
+          "rating": {
+            "type": "number",
+            "title": "Rating"
+          },
           "versions": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Versions"
           },
-          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
           "graph_versions": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Graph Versions"
           },
@@ -15679,7 +23269,14 @@
             "title": "Last Updated"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           },
           "active_version_id": {
@@ -15693,10 +23290,14 @@
           "changelog": {
             "anyOf": [
               {
-                "items": { "$ref": "#/components/schemas/ChangelogEntry" },
+                "items": {
+                  "$ref": "#/components/schemas/ChangelogEntry"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Changelog"
           }
@@ -15728,33 +23329,65 @@
       "StoreAgentsResponse": {
         "properties": {
           "agents": {
-            "items": { "$ref": "#/components/schemas/StoreAgent" },
+            "items": {
+              "$ref": "#/components/schemas/StoreAgent"
+            },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["agents", "pagination"],
+        "required": [
+          "agents",
+          "pagination"
+        ],
         "title": "StoreAgentsResponse"
       },
       "StoreAgentsSortOptions": {
         "type": "string",
-        "enum": ["rating", "runs", "name", "updated_at"],
+        "enum": [
+          "rating",
+          "runs",
+          "name",
+          "updated_at"
+        ],
         "title": "StoreAgentsSortOptions"
       },
       "StoreCreatorsSortOptions": {
         "type": "string",
-        "enum": ["agent_rating", "agent_runs", "num_agents"],
+        "enum": [
+          "agent_rating",
+          "agent_runs",
+          "num_agents"
+        ],
         "title": "StoreCreatorsSortOptions"
       },
       "StoreListingWithVersionsAdminView": {
         "properties": {
-          "listing_id": { "type": "string", "title": "Listing Id" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "slug": { "type": "string", "title": "Slug" },
+          "listing_id": {
+            "type": "string",
+            "title": "Listing Id"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "active_listing_version_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Active Listing Version Id"
           },
           "has_approved_version": {
@@ -15763,13 +23396,24 @@
             "default": false
           },
           "creator_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Creator Email"
           },
           "latest_version": {
             "anyOf": [
-              { "$ref": "#/components/schemas/StoreSubmissionAdminView" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/StoreSubmissionAdminView"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "versions": {
@@ -15782,7 +23426,11 @@
           }
         },
         "type": "object",
-        "required": ["listing_id", "graph_id", "slug"],
+        "required": [
+          "listing_id",
+          "graph_id",
+          "slug"
+        ],
         "title": "StoreListingWithVersionsAdminView",
         "description": "A store listing with its version history"
       },
@@ -15795,23 +23443,40 @@
             "type": "array",
             "title": "Listings"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["listings", "pagination"],
+        "required": [
+          "listings",
+          "pagination"
+        ],
         "title": "StoreListingsWithVersionsAdminViewResponse",
         "description": "Response model for listings with version history"
       },
       "StoreReview": {
         "properties": {
-          "score": { "type": "integer", "title": "Score" },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
           "comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Comments"
           }
         },
         "type": "object",
-        "required": ["score"],
+        "required": [
+          "score"
+        ],
         "title": "StoreReview"
       },
       "StoreReviewCreate": {
@@ -15820,78 +23485,176 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "score": { "type": "integer", "title": "Score" },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
           "comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Comments"
           }
         },
         "type": "object",
-        "required": ["store_listing_version_id", "score"],
+        "required": [
+          "store_listing_version_id",
+          "score"
+        ],
         "title": "StoreReviewCreate"
       },
       "StoreSubmission": {
         "properties": {
-          "listing_id": { "type": "string", "title": "Listing Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "slug": { "type": "string", "title": "Slug" },
+          "listing_id": {
+            "type": "string",
+            "title": "Listing Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": { "type": "integer", "title": "Listing Version" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
+          "listing_version": {
+            "type": "integer",
+            "title": "Listing Version"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
-          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/SubmissionStatus"
+          },
           "reviewed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Review Comments"
           },
           "run_count": {
@@ -15935,66 +23698,151 @@
       },
       "StoreSubmissionAdminView": {
         "properties": {
-          "listing_id": { "type": "string", "title": "Listing Id" },
-          "user_id": { "type": "string", "title": "User Id" },
-          "slug": { "type": "string", "title": "Slug" },
+          "listing_id": {
+            "type": "string",
+            "title": "Listing Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": { "type": "integer", "title": "Listing Version" },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
-          "description": { "type": "string", "title": "Description" },
+          "listing_version": {
+            "type": "integer",
+            "title": "Listing Version"
+          },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
-          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
+          "status": {
+            "$ref": "#/components/schemas/SubmissionStatus"
+          },
           "reviewed_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Review Comments"
           },
           "run_count": {
@@ -16013,7 +23861,14 @@
             "default": 0.0
           },
           "internal_comments": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Internal Comments"
           }
         },
@@ -16043,18 +23898,40 @@
       },
       "StoreSubmissionEditRequest": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -16065,26 +23942,52 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           }
         },
         "type": "object",
-        "required": ["name", "sub_heading"],
+        "required": [
+          "name",
+          "sub_heading"
+        ],
         "title": "StoreSubmissionEditRequest"
       },
       "StoreSubmissionRequest": {
@@ -16101,19 +24004,44 @@
             "title": "Graph Version",
             "description": "Graph version must be greater than 0"
           },
-          "slug": { "type": "string", "title": "Slug" },
-          "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "sub_heading": {
+            "type": "string",
+            "title": "Sub Heading"
+          },
           "video_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -16124,21 +24052,44 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Instructions"
           },
           "categories": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -16155,14 +24106,21 @@
       "StoreSubmissionsResponse": {
         "properties": {
           "submissions": {
-            "items": { "$ref": "#/components/schemas/StoreSubmission" },
+            "items": {
+              "$ref": "#/components/schemas/StoreSubmission"
+            },
             "type": "array",
             "title": "Submissions"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["submissions", "pagination"],
+        "required": [
+          "submissions",
+          "pagination"
+        ],
         "title": "StoreSubmissionsResponse"
       },
       "StreamChatRequest": {
@@ -16180,49 +24138,80 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": { "type": "string" },
+                "additionalProperties": {
+                  "type": "string"
+                },
                 "type": "object"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "type": "array",
                 "maxItems": 20
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "File Ids"
           },
           "mode": {
             "anyOf": [
-              { "type": "string", "enum": ["fast", "extended_thinking"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": [
+                  "fast",
+                  "extended_thinking"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Mode",
             "description": "Autopilot mode: 'fast' for baseline LLM, 'extended_thinking' for Claude Agent SDK. If None, uses the server default (extended_thinking)."
           },
           "model": {
             "anyOf": [
-              { "type": "string", "enum": ["standard", "advanced"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": [
+                  "standard",
+                  "advanced"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Model",
             "description": "Model tier: 'standard' for the default model, 'advanced' for the highest-capability model. If None, the server applies per-user LD targeting then falls back to config."
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "StreamChatRequest",
         "description": "Request model for streaming chat with optional context."
       },
       "SubmissionStatus": {
         "type": "string",
-        "enum": ["DRAFT", "PENDING", "APPROVED", "REJECTED"],
+        "enum": [
+          "DRAFT",
+          "PENDING",
+          "APPROVED",
+          "REJECTED"
+        ],
         "title": "SubmissionStatus"
       },
       "SubscriptionStatusResponse": {
@@ -16239,14 +24228,21 @@
             ],
             "title": "Tier"
           },
-          "monthly_cost": { "type": "integer", "title": "Monthly Cost" },
+          "monthly_cost": {
+            "type": "integer",
+            "title": "Monthly Cost"
+          },
           "tier_costs": {
-            "additionalProperties": { "type": "integer" },
+            "additionalProperties": {
+              "type": "integer"
+            },
             "type": "object",
             "title": "Tier Costs"
           },
           "tier_multipliers": {
-            "additionalProperties": { "type": "number" },
+            "additionalProperties": {
+              "type": "number"
+            },
             "type": "object",
             "title": "Tier Multipliers",
             "description": "Tier → rate-limit multiplier. Covers the same tiers listed in ``tier_costs`` so the frontend can render rate-limit badges relative to the lowest visible tier without knowing backend defaults."
@@ -16262,7 +24258,14 @@
             "default": false
           },
           "current_period_end": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Current Period End",
             "description": "Unix timestamp of the active subscription's current_period_end. Used to show the date Stripe will issue the next invoice (with prorated upgrade charges, if any). None when no active sub."
           },
@@ -16270,16 +24273,29 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"]
+                "enum": [
+                  "NO_TIER",
+                  "BASIC",
+                  "PRO",
+                  "MAX",
+                  "BUSINESS"
+                ]
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Pending Tier"
           },
           "pending_tier_effective_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Pending Tier Effective At"
           },
@@ -16301,7 +24317,14 @@
       },
       "SubscriptionTier": {
         "type": "string",
-        "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
+        "enum": [
+          "NO_TIER",
+          "BASIC",
+          "PRO",
+          "MAX",
+          "BUSINESS",
+          "ENTERPRISE"
+        ],
         "title": "SubscriptionTier",
         "description": "Subscription tiers with increasing cost allowances.\n\nMirrors the ``SubscriptionTier`` enum in ``schema.prisma``.\nOnce ``prisma generate`` is run, this can be replaced with::\n\n    from prisma.enums import SubscriptionTier"
       },
@@ -16309,7 +24332,13 @@
         "properties": {
           "tier": {
             "type": "string",
-            "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"],
+            "enum": [
+              "NO_TIER",
+              "BASIC",
+              "PRO",
+              "MAX",
+              "BUSINESS"
+            ],
             "title": "Tier"
           },
           "success_url": {
@@ -16324,7 +24353,9 @@
           }
         },
         "type": "object",
-        "required": ["tier"],
+        "required": [
+          "tier"
+        ],
         "title": "SubscriptionTierRequest"
       },
       "SuggestedGoalResponse": {
@@ -16333,9 +24364,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "suggested_goal"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "suggested_goal": {
@@ -16357,48 +24398,68 @@
           },
           "goal_type": {
             "type": "string",
-            "enum": ["vague", "unachievable"],
+            "enum": [
+              "vague",
+              "unachievable"
+            ],
             "title": "Goal Type",
             "description": "Type: 'vague' or 'unachievable'",
             "default": "vague"
           }
         },
         "type": "object",
-        "required": ["message", "suggested_goal"],
+        "required": [
+          "message",
+          "suggested_goal"
+        ],
         "title": "SuggestedGoalResponse",
         "description": "Response when the goal needs refinement with a suggested alternative."
       },
       "SuggestedPromptsResponse": {
         "properties": {
           "themes": {
-            "items": { "$ref": "#/components/schemas/SuggestedTheme" },
+            "items": {
+              "$ref": "#/components/schemas/SuggestedTheme"
+            },
             "type": "array",
             "title": "Themes"
           }
         },
         "type": "object",
-        "required": ["themes"],
+        "required": [
+          "themes"
+        ],
         "title": "SuggestedPromptsResponse",
         "description": "Response model for user-specific suggested prompts grouped by theme."
       },
       "SuggestedTheme": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "prompts": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Prompts"
           }
         },
         "type": "object",
-        "required": ["name", "prompts"],
+        "required": [
+          "name",
+          "prompts"
+        ],
         "title": "SuggestedTheme",
         "description": "A themed group of suggested prompts."
       },
       "SuggestionsResponse": {
         "properties": {
           "recent_searches": {
-            "items": { "$ref": "#/components/schemas/SearchEntry" },
+            "items": {
+              "$ref": "#/components/schemas/SearchEntry"
+            },
             "type": "array",
             "title": "Recent Searches"
           },
@@ -16411,13 +24472,19 @@
             "title": "Providers"
           },
           "top_blocks": {
-            "items": { "$ref": "#/components/schemas/BlockInfo" },
+            "items": {
+              "$ref": "#/components/schemas/BlockInfo"
+            },
             "type": "array",
             "title": "Top Blocks"
           }
         },
         "type": "object",
-        "required": ["recent_searches", "providers", "top_blocks"],
+        "required": [
+          "recent_searches",
+          "providers",
+          "top_blocks"
+        ],
         "title": "SuggestionsResponse"
       },
       "TimezoneResponse": {
@@ -17027,13 +25094,17 @@
                 ],
                 "minLength": 1
               },
-              { "type": "string" }
+              {
+                "type": "string"
+              }
             ],
             "title": "Timezone"
           }
         },
         "type": "object",
-        "required": ["timezone"],
+        "required": [
+          "timezone"
+        ],
         "title": "TimezoneResponse"
       },
       "TodoItem": {
@@ -17050,13 +25121,20 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "in_progress", "completed"],
+            "enum": [
+              "pending",
+              "in_progress",
+              "completed"
+            ],
             "title": "Status",
             "default": "pending"
           }
         },
         "type": "object",
-        "required": ["content", "activeForm"],
+        "required": [
+          "content",
+          "activeForm"
+        ],
         "title": "TodoItem",
         "description": "One entry in a ``TodoWrite`` checklist.\n\nMirrors the schema used by Claude Code's built-in ``TodoWrite`` tool so\nthe frontend's ``GenericTool`` accordion renders baseline-emitted todos\nidentically to SDK-emitted ones."
       },
@@ -17066,54 +25144,109 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "todo_write"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "todos": {
-            "items": { "$ref": "#/components/schemas/TodoItem" },
+            "items": {
+              "$ref": "#/components/schemas/TodoItem"
+            },
             "type": "array",
             "title": "Todos"
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "TodoWriteResponse",
         "description": "Ack returned by ``TodoWrite``.\n\nThe tool is effectively stateless — the authoritative task list lives in\nthe assistant's latest tool-call arguments, which are replayed from the\ntranscript on each turn. The tool output only needs to confirm that the\nupdate was accepted so the model can proceed."
       },
       "TokenIntrospectionResult": {
         "properties": {
-          "active": { "type": "boolean", "title": "Active" },
+          "active": {
+            "type": "boolean",
+            "title": "Active"
+          },
           "scopes": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Scopes"
           },
           "client_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Client Id"
           },
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "exp": {
-            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Exp"
           },
           "token_type": {
             "anyOf": [
-              { "type": "string", "enum": ["access_token", "refresh_token"] },
-              { "type": "null" }
+              {
+                "type": "string",
+                "enum": [
+                  "access_token",
+                  "refresh_token"
+                ]
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Token Type"
           }
         },
         "type": "object",
-        "required": ["active"],
+        "required": [
+          "active"
+        ],
         "title": "TokenIntrospectionResult",
         "description": "Result of token introspection (RFC 7662)"
       },
@@ -17134,8 +25267,14 @@
             "title": "Redirect Uri",
             "description": "Redirect URI (must match authorization request)"
           },
-          "client_id": { "type": "string", "title": "Client Id" },
-          "client_secret": { "type": "string", "title": "Client Secret" },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "type": "string",
+            "title": "Client Secret"
+          },
           "code_verifier": {
             "type": "string",
             "title": "Code Verifier",
@@ -17160,9 +25299,18 @@
             "const": "refresh_token",
             "title": "Grant Type"
           },
-          "refresh_token": { "type": "string", "title": "Refresh Token" },
-          "client_id": { "type": "string", "title": "Client Id" },
-          "client_secret": { "type": "string", "title": "Client Secret" }
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "client_id": {
+            "type": "string",
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "type": "string",
+            "title": "Client Secret"
+          }
         },
         "type": "object",
         "required": [
@@ -17181,20 +25329,28 @@
             "title": "Token Type",
             "default": "Bearer"
           },
-          "access_token": { "type": "string", "title": "Access Token" },
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
           "access_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Access Token Expires At"
           },
-          "refresh_token": { "type": "string", "title": "Refresh Token" },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
           "refresh_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Scopes"
           }
@@ -17213,32 +25369,51 @@
       "TransactionHistory": {
         "properties": {
           "transactions": {
-            "items": { "$ref": "#/components/schemas/UserTransaction" },
+            "items": {
+              "$ref": "#/components/schemas/UserTransaction"
+            },
             "type": "array",
             "title": "Transactions"
           },
           "next_transaction_time": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Next Transaction Time"
           }
         },
         "type": "object",
-        "required": ["transactions", "next_transaction_time"],
+        "required": [
+          "transactions",
+          "next_transaction_time"
+        ],
         "title": "TransactionHistory"
       },
       "TriggeredPresetSetupRequest": {
         "properties": {
-          "name": { "type": "string", "title": "Name" },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "description": {
             "type": "string",
             "title": "Description",
             "default": ""
           },
-          "graph_id": { "type": "string", "title": "Graph Id" },
-          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_id": {
+            "type": "string",
+            "title": "Graph Id"
+          },
+          "graph_version": {
+            "type": "integer",
+            "title": "Graph Version"
+          },
           "trigger_config": {
             "additionalProperties": true,
             "type": "object",
@@ -17253,7 +25428,12 @@
           }
         },
         "type": "object",
-        "required": ["name", "graph_id", "graph_version", "trigger_config"],
+        "required": [
+          "name",
+          "graph_id",
+          "graph_version",
+          "trigger_config"
+        ],
         "title": "TriggeredPresetSetupRequest"
       },
       "UnderstandingUpdatedResponse": {
@@ -17262,13 +25442,25 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "understanding_updated"
           },
-          "message": { "type": "string", "title": "Message" },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
           "session_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Session Id"
           },
           "updated_fields": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Updated Fields"
           },
@@ -17279,58 +25471,111 @@
           }
         },
         "type": "object",
-        "required": ["message"],
+        "required": [
+          "message"
+        ],
         "title": "UnderstandingUpdatedResponse",
         "description": "Response for add_understanding tool."
       },
       "UnifiedSearchResponse": {
         "properties": {
           "results": {
-            "items": { "$ref": "#/components/schemas/UnifiedSearchResult" },
+            "items": {
+              "$ref": "#/components/schemas/UnifiedSearchResult"
+            },
             "type": "array",
             "title": "Results"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["results", "pagination"],
+        "required": [
+          "results",
+          "pagination"
+        ],
         "title": "UnifiedSearchResponse",
         "description": "Response model for unified search across all content types."
       },
       "UnifiedSearchResult": {
         "properties": {
-          "content_type": { "type": "string", "title": "Content Type" },
-          "content_id": { "type": "string", "title": "Content Id" },
-          "searchable_text": { "type": "string", "title": "Searchable Text" },
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "content_id": {
+            "type": "string",
+            "title": "Content Id"
+          },
+          "searchable_text": {
+            "type": "string",
+            "title": "Searchable Text"
+          },
           "metadata": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Metadata"
           },
           "updated_at": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Updated At"
           },
           "combined_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Combined Score"
           },
           "semantic_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Semantic Score"
           },
           "lexical_score": {
-            "anyOf": [{ "type": "number" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Lexical Score"
           }
         },
         "type": "object",
-        "required": ["content_type", "content_id", "searchable_text"],
+        "required": [
+          "content_type",
+          "content_id",
+          "searchable_text"
+        ],
         "title": "UnifiedSearchResult",
         "description": "A single result from unified hybrid search across all content types."
       },
@@ -17343,25 +25588,38 @@
           }
         },
         "type": "object",
-        "required": ["logo_url"],
+        "required": [
+          "logo_url"
+        ],
         "title": "UpdateAppLogoRequest"
       },
       "UpdatePermissionsRequest": {
         "properties": {
           "permissions": {
-            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
+            "items": {
+              "$ref": "#/components/schemas/APIKeyPermission"
+            },
             "type": "array",
             "title": "Permissions"
           }
         },
         "type": "object",
-        "required": ["permissions"],
+        "required": [
+          "permissions"
+        ],
         "title": "UpdatePermissionsRequest"
       },
       "UpdateSessionTitleRequest": {
-        "properties": { "title": { "type": "string", "title": "Title" } },
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          }
+        },
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "title": "UpdateSessionTitleRequest",
         "description": "Request model for updating a session's title."
       },
@@ -17973,7 +26231,9 @@
           }
         },
         "type": "object",
-        "required": ["timezone"],
+        "required": [
+          "timezone"
+        ],
         "title": "UpdateTimezoneRequest"
       },
       "UsageWindowPublic": {
@@ -17992,18 +26252,35 @@
           }
         },
         "type": "object",
-        "required": ["percent_used", "resets_at"],
+        "required": [
+          "percent_used",
+          "resets_at"
+        ],
         "title": "UsageWindowPublic",
         "description": "Public view of a usage window — only the percentage and reset time.\n\nHides the raw spend and the cap so clients cannot derive per-turn cost\nor reverse-engineer platform margins.  ``percent_used`` is capped at 100."
       },
       "UserCostSummary": {
         "properties": {
           "user_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Email"
           },
           "total_cost_microdollars": {
@@ -18028,7 +26305,10 @@
             "title": "Total Cache Creation Tokens",
             "default": 0
           },
-          "request_count": { "type": "integer", "title": "Request Count" },
+          "request_count": {
+            "type": "integer",
+            "title": "Request Count"
+          },
           "cost_bearing_request_count": {
             "type": "integer",
             "title": "Cost Bearing Request Count",
@@ -18047,69 +26327,131 @@
       "UserHistoryResponse": {
         "properties": {
           "history": {
-            "items": { "$ref": "#/components/schemas/UserTransaction" },
+            "items": {
+              "$ref": "#/components/schemas/UserTransaction"
+            },
             "type": "array",
             "title": "History"
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         },
         "type": "object",
-        "required": ["history", "pagination"],
+        "required": [
+          "history",
+          "pagination"
+        ],
         "title": "UserHistoryResponse",
         "description": "Response model for listings with version history"
       },
       "UserOnboarding": {
         "properties": {
-          "userId": { "type": "string", "title": "Userid" },
+          "userId": {
+            "type": "string",
+            "title": "Userid"
+          },
           "completedSteps": {
-            "items": { "$ref": "#/components/schemas/OnboardingStep" },
+            "items": {
+              "$ref": "#/components/schemas/OnboardingStep"
+            },
             "type": "array",
             "title": "Completedsteps"
           },
-          "walletShown": { "type": "boolean", "title": "Walletshown" },
+          "walletShown": {
+            "type": "boolean",
+            "title": "Walletshown"
+          },
           "notified": {
-            "items": { "$ref": "#/components/schemas/OnboardingStep" },
+            "items": {
+              "$ref": "#/components/schemas/OnboardingStep"
+            },
             "type": "array",
             "title": "Notified"
           },
           "rewardedFor": {
-            "items": { "$ref": "#/components/schemas/OnboardingStep" },
+            "items": {
+              "$ref": "#/components/schemas/OnboardingStep"
+            },
             "type": "array",
             "title": "Rewardedfor"
           },
           "usageReason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usagereason"
           },
           "integrations": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Onboardingagentexecutionid"
           },
-          "agentRuns": { "type": "integer", "title": "Agentruns" },
+          "agentRuns": {
+            "type": "integer",
+            "title": "Agentruns"
+          },
           "lastRunAt": {
             "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Lastrunat"
           },
@@ -18140,47 +26482,98 @@
       "UserOnboardingUpdate": {
         "properties": {
           "walletShown": {
-            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Walletshown"
           },
           "notified": {
             "anyOf": [
               {
-                "items": { "$ref": "#/components/schemas/OnboardingStep" },
+                "items": {
+                  "$ref": "#/components/schemas/OnboardingStep"
+                },
                 "type": "array"
               },
-              { "type": "null" }
+              {
+                "type": "null"
+              }
             ],
             "title": "Notified"
           },
           "usageReason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usagereason"
           },
           "integrations": {
             "anyOf": [
-              { "items": { "type": "string" }, "type": "array" },
-              { "type": "null" }
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              { "additionalProperties": true, "type": "object" },
-              { "type": "null" }
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Onboardingagentexecutionid"
           }
         },
@@ -18189,10 +26582,23 @@
       },
       "UserPasswordCredentials": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "provider": { "type": "string", "title": "Provider" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
           "title": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Title"
           },
           "is_managed": {
@@ -18225,14 +26631,28 @@
           }
         },
         "type": "object",
-        "required": ["provider", "username", "password"],
+        "required": [
+          "provider",
+          "username",
+          "password"
+        ],
         "title": "UserPasswordCredentials"
       },
       "UserRateLimitResponse": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
           "daily_cost_limit_microdollars": {
@@ -18251,7 +26671,9 @@
             "type": "integer",
             "title": "Weekly Cost Used Microdollars"
           },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "tier": {
+            "$ref": "#/components/schemas/SubscriptionTier"
+          }
         },
         "type": "object",
         "required": [
@@ -18289,23 +26711,43 @@
       },
       "UserSearchResult": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           }
         },
         "type": "object",
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "title": "UserSearchResult"
       },
       "UserTierResponse": {
         "properties": {
-          "user_id": { "type": "string", "title": "User Id" },
-          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/SubscriptionTier"
+          }
         },
         "type": "object",
-        "required": ["user_id", "tier"],
+        "required": [
+          "user_id",
+          "tier"
+        ],
         "title": "UserTierResponse"
       },
       "UserTransaction": {
@@ -18325,7 +26767,11 @@
             "$ref": "#/components/schemas/CreditTransactionType",
             "default": "USAGE"
           },
-          "amount": { "type": "integer", "title": "Amount", "default": 0 },
+          "amount": {
+            "type": "integer",
+            "title": "Amount",
+            "default": 0
+          },
           "running_balance": {
             "type": "integer",
             "title": "Running Balance",
@@ -18337,15 +26783,36 @@
             "default": 0
           },
           "description": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Description"
           },
           "usage_graph_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usage Graph Id"
           },
           "usage_execution_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Usage Execution Id"
           },
           "usage_node_count": {
@@ -18359,66 +26826,145 @@
             "title": "Usage Start Time",
             "default": "9999-12-31T23:59:59.999999Z"
           },
-          "user_id": { "type": "string", "title": "User Id" },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Email"
           },
           "reason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Reason"
           },
           "admin_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Admin Email"
           },
           "extra_data": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Extra Data"
           }
         },
         "type": "object",
-        "required": ["user_id"],
+        "required": [
+          "user_id"
+        ],
         "title": "UserTransaction"
       },
       "ValidationError": {
         "properties": {
           "loc": {
-            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
             "type": "array",
             "title": "Location"
           },
-          "msg": { "type": "string", "title": "Message" },
-          "type": { "type": "string", "title": "Error Type" },
-          "input": { "title": "Input" },
-          "ctx": { "type": "object", "title": "Context" }
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
         },
         "type": "object",
-        "required": ["loc", "msg", "type"],
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
         "title": "ValidationError"
       },
       "VapidPublicKeyResponse": {
         "properties": {
-          "public_key": { "type": "string", "title": "Public Key" }
+          "public_key": {
+            "type": "string",
+            "title": "Public Key"
+          }
         },
         "type": "object",
-        "required": ["public_key"],
+        "required": [
+          "public_key"
+        ],
         "title": "VapidPublicKeyResponse"
       },
       "Webhook": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "user_id": { "type": "string", "title": "User Id" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "title": "User Id"
+          },
           "provider": {
             "type": "string",
             "title": "Provider",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "credentials_id": { "type": "string", "title": "Credentials Id" },
-          "webhook_type": { "type": "string", "title": "Webhook Type" },
-          "resource": { "type": "string", "title": "Resource" },
+          "credentials_id": {
+            "type": "string",
+            "title": "Credentials Id"
+          },
+          "webhook_type": {
+            "type": "string",
+            "title": "Webhook Type"
+          },
+          "resource": {
+            "type": "string",
+            "title": "Resource"
+          },
           "events": {
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Events"
           },
@@ -18427,12 +26973,19 @@
             "type": "object",
             "title": "Config"
           },
-          "secret": { "type": "string", "title": "Secret" },
+          "secret": {
+            "type": "string",
+            "title": "Secret"
+          },
           "provider_webhook_id": {
             "type": "string",
             "title": "Provider Webhook Id"
           },
-          "url": { "type": "string", "title": "Url", "readOnly": true }
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "readOnly": true
+          }
         },
         "type": "object",
         "required": [
@@ -18450,17 +27003,35 @@
       },
       "WorkspaceFileItem": {
         "properties": {
-          "id": { "type": "string", "title": "Id" },
-          "name": { "type": "string", "title": "Name" },
-          "path": { "type": "string", "title": "Path" },
-          "mime_type": { "type": "string", "title": "Mime Type" },
-          "size_bytes": { "type": "integer", "title": "Size Bytes" },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "mime_type": {
+            "type": "string",
+            "title": "Mime Type"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "title": "Size Bytes"
+          },
           "metadata": {
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
-          "created_at": { "type": "string", "title": "Created At" }
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          }
         },
         "type": "object",
         "required": [
@@ -18475,23 +27046,59 @@
       },
       "backend__api__features__workspace__routes__UploadFileResponse": {
         "properties": {
-          "file_id": { "type": "string", "title": "File Id" },
-          "name": { "type": "string", "title": "Name" },
-          "path": { "type": "string", "title": "Path" },
-          "mime_type": { "type": "string", "title": "Mime Type" },
-          "size_bytes": { "type": "integer", "title": "Size Bytes" }
+          "file_id": {
+            "type": "string",
+            "title": "File Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "mime_type": {
+            "type": "string",
+            "title": "Mime Type"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "title": "Size Bytes"
+          }
         },
         "type": "object",
-        "required": ["file_id", "name", "path", "mime_type", "size_bytes"],
+        "required": [
+          "file_id",
+          "name",
+          "path",
+          "mime_type",
+          "size_bytes"
+        ],
         "title": "UploadFileResponse"
       },
       "backend__api__model__UploadFileResponse": {
         "properties": {
-          "file_uri": { "type": "string", "title": "File Uri" },
-          "file_name": { "type": "string", "title": "File Name" },
-          "size": { "type": "integer", "title": "Size" },
-          "content_type": { "type": "string", "title": "Content Type" },
-          "expires_in_hours": { "type": "integer", "title": "Expires In Hours" }
+          "file_uri": {
+            "type": "string",
+            "title": "File Uri"
+          },
+          "file_name": {
+            "type": "string",
+            "title": "File Name"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "content_type": {
+            "type": "string",
+            "title": "Content Type"
+          },
+          "expires_in_hours": {
+            "type": "integer",
+            "title": "Expires In Hours"
+          }
         },
         "type": "object",
         "required": [
@@ -18510,7 +27117,10 @@
         "in": "header",
         "name": "X-Postmark-Webhook-Token"
       },
-      "HTTPBearer": { "type": "http", "scheme": "bearer" },
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      },
       "HTTPBearerJWT": {
         "type": "http",
         "scheme": "bearer",
@@ -18524,7 +27134,11 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": { "detail": { "type": "string" } }
+              "properties": {
+                "detail": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -9,12 +9,7 @@
   "paths": {
     "/api/admin/diagnostics/agents": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Get Agent Diagnostics",
         "description": "Get diagnostic information about agents.\n\nReturns:\n    - agents_with_active_executions: Number of unique agents with running/queued executions\n    - timestamp: Current timestamp",
         "operationId": "getV2Get agent diagnostics",
@@ -42,12 +37,7 @@
     },
     "/api/admin/diagnostics/executions": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Get Execution Diagnostics",
         "description": "Get comprehensive diagnostic information about execution status.\n\nReturns all execution metrics including:\n- Current state (running, queued)\n- Orphaned executions (>24h old, likely not in executor)\n- Failure metrics (1h, 24h, rate)\n- Long-running detection (stuck >1h, >24h)\n- Stuck queued detection\n- Throughput metrics (completions/hour)\n- RabbitMQ queue depths",
         "operationId": "getV2Get execution diagnostics",
@@ -75,12 +65,7 @@
     },
     "/api/admin/diagnostics/executions/cleanup-all-orphaned": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Cleanup ALL Orphaned Executions",
         "description": "Cleanup ALL orphaned executions (>24h old) by directly updating DB status.\nOperates on all executions, not just paginated results.\n\nReturns:\n    Number of executions cleaned up and success message",
         "operationId": "postV2Cleanup all orphaned executions",
@@ -108,12 +93,7 @@
     },
     "/api/admin/diagnostics/executions/cleanup-all-stuck-queued": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Cleanup ALL Stuck Queued Executions",
         "description": "Cleanup ALL stuck queued executions (QUEUED >1h) by updating DB status (admin only).\nOperates on entire dataset, not limited to pagination.\n\nReturns:\n    Number of executions cleaned up and success message",
         "operationId": "postV2Cleanup all stuck queued executions",
@@ -141,12 +121,7 @@
     },
     "/api/admin/diagnostics/executions/cleanup-orphaned": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Cleanup Orphaned Executions",
         "description": "Cleanup orphaned executions by directly updating DB status (admin only).\nFor executions in DB but not actually running in executor (old/stale records).\n\nArgs:\n    request: Contains list of execution_ids to cleanup\n\nReturns:\n    Number of executions cleaned up and success message",
         "operationId": "postV2Cleanup orphaned executions",
@@ -194,12 +169,7 @@
     },
     "/api/admin/diagnostics/executions/failed": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Failed Executions",
         "description": "Get detailed list of failed executions.\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n    hours: Number of hours to look back (default 24)\n\nReturns:\n    List of failed executions with error details",
         "operationId": "getV2List failed executions",
@@ -269,12 +239,7 @@
     },
     "/api/admin/diagnostics/executions/invalid": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Invalid Executions",
         "description": "Get detailed list of executions in invalid states (READ-ONLY).\n\nInvalid states indicate data corruption and require manual investigation:\n- QUEUED but has startedAt (impossible - can't start while queued)\n- RUNNING but no startedAt (impossible - can't run without starting)\n\n⚠️ NO BULK ACTIONS PROVIDED - These need case-by-case investigation.\n\nEach invalid execution likely has a different root cause (crashes, race conditions,\nDB corruption). Investigate the execution history and logs to determine appropriate\naction (manual cleanup, status fix, or leave as-is if system recovered).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of invalid state executions with details",
         "operationId": "getV2List invalid executions",
@@ -334,12 +299,7 @@
     },
     "/api/admin/diagnostics/executions/long-running": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Long-Running Executions",
         "description": "Get detailed list of long-running executions (RUNNING status >24h).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of long-running executions with details",
         "operationId": "getV2List long-running executions",
@@ -399,12 +359,7 @@
     },
     "/api/admin/diagnostics/executions/orphaned": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Orphaned Executions",
         "description": "Get detailed list of orphaned executions (>24h old, likely not in executor).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of orphaned executions with details",
         "operationId": "getV2List orphaned executions",
@@ -464,12 +419,7 @@
     },
     "/api/admin/diagnostics/executions/requeue": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Requeue Stuck Execution",
         "description": "Requeue a stuck QUEUED execution (admin only).\n\nUses add_graph_execution with existing graph_exec_id to requeue.\n\n⚠️ WARNING: Only use for stuck executions. This will re-execute and may cost credits.\n\nArgs:\n    request: Contains execution_id to requeue\n\nReturns:\n    Success status and message",
         "operationId": "postV2Requeue stuck execution",
@@ -517,12 +467,7 @@
     },
     "/api/admin/diagnostics/executions/requeue-all-stuck": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Requeue ALL Stuck Queued Executions",
         "description": "Requeue ALL stuck queued executions (QUEUED >1h) by publishing to RabbitMQ.\nOperates on all executions, not just paginated results.\n\nUses add_graph_execution with existing graph_exec_id to requeue.\n\n⚠️ WARNING: This will re-execute ALL stuck executions and may cost significant credits.\n\nReturns:\n    Number of executions requeued and success message",
         "operationId": "postV2Requeue all stuck queued executions",
@@ -550,12 +495,7 @@
     },
     "/api/admin/diagnostics/executions/requeue-bulk": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Requeue Multiple Stuck Executions",
         "description": "Requeue multiple stuck QUEUED executions (admin only).\n\nUses add_graph_execution with existing graph_exec_id to requeue.\n\n⚠️ WARNING: Only use for stuck executions. This will re-execute and may cost credits.\n\nArgs:\n    request: Contains list of execution_ids to requeue\n\nReturns:\n    Number of executions requeued and success message",
         "operationId": "postV2Requeue multiple stuck executions",
@@ -603,12 +543,7 @@
     },
     "/api/admin/diagnostics/executions/running": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Running Executions",
         "description": "Get detailed list of running and queued executions (recent, likely active).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of running executions with details",
         "operationId": "getV2List running executions",
@@ -668,12 +603,7 @@
     },
     "/api/admin/diagnostics/executions/stop": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Stop Single Execution",
         "description": "Stop a single execution (admin only).\n\nUses robust stop_graph_execution which cascades to children and waits for termination.\n\nArgs:\n    request: Contains execution_id to stop\n\nReturns:\n    Success status and message",
         "operationId": "postV2Stop single execution",
@@ -721,12 +651,7 @@
     },
     "/api/admin/diagnostics/executions/stop-all-long-running": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Stop ALL Long-Running Executions",
         "description": "Stop ALL long-running executions (RUNNING >24h) by sending cancel signals (admin only).\nOperates on entire dataset, not limited to pagination.\n\nReturns:\n    Number of executions stopped and success message",
         "operationId": "postV2Stop all long-running executions",
@@ -754,12 +679,7 @@
     },
     "/api/admin/diagnostics/executions/stop-bulk": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Stop Multiple Executions",
         "description": "Stop multiple active executions (admin only).\n\nUses robust stop_graph_execution which cascades to children and waits for termination.\n\nArgs:\n    request: Contains list of execution_ids to stop\n\nReturns:\n    Number of executions stopped and success message",
         "operationId": "postV2Stop multiple executions",
@@ -807,12 +727,7 @@
     },
     "/api/admin/diagnostics/executions/stuck-queued": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Stuck Queued Executions",
         "description": "Get detailed list of stuck queued executions (QUEUED >1h, never started).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of stuck queued executions with details",
         "operationId": "getV2List stuck queued executions",
@@ -872,12 +787,7 @@
     },
     "/api/admin/diagnostics/schedules": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Get Schedule Diagnostics",
         "description": "Get comprehensive diagnostic information about schedule health.\n\nReturns schedule metrics including:\n- Total schedules (user vs system)\n- Orphaned schedules by category\n- Upcoming executions",
         "operationId": "getV2Get schedule diagnostics",
@@ -905,12 +815,7 @@
     },
     "/api/admin/diagnostics/schedules/all": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List All User Schedules",
         "description": "Get detailed list of all user schedules (excludes system monitoring jobs).\n\nArgs:\n    limit: Maximum number of schedules to return (default 100)\n    offset: Number of schedules to skip (default 0)\n\nReturns:\n    List of schedules with details",
         "operationId": "getV2List all user schedules",
@@ -970,12 +875,7 @@
     },
     "/api/admin/diagnostics/schedules/cleanup-orphaned": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "Cleanup Orphaned Schedules",
         "description": "Cleanup orphaned schedules by deleting from scheduler (admin only).\n\nArgs:\n    request: Contains list of schedule_ids to delete\n\nReturns:\n    Number of schedules deleted and success message",
         "operationId": "postV2Cleanup orphaned schedules",
@@ -1023,12 +923,7 @@
     },
     "/api/admin/diagnostics/schedules/orphaned": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "diagnostics",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "diagnostics", "admin"],
         "summary": "List Orphaned Schedules",
         "description": "Get detailed list of orphaned schedules with orphan reasons.\n\nReturns:\n    List of orphaned schedules categorized by orphan type",
         "operationId": "getV2List orphaned schedules",
@@ -1056,12 +951,7 @@
     },
     "/api/admin/platform-costs/dashboard": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "platform-cost",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Dashboard",
         "operationId": "getV2Get platform cost dashboard",
         "security": [
@@ -1230,12 +1120,7 @@
     },
     "/api/admin/platform-costs/logs": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "platform-cost",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Logs",
         "operationId": "getV2Get platform cost logs",
         "security": [
@@ -1427,12 +1312,7 @@
     },
     "/api/admin/platform-costs/logs/export": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "platform-cost",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Export Platform Cost Logs",
         "operationId": "getV2Export platform cost logs",
         "security": [
@@ -1601,9 +1481,7 @@
     },
     "/api/analytics/log_raw_analytics": {
       "post": {
-        "tags": [
-          "analytics"
-        ],
+        "tags": ["analytics"],
         "summary": "Log Raw Analytics",
         "operationId": "postAnalyticsLogRawAnalytics",
         "requestBody": {
@@ -1648,9 +1526,7 @@
     },
     "/api/analytics/log_raw_metric": {
       "post": {
-        "tags": [
-          "analytics"
-        ],
+        "tags": ["analytics"],
         "summary": "Log Raw Metric",
         "operationId": "postAnalyticsLogRawMetric",
         "requestBody": {
@@ -1695,10 +1571,7 @@
     },
     "/api/api-keys": {
       "get": {
-        "tags": [
-          "v1",
-          "api-keys"
-        ],
+        "tags": ["v1", "api-keys"],
         "summary": "List user API keys",
         "description": "List all API keys for the user",
         "operationId": "getV1List user api keys",
@@ -1728,10 +1601,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "api-keys"
-        ],
+        "tags": ["v1", "api-keys"],
         "summary": "Create new API key",
         "description": "Create a new API key",
         "operationId": "postV1Create new api key",
@@ -1779,10 +1649,7 @@
     },
     "/api/api-keys/{key_id}": {
       "delete": {
-        "tags": [
-          "v1",
-          "api-keys"
-        ],
+        "tags": ["v1", "api-keys"],
         "summary": "Revoke API key",
         "description": "Revoke an API key",
         "operationId": "deleteV1Revoke api key",
@@ -1829,10 +1696,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v1",
-          "api-keys"
-        ],
+        "tags": ["v1", "api-keys"],
         "summary": "Get specific API key",
         "description": "Get a specific API key",
         "operationId": "getV1Get specific api key",
@@ -1881,10 +1745,7 @@
     },
     "/api/api-keys/{key_id}/permissions": {
       "put": {
-        "tags": [
-          "v1",
-          "api-keys"
-        ],
+        "tags": ["v1", "api-keys"],
         "summary": "Update key permissions",
         "description": "Update API key permissions",
         "operationId": "putV1Update key permissions",
@@ -1943,10 +1804,7 @@
     },
     "/api/api-keys/{key_id}/suspend": {
       "post": {
-        "tags": [
-          "v1",
-          "api-keys"
-        ],
+        "tags": ["v1", "api-keys"],
         "summary": "Suspend API key",
         "description": "Suspend an API key",
         "operationId": "postV1Suspend api key",
@@ -1995,10 +1853,7 @@
     },
     "/api/auth/user": {
       "post": {
-        "tags": [
-          "v1",
-          "auth"
-        ],
+        "tags": ["v1", "auth"],
         "summary": "Get or create user",
         "operationId": "postV1Get or create user",
         "responses": {
@@ -2023,10 +1878,7 @@
     },
     "/api/auth/user/email": {
       "post": {
-        "tags": [
-          "v1",
-          "auth"
-        ],
+        "tags": ["v1", "auth"],
         "summary": "Update user email",
         "operationId": "postV1Update user email",
         "requestBody": {
@@ -2078,10 +1930,7 @@
     },
     "/api/auth/user/preferences": {
       "get": {
-        "tags": [
-          "v1",
-          "auth"
-        ],
+        "tags": ["v1", "auth"],
         "summary": "Get notification preferences",
         "operationId": "getV1Get notification preferences",
         "responses": {
@@ -2106,10 +1955,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "auth"
-        ],
+        "tags": ["v1", "auth"],
         "summary": "Update notification preferences",
         "operationId": "postV1Update notification preferences",
         "requestBody": {
@@ -2156,10 +2002,7 @@
     },
     "/api/auth/user/timezone": {
       "get": {
-        "tags": [
-          "v1",
-          "auth"
-        ],
+        "tags": ["v1", "auth"],
         "summary": "Get user timezone",
         "description": "Get user timezone setting.",
         "operationId": "getV1Get user timezone",
@@ -2185,10 +2028,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "auth"
-        ],
+        "tags": ["v1", "auth"],
         "summary": "Update user timezone",
         "description": "Update user timezone. The timezone should be a valid IANA timezone identifier.",
         "operationId": "postV1Update user timezone",
@@ -2236,10 +2076,7 @@
     },
     "/api/blocks": {
       "get": {
-        "tags": [
-          "v1",
-          "blocks"
-        ],
+        "tags": ["v1", "blocks"],
         "summary": "List available blocks",
         "operationId": "getV1List available blocks",
         "responses": {
@@ -2271,10 +2108,7 @@
     },
     "/api/blocks/{block_id}/execute": {
       "post": {
-        "tags": [
-          "v1",
-          "blocks"
-        ],
+        "tags": ["v1", "blocks"],
         "summary": "Execute graph block",
         "operationId": "postV1Execute graph block",
         "security": [
@@ -2339,9 +2173,7 @@
     },
     "/api/builder/blocks": {
       "get": {
-        "tags": [
-          "v2"
-        ],
+        "tags": ["v2"],
         "summary": "Get Builder blocks",
         "description": "Get blocks based on either category, type, or provider.",
         "operationId": "getV2Get builder blocks",
@@ -2374,12 +2206,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "enum": [
-                    "all",
-                    "input",
-                    "action",
-                    "output"
-                  ],
+                  "enum": ["all", "input", "action", "output"],
                   "type": "string"
                 },
                 {
@@ -2456,9 +2283,7 @@
     },
     "/api/builder/blocks/batch": {
       "get": {
-        "tags": [
-          "v2"
-        ],
+        "tags": ["v2"],
         "summary": "Get specific blocks",
         "description": "Get specific blocks by their IDs.",
         "operationId": "getV2Get specific blocks",
@@ -2514,9 +2339,7 @@
     },
     "/api/builder/categories": {
       "get": {
-        "tags": [
-          "v2"
-        ],
+        "tags": ["v2"],
         "summary": "Get Builder block categories",
         "description": "Get all block categories with a specified number of blocks per category.",
         "operationId": "getV2Get builder block categories",
@@ -2570,9 +2393,7 @@
     },
     "/api/builder/counts": {
       "get": {
-        "tags": [
-          "v2"
-        ],
+        "tags": ["v2"],
         "summary": "Get Builder item counts",
         "description": "Get item counts for the menu categories in the Blocks Menu.",
         "operationId": "getV2Get builder item counts",
@@ -2600,9 +2421,7 @@
     },
     "/api/builder/providers": {
       "get": {
-        "tags": [
-          "v2"
-        ],
+        "tags": ["v2"],
         "summary": "Get Builder integration providers",
         "description": "Get all integration providers with their block counts.",
         "operationId": "getV2Get builder integration providers",
@@ -2662,11 +2481,7 @@
     },
     "/api/builder/search": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Builder search",
         "description": "Search for blocks (including integrations), marketplace agents, and user library agents.",
         "operationId": "getV2Builder search",
@@ -2793,9 +2608,7 @@
     },
     "/api/builder/suggestions": {
       "get": {
-        "tags": [
-          "v2"
-        ],
+        "tags": ["v2"],
         "summary": "Get Builder suggestions",
         "description": "Get all suggestions for the Blocks Menu.",
         "operationId": "getV2Get builder suggestions",
@@ -2823,11 +2636,7 @@
     },
     "/api/chat/config/ttl": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Get Ttl Config",
         "description": "Get the stream TTL configuration.\n\nReturns the Time-To-Live settings for chat streams, which determines\nhow long clients can reconnect to an active stream.\n\nReturns:\n    dict: TTL configuration with seconds and milliseconds values.",
         "operationId": "getV2GetTtlConfig",
@@ -2849,11 +2658,7 @@
     },
     "/api/chat/health": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Health Check",
         "description": "Health check endpoint for the chat service.\n\nPerforms a full cycle test of session creation and retrieval. Should always return healthy\nif the service and data layer are operational.\n\nReturns:\n    dict: A status dictionary indicating health, service name, and API version.",
         "operationId": "getV2HealthCheck",
@@ -2875,11 +2680,7 @@
     },
     "/api/chat/schema/tool-responses": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "[Dummy] Tool response type export for codegen",
         "description": "This endpoint is not meant to be called. It exists solely to expose tool response models in the OpenAPI schema for frontend codegen.",
         "operationId": "getV2[dummy] tool response type export for codegen",
@@ -2979,11 +2780,7 @@
     },
     "/api/chat/sessions": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "List Sessions",
         "description": "List chat sessions for the authenticated user.\n\nReturns a paginated list of chat sessions belonging to the current user,\nordered by most recently updated.\n\nArgs:\n    user_id: The authenticated user's ID.\n    limit: Maximum number of sessions to return (1-100).\n    offset: Number of sessions to skip for pagination.\n\nReturns:\n    ListSessionsResponse: List of session summaries and total count.",
         "operationId": "getV2ListSessions",
@@ -3044,11 +2841,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Create Session",
         "description": "Create (or get-or-create) a chat session.\n\nTwo modes, selected by the request body:\n\n- Default: create a fresh session for the user. ``dry_run=True`` forces\n  run_block and run_agent calls to use dry-run simulation.\n- Builder-bound: when ``builder_graph_id`` is set, get-or-create keyed\n  on ``(user_id, builder_graph_id)``. Returns the existing session for\n  that graph or creates one locked to it.  Graph ownership is validated\n  inside :func:`get_or_create_builder_session`; raises 404 on\n  unauthorized access.  Write-side scope is enforced per-tool\n  (``edit_agent`` / ``run_agent`` reject any ``agent_id`` other than\n  the bound graph) and a small blacklist hides tools that conflict\n  with the panel's scope (see :data:`BUILDER_BLOCKED_TOOLS`).\n\nArgs:\n    user_id: The authenticated user ID parsed from the JWT (required).\n    request: Optional request body with ``dry_run`` and/or\n        ``builder_graph_id``.\n\nReturns:\n    CreateSessionResponse: Details of the resulting session.",
         "operationId": "postV2CreateSession",
@@ -3103,11 +2896,7 @@
     },
     "/api/chat/sessions/{session_id}": {
       "delete": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Delete Session",
         "description": "Delete a chat session.\n\nPermanently removes a chat session and all its messages.\nOnly the owner can delete their sessions.\n\nArgs:\n    session_id: The session ID to delete.\n    user_id: The authenticated user's ID.\n\nReturns:\n    204 No Content on success.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "deleteV2DeleteSession",
@@ -3150,11 +2939,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Get Session",
         "description": "Retrieve the details of a specific chat session.\n\nSupports cursor-based pagination via ``limit`` and ``before_sequence``.\nWhen no pagination params are provided, returns the most recent messages.",
         "operationId": "getV2GetSession",
@@ -3232,11 +3017,7 @@
     },
     "/api/chat/sessions/{session_id}/assign-user": {
       "patch": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Session Assign User",
         "description": "Assign an authenticated user to a chat session.\n\nUsed (typically post-login) to claim an existing anonymous session as the current authenticated user.\n\nArgs:\n    session_id: The identifier for the (previously anonymous) session.\n    user_id: The authenticated user's ID to associate with the session.\n\nReturns:\n    dict: Status of the assignment.",
         "operationId": "patchV2SessionAssignUser",
@@ -3287,11 +3068,7 @@
     },
     "/api/chat/sessions/{session_id}/cancel": {
       "post": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Cancel Session Task",
         "description": "Cancel the active streaming task for a session.\n\nPublishes a cancel event to the executor via RabbitMQ FANOUT, then\npolls Redis until the task status flips from ``running`` or a timeout\n(5 s) is reached.  Returns only after the cancellation is confirmed.",
         "operationId": "postV2CancelSessionTask",
@@ -3340,11 +3117,7 @@
     },
     "/api/chat/sessions/{session_id}/messages/pending": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Get Pending Messages",
         "description": "Peek at the pending-message buffer without consuming it.\n\nReturns the current contents of the session's pending message buffer\nso the frontend can restore the queued-message indicator after a page\nrefresh and clear it correctly once a turn drains the buffer.",
         "operationId": "getV2GetPendingMessages",
@@ -3394,11 +3167,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Queue Pending Message",
         "description": "Queue a follow-up message while the session has an active turn.",
         "operationId": "postV2QueuePendingMessage",
@@ -3466,11 +3235,7 @@
     },
     "/api/chat/sessions/{session_id}/stream": {
       "delete": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Disconnect Session Stream",
         "description": "Disconnect all active SSE listeners for a session.\n\nCalled by the frontend when the user switches away from a chat so the\nbackend releases XREAD listeners immediately rather than waiting for\nthe 5-10 s timeout.",
         "operationId": "deleteV2DisconnectSessionStream",
@@ -3510,11 +3275,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Resume Session Stream",
         "description": "Resume an active stream for a session.\n\nCalled by the AI SDK's ``useChat(resume: true)`` on page load.\nChecks for an active (in-progress) task on the session and either replays\nthe full SSE stream or returns 204 No Content if nothing is running.\n\nAlways replays the active turn from ``0-0``. The AI SDK UI-message parser\nkeeps text/reasoning part state inside a single parser instance; resuming\nfrom a Redis cursor can skip the ``*-start`` events required by later\n``*-delta`` chunks.",
         "operationId": "getV2ResumeSessionStream",
@@ -3559,11 +3320,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Stream Chat Post",
         "description": "Start a new turn and return an AI SDK UI message stream.\n\nReturns an SSE stream (``text/event-stream``) with Vercel AI SDK chunks\n(text fragments, tool-call UI, tool results). The generation runs in a\nbackground task that survives client disconnects; reconnect via\n``GET /sessions/{session_id}/stream`` to resume.\n\nFollow-up messages typed while a turn is already running should use\n``POST /sessions/{session_id}/messages/pending``. If an older client still\nposts that follow-up here, we queue it defensively but still return a valid\nempty UI-message stream so AI SDK transports never receive a JSON body from\nthe stream endpoint.\n\nArgs:\n    session_id: The chat session identifier.\n    request: Request body with message, is_user_message, and optional context.\n    user_id: Authenticated user ID.",
         "operationId": "postV2StreamChatPost",
@@ -3626,11 +3383,7 @@
     },
     "/api/chat/sessions/{session_id}/title": {
       "patch": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Update session title",
         "description": "Update the title of a chat session.\n\nAllows the user to rename their chat session.\n\nArgs:\n    session_id: The session ID to update.\n    request: Request body containing the new title.\n    user_id: The authenticated user's ID.\n\nReturns:\n    dict: Status of the update.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "patchV2Update session title",
@@ -3694,11 +3447,7 @@
     },
     "/api/chat/suggested-prompts": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Get Suggested Prompts",
         "description": "Get LLM-generated suggested prompts grouped by theme.\n\nReturns personalized quick-action prompts based on the user's\nbusiness understanding. Returns empty themes list if no custom\nprompts are available.",
         "operationId": "getV2GetSuggestedPrompts",
@@ -3726,11 +3475,7 @@
     },
     "/api/chat/usage": {
       "get": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Get Copilot Usage",
         "description": "Get CoPilot usage status for the authenticated user.\n\nReturns the percentage of the daily/weekly allowance used — not the\nraw spend or cap — so clients cannot derive per-turn cost or platform\nmargins. Global defaults sourced from LaunchDarkly (falling back to\nconfig). Includes the user's rate-limit tier.",
         "operationId": "getV2GetCopilotUsage",
@@ -3758,11 +3503,7 @@
     },
     "/api/chat/usage/reset": {
       "post": {
-        "tags": [
-          "v2",
-          "chat",
-          "chat"
-        ],
+        "tags": ["v2", "chat", "chat"],
         "summary": "Reset Copilot Usage",
         "description": "Reset the daily CoPilot rate limit by spending credits.\n\nAllows users who have hit their daily cost limit to spend credits\nto reset their daily usage counter and continue working.\nReturns 400 if the feature is disabled or the user is not over the limit.\nReturns 402 if the user has insufficient credits.",
         "operationId": "postV2ResetCopilotUsage",
@@ -3802,12 +3543,7 @@
     },
     "/api/copilot/admin/rate_limit": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "copilot",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "copilot", "admin"],
         "summary": "Get User Rate Limit",
         "description": "Get a user's current usage and effective rate limits. Admin-only.\n\nAccepts either ``user_id`` or ``email`` as a query parameter.\nWhen ``email`` is provided the user is looked up by email first.",
         "operationId": "getV2Get user rate limit",
@@ -3879,12 +3615,7 @@
     },
     "/api/copilot/admin/rate_limit/reset": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "copilot",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "copilot", "admin"],
         "summary": "Reset User Rate Limit Usage",
         "description": "Reset a user's daily usage counter (and optionally weekly). Admin-only.",
         "operationId": "postV2Reset user rate limit usage",
@@ -3932,12 +3663,7 @@
     },
     "/api/copilot/admin/rate_limit/search_users": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "copilot",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "copilot", "admin"],
         "summary": "Search Users by Name or Email",
         "description": "Search users by partial email or name. Admin-only.\n\nQueries the User table directly — returns results even for users\nwithout credit transaction history.",
         "operationId": "getV2Search users by name or email",
@@ -4000,12 +3726,7 @@
     },
     "/api/copilot/admin/rate_limit/tier": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "copilot",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "copilot", "admin"],
         "summary": "Get User Rate Limit Tier",
         "description": "Get a user's current rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "getV2Get user rate limit tier",
@@ -4052,12 +3773,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "copilot",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "copilot", "admin"],
         "summary": "Set User Rate Limit Tier",
         "description": "Set a user's rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "postV2Set user rate limit tier",
@@ -4105,10 +3821,7 @@
     },
     "/api/credits": {
       "get": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Get user credits",
         "operationId": "getV1Get user credits",
         "responses": {
@@ -4137,10 +3850,7 @@
         ]
       },
       "patch": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Fulfill checkout session",
         "operationId": "patchV1Fulfill checkout session",
         "responses": {
@@ -4163,10 +3873,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Request credit top up",
         "operationId": "postV1Request credit top up",
         "requestBody": {
@@ -4211,12 +3918,7 @@
     },
     "/api/credits/admin/add_credits": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "credits",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Add Credits to User",
         "operationId": "postV2Add credits to user",
         "requestBody": {
@@ -4263,12 +3965,7 @@
     },
     "/api/credits/admin/copilot-usage/export": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "credits",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Export Copilot Weekly Usage vs Rate Limit",
         "description": "Export per-(user, ISO week) copilot spend with the user's tier limit.\n\nUses the same 90-day window cap and 100k row cap as the credit export.",
         "operationId": "getV2Export copilot weekly usage vs rate limit",
@@ -4346,12 +4043,7 @@
     },
     "/api/credits/admin/transactions/export": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "credits",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Export Credit Transactions",
         "description": "Export CreditTransaction rows in [start, end] for finance reporting.\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
         "operationId": "getV2Export credit transactions",
@@ -4461,12 +4153,7 @@
     },
     "/api/credits/admin/users_history": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "credits",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Get All Users History",
         "operationId": "getV2Get all users history",
         "security": [
@@ -4557,10 +4244,7 @@
     },
     "/api/credits/auto-top-up": {
       "get": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Get auto top up",
         "operationId": "getV1Get auto top up",
         "responses": {
@@ -4585,10 +4269,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Configure auto top up",
         "description": "Configure auto top-up settings and perform an immediate top-up if needed.\n\nRaises HTTPException(422) if the request parameters are invalid or if\nthe credit top-up fails.",
         "operationId": "postV1Configure auto top up",
@@ -4637,10 +4318,7 @@
     },
     "/api/credits/manage": {
       "get": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Manage payment methods",
         "operationId": "getV1Manage payment methods",
         "responses": {
@@ -4671,10 +4349,7 @@
     },
     "/api/credits/refunds": {
       "get": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Get refund requests",
         "operationId": "getV1Get refund requests",
         "responses": {
@@ -4705,10 +4380,7 @@
     },
     "/api/credits/stripe_webhook": {
       "post": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Handle Stripe webhooks",
         "operationId": "postV1Handle stripe webhooks",
         "responses": {
@@ -4725,10 +4397,7 @@
     },
     "/api/credits/subscription": {
       "get": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Get subscription tier, current cost, and all tier costs",
         "operationId": "getSubscriptionStatus",
         "responses": {
@@ -4753,10 +4422,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Update subscription tier or start a Stripe Checkout session",
         "operationId": "updateSubscriptionTier",
         "requestBody": {
@@ -4803,10 +4469,7 @@
     },
     "/api/credits/transactions": {
       "get": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Get credit history",
         "operationId": "getV1Get credit history",
         "security": [
@@ -4888,10 +4551,7 @@
     },
     "/api/credits/{transaction_key}/refund": {
       "post": {
-        "tags": [
-          "v1",
-          "credits"
-        ],
+        "tags": ["v1", "credits"],
         "summary": "Refund credit transaction",
         "operationId": "postV1Refund credit transaction",
         "security": [
@@ -4954,10 +4614,7 @@
     },
     "/api/email/": {
       "post": {
-        "tags": [
-          "v1",
-          "email"
-        ],
+        "tags": ["v1", "email"],
         "summary": "Handle Postmark Email Webhooks",
         "operationId": "postV1Handle postmark email webhooks",
         "requestBody": {
@@ -5030,10 +4687,7 @@
     },
     "/api/email/unsubscribe": {
       "post": {
-        "tags": [
-          "v1",
-          "email"
-        ],
+        "tags": ["v1", "email"],
         "summary": "One Click Email Unsubscribe",
         "operationId": "postV1One click email unsubscribe",
         "parameters": [
@@ -5071,10 +4725,7 @@
     },
     "/api/executions": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "List all executions",
         "operationId": "getV1List all executions",
         "responses": {
@@ -5105,12 +4756,7 @@
     },
     "/api/executions/admin/execution_accuracy_trends": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "admin",
-          "execution_analytics"
-        ],
+        "tags": ["v2", "admin", "admin", "execution_analytics"],
         "summary": "Get Execution Accuracy Trends and Alerts",
         "description": "Get execution accuracy trends with moving averages and alert detection.\nSimple single-query approach.",
         "operationId": "getV2Get execution accuracy trends and alerts",
@@ -5205,12 +4851,7 @@
     },
     "/api/executions/admin/execution_analytics": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "admin",
-          "execution_analytics"
-        ],
+        "tags": ["v2", "admin", "admin", "execution_analytics"],
         "summary": "Generate Execution Analytics",
         "description": "Generate activity summaries and correctness scores for graph executions.\n\nThis endpoint:\n1. Fetches all completed executions matching the criteria\n2. Identifies executions missing activity_status or correctness_score\n3. Generates missing data using AI in batches\n4. Updates the database with new stats\n5. Returns a detailed report of the analytics operation",
         "operationId": "postV2Generate execution analytics",
@@ -5258,12 +4899,7 @@
     },
     "/api/executions/admin/execution_analytics/config": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "admin",
-          "execution_analytics"
-        ],
+        "tags": ["v2", "admin", "admin", "execution_analytics"],
         "summary": "Get Execution Analytics Configuration",
         "description": "Get the configuration for execution analytics including:\n- Available AI models with metadata\n- Default system and user prompts\n- Recommended model selection",
         "operationId": "getV2Get execution analytics configuration",
@@ -5291,10 +4927,7 @@
     },
     "/api/executions/{graph_exec_id}": {
       "delete": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Delete graph execution",
         "operationId": "deleteV1Delete graph execution",
         "security": [
@@ -5335,10 +4968,7 @@
     },
     "/api/files/upload": {
       "post": {
-        "tags": [
-          "v1",
-          "files"
-        ],
+        "tags": ["v1", "files"],
         "summary": "Upload file to cloud storage",
         "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    provider: Cloud storage provider (\"gcs\", \"s3\", \"azure\")\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    Dict containing the cloud storage path and signed URL",
         "operationId": "postV1Upload file to cloud storage",
@@ -5398,10 +5028,7 @@
     },
     "/api/graphs": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "List user graphs",
         "operationId": "getV1List user graphs",
         "responses": {
@@ -5430,10 +5057,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Create new graph",
         "operationId": "postV1Create new graph",
         "requestBody": {
@@ -5480,10 +5104,7 @@
     },
     "/api/graphs/{graph_id}": {
       "delete": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Delete graph permanently",
         "operationId": "deleteV1Delete graph permanently",
         "security": [
@@ -5529,10 +5150,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Get specific graph",
         "operationId": "getV1Get specific graph",
         "security": [
@@ -5604,10 +5222,7 @@
         }
       },
       "put": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Update graph version",
         "operationId": "putV1Update graph version",
         "security": [
@@ -5665,10 +5280,7 @@
     },
     "/api/graphs/{graph_id}/execute/{graph_version}": {
       "post": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Execute graph agent",
         "operationId": "postV1Execute graph agent",
         "security": [
@@ -5757,10 +5369,7 @@
     },
     "/api/graphs/{graph_id}/executions": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "List graph executions",
         "operationId": "getV1List graph executions",
         "security": [
@@ -5835,10 +5444,7 @@
     },
     "/api/graphs/{graph_id}/executions/{graph_exec_id}": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Get execution details",
         "operationId": "getV1Get execution details",
         "security": [
@@ -5903,9 +5509,7 @@
     },
     "/api/graphs/{graph_id}/executions/{graph_exec_id}/share": {
       "delete": {
-        "tags": [
-          "v1"
-        ],
+        "tags": ["v1"],
         "summary": "Disable Execution Sharing",
         "description": "Disable sharing for a graph execution.",
         "operationId": "deleteV1DisableExecutionSharing",
@@ -5954,9 +5558,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v1"
-        ],
+        "tags": ["v1"],
         "summary": "Enable Execution Sharing",
         "description": "Enable sharing for a graph execution.",
         "operationId": "postV1EnableExecutionSharing",
@@ -6024,10 +5626,7 @@
     },
     "/api/graphs/{graph_id}/executions/{graph_exec_id}/stop": {
       "post": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Stop graph execution",
         "operationId": "postV1Stop graph execution",
         "security": [
@@ -6092,10 +5691,7 @@
     },
     "/api/graphs/{graph_id}/schedules": {
       "get": {
-        "tags": [
-          "v1",
-          "schedules"
-        ],
+        "tags": ["v1", "schedules"],
         "summary": "List execution schedules for a graph",
         "operationId": "getV1List execution schedules for a graph",
         "security": [
@@ -6145,10 +5741,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v1",
-          "schedules"
-        ],
+        "tags": ["v1", "schedules"],
         "summary": "Create execution schedule",
         "operationId": "postV1Create execution schedule",
         "security": [
@@ -6208,10 +5801,7 @@
     },
     "/api/graphs/{graph_id}/settings": {
       "patch": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Update graph settings",
         "description": "Update graph settings for the user's library agent.",
         "operationId": "patchV1Update graph settings",
@@ -6270,10 +5860,7 @@
     },
     "/api/graphs/{graph_id}/versions": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Get all graph versions",
         "operationId": "getV1Get all graph versions",
         "security": [
@@ -6325,10 +5912,7 @@
     },
     "/api/graphs/{graph_id}/versions/active": {
       "put": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Set active graph version",
         "operationId": "putV1Set active graph version",
         "security": [
@@ -6384,10 +5968,7 @@
     },
     "/api/graphs/{graph_id}/versions/{version}": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Get graph version",
         "operationId": "getV1Get graph version",
         "security": [
@@ -6461,10 +6042,7 @@
     },
     "/api/integrations/ayrshare/sso_url": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Get Ayrshare Sso Url",
         "description": "Generate a JWT SSO URL so the user can link their social accounts.\n\nThe per-user Ayrshare profile key is provisioned and persisted as a\nstandard ``is_managed=True`` credential by\n:class:`~backend.integrations.managed_providers.ayrshare.AyrshareManagedProvider`.\nThis endpoint only signs a short-lived JWT pointing at the Ayrshare-\nhosted social-linking page; all profile lifecycle logic lives with the\nmanaged provider.",
         "operationId": "getV1GetAyrshareSsoUrl",
@@ -6492,10 +6070,7 @@
     },
     "/api/integrations/credentials": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "List Credentials",
         "operationId": "getV1List credentials",
         "responses": {
@@ -6526,10 +6101,7 @@
     },
     "/api/integrations/providers": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "List Providers",
         "description": "Get metadata for every available provider.\n\nReturns both statically defined providers (from ``ProviderName`` enum) and\ndynamically registered providers (from SDK decorators). Each entry includes\na ``description`` declared via ``ProviderBuilder.with_description(...)`` in\nthe provider's ``_config.py``.\n\nNote: The complete list of provider names is also available as a constant\nin the generated TypeScript client via PROVIDER_NAMES.",
         "operationId": "getV1ListProviders",
@@ -6553,10 +6125,7 @@
     },
     "/api/integrations/providers/constants": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Get Provider Constants",
         "description": "Get provider names as constants.\n\nThis endpoint returns a model with provider names as constants,\nspecifically designed for OpenAPI code generation tools to create\nTypeScript constants.",
         "operationId": "getV1GetProviderConstants",
@@ -6576,10 +6145,7 @@
     },
     "/api/integrations/providers/enum-example": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Get Provider Enum Example",
         "description": "Example endpoint that uses the CompleteProviderNames enum.\n\nThis endpoint exists to ensure that the CompleteProviderNames enum is included\nin the OpenAPI schema, which will cause Orval to generate it as a\nTypeScript enum/constant.",
         "operationId": "getV1GetProviderEnumExample",
@@ -6599,10 +6165,7 @@
     },
     "/api/integrations/providers/names": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Get Provider Names",
         "description": "Get all provider names in a structured format.\n\nThis endpoint is specifically designed to expose the provider names\nin the OpenAPI schema so that code generators like Orval can create\nappropriate TypeScript constants.",
         "operationId": "getV1GetProviderNames",
@@ -6622,10 +6185,7 @@
     },
     "/api/integrations/providers/system": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "List System Providers",
         "description": "Get a list of providers that have platform credits (system credentials) available.\n\nThese providers can be used without the user providing their own API keys.",
         "operationId": "getV1ListSystemProviders",
@@ -6649,10 +6209,7 @@
     },
     "/api/integrations/webhooks/{webhook_id}/ping": {
       "post": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Webhook Ping",
         "operationId": "postV1WebhookPing",
         "security": [
@@ -6698,10 +6255,7 @@
     },
     "/api/integrations/{provider}/callback": {
       "post": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Exchange OAuth code for tokens",
         "operationId": "postV1Exchange oauth code for tokens",
         "security": [
@@ -6760,10 +6314,7 @@
     },
     "/api/integrations/{provider}/credentials": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "List Credentials By Provider",
         "operationId": "getV1ListCredentialsByProvider",
         "security": [
@@ -6814,10 +6365,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Create Credentials",
         "operationId": "postV1Create credentials",
         "security": [
@@ -6899,10 +6447,7 @@
     },
     "/api/integrations/{provider}/credentials/{cred_id}": {
       "delete": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Delete Credentials",
         "operationId": "deleteV1DeleteCredentials",
         "security": [
@@ -6976,10 +6521,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Get Specific Credential By ID",
         "operationId": "getV1Get specific credential by id",
         "security": [
@@ -7037,10 +6579,7 @@
     },
     "/api/integrations/{provider}/credentials/{cred_id}/picker-token": {
       "post": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Issue a short-lived access token for a provider-hosted picker",
         "description": "Return the raw access token for an OAuth2 credential so the frontend\ncan initialize a provider-hosted picker (e.g. Google Drive Picker).\n\n`GET /{provider}/credentials/{cred_id}` deliberately strips secrets (see\n`CredentialsMetaResponse` + `TestGetCredentialReturnsMetaOnly` in\n`router_test.py`). That hardening broke the Drive picker, which needs the\nraw access token to call `google.picker.Builder.setOAuthToken(...)`. This\nendpoint carves a narrow, explicit hole: the caller must own the\ncredential, it must be OAuth2, and the endpoint returns only the access\ntoken + its expiry — nothing else about the credential. SDK-default\ncredentials are excluded for the same reason as `get_credential`.",
         "operationId": "postV1GetPickerToken",
@@ -7099,10 +6638,7 @@
     },
     "/api/integrations/{provider}/login": {
       "get": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Initiate OAuth flow",
         "operationId": "getV1Initiate oauth flow",
         "security": [
@@ -7177,10 +6713,7 @@
     },
     "/api/integrations/{provider}/webhooks/{webhook_id}/ingress": {
       "post": {
-        "tags": [
-          "v1",
-          "integrations"
-        ],
+        "tags": ["v1", "integrations"],
         "summary": "Webhook Ingress Generic",
         "operationId": "postV1WebhookIngressGeneric",
         "parameters": [
@@ -7228,11 +6761,7 @@
     },
     "/api/library/agents": {
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "List Library Agents",
         "description": "Get all agents in the user's library (both created and saved).",
         "operationId": "getV2List library agents",
@@ -7355,11 +6884,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "Add Marketplace Agent",
         "description": "Add an agent from the marketplace to the user's library.",
         "operationId": "postV2Add marketplace agent",
@@ -7407,11 +6932,7 @@
     },
     "/api/library/agents/by-graph/{graph_id}": {
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent By Graph Id",
         "operationId": "getV2GetLibraryAgentByGraphId",
         "security": [
@@ -7475,11 +6996,7 @@
     },
     "/api/library/agents/favorites": {
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "List Favorite Library Agents",
         "description": "Get all favorite agents in the user's library.",
         "operationId": "getV2List favorite library agents",
@@ -7545,13 +7062,7 @@
     },
     "/api/library/agents/marketplace/{store_listing_version_id}": {
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "private",
-          "store",
-          "library"
-        ],
+        "tags": ["v2", "library", "private", "store", "library"],
         "summary": "Get Agent By Store ID",
         "description": "Get Library Agent from Store Listing Version ID.",
         "operationId": "getV2Get agent by store id",
@@ -7608,11 +7119,7 @@
     },
     "/api/library/agents/{library_agent_id}": {
       "delete": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "Delete Library Agent",
         "description": "Soft-delete the specified library agent.",
         "operationId": "deleteV2Delete library agent",
@@ -7657,11 +7164,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent",
         "operationId": "getV2Get library agent",
         "security": [
@@ -7707,11 +7210,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "Update Library Agent",
         "description": "Update the library agent with the given fields.",
         "operationId": "patchV2Update library agent",
@@ -7770,11 +7269,7 @@
     },
     "/api/library/agents/{library_agent_id}/fork": {
       "post": {
-        "tags": [
-          "v2",
-          "library",
-          "private"
-        ],
+        "tags": ["v2", "library", "private"],
         "summary": "Fork Library Agent",
         "operationId": "postV2Fork library agent",
         "security": [
@@ -7822,12 +7317,7 @@
     },
     "/api/library/folders": {
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "List Library Folders",
         "description": "List folders for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n    parent_id: Optional parent folder ID to filter by.\n    include_relations: Whether to include agent and subfolder relations for counts.\n\nReturns:\n    A FolderListResponse containing folders.",
         "operationId": "getV2List library folders",
@@ -7898,12 +7388,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Create Folder",
         "description": "Create a new folder.\n\nArgs:\n    payload: The folder creation request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The created LibraryFolder.",
         "operationId": "postV2Create folder",
@@ -7963,12 +7448,7 @@
     },
     "/api/library/folders/agents/bulk-move": {
       "post": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Bulk Move Agents",
         "description": "Move multiple agents to a folder.\n\nArgs:\n    payload: The bulk move request with agent IDs and target folder.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryAgents.",
         "operationId": "postV2Bulk move agents",
@@ -8026,12 +7506,7 @@
     },
     "/api/library/folders/tree": {
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Get Folder Tree",
         "description": "Get the full folder tree for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n\nReturns:\n    A FolderTreeResponse containing the nested folder structure.",
         "operationId": "getV2Get folder tree",
@@ -8062,12 +7537,7 @@
     },
     "/api/library/folders/{folder_id}": {
       "delete": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Delete Folder",
         "description": "Soft-delete a folder and all its contents.\n\nArgs:\n    folder_id: ID of the folder to delete.\n    user_id: ID of the authenticated user.\n\nReturns:\n    204 No Content if successful.",
         "operationId": "deleteV2Delete folder",
@@ -8113,12 +7583,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Get Folder",
         "description": "Get a specific folder.\n\nArgs:\n    folder_id: ID of the folder to retrieve.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The requested LibraryFolder.",
         "operationId": "getV2Get folder",
@@ -8171,12 +7636,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Update Folder",
         "description": "Update a folder's properties.\n\nArgs:\n    folder_id: ID of the folder to update.\n    payload: The folder update request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryFolder.",
         "operationId": "patchV2Update folder",
@@ -8247,12 +7707,7 @@
     },
     "/api/library/folders/{folder_id}/move": {
       "post": {
-        "tags": [
-          "v2",
-          "library",
-          "folders",
-          "private"
-        ],
+        "tags": ["v2", "library", "folders", "private"],
         "summary": "Move Folder",
         "description": "Move a folder to a new parent.\n\nArgs:\n    folder_id: ID of the folder to move.\n    payload: The move request with target parent.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The moved LibraryFolder.",
         "operationId": "postV2Move folder",
@@ -8323,10 +7778,7 @@
     },
     "/api/library/presets": {
       "get": {
-        "tags": [
-          "v2",
-          "presets"
-        ],
+        "tags": ["v2", "presets"],
         "summary": "List presets",
         "description": "Retrieve a paginated list of presets for the current user.",
         "operationId": "getV2List presets",
@@ -8404,10 +7856,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "presets"
-        ],
+        "tags": ["v2", "presets"],
         "summary": "Create a new preset",
         "description": "Create a new preset for the current user.",
         "operationId": "postV2Create a new preset",
@@ -8463,10 +7912,7 @@
     },
     "/api/library/presets/setup-trigger": {
       "post": {
-        "tags": [
-          "v2",
-          "presets"
-        ],
+        "tags": ["v2", "presets"],
         "summary": "Setup Trigger",
         "description": "Sets up a webhook-triggered `LibraryAgentPreset` for a `LibraryAgent`.\nReturns the correspondingly created `LibraryAgentPreset` with `webhook_id` set.",
         "operationId": "postV2SetupTrigger",
@@ -8514,10 +7960,7 @@
     },
     "/api/library/presets/{preset_id}": {
       "delete": {
-        "tags": [
-          "v2",
-          "presets"
-        ],
+        "tags": ["v2", "presets"],
         "summary": "Delete a preset",
         "description": "Delete an existing preset by its ID.",
         "operationId": "deleteV2Delete a preset",
@@ -8557,10 +8000,7 @@
         }
       },
       "get": {
-        "tags": [
-          "v2",
-          "presets"
-        ],
+        "tags": ["v2", "presets"],
         "summary": "Get a specific preset",
         "description": "Retrieve details for a specific preset by its ID.",
         "operationId": "getV2Get a specific preset",
@@ -8607,10 +8047,7 @@
         }
       },
       "patch": {
-        "tags": [
-          "v2",
-          "presets"
-        ],
+        "tags": ["v2", "presets"],
         "summary": "Update an existing preset",
         "description": "Update an existing preset by its ID.",
         "operationId": "patchV2Update an existing preset",
@@ -8669,11 +8106,7 @@
     },
     "/api/library/presets/{preset_id}/execute": {
       "post": {
-        "tags": [
-          "v2",
-          "presets",
-          "presets"
-        ],
+        "tags": ["v2", "presets", "presets"],
         "summary": "Execute a preset",
         "description": "Execute a preset with the given graph and node input for the current user.",
         "operationId": "postV2Execute a preset",
@@ -8731,11 +8164,7 @@
     },
     "/api/mcp/discover-tools": {
       "post": {
-        "tags": [
-          "v2",
-          "mcp",
-          "mcp"
-        ],
+        "tags": ["v2", "mcp", "mcp"],
         "summary": "Discover available tools on an MCP server",
         "description": "Connect to an MCP server and return its available tools.\n\nIf the user has a stored MCP credential for this server URL, it will be\nused automatically — no need to pass an explicit auth token.",
         "operationId": "postV2Discover available tools on an mcp server",
@@ -8783,11 +8212,7 @@
     },
     "/api/mcp/oauth/callback": {
       "post": {
-        "tags": [
-          "v2",
-          "mcp",
-          "mcp"
-        ],
+        "tags": ["v2", "mcp", "mcp"],
         "summary": "Exchange OAuth code for MCP tokens",
         "description": "Exchange the authorization code for tokens and store the credential.\n\nThe frontend calls this after receiving the OAuth code from the popup.\nOn success, subsequent ``/discover-tools`` calls for the same server URL\nwill automatically use the stored credential.",
         "operationId": "postV2Exchange oauth code for mcp tokens",
@@ -8835,11 +8260,7 @@
     },
     "/api/mcp/oauth/login": {
       "post": {
-        "tags": [
-          "v2",
-          "mcp",
-          "mcp"
-        ],
+        "tags": ["v2", "mcp", "mcp"],
         "summary": "Initiate OAuth login for an MCP server",
         "description": "Discover OAuth metadata from the MCP server and return a login URL.\n\n1. Discovers the protected-resource metadata (RFC 9728)\n2. Fetches the authorization server metadata (RFC 8414)\n3. Performs Dynamic Client Registration (RFC 7591) if available\n4. Returns the authorization URL for the frontend to open in a popup",
         "operationId": "postV2Initiate oauth login for an mcp server",
@@ -8887,11 +8308,7 @@
     },
     "/api/mcp/token": {
       "post": {
-        "tags": [
-          "v2",
-          "mcp",
-          "mcp"
-        ],
+        "tags": ["v2", "mcp", "mcp"],
         "summary": "Store a bearer token for an MCP server",
         "description": "Store a manually provided bearer token as an MCP credential.\n\nUsed by the Copilot MCPSetupCard when the server doesn't support the MCP\nOAuth discovery flow (returns 400 from /oauth/login).  Subsequent\n``run_mcp_tool`` calls will automatically pick up the token via\n``_auto_lookup_credential``.",
         "operationId": "postV2Store a bearer token for an mcp server",
@@ -8939,9 +8356,7 @@
     },
     "/api/oauth/app/{client_id}": {
       "get": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Get Oauth App Info",
         "description": "Get public information about an OAuth application.\n\nThis endpoint is used by the consent screen to display application details\nto the user before they authorize access.\n\nReturns:\n- name: Application name\n- description: Application description (if provided)\n- scopes: List of scopes the application is allowed to request",
         "operationId": "getOauthGetOauthAppInfo",
@@ -8993,9 +8408,7 @@
     },
     "/api/oauth/apps/mine": {
       "get": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "List My Oauth Apps",
         "description": "List all OAuth applications owned by the current user.\n\nReturns a list of OAuth applications with their details including:\n- id, name, description, logo_url\n- client_id (public identifier)\n- redirect_uris, grant_types, scopes\n- is_active status\n- created_at, updated_at timestamps\n\nNote: client_secret is never returned for security reasons.",
         "operationId": "getOauthListMyOauthApps",
@@ -9027,9 +8440,7 @@
     },
     "/api/oauth/apps/{app_id}/logo": {
       "patch": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Update App Logo",
         "description": "Update the logo URL for an OAuth application.\n\nOnly the application owner can update the logo.\nThe logo should be uploaded first using the media upload endpoint,\nthen this endpoint is called with the resulting URL.\n\nLogo requirements:\n- Must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppLogo",
@@ -9088,9 +8499,7 @@
     },
     "/api/oauth/apps/{app_id}/logo/upload": {
       "post": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Upload App Logo",
         "description": "Upload a logo image for an OAuth application.\n\nRequirements:\n- Image must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n- Allowed formats: JPEG, PNG, WebP\n- Maximum file size: 3MB\n\nThe image is uploaded to cloud storage and the app's logoUrl is updated.\nReturns the updated application info.",
         "operationId": "postOauthUploadAppLogo",
@@ -9149,9 +8558,7 @@
     },
     "/api/oauth/apps/{app_id}/status": {
       "patch": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Update App Status",
         "description": "Enable or disable an OAuth application.\n\nOnly the application owner can update the status.\nWhen disabled, the application cannot be used for new authorizations\nand existing access tokens will fail validation.\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppStatus",
@@ -9210,9 +8617,7 @@
     },
     "/api/oauth/authorize": {
       "post": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Authorize",
         "description": "OAuth 2.0 Authorization Endpoint\n\nUser must be logged in (authenticated with Supabase JWT).\nThis endpoint creates an authorization code and returns a redirect URL.\n\nPKCE (Proof Key for Code Exchange) is REQUIRED for all authorization requests.\n\nThe frontend consent screen should call this endpoint after the user approves,\nthen redirect the user to the returned `redirect_url`.\n\nRequest Body:\n- client_id: The OAuth application's client ID\n- redirect_uri: Where to redirect after authorization (must match registered URI)\n- scopes: List of permissions (e.g., \"EXECUTE_GRAPH READ_GRAPH\")\n- state: Anti-CSRF token provided by client (will be returned in redirect)\n- response_type: Must be \"code\" (for authorization code flow)\n- code_challenge: PKCE code challenge (required)\n- code_challenge_method: \"S256\" (recommended) or \"plain\"\n\nReturns:\n- redirect_url: The URL to redirect the user to (includes authorization code)\n\nError cases return a redirect_url with error parameters, or raise HTTPException\nfor critical errors (like invalid redirect_uri).",
         "operationId": "postOauthAuthorize",
@@ -9260,9 +8665,7 @@
     },
     "/api/oauth/introspect": {
       "post": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Introspect",
         "description": "OAuth 2.0 Token Introspection Endpoint (RFC 7662)\n\nAllows clients to check if a token is valid and get its metadata.\n\nReturns:\n- active: Whether the token is currently active\n- scopes: List of authorized scopes (if active)\n- client_id: The client the token was issued to (if active)\n- user_id: The user the token represents (if active)\n- exp: Expiration timestamp (if active)\n- token_type: \"access_token\" or \"refresh_token\" (if active)",
         "operationId": "postOauthIntrospect",
@@ -9302,9 +8705,7 @@
     },
     "/api/oauth/revoke": {
       "post": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Revoke",
         "description": "OAuth 2.0 Token Revocation Endpoint (RFC 7009)\n\nAllows clients to revoke an access or refresh token.\n\nNote: Revoking a refresh token does NOT revoke associated access tokens.\nRevoking an access token does NOT revoke the associated refresh token.",
         "operationId": "postOauthRevoke",
@@ -9342,9 +8743,7 @@
     },
     "/api/oauth/token": {
       "post": {
-        "tags": [
-          "oauth"
-        ],
+        "tags": ["oauth"],
         "summary": "Token",
         "description": "OAuth 2.0 Token Endpoint\n\nExchanges authorization code or refresh token for access token.\n\nGrant Types:\n1. authorization_code: Exchange authorization code for tokens\n   - Required: grant_type, code, redirect_uri, client_id, client_secret\n   - Optional: code_verifier (required if PKCE was used)\n\n2. refresh_token: Exchange refresh token for new access token\n   - Required: grant_type, refresh_token, client_id, client_secret\n\nReturns:\n- access_token: Bearer token for API access (1 hour TTL)\n- token_type: \"Bearer\"\n- expires_in: Seconds until access token expires\n- refresh_token: Token for refreshing access (30 days TTL)\n- scopes: List of scopes",
         "operationId": "postOauthToken",
@@ -9392,10 +8791,7 @@
     },
     "/api/onboarding": {
       "get": {
-        "tags": [
-          "v1",
-          "onboarding"
-        ],
+        "tags": ["v1", "onboarding"],
         "summary": "Onboarding state",
         "operationId": "getV1Onboarding state",
         "responses": {
@@ -9420,10 +8816,7 @@
         ]
       },
       "patch": {
-        "tags": [
-          "v1",
-          "onboarding"
-        ],
+        "tags": ["v1", "onboarding"],
         "summary": "Update onboarding state",
         "operationId": "patchV1Update onboarding state",
         "requestBody": {
@@ -9470,10 +8863,7 @@
     },
     "/api/onboarding/agents": {
       "get": {
-        "tags": [
-          "v1",
-          "onboarding"
-        ],
+        "tags": ["v1", "onboarding"],
         "summary": "Recommended onboarding agents",
         "operationId": "getV1Recommended onboarding agents",
         "responses": {
@@ -9504,11 +8894,7 @@
     },
     "/api/onboarding/completed": {
       "get": {
-        "tags": [
-          "v1",
-          "onboarding",
-          "public"
-        ],
+        "tags": ["v1", "onboarding", "public"],
         "summary": "Check if onboarding is completed",
         "operationId": "getV1Check if onboarding is completed",
         "responses": {
@@ -9535,10 +8921,7 @@
     },
     "/api/onboarding/profile": {
       "post": {
-        "tags": [
-          "v1",
-          "onboarding"
-        ],
+        "tags": ["v1", "onboarding"],
         "summary": "Submit onboarding profile",
         "operationId": "postV1Submit onboarding profile",
         "requestBody": {
@@ -9583,10 +8966,7 @@
     },
     "/api/onboarding/reset": {
       "post": {
-        "tags": [
-          "v1",
-          "onboarding"
-        ],
+        "tags": ["v1", "onboarding"],
         "summary": "Reset onboarding progress",
         "operationId": "postV1Reset onboarding progress",
         "responses": {
@@ -9613,10 +8993,7 @@
     },
     "/api/onboarding/step": {
       "post": {
-        "tags": [
-          "v1",
-          "onboarding"
-        ],
+        "tags": ["v1", "onboarding"],
         "summary": "Complete onboarding step",
         "operationId": "postV1Complete onboarding step",
         "security": [
@@ -9674,10 +9051,7 @@
     },
     "/api/otto/ask": {
       "post": {
-        "tags": [
-          "v2",
-          "otto"
-        ],
+        "tags": ["v2", "otto"],
         "summary": "Proxy Otto Chat Request",
         "description": "Proxy requests to Otto API while adding necessary security headers and logging.\nRequires an authenticated user.",
         "operationId": "postV2Proxy otto chat request",
@@ -9725,9 +9099,7 @@
     },
     "/api/platform-linking/links": {
       "get": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "List all platform servers linked to the authenticated user",
         "operationId": "getPlatform-linkingList all platform servers linked to the authenticated user",
         "responses": {
@@ -9758,9 +9130,7 @@
     },
     "/api/platform-linking/links/{link_id}": {
       "delete": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "Unlink a platform server",
         "operationId": "deletePlatform-linkingUnlink a platform server",
         "security": [
@@ -9808,9 +9178,7 @@
     },
     "/api/platform-linking/tokens/{token}/confirm": {
       "post": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "Confirm a SERVER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a server link token (user must be authenticated)",
         "security": [
@@ -9860,9 +9228,7 @@
     },
     "/api/platform-linking/tokens/{token}/info": {
       "get": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "Get display info for a link token",
         "operationId": "getPlatform-linkingGet display info for a link token",
         "security": [
@@ -9912,9 +9278,7 @@
     },
     "/api/platform-linking/user-links": {
       "get": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "List all DM links for the authenticated user",
         "operationId": "getPlatform-linkingList all dm links for the authenticated user",
         "responses": {
@@ -9945,9 +9309,7 @@
     },
     "/api/platform-linking/user-links/{link_id}": {
       "delete": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "Unlink a DM / user link",
         "operationId": "deletePlatform-linkingUnlink a dm / user link",
         "security": [
@@ -9995,9 +9357,7 @@
     },
     "/api/platform-linking/user-tokens/{token}/confirm": {
       "post": {
-        "tags": [
-          "platform-linking"
-        ],
+        "tags": ["platform-linking"],
         "summary": "Confirm a USER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a user link token (user must be authenticated)",
         "security": [
@@ -10047,9 +9407,7 @@
     },
     "/api/public/shared/{share_token}": {
       "get": {
-        "tags": [
-          "v1"
-        ],
+        "tags": ["v1"],
         "summary": "Get Shared Execution",
         "description": "Get a shared graph execution by share token (no auth required).",
         "operationId": "getV1GetSharedExecution",
@@ -10091,10 +9449,7 @@
     },
     "/api/public/shared/{share_token}/files/{file_id}/download": {
       "get": {
-        "tags": [
-          "v1",
-          "graphs"
-        ],
+        "tags": ["v1", "graphs"],
         "summary": "Download a file from a shared execution",
         "description": "Download a workspace file from a shared execution (no auth required).\n\nValidates that the file was explicitly exposed when sharing was enabled.\nReturns a uniform 404 for all failure modes to prevent enumeration attacks.",
         "operationId": "download_shared_file",
@@ -10144,9 +9499,7 @@
     },
     "/api/push/subscribe": {
       "post": {
-        "tags": [
-          "push"
-        ],
+        "tags": ["push"],
         "summary": "Register a push subscription for the current user",
         "operationId": "postPushRegister a push subscription for the current user",
         "requestBody": {
@@ -10186,9 +9539,7 @@
     },
     "/api/push/unsubscribe": {
       "post": {
-        "tags": [
-          "push"
-        ],
+        "tags": ["push"],
         "summary": "Remove a push subscription",
         "operationId": "postPushRemove a push subscription",
         "requestBody": {
@@ -10228,9 +9579,7 @@
     },
     "/api/push/vapid-key": {
       "get": {
-        "tags": [
-          "push"
-        ],
+        "tags": ["push"],
         "summary": "Get VAPID public key for push subscription",
         "operationId": "getPushGet vapid public key for push subscription",
         "responses": {
@@ -10249,14 +9598,7 @@
     },
     "/api/review/action": {
       "post": {
-        "tags": [
-          "v2",
-          "executions",
-          "review",
-          "v2",
-          "executions",
-          "review"
-        ],
+        "tags": ["v2", "executions", "review", "v2", "executions", "review"],
         "summary": "Process Review Action",
         "description": "Process reviews with approve or reject actions.",
         "operationId": "postV2ProcessReviewAction",
@@ -10304,14 +9646,7 @@
     },
     "/api/review/execution/{graph_exec_id}": {
       "get": {
-        "tags": [
-          "v2",
-          "executions",
-          "review",
-          "v2",
-          "executions",
-          "review"
-        ],
+        "tags": ["v2", "executions", "review", "v2", "executions", "review"],
         "summary": "Get Pending Reviews for Execution",
         "description": "Get all pending reviews for a specific graph execution.\n\nRetrieves all reviews with status \"WAITING\" for the specified graph execution\nthat belong to the authenticated user. Results are ordered by creation time\n(oldest first) to preserve review order within the execution.\n\nArgs:\n    graph_exec_id: ID of the graph execution to get reviews for\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects for the specified execution\n\nRaises:\n    HTTPException:\n        - 404: If the graph execution doesn't exist or isn't owned by this user\n        - 500: If authentication fails or database error occurs\n\nNote:\n    Only returns reviews owned by the authenticated user for security.\n    Reviews with invalid status are excluded with warning logs.",
         "operationId": "getV2Get pending reviews for execution",
@@ -10373,14 +9708,7 @@
     },
     "/api/review/pending": {
       "get": {
-        "tags": [
-          "v2",
-          "executions",
-          "review",
-          "v2",
-          "executions",
-          "review"
-        ],
+        "tags": ["v2", "executions", "review", "v2", "executions", "review"],
         "summary": "Get Pending Reviews",
         "description": "Get all pending reviews for the current user.\n\nRetrieves all reviews with status \"WAITING\" that belong to the authenticated user.\nResults are ordered by creation time (newest first).\n\nArgs:\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects with status converted to typed literals\n\nRaises:\n    HTTPException: If authentication fails or database error occurs\n\nNote:\n    Reviews with invalid status values are logged as warnings but excluded\n    from results rather than failing the entire request.",
         "operationId": "getV2Get pending reviews",
@@ -10457,10 +9785,7 @@
     },
     "/api/schedules": {
       "get": {
-        "tags": [
-          "v1",
-          "schedules"
-        ],
+        "tags": ["v1", "schedules"],
         "summary": "List execution schedules for a user",
         "operationId": "getV1List execution schedules for a user",
         "responses": {
@@ -10491,10 +9816,7 @@
     },
     "/api/schedules/{schedule_id}": {
       "delete": {
-        "tags": [
-          "v1",
-          "schedules"
-        ],
+        "tags": ["v1", "schedules"],
         "summary": "Delete execution schedule",
         "operationId": "deleteV1Delete execution schedule",
         "security": [
@@ -10546,12 +9868,7 @@
     },
     "/api/store/admin/listings": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "store",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "store", "admin"],
         "summary": "Get Admin Listings History",
         "description": "Get store listings with their version history for admins.\n\nThis provides a consolidated view of listings with their versions,\nallowing for an expandable UI in the admin dashboard.\n\nArgs:\n    status: Filter by submission status (PENDING, APPROVED, REJECTED)\n    search: Search by name, description, or user email\n    page: Page number for pagination\n    page_size: Number of items per page\n\nReturns:\n    Paginated listings with their versions",
         "operationId": "getV2Get admin listings history",
@@ -10643,14 +9960,7 @@
     },
     "/api/store/admin/submissions/download/{store_listing_version_id}": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "store",
-          "admin",
-          "store",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "store", "admin", "store", "admin"],
         "summary": "Admin Download Agent File",
         "description": "Download the agent file by streaming its content.\n\nArgs:\n    store_listing_version_id (str): The ID of the agent to download\n\nReturns:\n    StreamingResponse: A streaming response containing the agent's graph data.\n\nRaises:\n    HTTPException: If the agent is not found or an unexpected error occurs.",
         "operationId": "getV2Admin download agent file",
@@ -10699,12 +10009,7 @@
     },
     "/api/store/admin/submissions/{store_listing_version_id}/add-to-library": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "store",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "store", "admin"],
         "summary": "Admin Add Pending Agent to Library",
         "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can load the graph because get_graph() checks library\nmembership as a fallback: \"you added it, you keep it.\"",
         "operationId": "postV2Admin add pending agent to library",
@@ -10753,12 +10058,7 @@
     },
     "/api/store/admin/submissions/{store_listing_version_id}/preview": {
       "get": {
-        "tags": [
-          "v2",
-          "admin",
-          "store",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "store", "admin"],
         "summary": "Admin Preview Submission Listing",
         "description": "Preview a marketplace submission as it would appear on the listing page.\nBypasses the APPROVED-only StoreAgent view so admins can preview pending\nsubmissions before approving.",
         "operationId": "getV2Admin preview submission listing",
@@ -10807,12 +10107,7 @@
     },
     "/api/store/admin/submissions/{store_listing_version_id}/review": {
       "post": {
-        "tags": [
-          "v2",
-          "admin",
-          "store",
-          "admin"
-        ],
+        "tags": ["v2", "admin", "store", "admin"],
         "summary": "Review Store Submission",
         "description": "Review a store listing submission.\n\nArgs:\n    store_listing_version_id: ID of the submission to review\n    request: Review details including approval status and comments\n    user_id: Authenticated admin user performing the review\n\nReturns:\n    StoreSubmissionAdminView with updated review information",
         "operationId": "postV2Review store submission",
@@ -10871,11 +10166,7 @@
     },
     "/api/store/agents": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "public"
-        ],
+        "tags": ["v2", "store", "public"],
         "summary": "List store agents",
         "description": "Get a paginated list of agents from the marketplace,\nwith optional filtering and sorting.\n\nUsed for:\n- Home Page Featured Agents\n- Home Page Top Agents\n- Search Results\n- Agent Details - Other Agents By Creator\n- Agent Details - Similar Agents\n- Creator Details - Agents By Creator",
         "operationId": "getV2List store agents",
@@ -11013,11 +10304,7 @@
     },
     "/api/store/agents/{username}/{agent_name}": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "public"
-        ],
+        "tags": ["v2", "store", "public"],
         "summary": "Get specific agent",
         "description": "Get details of a marketplace agent",
         "operationId": "getV2Get specific agent",
@@ -11077,10 +10364,7 @@
     },
     "/api/store/agents/{username}/{agent_name}/review": {
       "post": {
-        "tags": [
-          "v2",
-          "store"
-        ],
+        "tags": ["v2", "store"],
         "summary": "Create agent review",
         "description": "Post a user review on a marketplace agent listing",
         "operationId": "postV2Create agent review",
@@ -11148,11 +10432,7 @@
     },
     "/api/store/creators": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "public"
-        ],
+        "tags": ["v2", "store", "public"],
         "summary": "List store creators",
         "description": "List or search marketplace creators",
         "operationId": "getV2List store creators",
@@ -11252,11 +10532,7 @@
     },
     "/api/store/creators/{username}": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "public"
-        ],
+        "tags": ["v2", "store", "public"],
         "summary": "Get creator details",
         "description": "Get details on a marketplace creator",
         "operationId": "getV2Get creator details",
@@ -11297,10 +10573,7 @@
     },
     "/api/store/listings/versions/{store_listing_version_id}": {
       "get": {
-        "tags": [
-          "v2",
-          "store"
-        ],
+        "tags": ["v2", "store"],
         "summary": "Get agent by version",
         "operationId": "getV2Get agent by version",
         "security": [
@@ -11348,10 +10621,7 @@
     },
     "/api/store/listings/versions/{store_listing_version_id}/graph": {
       "get": {
-        "tags": [
-          "v2",
-          "store"
-        ],
+        "tags": ["v2", "store"],
         "summary": "Get agent graph",
         "description": "Get outline of graph belonging to a specific marketplace listing version",
         "operationId": "getV2Get agent graph",
@@ -11400,11 +10670,7 @@
     },
     "/api/store/listings/versions/{store_listing_version_id}/graph/download": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "public"
-        ],
+        "tags": ["v2", "store", "public"],
         "summary": "Download agent file",
         "description": "Download agent graph file for a specific marketplace listing version",
         "operationId": "getV2Download agent file",
@@ -11443,11 +10709,7 @@
     },
     "/api/store/metrics/cache": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "metrics"
-        ],
+        "tags": ["v2", "store", "metrics"],
         "summary": "Get cache metrics in Prometheus format",
         "description": "Get cache metrics in Prometheus text format.\n\nReturns Prometheus-compatible metrics for monitoring cache performance.\nMetrics include size, maxsize, TTL, and hit rate for each cache.\n\nReturns:\n    str: Prometheus-formatted metrics text",
         "operationId": "getV2Get cache metrics in prometheus format",
@@ -11467,11 +10729,7 @@
     },
     "/api/store/my-unpublished-agents": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Get my agents",
         "description": "List the authenticated user's unpublished agents",
         "operationId": "getV2Get my agents",
@@ -11533,11 +10791,7 @@
     },
     "/api/store/profile": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Get user profile",
         "description": "Get the profile details for the authenticated user.",
         "operationId": "getV2Get user profile",
@@ -11563,11 +10817,7 @@
         ]
       },
       "post": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Update user profile",
         "description": "Update the store profile for the authenticated user.",
         "operationId": "postV2Update user profile",
@@ -11615,11 +10865,7 @@
     },
     "/api/store/search": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "public"
-        ],
+        "tags": ["v2", "store", "public"],
         "summary": "Unified search across all content types",
         "description": "Search across all content types (marketplace agents, blocks, documentation)\nusing hybrid search.\n\nCombines semantic (embedding-based) and lexical (text-based) search for best results.",
         "operationId": "getV2Unified search across all content types",
@@ -11708,11 +10954,7 @@
     },
     "/api/store/submissions": {
       "get": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "List my submissions",
         "description": "List the authenticated user's marketplace listing submissions",
         "operationId": "getV2List my submissions",
@@ -11772,11 +11014,7 @@
         }
       },
       "post": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Create store submission",
         "description": "Submit a new marketplace listing for review",
         "operationId": "postV2Create store submission",
@@ -11824,11 +11062,7 @@
     },
     "/api/store/submissions/generate_image": {
       "post": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Generate submission image",
         "description": "Generate an image for a marketplace listing submission based on the properties\nof a given graph.",
         "operationId": "postV2Generate submission image",
@@ -11877,11 +11111,7 @@
     },
     "/api/store/submissions/media": {
       "post": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Upload submission media",
         "description": "Upload media for a marketplace listing submission",
         "operationId": "postV2Upload submission media",
@@ -11930,11 +11160,7 @@
     },
     "/api/store/submissions/{store_listing_version_id}": {
       "put": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Edit store submission",
         "description": "Update a pending marketplace listing submission",
         "operationId": "putV2Edit store submission",
@@ -11993,11 +11219,7 @@
     },
     "/api/store/submissions/{submission_id}": {
       "delete": {
-        "tags": [
-          "v2",
-          "store",
-          "private"
-        ],
+        "tags": ["v2", "store", "private"],
         "summary": "Delete store submission",
         "description": "Delete a marketplace listing submission",
         "operationId": "deleteV2Delete store submission",
@@ -12047,9 +11269,7 @@
     },
     "/api/workspace/files": {
       "get": {
-        "tags": [
-          "workspace"
-        ],
+        "tags": ["workspace"],
         "summary": "List workspace files",
         "description": "List files in the user's workspace.\n\nWhen session_id is provided, only files for that session are returned.\nOtherwise, all files across sessions are listed. Results are paginated\nvia `limit`/`offset`; `has_more` indicates whether additional pages exist.",
         "operationId": "listWorkspaceFiles",
@@ -12128,9 +11348,7 @@
     },
     "/api/workspace/files/upload": {
       "post": {
-        "tags": [
-          "workspace"
-        ],
+        "tags": ["workspace"],
         "summary": "Upload file to workspace",
         "description": "Upload a file to the user's workspace.\n\nFiles are stored in session-scoped paths when session_id is provided,\nso the agent's session-scoped tools can discover them automatically.",
         "operationId": "uploadWorkspaceFile",
@@ -12206,9 +11424,7 @@
     },
     "/api/workspace/files/{file_id}": {
       "delete": {
-        "tags": [
-          "workspace"
-        ],
+        "tags": ["workspace"],
         "summary": "Delete a workspace file",
         "description": "Soft-delete a workspace file and attempt to remove it from storage.\n\nUsed when a user clears a file input in the builder.",
         "operationId": "deleteWorkspaceFile",
@@ -12257,9 +11473,7 @@
     },
     "/api/workspace/files/{file_id}/download": {
       "get": {
-        "tags": [
-          "workspace"
-        ],
+        "tags": ["workspace"],
         "summary": "Download file by ID",
         "description": "Download a file by its ID.\n\nReturns the file content directly or redirects to a signed URL for GCS.",
         "operationId": "getWorkspaceDownloadFileById",
@@ -12306,9 +11520,7 @@
     },
     "/api/workspace/storage/usage": {
       "get": {
-        "tags": [
-          "workspace"
-        ],
+        "tags": ["workspace"],
         "summary": "Get workspace storage usage",
         "description": "Get storage usage information for the user's workspace.",
         "operationId": "getWorkspaceStorageUsage",
@@ -12336,9 +11548,7 @@
     },
     "/health": {
       "get": {
-        "tags": [
-          "health"
-        ],
+        "tags": ["health"],
         "summary": "Health",
         "operationId": "getHealthHealth",
         "responses": {
@@ -12413,10 +11623,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "provider",
-          "api_key"
-        ],
+        "required": ["provider", "api_key"],
         "title": "APIKeyCredentials"
       },
       "APIKeyInfo": {
@@ -12545,11 +11752,7 @@
       },
       "APIKeyStatus": {
         "type": "string",
-        "enum": [
-          "ACTIVE",
-          "REVOKED",
-          "SUSPENDED"
-        ],
+        "enum": ["ACTIVE", "REVOKED", "SUSPENDED"],
         "title": "APIKeyStatus"
       },
       "AccuracyAlertData": {
@@ -12693,10 +11896,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "latest_data",
-          "alert"
-        ],
+        "required": ["latest_data", "alert"],
         "title": "AccuracyTrendsResponse",
         "description": "Response model for accuracy trends and alerts."
       },
@@ -12723,10 +11923,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "turn_id",
-          "last_message_id"
-        ],
+        "required": ["turn_id", "last_message_id"],
         "title": "ActiveStreamInfo",
         "description": "Information about an active stream for reconnection."
       },
@@ -12742,10 +11939,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "new_balance",
-          "transaction_key"
-        ],
+        "required": ["new_balance", "transaction_key"],
         "title": "AddUserCreditsResponse"
       },
       "AgentDetails": {
@@ -12798,11 +11992,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "name",
-          "description"
-        ],
+        "required": ["id", "name", "description"],
         "title": "AgentDetails",
         "description": "Detailed agent information."
       },
@@ -12859,10 +12049,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "agent"
-        ],
+        "required": ["message", "agent"],
         "title": "AgentDetailsResponse",
         "description": "Response for get_details action."
       },
@@ -12878,10 +12065,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "agents_with_active_executions",
-          "timestamp"
-        ],
+        "required": ["agents_with_active_executions", "timestamp"],
         "title": "AgentDiagnosticsResponse",
         "description": "Response model for agent diagnostics"
       },
@@ -13095,12 +12279,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "name",
-          "description",
-          "source"
-        ],
+        "required": ["id", "name", "description", "source"],
         "title": "AgentInfo",
         "description": "Information about an agent."
       },
@@ -13187,11 +12366,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "agent_name",
-          "agent_id"
-        ],
+        "required": ["message", "agent_name", "agent_id"],
         "title": "AgentOutputResponse",
         "description": "Response for agent_output tool."
       },
@@ -13359,11 +12534,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "agents",
-          "count"
-        ],
+        "required": ["message", "agents", "count"],
         "title": "AgentsFoundResponse",
         "description": "Response for find_agent tool."
       },
@@ -13386,11 +12557,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "answer",
-          "documents",
-          "success"
-        ],
+        "required": ["answer", "documents", "success"],
         "title": "ApiResponse"
       },
       "AuthorizeRequest": {
@@ -13431,10 +12598,7 @@
           },
           "code_challenge_method": {
             "type": "string",
-            "enum": [
-              "S256",
-              "plain"
-            ],
+            "enum": ["S256", "plain"],
             "title": "Code Challenge Method",
             "description": "PKCE code challenge method (S256 recommended)",
             "default": "S256"
@@ -13460,9 +12624,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "redirect_url"
-        ],
+        "required": ["redirect_url"],
         "title": "AuthorizeResponse",
         "description": "OAuth 2.0 authorization response with redirect URL"
       },
@@ -13478,10 +12640,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "amount",
-          "threshold"
-        ],
+        "required": ["amount", "threshold"],
         "title": "AutoTopUpConfig"
       },
       "AyrshareSSOResponse": {
@@ -13499,10 +12658,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "sso_url",
-          "expires_at"
-        ],
+        "required": ["sso_url", "expires_at"],
         "title": "AyrshareSSOResponse"
       },
       "BaseGraph-Input": {
@@ -13589,10 +12745,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "description"
-        ],
+        "required": ["name", "description"],
         "title": "BaseGraph",
         "description": "Graph with nodes, links, and computed I/O schema fields.\n\nUsed to represent sub-graphs within a `Graph`. Contains the full graph\nstructure including nodes and links, plus computed fields for schemas\nand trigger info. Does NOT include user_id or created_at (see GraphModel)."
       },
@@ -13750,11 +12903,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "total_blocks",
-          "blocks"
-        ],
+        "required": ["name", "total_blocks", "blocks"],
         "title": "BlockCategoryResponse"
       },
       "BlockCost": {
@@ -13778,23 +12927,12 @@
           }
         },
         "type": "object",
-        "required": [
-          "cost_amount",
-          "cost_filter",
-          "cost_type"
-        ],
+        "required": ["cost_amount", "cost_filter", "cost_type"],
         "title": "BlockCost"
       },
       "BlockCostType": {
         "type": "string",
-        "enum": [
-          "run",
-          "byte",
-          "second",
-          "items",
-          "cost_usd",
-          "tokens"
-        ],
+        "enum": ["run", "byte", "second", "items", "cost_usd", "tokens"],
         "title": "BlockCostType"
       },
       "BlockDetails": {
@@ -13833,11 +12971,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "name",
-          "description"
-        ],
+        "required": ["id", "name", "description"],
         "title": "BlockDetails",
         "description": "Detailed block information."
       },
@@ -13872,10 +13006,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "block"
-        ],
+        "required": ["message", "block"],
         "title": "BlockDetailsResponse",
         "description": "Response for block details (first run_block attempt)."
       },
@@ -14001,12 +13132,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "name",
-          "description",
-          "categories"
-        ],
+        "required": ["id", "name", "description", "categories"],
         "title": "BlockInfoSummary",
         "description": "Summary of a block for search results."
       },
@@ -14041,10 +13167,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "type"
-        ],
+        "required": ["name", "type"],
         "title": "BlockInputFieldInfo",
         "description": "Information about a block input field."
       },
@@ -14091,12 +13214,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "blocks",
-          "count",
-          "query"
-        ],
+        "required": ["message", "blocks", "count", "query"],
         "title": "BlockListResponse",
         "description": "Response for find_block tool."
       },
@@ -14155,12 +13273,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "block_id",
-          "block_name",
-          "outputs"
-        ],
+        "required": ["message", "block_id", "block_name", "outputs"],
         "title": "BlockOutputResponse",
         "description": "Response for run_block tool."
       },
@@ -14178,10 +13291,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "blocks",
-          "pagination"
-        ],
+        "required": ["blocks", "pagination"],
         "title": "BlockResponse"
       },
       "Body_patchOauthUpdateAppStatus": {
@@ -14193,9 +13303,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "is_active"
-        ],
+        "required": ["is_active"],
         "title": "Body_patchOauthUpdateAppStatus"
       },
       "Body_postAnalyticsLogRawAnalytics": {
@@ -14217,11 +13325,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "type",
-          "data",
-          "data_index"
-        ],
+        "required": ["type", "data", "data_index"],
         "title": "Body_postAnalyticsLogRawAnalytics"
       },
       "Body_postOauthIntrospect": {
@@ -14235,10 +13339,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "access_token",
-                  "refresh_token"
-                ]
+                "enum": ["access_token", "refresh_token"]
               },
               {
                 "type": "null"
@@ -14259,11 +13360,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "token",
-          "client_id",
-          "client_secret"
-        ],
+        "required": ["token", "client_id", "client_secret"],
         "title": "Body_postOauthIntrospect"
       },
       "Body_postOauthRevoke": {
@@ -14277,10 +13374,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "access_token",
-                  "refresh_token"
-                ]
+                "enum": ["access_token", "refresh_token"]
               },
               {
                 "type": "null"
@@ -14301,11 +13395,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "token",
-          "client_id",
-          "client_secret"
-        ],
+        "required": ["token", "client_id", "client_secret"],
         "title": "Body_postOauthRevoke"
       },
       "Body_postOauthUploadAppLogo": {
@@ -14317,9 +13407,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "file"
-        ],
+        "required": ["file"],
         "title": "Body_postOauthUploadAppLogo"
       },
       "Body_postV1Exchange_oauth_code_for_tokens": {
@@ -14334,10 +13422,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "code",
-          "state_token"
-        ],
+        "required": ["code", "state_token"],
         "title": "Body_postV1Exchange oauth code for tokens"
       },
       "Body_postV1Execute_graph_agent": {
@@ -14358,11 +13443,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "builder",
-                  "library",
-                  "onboarding"
-                ]
+                "enum": ["builder", "library", "onboarding"]
               },
               {
                 "type": "null"
@@ -14388,9 +13469,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "file"
-        ],
+        "required": ["file"],
         "title": "Body_postV1Upload file to cloud storage"
       },
       "Body_postV2Add_credits_to_user": {
@@ -14409,11 +13488,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id",
-          "amount",
-          "comments"
-        ],
+        "required": ["user_id", "amount", "comments"],
         "title": "Body_postV2Add credits to user"
       },
       "Body_postV2Add_marketplace_agent": {
@@ -14424,18 +13499,13 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "onboarding",
-              "marketplace"
-            ],
+            "enum": ["onboarding", "marketplace"],
             "title": "Source",
             "default": "marketplace"
           }
         },
         "type": "object",
-        "required": [
-          "store_listing_version_id"
-        ],
+        "required": ["store_listing_version_id"],
         "title": "Body_postV2Add marketplace agent"
       },
       "Body_postV2Execute_a_preset": {
@@ -14469,9 +13539,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id"
-        ],
+        "required": ["user_id"],
         "title": "Body_postV2Reset user rate limit usage"
       },
       "Body_postV2Upload_submission_media": {
@@ -14483,9 +13551,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "file"
-        ],
+        "required": ["file"],
         "title": "Body_postV2Upload submission media"
       },
       "Body_uploadWorkspaceFile": {
@@ -14497,9 +13563,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "file"
-        ],
+        "required": ["file"],
         "title": "Body_uploadWorkspaceFile"
       },
       "BulkMoveAgentsRequest": {
@@ -14524,9 +13588,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "agent_ids"
-        ],
+        "required": ["agent_ids"],
         "title": "BulkMoveAgentsRequest",
         "description": "Request model for moving multiple agents to a folder."
       },
@@ -14549,9 +13611,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "cancelled"
-        ],
+        "required": ["cancelled"],
         "title": "CancelSessionResponse",
         "description": "Response model for the cancel session endpoint."
       },
@@ -14572,11 +13632,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "version",
-          "changes_summary",
-          "date"
-        ],
+        "required": ["version", "changes_summary", "date"],
         "title": "ChangelogEntry"
       },
       "ChatRequest": {
@@ -14614,11 +13670,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "query",
-          "conversation_history",
-          "message_id"
-        ],
+        "required": ["query", "conversation_history", "message_id"],
         "title": "ChatRequest"
       },
       "ChatSessionMetadata": {
@@ -14674,9 +13726,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "ClarificationNeededResponse",
         "description": "Response when the LLM needs more information from the user."
       },
@@ -14703,10 +13753,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "question",
-          "keyword"
-        ],
+        "required": ["question", "keyword"],
         "title": "ClarifyingQuestion",
         "description": "A question that needs user clarification."
       },
@@ -14808,11 +13855,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "success",
-          "platform",
-          "platform_user_id"
-        ],
+        "required": ["success", "platform", "platform_user_id"],
         "title": "ConfirmUserLinkResponse"
       },
       "ContentType": {
@@ -14849,12 +13892,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "rows",
-          "total_rows",
-          "window_days",
-          "max_window_days"
-        ],
+        "required": ["rows", "total_rows", "window_days", "max_window_days"],
         "title": "CopilotUsageExportResponse"
       },
       "CopilotWeeklyUsageRow": {
@@ -14925,10 +13963,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "bucket",
-          "count"
-        ],
+        "required": ["bucket", "count"],
         "title": "CostBucket"
       },
       "CostLogRow": {
@@ -15084,12 +14119,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "created_at",
-          "block_name",
-          "provider"
-        ],
+        "required": ["id", "created_at", "block_name", "provider"],
         "title": "CostLogRow"
       },
       "CountResponse": {
@@ -15161,10 +14191,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "permissions"
-        ],
+        "required": ["name", "permissions"],
         "title": "CreateAPIKeyRequest"
       },
       "CreateAPIKeyResponse": {
@@ -15178,10 +14205,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "api_key",
-          "plain_text_key"
-        ],
+        "required": ["api_key", "plain_text_key"],
         "title": "CreateAPIKeyResponse"
       },
       "CreateGraph": {
@@ -15193,10 +14217,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "builder",
-                  "upload"
-                ]
+                "enum": ["builder", "upload"]
               },
               {
                 "type": "null"
@@ -15206,9 +14227,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "graph"
-        ],
+        "required": ["graph"],
         "title": "CreateGraph"
       },
       "CreateSessionRequest": {
@@ -15265,11 +14284,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "created_at",
-          "user_id"
-        ],
+        "required": ["id", "created_at", "user_id"],
         "title": "CreateSessionResponse",
         "description": "Response model containing information on a newly created chat session."
       },
@@ -15359,10 +14374,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "creators",
-          "pagination"
-        ],
+        "required": ["creators", "pagination"],
         "title": "CreatorsResponse"
       },
       "CredentialsDeletionNeedsConfirmationResponse": {
@@ -15385,9 +14397,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "CredentialsDeletionNeedsConfirmationResponse"
       },
       "CredentialsDeletionResponse": {
@@ -15412,9 +14422,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "revoked"
-        ],
+        "required": ["revoked"],
         "title": "CredentialsDeletionResponse"
       },
       "CredentialsMetaInput": {
@@ -15441,21 +14449,12 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "api_key",
-              "oauth2",
-              "user_password",
-              "host_scoped"
-            ],
+            "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
             "title": "Type"
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "provider",
-          "type"
-        ],
+        "required": ["id", "provider", "type"],
         "title": "CredentialsMetaInput",
         "credentials_provider": [],
         "credentials_types": []
@@ -15472,12 +14471,7 @@
           },
           "type": {
             "type": "string",
-            "enum": [
-              "api_key",
-              "oauth2",
-              "user_password",
-              "host_scoped"
-            ],
+            "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
             "title": "Type"
           },
           "title": {
@@ -15535,14 +14529,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "provider",
-          "type",
-          "title",
-          "scopes",
-          "username"
-        ],
+        "required": ["id", "provider", "type", "title", "scopes", "username"],
         "title": "CredentialsMetaResponse"
       },
       "CreditTransactionType": {
@@ -15596,9 +14583,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "deleted"
-        ],
+        "required": ["deleted"],
         "title": "DeleteFileResponse"
       },
       "DeleteGraphResponse": {
@@ -15609,9 +14594,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "version_counts"
-        ],
+        "required": ["version_counts"],
         "title": "DeleteGraphResponse"
       },
       "DeleteLinkResponse": {
@@ -15622,9 +14605,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "success"
-        ],
+        "required": ["success"],
         "title": "DeleteLinkResponse"
       },
       "DiscoverToolsRequest": {
@@ -15648,9 +14629,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "server_url"
-        ],
+        "required": ["server_url"],
         "title": "DiscoverToolsRequest",
         "description": "Request to discover tools on an MCP server."
       },
@@ -15687,9 +14666,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "tools"
-        ],
+        "required": ["tools"],
         "title": "DiscoverToolsResponse",
         "description": "Response containing the list of tools available on an MCP server."
       },
@@ -15739,12 +14716,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "title",
-          "path",
-          "content"
-        ],
+        "required": ["message", "title", "path", "content"],
         "title": "DocPageResponse",
         "description": "Response for get_doc_page tool."
       },
@@ -15783,13 +14755,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "title",
-          "path",
-          "section",
-          "snippet",
-          "score"
-        ],
+        "required": ["title", "path", "section", "snippet", "score"],
         "title": "DocSearchResult",
         "description": "A single documentation search result."
       },
@@ -15831,12 +14797,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "results",
-          "count",
-          "query"
-        ],
+        "required": ["message", "results", "count", "query"],
         "title": "DocSearchResultsResponse",
         "description": "Response for search_docs tool."
       },
@@ -15852,10 +14813,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "url",
-          "relevance_score"
-        ],
+        "required": ["url", "relevance_score"],
         "title": "Document"
       },
       "ErrorResponse": {
@@ -15904,9 +14862,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "ErrorResponse",
         "description": "Response for errors."
       },
@@ -16031,9 +14987,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "graph_id"
-        ],
+        "required": ["graph_id"],
         "title": "ExecutionAnalyticsRequest"
       },
       "ExecutionAnalyticsResponse": {
@@ -16378,11 +15332,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "execution_id",
-          "status",
-          "outputs"
-        ],
+        "required": ["execution_id", "status", "outputs"],
         "title": "ExecutionOutputInfo",
         "description": "Summary of a single execution's outputs."
       },
@@ -16448,12 +15398,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "execution_id",
-          "graph_id",
-          "graph_name"
-        ],
+        "required": ["message", "execution_id", "graph_id", "graph_name"],
         "title": "ExecutionStartedResponse",
         "description": "Response for run/schedule actions."
       },
@@ -16567,10 +15512,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "executions",
-          "total"
-        ],
+        "required": ["executions", "total"],
         "title": "FailedExecutionsListResponse",
         "description": "Response model for list of failed executions"
       },
@@ -16619,9 +15561,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "title": "FolderCreateRequest",
         "description": "Request model for creating a folder."
       },
@@ -16639,10 +15579,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "folders",
-          "pagination"
-        ],
+        "required": ["folders", "pagination"],
         "title": "FolderListResponse",
         "description": "Response schema for a list of folders."
       },
@@ -16675,9 +15612,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "tree"
-        ],
+        "required": ["tree"],
         "title": "FolderTreeResponse",
         "description": "Response schema for folder tree structure."
       },
@@ -16814,10 +15749,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "description"
-        ],
+        "required": ["name", "description"],
         "title": "Graph",
         "description": "Creatable graph model used in API create/update endpoints."
       },
@@ -17369,10 +16301,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "executions",
-          "pagination"
-        ],
+        "required": ["executions", "pagination"],
         "title": "GraphExecutionsPaginated",
         "description": "Response schema for paginated graph executions."
       },
@@ -17817,11 +16746,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "provider",
-          "config_schema",
-          "credentials_input_name"
-        ],
+        "required": ["provider", "config_schema", "credentials_input_name"],
         "title": "GraphTriggerInfo"
       },
       "HTTPValidationError": {
@@ -17891,10 +16816,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "provider",
-          "host"
-        ],
+        "required": ["provider", "host"],
         "title": "HostScopedCredentials"
       },
       "ImageURLResponse": {
@@ -17905,9 +16827,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "image_url"
-        ],
+        "required": ["image_url"],
         "title": "ImageURLResponse"
       },
       "InputValidationErrorResponse": {
@@ -17969,11 +16889,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "unrecognized_fields",
-          "inputs"
-        ],
+        "required": ["message", "unrecognized_fields", "inputs"],
         "title": "InputValidationErrorResponse",
         "description": "Response when run_agent receives unknown input fields."
       },
@@ -18406,11 +17322,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "graph_execution_id",
-          "name",
-          "description"
-        ],
+        "required": ["graph_execution_id", "name", "description"],
         "title": "LibraryAgentPresetCreatableFromGraphExecution",
         "description": "Request model used when creating a new preset for a library agent."
       },
@@ -18428,10 +17340,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "presets",
-          "pagination"
-        ],
+        "required": ["presets", "pagination"],
         "title": "LibraryAgentPresetResponse",
         "description": "Response schema for a list of agent presets and pagination info."
       },
@@ -18515,30 +17424,19 @@
           }
         },
         "type": "object",
-        "required": [
-          "agents",
-          "pagination"
-        ],
+        "required": ["agents", "pagination"],
         "title": "LibraryAgentResponse",
         "description": "Response schema for a list of library agents and pagination info."
       },
       "LibraryAgentSort": {
         "type": "string",
-        "enum": [
-          "createdAt",
-          "updatedAt"
-        ],
+        "enum": ["createdAt", "updatedAt"],
         "title": "LibraryAgentSort",
         "description": "Possible sort options for sorting library agents."
       },
       "LibraryAgentStatus": {
         "type": "string",
-        "enum": [
-          "COMPLETED",
-          "HEALTHY",
-          "WAITING",
-          "ERROR"
-        ],
+        "enum": ["COMPLETED", "HEALTHY", "WAITING", "ERROR"],
         "title": "LibraryAgentStatus"
       },
       "LibraryAgentUpdateRequest": {
@@ -18688,13 +17586,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "user_id",
-          "name",
-          "created_at",
-          "updated_at"
-        ],
+        "required": ["id", "user_id", "name", "created_at", "updated_at"],
         "title": "LibraryFolder",
         "description": "Represents a folder for organizing library agents."
       },
@@ -18775,13 +17667,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "user_id",
-          "name",
-          "created_at",
-          "updated_at"
-        ],
+        "required": ["id", "user_id", "name", "created_at", "updated_at"],
         "title": "LibraryFolderTree",
         "description": "Folder with nested children for tree view."
       },
@@ -18814,12 +17700,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "source_id",
-          "sink_id",
-          "source_name",
-          "sink_name"
-        ],
+        "required": ["source_id", "sink_id", "source_name", "sink_name"],
         "title": "Link"
       },
       "LinkTokenInfoResponse": {
@@ -18844,18 +17725,12 @@
           }
         },
         "type": "object",
-        "required": [
-          "platform",
-          "link_type"
-        ],
+        "required": ["platform", "link_type"],
         "title": "LinkTokenInfoResponse"
       },
       "LinkType": {
         "type": "string",
-        "enum": [
-          "SERVER",
-          "USER"
-        ],
+        "enum": ["SERVER", "USER"],
         "title": "LinkType"
       },
       "ListFilesResponse": {
@@ -18879,9 +17754,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "files"
-        ],
+        "required": ["files"],
         "title": "ListFilesResponse"
       },
       "ListSessionsResponse": {
@@ -18899,10 +17772,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "sessions",
-          "total"
-        ],
+        "required": ["sessions", "total"],
         "title": "ListSessionsResponse",
         "description": "Response model for listing chat sessions."
       },
@@ -18924,11 +17794,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "metric_name",
-          "metric_value",
-          "data_string"
-        ],
+        "required": ["metric_name", "metric_value", "data_string"],
         "title": "LogRawMetricRequest"
       },
       "LoginResponse": {
@@ -18943,10 +17809,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "login_url",
-          "state_token"
-        ],
+        "required": ["login_url", "state_token"],
         "title": "LoginResponse"
       },
       "MCPOAuthCallbackRequest": {
@@ -18963,10 +17826,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "code",
-          "state_token"
-        ],
+        "required": ["code", "state_token"],
         "title": "MCPOAuthCallbackRequest",
         "description": "Request to exchange an OAuth code for tokens."
       },
@@ -18979,9 +17839,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "server_url"
-        ],
+        "required": ["server_url"],
         "title": "MCPOAuthLoginRequest",
         "description": "Request to start an OAuth flow for an MCP server."
       },
@@ -18997,10 +17855,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "login_url",
-          "state_token"
-        ],
+        "required": ["login_url", "state_token"],
         "title": "MCPOAuthLoginResponse",
         "description": "Response with the OAuth login URL for the user to authenticate."
       },
@@ -19021,10 +17876,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "server_url",
-          "token"
-        ],
+        "required": ["server_url", "token"],
         "title": "MCPStoreTokenRequest",
         "description": "Request to store a bearer token for an MCP server that doesn't support OAuth."
       },
@@ -19045,11 +17897,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "description",
-          "input_schema"
-        ],
+        "required": ["name", "description", "input_schema"],
         "title": "MCPToolInfo",
         "description": "Information about a single MCP tool discovered from a server."
       },
@@ -19092,11 +17940,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "server_url",
-          "tool_name"
-        ],
+        "required": ["message", "server_url", "tool_name"],
         "title": "MCPToolOutputResponse",
         "description": "Response after executing an MCP tool."
       },
@@ -19117,11 +17961,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "description",
-          "input_schema"
-        ],
+        "required": ["name", "description", "input_schema"],
         "title": "MCPToolResponse",
         "description": "A single MCP tool returned by discovery."
       },
@@ -19159,11 +17999,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "server_url",
-          "tools"
-        ],
+        "required": ["message", "server_url", "tools"],
         "title": "MCPToolsDiscoveredResponse",
         "description": "Response when MCP tools are discovered from a server (agent-internal)."
       },
@@ -19186,12 +18022,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "name",
-          "slug",
-          "creator"
-        ],
+        "required": ["id", "name", "slug", "creator"],
         "title": "MarketplaceListing",
         "description": "Marketplace listing information for a library agent."
       },
@@ -19211,11 +18042,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "id",
-          "slug"
-        ],
+        "required": ["name", "id", "slug"],
         "title": "MarketplaceListingCreator",
         "description": "Creator information for a marketplace listing."
       },
@@ -19252,9 +18079,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "MemoryForgetCandidatesResponse",
         "description": "Response with candidate memories to forget."
       },
@@ -19295,9 +18120,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "MemoryForgetConfirmResponse",
         "description": "Response after deleting specific memory edges."
       },
@@ -19338,9 +18161,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "MemorySearchResponse",
         "description": "Response when memories are searched."
       },
@@ -19371,10 +18192,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "memory_name"
-        ],
+        "required": ["message", "memory_name"],
         "title": "MemoryStoreResponse",
         "description": "Response when a memory is stored."
       },
@@ -19390,10 +18208,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "query",
-          "response"
-        ],
+        "required": ["query", "response"],
         "title": "Message"
       },
       "ModelInfo": {
@@ -19412,11 +18227,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "value",
-          "label",
-          "provider"
-        ],
+        "required": ["value", "label", "provider"],
         "title": "ModelInfo"
       },
       "MyUnpublishedAgent": {
@@ -19489,10 +18300,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "agents",
-          "pagination"
-        ],
+        "required": ["agents", "pagination"],
         "title": "MyUnpublishedAgentsResponse"
       },
       "NeedLoginResponse": {
@@ -19530,9 +18338,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "NeedLoginResponse",
         "description": "Response when login is needed."
       },
@@ -19572,9 +18378,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "NoResultsResponse",
         "description": "Response when no agents found."
       },
@@ -19614,9 +18418,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "block_id"
-        ],
+        "required": ["block_id"],
         "title": "Node"
       },
       "NodeExecutionResult": {
@@ -19781,11 +18583,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "block_id",
-          "graph_id",
-          "graph_version"
-        ],
+        "required": ["block_id", "graph_id", "graph_version"],
         "title": "NodeModel"
       },
       "NotificationPreference": {
@@ -19827,10 +18625,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id",
-          "email"
-        ],
+        "required": ["user_id", "email"],
         "title": "NotificationPreference"
       },
       "NotificationPreferenceDTO": {
@@ -19859,11 +18654,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "email",
-          "preferences",
-          "daily_limit"
-        ],
+        "required": ["email", "preferences", "daily_limit"],
         "title": "NotificationPreferenceDTO"
       },
       "NotificationType": {
@@ -19982,11 +18773,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "provider",
-          "access_token",
-          "scopes"
-        ],
+        "required": ["provider", "access_token", "scopes"],
         "title": "OAuth2Credentials"
       },
       "OAuthApplicationInfo": {
@@ -20118,10 +18905,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "scopes"
-        ],
+        "required": ["name", "scopes"],
         "title": "OAuthApplicationPublicInfo",
         "description": "Public information about an OAuth application (for consent screen)"
       },
@@ -20149,10 +18933,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_name",
-          "user_role"
-        ],
+        "required": ["user_name", "user_role"],
         "title": "OnboardingProfileRequest",
         "description": "Request body for onboarding profile submission."
       },
@@ -20164,9 +18945,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "is_completed"
-        ],
+        "required": ["is_completed"],
         "title": "OnboardingStatusResponse",
         "description": "Response for onboarding completion check."
       },
@@ -20269,10 +19048,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "schedules",
-          "total"
-        ],
+        "required": ["schedules", "total"],
         "title": "OrphanedSchedulesListResponse",
         "description": "Response model for list of orphaned schedules"
       },
@@ -20282,42 +19058,29 @@
             "type": "integer",
             "title": "Total Items",
             "description": "Total number of items.",
-            "examples": [
-              42
-            ]
+            "examples": [42]
           },
           "total_pages": {
             "type": "integer",
             "title": "Total Pages",
             "description": "Total number of pages.",
-            "examples": [
-              2
-            ]
+            "examples": [2]
           },
           "current_page": {
             "type": "integer",
             "title": "Current Page",
             "description": "Current_page page number.",
-            "examples": [
-              1
-            ]
+            "examples": [1]
           },
           "page_size": {
             "type": "integer",
             "title": "Page Size",
             "description": "Number of items per page.",
-            "examples": [
-              25
-            ]
+            "examples": [25]
           }
         },
         "type": "object",
-        "required": [
-          "total_items",
-          "total_pages",
-          "current_page",
-          "page_size"
-        ],
+        "required": ["total_items", "total_pages", "current_page", "page_size"],
         "title": "Pagination"
       },
       "PeekPendingMessagesResponse": {
@@ -20335,10 +19098,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "messages",
-          "count"
-        ],
+        "required": ["messages", "count"],
         "title": "PeekPendingMessagesResponse",
         "description": "Response for the pending-message peek (GET) endpoint.\n\nReturns a read-only view of the pending buffer — messages are NOT\nconsumed.  The frontend uses this to restore the queued-message\nindicator after a page refresh and to decide when to clear it once\na turn has ended."
       },
@@ -20524,9 +19284,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "access_token"
-        ],
+        "required": ["access_token"],
         "title": "PickerTokenResponse",
         "description": "Short-lived OAuth access token shipped to the browser for rendering a\nprovider-hosted picker UI (e.g. Google Drive Picker). Deliberately narrow:\nonly the fields the client needs to initialize the picker widget. Issued\nfrom the user's own stored credential so ownership and scope gating are\nenforced by the credential lookup."
       },
@@ -20641,11 +19399,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "logs",
-          "total_rows",
-          "truncated"
-        ],
+        "required": ["logs", "total_rows", "truncated"],
         "title": "PlatformCostExportResponse"
       },
       "PlatformCostLogsResponse": {
@@ -20662,10 +19416,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "logs",
-          "pagination"
-        ],
+        "required": ["logs", "pagination"],
         "title": "PlatformCostLogsResponse"
       },
       "PlatformLinkInfo": {
@@ -20758,28 +19509,8 @@
       "PostmarkBounceEnum": {
         "type": "integer",
         "enum": [
-          1,
-          2,
-          16,
-          32,
-          64,
-          128,
-          256,
-          512,
-          1024,
-          2048,
-          4096,
-          8192,
-          16384,
-          100000,
-          100001,
-          100002,
-          100003,
-          100006,
-          100007,
-          100008,
-          100009,
-          100010
+          1, 2, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+          100000, 100001, 100002, 100003, 100006, 100007, 100008, 100009, 100010
         ],
         "title": "PostmarkBounceEnum"
       },
@@ -21346,13 +20077,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "username",
-          "name",
-          "description",
-          "avatar_url",
-          "links"
-        ],
+        "required": ["username", "name", "description", "avatar_url", "links"],
         "title": "Profile",
         "description": "Marketplace user profile (only attributes that the user can update)"
       },
@@ -21422,11 +20147,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "description",
-          "integration_count"
-        ],
+        "required": ["name", "description", "integration_count"],
         "title": "Provider"
       },
       "ProviderConstants": {
@@ -21537,9 +20258,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "provider"
-        ],
+        "required": ["provider"],
         "title": "ProviderEnumResponse",
         "description": "Response containing a provider from the enum."
       },
@@ -21565,12 +20284,7 @@
           "supported_auth_types": {
             "items": {
               "type": "string",
-              "enum": [
-                "api_key",
-                "oauth2",
-                "user_password",
-                "host_scoped"
-              ]
+              "enum": ["api_key", "oauth2", "user_password", "host_scoped"]
             },
             "type": "array",
             "title": "Supported Auth Types",
@@ -21578,9 +20292,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "title": "ProviderMetadata",
         "description": "Display metadata for a provider, shown in the settings integrations UI."
       },
@@ -21613,10 +20325,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "providers",
-          "pagination"
-        ],
+        "required": ["providers", "pagination"],
         "title": "ProviderResponse"
       },
       "PushSubscribeRequest": {
@@ -21644,10 +20353,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "endpoint",
-          "keys"
-        ],
+        "required": ["endpoint", "keys"],
         "title": "PushSubscribeRequest"
       },
       "PushSubscriptionKeys": {
@@ -21666,10 +20372,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "p256dh",
-          "auth"
-        ],
+        "required": ["p256dh", "auth"],
         "title": "PushSubscriptionKeys"
       },
       "PushUnsubscribeRequest": {
@@ -21682,9 +20385,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "endpoint"
-        ],
+        "required": ["endpoint"],
         "title": "PushUnsubscribeRequest"
       },
       "QueuePendingMessageRequest": {
@@ -21725,9 +20426,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "QueuePendingMessageRequest",
         "description": "Request model for queueing a follow-up while a turn is running."
       },
@@ -21747,11 +20446,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "buffer_length",
-          "max_buffer_length",
-          "turn_in_flight"
-        ],
+        "required": ["buffer_length", "max_buffer_length", "turn_in_flight"],
         "title": "QueuePendingMessageResponse",
         "description": "Response returned when a message is queued because the session already\nhas a turn in flight.\n\n- ``buffer_length``: how many messages are now in the session's\n  pending buffer (after this push)\n- ``max_buffer_length``: the per-session cap (server-side constant)\n- ``turn_in_flight``: ``True`` if a copilot turn was running when\n  we checked — purely informational for UX feedback."
       },
@@ -21816,9 +20511,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "status"
-        ],
+        "required": ["status"],
         "title": "RecentExecution",
         "description": "Summary of a recent execution for quality assessment.\n\nUsed by the LLM to understand the agent's recent performance with specific examples\nrather than just aggregate statistics."
       },
@@ -21891,9 +20584,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "credit_amount"
-        ],
+        "required": ["credit_amount"],
         "title": "RequestTopUp"
       },
       "RequeueExecutionResponse": {
@@ -21913,10 +20604,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "success",
-          "message"
-        ],
+        "required": ["success", "message"],
         "title": "RequeueExecutionResponse",
         "description": "Response model for requeue execution operations"
       },
@@ -22039,10 +20727,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "node_exec_id",
-          "approved"
-        ],
+        "required": ["node_exec_id", "approved"],
         "title": "ReviewItem",
         "description": "Single review item for processing."
       },
@@ -22058,9 +20743,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "reviews"
-        ],
+        "required": ["reviews"],
         "title": "ReviewRequest",
         "description": "Request model for processing ALL pending reviews for an execution.\n\nThis request must include ALL pending reviews for a graph execution.\nEach review will be either approved (with optional data modifications)\nor rejected (data ignored). The execution will resume only after ALL reviews are processed.\n\nEach review item can individually specify whether to auto-approve future executions\nof the same block via the `auto_approve_future` field on ReviewItem."
       },
@@ -22095,21 +20778,13 @@
           }
         },
         "type": "object",
-        "required": [
-          "approved_count",
-          "rejected_count",
-          "failed_count"
-        ],
+        "required": ["approved_count", "rejected_count", "failed_count"],
         "title": "ReviewResponse",
         "description": "Response from review endpoint."
       },
       "ReviewStatus": {
         "type": "string",
-        "enum": [
-          "WAITING",
-          "APPROVED",
-          "REJECTED"
-        ],
+        "enum": ["WAITING", "APPROVED", "REJECTED"],
         "title": "ReviewStatus"
       },
       "ReviewSubmissionRequest": {
@@ -22139,11 +20814,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "store_listing_version_id",
-          "is_approved",
-          "comments"
-        ],
+        "required": ["store_listing_version_id", "is_approved", "comments"],
         "title": "ReviewSubmissionRequest"
       },
       "RunningExecutionDetail": {
@@ -22242,10 +20913,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "executions",
-          "total"
-        ],
+        "required": ["executions", "total"],
         "title": "RunningExecutionsListResponse",
         "description": "Response model for list of running executions"
       },
@@ -22260,9 +20928,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "schedule_ids"
-        ],
+        "required": ["schedule_ids"],
         "title": "ScheduleCleanupRequest",
         "description": "Request model for cleaning up schedules"
       },
@@ -22283,10 +20949,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "success",
-          "message"
-        ],
+        "required": ["success", "message"],
         "title": "ScheduleCleanupResponse",
         "description": "Response model for schedule cleanup operations"
       },
@@ -22337,11 +21000,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "cron",
-          "inputs"
-        ],
+        "required": ["name", "cron", "inputs"],
         "title": "ScheduleCreationRequest"
       },
       "ScheduleDetail": {
@@ -22511,10 +21170,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "schedules",
-          "total"
-        ],
+        "required": ["schedules", "total"],
         "title": "SchedulesListResponse",
         "description": "Response model for list of schedules"
       },
@@ -22623,12 +21279,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "items",
-          "search_id",
-          "total_items",
-          "pagination"
-        ],
+        "required": ["items", "search_id", "total_items", "pagination"],
         "title": "SearchResponse"
       },
       "SessionDetailResponse": {
@@ -22708,13 +21359,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "created_at",
-          "updated_at",
-          "user_id",
-          "messages"
-        ],
+        "required": ["id", "created_at", "updated_at", "user_id", "messages"],
         "title": "SessionDetailResponse",
         "description": "Response model providing complete details for a chat session, including messages."
       },
@@ -22749,12 +21394,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "id",
-          "created_at",
-          "updated_at",
-          "is_processing"
-        ],
+        "required": ["id", "created_at", "updated_at", "is_processing"],
         "title": "SessionSummaryResponse",
         "description": "Response model for a session summary (without messages)."
       },
@@ -22766,9 +21406,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "active_graph_version"
-        ],
+        "required": ["active_graph_version"],
         "title": "SetGraphActiveVersion"
       },
       "SetUserTierRequest": {
@@ -22782,10 +21420,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id",
-          "tier"
-        ],
+        "required": ["user_id", "tier"],
         "title": "SetUserTierRequest"
       },
       "SetupInfo": {
@@ -22811,10 +21446,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "agent_id",
-          "agent_name"
-        ],
+        "required": ["agent_id", "agent_name"],
         "title": "SetupInfo",
         "description": "Complete setup information."
       },
@@ -22866,10 +21498,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "setup_info"
-        ],
+        "required": ["message", "setup_info"],
         "title": "SetupRequirementsResponse",
         "description": "Response for validate action."
       },
@@ -22891,10 +21520,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "share_url",
-          "share_token"
-        ],
+        "required": ["share_url", "share_token"],
         "title": "ShareResponse",
         "description": "Response from share endpoints."
       },
@@ -23041,9 +21667,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "execution_id"
-        ],
+        "required": ["execution_id"],
         "title": "StopExecutionRequest",
         "description": "Request model for stopping a single execution"
       },
@@ -23064,10 +21688,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "success",
-          "message"
-        ],
+        "required": ["success", "message"],
         "title": "StopExecutionResponse",
         "description": "Response model for stop execution operations"
       },
@@ -23082,9 +21703,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "execution_ids"
-        ],
+        "required": ["execution_ids"],
         "title": "StopExecutionsRequest",
         "description": "Request model for stopping multiple executions"
       },
@@ -23108,12 +21727,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "used_bytes",
-          "limit_bytes",
-          "used_percent",
-          "file_count"
-        ],
+        "required": ["used_bytes", "limit_bytes", "used_percent", "file_count"],
         "title": "StorageUsageResponse"
       },
       "StoreAgent": {
@@ -23340,29 +21954,17 @@
           }
         },
         "type": "object",
-        "required": [
-          "agents",
-          "pagination"
-        ],
+        "required": ["agents", "pagination"],
         "title": "StoreAgentsResponse"
       },
       "StoreAgentsSortOptions": {
         "type": "string",
-        "enum": [
-          "rating",
-          "runs",
-          "name",
-          "updated_at"
-        ],
+        "enum": ["rating", "runs", "name", "updated_at"],
         "title": "StoreAgentsSortOptions"
       },
       "StoreCreatorsSortOptions": {
         "type": "string",
-        "enum": [
-          "agent_rating",
-          "agent_runs",
-          "num_agents"
-        ],
+        "enum": ["agent_rating", "agent_runs", "num_agents"],
         "title": "StoreCreatorsSortOptions"
       },
       "StoreListingWithVersionsAdminView": {
@@ -23426,11 +22028,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "listing_id",
-          "graph_id",
-          "slug"
-        ],
+        "required": ["listing_id", "graph_id", "slug"],
         "title": "StoreListingWithVersionsAdminView",
         "description": "A store listing with its version history"
       },
@@ -23448,10 +22046,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "listings",
-          "pagination"
-        ],
+        "required": ["listings", "pagination"],
         "title": "StoreListingsWithVersionsAdminViewResponse",
         "description": "Response model for listings with version history"
       },
@@ -23474,9 +22069,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "score"
-        ],
+        "required": ["score"],
         "title": "StoreReview"
       },
       "StoreReviewCreate": {
@@ -23502,10 +22095,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "store_listing_version_id",
-          "score"
-        ],
+        "required": ["store_listing_version_id", "score"],
         "title": "StoreReviewCreate"
       },
       "StoreSubmission": {
@@ -23984,10 +22574,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "sub_heading"
-        ],
+        "required": ["name", "sub_heading"],
         "title": "StoreSubmissionEditRequest"
       },
       "StoreSubmissionRequest": {
@@ -24117,10 +22704,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "submissions",
-          "pagination"
-        ],
+        "required": ["submissions", "pagination"],
         "title": "StoreSubmissionsResponse"
       },
       "StreamChatRequest": {
@@ -24168,10 +22752,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "fast",
-                  "extended_thinking"
-                ]
+                "enum": ["fast", "extended_thinking"]
               },
               {
                 "type": "null"
@@ -24184,10 +22765,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "standard",
-                  "advanced"
-                ]
+                "enum": ["standard", "advanced"]
               },
               {
                 "type": "null"
@@ -24198,20 +22776,13 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "StreamChatRequest",
         "description": "Request model for streaming chat with optional context."
       },
       "SubmissionStatus": {
         "type": "string",
-        "enum": [
-          "DRAFT",
-          "PENDING",
-          "APPROVED",
-          "REJECTED"
-        ],
+        "enum": ["DRAFT", "PENDING", "APPROVED", "REJECTED"],
         "title": "SubmissionStatus"
       },
       "SubscriptionStatusResponse": {
@@ -24273,13 +22844,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "NO_TIER",
-                  "BASIC",
-                  "PRO",
-                  "MAX",
-                  "BUSINESS"
-                ]
+                "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"]
               },
               {
                 "type": "null"
@@ -24317,14 +22882,7 @@
       },
       "SubscriptionTier": {
         "type": "string",
-        "enum": [
-          "NO_TIER",
-          "BASIC",
-          "PRO",
-          "MAX",
-          "BUSINESS",
-          "ENTERPRISE"
-        ],
+        "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
         "title": "SubscriptionTier",
         "description": "Subscription tiers with increasing cost allowances.\n\nMirrors the ``SubscriptionTier`` enum in ``schema.prisma``.\nOnce ``prisma generate`` is run, this can be replaced with::\n\n    from prisma.enums import SubscriptionTier"
       },
@@ -24332,13 +22890,7 @@
         "properties": {
           "tier": {
             "type": "string",
-            "enum": [
-              "NO_TIER",
-              "BASIC",
-              "PRO",
-              "MAX",
-              "BUSINESS"
-            ],
+            "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"],
             "title": "Tier"
           },
           "success_url": {
@@ -24353,9 +22905,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "tier"
-        ],
+        "required": ["tier"],
         "title": "SubscriptionTierRequest"
       },
       "SuggestedGoalResponse": {
@@ -24398,20 +22948,14 @@
           },
           "goal_type": {
             "type": "string",
-            "enum": [
-              "vague",
-              "unachievable"
-            ],
+            "enum": ["vague", "unachievable"],
             "title": "Goal Type",
             "description": "Type: 'vague' or 'unachievable'",
             "default": "vague"
           }
         },
         "type": "object",
-        "required": [
-          "message",
-          "suggested_goal"
-        ],
+        "required": ["message", "suggested_goal"],
         "title": "SuggestedGoalResponse",
         "description": "Response when the goal needs refinement with a suggested alternative."
       },
@@ -24426,9 +22970,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "themes"
-        ],
+        "required": ["themes"],
         "title": "SuggestedPromptsResponse",
         "description": "Response model for user-specific suggested prompts grouped by theme."
       },
@@ -24447,10 +22989,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "prompts"
-        ],
+        "required": ["name", "prompts"],
         "title": "SuggestedTheme",
         "description": "A themed group of suggested prompts."
       },
@@ -24480,11 +23019,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "recent_searches",
-          "providers",
-          "top_blocks"
-        ],
+        "required": ["recent_searches", "providers", "top_blocks"],
         "title": "SuggestionsResponse"
       },
       "TimezoneResponse": {
@@ -25102,9 +23637,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "timezone"
-        ],
+        "required": ["timezone"],
         "title": "TimezoneResponse"
       },
       "TodoItem": {
@@ -25121,20 +23654,13 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "in_progress",
-              "completed"
-            ],
+            "enum": ["pending", "in_progress", "completed"],
             "title": "Status",
             "default": "pending"
           }
         },
         "type": "object",
-        "required": [
-          "content",
-          "activeForm"
-        ],
+        "required": ["content", "activeForm"],
         "title": "TodoItem",
         "description": "One entry in a ``TodoWrite`` checklist.\n\nMirrors the schema used by Claude Code's built-in ``TodoWrite`` tool so\nthe frontend's ``GenericTool`` accordion renders baseline-emitted todos\nidentically to SDK-emitted ones."
       },
@@ -25168,9 +23694,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "TodoWriteResponse",
         "description": "Ack returned by ``TodoWrite``.\n\nThe tool is effectively stateless — the authoritative task list lives in\nthe assistant's latest tool-call arguments, which are replayed from the\ntranscript on each turn. The tool output only needs to confirm that the\nupdate was accepted so the model can proceed."
       },
@@ -25231,10 +23755,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": [
-                  "access_token",
-                  "refresh_token"
-                ]
+                "enum": ["access_token", "refresh_token"]
               },
               {
                 "type": "null"
@@ -25244,9 +23765,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "active"
-        ],
+        "required": ["active"],
         "title": "TokenIntrospectionResult",
         "description": "Result of token introspection (RFC 7662)"
       },
@@ -25389,10 +23908,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "transactions",
-          "next_transaction_time"
-        ],
+        "required": ["transactions", "next_transaction_time"],
         "title": "TransactionHistory"
       },
       "TriggeredPresetSetupRequest": {
@@ -25428,12 +23944,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "name",
-          "graph_id",
-          "graph_version",
-          "trigger_config"
-        ],
+        "required": ["name", "graph_id", "graph_version", "trigger_config"],
         "title": "TriggeredPresetSetupRequest"
       },
       "UnderstandingUpdatedResponse": {
@@ -25471,9 +23982,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "message"
-        ],
+        "required": ["message"],
         "title": "UnderstandingUpdatedResponse",
         "description": "Response for add_understanding tool."
       },
@@ -25491,10 +24000,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "results",
-          "pagination"
-        ],
+        "required": ["results", "pagination"],
         "title": "UnifiedSearchResponse",
         "description": "Response model for unified search across all content types."
       },
@@ -25571,11 +24077,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "content_type",
-          "content_id",
-          "searchable_text"
-        ],
+        "required": ["content_type", "content_id", "searchable_text"],
         "title": "UnifiedSearchResult",
         "description": "A single result from unified hybrid search across all content types."
       },
@@ -25588,9 +24090,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "logo_url"
-        ],
+        "required": ["logo_url"],
         "title": "UpdateAppLogoRequest"
       },
       "UpdatePermissionsRequest": {
@@ -25604,9 +24104,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "permissions"
-        ],
+        "required": ["permissions"],
         "title": "UpdatePermissionsRequest"
       },
       "UpdateSessionTitleRequest": {
@@ -25617,9 +24115,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "title": "UpdateSessionTitleRequest",
         "description": "Request model for updating a session's title."
       },
@@ -26231,9 +24727,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "timezone"
-        ],
+        "required": ["timezone"],
         "title": "UpdateTimezoneRequest"
       },
       "UsageWindowPublic": {
@@ -26252,10 +24746,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "percent_used",
-          "resets_at"
-        ],
+        "required": ["percent_used", "resets_at"],
         "title": "UsageWindowPublic",
         "description": "Public view of a usage window — only the percentage and reset time.\n\nHides the raw spend and the cap so clients cannot derive per-turn cost\nor reverse-engineer platform margins.  ``percent_used`` is capped at 100."
       },
@@ -26338,10 +24829,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "history",
-          "pagination"
-        ],
+        "required": ["history", "pagination"],
         "title": "UserHistoryResponse",
         "description": "Response model for listings with version history"
       },
@@ -26631,11 +25119,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "provider",
-          "username",
-          "password"
-        ],
+        "required": ["provider", "username", "password"],
         "title": "UserPasswordCredentials"
       },
       "UserRateLimitResponse": {
@@ -26728,9 +25212,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id"
-        ],
+        "required": ["user_id"],
         "title": "UserSearchResult"
       },
       "UserTierResponse": {
@@ -26744,10 +25226,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id",
-          "tier"
-        ],
+        "required": ["user_id", "tier"],
         "title": "UserTierResponse"
       },
       "UserTransaction": {
@@ -26876,9 +25355,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "user_id"
-        ],
+        "required": ["user_id"],
         "title": "UserTransaction"
       },
       "ValidationError": {
@@ -26914,11 +25391,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
+        "required": ["loc", "msg", "type"],
         "title": "ValidationError"
       },
       "VapidPublicKeyResponse": {
@@ -26929,9 +25402,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "public_key"
-        ],
+        "required": ["public_key"],
         "title": "VapidPublicKeyResponse"
       },
       "Webhook": {
@@ -27068,13 +25539,7 @@
           }
         },
         "type": "object",
-        "required": [
-          "file_id",
-          "name",
-          "path",
-          "mime_type",
-          "size_bytes"
-        ],
+        "required": ["file_id", "name", "path", "mime_type", "size_bytes"],
         "title": "UploadFileResponse"
       },
       "backend__api__model__UploadFileResponse": {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -28,11 +28,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions": {
@@ -56,11 +52,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-orphaned": {
@@ -84,11 +76,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-all-stuck-queued": {
@@ -112,11 +100,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/cleanup-orphaned": {
@@ -128,9 +112,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
             }
           },
           "required": true
@@ -153,18 +135,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/failed": {
@@ -173,41 +149,25 @@
         "summary": "List Failed Executions",
         "description": "Get detailed list of failed executions.\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n    hours: Number of hours to look back (default 24)\n\nReturns:\n    List of failed executions with error details",
         "operationId": "getV2List failed executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           },
           {
             "name": "hours",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 24,
-              "title": "Hours"
-            }
+            "schema": { "type": "integer", "default": 24, "title": "Hours" }
           }
         ],
         "responses": {
@@ -228,9 +188,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -243,31 +201,19 @@
         "summary": "List Invalid Executions",
         "description": "Get detailed list of executions in invalid states (READ-ONLY).\n\nInvalid states indicate data corruption and require manual investigation:\n- QUEUED but has startedAt (impossible - can't start while queued)\n- RUNNING but no startedAt (impossible - can't run without starting)\n\n⚠️ NO BULK ACTIONS PROVIDED - These need case-by-case investigation.\n\nEach invalid execution likely has a different root cause (crashes, race conditions,\nDB corruption). Investigate the execution history and logs to determine appropriate\naction (manual cleanup, status fix, or leave as-is if system recovered).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of invalid state executions with details",
         "operationId": "getV2List invalid executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -288,9 +234,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -303,31 +247,19 @@
         "summary": "List Long-Running Executions",
         "description": "Get detailed list of long-running executions (RUNNING status >24h).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of long-running executions with details",
         "operationId": "getV2List long-running executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -348,9 +280,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -363,31 +293,19 @@
         "summary": "List Orphaned Executions",
         "description": "Get detailed list of orphaned executions (>24h old, likely not in executor).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of orphaned executions with details",
         "operationId": "getV2List orphaned executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -408,9 +326,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -426,9 +342,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
             }
           },
           "required": true
@@ -451,18 +365,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/requeue-all-stuck": {
@@ -486,11 +394,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/requeue-bulk": {
@@ -502,9 +406,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
             }
           },
           "required": true
@@ -527,18 +429,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/running": {
@@ -547,31 +443,19 @@
         "summary": "List Running Executions",
         "description": "Get detailed list of running and queued executions (recent, likely active).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of running executions with details",
         "operationId": "getV2List running executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -592,9 +476,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -610,9 +492,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionRequest" }
             }
           },
           "required": true
@@ -635,18 +515,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/stop-all-long-running": {
@@ -670,11 +544,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/stop-bulk": {
@@ -686,9 +556,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StopExecutionsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StopExecutionsRequest" }
             }
           },
           "required": true
@@ -711,18 +579,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/executions/stuck-queued": {
@@ -731,31 +593,19 @@
         "summary": "List Stuck Queued Executions",
         "description": "Get detailed list of stuck queued executions (QUEUED >1h, never started).\n\nArgs:\n    limit: Maximum number of executions to return (default 100)\n    offset: Number of executions to skip (default 0)\n\nReturns:\n    List of stuck queued executions with details",
         "operationId": "getV2List stuck queued executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -776,9 +626,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -806,11 +654,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/schedules/all": {
@@ -819,31 +663,19 @@
         "summary": "List All User Schedules",
         "description": "Get detailed list of all user schedules (excludes system monitoring jobs).\n\nArgs:\n    limit: Maximum number of schedules to return (default 100)\n    offset: Number of schedules to skip (default 0)\n\nReturns:\n    List of schedules with details",
         "operationId": "getV2List all user schedules",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 100,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 100, "title": "Limit" }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 0,
-              "title": "Offset"
-            }
+            "schema": { "type": "integer", "default": 0, "title": "Offset" }
           }
         ],
         "responses": {
@@ -864,9 +696,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -907,18 +737,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/diagnostics/schedules/orphaned": {
@@ -942,11 +766,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/admin/platform-costs/dashboard": {
@@ -954,11 +774,7 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Dashboard",
         "operationId": "getV2Get platform cost dashboard",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -966,13 +782,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Start"
             }
@@ -983,13 +794,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "End"
             }
@@ -999,14 +805,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Provider"
             }
           },
@@ -1015,14 +814,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -1031,14 +823,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Model"
             }
           },
@@ -1047,14 +832,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Block Name"
             }
           },
@@ -1063,14 +841,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Tracking Type"
             }
           },
@@ -1079,14 +850,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Graph Exec Id"
             }
           }
@@ -1109,9 +873,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1123,11 +885,7 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Get Platform Cost Logs",
         "operationId": "getV2Get platform cost logs",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -1135,13 +893,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Start"
             }
@@ -1152,13 +905,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "End"
             }
@@ -1168,14 +916,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Provider"
             }
           },
@@ -1184,14 +925,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -1223,14 +957,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Model"
             }
           },
@@ -1239,14 +966,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Block Name"
             }
           },
@@ -1255,14 +975,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Tracking Type"
             }
           },
@@ -1271,14 +984,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Graph Exec Id"
             }
           }
@@ -1301,9 +1007,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1315,11 +1019,7 @@
         "tags": ["v2", "admin", "platform-cost", "admin"],
         "summary": "Export Platform Cost Logs",
         "operationId": "getV2Export platform cost logs",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -1327,13 +1027,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Start"
             }
@@ -1344,13 +1039,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "End"
             }
@@ -1360,14 +1050,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Provider"
             }
           },
@@ -1376,14 +1059,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -1392,14 +1068,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Model"
             }
           },
@@ -1408,14 +1077,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Block Name"
             }
           },
@@ -1424,14 +1086,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Tracking Type"
             }
           },
@@ -1440,14 +1095,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Graph Exec Id"
             }
           }
@@ -1470,9 +1118,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1497,11 +1143,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1510,18 +1152,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/analytics/log_raw_metric": {
@@ -1532,9 +1168,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LogRawMetricRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/LogRawMetricRequest" }
             }
           },
           "required": true
@@ -1542,11 +1176,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -1555,18 +1185,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/api-keys": {
@@ -1581,9 +1205,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/APIKeyInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/APIKeyInfo" },
                   "type": "array",
                   "title": "Response Getv1List User Api Keys"
                 }
@@ -1594,11 +1216,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "api-keys"],
@@ -1608,9 +1226,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateAPIKeyRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/CreateAPIKeyRequest" }
             }
           },
           "required": true
@@ -1633,18 +1249,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/api-keys/{key_id}": {
@@ -1653,20 +1263,13 @@
         "summary": "Revoke API key",
         "description": "Revoke an API key",
         "operationId": "deleteV1Revoke api key",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "responses": {
@@ -1674,9 +1277,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1687,9 +1288,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1700,20 +1299,13 @@
         "summary": "Get specific API key",
         "description": "Get a specific API key",
         "operationId": "getV1Get specific api key",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "responses": {
@@ -1721,9 +1313,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1734,9 +1324,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1749,20 +1337,13 @@
         "summary": "Update key permissions",
         "description": "Update API key permissions",
         "operationId": "putV1Update key permissions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "requestBody": {
@@ -1780,9 +1361,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1793,9 +1372,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1808,20 +1385,13 @@
         "summary": "Suspend API key",
         "description": "Suspend an API key",
         "operationId": "postV1Suspend api key",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "key_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Key Id"
-            }
+            "schema": { "type": "string", "title": "Key Id" }
           }
         ],
         "responses": {
@@ -1829,9 +1399,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/APIKeyInfo"
-                }
+                "schema": { "$ref": "#/components/schemas/APIKeyInfo" }
               }
             }
           },
@@ -1842,9 +1410,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -1859,21 +1425,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/auth/user/email": {
@@ -1884,10 +1442,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "type": "string",
-                "title": "Email"
-              }
+              "schema": { "type": "string", "title": "Email" }
             }
           },
           "required": true
@@ -1898,9 +1453,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
+                  "additionalProperties": { "type": "string" },
                   "type": "object",
                   "title": "Response Postv1Update User Email"
                 }
@@ -1914,18 +1467,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/auth/user/preferences": {
@@ -1948,11 +1495,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "auth"],
@@ -1986,18 +1529,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/auth/user/timezone": {
@@ -2011,9 +1548,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimezoneResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
               }
             }
           },
@@ -2021,11 +1556,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "auth"],
@@ -2035,9 +1566,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateTimezoneRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/UpdateTimezoneRequest" }
             }
           },
           "required": true
@@ -2047,9 +1576,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimezoneResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
               }
             }
           },
@@ -2060,18 +1587,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/blocks": {
@@ -2085,10 +1606,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "additionalProperties": true,
-                    "type": "object"
-                  },
+                  "items": { "additionalProperties": true, "type": "object" },
                   "type": "array",
                   "title": "Response Getv1List Available Blocks"
                 }
@@ -2099,11 +1617,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/blocks/{block_id}/execute": {
@@ -2111,20 +1625,13 @@
         "tags": ["v1", "blocks"],
         "summary": "Execute graph block",
         "operationId": "postV1Execute graph block",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "block_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Block Id"
-            }
+            "schema": { "type": "string", "title": "Block Id" }
           }
         ],
         "requestBody": {
@@ -2146,10 +1653,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {}
-                  },
+                  "additionalProperties": { "type": "array", "items": {} },
                   "title": "Response Postv1Execute Graph Block"
                 }
               }
@@ -2162,9 +1666,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2177,25 +1679,14 @@
         "summary": "Get Builder blocks",
         "description": "Get blocks based on either category, type, or provider.",
         "operationId": "getV2Get builder blocks",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "category",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Category"
             }
           },
@@ -2209,9 +1700,7 @@
                   "enum": ["all", "input", "action", "output"],
                   "type": "string"
                 },
-                {
-                  "type": "null"
-                }
+                { "type": "null" }
               ],
               "title": "Type"
             }
@@ -2226,9 +1715,7 @@
                   "type": "string",
                   "description": "Provider name for integrations. Can be any string value, including custom provider names."
                 },
-                {
-                  "type": "null"
-                }
+                { "type": "null" }
               ],
               "title": "Provider"
             }
@@ -2237,21 +1724,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -2259,9 +1738,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BlockResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/BlockResponse" }
               }
             }
           },
@@ -2272,9 +1749,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2287,11 +1762,7 @@
         "summary": "Get specific blocks",
         "description": "Get specific blocks by their IDs.",
         "operationId": "getV2Get specific blocks",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "block_ids",
@@ -2299,9 +1770,7 @@
             "required": true,
             "schema": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
+              "items": { "type": "string" },
               "title": "Block Ids"
             }
           }
@@ -2313,9 +1782,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/BlockInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/BlockInfo" },
                   "title": "Response Getv2Get Specific Blocks"
                 }
               }
@@ -2328,9 +1795,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2343,11 +1808,7 @@
         "summary": "Get Builder block categories",
         "description": "Get all block categories with a specified number of blocks per category.",
         "operationId": "getV2Get builder block categories",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "blocks_per_category",
@@ -2382,9 +1843,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2402,9 +1861,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CountResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/CountResponse" }
               }
             }
           },
@@ -2412,11 +1869,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/builder/providers": {
@@ -2425,31 +1878,19 @@
         "summary": "Get Builder integration providers",
         "description": "Get all integration providers with their block counts.",
         "operationId": "getV2Get builder integration providers",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -2457,9 +1898,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ProviderResponse" }
               }
             }
           },
@@ -2470,9 +1909,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2485,25 +1922,14 @@
         "summary": "Builder search",
         "description": "Search for blocks (including integrations), marketplace agents, and user library agents.",
         "operationId": "getV2Builder search",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "search_query",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search Query"
             }
           },
@@ -2512,14 +1938,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Filter"
             }
           },
@@ -2528,14 +1947,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search Id"
             }
           },
@@ -2545,15 +1957,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
               ],
               "title": "By Creator"
             }
@@ -2562,21 +1967,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 50,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 50, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -2584,9 +1981,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SearchResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
               }
             }
           },
@@ -2597,9 +1992,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2617,9 +2010,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SuggestionsResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/SuggestionsResponse" }
               }
             }
           },
@@ -2627,11 +2018,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/chat/config/ttl": {
@@ -2691,84 +2078,46 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/AgentsFoundResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/NoResultsResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/AgentDetailsResponse"
-                    },
+                    { "$ref": "#/components/schemas/AgentsFoundResponse" },
+                    { "$ref": "#/components/schemas/NoResultsResponse" },
+                    { "$ref": "#/components/schemas/AgentDetailsResponse" },
                     {
                       "$ref": "#/components/schemas/SetupRequirementsResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/ExecutionStartedResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/NeedLoginResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ErrorResponse"
-                    },
+                    { "$ref": "#/components/schemas/ExecutionStartedResponse" },
+                    { "$ref": "#/components/schemas/NeedLoginResponse" },
+                    { "$ref": "#/components/schemas/ErrorResponse" },
                     {
                       "$ref": "#/components/schemas/InputValidationErrorResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/AgentOutputResponse"
-                    },
+                    { "$ref": "#/components/schemas/AgentOutputResponse" },
                     {
                       "$ref": "#/components/schemas/UnderstandingUpdatedResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/AgentPreviewResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/AgentSavedResponse"
-                    },
+                    { "$ref": "#/components/schemas/AgentPreviewResponse" },
+                    { "$ref": "#/components/schemas/AgentSavedResponse" },
                     {
                       "$ref": "#/components/schemas/ClarificationNeededResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/SuggestedGoalResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/BlockListResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/BlockDetailsResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/BlockOutputResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DocSearchResultsResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/DocPageResponse"
-                    },
+                    { "$ref": "#/components/schemas/SuggestedGoalResponse" },
+                    { "$ref": "#/components/schemas/BlockListResponse" },
+                    { "$ref": "#/components/schemas/BlockDetailsResponse" },
+                    { "$ref": "#/components/schemas/BlockOutputResponse" },
+                    { "$ref": "#/components/schemas/DocSearchResultsResponse" },
+                    { "$ref": "#/components/schemas/DocPageResponse" },
                     {
                       "$ref": "#/components/schemas/MCPToolsDiscoveredResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/MCPToolOutputResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/MemoryStoreResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/MemorySearchResponse"
-                    },
+                    { "$ref": "#/components/schemas/MCPToolOutputResponse" },
+                    { "$ref": "#/components/schemas/MemoryStoreResponse" },
+                    { "$ref": "#/components/schemas/MemorySearchResponse" },
                     {
                       "$ref": "#/components/schemas/MemoryForgetCandidatesResponse"
                     },
                     {
                       "$ref": "#/components/schemas/MemoryForgetConfirmResponse"
                     },
-                    {
-                      "$ref": "#/components/schemas/TodoWriteResponse"
-                    }
+                    { "$ref": "#/components/schemas/TodoWriteResponse" }
                   ],
                   "title": "Response Getv2[Dummy] Tool Response Type Export For Codegen"
                 }
@@ -2784,11 +2133,7 @@
         "summary": "List Sessions",
         "description": "List chat sessions for the authenticated user.\n\nReturns a paginated list of chat sessions belonging to the current user,\nordered by most recently updated.\n\nArgs:\n    user_id: The authenticated user's ID.\n    limit: Maximum number of sessions to return (1-100).\n    offset: Number of sessions to skip for pagination.\n\nReturns:\n    ListSessionsResponse: List of session summaries and total count.",
         "operationId": "getV2ListSessions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "limit",
@@ -2832,9 +2177,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2845,22 +2188,14 @@
         "summary": "Create Session",
         "description": "Create (or get-or-create) a chat session.\n\nTwo modes, selected by the request body:\n\n- Default: create a fresh session for the user. ``dry_run=True`` forces\n  run_block and run_agent calls to use dry-run simulation.\n- Builder-bound: when ``builder_graph_id`` is set, get-or-create keyed\n  on ``(user_id, builder_graph_id)``. Returns the existing session for\n  that graph or creates one locked to it.  Graph ownership is validated\n  inside :func:`get_or_create_builder_session`; raises 404 on\n  unauthorized access.  Write-side scope is enforced per-tool\n  (``edit_agent`` / ``run_agent`` reject any ``agent_id`` other than\n  the bound graph) and a small blacklist hides tools that conflict\n  with the panel's scope (see :data:`BUILDER_BLOCKED_TOOLS`).\n\nArgs:\n    user_id: The authenticated user ID parsed from the JWT (required).\n    request: Optional request body with ``dry_run`` and/or\n        ``builder_graph_id``.\n\nReturns:\n    CreateSessionResponse: Details of the resulting session.",
         "operationId": "postV2CreateSession",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateSessionRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
+                  { "$ref": "#/components/schemas/CreateSessionRequest" },
+                  { "type": "null" }
                 ],
                 "title": "Request"
               }
@@ -2885,9 +2220,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2900,39 +2233,26 @@
         "summary": "Delete Session",
         "description": "Delete a chat session.\n\nPermanently removes a chat session and all its messages.\nOnly the owner can delete their sessions.\n\nArgs:\n    session_id: The session ID to delete.\n    user_id: The authenticated user's ID.\n\nReturns:\n    204 No Content on success.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "deleteV2DeleteSession",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -2943,20 +2263,13 @@
         "summary": "Get Session",
         "description": "Retrieve the details of a specific chat session.\n\nSupports cursor-based pagination via ``limit`` and ``before_sequence``.\nWhen no pagination params are provided, returns the most recent messages.",
         "operationId": "getV2GetSession",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           },
           {
             "name": "limit",
@@ -2976,13 +2289,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "integer",
-                  "minimum": 0
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "integer", "minimum": 0 },
+                { "type": "null" }
               ],
               "title": "Before Sequence"
             }
@@ -3006,9 +2314,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3021,20 +2327,13 @@
         "summary": "Session Assign User",
         "description": "Assign an authenticated user to a chat session.\n\nUsed (typically post-login) to claim an existing anonymous session as the current authenticated user.\n\nArgs:\n    session_id: The identifier for the (previously anonymous) session.\n    user_id: The authenticated user's ID to associate with the session.\n\nReturns:\n    dict: Status of the assignment.",
         "operationId": "patchV2SessionAssignUser",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
@@ -3057,9 +2356,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3072,20 +2369,13 @@
         "summary": "Cancel Session Task",
         "description": "Cancel the active streaming task for a session.\n\nPublishes a cancel event to the executor via RabbitMQ FANOUT, then\npolls Redis until the task status flips from ``running`` or a timeout\n(5 s) is reached.  Returns only after the cancellation is confirmed.",
         "operationId": "postV2CancelSessionTask",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
@@ -3106,9 +2396,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3121,20 +2409,13 @@
         "summary": "Get Pending Messages",
         "description": "Peek at the pending-message buffer without consuming it.\n\nReturns the current contents of the session's pending message buffer\nso the frontend can restore the queued-message indicator after a page\nrefresh and clear it correctly once a turn drains the buffer.",
         "operationId": "getV2GetPendingMessages",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
@@ -3151,16 +2432,12 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3171,20 +2448,13 @@
         "summary": "Queue Pending Message",
         "description": "Queue a follow-up message while the session has an active turn.",
         "operationId": "postV2QueuePendingMessage",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "requestBody": {
@@ -3211,9 +2481,7 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "409": {
             "description": "Session has no active turn to receive pending messages"
           },
@@ -3221,15 +2489,11 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "429": {
-            "description": "Call-frequency cap exceeded"
-          }
+          "429": { "description": "Call-frequency cap exceeded" }
         }
       }
     },
@@ -3239,26 +2503,17 @@
         "summary": "Disconnect Session Stream",
         "description": "Disconnect all active SSE listeners for a session.\n\nCalled by the frontend when the user switches away from a chat so the\nbackend releases XREAD listeners immediately rather than waiting for\nthe 5-10 s timeout.",
         "operationId": "deleteV2DisconnectSessionStream",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -3266,9 +2521,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3279,30 +2532,19 @@
         "summary": "Resume Session Stream",
         "description": "Resume an active stream for a session.\n\nCalled by the AI SDK's ``useChat(resume: true)`` on page load.\nChecks for an active (in-progress) task on the session and either replays\nthe full SSE stream or returns 204 No Content if nothing is running.\n\nAlways replays the active turn from ``0-0``. The AI SDK UI-message parser\nkeeps text/reasoning part state inside a single parser instance; resuming\nfrom a Redis cursor can skip the ``*-start`` events required by later\n``*-delta`` chunks.",
         "operationId": "getV2ResumeSessionStream",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -3311,9 +2553,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3324,54 +2564,37 @@
         "summary": "Stream Chat Post",
         "description": "Start a new turn and return an AI SDK UI message stream.\n\nReturns an SSE stream (``text/event-stream``) with Vercel AI SDK chunks\n(text fragments, tool-call UI, tool results). The generation runs in a\nbackground task that survives client disconnects; reconnect via\n``GET /sessions/{session_id}/stream`` to resume.\n\nFollow-up messages typed while a turn is already running should use\n``POST /sessions/{session_id}/messages/pending``. If an older client still\nposts that follow-up here, we queue it defensively but still return a valid\nempty UI-message stream so AI SDK transports never receive a JSON body from\nthe stream endpoint.\n\nArgs:\n    session_id: The chat session identifier.\n    request: Request body with message, is_user_message, and optional context.\n    user_id: Authenticated user ID.",
         "operationId": "postV2StreamChatPost",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StreamChatRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/StreamChatRequest" }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
@@ -3387,20 +2610,13 @@
         "summary": "Update session title",
         "description": "Update the title of a chat session.\n\nAllows the user to rename their chat session.\n\nArgs:\n    session_id: The session ID to update.\n    request: Request body containing the new title.\n    user_id: The authenticated user's ID.\n\nReturns:\n    dict: Status of the update.\n\nRaises:\n    HTTPException: 404 if session not found or not owned by user.",
         "operationId": "patchV2Update session title",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Session Id"
-            }
+            "schema": { "type": "string", "title": "Session Id" }
           }
         ],
         "requestBody": {
@@ -3429,16 +2645,12 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Session not found or access denied"
-          },
+          "404": { "description": "Session not found or access denied" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3466,11 +2678,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/chat/usage": {
@@ -3484,9 +2692,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CoPilotUsagePublic"
-                }
+                "schema": { "$ref": "#/components/schemas/CoPilotUsagePublic" }
               }
             }
           },
@@ -3494,11 +2700,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/chat/usage/reset": {
@@ -3524,9 +2726,7 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "402": {
-            "description": "Payment Required (insufficient credits)"
-          },
+          "402": { "description": "Payment Required (insufficient credits)" },
           "429": {
             "description": "Too Many Requests (max daily resets exceeded or reset in progress)"
           },
@@ -3534,11 +2734,7 @@
             "description": "Service Unavailable (Redis reset failed; credits refunded or support needed)"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/copilot/admin/rate_limit": {
@@ -3547,25 +2743,14 @@
         "summary": "Get User Rate Limit",
         "description": "Get a user's current usage and effective rate limits. Admin-only.\n\nAccepts either ``user_id`` or ``email`` as a query parameter.\nWhen ``email`` is provided the user is looked up by email first.",
         "operationId": "getV2Get user rate limit",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -3574,14 +2759,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Email"
             }
           }
@@ -3604,9 +2782,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3647,18 +2823,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/copilot/admin/rate_limit/search_users": {
@@ -3667,30 +2837,19 @@
         "summary": "Search Users by Name or Email",
         "description": "Search users by partial email or name. Admin-only.\n\nQueries the User table directly — returns results even for users\nwithout credit transaction history.",
         "operationId": "getV2Search users by name or email",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Query"
-            }
+            "schema": { "type": "string", "title": "Query" }
           },
           {
             "name": "limit",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "title": "Limit"
-            }
+            "schema": { "type": "integer", "default": 20, "title": "Limit" }
           }
         ],
         "responses": {
@@ -3700,9 +2859,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/UserSearchResult"
-                  },
+                  "items": { "$ref": "#/components/schemas/UserSearchResult" },
                   "title": "Response Getv2Search Users By Name Or Email"
                 }
               }
@@ -3715,9 +2872,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3730,20 +2885,13 @@
         "summary": "Get User Rate Limit Tier",
         "description": "Get a user's current rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "getV2Get user rate limit tier",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "user_id",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "User Id"
-            }
+            "schema": { "type": "string", "title": "User Id" }
           }
         ],
         "responses": {
@@ -3751,9 +2899,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserTierResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
               }
             }
           },
@@ -3764,9 +2910,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3777,18 +2921,12 @@
         "summary": "Set User Rate Limit Tier",
         "description": "Set a user's rate-limit tier. Admin-only.\n\nReturns 404 if the user does not exist in the database.",
         "operationId": "postV2Set user rate limit tier",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetUserTierRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/SetUserTierRequest" }
             }
           }
         },
@@ -3797,9 +2935,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserTierResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/UserTierResponse" }
               }
             }
           },
@@ -3810,9 +2946,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -3830,9 +2964,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "integer"
-                  },
+                  "additionalProperties": { "type": "integer" },
                   "type": "object",
                   "title": "Response Getv1Get User Credits"
                 }
@@ -3843,11 +2975,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "patch": {
         "tags": ["v1", "credits"],
@@ -3856,21 +2984,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -3879,9 +2999,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RequestTopUp"
-              }
+              "schema": { "$ref": "#/components/schemas/RequestTopUp" }
             }
           },
           "required": true
@@ -3889,11 +3007,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -3902,18 +3016,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/admin/add_credits": {
@@ -3949,18 +3057,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/admin/copilot-usage/export": {
@@ -3969,11 +3071,7 @@
         "summary": "Export Copilot Weekly Usage vs Rate Limit",
         "description": "Export per-(user, ISO week) copilot spend with the user's tier limit.\n\nUses the same 90-day window cap and 100k row cap as the credit export.",
         "operationId": "getV2Export copilot weekly usage vs rate limit",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -3981,13 +3079,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -4000,13 +3093,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -4032,9 +3120,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4047,11 +3133,7 @@
         "summary": "Export Credit Transactions",
         "description": "Export CreditTransaction rows in [start, end] for finance reporting.\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
         "operationId": "getV2Export credit transactions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "start",
@@ -4059,13 +3141,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "Start"
@@ -4078,13 +3155,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "description": "ISO timestamp (inclusive)",
               "title": "End"
@@ -4097,12 +3169,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/CreditTransactionType"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/CreditTransactionType" },
+                { "type": "null" }
               ],
               "title": "Transaction Type"
             }
@@ -4112,14 +3180,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           }
@@ -4142,9 +3203,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4156,25 +3215,14 @@
         "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Get All Users History",
         "operationId": "getV2Get all users history",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "search",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search"
             }
           },
@@ -4182,21 +3230,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
           },
           {
             "name": "transaction_filter",
@@ -4204,12 +3244,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/CreditTransactionType"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/CreditTransactionType" },
+                { "type": "null" }
               ],
               "title": "Transaction Filter"
             }
@@ -4220,9 +3256,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserHistoryResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/UserHistoryResponse" }
               }
             }
           },
@@ -4233,9 +3267,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4252,9 +3284,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoTopUpConfig"
-                }
+                "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
               }
             }
           },
@@ -4262,11 +3292,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -4276,9 +3302,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AutoTopUpConfig"
-              }
+              "schema": { "$ref": "#/components/schemas/AutoTopUpConfig" }
             }
           },
           "required": true
@@ -4302,18 +3326,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/manage": {
@@ -4327,9 +3345,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
+                  "additionalProperties": { "type": "string" },
                   "type": "object",
                   "title": "Response Getv1Manage Payment Methods"
                 }
@@ -4340,11 +3356,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/refunds": {
@@ -4358,9 +3370,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/RefundRequest"
-                  },
+                  "items": { "$ref": "#/components/schemas/RefundRequest" },
                   "type": "array",
                   "title": "Response Getv1Get Refund Requests"
                 }
@@ -4371,11 +3381,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/stripe_webhook": {
@@ -4386,11 +3392,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           }
         }
       }
@@ -4415,11 +3417,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "credits"],
@@ -4453,18 +3451,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/credits/transactions": {
@@ -4472,11 +3464,7 @@
         "tags": ["v1", "credits"],
         "summary": "Get credit history",
         "operationId": "getV1Get credit history",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "transaction_time",
@@ -4484,13 +3472,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                {
-                  "type": "null"
-                }
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
               ],
               "title": "Transaction Time"
             }
@@ -4500,14 +3483,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Transaction Type"
             }
           },
@@ -4527,9 +3503,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TransactionHistory"
-                }
+                "schema": { "$ref": "#/components/schemas/TransactionHistory" }
               }
             }
           },
@@ -4540,9 +3514,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4554,20 +3526,13 @@
         "tags": ["v1", "credits"],
         "summary": "Refund credit transaction",
         "operationId": "postV1Refund credit transaction",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "transaction_key",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Transaction Key"
-            }
+            "schema": { "type": "string", "title": "Transaction Key" }
           }
         ],
         "requestBody": {
@@ -4576,9 +3541,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                },
+                "additionalProperties": { "type": "string" },
                 "title": "Metadata"
               }
             }
@@ -4603,9 +3566,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4622,21 +3583,13 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/PostmarkDeliveryWebhook"
-                  },
-                  {
-                    "$ref": "#/components/schemas/PostmarkBounceWebhook"
-                  },
+                  { "$ref": "#/components/schemas/PostmarkDeliveryWebhook" },
+                  { "$ref": "#/components/schemas/PostmarkBounceWebhook" },
                   {
                     "$ref": "#/components/schemas/PostmarkSpamComplaintWebhook"
                   },
-                  {
-                    "$ref": "#/components/schemas/PostmarkOpenWebhook"
-                  },
-                  {
-                    "$ref": "#/components/schemas/PostmarkClickWebhook"
-                  },
+                  { "$ref": "#/components/schemas/PostmarkOpenWebhook" },
+                  { "$ref": "#/components/schemas/PostmarkClickWebhook" },
                   {
                     "$ref": "#/components/schemas/PostmarkSubscriptionChangeWebhook"
                   }
@@ -4661,28 +3614,18 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "APIKeyAuthenticator-X-Postmark-Webhook-Token": []
-          }
-        ]
+        "security": [{ "APIKeyAuthenticator-X-Postmark-Webhook-Token": [] }]
       }
     },
     "/api/email/unsubscribe": {
@@ -4695,28 +3638,19 @@
             "name": "token",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Token"
-            }
+            "schema": { "type": "string", "title": "Token" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4747,11 +3681,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/executions/admin/execution_accuracy_trends": {
@@ -4760,34 +3690,20 @@
         "summary": "Get Execution Accuracy Trends and Alerts",
         "description": "Get execution accuracy trends with moving averages and alert detection.\nSimple single-query approach.",
         "operationId": "getV2Get execution accuracy trends and alerts",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "user_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "User Id"
             }
           },
@@ -4795,11 +3711,7 @@
             "name": "days_back",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 30,
-              "title": "Days Back"
-            }
+            "schema": { "type": "integer", "default": 30, "title": "Days Back" }
           },
           {
             "name": "drop_threshold",
@@ -4840,9 +3752,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4883,18 +3793,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/executions/admin/execution_analytics/config": {
@@ -4918,11 +3822,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/executions/{graph_exec_id}": {
@@ -4930,26 +3830,17 @@
         "tags": ["v1", "graphs"],
         "summary": "Delete graph execution",
         "operationId": "deleteV1Delete graph execution",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -4957,9 +3848,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -4972,11 +3861,7 @@
         "summary": "Upload file to cloud storage",
         "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    provider: Cloud storage provider (\"gcs\", \"s3\", \"azure\")\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    Dict containing the cloud storage path and signed URL",
         "operationId": "postV1Upload file to cloud storage",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "expiration_hours",
@@ -5017,9 +3902,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5037,9 +3920,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/GraphMeta"
-                  },
+                  "items": { "$ref": "#/components/schemas/GraphMeta" },
                   "type": "array",
                   "title": "Response Getv1List User Graphs"
                 }
@@ -5050,11 +3931,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v1", "graphs"],
@@ -5063,9 +3940,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateGraph"
-              }
+              "schema": { "$ref": "#/components/schemas/CreateGraph" }
             }
           },
           "required": true
@@ -5075,9 +3950,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -5088,18 +3961,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/graphs/{graph_id}": {
@@ -5107,20 +3974,13 @@
         "tags": ["v1", "graphs"],
         "summary": "Delete graph permanently",
         "operationId": "deleteV1Delete graph permanently",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -5128,9 +3988,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteGraphResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteGraphResponse" }
               }
             }
           },
@@ -5141,9 +3999,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5153,34 +4009,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Get specific graph",
         "operationId": "getV1Get specific graph",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Version"
             }
           },
@@ -5200,9 +4042,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -5213,9 +4053,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5225,29 +4063,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Update graph version",
         "operationId": "putV1Update graph version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Graph"
-              }
+              "schema": { "$ref": "#/components/schemas/Graph" }
             }
           }
         },
@@ -5256,9 +4085,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -5269,9 +4096,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5283,34 +4108,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Execute graph agent",
         "operationId": "postV1Execute graph agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Graph Version"
             }
           },
@@ -5319,14 +4130,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Preset Id"
             }
           }
@@ -5345,9 +4149,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphExecutionMeta"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
               }
             }
           },
@@ -5358,9 +4160,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5372,20 +4172,13 @@
         "tags": ["v1", "graphs"],
         "summary": "List graph executions",
         "operationId": "getV1List graph executions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "page",
@@ -5433,9 +4226,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5447,29 +4238,19 @@
         "tags": ["v1", "graphs"],
         "summary": "Get execution details",
         "operationId": "getV1Get execution details",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
@@ -5479,12 +4260,8 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/GraphExecution"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GraphExecutionWithNodes"
-                    }
+                    { "$ref": "#/components/schemas/GraphExecution" },
+                    { "$ref": "#/components/schemas/GraphExecutionWithNodes" }
                   ],
                   "title": "Response Getv1Get Execution Details"
                 }
@@ -5498,9 +4275,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5513,35 +4288,23 @@
         "summary": "Disable Execution Sharing",
         "description": "Disable sharing for a graph execution.",
         "operationId": "deleteV1DisableExecutionSharing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -5549,9 +4312,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5562,29 +4323,19 @@
         "summary": "Enable Execution Sharing",
         "description": "Enable sharing for a graph execution.",
         "operationId": "postV1EnableExecutionSharing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "requestBody": {
@@ -5602,9 +4353,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ShareResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ShareResponse" }
               }
             }
           },
@@ -5615,9 +4364,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5629,29 +4376,19 @@
         "tags": ["v1", "graphs"],
         "summary": "Stop graph execution",
         "operationId": "postV1Stop graph execution",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
@@ -5661,12 +4398,8 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/GraphExecutionMeta"
-                    },
-                    {
-                      "type": "null"
-                    }
+                    { "$ref": "#/components/schemas/GraphExecutionMeta" },
+                    { "type": "null" }
                   ],
                   "title": "Response Postv1Stop Graph Execution"
                 }
@@ -5680,9 +4413,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5694,20 +4425,13 @@
         "tags": ["v1", "schedules"],
         "summary": "List execution schedules for a graph",
         "operationId": "getV1List execution schedules for a graph",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -5732,9 +4456,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5744,11 +4466,7 @@
         "tags": ["v1", "schedules"],
         "summary": "Create execution schedule",
         "operationId": "postV1Create execution schedule",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
@@ -5790,9 +4508,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5805,29 +4521,20 @@
         "summary": "Update graph settings",
         "description": "Update graph settings for the user's library agent.",
         "operationId": "patchV1Update graph settings",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GraphSettings"
-              }
+              "schema": { "$ref": "#/components/schemas/GraphSettings" }
             }
           }
         },
@@ -5836,9 +4543,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphSettings"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphSettings" }
               }
             }
           },
@@ -5849,9 +4554,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5863,20 +4566,13 @@
         "tags": ["v1", "graphs"],
         "summary": "Get all graph versions",
         "operationId": "getV1Get all graph versions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -5886,9 +4582,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GraphModel"
-                  },
+                  "items": { "$ref": "#/components/schemas/GraphModel" },
                   "title": "Response Getv1Get All Graph Versions"
                 }
               }
@@ -5901,9 +4595,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5915,40 +4607,27 @@
         "tags": ["v1", "graphs"],
         "summary": "Set active graph version",
         "operationId": "putV1Set active graph version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetGraphActiveVersion"
-              }
+              "schema": { "$ref": "#/components/schemas/SetGraphActiveVersion" }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -5957,9 +4636,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -5971,34 +4648,20 @@
         "tags": ["v1", "graphs"],
         "summary": "Get graph version",
         "operationId": "getV1Get graph version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "version",
             "in": "path",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Version"
             }
           },
@@ -6018,9 +4681,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphModel"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphModel" }
               }
             }
           },
@@ -6031,9 +4692,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6051,9 +4710,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AyrshareSSOResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/AyrshareSSOResponse" }
               }
             }
           },
@@ -6061,11 +4718,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/integrations/credentials": {
@@ -6092,11 +4745,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/integrations/providers": {
@@ -6111,9 +4760,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ProviderMetadata"
-                  },
+                  "items": { "$ref": "#/components/schemas/ProviderMetadata" },
                   "type": "array",
                   "title": "Response Getv1Listproviders"
                 }
@@ -6134,9 +4781,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProviderConstants"
-                }
+                "schema": { "$ref": "#/components/schemas/ProviderConstants" }
               }
             }
           }
@@ -6195,9 +4840,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "type": "string"
-                  },
+                  "items": { "type": "string" },
                   "type": "array",
                   "title": "Response Getv1Listsystemproviders"
                 }
@@ -6212,30 +4855,19 @@
         "tags": ["v1", "integrations"],
         "summary": "Webhook Ping",
         "operationId": "postV1WebhookPing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Our ID for the webhook"
-            }
+            "schema": { "type": "string", "title": "Our ID for the webhook" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -6244,9 +4876,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6258,11 +4888,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Exchange OAuth code for tokens",
         "operationId": "postV1Exchange oauth code for tokens",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6303,9 +4929,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6317,11 +4941,7 @@
         "tags": ["v1", "integrations"],
         "summary": "List Credentials By Provider",
         "operationId": "getV1ListCredentialsByProvider",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6356,9 +4976,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6368,11 +4986,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Create Credentials",
         "operationId": "postV1Create credentials",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6391,18 +5005,10 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/OAuth2Credentials"
-                  },
-                  {
-                    "$ref": "#/components/schemas/APIKeyCredentials"
-                  },
-                  {
-                    "$ref": "#/components/schemas/UserPasswordCredentials"
-                  },
-                  {
-                    "$ref": "#/components/schemas/HostScopedCredentials"
-                  }
+                  { "$ref": "#/components/schemas/OAuth2Credentials" },
+                  { "$ref": "#/components/schemas/APIKeyCredentials" },
+                  { "$ref": "#/components/schemas/UserPasswordCredentials" },
+                  { "$ref": "#/components/schemas/HostScopedCredentials" }
                 ],
                 "discriminator": {
                   "propertyName": "type",
@@ -6436,9 +5042,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6450,11 +5054,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Delete Credentials",
         "operationId": "deleteV1DeleteCredentials",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6512,9 +5112,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6524,11 +5122,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Get Specific Credential By ID",
         "operationId": "getV1Get specific credential by id",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6568,9 +5162,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6583,11 +5175,7 @@
         "summary": "Issue a short-lived access token for a provider-hosted picker",
         "description": "Return the raw access token for an OAuth2 credential so the frontend\ncan initialize a provider-hosted picker (e.g. Google Drive Picker).\n\n`GET /{provider}/credentials/{cred_id}` deliberately strips secrets (see\n`CredentialsMetaResponse` + `TestGetCredentialReturnsMetaOnly` in\n`router_test.py`). That hardening broke the Drive picker, which needs the\nraw access token to call `google.picker.Builder.setOAuthToken(...)`. This\nendpoint carves a narrow, explicit hole: the caller must own the\ncredential, it must be OAuth2, and the endpoint returns only the access\ntoken + its expiry — nothing else about the credential. SDK-default\ncredentials are excluded for the same reason as `get_credential`.",
         "operationId": "postV1GetPickerToken",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6614,9 +5202,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PickerTokenResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/PickerTokenResponse" }
               }
             }
           },
@@ -6627,9 +5213,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6641,11 +5225,7 @@
         "tags": ["v1", "integrations"],
         "summary": "Initiate OAuth flow",
         "operationId": "getV1Initiate oauth flow",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "provider",
@@ -6672,14 +5252,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "ID of existing credential to upgrade scopes for"
             }
           }
@@ -6689,9 +5262,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LoginResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/LoginResponse" }
               }
             }
           },
@@ -6702,9 +5273,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6731,28 +5300,19 @@
             "name": "webhook_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Our ID for the webhook"
-            }
+            "schema": { "type": "string", "title": "Our ID for the webhook" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6765,25 +5325,14 @@
         "summary": "List Library Agents",
         "description": "Get all agents in the user's library (both created and saved).",
         "operationId": "getV2List library agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "search_term",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Search term to filter agents",
               "title": "Search Term"
             },
@@ -6831,14 +5380,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter by folder ID",
               "title": "Folder Id"
             },
@@ -6875,9 +5417,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6888,11 +5428,7 @@
         "summary": "Add Marketplace Agent",
         "description": "Add an agent from the marketplace to the user's library.",
         "operationId": "postV2Add marketplace agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -6908,9 +5444,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -6921,9 +5455,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -6935,34 +5467,20 @@
         "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent By Graph Id",
         "operationId": "getV2GetLibraryAgentByGraphId",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           },
           {
             "name": "version",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "integer" }, { "type": "null" }],
               "title": "Version"
             }
           }
@@ -6972,9 +5490,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -6985,9 +5501,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7000,11 +5514,7 @@
         "summary": "List Favorite Library Agents",
         "description": "Get all favorite agents in the user's library.",
         "operationId": "getV2List favorite library agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -7051,9 +5561,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7066,20 +5574,13 @@
         "summary": "Get Agent By Store ID",
         "description": "Get Library Agent from Store Listing Version ID.",
         "operationId": "getV2Get agent by store id",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -7089,12 +5590,8 @@
               "application/json": {
                 "schema": {
                   "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/LibraryAgent"
-                    },
-                    {
-                      "type": "null"
-                    }
+                    { "$ref": "#/components/schemas/LibraryAgent" },
+                    { "type": "null" }
                   ],
                   "title": "Response Getv2Get Agent By Store Id"
                 }
@@ -7108,9 +5605,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7123,30 +5618,19 @@
         "summary": "Delete Library Agent",
         "description": "Soft-delete the specified library agent.",
         "operationId": "deleteV2Delete library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -7155,9 +5639,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7167,20 +5649,13 @@
         "tags": ["v2", "library", "private"],
         "summary": "Get Library Agent",
         "operationId": "getV2Get library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
@@ -7188,9 +5663,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7201,9 +5674,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7214,20 +5685,13 @@
         "summary": "Update Library Agent",
         "description": "Update the library agent with the given fields.",
         "operationId": "patchV2Update library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "requestBody": {
@@ -7245,9 +5709,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7258,9 +5720,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7272,20 +5732,13 @@
         "tags": ["v2", "library", "private"],
         "summary": "Fork Library Agent",
         "operationId": "postV2Fork library agent",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "library_agent_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Library Agent Id"
-            }
+            "schema": { "type": "string", "title": "Library Agent Id" }
           }
         ],
         "responses": {
@@ -7293,9 +5746,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -7306,9 +5757,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7321,25 +5770,14 @@
         "summary": "List Library Folders",
         "description": "List folders for the authenticated user.\n\nArgs:\n    user_id: ID of the authenticated user.\n    parent_id: Optional parent folder ID to filter by.\n    include_relations: Whether to include agent and subfolder relations for counts.\n\nReturns:\n    A FolderListResponse containing folders.",
         "operationId": "getV2List library folders",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "parent_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter by parent folder ID. If not provided, returns root-level folders.",
               "title": "Parent Id"
             },
@@ -7363,9 +5801,7 @@
             "description": "List of folders",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FolderListResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/FolderListResponse" }
               }
             }
           },
@@ -7376,15 +5812,11 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       },
       "post": {
@@ -7392,18 +5824,12 @@
         "summary": "Create Folder",
         "description": "Create a new folder.\n\nArgs:\n    payload: The folder creation request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The created LibraryFolder.",
         "operationId": "postV2Create folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FolderCreateRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/FolderCreateRequest" }
             }
           }
         },
@@ -7412,37 +5838,25 @@
             "description": "Folder created successfully",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
-          "400": {
-            "description": "Validation error"
-          },
+          "400": { "description": "Validation error" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Parent folder not found"
-          },
-          "409": {
-            "description": "Folder name conflict"
-          },
+          "404": { "description": "Parent folder not found" },
+          "409": { "description": "Folder name conflict" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       }
     },
@@ -7455,9 +5869,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkMoveAgentsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/BulkMoveAgentsRequest" }
             }
           },
           "required": true
@@ -7468,9 +5880,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/LibraryAgent"
-                  },
+                  "items": { "$ref": "#/components/schemas/LibraryAgent" },
                   "type": "array",
                   "title": "Response Postv2Bulk Move Agents"
                 }
@@ -7480,28 +5890,18 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
+          "404": { "description": "Folder not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/library/folders/tree": {
@@ -7515,24 +5915,16 @@
             "description": "Folder tree structure",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FolderTreeResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/FolderTreeResponse" }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/library/folders/{folder_id}": {
@@ -7541,45 +5933,30 @@
         "summary": "Delete Folder",
         "description": "Soft-delete a folder and all its contents.\n\nArgs:\n    folder_id: ID of the folder to delete.\n    user_id: ID of the authenticated user.\n\nReturns:\n    204 No Content if successful.",
         "operationId": "deleteV2Delete folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Folder deleted successfully"
-          },
+          "204": { "description": "Folder deleted successfully" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
+          "404": { "description": "Folder not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       },
       "get": {
@@ -7587,20 +5964,13 @@
         "summary": "Get Folder",
         "description": "Get a specific folder.\n\nArgs:\n    folder_id: ID of the folder to retrieve.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The requested LibraryFolder.",
         "operationId": "getV2Get folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "responses": {
@@ -7608,31 +5978,23 @@
             "description": "Folder details",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
+          "404": { "description": "Folder not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       },
       "patch": {
@@ -7640,29 +6002,20 @@
         "summary": "Update Folder",
         "description": "Update a folder's properties.\n\nArgs:\n    folder_id: ID of the folder to update.\n    payload: The folder update request.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The updated LibraryFolder.",
         "operationId": "patchV2Update folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FolderUpdateRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/FolderUpdateRequest" }
             }
           }
         },
@@ -7671,37 +6024,25 @@
             "description": "Folder updated successfully",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
-          "400": {
-            "description": "Validation error"
-          },
+          "400": { "description": "Validation error" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder not found"
-          },
-          "409": {
-            "description": "Folder name conflict"
-          },
+          "404": { "description": "Folder not found" },
+          "409": { "description": "Folder name conflict" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       }
     },
@@ -7711,29 +6052,20 @@
         "summary": "Move Folder",
         "description": "Move a folder to a new parent.\n\nArgs:\n    folder_id: ID of the folder to move.\n    payload: The move request with target parent.\n    user_id: ID of the authenticated user.\n\nReturns:\n    The moved LibraryFolder.",
         "operationId": "postV2Move folder",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "folder_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Folder Id"
-            }
+            "schema": { "type": "string", "title": "Folder Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FolderMoveRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/FolderMoveRequest" }
             }
           }
         },
@@ -7742,37 +6074,25 @@
             "description": "Folder moved successfully",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryFolder"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryFolder" }
               }
             }
           },
-          "400": {
-            "description": "Validation error (circular reference)"
-          },
+          "400": { "description": "Validation error (circular reference)" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Folder or target parent not found"
-          },
-          "409": {
-            "description": "Folder name conflict in target location"
-          },
+          "404": { "description": "Folder or target parent not found" },
+          "409": { "description": "Folder name conflict in target location" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
-          "500": {
-            "description": "Server error"
-          }
+          "500": { "description": "Server error" }
         }
       }
     },
@@ -7782,11 +6102,7 @@
         "summary": "List presets",
         "description": "Retrieve a paginated list of presets for the current user.",
         "operationId": "getV2List presets",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -7815,14 +6131,7 @@
             "in": "query",
             "required": true,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Allows to filter presets by a specific agent graph",
               "title": "Graph Id"
             },
@@ -7847,9 +6156,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7860,11 +6167,7 @@
         "summary": "Create a new preset",
         "description": "Create a new preset for the current user.",
         "operationId": "postV2Create a new preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -7888,9 +6191,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -7901,9 +6202,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -7931,9 +6230,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -7944,18 +6241,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/library/presets/{preset_id}": {
@@ -7964,26 +6255,17 @@
         "summary": "Delete a preset",
         "description": "Delete an existing preset by its ID.",
         "operationId": "deleteV2Delete a preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -7991,9 +6273,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8004,20 +6284,13 @@
         "summary": "Get a specific preset",
         "description": "Retrieve details for a specific preset by its ID.",
         "operationId": "getV2Get a specific preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "responses": {
@@ -8025,9 +6298,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -8038,9 +6309,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8051,20 +6320,13 @@
         "summary": "Update an existing preset",
         "description": "Update an existing preset by its ID.",
         "operationId": "patchV2Update an existing preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "requestBody": {
@@ -8082,9 +6344,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgentPreset"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgentPreset" }
               }
             }
           },
@@ -8095,9 +6355,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8110,20 +6368,13 @@
         "summary": "Execute a preset",
         "description": "Execute a preset with the given graph and node input for the current user.",
         "operationId": "postV2Execute a preset",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "preset_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Preset Id"
-            }
+            "schema": { "type": "string", "title": "Preset Id" }
           }
         ],
         "requestBody": {
@@ -8140,9 +6391,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GraphExecutionMeta"
-                }
+                "schema": { "$ref": "#/components/schemas/GraphExecutionMeta" }
               }
             }
           },
@@ -8153,9 +6402,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8171,9 +6418,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DiscoverToolsRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/DiscoverToolsRequest" }
             }
           },
           "required": true
@@ -8196,18 +6441,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/mcp/oauth/callback": {
@@ -8244,18 +6483,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/mcp/oauth/login": {
@@ -8267,9 +6500,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MCPOAuthLoginRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/MCPOAuthLoginRequest" }
             }
           },
           "required": true
@@ -8292,18 +6523,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/mcp/token": {
@@ -8315,9 +6540,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MCPStoreTokenRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/MCPStoreTokenRequest" }
             }
           },
           "required": true
@@ -8340,18 +6563,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/oauth/app/{client_id}": {
@@ -8360,20 +6577,13 @@
         "summary": "Get Oauth App Info",
         "description": "Get public information about an OAuth application.\n\nThis endpoint is used by the consent screen to display application details\nto the user before they authorize access.\n\nReturns:\n- name: Application name\n- description: Application description (if provided)\n- scopes: List of scopes the application is allowed to request",
         "operationId": "getOauthGetOauthAppInfo",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "client_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Client Id"
-            }
+            "schema": { "type": "string", "title": "Client Id" }
           }
         ],
         "responses": {
@@ -8390,16 +6600,12 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Application not found or disabled"
-          },
+          "404": { "description": "Application not found or disabled" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8431,11 +6637,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/oauth/apps/{app_id}/logo": {
@@ -8444,29 +6646,20 @@
         "summary": "Update App Logo",
         "description": "Update the logo URL for an OAuth application.\n\nOnly the application owner can update the logo.\nThe logo should be uploaded first using the media upload endpoint,\nthen this endpoint is called with the resulting URL.\n\nLogo requirements:\n- Must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppLogo",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "App Id"
-            }
+            "schema": { "type": "string", "title": "App Id" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateAppLogoRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/UpdateAppLogoRequest" }
             }
           }
         },
@@ -8488,9 +6681,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8503,20 +6694,13 @@
         "summary": "Upload App Logo",
         "description": "Upload a logo image for an OAuth application.\n\nRequirements:\n- Image must be square (1:1 aspect ratio)\n- Minimum 512x512 pixels\n- Maximum 2048x2048 pixels\n- Allowed formats: JPEG, PNG, WebP\n- Maximum file size: 3MB\n\nThe image is uploaded to cloud storage and the app's logoUrl is updated.\nReturns the updated application info.",
         "operationId": "postOauthUploadAppLogo",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "App Id"
-            }
+            "schema": { "type": "string", "title": "App Id" }
           }
         ],
         "requestBody": {
@@ -8547,9 +6731,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8562,20 +6744,13 @@
         "summary": "Update App Status",
         "description": "Enable or disable an OAuth application.\n\nOnly the application owner can update the status.\nWhen disabled, the application cannot be used for new authorizations\nand existing access tokens will fail validation.\n\nReturns the updated application info.",
         "operationId": "patchOauthUpdateAppStatus",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "app_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "App Id"
-            }
+            "schema": { "type": "string", "title": "App Id" }
           }
         ],
         "requestBody": {
@@ -8606,9 +6781,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8624,9 +6797,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AuthorizeRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/AuthorizeRequest" }
             }
           },
           "required": true
@@ -8636,9 +6807,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizeResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/AuthorizeResponse" }
               }
             }
           },
@@ -8649,18 +6818,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/oauth/introspect": {
@@ -8694,9 +6857,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8712,9 +6873,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_postOauthRevoke"
-              }
+              "schema": { "$ref": "#/components/schemas/Body_postOauthRevoke" }
             }
           },
           "required": true
@@ -8722,19 +6881,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8752,12 +6905,8 @@
             "application/json": {
               "schema": {
                 "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/TokenRequestByCode"
-                  },
-                  {
-                    "$ref": "#/components/schemas/TokenRequestByRefreshToken"
-                  }
+                  { "$ref": "#/components/schemas/TokenRequestByCode" },
+                  { "$ref": "#/components/schemas/TokenRequestByRefreshToken" }
                 ],
                 "title": "Request"
               }
@@ -8770,9 +6919,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/TokenResponse" }
               }
             }
           },
@@ -8780,9 +6927,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -8799,9 +6944,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOnboarding"
-                }
+                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
               }
             }
           },
@@ -8809,11 +6952,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "patch": {
         "tags": ["v1", "onboarding"],
@@ -8822,9 +6961,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserOnboardingUpdate"
-              }
+              "schema": { "$ref": "#/components/schemas/UserOnboardingUpdate" }
             }
           },
           "required": true
@@ -8834,9 +6971,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOnboarding"
-                }
+                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
               }
             }
           },
@@ -8847,18 +6982,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/agents": {
@@ -8872,9 +7001,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/StoreAgentDetails"
-                  },
+                  "items": { "$ref": "#/components/schemas/StoreAgentDetails" },
                   "type": "array",
                   "title": "Response Getv1Recommended Onboarding Agents"
                 }
@@ -8885,11 +7012,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/completed": {
@@ -8912,11 +7035,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/profile": {
@@ -8937,11 +7056,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -8950,18 +7065,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/reset": {
@@ -8974,9 +7083,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UserOnboarding"
-                }
+                "schema": { "$ref": "#/components/schemas/UserOnboarding" }
               }
             }
           },
@@ -8984,11 +7091,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/onboarding/step": {
@@ -8996,11 +7099,7 @@
         "tags": ["v1", "onboarding"],
         "summary": "Complete onboarding step",
         "operationId": "postV1Complete onboarding step",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "step",
@@ -9027,11 +7126,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -9040,9 +7135,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9058,9 +7151,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChatRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/ChatRequest" }
             }
           },
           "required": true
@@ -9070,9 +7161,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ApiResponse" }
               }
             }
           },
@@ -9083,18 +7172,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/links": {
@@ -9108,9 +7191,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PlatformLinkInfo"
-                  },
+                  "items": { "$ref": "#/components/schemas/PlatformLinkInfo" },
                   "type": "array",
                   "title": "Response Getplatform-Linkinglist All Platform Servers Linked To The Authenticated User"
                 }
@@ -9121,11 +7202,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/links/{link_id}": {
@@ -9133,20 +7210,13 @@
         "tags": ["platform-linking"],
         "summary": "Unlink a platform server",
         "operationId": "deletePlatform-linkingUnlink a platform server",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Link Id"
-            }
+            "schema": { "type": "string", "title": "Link Id" }
           }
         ],
         "responses": {
@@ -9154,9 +7224,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteLinkResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
               }
             }
           },
@@ -9167,9 +7235,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9181,11 +7247,7 @@
         "tags": ["platform-linking"],
         "summary": "Confirm a SERVER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a server link token (user must be authenticated)",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "token",
@@ -9204,9 +7266,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConfirmLinkResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ConfirmLinkResponse" }
               }
             }
           },
@@ -9217,9 +7277,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9231,11 +7289,7 @@
         "tags": ["platform-linking"],
         "summary": "Get display info for a link token",
         "operationId": "getPlatform-linkingGet display info for a link token",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "token",
@@ -9267,9 +7321,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9300,11 +7352,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/platform-linking/user-links/{link_id}": {
@@ -9312,20 +7360,13 @@
         "tags": ["platform-linking"],
         "summary": "Unlink a DM / user link",
         "operationId": "deletePlatform-linkingUnlink a dm / user link",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "link_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Link Id"
-            }
+            "schema": { "type": "string", "title": "Link Id" }
           }
         ],
         "responses": {
@@ -9333,9 +7374,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteLinkResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteLinkResponse" }
               }
             }
           },
@@ -9346,9 +7385,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9360,11 +7397,7 @@
         "tags": ["platform-linking"],
         "summary": "Confirm a USER link token (user must be authenticated)",
         "operationId": "postPlatform-linkingConfirm a user link token (user must be authenticated)",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "token",
@@ -9396,9 +7429,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9438,9 +7469,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9478,19 +7507,13 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9505,17 +7528,13 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PushSubscribeRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/PushSubscribeRequest" }
             }
           },
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -9523,18 +7542,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/push/unsubscribe": {
@@ -9553,9 +7566,7 @@
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
+          "204": { "description": "Successful Response" },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
@@ -9563,18 +7574,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/push/vapid-key": {
@@ -9605,9 +7610,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ReviewRequest"
-              }
+              "schema": { "$ref": "#/components/schemas/ReviewRequest" }
             }
           },
           "required": true
@@ -9617,9 +7620,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReviewResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ReviewResponse" }
               }
             }
           },
@@ -9630,18 +7631,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/review/execution/{graph_exec_id}": {
@@ -9650,20 +7645,13 @@
         "summary": "Get Pending Reviews for Execution",
         "description": "Get all pending reviews for a specific graph execution.\n\nRetrieves all reviews with status \"WAITING\" for the specified graph execution\nthat belong to the authenticated user. Results are ordered by creation time\n(oldest first) to preserve review order within the execution.\n\nArgs:\n    graph_exec_id: ID of the graph execution to get reviews for\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects for the specified execution\n\nRaises:\n    HTTPException:\n        - 404: If the graph execution doesn't exist or isn't owned by this user\n        - 500: If authentication fails or database error occurs\n\nNote:\n    Only returns reviews owned by the authenticated user for security.\n    Reviews with invalid status are excluded with warning logs.",
         "operationId": "getV2Get pending reviews for execution",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_exec_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Exec Id"
-            }
+            "schema": { "type": "string", "title": "Graph Exec Id" }
           }
         ],
         "responses": {
@@ -9684,24 +7672,18 @@
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
-          "404": {
-            "description": "Graph execution not found"
-          },
+          "404": { "description": "Graph execution not found" },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": {
-              "application/json": {}
-            }
+            "content": { "application/json": {} }
           }
         }
       }
@@ -9712,11 +7694,7 @@
         "summary": "Get Pending Reviews",
         "description": "Get all pending reviews for the current user.\n\nRetrieves all reviews with status \"WAITING\" that belong to the authenticated user.\nResults are ordered by creation time (newest first).\n\nArgs:\n    user_id: Authenticated user ID from security dependency\n\nReturns:\n    List of pending review objects with status converted to typed literals\n\nRaises:\n    HTTPException: If authentication fails or database error occurs\n\nNote:\n    Reviews with invalid status values are logged as warnings but excluded\n    from results rather than failing the entire request.",
         "operationId": "getV2Get pending reviews",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -9768,17 +7746,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           },
           "500": {
             "description": "Server error",
-            "content": {
-              "application/json": {}
-            }
+            "content": { "application/json": {} }
           }
         }
       }
@@ -9807,11 +7781,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/schedules/{schedule_id}": {
@@ -9819,11 +7789,7 @@
         "tags": ["v1", "schedules"],
         "summary": "Delete execution schedule",
         "operationId": "deleteV1Delete execution schedule",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "schedule_id",
@@ -9857,9 +7823,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9872,11 +7836,7 @@
         "summary": "Get Admin Listings History",
         "description": "Get store listings with their version history for admins.\n\nThis provides a consolidated view of listings with their versions,\nallowing for an expandable UI in the admin dashboard.\n\nArgs:\n    status: Filter by submission status (PENDING, APPROVED, REJECTED)\n    search: Search by name, description, or user email\n    page: Page number for pagination\n    page_size: Number of items per page\n\nReturns:\n    Paginated listings with their versions",
         "operationId": "getV2Get admin listings history",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "status",
@@ -9884,12 +7844,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/SubmissionStatus"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/SubmissionStatus" },
+                { "type": "null" }
               ],
               "title": "Status"
             }
@@ -9899,14 +7855,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Search"
             }
           },
@@ -9914,21 +7863,13 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 1,
-              "title": "Page"
-            }
+            "schema": { "type": "integer", "default": 1, "title": "Page" }
           },
           {
             "name": "page_size",
             "in": "query",
             "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 20,
-              "title": "Page Size"
-            }
+            "schema": { "type": "integer", "default": 20, "title": "Page Size" }
           }
         ],
         "responses": {
@@ -9949,9 +7890,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -9964,11 +7903,7 @@
         "summary": "Admin Download Agent File",
         "description": "Download the agent file by streaming its content.\n\nArgs:\n    store_listing_version_id (str): The ID of the agent to download\n\nReturns:\n    StreamingResponse: A streaming response containing the agent's graph data.\n\nRaises:\n    HTTPException: If the agent is not found or an unexpected error occurs.",
         "operationId": "getV2Admin download agent file",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
@@ -9985,11 +7920,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -9998,9 +7929,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10013,20 +7942,13 @@
         "summary": "Admin Add Pending Agent to Library",
         "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can load the graph because get_graph() checks library\nmembership as a fallback: \"you added it, you keep it.\"",
         "operationId": "postV2Admin add pending agent to library",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -10034,9 +7956,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                }
+                "schema": { "$ref": "#/components/schemas/LibraryAgent" }
               }
             }
           },
@@ -10047,9 +7967,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10062,20 +7980,13 @@
         "summary": "Admin Preview Submission Listing",
         "description": "Preview a marketplace submission as it would appear on the listing page.\nBypasses the APPROVED-only StoreAgent view so admins can preview pending\nsubmissions before approving.",
         "operationId": "getV2Admin preview submission listing",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -10083,9 +7994,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
               }
             }
           },
@@ -10096,9 +8005,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10111,20 +8018,13 @@
         "summary": "Review Store Submission",
         "description": "Review a store listing submission.\n\nArgs:\n    store_listing_version_id: ID of the submission to review\n    request: Review details including approval status and comments\n    user_id: Authenticated admin user performing the review\n\nReturns:\n    StoreSubmissionAdminView with updated review information",
         "operationId": "postV2Review store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "requestBody": {
@@ -10155,9 +8055,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10188,14 +8086,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter agents by creator username",
               "title": "Creator"
             },
@@ -10206,14 +8097,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Filter agents by category",
               "title": "Category"
             },
@@ -10224,14 +8108,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -10243,12 +8120,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/StoreAgentsSortOptions"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/StoreAgentsSortOptions" },
+                { "type": "null" }
               ],
               "description": "Property to sort results by. Ignored if search_query is provided.",
               "title": "Sorted By"
@@ -10283,9 +8156,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentsResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentsResponse" }
               }
             }
           },
@@ -10293,9 +8164,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10313,19 +8182,13 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Username"
-            }
+            "schema": { "type": "string", "title": "Username" }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Name"
-            }
+            "schema": { "type": "string", "title": "Agent Name" }
           },
           {
             "name": "include_changelog",
@@ -10343,9 +8206,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
               }
             }
           },
@@ -10353,9 +8214,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10368,38 +8227,26 @@
         "summary": "Create agent review",
         "description": "Post a user review on a marketplace agent listing",
         "operationId": "postV2Create agent review",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Username"
-            }
+            "schema": { "type": "string", "title": "Username" }
           },
           {
             "name": "agent_name",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Agent Name"
-            }
+            "schema": { "type": "string", "title": "Agent Name" }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StoreReviewCreate"
-              }
+              "schema": { "$ref": "#/components/schemas/StoreReviewCreate" }
             }
           }
         },
@@ -10408,9 +8255,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreReview"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreReview" }
               }
             }
           },
@@ -10421,9 +8266,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10454,14 +8297,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "description": "Literal + semantic search on names and descriptions",
               "title": "Search Query"
             },
@@ -10473,12 +8309,8 @@
             "required": false,
             "schema": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/StoreCreatorsSortOptions"
-                },
-                {
-                  "type": "null"
-                }
+                { "$ref": "#/components/schemas/StoreCreatorsSortOptions" },
+                { "type": "null" }
               ],
               "title": "Sorted By"
             }
@@ -10511,9 +8343,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreatorsResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/CreatorsResponse" }
               }
             }
           },
@@ -10521,9 +8351,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10541,10 +8369,7 @@
             "name": "username",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Username"
-            }
+            "schema": { "type": "string", "title": "Username" }
           }
         ],
         "responses": {
@@ -10552,9 +8377,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreatorDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/CreatorDetails" }
               }
             }
           },
@@ -10562,9 +8385,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10576,20 +8397,13 @@
         "tags": ["v2", "store"],
         "summary": "Get agent by version",
         "operationId": "getV2Get agent by version",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -10597,9 +8411,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreAgentDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreAgentDetails" }
               }
             }
           },
@@ -10610,9 +8422,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10625,20 +8435,13 @@
         "summary": "Get agent graph",
         "description": "Get outline of graph belonging to a specific marketplace listing version",
         "operationId": "getV2Get agent graph",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
@@ -10659,9 +8462,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10679,28 +8480,19 @@
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10716,13 +8508,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
+            "content": { "text/plain": { "schema": { "type": "string" } } }
           }
         }
       }
@@ -10733,11 +8519,7 @@
         "summary": "Get my agents",
         "description": "List the authenticated user's unpublished agents",
         "operationId": "getV2Get my agents",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -10780,9 +8562,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10800,9 +8580,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
               }
             }
           },
@@ -10810,11 +8588,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       },
       "post": {
         "tags": ["v2", "store", "private"],
@@ -10824,9 +8598,7 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Profile"
-              }
+              "schema": { "$ref": "#/components/schemas/Profile" }
             }
           },
           "required": true
@@ -10836,9 +8608,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileDetails"
-                }
+                "schema": { "$ref": "#/components/schemas/ProfileDetails" }
               }
             }
           },
@@ -10849,18 +8619,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/store/search": {
@@ -10869,20 +8633,13 @@
         "summary": "Unified search across all content types",
         "description": "Search across all content types (marketplace agents, blocks, documentation)\nusing hybrid search.\n\nCombines semantic (embedding-based) and lexical (text-based) search for best results.",
         "operationId": "getV2Unified search across all content types",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
+        "security": [{ "HTTPBearer": [] }],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Query"
-            }
+            "schema": { "type": "string", "title": "Query" }
           },
           {
             "name": "content_types",
@@ -10892,13 +8649,9 @@
               "anyOf": [
                 {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ContentType"
-                  }
+                  "items": { "$ref": "#/components/schemas/ContentType" }
                 },
-                {
-                  "type": "null"
-                }
+                { "type": "null" }
               ],
               "description": "Content types to search. If not specified, searches all.",
               "title": "Content Types"
@@ -10943,9 +8696,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -10958,11 +8709,7 @@
         "summary": "List my submissions",
         "description": "List the authenticated user's marketplace listing submissions",
         "operationId": "getV2List my submissions",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "page",
@@ -11005,9 +8752,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11018,11 +8763,7 @@
         "summary": "Create store submission",
         "description": "Submit a new marketplace listing for review",
         "operationId": "postV2Create store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "requestBody": {
           "required": true,
           "content": {
@@ -11038,9 +8779,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreSubmission"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
               }
             }
           },
@@ -11051,9 +8790,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11066,20 +8803,13 @@
         "summary": "Generate submission image",
         "description": "Generate an image for a marketplace listing submission based on the properties\nof a given graph.",
         "operationId": "postV2Generate submission image",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "graph_id",
             "in": "query",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Graph Id"
-            }
+            "schema": { "type": "string", "title": "Graph Id" }
           }
         ],
         "responses": {
@@ -11087,9 +8817,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImageURLResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ImageURLResponse" }
               }
             }
           },
@@ -11100,9 +8828,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11144,18 +8870,12 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/api/store/submissions/{store_listing_version_id}": {
@@ -11164,20 +8884,13 @@
         "summary": "Edit store submission",
         "description": "Update a pending marketplace listing submission",
         "operationId": "putV2Edit store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "store_listing_version_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Store Listing Version Id"
-            }
+            "schema": { "type": "string", "title": "Store Listing Version Id" }
           }
         ],
         "requestBody": {
@@ -11195,9 +8908,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/StoreSubmission"
-                }
+                "schema": { "$ref": "#/components/schemas/StoreSubmission" }
               }
             }
           },
@@ -11208,9 +8919,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11223,20 +8932,13 @@
         "summary": "Delete store submission",
         "description": "Delete a marketplace listing submission",
         "operationId": "deleteV2Delete store submission",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "submission_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Submission Id"
-            }
+            "schema": { "type": "string", "title": "Submission Id" }
           }
         ],
         "responses": {
@@ -11258,9 +8960,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11273,25 +8973,14 @@
         "summary": "List workspace files",
         "description": "List files in the user's workspace.\n\nWhen session_id is provided, only files for that session are returned.\nOtherwise, all files across sessions are listed. Results are paginated\nvia `limit`/`offset`; `has_more` indicates whether additional pages exist.",
         "operationId": "listWorkspaceFiles",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Session Id"
             }
           },
@@ -11324,9 +9013,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFilesResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/ListFilesResponse" }
               }
             }
           },
@@ -11337,9 +9024,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11352,25 +9037,14 @@
         "summary": "Upload file to workspace",
         "description": "Upload a file to the user's workspace.\n\nFiles are stored in session-scoped paths when session_id is provided,\nso the agent's session-scoped tools can discover them automatically.",
         "operationId": "uploadWorkspaceFile",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "session_id",
             "in": "query",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
               "title": "Session Id"
             }
           },
@@ -11413,9 +9087,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11428,20 +9100,13 @@
         "summary": "Delete a workspace file",
         "description": "Soft-delete a workspace file and attempt to remove it from storage.\n\nUsed when a user clears a file input in the builder.",
         "operationId": "deleteWorkspaceFile",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "File Id"
-            }
+            "schema": { "type": "string", "title": "File Id" }
           }
         ],
         "responses": {
@@ -11449,9 +9114,7 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteFileResponse"
-                }
+                "schema": { "$ref": "#/components/schemas/DeleteFileResponse" }
               }
             }
           },
@@ -11462,9 +9125,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11477,30 +9138,19 @@
         "summary": "Download file by ID",
         "description": "Download a file by its ID.\n\nReturns the file content directly or redirects to a signed URL for GCS.",
         "operationId": "getWorkspaceDownloadFileById",
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ],
+        "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [
           {
             "name": "file_id",
             "in": "path",
             "required": true,
-            "schema": {
-              "type": "string",
-              "title": "File Id"
-            }
+            "schema": { "type": "string", "title": "File Id" }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
@@ -11509,9 +9159,7 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -11539,11 +9187,7 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           }
         },
-        "security": [
-          {
-            "HTTPBearerJWT": []
-          }
-        ]
+        "security": [{ "HTTPBearerJWT": [] }]
       }
     },
     "/health": {
@@ -11554,11 +9198,7 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+            "content": { "application/json": { "schema": {} } }
           }
         }
       }
@@ -11568,23 +9208,10 @@
     "schemas": {
       "APIKeyCredentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -11610,14 +9237,7 @@
             "writeOnly": true
           },
           "expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Expires At",
             "description": "Unix timestamp (seconds) indicating when the API key expires (if at all)"
           }
@@ -11628,14 +9248,9 @@
       },
       "APIKeyInfo": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "scopes": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Scopes"
           },
@@ -11652,48 +9267,27 @@
           },
           "expires_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Expires At"
           },
           "last_used_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Last Used At"
           },
           "revoked_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Revoked At"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "head": {
             "type": "string",
             "title": "Head",
@@ -11704,18 +9298,9 @@
             "title": "Tail",
             "description": "The last 8 characters of the key"
           },
-          "status": {
-            "$ref": "#/components/schemas/APIKeyStatus"
-          },
+          "status": { "$ref": "#/components/schemas/APIKeyStatus" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           }
         },
@@ -11757,33 +9342,14 @@
       },
       "AccuracyAlertData": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
-          "drop_percent": {
-            "type": "number",
-            "title": "Drop Percent"
-          },
-          "three_day_avg": {
-            "type": "number",
-            "title": "Three Day Avg"
-          },
-          "seven_day_avg": {
-            "type": "number",
-            "title": "Seven Day Avg"
-          },
+          "drop_percent": { "type": "number", "title": "Drop Percent" },
+          "three_day_avg": { "type": "number", "title": "Three Day Avg" },
+          "seven_day_avg": { "type": "number", "title": "Seven Day Avg" },
           "detected_at": {
             "type": "string",
             "format": "date-time",
@@ -11804,53 +9370,21 @@
       },
       "AccuracyLatestData": {
         "properties": {
-          "date": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Date"
-          },
+          "date": { "type": "string", "format": "date-time", "title": "Date" },
           "daily_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Daily Score"
           },
           "three_day_avg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Three Day Avg"
           },
           "seven_day_avg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Seven Day Avg"
           },
           "fourteen_day_avg": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Fourteen Day Avg"
           }
         },
@@ -11867,30 +9401,20 @@
       },
       "AccuracyTrendsResponse": {
         "properties": {
-          "latest_data": {
-            "$ref": "#/components/schemas/AccuracyLatestData"
-          },
+          "latest_data": { "$ref": "#/components/schemas/AccuracyLatestData" },
           "alert": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/AccuracyAlertData"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/AccuracyAlertData" },
+              { "type": "null" }
             ]
           },
           "historical_data": {
             "anyOf": [
               {
-                "items": {
-                  "$ref": "#/components/schemas/AccuracyLatestData"
-                },
+                "items": { "$ref": "#/components/schemas/AccuracyLatestData" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Historical Data"
           }
@@ -11902,23 +9426,10 @@
       },
       "ActiveStreamInfo": {
         "properties": {
-          "turn_id": {
-            "type": "string",
-            "title": "Turn Id"
-          },
-          "last_message_id": {
-            "type": "string",
-            "title": "Last Message Id"
-          },
+          "turn_id": { "type": "string", "title": "Turn Id" },
+          "last_message_id": { "type": "string", "title": "Last Message Id" },
           "started_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Started At"
           }
         },
@@ -11929,14 +9440,8 @@
       },
       "AddUserCreditsResponse": {
         "properties": {
-          "new_balance": {
-            "type": "integer",
-            "title": "New Balance"
-          },
-          "transaction_key": {
-            "type": "string",
-            "title": "Transaction Key"
-          }
+          "new_balance": { "type": "integer", "title": "New Balance" },
+          "transaction_key": { "type": "string", "title": "Transaction Key" }
         },
         "type": "object",
         "required": ["new_balance", "transaction_key"],
@@ -11944,18 +9449,9 @@
       },
       "AgentDetails": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "in_library": {
             "type": "boolean",
             "title": "In Library",
@@ -11968,9 +9464,7 @@
             "default": {}
           },
           "credentials": {
-            "items": {
-              "$ref": "#/components/schemas/CredentialsMetaInput"
-            },
+            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -11980,13 +9474,8 @@
           },
           "trigger_info": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Trigger Info"
           }
@@ -12002,49 +9491,23 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_details"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "agent": {
-            "$ref": "#/components/schemas/AgentDetails"
-          },
+          "agent": { "$ref": "#/components/schemas/AgentDetails" },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
             "default": false
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           }
         },
@@ -12059,10 +9522,7 @@
             "type": "integer",
             "title": "Agents With Active Executions"
           },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
+          "timestamp": { "type": "string", "title": "Timestamp" }
         },
         "type": "object",
         "required": ["agents_with_active_executions", "timestamp"],
@@ -12084,18 +9544,9 @@
       },
       "AgentInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "source": {
             "type": "string",
             "title": "Source",
@@ -12107,173 +9558,77 @@
             "default": false
           },
           "creator": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Creator"
           },
           "category": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Category"
           },
           "rating": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Rating"
           },
           "runs": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Runs"
           },
           "is_featured": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Featured"
           },
           "status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Status"
           },
           "can_access_graph": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Can Access Graph"
           },
           "has_external_trigger": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Has External Trigger"
           },
           "new_output": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "New Output"
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
           "input_schema": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Input Schema",
             "description": "JSON Schema for the agent's inputs (for AgentExecutorBlock)"
           },
           "output_schema": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Output Schema",
             "description": "JSON Schema for the agent's outputs (for AgentExecutorBlock)"
           },
           "inputs": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs",
             "description": "Input schema for the agent, including field names, types, and defaults"
           },
           "graph": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/BaseGraph-Output"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/BaseGraph-Output" },
+              { "type": "null" }
             ],
             "description": "Full graph structure (nodes + links) when include_graph is requested"
           }
@@ -12289,73 +9644,34 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_output"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_id": { "type": "string", "title": "Agent Id" },
           "library_agent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Link"
           },
           "execution": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/ExecutionOutputInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/ExecutionOutputInfo" },
+              { "type": "null" }
             ]
           },
           "available_executions": {
             "anyOf": [
               {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
+                "items": { "additionalProperties": true, "type": "object" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Available Executions"
           },
@@ -12376,19 +9692,9 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_preview"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "agent_json": {
@@ -12396,18 +9702,9 @@
             "type": "object",
             "title": "Agent Json"
           },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "node_count": {
-            "type": "integer",
-            "title": "Node Count"
-          },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "description": { "type": "string", "title": "Description" },
+          "node_count": { "type": "integer", "title": "Node Count" },
           "link_count": {
             "type": "integer",
             "title": "Link Count",
@@ -12431,52 +9728,23 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_saved"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
-          "library_agent_id": {
-            "type": "string",
-            "title": "Library Agent Id"
-          },
+          "library_agent_id": { "type": "string", "title": "Library Agent Id" },
           "library_agent_link": {
             "type": "string",
             "title": "Library Agent Link"
           },
-          "agent_page_link": {
-            "type": "string",
-            "title": "Agent Page Link"
-          }
+          "agent_page_link": { "type": "string", "title": "Agent Page Link" }
         },
         "type": "object",
         "required": [
@@ -12496,19 +9764,9 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agents_found"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "title": {
@@ -12517,16 +9775,11 @@
             "default": "Available Agents"
           },
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/AgentInfo"
-            },
+            "items": { "$ref": "#/components/schemas/AgentInfo" },
             "type": "array",
             "title": "Agents"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          },
+          "count": { "type": "integer", "title": "Count" },
           "name": {
             "type": "string",
             "title": "Name",
@@ -12540,21 +9793,13 @@
       },
       "ApiResponse": {
         "properties": {
-          "answer": {
-            "type": "string",
-            "title": "Answer"
-          },
+          "answer": { "type": "string", "title": "Answer" },
           "documents": {
-            "items": {
-              "$ref": "#/components/schemas/Document"
-            },
+            "items": { "$ref": "#/components/schemas/Document" },
             "type": "array",
             "title": "Documents"
           },
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          }
+          "success": { "type": "boolean", "title": "Success" }
         },
         "type": "object",
         "required": ["answer", "documents", "success"],
@@ -12573,9 +9818,7 @@
             "description": "Redirect URI"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes",
             "description": "List of scopes"
@@ -12630,14 +9873,8 @@
       },
       "AutoTopUpConfig": {
         "properties": {
-          "amount": {
-            "type": "integer",
-            "title": "Amount"
-          },
-          "threshold": {
-            "type": "integer",
-            "title": "Threshold"
-          }
+          "amount": { "type": "integer", "title": "Amount" },
+          "threshold": { "type": "integer", "title": "Threshold" }
         },
         "type": "object",
         "required": ["amount", "threshold"],
@@ -12663,83 +9900,38 @@
       },
       "BaseGraph-Input": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/Node"
-            },
+            "items": { "$ref": "#/components/schemas/Node" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           }
@@ -12751,83 +9943,38 @@
       },
       "BaseGraph-Output": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/Node"
-            },
+            "items": { "$ref": "#/components/schemas/Node" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           },
@@ -12860,12 +10007,8 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ],
             "readOnly": true
           }
@@ -12886,18 +10029,10 @@
       },
       "BlockCategoryResponse": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "total_blocks": {
-            "type": "integer",
-            "title": "Total Blocks"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "total_blocks": { "type": "integer", "title": "Total Blocks" },
           "blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfo" },
             "type": "array",
             "title": "Blocks"
           }
@@ -12908,18 +10043,13 @@
       },
       "BlockCost": {
         "properties": {
-          "cost_amount": {
-            "type": "integer",
-            "title": "Cost Amount"
-          },
+          "cost_amount": { "type": "integer", "title": "Cost Amount" },
           "cost_filter": {
             "additionalProperties": true,
             "type": "object",
             "title": "Cost Filter"
           },
-          "cost_type": {
-            "$ref": "#/components/schemas/BlockCostType"
-          },
+          "cost_type": { "$ref": "#/components/schemas/BlockCostType" },
           "cost_divisor": {
             "type": "integer",
             "title": "Cost Divisor",
@@ -12937,18 +10067,9 @@
       },
       "BlockDetails": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -12962,9 +10083,7 @@
             "default": {}
           },
           "credentials": {
-            "items": {
-              "$ref": "#/components/schemas/CredentialsMetaInput"
-            },
+            "items": { "$ref": "#/components/schemas/CredentialsMetaInput" },
             "type": "array",
             "title": "Credentials",
             "default": []
@@ -12981,24 +10100,12 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_details"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "block": {
-            "$ref": "#/components/schemas/BlockDetails"
-          },
+          "block": { "$ref": "#/components/schemas/BlockDetails" },
           "user_authenticated": {
             "type": "boolean",
             "title": "User Authenticated",
@@ -13012,14 +10119,8 @@
       },
       "BlockInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "inputSchema": {
             "additionalProperties": true,
             "type": "object",
@@ -13031,42 +10132,26 @@
             "title": "Outputschema"
           },
           "costs": {
-            "items": {
-              "$ref": "#/components/schemas/BlockCost"
-            },
+            "items": { "$ref": "#/components/schemas/BlockCost" },
             "type": "array",
             "title": "Costs"
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "description": { "type": "string", "title": "Description" },
           "categories": {
             "items": {
-              "additionalProperties": {
-                "type": "string"
-              },
+              "additionalProperties": { "type": "string" },
               "type": "object"
             },
             "type": "array",
             "title": "Categories"
           },
           "contributors": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
+            "items": { "additionalProperties": true, "type": "object" },
             "type": "array",
             "title": "Contributors"
           },
-          "staticOutput": {
-            "type": "boolean",
-            "title": "Staticoutput"
-          },
-          "uiType": {
-            "type": "string",
-            "title": "Uitype"
-          }
+          "staticOutput": { "type": "boolean", "title": "Staticoutput" },
+          "uiType": { "type": "string", "title": "Uitype" }
         },
         "type": "object",
         "required": [
@@ -13085,22 +10170,11 @@
       },
       "BlockInfoSummary": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
@@ -13123,9 +10197,7 @@
             "default": false
           },
           "required_inputs": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInputFieldInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInputFieldInfo" },
             "type": "array",
             "title": "Required Inputs",
             "description": "List of input fields for this block"
@@ -13138,14 +10210,8 @@
       },
       "BlockInputFieldInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "type": { "type": "string", "title": "Type" },
           "description": {
             "type": "string",
             "title": "Description",
@@ -13156,15 +10222,7 @@
             "title": "Required",
             "default": false
           },
-          "default": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Default"
-          }
+          "default": { "anyOf": [{}, { "type": "null" }], "title": "Default" }
         },
         "type": "object",
         "required": ["name", "type"],
@@ -13177,36 +10235,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_list"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfoSummary"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfoSummary" },
             "type": "array",
             "title": "Blocks"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          },
-          "query": {
-            "type": "string",
-            "title": "Query"
-          },
+          "count": { "type": "integer", "title": "Count" },
+          "query": { "type": "string", "title": "Query" },
           "usage_hint": {
             "type": "string",
             "title": "Usage Hint",
@@ -13224,51 +10264,21 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "block_output"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
-          "block_name": {
-            "type": "string",
-            "title": "Block Name"
-          },
+          "block_id": { "type": "string", "title": "Block Id" },
+          "block_name": { "type": "string", "title": "Block Name" },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           },
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": true
-          },
+          "success": { "type": "boolean", "title": "Success", "default": true },
           "is_dry_run": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Dry Run"
           }
         },
@@ -13280,15 +10290,11 @@
       "BlockResponse": {
         "properties": {
           "blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfo" },
             "type": "array",
             "title": "Blocks"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["blocks", "pagination"],
@@ -13308,10 +10314,7 @@
       },
       "Body_postAnalyticsLogRawAnalytics": {
         "properties": {
-          "type": {
-            "type": "string",
-            "title": "Type"
-          },
+          "type": { "type": "string", "title": "Type" },
           "data": {
             "additionalProperties": true,
             "type": "object",
@@ -13337,13 +10340,8 @@
           },
           "token_type_hint": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["access_token", "refresh_token"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["access_token", "refresh_token"] },
+              { "type": "null" }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -13372,13 +10370,8 @@
           },
           "token_type_hint": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["access_token", "refresh_token"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["access_token", "refresh_token"] },
+              { "type": "null" }
             ],
             "title": "Token Type Hint",
             "description": "Hint about token type ('access_token' or 'refresh_token')"
@@ -13400,11 +10393,7 @@
       },
       "Body_postOauthUploadAppLogo": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -13416,10 +10405,7 @@
             "type": "string",
             "title": "Authorization code acquired by user login"
           },
-          "state_token": {
-            "type": "string",
-            "title": "Anti-CSRF nonce"
-          }
+          "state_token": { "type": "string", "title": "Anti-CSRF nonce" }
         },
         "type": "object",
         "required": ["code", "state_token"],
@@ -13445,28 +10431,18 @@
                 "type": "string",
                 "enum": ["builder", "library", "onboarding"]
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Source"
           },
-          "dry_run": {
-            "type": "boolean",
-            "title": "Dry Run",
-            "default": false
-          }
+          "dry_run": { "type": "boolean", "title": "Dry Run", "default": false }
         },
         "type": "object",
         "title": "Body_postV1Execute graph agent"
       },
       "Body_postV1Upload_file_to_cloud_storage": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -13474,18 +10450,9 @@
       },
       "Body_postV2Add_credits_to_user": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "amount": {
-            "type": "integer",
-            "title": "Amount"
-          },
-          "comments": {
-            "type": "string",
-            "title": "Comments"
-          }
+          "user_id": { "type": "string", "title": "User Id" },
+          "amount": { "type": "integer", "title": "Amount" },
+          "comments": { "type": "string", "title": "Comments" }
         },
         "type": "object",
         "required": ["user_id", "amount", "comments"],
@@ -13528,10 +10495,7 @@
       },
       "Body_postV2Reset_user_rate_limit_usage": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "reset_weekly": {
             "type": "boolean",
             "title": "Reset Weekly",
@@ -13544,11 +10508,7 @@
       },
       "Body_postV2Upload_submission_media": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -13556,11 +10516,7 @@
       },
       "Body_uploadWorkspaceFile": {
         "properties": {
-          "file": {
-            "type": "string",
-            "format": "binary",
-            "title": "File"
-          }
+          "file": { "type": "string", "format": "binary", "title": "File" }
         },
         "type": "object",
         "required": ["file"],
@@ -13569,21 +10525,12 @@
       "BulkMoveAgentsRequest": {
         "properties": {
           "agent_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Agent Ids"
           },
           "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Id"
           }
         },
@@ -13594,19 +10541,9 @@
       },
       "CancelSessionResponse": {
         "properties": {
-          "cancelled": {
-            "type": "boolean",
-            "title": "Cancelled"
-          },
+          "cancelled": { "type": "boolean", "title": "Cancelled" },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reason"
           }
         },
@@ -13617,19 +10554,9 @@
       },
       "ChangelogEntry": {
         "properties": {
-          "version": {
-            "type": "string",
-            "title": "Version"
-          },
-          "changes_summary": {
-            "type": "string",
-            "title": "Changes Summary"
-          },
-          "date": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Date"
-          }
+          "version": { "type": "string", "title": "Version" },
+          "changes_summary": { "type": "string", "title": "Changes Summary" },
+          "date": { "type": "string", "format": "date-time", "title": "Date" }
         },
         "type": "object",
         "required": ["version", "changes_summary", "date"],
@@ -13637,35 +10564,20 @@
       },
       "ChatRequest": {
         "properties": {
-          "query": {
-            "type": "string",
-            "title": "Query"
-          },
+          "query": { "type": "string", "title": "Query" },
           "conversation_history": {
-            "items": {
-              "$ref": "#/components/schemas/Message"
-            },
+            "items": { "$ref": "#/components/schemas/Message" },
             "type": "array",
             "title": "Conversation History"
           },
-          "message_id": {
-            "type": "string",
-            "title": "Message Id"
-          },
+          "message_id": { "type": "string", "title": "Message Id" },
           "include_graph_data": {
             "type": "boolean",
             "title": "Include Graph Data",
             "default": false
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           }
         },
@@ -13681,14 +10593,7 @@
             "default": false
           },
           "builder_graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Builder Graph Id"
           }
         },
@@ -13702,25 +10607,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "agent_builder_clarification_needed"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "questions": {
-            "items": {
-              "$ref": "#/components/schemas/ClarifyingQuestion"
-            },
+            "items": { "$ref": "#/components/schemas/ClarifyingQuestion" },
             "type": "array",
             "title": "Questions"
           }
@@ -13732,23 +10625,10 @@
       },
       "ClarifyingQuestion": {
         "properties": {
-          "question": {
-            "type": "string",
-            "title": "Question"
-          },
-          "keyword": {
-            "type": "string",
-            "title": "Keyword"
-          },
+          "question": { "type": "string", "title": "Question" },
+          "keyword": { "type": "string", "title": "Keyword" },
           "example": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Example"
           }
         },
@@ -13761,23 +10641,15 @@
         "properties": {
           "daily": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsageWindowPublic"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/UsageWindowPublic" },
+              { "type": "null" }
             ],
             "description": "Null when no daily cap is configured (unlimited)."
           },
           "weekly": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsageWindowPublic"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/UsageWindowPublic" },
+              { "type": "null" }
             ],
             "description": "Null when no weekly cap is configured (unlimited)."
           },
@@ -13798,31 +10670,18 @@
       },
       "ConfirmLinkResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "SERVER"
           },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
+          "platform": { "type": "string", "title": "Platform" },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
           },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           }
         },
@@ -13837,22 +10696,13 @@
       },
       "ConfirmUserLinkResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "link_type": {
             "$ref": "#/components/schemas/LinkType",
             "default": "USER"
           },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "platform_user_id": {
-            "type": "string",
-            "title": "Platform User Id"
-          }
+          "platform": { "type": "string", "title": "Platform" },
+          "platform_user_id": { "type": "string", "title": "Platform User Id" }
         },
         "type": "object",
         "required": ["success", "platform", "platform_user_id"],
@@ -13872,24 +10722,13 @@
       "CopilotUsageExportResponse": {
         "properties": {
           "rows": {
-            "items": {
-              "$ref": "#/components/schemas/CopilotWeeklyUsageRow"
-            },
+            "items": { "$ref": "#/components/schemas/CopilotWeeklyUsageRow" },
             "type": "array",
             "title": "Rows"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "window_days": {
-            "type": "integer",
-            "title": "Window Days"
-          },
-          "max_window_days": {
-            "type": "integer",
-            "title": "Max Window Days"
-          }
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "max_window_days": { "type": "integer", "title": "Max Window Days" }
         },
         "type": "object",
         "required": ["rows", "total_rows", "window_days", "max_window_days"],
@@ -13897,19 +10736,9 @@
       },
       "CopilotWeeklyUsageRow": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
           "week_start": {
@@ -13926,18 +10755,12 @@
             "type": "integer",
             "title": "Copilot Cost Microdollars"
           },
-          "tier": {
-            "type": "string",
-            "title": "Tier"
-          },
+          "tier": { "type": "string", "title": "Tier" },
           "weekly_limit_microdollars": {
             "type": "integer",
             "title": "Weekly Limit Microdollars"
           },
-          "percent_used": {
-            "type": "number",
-            "title": "Percent Used"
-          }
+          "percent_used": { "type": "number", "title": "Percent Used" }
         },
         "type": "object",
         "required": [
@@ -13953,14 +10776,8 @@
       },
       "CostBucket": {
         "properties": {
-          "bucket": {
-            "type": "string",
-            "title": "Bucket"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
+          "bucket": { "type": "string", "title": "Bucket" },
+          "count": { "type": "integer", "title": "Count" }
         },
         "type": "object",
         "required": ["bucket", "count"],
@@ -13968,153 +10785,60 @@
       },
       "CostLogRow": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
+          "id": { "type": "string", "title": "Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Email"
           },
           "graph_exec_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Exec Id"
           },
           "node_exec_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Node Exec Id"
           },
-          "block_name": {
-            "type": "string",
-            "title": "Block Name"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "block_name": { "type": "string", "title": "Block Name" },
+          "provider": { "type": "string", "title": "Provider" },
           "tracking_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Tracking Type"
           },
           "cost_microdollars": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Cost Microdollars"
           },
           "input_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Input Tokens"
           },
           "output_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Output Tokens"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Duration"
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Model"
           },
           "cache_read_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Cache Read Tokens"
           },
           "cache_creation_tokens": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Cache Creation Tokens"
           }
         },
@@ -14124,34 +10848,16 @@
       },
       "CountResponse": {
         "properties": {
-          "all_blocks": {
-            "type": "integer",
-            "title": "All Blocks"
-          },
-          "input_blocks": {
-            "type": "integer",
-            "title": "Input Blocks"
-          },
-          "action_blocks": {
-            "type": "integer",
-            "title": "Action Blocks"
-          },
-          "output_blocks": {
-            "type": "integer",
-            "title": "Output Blocks"
-          },
-          "integrations": {
-            "type": "integer",
-            "title": "Integrations"
-          },
+          "all_blocks": { "type": "integer", "title": "All Blocks" },
+          "input_blocks": { "type": "integer", "title": "Input Blocks" },
+          "action_blocks": { "type": "integer", "title": "Action Blocks" },
+          "output_blocks": { "type": "integer", "title": "Output Blocks" },
+          "integrations": { "type": "integer", "title": "Integrations" },
           "marketplace_agents": {
             "type": "integer",
             "title": "Marketplace Agents"
           },
-          "my_agents": {
-            "type": "integer",
-            "title": "My Agents"
-          }
+          "my_agents": { "type": "integer", "title": "My Agents" }
         },
         "type": "object",
         "required": [
@@ -14167,26 +10873,14 @@
       },
       "CreateAPIKeyRequest": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "permissions": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Permissions"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           }
         },
@@ -14196,13 +10890,8 @@
       },
       "CreateAPIKeyResponse": {
         "properties": {
-          "api_key": {
-            "$ref": "#/components/schemas/APIKeyInfo"
-          },
-          "plain_text_key": {
-            "type": "string",
-            "title": "Plain Text Key"
-          }
+          "api_key": { "$ref": "#/components/schemas/APIKeyInfo" },
+          "plain_text_key": { "type": "string", "title": "Plain Text Key" }
         },
         "type": "object",
         "required": ["api_key", "plain_text_key"],
@@ -14210,18 +10899,11 @@
       },
       "CreateGraph": {
         "properties": {
-          "graph": {
-            "$ref": "#/components/schemas/Graph"
-          },
+          "graph": { "$ref": "#/components/schemas/Graph" },
           "source": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["builder", "upload"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["builder", "upload"] },
+              { "type": "null" }
             ],
             "title": "Source"
           }
@@ -14239,13 +10921,8 @@
           },
           "builder_graph_id": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 128
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 128 },
+              { "type": "null" }
             ],
             "title": "Builder Graph Id"
           }
@@ -14257,30 +10934,15 @@
       },
       "CreateSessionResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "created_at": { "type": "string", "title": "Created At" },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": {
-              "dry_run": false
-            }
+            "default": { "dry_run": false }
           }
         },
         "type": "object",
@@ -14290,56 +10952,24 @@
       },
       "CreatorDetails": {
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Avatar Url"
           },
           "links": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": {
-            "type": "boolean",
-            "title": "Is Featured"
-          },
-          "num_agents": {
-            "type": "integer",
-            "title": "Num Agents"
-          },
-          "agent_runs": {
-            "type": "integer",
-            "title": "Agent Runs"
-          },
-          "agent_rating": {
-            "type": "number",
-            "title": "Agent Rating"
-          },
+          "is_featured": { "type": "boolean", "title": "Is Featured" },
+          "num_agents": { "type": "integer", "title": "Num Agents" },
+          "agent_runs": { "type": "integer", "title": "Agent Runs" },
+          "agent_rating": { "type": "number", "title": "Agent Rating" },
           "top_categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Top Categories"
           }
@@ -14363,15 +10993,11 @@
       "CreatorsResponse": {
         "properties": {
           "creators": {
-            "items": {
-              "$ref": "#/components/schemas/CreatorDetails"
-            },
+            "items": { "$ref": "#/components/schemas/CreatorDetails" },
             "type": "array",
             "title": "Creators"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["creators", "pagination"],
@@ -14391,10 +11017,7 @@
             "title": "Need Confirmation",
             "default": true
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["message"],
@@ -14409,14 +11032,7 @@
             "default": true
           },
           "revoked": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Revoked",
             "description": "Indicates whether the credentials were also revoked by their provider. `None`/`null` if not applicable, e.g. when deleting non-revocable credentials such as API keys."
           }
@@ -14427,19 +11043,9 @@
       },
       "CredentialsMetaInput": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
+          "id": { "type": "string", "title": "Id" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "provider": {
@@ -14461,64 +11067,30 @@
       },
       "CredentialsMetaResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "type": {
             "type": "string",
             "enum": ["api_key", "oauth2", "user_password", "host_scoped"],
             "title": "Type"
           },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "scopes": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "Scopes"
           },
           "username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Username"
           },
           "host": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Host",
             "description": "Host pattern for host-scoped or MCP server URL for MCP credentials"
           },
@@ -14547,24 +11119,13 @@
       "CreditTransactionsExportResponse": {
         "properties": {
           "transactions": {
-            "items": {
-              "$ref": "#/components/schemas/UserTransaction"
-            },
+            "items": { "$ref": "#/components/schemas/UserTransaction" },
             "type": "array",
             "title": "Transactions"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "window_days": {
-            "type": "integer",
-            "title": "Window Days"
-          },
-          "max_window_days": {
-            "type": "integer",
-            "title": "Max Window Days"
-          }
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "window_days": { "type": "integer", "title": "Window Days" },
+          "max_window_days": { "type": "integer", "title": "Max Window Days" }
         },
         "type": "object",
         "required": [
@@ -14576,34 +11137,21 @@
         "title": "CreditTransactionsExportResponse"
       },
       "DeleteFileResponse": {
-        "properties": {
-          "deleted": {
-            "type": "boolean",
-            "title": "Deleted"
-          }
-        },
+        "properties": { "deleted": { "type": "boolean", "title": "Deleted" } },
         "type": "object",
         "required": ["deleted"],
         "title": "DeleteFileResponse"
       },
       "DeleteGraphResponse": {
         "properties": {
-          "version_counts": {
-            "type": "integer",
-            "title": "Version Counts"
-          }
+          "version_counts": { "type": "integer", "title": "Version Counts" }
         },
         "type": "object",
         "required": ["version_counts"],
         "title": "DeleteGraphResponse"
       },
       "DeleteLinkResponse": {
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          }
-        },
+        "properties": { "success": { "type": "boolean", "title": "Success" } },
         "type": "object",
         "required": ["success"],
         "title": "DeleteLinkResponse"
@@ -14616,14 +11164,7 @@
             "description": "URL of the MCP server"
           },
           "auth_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Auth Token",
             "description": "Optional Bearer token for authenticated MCP servers"
           }
@@ -14636,32 +11177,16 @@
       "DiscoverToolsResponse": {
         "properties": {
           "tools": {
-            "items": {
-              "$ref": "#/components/schemas/MCPToolResponse"
-            },
+            "items": { "$ref": "#/components/schemas/MCPToolResponse" },
             "type": "array",
             "title": "Tools"
           },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           },
           "protocol_version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Protocol Version"
           }
         },
@@ -14676,42 +11201,16 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_page"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "content": {
-            "type": "string",
-            "title": "Content"
-          },
+          "title": { "type": "string", "title": "Title" },
+          "path": { "type": "string", "title": "Path" },
+          "content": { "type": "string", "title": "Content" },
           "doc_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Doc Url"
           }
         },
@@ -14722,35 +11221,13 @@
       },
       "DocSearchResult": {
         "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "section": {
-            "type": "string",
-            "title": "Section"
-          },
-          "snippet": {
-            "type": "string",
-            "title": "Snippet"
-          },
-          "score": {
-            "type": "number",
-            "title": "Score"
-          },
+          "title": { "type": "string", "title": "Title" },
+          "path": { "type": "string", "title": "Path" },
+          "section": { "type": "string", "title": "Section" },
+          "snippet": { "type": "string", "title": "Snippet" },
+          "score": { "type": "number", "title": "Score" },
           "doc_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Doc Url"
           }
         },
@@ -14765,36 +11242,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "doc_search_results"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "results": {
-            "items": {
-              "$ref": "#/components/schemas/DocSearchResult"
-            },
+            "items": { "$ref": "#/components/schemas/DocSearchResult" },
             "type": "array",
             "title": "Results"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          },
-          "query": {
-            "type": "string",
-            "title": "Query"
-          }
+          "count": { "type": "integer", "title": "Count" },
+          "query": { "type": "string", "title": "Query" }
         },
         "type": "object",
         "required": ["message", "results", "count", "query"],
@@ -14803,14 +11262,8 @@
       },
       "Document": {
         "properties": {
-          "url": {
-            "type": "string",
-            "title": "Url"
-          },
-          "relevance_score": {
-            "type": "number",
-            "title": "Relevance Score"
-          }
+          "url": { "type": "string", "title": "Url" },
+          "relevance_score": { "type": "number", "title": "Relevance Score" }
         },
         "type": "object",
         "required": ["url", "relevance_score"],
@@ -14822,41 +11275,19 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "error"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error"
           },
           "details": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Details"
           }
@@ -14869,9 +11300,7 @@
       "ExecutionAnalyticsConfig": {
         "properties": {
           "available_models": {
-            "items": {
-              "$ref": "#/components/schemas/ModelInfo"
-            },
+            "items": { "$ref": "#/components/schemas/ModelInfo" },
             "type": "array",
             "title": "Available Models"
           },
@@ -14905,38 +11334,19 @@
             "description": "Graph ID to analyze"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version",
             "description": "Optional graph version"
           },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id",
             "description": "Optional user ID filter"
           },
           "created_after": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Created After",
             "description": "Optional created date lower bound"
@@ -14956,26 +11366,12 @@
             "default": 10
           },
           "system_prompt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "System Prompt",
             "description": "Custom system prompt (default: built-in prompt)"
           },
           "user_prompt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Prompt",
             "description": "Custom user prompt with {{GRAPH_NAME}} and {{EXECUTION_DATA}} placeholders (default: built-in prompt)"
           },
@@ -15033,80 +11429,34 @@
       },
       "ExecutionAnalyticsResult": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "version_id": {
-            "type": "integer",
-            "title": "Version Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "exec_id": {
-            "type": "string",
-            "title": "Exec Id"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "version_id": { "type": "integer", "title": "Version Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "exec_id": { "type": "string", "title": "Exec Id" },
           "summary_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Summary Text"
           },
           "score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Score"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error Message"
           },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At"
           }
@@ -15145,22 +11495,13 @@
             "type": "integer",
             "title": "Orphaned Running"
           },
-          "orphaned_queued": {
-            "type": "integer",
-            "title": "Orphaned Queued"
-          },
-          "failed_count_1h": {
-            "type": "integer",
-            "title": "Failed Count 1H"
-          },
+          "orphaned_queued": { "type": "integer", "title": "Orphaned Queued" },
+          "failed_count_1h": { "type": "integer", "title": "Failed Count 1H" },
           "failed_count_24h": {
             "type": "integer",
             "title": "Failed Count 24H"
           },
-          "failure_rate_24h": {
-            "type": "number",
-            "title": "Failure Rate 24H"
-          },
+          "failure_rate_24h": { "type": "number", "title": "Failure Rate 24H" },
           "stuck_running_24h": {
             "type": "integer",
             "title": "Stuck Running 24H"
@@ -15170,20 +11511,10 @@
             "title": "Stuck Running 1H"
           },
           "oldest_running_hours": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Oldest Running Hours"
           },
-          "stuck_queued_1h": {
-            "type": "integer",
-            "title": "Stuck Queued 1H"
-          },
+          "stuck_queued_1h": { "type": "integer", "title": "Stuck Queued 1H" },
           "queued_never_started": {
             "type": "integer",
             "title": "Queued Never Started"
@@ -15196,22 +11527,13 @@
             "type": "integer",
             "title": "Invalid Running Without Start"
           },
-          "completed_1h": {
-            "type": "integer",
-            "title": "Completed 1H"
-          },
-          "completed_24h": {
-            "type": "integer",
-            "title": "Completed 24H"
-          },
+          "completed_1h": { "type": "integer", "title": "Completed 1H" },
+          "completed_24h": { "type": "integer", "title": "Completed 24H" },
           "throughput_per_hour": {
             "type": "number",
             "title": "Throughput Per Hour"
           },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
+          "timestamp": { "type": "string", "title": "Timestamp" }
         },
         "type": "object",
         "required": [
@@ -15241,21 +11563,13 @@
       },
       "ExecutionOptions": {
         "properties": {
-          "manual": {
-            "type": "boolean",
-            "title": "Manual",
-            "default": true
-          },
+          "manual": { "type": "boolean", "title": "Manual", "default": true },
           "scheduled": {
             "type": "boolean",
             "title": "Scheduled",
             "default": true
           },
-          "webhook": {
-            "type": "boolean",
-            "title": "Webhook",
-            "default": false
-          }
+          "webhook": { "type": "boolean", "title": "Webhook", "default": false }
         },
         "type": "object",
         "title": "ExecutionOptions",
@@ -15263,70 +11577,41 @@
       },
       "ExecutionOutputInfo": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "status": { "type": "string", "title": "Status" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At"
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           },
           "inputs_summary": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs Summary"
           },
           "node_executions": {
             "anyOf": [
               {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
+                "items": { "additionalProperties": true, "type": "object" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Node Executions"
           }
@@ -15342,60 +11627,23 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "execution_started"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
           "library_agent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Id"
           },
           "library_agent_link": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Library Agent Link"
           },
-          "status": {
-            "type": "string",
-            "title": "Status",
-            "default": "QUEUED"
-          }
+          "status": { "type": "string", "title": "Status", "default": "QUEUED" }
         },
         "type": "object",
         "required": ["message", "execution_id", "graph_id", "graph_name"],
@@ -15404,41 +11652,16 @@
       },
       "FailedExecutionDetail": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15446,37 +11669,20 @@
           },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "failed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Failed At"
           },
           "error_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error Message"
           }
         },
@@ -15500,16 +11706,11 @@
       "FailedExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": {
-              "$ref": "#/components/schemas/FailedExecutionDetail"
-            },
+            "items": { "$ref": "#/components/schemas/FailedExecutionDetail" },
             "type": "array",
             "title": "Executions"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["executions", "total"],
@@ -15525,38 +11726,19 @@
             "title": "Name"
           },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
             "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^#[0-9A-Fa-f]{6}$"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "pattern": "^#[0-9A-Fa-f]{6}$" },
+              { "type": "null" }
             ],
             "title": "Color",
             "description": "Hex color code (#RRGGBB)"
           },
           "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Parent Id"
           }
         },
@@ -15568,15 +11750,11 @@
       "FolderListResponse": {
         "properties": {
           "folders": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryFolder"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryFolder" },
             "type": "array",
             "title": "Folders"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["folders", "pagination"],
@@ -15586,14 +11764,7 @@
       "FolderMoveRequest": {
         "properties": {
           "target_parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Target Parent Id"
           }
         },
@@ -15604,9 +11775,7 @@
       "FolderTreeResponse": {
         "properties": {
           "tree": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryFolderTree"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
             "type": "array",
             "title": "Tree"
           }
@@ -15620,37 +11789,17 @@
         "properties": {
           "name": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 100, "minLength": 1 },
+              { "type": "null" }
             ],
             "title": "Name"
           },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Color"
           }
         },
@@ -15660,90 +11809,43 @@
       },
       "Graph": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/Node"
-            },
+            "items": { "$ref": "#/components/schemas/Node" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": {
-              "$ref": "#/components/schemas/BaseGraph-Input"
-            },
+            "items": { "$ref": "#/components/schemas/BaseGraph-Input" },
             "type": "array",
             "title": "Sub Graphs"
           }
@@ -15755,22 +11857,10 @@
       },
       "GraphExecution": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -15784,9 +11874,7 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credential Inputs"
           },
@@ -15799,48 +11887,27 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Preset Id"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -15851,14 +11918,7 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -15868,19 +11928,12 @@
           },
           "stats": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Stats"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Stats" },
+              { "type": "null" }
             ]
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           }
@@ -15904,43 +11957,17 @@
       "GraphExecutionJobInfo": {
         "properties": {
           "schedule_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Schedule Id"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "agent_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Name"
           },
-          "cron": {
-            "type": "string",
-            "title": "Cron"
-          },
+          "cron": { "type": "string", "title": "Cron" },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
@@ -15953,18 +11980,9 @@
             "type": "object",
             "title": "Input Credentials"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
           "timezone": {
             "type": "string",
             "title": "Timezone",
@@ -15987,31 +12005,14 @@
       },
       "GraphExecutionMeta": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs"
           },
@@ -16023,9 +12024,7 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credential Inputs"
           },
@@ -16038,48 +12037,27 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Preset Id"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -16090,14 +12068,7 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -16107,12 +12078,8 @@
           },
           "stats": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Stats"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Stats" },
+              { "type": "null" }
             ]
           }
         },
@@ -16133,22 +12100,10 @@
       },
       "GraphExecutionWithNodes": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -16162,9 +12117,7 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credential Inputs"
           },
@@ -16177,48 +12130,27 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Nodes Input Masks"
           },
           "preset_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Preset Id"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At",
             "description": "When execution started running. Null if not yet started (QUEUED)."
           },
           "ended_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Ended At",
             "description": "When execution finished. Null if not yet completed (QUEUED, RUNNING, INCOMPLETE, REVIEW)."
@@ -16229,14 +12161,7 @@
             "default": false
           },
           "share_token": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Share Token"
           },
           "is_dry_run": {
@@ -16246,26 +12171,17 @@
           },
           "stats": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Stats"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Stats" },
+              { "type": "null" }
             ]
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           },
           "node_executions": {
-            "items": {
-              "$ref": "#/components/schemas/NodeExecutionResult"
-            },
+            "items": { "$ref": "#/components/schemas/NodeExecutionResult" },
             "type": "array",
             "title": "Node Executions"
           }
@@ -16290,15 +12206,11 @@
       "GraphExecutionsPaginated": {
         "properties": {
           "executions": {
-            "items": {
-              "$ref": "#/components/schemas/GraphExecutionMeta"
-            },
+            "items": { "$ref": "#/components/schemas/GraphExecutionMeta" },
             "type": "array",
             "title": "Executions"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["executions", "pagination"],
@@ -16307,75 +12219,32 @@
       },
       "GraphMeta": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -16396,99 +12265,49 @@
       },
       "GraphModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "nodes": {
-            "items": {
-              "$ref": "#/components/schemas/NodeModel"
-            },
+            "items": { "$ref": "#/components/schemas/NodeModel" },
             "type": "array",
             "title": "Nodes"
           },
           "links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Links"
           },
           "sub_graphs": {
-            "items": {
-              "$ref": "#/components/schemas/BaseGraph-Output"
-            },
+            "items": { "$ref": "#/components/schemas/BaseGraph-Output" },
             "type": "array",
             "title": "Sub Graphs"
           },
@@ -16521,12 +12340,8 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ],
             "readOnly": true
           },
@@ -16556,76 +12371,32 @@
       },
       "GraphModelWithoutNodes": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "version": {
-            "type": "integer",
-            "title": "Version",
-            "default": 1
-          },
+          "id": { "type": "string", "title": "Id" },
+          "version": { "type": "integer", "title": "Version", "default": 1 },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "forked_from_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Forked From Id"
           },
           "forked_from_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Forked From Version"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -16660,12 +12431,8 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ],
             "readOnly": true
           },
@@ -16706,14 +12473,7 @@
             "default": false
           },
           "builder_chat_session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Builder Chat Session Id"
           }
         },
@@ -16734,14 +12494,7 @@
             "description": "Input schema for the trigger block"
           },
           "credentials_input_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Credentials Input Name"
           }
         },
@@ -16752,9 +12505,7 @@
       "HTTPValidationError": {
         "properties": {
           "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
+            "items": { "$ref": "#/components/schemas/ValidationError" },
             "type": "array",
             "title": "Detail"
           }
@@ -16764,23 +12515,10 @@
       },
       "HostScopedCredentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -16821,10 +12559,7 @@
       },
       "ImageURLResponse": {
         "properties": {
-          "image_url": {
-            "type": "string",
-            "title": "Image Url"
-          }
+          "image_url": { "type": "string", "title": "Image Url" }
         },
         "type": "object",
         "required": ["image_url"],
@@ -16836,25 +12571,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "input_validation_error"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "unrecognized_fields": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Unrecognized Fields",
             "description": "List of input field names that were not recognized"
@@ -16866,25 +12589,11 @@
             "description": "The agent's valid input schema for reference"
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           }
         },
@@ -16895,40 +12604,19 @@
       },
       "LibraryAgent": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "image_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Image Url"
           },
-          "creator_name": {
-            "type": "string",
-            "title": "Creator Name"
-          },
+          "creator_name": { "type": "string", "title": "Creator Name" },
           "creator_image_url": {
             "type": "string",
             "title": "Creator Image Url"
           },
-          "status": {
-            "$ref": "#/components/schemas/LibraryAgentStatus"
-          },
+          "status": { "$ref": "#/components/schemas/LibraryAgentStatus" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -16939,23 +12627,10 @@
             "format": "date-time",
             "title": "Updated At"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "input_schema": {
@@ -16970,13 +12645,8 @@
           },
           "credentials_input_schema": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Credentials Input Schema",
             "description": "Input schema for credentials required by the agent"
@@ -16998,49 +12668,26 @@
           },
           "trigger_setup_info": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphTriggerInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphTriggerInfo" },
+              { "type": "null" }
             ]
           },
-          "new_output": {
-            "type": "boolean",
-            "title": "New Output"
-          },
+          "new_output": { "type": "boolean", "title": "New Output" },
           "execution_count": {
             "type": "integer",
             "title": "Execution Count",
             "default": 0
           },
           "success_rate": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Success Rate"
           },
           "avg_correctness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Avg Correctness Score"
           },
           "recent_executions": {
-            "items": {
-              "$ref": "#/components/schemas/RecentExecution"
-            },
+            "items": { "$ref": "#/components/schemas/RecentExecution" },
             "type": "array",
             "title": "Recent Executions",
             "description": "List of recent executions with status, score, and summary"
@@ -17054,41 +12701,17 @@
             "type": "boolean",
             "title": "Is Latest Version"
           },
-          "is_favorite": {
-            "type": "boolean",
-            "title": "Is Favorite"
-          },
+          "is_favorite": { "type": "boolean", "title": "Is Favorite" },
           "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Id"
           },
           "folder_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Name"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "is_scheduled": {
@@ -17098,28 +12721,15 @@
             "default": false
           },
           "next_scheduled_run": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Next Scheduled Run",
             "description": "ISO 8601 timestamp of the next scheduled run, if any"
           },
-          "settings": {
-            "$ref": "#/components/schemas/GraphSettings"
-          },
+          "settings": { "$ref": "#/components/schemas/GraphSettings" },
           "marketplace_listing": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/MarketplaceListing"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/MarketplaceListing" },
+              { "type": "null" }
             ]
           }
         },
@@ -17152,14 +12762,8 @@
       },
       "LibraryAgentPreset": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -17172,38 +12776,19 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Webhook Id"
           },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -17216,12 +12801,8 @@
           },
           "webhook": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/Webhook"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/Webhook" },
+              { "type": "null" }
             ]
           }
         },
@@ -17244,14 +12825,8 @@
       },
       "LibraryAgentPresetCreatable": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -17264,28 +12839,15 @@
             "type": "object",
             "title": "Credentials"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
             "default": true
           },
           "webhook_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Webhook Id"
           }
         },
@@ -17307,14 +12869,8 @@
             "type": "string",
             "title": "Graph Execution Id"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "is_active": {
             "type": "boolean",
             "title": "Is Active",
@@ -17329,15 +12885,11 @@
       "LibraryAgentPresetResponse": {
         "properties": {
           "presets": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryAgentPreset"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryAgentPreset" },
             "type": "array",
             "title": "Presets"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["presets", "pagination"],
@@ -17348,13 +12900,8 @@
         "properties": {
           "inputs": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Inputs"
           },
@@ -17366,43 +12913,20 @@
                 },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Credentials"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Name"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Active"
           }
         },
@@ -17413,15 +12937,11 @@
       "LibraryAgentResponse": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryAgent"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryAgent" },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -17442,73 +12962,34 @@
       "LibraryAgentUpdateRequest": {
         "properties": {
           "auto_update_version": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Auto Update Version",
             "description": "Auto-update the agent version"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version",
             "description": "Specific graph version to update to"
           },
           "is_favorite": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Favorite",
             "description": "Mark the agent as a favorite"
           },
           "is_archived": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Is Archived",
             "description": "Archive the agent"
           },
           "settings": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/GraphSettings"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/GraphSettings" },
+              { "type": "null" }
             ],
             "description": "User-specific settings for this library agent"
           },
           "folder_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Folder Id",
             "description": "Folder ID to move agent to (None to move to root)"
           }
@@ -17519,49 +13000,19 @@
       },
       "LibraryFolder": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "name": { "type": "string", "title": "Name" },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Parent Id"
           },
           "created_at": {
@@ -17592,49 +13043,19 @@
       },
       "LibraryFolderTree": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "name": { "type": "string", "title": "Name" },
           "icon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Icon"
           },
           "color": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Color"
           },
           "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Parent Id"
           },
           "created_at": {
@@ -17658,9 +13079,7 @@
             "default": 0
           },
           "children": {
-            "items": {
-              "$ref": "#/components/schemas/LibraryFolderTree"
-            },
+            "items": { "$ref": "#/components/schemas/LibraryFolderTree" },
             "type": "array",
             "title": "Children",
             "default": []
@@ -17673,26 +13092,11 @@
       },
       "Link": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "source_id": {
-            "type": "string",
-            "title": "Source Id"
-          },
-          "sink_id": {
-            "type": "string",
-            "title": "Sink Id"
-          },
-          "source_name": {
-            "type": "string",
-            "title": "Source Name"
-          },
-          "sink_name": {
-            "type": "string",
-            "title": "Sink Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "source_id": { "type": "string", "title": "Source Id" },
+          "sink_id": { "type": "string", "title": "Sink Id" },
+          "source_name": { "type": "string", "title": "Source Name" },
+          "sink_name": { "type": "string", "title": "Sink Name" },
           "is_static": {
             "type": "boolean",
             "title": "Is Static",
@@ -17705,22 +13109,10 @@
       },
       "LinkTokenInfoResponse": {
         "properties": {
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "link_type": {
-            "$ref": "#/components/schemas/LinkType"
-          },
+          "platform": { "type": "string", "title": "Platform" },
+          "link_type": { "$ref": "#/components/schemas/LinkType" },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           }
         },
@@ -17736,17 +13128,11 @@
       "ListFilesResponse": {
         "properties": {
           "files": {
-            "items": {
-              "$ref": "#/components/schemas/WorkspaceFileItem"
-            },
+            "items": { "$ref": "#/components/schemas/WorkspaceFileItem" },
             "type": "array",
             "title": "Files"
           },
-          "offset": {
-            "type": "integer",
-            "title": "Offset",
-            "default": 0
-          },
+          "offset": { "type": "integer", "title": "Offset", "default": 0 },
           "has_more": {
             "type": "boolean",
             "title": "Has More",
@@ -17760,16 +13146,11 @@
       "ListSessionsResponse": {
         "properties": {
           "sessions": {
-            "items": {
-              "$ref": "#/components/schemas/SessionSummaryResponse"
-            },
+            "items": { "$ref": "#/components/schemas/SessionSummaryResponse" },
             "type": "array",
             "title": "Sessions"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["sessions", "total"],
@@ -17783,10 +13164,7 @@
             "minLength": 1,
             "title": "Metric Name"
           },
-          "metric_value": {
-            "type": "number",
-            "title": "Metric Value"
-          },
+          "metric_value": { "type": "number", "title": "Metric Value" },
           "data_string": {
             "type": "string",
             "minLength": 1,
@@ -17799,14 +13177,8 @@
       },
       "LoginResponse": {
         "properties": {
-          "login_url": {
-            "type": "string",
-            "title": "Login Url"
-          },
-          "state_token": {
-            "type": "string",
-            "title": "State Token"
-          }
+          "login_url": { "type": "string", "title": "Login Url" },
+          "state_token": { "type": "string", "title": "State Token" }
         },
         "type": "object",
         "required": ["login_url", "state_token"],
@@ -17845,14 +13217,8 @@
       },
       "MCPOAuthLoginResponse": {
         "properties": {
-          "login_url": {
-            "type": "string",
-            "title": "Login Url"
-          },
-          "state_token": {
-            "type": "string",
-            "title": "State Token"
-          }
+          "login_url": { "type": "string", "title": "Login Url" },
+          "state_token": { "type": "string", "title": "State Token" }
         },
         "type": "object",
         "required": ["login_url", "state_token"],
@@ -17882,14 +13248,8 @@
       },
       "MCPToolInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -17907,37 +13267,15 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tool_output"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "server_url": {
-            "type": "string",
-            "title": "Server Url"
-          },
-          "tool_name": {
-            "type": "string",
-            "title": "Tool Name"
-          },
-          "result": {
-            "title": "Result"
-          },
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": true
-          }
+          "server_url": { "type": "string", "title": "Server Url" },
+          "tool_name": { "type": "string", "title": "Tool Name" },
+          "result": { "title": "Result" },
+          "success": { "type": "boolean", "title": "Success", "default": true }
         },
         "type": "object",
         "required": ["message", "server_url", "tool_name"],
@@ -17946,14 +13284,8 @@
       },
       "MCPToolResponse": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
@@ -17971,29 +13303,14 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "mcp_tools_discovered"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "server_url": {
-            "type": "string",
-            "title": "Server Url"
-          },
+          "server_url": { "type": "string", "title": "Server Url" },
           "tools": {
-            "items": {
-              "$ref": "#/components/schemas/MCPToolInfo"
-            },
+            "items": { "$ref": "#/components/schemas/MCPToolInfo" },
             "type": "array",
             "title": "Tools"
           }
@@ -18005,18 +13322,9 @@
       },
       "MarketplaceListing": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "slug": { "type": "string", "title": "Slug" },
           "creator": {
             "$ref": "#/components/schemas/MarketplaceListingCreator"
           }
@@ -18028,18 +13336,9 @@
       },
       "MarketplaceListingCreator": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          }
+          "name": { "type": "string", "title": "Name" },
+          "id": { "type": "string", "title": "Id" },
+          "slug": { "type": "string", "title": "Slug" }
         },
         "type": "object",
         "required": ["name", "id", "slug"],
@@ -18052,26 +13351,14 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_candidates"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "candidates": {
             "items": {
-              "additionalProperties": {
-                "type": "string"
-              },
+              "additionalProperties": { "type": "string" },
               "type": "object"
             },
             "type": "array",
@@ -18089,32 +13376,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_forget_confirm"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "deleted_uuids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Deleted Uuids"
           },
           "failed_uuids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Failed Uuids"
           }
@@ -18130,32 +13403,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_search"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "facts": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Facts"
           },
           "recent_episodes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Recent Episodes"
           }
@@ -18171,25 +13430,12 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "memory_store"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "memory_name": {
-            "type": "string",
-            "title": "Memory Name"
-          }
+          "memory_name": { "type": "string", "title": "Memory Name" }
         },
         "type": "object",
         "required": ["message", "memory_name"],
@@ -18198,14 +13444,8 @@
       },
       "Message": {
         "properties": {
-          "query": {
-            "type": "string",
-            "title": "Query"
-          },
-          "response": {
-            "type": "string",
-            "title": "Response"
-          }
+          "query": { "type": "string", "title": "Query" },
+          "response": { "type": "string", "title": "Response" }
         },
         "type": "object",
         "required": ["query", "response"],
@@ -18213,18 +13453,9 @@
       },
       "ModelInfo": {
         "properties": {
-          "value": {
-            "type": "string",
-            "title": "Value"
-          },
-          "label": {
-            "type": "string",
-            "title": "Label"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          }
+          "value": { "type": "string", "title": "Value" },
+          "label": { "type": "string", "title": "Label" },
+          "provider": { "type": "string", "title": "Provider" }
         },
         "type": "object",
         "required": ["value", "label", "provider"],
@@ -18232,47 +13463,21 @@
       },
       "MyUnpublishedAgent": {
         "properties": {
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
           "agent_image": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Image"
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "description": { "type": "string", "title": "Description" },
           "last_edited": {
             "type": "string",
             "format": "date-time",
             "title": "Last Edited"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -18289,15 +13494,11 @@
       "MyUnpublishedAgentsResponse": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/MyUnpublishedAgent"
-            },
+            "items": { "$ref": "#/components/schemas/MyUnpublishedAgent" },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -18309,30 +13510,15 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "need_login"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "agent_info": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Agent Info"
           }
@@ -18348,34 +13534,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "no_results"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "suggestions": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Suggestions",
             "default": []
           },
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "default": "no_results"
-          }
+          "name": { "type": "string", "title": "Name", "default": "no_results" }
         },
         "type": "object",
         "required": ["message"],
@@ -18384,14 +13554,8 @@
       },
       "Node": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "block_id": { "type": "string", "title": "Block Id" },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -18403,16 +13567,12 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Output Links"
           }
@@ -18423,47 +13583,21 @@
       },
       "NodeExecutionResult": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "graph_exec_id": {
-            "type": "string",
-            "title": "Graph Exec Id"
-          },
-          "node_exec_id": {
-            "type": "string",
-            "title": "Node Exec Id"
-          },
-          "node_id": {
-            "type": "string",
-            "title": "Node Id"
-          },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "graph_exec_id": { "type": "string", "title": "Graph Exec Id" },
+          "node_exec_id": { "type": "string", "title": "Node Exec Id" },
+          "node_id": { "type": "string", "title": "Node Id" },
+          "block_id": { "type": "string", "title": "Block Id" },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "input_data": {
             "additionalProperties": true,
             "type": "object",
             "title": "Input Data"
           },
           "output_data": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Output Data"
           },
@@ -18474,37 +13608,22 @@
           },
           "queue_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Queue Time"
           },
           "start_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Start Time"
           },
           "end_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "End Time"
           }
@@ -18530,14 +13649,8 @@
       },
       "NodeModel": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "block_id": {
-            "type": "string",
-            "title": "Block Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "block_id": { "type": "string", "title": "Block Id" },
           "input_default": {
             "additionalProperties": true,
             "type": "object",
@@ -18549,36 +13662,19 @@
             "title": "Metadata"
           },
           "input_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Input Links"
           },
           "output_links": {
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
+            "items": { "$ref": "#/components/schemas/Link" },
             "type": "array",
             "title": "Output Links"
           },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "webhook_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Webhook Id"
           }
         },
@@ -18588,19 +13684,10 @@
       },
       "NotificationPreference": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "email": {
-            "type": "string",
-            "format": "email",
-            "title": "Email"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "email": { "type": "string", "format": "email", "title": "Email" },
           "preferences": {
-            "additionalProperties": {
-              "type": "boolean"
-            },
+            "additionalProperties": { "type": "boolean" },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -18637,9 +13724,7 @@
             "description": "User's email address"
           },
           "preferences": {
-            "additionalProperties": {
-              "type": "boolean"
-            },
+            "additionalProperties": { "type": "boolean" },
             "propertyNames": {
               "$ref": "#/components/schemas/NotificationType"
             },
@@ -18677,23 +13762,10 @@
       },
       "OAuth2Credentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -18713,14 +13785,7 @@
             "default": "oauth2"
           },
           "username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Username"
           },
           "access_token": {
@@ -18730,44 +13795,22 @@
             "writeOnly": true
           },
           "access_token_expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Access Token Expires At"
           },
           "refresh_token": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "password",
-                "writeOnly": true
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "password", "writeOnly": true },
+              { "type": "null" }
             ],
             "title": "Refresh Token"
           },
           "refresh_token_expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes"
           }
@@ -18778,69 +13821,34 @@
       },
       "OAuthApplicationInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Logo Url"
           },
-          "client_id": {
-            "type": "string",
-            "title": "Client Id"
-          },
+          "client_id": { "type": "string", "title": "Client Id" },
           "redirect_uris": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Redirect Uris"
           },
           "grant_types": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Grant Types"
           },
           "scopes": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Scopes"
           },
-          "owner_id": {
-            "type": "string",
-            "title": "Owner Id"
-          },
-          "is_active": {
-            "type": "boolean",
-            "title": "Is Active"
-          },
+          "owner_id": { "type": "string", "title": "Owner Id" },
+          "is_active": { "type": "boolean", "title": "Is Active" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -18870,36 +13878,17 @@
       },
       "OAuthApplicationPublicInfo": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "logo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Logo Url"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes"
           }
@@ -18924,9 +13913,7 @@
             "title": "User Role"
           },
           "pain_points": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "maxItems": 20,
             "title": "Pain Points"
@@ -18939,10 +13926,7 @@
       },
       "OnboardingStatusResponse": {
         "properties": {
-          "is_completed": {
-            "type": "boolean",
-            "title": "Is Completed"
-          }
+          "is_completed": { "type": "boolean", "title": "Is Completed" }
         },
         "type": "object",
         "required": ["is_completed"],
@@ -18979,45 +13963,17 @@
       },
       "OrphanedScheduleDetail": {
         "properties": {
-          "schedule_id": {
-            "type": "string",
-            "title": "Schedule Id"
-          },
-          "schedule_name": {
-            "type": "string",
-            "title": "Schedule Name"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "orphan_reason": {
-            "type": "string",
-            "title": "Orphan Reason"
-          },
+          "schedule_id": { "type": "string", "title": "Schedule Id" },
+          "schedule_name": { "type": "string", "title": "Schedule Name" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "orphan_reason": { "type": "string", "title": "Orphan Reason" },
           "error_detail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error Detail"
           },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          }
+          "next_run_time": { "type": "string", "title": "Next Run Time" }
         },
         "type": "object",
         "required": [
@@ -19036,16 +13992,11 @@
       "OrphanedSchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": {
-              "$ref": "#/components/schemas/OrphanedScheduleDetail"
-            },
+            "items": { "$ref": "#/components/schemas/OrphanedScheduleDetail" },
             "type": "array",
             "title": "Schedules"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["schedules", "total"],
@@ -19086,16 +14037,11 @@
       "PeekPendingMessagesResponse": {
         "properties": {
           "messages": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Messages"
           },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
+          "count": { "type": "integer", "title": "Count" }
         },
         "type": "object",
         "required": ["messages", "count"],
@@ -19137,42 +14083,19 @@
           },
           "payload": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "items": {}, "type": "array" },
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "null" }
             ],
             "title": "Payload",
             "description": "The actual data payload awaiting review"
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions",
             "description": "Instructions or message for the reviewer"
           },
@@ -19186,26 +14109,12 @@
             "description": "Review status"
           },
           "review_message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Review Message",
             "description": "Optional message from the reviewer"
           },
           "was_edited": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Was Edited",
             "description": "Whether the data was modified during review"
           },
@@ -19223,26 +14132,16 @@
           },
           "updated_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Updated At",
             "description": "When the review was last updated"
           },
           "reviewed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Reviewed At",
             "description": "When the review was completed"
@@ -19271,14 +14170,7 @@
             "description": "OAuth access token suitable for the picker SDK call."
           },
           "access_token_expires_at": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Access Token Expires At",
             "description": "Unix timestamp at which the access token expires, if known."
           }
@@ -19291,16 +14183,12 @@
       "PlatformCostDashboard": {
         "properties": {
           "by_provider": {
-            "items": {
-              "$ref": "#/components/schemas/ProviderCostSummary"
-            },
+            "items": { "$ref": "#/components/schemas/ProviderCostSummary" },
             "type": "array",
             "title": "By Provider"
           },
           "by_user": {
-            "items": {
-              "$ref": "#/components/schemas/UserCostSummary"
-            },
+            "items": { "$ref": "#/components/schemas/UserCostSummary" },
             "type": "array",
             "title": "By User"
           },
@@ -19308,14 +14196,8 @@
             "type": "integer",
             "title": "Total Cost Microdollars"
           },
-          "total_requests": {
-            "type": "integer",
-            "title": "Total Requests"
-          },
-          "total_users": {
-            "type": "integer",
-            "title": "Total Users"
-          },
+          "total_requests": { "type": "integer", "title": "Total Requests" },
+          "total_users": { "type": "integer", "title": "Total Users" },
           "total_input_tokens": {
             "type": "integer",
             "title": "Total Input Tokens",
@@ -19362,9 +14244,7 @@
             "default": 0.0
           },
           "cost_buckets": {
-            "items": {
-              "$ref": "#/components/schemas/CostBucket"
-            },
+            "items": { "$ref": "#/components/schemas/CostBucket" },
             "type": "array",
             "title": "Cost Buckets",
             "default": []
@@ -19383,20 +14263,12 @@
       "PlatformCostExportResponse": {
         "properties": {
           "logs": {
-            "items": {
-              "$ref": "#/components/schemas/CostLogRow"
-            },
+            "items": { "$ref": "#/components/schemas/CostLogRow" },
             "type": "array",
             "title": "Logs"
           },
-          "total_rows": {
-            "type": "integer",
-            "title": "Total Rows"
-          },
-          "truncated": {
-            "type": "boolean",
-            "title": "Truncated"
-          }
+          "total_rows": { "type": "integer", "title": "Total Rows" },
+          "truncated": { "type": "boolean", "title": "Truncated" }
         },
         "type": "object",
         "required": ["logs", "total_rows", "truncated"],
@@ -19405,15 +14277,11 @@
       "PlatformCostLogsResponse": {
         "properties": {
           "logs": {
-            "items": {
-              "$ref": "#/components/schemas/CostLogRow"
-            },
+            "items": { "$ref": "#/components/schemas/CostLogRow" },
             "type": "array",
             "title": "Logs"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["logs", "pagination"],
@@ -19421,14 +14289,8 @@
       },
       "PlatformLinkInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "platform": { "type": "string", "title": "Platform" },
           "platform_server_id": {
             "type": "string",
             "title": "Platform Server Id"
@@ -19438,14 +14300,7 @@
             "title": "Owner Platform User Id"
           },
           "server_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Server Name"
           },
           "linked_at": {
@@ -19467,27 +14322,11 @@
       },
       "PlatformUserLinkInfo": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "platform_user_id": {
-            "type": "string",
-            "title": "Platform User Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "platform": { "type": "string", "title": "Platform" },
+          "platform_user_id": { "type": "string", "title": "Platform User Id" },
           "platform_username": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Platform Username"
           },
           "linked_at": {
@@ -19522,81 +14361,26 @@
             "title": "Recordtype",
             "default": "Bounce"
           },
-          "ID": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "Type": {
-            "type": "string",
-            "title": "Type"
-          },
-          "TypeCode": {
-            "$ref": "#/components/schemas/PostmarkBounceEnum"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "Details": {
-            "type": "string",
-            "title": "Details"
-          },
-          "Email": {
-            "type": "string",
-            "title": "Email"
-          },
-          "From": {
-            "type": "string",
-            "title": "From"
-          },
-          "BouncedAt": {
-            "type": "string",
-            "title": "Bouncedat"
-          },
-          "Inactive": {
-            "type": "boolean",
-            "title": "Inactive"
-          },
-          "DumpAvailable": {
-            "type": "boolean",
-            "title": "Dumpavailable"
-          },
-          "CanActivate": {
-            "type": "boolean",
-            "title": "Canactivate"
-          },
-          "Subject": {
-            "type": "string",
-            "title": "Subject"
-          },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "Content": {
-            "type": "string",
-            "title": "Content"
-          },
-          "Name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "Description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "ID": { "type": "integer", "title": "Id" },
+          "Type": { "type": "string", "title": "Type" },
+          "TypeCode": { "$ref": "#/components/schemas/PostmarkBounceEnum" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "Details": { "type": "string", "title": "Details" },
+          "Email": { "type": "string", "title": "Email" },
+          "From": { "type": "string", "title": "From" },
+          "BouncedAt": { "type": "string", "title": "Bouncedat" },
+          "Inactive": { "type": "boolean", "title": "Inactive" },
+          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
+          "CanActivate": { "type": "boolean", "title": "Canactivate" },
+          "Subject": { "type": "string", "title": "Subject" },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "Content": { "type": "string", "title": "Content" },
+          "Name": { "type": "string", "title": "Name" },
+          "Description": { "type": "string", "title": "Description" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -19633,67 +14417,32 @@
             "title": "Recordtype",
             "default": "Click"
           },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "ReceivedAt": {
-            "type": "string",
-            "title": "Receivedat"
-          },
-          "Platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "ClickLocation": {
-            "type": "string",
-            "title": "Clicklocation"
-          },
-          "OriginalLink": {
-            "type": "string",
-            "title": "Originallink"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "UserAgent": {
-            "type": "string",
-            "title": "Useragent"
-          },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "ReceivedAt": { "type": "string", "title": "Receivedat" },
+          "Platform": { "type": "string", "title": "Platform" },
+          "ClickLocation": { "type": "string", "title": "Clicklocation" },
+          "OriginalLink": { "type": "string", "title": "Originallink" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "UserAgent": { "type": "string", "title": "Useragent" },
           "OS": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Geo"
           }
@@ -19724,38 +14473,15 @@
             "title": "Recordtype",
             "default": "Delivery"
           },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "DeliveredAt": {
-            "type": "string",
-            "title": "Deliveredat"
-          },
-          "Details": {
-            "type": "string",
-            "title": "Details"
-          },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "DeliveredAt": { "type": "string", "title": "Deliveredat" },
+          "Details": { "type": "string", "title": "Details" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -19781,67 +14507,32 @@
             "title": "Recordtype",
             "default": "Open"
           },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           },
-          "FirstOpen": {
-            "type": "boolean",
-            "title": "Firstopen"
-          },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "ReceivedAt": {
-            "type": "string",
-            "title": "Receivedat"
-          },
-          "Platform": {
-            "type": "string",
-            "title": "Platform"
-          },
-          "ReadSeconds": {
-            "type": "integer",
-            "title": "Readseconds"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "UserAgent": {
-            "type": "string",
-            "title": "Useragent"
-          },
+          "FirstOpen": { "type": "boolean", "title": "Firstopen" },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "ReceivedAt": { "type": "string", "title": "Receivedat" },
+          "Platform": { "type": "string", "title": "Platform" },
+          "ReadSeconds": { "type": "integer", "title": "Readseconds" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "UserAgent": { "type": "string", "title": "Useragent" },
           "OS": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Os"
           },
           "Client": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Client"
           },
           "Geo": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Geo"
           }
@@ -19872,82 +14563,26 @@
             "title": "Recordtype",
             "default": "SpamComplaint"
           },
-          "ID": {
-            "type": "integer",
-            "title": "Id"
-          },
-          "Type": {
-            "type": "string",
-            "title": "Type"
-          },
-          "TypeCode": {
-            "type": "integer",
-            "title": "Typecode"
-          },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "Details": {
-            "type": "string",
-            "title": "Details"
-          },
-          "Email": {
-            "type": "string",
-            "title": "Email"
-          },
-          "From": {
-            "type": "string",
-            "title": "From"
-          },
-          "BouncedAt": {
-            "type": "string",
-            "title": "Bouncedat"
-          },
-          "Inactive": {
-            "type": "boolean",
-            "title": "Inactive"
-          },
-          "DumpAvailable": {
-            "type": "boolean",
-            "title": "Dumpavailable"
-          },
-          "CanActivate": {
-            "type": "boolean",
-            "title": "Canactivate"
-          },
-          "Subject": {
-            "type": "string",
-            "title": "Subject"
-          },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "Content": {
-            "type": "string",
-            "title": "Content"
-          },
-          "Name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "Description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "ID": { "type": "integer", "title": "Id" },
+          "Type": { "type": "string", "title": "Type" },
+          "TypeCode": { "type": "integer", "title": "Typecode" },
+          "Tag": { "type": "string", "title": "Tag" },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "Details": { "type": "string", "title": "Details" },
+          "Email": { "type": "string", "title": "Email" },
+          "From": { "type": "string", "title": "From" },
+          "BouncedAt": { "type": "string", "title": "Bouncedat" },
+          "Inactive": { "type": "boolean", "title": "Inactive" },
+          "DumpAvailable": { "type": "boolean", "title": "Dumpavailable" },
+          "CanActivate": { "type": "boolean", "title": "Canactivate" },
+          "Subject": { "type": "string", "title": "Subject" },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "Content": { "type": "string", "title": "Content" },
+          "Name": { "type": "string", "title": "Name" },
+          "Description": { "type": "string", "title": "Description" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -19984,46 +14619,20 @@
             "title": "Recordtype",
             "default": "SubscriptionChange"
           },
-          "MessageID": {
-            "type": "string",
-            "title": "Messageid"
-          },
-          "ServerID": {
-            "type": "integer",
-            "title": "Serverid"
-          },
-          "MessageStream": {
-            "type": "string",
-            "title": "Messagestream"
-          },
-          "ChangedAt": {
-            "type": "string",
-            "title": "Changedat"
-          },
-          "Recipient": {
-            "type": "string",
-            "title": "Recipient"
-          },
-          "Origin": {
-            "type": "string",
-            "title": "Origin"
-          },
-          "SuppressSending": {
-            "type": "boolean",
-            "title": "Suppresssending"
-          },
+          "MessageID": { "type": "string", "title": "Messageid" },
+          "ServerID": { "type": "integer", "title": "Serverid" },
+          "MessageStream": { "type": "string", "title": "Messagestream" },
+          "ChangedAt": { "type": "string", "title": "Changedat" },
+          "Recipient": { "type": "string", "title": "Recipient" },
+          "Origin": { "type": "string", "title": "Origin" },
+          "SuppressSending": { "type": "boolean", "title": "Suppresssending" },
           "SuppressionReason": {
             "type": "string",
             "title": "Suppressionreason"
           },
-          "Tag": {
-            "type": "string",
-            "title": "Tag"
-          },
+          "Tag": { "type": "string", "title": "Tag" },
           "Metadata": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Metadata"
           }
@@ -20045,33 +14654,15 @@
       },
       "Profile": {
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Avatar Url"
           },
           "links": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Links"
           }
@@ -20083,40 +14674,19 @@
       },
       "ProfileDetails": {
         "properties": {
-          "username": {
-            "type": "string",
-            "title": "Username"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "username": { "type": "string", "title": "Username" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
           "avatar_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Avatar Url"
           },
           "links": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Links"
           },
-          "is_featured": {
-            "type": "boolean",
-            "title": "Is Featured"
-          }
+          "is_featured": { "type": "boolean", "title": "Is Featured" }
         },
         "type": "object",
         "required": [
@@ -20137,10 +14707,7 @@
             "title": "Name",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "description": { "type": "string", "title": "Description" },
           "integration_count": {
             "type": "integer",
             "title": "Integration Count"
@@ -20153,9 +14720,7 @@
       "ProviderConstants": {
         "properties": {
           "PROVIDER_NAMES": {
-            "additionalProperties": {
-              "type": "string"
-            },
+            "additionalProperties": { "type": "string" },
             "type": "object",
             "title": "Provider Names",
             "description": "All available provider names as a constant mapping",
@@ -20176,30 +14741,13 @@
       },
       "ProviderCostSummary": {
         "properties": {
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "provider": { "type": "string", "title": "Provider" },
           "tracking_type": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Tracking Type"
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Model"
           },
           "total_cost_microdollars": {
@@ -20234,10 +14782,7 @@
             "title": "Total Tracking Amount",
             "default": 0.0
           },
-          "request_count": {
-            "type": "integer",
-            "title": "Request Count"
-          }
+          "request_count": { "type": "integer", "title": "Request Count" }
         },
         "type": "object",
         "required": [
@@ -20270,14 +14815,7 @@
             "description": "Provider slug (e.g. ``github``)"
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description",
             "description": "One-line human-readable summary of what the provider does. Declared via ``ProviderBuilder.with_description(...)`` in the provider's ``_config.py``. ``None`` if not set."
           },
@@ -20299,9 +14837,7 @@
       "ProviderNamesResponse": {
         "properties": {
           "providers": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Providers",
             "description": "List of all available provider names"
@@ -20314,15 +14850,11 @@
       "ProviderResponse": {
         "properties": {
           "providers": {
-            "items": {
-              "$ref": "#/components/schemas/Provider"
-            },
+            "items": { "$ref": "#/components/schemas/Provider" },
             "type": "array",
             "title": "Providers"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["providers", "pagination"],
@@ -20336,18 +14868,11 @@
             "minLength": 1,
             "title": "Endpoint"
           },
-          "keys": {
-            "$ref": "#/components/schemas/PushSubscriptionKeys"
-          },
+          "keys": { "$ref": "#/components/schemas/PushSubscriptionKeys" },
           "user_agent": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 512
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 512 },
+              { "type": "null" }
             ],
             "title": "User Agent"
           }
@@ -20398,29 +14923,21 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": {
-                  "type": "string"
-                },
+                "additionalProperties": { "type": "string" },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
+                "items": { "type": "string" },
                 "type": "array",
                 "maxItems": 20
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "File Ids"
           }
@@ -20432,18 +14949,12 @@
       },
       "QueuePendingMessageResponse": {
         "properties": {
-          "buffer_length": {
-            "type": "integer",
-            "title": "Buffer Length"
-          },
+          "buffer_length": { "type": "integer", "title": "Buffer Length" },
           "max_buffer_length": {
             "type": "integer",
             "title": "Max Buffer Length"
           },
-          "turn_in_flight": {
-            "type": "boolean",
-            "title": "Turn In Flight"
-          }
+          "turn_in_flight": { "type": "boolean", "title": "Turn In Flight" }
         },
         "type": "object",
         "required": ["buffer_length", "max_buffer_length", "turn_in_flight"],
@@ -20452,10 +14963,7 @@
       },
       "RateLimitResetResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "credits_charged": {
             "type": "integer",
             "title": "Credits Charged",
@@ -20483,30 +14991,13 @@
       },
       "RecentExecution": {
         "properties": {
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "correctness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Correctness Score"
           },
           "activity_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Activity Summary"
           }
         },
@@ -20517,41 +15008,16 @@
       },
       "RefundRequest": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "transaction_key": {
-            "type": "string",
-            "title": "Transaction Key"
-          },
-          "amount": {
-            "type": "integer",
-            "title": "Amount"
-          },
-          "reason": {
-            "type": "string",
-            "title": "Reason"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "transaction_key": { "type": "string", "title": "Transaction Key" },
+          "amount": { "type": "integer", "title": "Amount" },
+          "reason": { "type": "string", "title": "Reason" },
           "result": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Result"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -20578,10 +15044,7 @@
       },
       "RequestTopUp": {
         "properties": {
-          "credit_amount": {
-            "type": "integer",
-            "title": "Credit Amount"
-          }
+          "credit_amount": { "type": "integer", "title": "Credit Amount" }
         },
         "type": "object",
         "required": ["credit_amount"],
@@ -20589,19 +15052,13 @@
       },
       "RequeueExecutionResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "requeued_count": {
             "type": "integer",
             "title": "Requeued Count",
             "default": 0
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -20679,42 +15136,21 @@
           },
           "message": {
             "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 2000
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "maxLength": 2000 },
+              { "type": "null" }
             ],
             "title": "Message",
             "description": "Optional review message"
           },
           "reviewed_data": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "items": {},
-                "type": "array"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "items": {}, "type": "array" },
+              { "type": "string" },
+              { "type": "integer" },
+              { "type": "number" },
+              { "type": "boolean" },
+              { "type": "null" }
             ],
             "title": "Reviewed Data",
             "description": "Optional edited data (ignored if approved=False)"
@@ -20734,9 +15170,7 @@
       "ReviewRequest": {
         "properties": {
           "reviews": {
-            "items": {
-              "$ref": "#/components/schemas/ReviewItem"
-            },
+            "items": { "$ref": "#/components/schemas/ReviewItem" },
             "type": "array",
             "title": "Reviews",
             "description": "All reviews with their approval status, data, and messages"
@@ -20765,14 +15199,7 @@
             "description": "Number of reviews that failed processing"
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error",
             "description": "Error message if operation failed"
           }
@@ -20793,23 +15220,10 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "is_approved": {
-            "type": "boolean",
-            "title": "Is Approved"
-          },
-          "comments": {
-            "type": "string",
-            "title": "Comments"
-          },
+          "is_approved": { "type": "boolean", "title": "Is Approved" },
+          "comments": { "type": "string", "title": "Comments" },
           "internal_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Internal Comments"
           }
         },
@@ -20819,41 +15233,16 @@
       },
       "RunningExecutionDetail": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "execution_id": { "type": "string", "title": "Execution Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
-          "status": {
-            "type": "string",
-            "title": "Status"
-          },
+          "status": { "type": "string", "title": "Status" },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -20861,25 +15250,13 @@
           },
           "started_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Started At"
           },
           "queue_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Queue Status"
           }
         },
@@ -20901,16 +15278,11 @@
       "RunningExecutionsListResponse": {
         "properties": {
           "executions": {
-            "items": {
-              "$ref": "#/components/schemas/RunningExecutionDetail"
-            },
+            "items": { "$ref": "#/components/schemas/RunningExecutionDetail" },
             "type": "array",
             "title": "Executions"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["executions", "total"],
@@ -20920,9 +15292,7 @@
       "ScheduleCleanupRequest": {
         "properties": {
           "schedule_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Schedule Ids"
           }
@@ -20934,19 +15304,13 @@
       },
       "ScheduleCleanupResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "deleted_count": {
             "type": "integer",
             "title": "Deleted Count",
             "default": 0
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -20956,24 +15320,11 @@
       "ScheduleCreationRequest": {
         "properties": {
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "cron": {
-            "type": "string",
-            "title": "Cron"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "cron": { "type": "string", "title": "Cron" },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -20987,14 +15338,7 @@
             "title": "Credentials"
           },
           "timezone": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Timezone",
             "description": "User's timezone for scheduling (e.g., 'America/New_York'). If not provided, will use user's saved timezone or UTC."
           }
@@ -21005,62 +15349,23 @@
       },
       "ScheduleDetail": {
         "properties": {
-          "schedule_id": {
-            "type": "string",
-            "title": "Schedule Id"
-          },
-          "schedule_name": {
-            "type": "string",
-            "title": "Schedule Name"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "schedule_id": { "type": "string", "title": "Schedule Id" },
+          "schedule_name": { "type": "string", "title": "Schedule Name" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
-          "cron": {
-            "type": "string",
-            "title": "Cron"
-          },
-          "timezone": {
-            "type": "string",
-            "title": "Timezone"
-          },
-          "next_run_time": {
-            "type": "string",
-            "title": "Next Run Time"
-          },
+          "cron": { "type": "string", "title": "Cron" },
+          "timezone": { "type": "string", "title": "Timezone" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
           "created_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Created At"
           }
@@ -21083,14 +15388,8 @@
       },
       "ScheduleHealthMetrics": {
         "properties": {
-          "total_schedules": {
-            "type": "integer",
-            "title": "Total Schedules"
-          },
-          "user_schedules": {
-            "type": "integer",
-            "title": "User Schedules"
-          },
+          "total_schedules": { "type": "integer", "title": "Total Schedules" },
+          "user_schedules": { "type": "integer", "title": "User Schedules" },
           "system_schedules": {
             "type": "integer",
             "title": "System Schedules"
@@ -21111,10 +15410,7 @@
             "type": "integer",
             "title": "Orphaned Validation Failed"
           },
-          "total_orphaned": {
-            "type": "integer",
-            "title": "Total Orphaned"
-          },
+          "total_orphaned": { "type": "integer", "title": "Total Orphaned" },
           "schedules_next_hour": {
             "type": "integer",
             "title": "Schedules Next Hour"
@@ -21131,10 +15427,7 @@
             "type": "integer",
             "title": "Total Runs Next 24H"
           },
-          "timestamp": {
-            "type": "string",
-            "title": "Timestamp"
-          }
+          "timestamp": { "type": "string", "title": "Timestamp" }
         },
         "type": "object",
         "required": [
@@ -21158,16 +15451,11 @@
       "SchedulesListResponse": {
         "properties": {
           "schedules": {
-            "items": {
-              "$ref": "#/components/schemas/ScheduleDetail"
-            },
+            "items": { "$ref": "#/components/schemas/ScheduleDetail" },
             "type": "array",
             "title": "Schedules"
           },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          }
+          "total": { "type": "integer", "title": "Total" }
         },
         "type": "object",
         "required": ["schedules", "total"],
@@ -21177,14 +15465,7 @@
       "SearchEntry": {
         "properties": {
           "search_query": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Search Query"
           },
           "filter": {
@@ -21201,35 +15482,19 @@
                 },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Filter"
           },
           "by_creator": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "By Creator"
           },
           "search_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Search Id"
           }
         },
@@ -21241,28 +15506,17 @@
           "items": {
             "items": {
               "anyOf": [
-                {
-                  "$ref": "#/components/schemas/BlockInfo"
-                },
-                {
-                  "$ref": "#/components/schemas/LibraryAgent"
-                },
-                {
-                  "$ref": "#/components/schemas/StoreAgent"
-                }
+                { "$ref": "#/components/schemas/BlockInfo" },
+                { "$ref": "#/components/schemas/LibraryAgent" },
+                { "$ref": "#/components/schemas/StoreAgent" }
               ]
             },
             "type": "array",
             "title": "Items"
           },
-          "search_id": {
-            "type": "string",
-            "title": "Search Id"
-          },
+          "search_id": { "type": "string", "title": "Search Id" },
           "total_items": {
-            "additionalProperties": {
-              "type": "integer"
-            },
+            "additionalProperties": { "type": "integer" },
             "propertyNames": {
               "enum": [
                 "blocks",
@@ -21274,9 +15528,7 @@
             "type": "object",
             "title": "Total Items"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["items", "search_id", "total_items", "pagination"],
@@ -21284,45 +15536,22 @@
       },
       "SessionDetailResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "title": "Updated At"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "created_at": { "type": "string", "title": "Created At" },
+          "updated_at": { "type": "string", "title": "Updated At" },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "messages": {
-            "items": {
-              "additionalProperties": true,
-              "type": "object"
-            },
+            "items": { "additionalProperties": true, "type": "object" },
             "type": "array",
             "title": "Messages"
           },
           "active_stream": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/ActiveStreamInfo"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/ActiveStreamInfo" },
+              { "type": "null" }
             ]
           },
           "has_more_messages": {
@@ -21331,14 +15560,7 @@
             "default": false
           },
           "oldest_sequence": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Oldest Sequence"
           },
           "total_prompt_tokens": {
@@ -21353,9 +15575,7 @@
           },
           "metadata": {
             "$ref": "#/components/schemas/ChatSessionMetadata",
-            "default": {
-              "dry_run": false
-            }
+            "default": { "dry_run": false }
           }
         },
         "type": "object",
@@ -21365,33 +15585,14 @@
       },
       "SessionSummaryResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          },
-          "updated_at": {
-            "type": "string",
-            "title": "Updated At"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "created_at": { "type": "string", "title": "Created At" },
+          "updated_at": { "type": "string", "title": "Updated At" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
-          "is_processing": {
-            "type": "boolean",
-            "title": "Is Processing"
-          }
+          "is_processing": { "type": "boolean", "title": "Is Processing" }
         },
         "type": "object",
         "required": ["id", "created_at", "updated_at", "is_processing"],
@@ -21411,13 +15612,8 @@
       },
       "SetUserTierRequest": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "tier": {
-            "$ref": "#/components/schemas/SubscriptionTier"
-          }
+          "user_id": { "type": "string", "title": "User Id" },
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
         },
         "type": "object",
         "required": ["user_id", "tier"],
@@ -21425,25 +15621,14 @@
       },
       "SetupInfo": {
         "properties": {
-          "agent_id": {
-            "type": "string",
-            "title": "Agent Id"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
+          "agent_id": { "type": "string", "title": "Agent Id" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
           "requirements": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Requirements"
           },
-          "user_readiness": {
-            "$ref": "#/components/schemas/UserReadiness"
-          }
+          "user_readiness": { "$ref": "#/components/schemas/UserReadiness" }
         },
         "type": "object",
         "required": ["agent_id", "agent_name"],
@@ -21456,44 +15641,18 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "setup_requirements"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
-          "setup_info": {
-            "$ref": "#/components/schemas/SetupInfo"
-          },
+          "setup_info": { "$ref": "#/components/schemas/SetupInfo" },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Id"
           },
           "graph_version": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Graph Version"
           }
         },
@@ -21510,14 +15669,8 @@
       },
       "ShareResponse": {
         "properties": {
-          "share_url": {
-            "type": "string",
-            "title": "Share Url"
-          },
-          "share_token": {
-            "type": "string",
-            "title": "Share Token"
-          }
+          "share_url": { "type": "string", "title": "Share Url" },
+          "share_token": { "type": "string", "title": "Share Token" }
         },
         "type": "object",
         "required": ["share_url", "share_token"],
@@ -21526,38 +15679,20 @@
       },
       "SharedExecutionResponse": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "graph_name": {
-            "type": "string",
-            "title": "Graph Name"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "graph_name": { "type": "string", "title": "Graph Name" },
           "graph_description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Graph Description"
           },
-          "status": {
-            "$ref": "#/components/schemas/AgentExecutionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/AgentExecutionStatus" },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
           "outputs": {
-            "additionalProperties": {
-              "items": {},
-              "type": "array"
-            },
+            "additionalProperties": { "items": {}, "type": "array" },
             "type": "object",
             "title": "Outputs"
           }
@@ -21619,38 +15754,17 @@
             "default": 0
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Error",
             "description": "Error message if any"
           },
           "activity_status": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Activity Status",
             "description": "AI-generated summary of what the agent did"
           },
           "correctness_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Correctness Score",
             "description": "AI-generated score (0.0-1.0) indicating how well the execution achieved its intended purpose"
           }
@@ -21661,10 +15775,7 @@
       },
       "StopExecutionRequest": {
         "properties": {
-          "execution_id": {
-            "type": "string",
-            "title": "Execution Id"
-          }
+          "execution_id": { "type": "string", "title": "Execution Id" }
         },
         "type": "object",
         "required": ["execution_id"],
@@ -21673,19 +15784,13 @@
       },
       "StopExecutionResponse": {
         "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
+          "success": { "type": "boolean", "title": "Success" },
           "stopped_count": {
             "type": "integer",
             "title": "Stopped Count",
             "default": 0
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
+          "message": { "type": "string", "title": "Message" }
         },
         "type": "object",
         "required": ["success", "message"],
@@ -21695,9 +15800,7 @@
       "StopExecutionsRequest": {
         "properties": {
           "execution_ids": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Execution Ids"
           }
@@ -21709,22 +15812,10 @@
       },
       "StorageUsageResponse": {
         "properties": {
-          "used_bytes": {
-            "type": "integer",
-            "title": "Used Bytes"
-          },
-          "limit_bytes": {
-            "type": "integer",
-            "title": "Limit Bytes"
-          },
-          "used_percent": {
-            "type": "number",
-            "title": "Used Percent"
-          },
-          "file_count": {
-            "type": "integer",
-            "title": "File Count"
-          }
+          "used_bytes": { "type": "integer", "title": "Used Bytes" },
+          "limit_bytes": { "type": "integer", "title": "Limit Bytes" },
+          "used_percent": { "type": "number", "title": "Used Percent" },
+          "file_count": { "type": "integer", "title": "File Count" }
         },
         "type": "object",
         "required": ["used_bytes", "limit_bytes", "used_percent", "file_count"],
@@ -21732,46 +15823,16 @@
       },
       "StoreAgent": {
         "properties": {
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "agent_image": {
-            "type": "string",
-            "title": "Agent Image"
-          },
-          "creator": {
-            "type": "string",
-            "title": "Creator"
-          },
-          "creator_avatar": {
-            "type": "string",
-            "title": "Creator Avatar"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
-          "runs": {
-            "type": "integer",
-            "title": "Runs"
-          },
-          "rating": {
-            "type": "number",
-            "title": "Rating"
-          },
-          "agent_graph_id": {
-            "type": "string",
-            "title": "Agent Graph Id"
-          }
+          "slug": { "type": "string", "title": "Slug" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_image": { "type": "string", "title": "Agent Image" },
+          "creator": { "type": "string", "title": "Creator" },
+          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
+          "runs": { "type": "integer", "title": "Runs" },
+          "rating": { "type": "number", "title": "Rating" },
+          "agent_graph_id": { "type": "string", "title": "Agent Graph Id" }
         },
         "type": "object",
         "required": [
@@ -21794,86 +15855,41 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "agent_name": {
-            "type": "string",
-            "title": "Agent Name"
-          },
-          "agent_video": {
-            "type": "string",
-            "title": "Agent Video"
-          },
+          "slug": { "type": "string", "title": "Slug" },
+          "agent_name": { "type": "string", "title": "Agent Name" },
+          "agent_video": { "type": "string", "title": "Agent Video" },
           "agent_output_demo": {
             "type": "string",
             "title": "Agent Output Demo"
           },
           "agent_image": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Agent Image"
           },
-          "creator": {
-            "type": "string",
-            "title": "Creator"
-          },
-          "creator_avatar": {
-            "type": "string",
-            "title": "Creator Avatar"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "creator": { "type": "string", "title": "Creator" },
+          "creator_avatar": { "type": "string", "title": "Creator Avatar" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
-          "runs": {
-            "type": "integer",
-            "title": "Runs"
-          },
-          "rating": {
-            "type": "number",
-            "title": "Rating"
-          },
+          "runs": { "type": "integer", "title": "Runs" },
+          "rating": { "type": "number", "title": "Rating" },
           "versions": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Versions"
           },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
           "graph_versions": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Graph Versions"
           },
@@ -21883,14 +15899,7 @@
             "title": "Last Updated"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           },
           "active_version_id": {
@@ -21904,14 +15913,10 @@
           "changelog": {
             "anyOf": [
               {
-                "items": {
-                  "$ref": "#/components/schemas/ChangelogEntry"
-                },
+                "items": { "$ref": "#/components/schemas/ChangelogEntry" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Changelog"
           }
@@ -21943,15 +15948,11 @@
       "StoreAgentsResponse": {
         "properties": {
           "agents": {
-            "items": {
-              "$ref": "#/components/schemas/StoreAgent"
-            },
+            "items": { "$ref": "#/components/schemas/StoreAgent" },
             "type": "array",
             "title": "Agents"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["agents", "pagination"],
@@ -21969,27 +15970,11 @@
       },
       "StoreListingWithVersionsAdminView": {
         "properties": {
-          "listing_id": {
-            "type": "string",
-            "title": "Listing Id"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "listing_id": { "type": "string", "title": "Listing Id" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "slug": { "type": "string", "title": "Slug" },
           "active_listing_version_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Active Listing Version Id"
           },
           "has_approved_version": {
@@ -21998,24 +15983,13 @@
             "default": false
           },
           "creator_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Creator Email"
           },
           "latest_version": {
             "anyOf": [
-              {
-                "$ref": "#/components/schemas/StoreSubmissionAdminView"
-              },
-              {
-                "type": "null"
-              }
+              { "$ref": "#/components/schemas/StoreSubmissionAdminView" },
+              { "type": "null" }
             ]
           },
           "versions": {
@@ -22041,9 +16015,7 @@
             "type": "array",
             "title": "Listings"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["listings", "pagination"],
@@ -22052,19 +16024,9 @@
       },
       "StoreReview": {
         "properties": {
-          "score": {
-            "type": "integer",
-            "title": "Score"
-          },
+          "score": { "type": "integer", "title": "Score" },
           "comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Comments"
           }
         },
@@ -22078,19 +16040,9 @@
             "type": "string",
             "title": "Store Listing Version Id"
           },
-          "score": {
-            "type": "integer",
-            "title": "Score"
-          },
+          "score": { "type": "integer", "title": "Score" },
           "comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Comments"
           }
         },
@@ -22100,151 +16052,66 @@
       },
       "StoreSubmission": {
         "properties": {
-          "listing_id": {
-            "type": "string",
-            "title": "Listing Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "listing_id": { "type": "string", "title": "Listing Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "slug": { "type": "string", "title": "Slug" },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": {
-            "type": "integer",
-            "title": "Listing Version"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "listing_version": { "type": "integer", "title": "Listing Version" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
-          "status": {
-            "$ref": "#/components/schemas/SubmissionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
           "reviewed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Review Comments"
           },
           "run_count": {
@@ -22288,151 +16155,66 @@
       },
       "StoreSubmissionAdminView": {
         "properties": {
-          "listing_id": {
-            "type": "string",
-            "title": "Listing Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
+          "listing_id": { "type": "string", "title": "Listing Id" },
+          "user_id": { "type": "string", "title": "User Id" },
+          "slug": { "type": "string", "title": "Slug" },
           "listing_version_id": {
             "type": "string",
             "title": "Listing Version Id"
           },
-          "listing_version": {
-            "type": "integer",
-            "title": "Listing Version"
-          },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
-          "description": {
-            "type": "string",
-            "title": "Description"
-          },
+          "listing_version": { "type": "integer", "title": "Listing Version" },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "description": { "type": "string", "title": "Description" },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls"
           },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "submitted_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Submitted At"
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
-          "status": {
-            "$ref": "#/components/schemas/SubmissionStatus"
-          },
+          "status": { "$ref": "#/components/schemas/SubmissionStatus" },
           "reviewed_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Reviewed At"
           },
           "reviewer_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reviewer Id"
           },
           "review_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Review Comments"
           },
           "run_count": {
@@ -22451,14 +16233,7 @@
             "default": 0.0
           },
           "internal_comments": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Internal Comments"
           }
         },
@@ -22488,40 +16263,18 @@
       },
       "StoreSubmissionEditRequest": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -22532,44 +16285,21 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -22591,44 +16321,19 @@
             "title": "Graph Version",
             "description": "Graph version must be greater than 0"
           },
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "sub_heading": {
-            "type": "string",
-            "title": "Sub Heading"
-          },
+          "slug": { "type": "string", "title": "Slug" },
+          "name": { "type": "string", "title": "Name" },
+          "sub_heading": { "type": "string", "title": "Sub Heading" },
           "video_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
           },
           "agent_output_demo_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Agent Output Demo Url"
           },
           "image_urls": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Image Urls",
             "default": []
@@ -22639,44 +16344,21 @@
             "default": ""
           },
           "instructions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Instructions"
           },
           "categories": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Categories",
             "default": []
           },
           "changes_summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Changes Summary"
           },
           "recommended_schedule_cron": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Recommended Schedule Cron"
           }
         },
@@ -22693,15 +16375,11 @@
       "StoreSubmissionsResponse": {
         "properties": {
           "submissions": {
-            "items": {
-              "$ref": "#/components/schemas/StoreSubmission"
-            },
+            "items": { "$ref": "#/components/schemas/StoreSubmission" },
             "type": "array",
             "title": "Submissions"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["submissions", "pagination"],
@@ -22722,54 +16400,36 @@
           "context": {
             "anyOf": [
               {
-                "additionalProperties": {
-                  "type": "string"
-                },
+                "additionalProperties": { "type": "string" },
                 "type": "object"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Context"
           },
           "file_ids": {
             "anyOf": [
               {
-                "items": {
-                  "type": "string"
-                },
+                "items": { "type": "string" },
                 "type": "array",
                 "maxItems": 20
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "File Ids"
           },
           "mode": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["fast", "extended_thinking"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["fast", "extended_thinking"] },
+              { "type": "null" }
             ],
             "title": "Mode",
             "description": "Autopilot mode: 'fast' for baseline LLM, 'extended_thinking' for Claude Agent SDK. If None, uses the server default (extended_thinking)."
           },
           "model": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["standard", "advanced"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["standard", "advanced"] },
+              { "type": "null" }
             ],
             "title": "Model",
             "description": "Model tier: 'standard' for the default model, 'advanced' for the highest-capability model. If None, the server applies per-user LD targeting then falls back to config."
@@ -22799,21 +16459,14 @@
             ],
             "title": "Tier"
           },
-          "monthly_cost": {
-            "type": "integer",
-            "title": "Monthly Cost"
-          },
+          "monthly_cost": { "type": "integer", "title": "Monthly Cost" },
           "tier_costs": {
-            "additionalProperties": {
-              "type": "integer"
-            },
+            "additionalProperties": { "type": "integer" },
             "type": "object",
             "title": "Tier Costs"
           },
           "tier_multipliers": {
-            "additionalProperties": {
-              "type": "number"
-            },
+            "additionalProperties": { "type": "number" },
             "type": "object",
             "title": "Tier Multipliers",
             "description": "Tier → rate-limit multiplier. Covers the same tiers listed in ``tier_costs`` so the frontend can render rate-limit badges relative to the lowest visible tier without knowing backend defaults."
@@ -22829,14 +16482,7 @@
             "default": false
           },
           "current_period_end": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Current Period End",
             "description": "Unix timestamp of the active subscription's current_period_end. Used to show the date Stripe will issue the next invoice (with prorated upgrade charges, if any). None when no active sub."
           },
@@ -22846,21 +16492,14 @@
                 "type": "string",
                 "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS"]
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Pending Tier"
           },
           "pending_tier_effective_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Pending Tier Effective At"
           },
@@ -22914,19 +16553,9 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "suggested_goal"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "suggested_goal": {
@@ -22962,9 +16591,7 @@
       "SuggestedPromptsResponse": {
         "properties": {
           "themes": {
-            "items": {
-              "$ref": "#/components/schemas/SuggestedTheme"
-            },
+            "items": { "$ref": "#/components/schemas/SuggestedTheme" },
             "type": "array",
             "title": "Themes"
           }
@@ -22976,14 +16603,9 @@
       },
       "SuggestedTheme": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "prompts": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Prompts"
           }
@@ -22996,9 +16618,7 @@
       "SuggestionsResponse": {
         "properties": {
           "recent_searches": {
-            "items": {
-              "$ref": "#/components/schemas/SearchEntry"
-            },
+            "items": { "$ref": "#/components/schemas/SearchEntry" },
             "type": "array",
             "title": "Recent Searches"
           },
@@ -23011,9 +16631,7 @@
             "title": "Providers"
           },
           "top_blocks": {
-            "items": {
-              "$ref": "#/components/schemas/BlockInfo"
-            },
+            "items": { "$ref": "#/components/schemas/BlockInfo" },
             "type": "array",
             "title": "Top Blocks"
           }
@@ -23629,9 +17247,7 @@
                 ],
                 "minLength": 1
               },
-              {
-                "type": "string"
-              }
+              { "type": "string" }
             ],
             "title": "Timezone"
           }
@@ -23670,25 +17286,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "todo_write"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "todos": {
-            "items": {
-              "$ref": "#/components/schemas/TodoItem"
-            },
+            "items": { "$ref": "#/components/schemas/TodoItem" },
             "type": "array",
             "title": "Todos"
           }
@@ -23700,66 +17304,30 @@
       },
       "TokenIntrospectionResult": {
         "properties": {
-          "active": {
-            "type": "boolean",
-            "title": "Active"
-          },
+          "active": { "type": "boolean", "title": "Active" },
           "scopes": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "Scopes"
           },
           "client_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Client Id"
           },
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "exp": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
             "title": "Exp"
           },
           "token_type": {
             "anyOf": [
-              {
-                "type": "string",
-                "enum": ["access_token", "refresh_token"]
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "enum": ["access_token", "refresh_token"] },
+              { "type": "null" }
             ],
             "title": "Token Type"
           }
@@ -23786,14 +17354,8 @@
             "title": "Redirect Uri",
             "description": "Redirect URI (must match authorization request)"
           },
-          "client_id": {
-            "type": "string",
-            "title": "Client Id"
-          },
-          "client_secret": {
-            "type": "string",
-            "title": "Client Secret"
-          },
+          "client_id": { "type": "string", "title": "Client Id" },
+          "client_secret": { "type": "string", "title": "Client Secret" },
           "code_verifier": {
             "type": "string",
             "title": "Code Verifier",
@@ -23818,18 +17380,9 @@
             "const": "refresh_token",
             "title": "Grant Type"
           },
-          "refresh_token": {
-            "type": "string",
-            "title": "Refresh Token"
-          },
-          "client_id": {
-            "type": "string",
-            "title": "Client Id"
-          },
-          "client_secret": {
-            "type": "string",
-            "title": "Client Secret"
-          }
+          "refresh_token": { "type": "string", "title": "Refresh Token" },
+          "client_id": { "type": "string", "title": "Client Id" },
+          "client_secret": { "type": "string", "title": "Client Secret" }
         },
         "type": "object",
         "required": [
@@ -23848,28 +17401,20 @@
             "title": "Token Type",
             "default": "Bearer"
           },
-          "access_token": {
-            "type": "string",
-            "title": "Access Token"
-          },
+          "access_token": { "type": "string", "title": "Access Token" },
           "access_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Access Token Expires At"
           },
-          "refresh_token": {
-            "type": "string",
-            "title": "Refresh Token"
-          },
+          "refresh_token": { "type": "string", "title": "Refresh Token" },
           "refresh_token_expires_at": {
             "type": "string",
             "format": "date-time",
             "title": "Refresh Token Expires At"
           },
           "scopes": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Scopes"
           }
@@ -23888,21 +17433,14 @@
       "TransactionHistory": {
         "properties": {
           "transactions": {
-            "items": {
-              "$ref": "#/components/schemas/UserTransaction"
-            },
+            "items": { "$ref": "#/components/schemas/UserTransaction" },
             "type": "array",
             "title": "Transactions"
           },
           "next_transaction_time": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Next Transaction Time"
           }
@@ -23913,23 +17451,14 @@
       },
       "TriggeredPresetSetupRequest": {
         "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
+          "name": { "type": "string", "title": "Name" },
           "description": {
             "type": "string",
             "title": "Description",
             "default": ""
           },
-          "graph_id": {
-            "type": "string",
-            "title": "Graph Id"
-          },
-          "graph_version": {
-            "type": "integer",
-            "title": "Graph Version"
-          },
+          "graph_id": { "type": "string", "title": "Graph Id" },
+          "graph_version": { "type": "integer", "title": "Graph Version" },
           "trigger_config": {
             "additionalProperties": true,
             "type": "object",
@@ -23953,25 +17482,13 @@
             "$ref": "#/components/schemas/ResponseType",
             "default": "understanding_updated"
           },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
+          "message": { "type": "string", "title": "Message" },
           "session_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Session Id"
           },
           "updated_fields": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Updated Fields"
           },
@@ -23989,15 +17506,11 @@
       "UnifiedSearchResponse": {
         "properties": {
           "results": {
-            "items": {
-              "$ref": "#/components/schemas/UnifiedSearchResult"
-            },
+            "items": { "$ref": "#/components/schemas/UnifiedSearchResult" },
             "type": "array",
             "title": "Results"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["results", "pagination"],
@@ -24006,73 +17519,33 @@
       },
       "UnifiedSearchResult": {
         "properties": {
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
-          "content_id": {
-            "type": "string",
-            "title": "Content Id"
-          },
-          "searchable_text": {
-            "type": "string",
-            "title": "Searchable Text"
-          },
+          "content_type": { "type": "string", "title": "Content Type" },
+          "content_id": { "type": "string", "title": "Content Id" },
+          "searchable_text": { "type": "string", "title": "Searchable Text" },
           "metadata": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Metadata"
           },
           "updated_at": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Updated At"
           },
           "combined_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Combined Score"
           },
           "semantic_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Semantic Score"
           },
           "lexical_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "number" }, { "type": "null" }],
             "title": "Lexical Score"
           }
         },
@@ -24096,9 +17569,7 @@
       "UpdatePermissionsRequest": {
         "properties": {
           "permissions": {
-            "items": {
-              "$ref": "#/components/schemas/APIKeyPermission"
-            },
+            "items": { "$ref": "#/components/schemas/APIKeyPermission" },
             "type": "array",
             "title": "Permissions"
           }
@@ -24108,12 +17579,7 @@
         "title": "UpdatePermissionsRequest"
       },
       "UpdateSessionTitleRequest": {
-        "properties": {
-          "title": {
-            "type": "string",
-            "title": "Title"
-          }
-        },
+        "properties": { "title": { "type": "string", "title": "Title" } },
         "type": "object",
         "required": ["title"],
         "title": "UpdateSessionTitleRequest",
@@ -24753,25 +18219,11 @@
       "UserCostSummary": {
         "properties": {
           "user_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Id"
           },
           "email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Email"
           },
           "total_cost_microdollars": {
@@ -24796,10 +18248,7 @@
             "title": "Total Cache Creation Tokens",
             "default": 0
           },
-          "request_count": {
-            "type": "integer",
-            "title": "Request Count"
-          },
+          "request_count": { "type": "integer", "title": "Request Count" },
           "cost_bearing_request_count": {
             "type": "integer",
             "title": "Cost Bearing Request Count",
@@ -24818,15 +18267,11 @@
       "UserHistoryResponse": {
         "properties": {
           "history": {
-            "items": {
-              "$ref": "#/components/schemas/UserTransaction"
-            },
+            "items": { "$ref": "#/components/schemas/UserTransaction" },
             "type": "array",
             "title": "History"
           },
-          "pagination": {
-            "$ref": "#/components/schemas/Pagination"
-          }
+          "pagination": { "$ref": "#/components/schemas/Pagination" }
         },
         "type": "object",
         "required": ["history", "pagination"],
@@ -24835,111 +18280,56 @@
       },
       "UserOnboarding": {
         "properties": {
-          "userId": {
-            "type": "string",
-            "title": "Userid"
-          },
+          "userId": { "type": "string", "title": "Userid" },
           "completedSteps": {
-            "items": {
-              "$ref": "#/components/schemas/OnboardingStep"
-            },
+            "items": { "$ref": "#/components/schemas/OnboardingStep" },
             "type": "array",
             "title": "Completedsteps"
           },
-          "walletShown": {
-            "type": "boolean",
-            "title": "Walletshown"
-          },
+          "walletShown": { "type": "boolean", "title": "Walletshown" },
           "notified": {
-            "items": {
-              "$ref": "#/components/schemas/OnboardingStep"
-            },
+            "items": { "$ref": "#/components/schemas/OnboardingStep" },
             "type": "array",
             "title": "Notified"
           },
           "rewardedFor": {
-            "items": {
-              "$ref": "#/components/schemas/OnboardingStep"
-            },
+            "items": { "$ref": "#/components/schemas/OnboardingStep" },
             "type": "array",
             "title": "Rewardedfor"
           },
           "usageReason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usagereason"
           },
           "integrations": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Onboardingagentexecutionid"
           },
-          "agentRuns": {
-            "type": "integer",
-            "title": "Agentruns"
-          },
+          "agentRuns": { "type": "integer", "title": "Agentruns" },
           "lastRunAt": {
             "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
             ],
             "title": "Lastrunat"
           },
@@ -24970,98 +18360,47 @@
       "UserOnboardingUpdate": {
         "properties": {
           "walletShown": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "boolean" }, { "type": "null" }],
             "title": "Walletshown"
           },
           "notified": {
             "anyOf": [
               {
-                "items": {
-                  "$ref": "#/components/schemas/OnboardingStep"
-                },
+                "items": { "$ref": "#/components/schemas/OnboardingStep" },
                 "type": "array"
               },
-              {
-                "type": "null"
-              }
+              { "type": "null" }
             ],
             "title": "Notified"
           },
           "usageReason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usagereason"
           },
           "integrations": {
             "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
             ],
             "title": "Integrations"
           },
           "otherIntegrations": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Otherintegrations"
           },
           "selectedStoreListingVersionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Selectedstorelistingversionid"
           },
           "agentInput": {
             "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
+              { "additionalProperties": true, "type": "object" },
+              { "type": "null" }
             ],
             "title": "Agentinput"
           },
           "onboardingAgentExecutionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Onboardingagentexecutionid"
           }
         },
@@ -25070,23 +18409,10 @@
       },
       "UserPasswordCredentials": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "provider": { "type": "string", "title": "Provider" },
           "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Title"
           },
           "is_managed": {
@@ -25124,19 +18450,9 @@
       },
       "UserRateLimitResponse": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
           "daily_cost_limit_microdollars": {
@@ -25155,9 +18471,7 @@
             "type": "integer",
             "title": "Weekly Cost Used Microdollars"
           },
-          "tier": {
-            "$ref": "#/components/schemas/SubscriptionTier"
-          }
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
         },
         "type": "object",
         "required": [
@@ -25195,19 +18509,9 @@
       },
       "UserSearchResult": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           }
         },
@@ -25217,13 +18521,8 @@
       },
       "UserTierResponse": {
         "properties": {
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
-          "tier": {
-            "$ref": "#/components/schemas/SubscriptionTier"
-          }
+          "user_id": { "type": "string", "title": "User Id" },
+          "tier": { "$ref": "#/components/schemas/SubscriptionTier" }
         },
         "type": "object",
         "required": ["user_id", "tier"],
@@ -25246,11 +18545,7 @@
             "$ref": "#/components/schemas/CreditTransactionType",
             "default": "USAGE"
           },
-          "amount": {
-            "type": "integer",
-            "title": "Amount",
-            "default": 0
-          },
+          "amount": { "type": "integer", "title": "Amount", "default": 0 },
           "running_balance": {
             "type": "integer",
             "title": "Running Balance",
@@ -25262,36 +18557,15 @@
             "default": 0
           },
           "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
           },
           "usage_graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usage Graph Id"
           },
           "usage_execution_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Usage Execution Id"
           },
           "usage_node_count": {
@@ -25305,52 +18579,21 @@
             "title": "Usage Start Time",
             "default": "9999-12-31T23:59:59.999999Z"
           },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "user_id": { "type": "string", "title": "User Id" },
           "user_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "User Email"
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Reason"
           },
           "admin_email": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Admin Email"
           },
           "extra_data": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Extra Data"
           }
         },
@@ -25361,34 +18604,14 @@
       "ValidationError": {
         "properties": {
           "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
             "type": "array",
             "title": "Location"
           },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          },
-          "input": {
-            "title": "Input"
-          },
-          "ctx": {
-            "type": "object",
-            "title": "Context"
-          }
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" },
+          "input": { "title": "Input" },
+          "ctx": { "type": "object", "title": "Context" }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],
@@ -25396,10 +18619,7 @@
       },
       "VapidPublicKeyResponse": {
         "properties": {
-          "public_key": {
-            "type": "string",
-            "title": "Public Key"
-          }
+          "public_key": { "type": "string", "title": "Public Key" }
         },
         "type": "object",
         "required": ["public_key"],
@@ -25407,35 +18627,18 @@
       },
       "Webhook": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "user_id": {
-            "type": "string",
-            "title": "User Id"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "user_id": { "type": "string", "title": "User Id" },
           "provider": {
             "type": "string",
             "title": "Provider",
             "description": "Provider name for integrations. Can be any string value, including custom provider names."
           },
-          "credentials_id": {
-            "type": "string",
-            "title": "Credentials Id"
-          },
-          "webhook_type": {
-            "type": "string",
-            "title": "Webhook Type"
-          },
-          "resource": {
-            "type": "string",
-            "title": "Resource"
-          },
+          "credentials_id": { "type": "string", "title": "Credentials Id" },
+          "webhook_type": { "type": "string", "title": "Webhook Type" },
+          "resource": { "type": "string", "title": "Resource" },
           "events": {
-            "items": {
-              "type": "string"
-            },
+            "items": { "type": "string" },
             "type": "array",
             "title": "Events"
           },
@@ -25444,19 +18647,12 @@
             "type": "object",
             "title": "Config"
           },
-          "secret": {
-            "type": "string",
-            "title": "Secret"
-          },
+          "secret": { "type": "string", "title": "Secret" },
           "provider_webhook_id": {
             "type": "string",
             "title": "Provider Webhook Id"
           },
-          "url": {
-            "type": "string",
-            "title": "Url",
-            "readOnly": true
-          }
+          "url": { "type": "string", "title": "Url", "readOnly": true }
         },
         "type": "object",
         "required": [
@@ -25474,35 +18670,17 @@
       },
       "WorkspaceFileItem": {
         "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "path": { "type": "string", "title": "Path" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" },
           "metadata": {
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
           },
-          "created_at": {
-            "type": "string",
-            "title": "Created At"
-          }
+          "created_at": { "type": "string", "title": "Created At" }
         },
         "type": "object",
         "required": [
@@ -25517,26 +18695,11 @@
       },
       "backend__api__features__workspace__routes__UploadFileResponse": {
         "properties": {
-          "file_id": {
-            "type": "string",
-            "title": "File Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "mime_type": {
-            "type": "string",
-            "title": "Mime Type"
-          },
-          "size_bytes": {
-            "type": "integer",
-            "title": "Size Bytes"
-          }
+          "file_id": { "type": "string", "title": "File Id" },
+          "name": { "type": "string", "title": "Name" },
+          "path": { "type": "string", "title": "Path" },
+          "mime_type": { "type": "string", "title": "Mime Type" },
+          "size_bytes": { "type": "integer", "title": "Size Bytes" }
         },
         "type": "object",
         "required": ["file_id", "name", "path", "mime_type", "size_bytes"],
@@ -25544,26 +18707,11 @@
       },
       "backend__api__model__UploadFileResponse": {
         "properties": {
-          "file_uri": {
-            "type": "string",
-            "title": "File Uri"
-          },
-          "file_name": {
-            "type": "string",
-            "title": "File Name"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "content_type": {
-            "type": "string",
-            "title": "Content Type"
-          },
-          "expires_in_hours": {
-            "type": "integer",
-            "title": "Expires In Hours"
-          }
+          "file_uri": { "type": "string", "title": "File Uri" },
+          "file_name": { "type": "string", "title": "File Name" },
+          "size": { "type": "integer", "title": "Size" },
+          "content_type": { "type": "string", "title": "Content Type" },
+          "expires_in_hours": { "type": "integer", "title": "Expires In Hours" }
         },
         "type": "object",
         "required": [
@@ -25582,10 +18730,7 @@
         "in": "header",
         "name": "X-Postmark-Webhook-Token"
       },
-      "HTTPBearer": {
-        "type": "http",
-        "scheme": "bearer"
-      },
+      "HTTPBearer": { "type": "http", "scheme": "bearer" },
       "HTTPBearerJWT": {
         "type": "http",
         "scheme": "bearer",
@@ -25599,11 +18744,7 @@
           "application/json": {
             "schema": {
               "type": "object",
-              "properties": {
-                "detail": {
-                  "type": "string"
-                }
-              }
+              "properties": { "detail": { "type": "string" } }
             }
           }
         }


### PR DESCRIPTION
## Why

Admin currently has to paginate through the User Spending history UI to pull credit movement, and the Platform Cost dashboard already has a CSV export but the User Spending dashboard does not. This PR adds CSV export controls so credit transactions and per-user weekly copilot:* usage can be pulled in one shot.

## What

### Backend
- `GET /api/credits/admin/transactions/export?start&end&transaction_type&user_id&include_inactive`
  - Full window of `CreditTransaction` rows, no pagination
  - Optional filter by `CreditTransactionType` (TOP_UP / GRANT / USAGE / etc.) and/or `user_id`
  - **`include_inactive` defaults to false** so abandoned-Stripe-checkout phantom rows aren't surfaced in normal exports — pass `true` to debug "why did this checkout never complete"
  - CSV columns: `transaction_id, user_id, user_email, created_at, type, amount_usd, running_balance_usd, admin_email, reason`
- `GET /api/credits/admin/copilot-usage/export?start&end`
  - Aggregates `PlatformCostLog` rows where `block_name ILIKE 'copilot:%'` per user per ISO week (UTC-anchored via `AT TIME ZONE 'UTC'`)
  - Joins user tier and computes `percent_used` against `weekly_cost_limit_microdollars * get_tier_multipliers()` (LD-aware)
  - CSV columns: `user_id, user_email, week_start, week_end, copilot_cost_usd, tier, weekly_limit_usd, percent_used`
  - `week_end` is inclusive end-of-Sunday (Mon–Sun convention), not next-Monday
- Both routes: 90-day window cap (timedelta-strict, sub-day overruns rejected) and 100k row cap; exceed → HTTP 400 with detail
- Unit tests for the data-layer functions + route-level tests covering success / exceeds-window / missing-window / role-check / metadata-reason normalization / NO_TIER fallback / unknown-tier fallback

### Frontend
- Two sibling buttons on `/admin/spending` ("Export CSV" + "Copilot Usage CSV"), each opens a date-range dialog and triggers a browser download
- CSV builders in `spending/helpers.ts`, mirroring the existing `buildCostLogsCsv` pattern from the Platform Cost dashboard
- Surfaces 400-detail messages in toasts when caps are exceeded
- Vitest unit tests covering the CSV builders, date helpers (UTC arithmetic), defer-revoke download flow

### Out of scope
- Stripe subscription invoice export — that data isn't in our DB; pull from Stripe dashboard directly
- Historical-tier reconstruction for the copilot usage export — `PlatformCostLog` has no per-row tier snapshot, so `percent_used` reflects the user's CURRENT tier limit (documented in the docstring)

## How

Mirrors the existing Platform Cost dashboard export pattern:
- Backend returns JSON response (paginated full-window) with row count + window metadata, frontend builds CSV client-side
- Window/row caps validated server-side, surfaced as HTTP 400 with detail
- Generated client (`getV2Export...`) used directly with proper `Date | null` typing on params

## Checklist

- [x] Lint passes (ruff, prettier)
- [x] tsc clean
- [x] No backwards-compat shims; no narrative comments
- [x] No \`any\`; no \`useCallback\`/\`useMemo\` in new code
- [x] Cap exceed returns HTTP 400 with detail surfaced in toast
- [x] Inactive rows hidden by default with `include_inactive` opt-in