### PR TITLE
fix(export): parse Prisma raw timestamptz strings in copilot weekly usage

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/credit_admin_routes.py
@@ -121,7 +121,7 @@ async def export_credit_transactions(
     ),
     admin_user_id: str = Security(get_user_id),
 ) -> CreditTransactionsExportResponse:
-    """Export CreditTransaction rows in [start, end] for finance reporting.
+    """Export CreditTransaction rows in [start, end].
 
     Capped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;
     over-cap requests fail fast with 400 so callers narrow the window

--- a/autogpt_platform/backend/backend/data/platform_cost.py
+++ b/autogpt_platform/backend/backend/data/platform_cost.py
@@ -818,11 +818,17 @@ async def get_copilot_weekly_usage_for_export(
 
     out: list[CopilotWeeklyUsageRow] = []
     for r in rows:
-        week_start: datetime = r["week_start"]
+        # Prisma's query_raw returns timestamptz columns as ISO strings, not
+        # datetimes — parse defensively so either shape works.
+        raw_week_start = r["week_start"]
+        if isinstance(raw_week_start, str):
+            week_start = datetime.fromisoformat(raw_week_start.replace("Z", "+00:00"))
+        else:
+            week_start = raw_week_start
         if week_start.tzinfo is None:
             week_start = week_start.replace(tzinfo=timezone.utc)
-        # Inclusive end-of-week (Sunday 23:59:59.999999 UTC) — matches finance
-        # conventions where "the week" is Mon–Sun, not Mon–next Mon.
+        # Inclusive end-of-week (Sunday 23:59:59.999999 UTC); "the week" is
+        # Mon–Sun, not Mon–next Mon.
         week_end = week_start + timedelta(days=7, microseconds=-1)
         cost = int(r.get("cost_microdollars") or 0)
         tier_str = r.get("tier") or DEFAULT_TIER.value

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -3131,7 +3131,7 @@
       "get": {
         "tags": ["v2", "admin", "credits", "admin"],
         "summary": "Export Credit Transactions",
-        "description": "Export CreditTransaction rows in [start, end] for finance reporting.\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
+        "description": "Export CreditTransaction rows in [start, end].\n\nCapped at CREDIT_EXPORT_MAX_DAYS days and CREDIT_EXPORT_MAX_ROWS rows;\nover-cap requests fail fast with 400 so callers narrow the window\ninstead of receiving silently truncated data.",
         "operationId": "getV2Export credit transactions",
         "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [


### PR DESCRIPTION
## Summary

Follow-up to #12958: the copilot weekly usage export crashed with `'str' object has no attribute 'tzinfo'` because Prisma's `query_raw_with_schema` returns timestamptz columns as ISO strings, not datetimes. The narrow guard `week_start.tzinfo is None` then fell over and turned the 30d export into a 500.

This parses the raw value defensively so either shape works, and removes a stray "for finance" framing from the export route docstring/inline comment.

Caught during round-2 manual verification of #12958: API-5 (`GET /api/credits/admin/copilot-usage/export?start=…&end=…` for 30d) returned 500 against the merged code; with this patch it returns 200 with the expected payload.

## Changes

- `backend/data/platform_cost.py` — parse `r["week_start"]` if it's a `str` before checking `tzinfo`; drop "matches finance conventions" wording from the inline comment.
- `backend/api/features/admin/credit_admin_routes.py` — drop "for finance reporting" from the route docstring.
- `frontend/src/app/api/openapi.json` — regenerated to reflect the docstring change.

## Test plan

- [x] `curl GET /api/credits/admin/copilot-usage/export?start=…&end=…` (30d, admin token) → 200 with `rows`/`total_rows`/`window_days`/`max_window_days` payload.
- [x] `curl GET /api/credits/admin/copilot-usage/export?start=…&end=…` (120d) → 400 cap-exceeded (regression check).
- [x] `curl GET /api/credits/admin/transactions/export` (30d) → 200, `?start=2024-12-30&end=…` (16+ months) → 400 (regression check).
- [ ] Unit test that exercises the str-shaped row path (worth adding in this PR or a follow-up).