### PR TITLE
fix(backend/copilot): re-prompt on thinking-only finish; route storage-limit through DB-manager

### DIFF
--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -95,6 +95,19 @@ class SDKResponseAdapter:
         # case so the turn renders as cleanly complete.
         self._text_since_last_tool_result = False
         self._any_tool_results_seen = False
+        # Set by the ResultMessage branch when a thinking-only final turn is
+        # detected and we have not yet asked the model for a closing TextBlock.
+        # The driver in ``service.py`` reads this after ``_iter_sdk_messages``
+        # ends and, if true, sends one synthetic re-prompt before falling back
+        # to the placeholder.  Bounded to one re-prompt per turn.
+        self.pending_thinking_only_reprompt = False
+        self.thinking_only_reprompted = False
+        # Captures the most recent ``ThinkingBlock`` content seen on this
+        # turn, used as the second-tier fallback when re-prompting still
+        # produces no visible TextBlock — the model often packs the actual
+        # answer into thinking, so we promote it to text rather than show
+        # the bare placeholder.
+        self._last_thinking_content = ""
         # --- Partial-message streaming state (CHAT_SDK_INCLUDE_PARTIAL_MESSAGES)
         # When ``include_partial_messages=True`` is set on
         # ``ClaudeAgentOptions``, the CLI emits raw Anthropic streaming
@@ -252,6 +265,8 @@ class SDKResponseAdapter:
                     # ``_end_reasoning_if_open`` still drains on stop.
                     self._flush_pending_thinking(responses)
                     tail = self._thinking_tail_for_summary_block(block.thinking)
+                    if block.thinking:
+                        self._last_thinking_content = block.thinking
                     if tail:
                         self._end_text_if_open(responses)
                         self._ensure_reasoning_started(responses)
@@ -425,6 +440,23 @@ class SDKResponseAdapter:
                 and not self._text_since_last_tool_result
                 and sdk_message.subtype == "success"
             ):
+                # First time we hit this in a turn, ask the driver to
+                # re-prompt the model for a closing TextBlock — the answer
+                # often lives inside the ThinkingBlock and the user sees
+                # nothing without that follow-up.  Skip emitting StreamFinish
+                # so the driver can re-enter the SDK loop with a synthetic
+                # query.  If the re-prompt also returns thinking-only, we
+                # fall through here a second time with
+                # ``thinking_only_reprompted`` already true and emit the
+                # placeholder.
+                if not self.thinking_only_reprompted:
+                    self.pending_thinking_only_reprompt = True
+                    self._end_text_if_open(responses)
+                    self._end_reasoning_if_open(responses)
+                    if self.step_open:
+                        responses.append(StreamFinishStep())
+                        self.step_open = False
+                    return responses
                 # UserMessage (tool_result) closed the last step, so we must
                 # open a fresh one before emitting any text — the AI SDK v5
                 # transport rejects text-delta chunks that aren't wrapped in
@@ -437,10 +469,18 @@ class SDKResponseAdapter:
                 # start/end events to distinct UI parts).
                 self._end_reasoning_if_open(responses)
                 self._ensure_text_started(responses)
+                # Prefer promoting the most recent thinking block to visible
+                # text — when the model packed the actual answer into
+                # extended-thinking instead of emitting a TextBlock, the
+                # placeholder hides a real response that's already in hand.
+                fallback_text = (
+                    self._last_thinking_content.strip()
+                    or "(Done — no further commentary.)"
+                )
                 responses.append(
                     StreamTextDelta(
                         id=self.text_block_id,
-                        delta="(Done — no further commentary.)",
+                        delta=fallback_text,
                     )
                 )
             self._end_text_if_open(responses)

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -382,6 +382,11 @@ class SDKResponseAdapter:
                 # ``ResultMessage`` time stays accurate.
                 self._text_since_last_tool_result = False
                 self._any_tool_results_seen = True
+                # Stale thinking from before this tool call must not
+                # contaminate the post-tool fallback — only the model's
+                # NEXT thinking block (after seeing the tool result)
+                # carries the actual answer.
+                self._last_thinking_content = ""
 
             # Close the current step after tool results — the next
             # AssistantMessage will open a new step for the continuation.

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -524,6 +524,88 @@ def test_result_success_thinking_only_after_reprompt_promotes_thinking():
     assert isinstance(results[-1], StreamFinish)
 
 
+def test_result_success_thinking_only_two_rounds_with_driver_reset_emits_fallback():
+    """Regression: the driver's reset between the deferred first round and
+    the re-prompt second round must leave enough state for the guard to
+    fire when the second round also returns thinking-only.  Specifically,
+    ``_any_tool_results_seen`` must remain True after the reset — the
+    guard requires it.
+    """
+    adapter = _adapter()
+
+    # --- Round 1: tool_use → tool_result → thinking-only finish.
+    adapter.convert_message(
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="t1", name=f"{MCP_TOOL_PREFIX}find_block", input={})
+            ],
+            model="test",
+        )
+    )
+    adapter.convert_message(
+        UserMessage(
+            content=[
+                ToolResultBlock(tool_use_id="t1", content="result", is_error=False)
+            ],
+            parent_tool_use_id=None,
+        )
+    )
+    adapter.convert_message(
+        AssistantMessage(
+            content=[
+                ThinkingBlock(thinking="Round 1 internal reasoning.", signature="")
+            ],
+            model="test",
+        )
+    )
+    round1 = adapter.convert_message(
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=50,
+            is_error=False,
+            num_turns=2,
+            session_id="s1",
+            result="",
+        )
+    )
+    assert adapter.pending_thinking_only_reprompt is True
+    assert [r for r in round1 if isinstance(r, StreamFinish)] == []
+
+    # --- Driver behaviour between rounds (must mirror service.py exactly).
+    adapter.pending_thinking_only_reprompt = False
+    adapter.thinking_only_reprompted = True
+    adapter._text_since_last_tool_result = False
+    # Intentionally do NOT touch ``_any_tool_results_seen`` — the guard at
+    # ResultMessage time needs it to stay True so the placeholder fires
+    # if the re-prompt round also returns thinking-only.
+
+    # --- Round 2: model returns thinking-only again.
+    adapter.convert_message(
+        AssistantMessage(
+            content=[
+                ThinkingBlock(thinking="Round 2 internal reasoning.", signature="")
+            ],
+            model="test",
+        )
+    )
+    round2 = adapter.convert_message(
+        ResultMessage(
+            subtype="success",
+            duration_ms=100,
+            duration_api_ms=50,
+            is_error=False,
+            num_turns=4,
+            session_id="s1",
+            result="",
+        )
+    )
+    text_deltas = [r for r in round2 if isinstance(r, StreamTextDelta)]
+    assert len(text_deltas) == 1, "second pass must emit fallback text"
+    assert text_deltas[0].delta.strip()  # non-empty
+    assert isinstance(round2[-1], StreamFinish)
+
+
 def test_result_success_thinking_only_after_reprompt_falls_back_to_placeholder():
     """After re-prompt with no thinking content captured either, the
     adapter emits the placeholder so the turn still visibly completes."""

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -452,14 +452,12 @@ def test_render_reasoning_on_is_default():
     assert "StreamReasoningDelta" in types
 
 
-def test_result_success_synthesizes_fallback_text_when_final_turn_is_thinking_only():
-    """If the model's last LLM call after a tool_result produced only a
-    ThinkingBlock (no TextBlock), the UI would hang on the tool output
-    with no response text.  The adapter should inject a short closing
-    line before ``StreamFinish`` so the turn visibly completes."""
+def test_result_success_thinking_only_first_pass_defers_for_reprompt():
+    """First time we see a thinking-only final turn the adapter must defer:
+    no text, no StreamFinish.  Driver reads ``pending_thinking_only_reprompt``
+    and re-prompts the model for a closing TextBlock before falling back."""
     adapter = _adapter()
 
-    # Tool use + tool_result (simulates the tool round).
     adapter.convert_message(
         AssistantMessage(
             content=[
@@ -477,11 +475,6 @@ def test_result_success_synthesizes_fallback_text_when_final_turn_is_thinking_on
         )
     )
 
-    # Model's "final turn" after tool_result is thinking-only.  This test
-    # simulates the *degenerate* case where the SDK never surfaces an
-    # AssistantMessage carrying the ThinkingBlock at all (not even the
-    # streamed reasoning events) before ResultMessage — only the tool_result
-    # has arrived.  The fallback guard should still synthesize closing text.
     msg = ResultMessage(
         subtype="success",
         duration_ms=100,
@@ -493,10 +486,67 @@ def test_result_success_synthesizes_fallback_text_when_final_turn_is_thinking_on
     )
     results = adapter.convert_message(msg)
 
-    # Fallback text should be injected before the finish events.
     text_deltas = [r for r in results if isinstance(r, StreamTextDelta)]
-    assert len(text_deltas) == 1, "should synthesize exactly one fallback text"
-    assert text_deltas[0].delta.strip()  # non-empty
+    finishes = [r for r in results if isinstance(r, StreamFinish)]
+    assert text_deltas == [], "first pass must not emit placeholder"
+    assert finishes == [], "first pass must skip StreamFinish so driver can re-prompt"
+    assert adapter.pending_thinking_only_reprompt is True
+    assert adapter.thinking_only_reprompted is False
+
+
+def test_result_success_thinking_only_after_reprompt_promotes_thinking():
+    """After re-prompt, if the model still produces thinking-only, the
+    adapter promotes the most recent ThinkingBlock content to visible text
+    rather than showing the bare placeholder."""
+    adapter = _adapter()
+    adapter._last_thinking_content = (
+        "Here are the best restaurants: Dishoom, The Clove Club, Padella."
+    )
+    # Simulate the driver having already fired the re-prompt round once.
+    adapter.thinking_only_reprompted = True
+    adapter._any_tool_results_seen = True
+    adapter._text_since_last_tool_result = False
+
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=4,
+        session_id="s1",
+        result="",
+    )
+    results = adapter.convert_message(msg)
+
+    text_deltas = [r for r in results if isinstance(r, StreamTextDelta)]
+    assert len(text_deltas) == 1
+    assert "Dishoom" in text_deltas[0].delta
+    assert isinstance(results[-1], StreamFinish)
+
+
+def test_result_success_thinking_only_after_reprompt_falls_back_to_placeholder():
+    """After re-prompt with no thinking content captured either, the
+    adapter emits the placeholder so the turn still visibly completes."""
+    adapter = _adapter()
+    adapter._last_thinking_content = ""
+    adapter.thinking_only_reprompted = True
+    adapter._any_tool_results_seen = True
+    adapter._text_since_last_tool_result = False
+
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=4,
+        session_id="s1",
+        result="",
+    )
+    results = adapter.convert_message(msg)
+
+    text_deltas = [r for r in results if isinstance(r, StreamTextDelta)]
+    assert len(text_deltas) == 1
+    assert text_deltas[0].delta == "(Done — no further commentary.)"
     assert isinstance(results[-1], StreamFinish)
 
 
@@ -843,15 +893,11 @@ def test_flush_unresolved_at_result_message():
         "StreamToolInputAvailable",
         "StreamToolOutputAvailable",  # flushed with empty output
         "StreamFinishStep",  # step closed by flush
-        # Flush marks a tool_result as seen, so the thinking-only-final-turn
-        # guard at ResultMessage time synthesizes a closing text delta.
-        "StreamStartStep",
-        "StreamTextStart",
-        "StreamTextDelta",
-        "StreamTextEnd",
-        "StreamFinishStep",
-        "StreamFinish",
     ]
+    # Flush marked a tool_result as seen with no text since, so the
+    # thinking-only-final-turn guard defers placeholder emission and asks
+    # the driver to re-prompt (no StreamFinish yet).
+    assert adapter.pending_thinking_only_reprompt is True
     # The flushed output should be empty (no stash available)
     output_event = [
         r for r in all_responses if isinstance(r, StreamToolOutputAvailable)

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter_test.py
@@ -606,6 +606,62 @@ def test_result_success_thinking_only_two_rounds_with_driver_reset_emits_fallbac
     assert isinstance(round2[-1], StreamFinish)
 
 
+def test_tool_result_clears_stale_thinking_so_fallback_does_not_leak_pre_tool_thinking():
+    """Stale ``ThinkingBlock`` content from before a tool call must not be
+    promoted as fallback text once the tool result has landed.  Without
+    this reset, a turn that thinks → tool_use → tool_result → silent
+    finish would surface the *pre-tool* reasoning to the user, which
+    pre-dates the actual answer the user is waiting for."""
+    adapter = _adapter()
+
+    # Pre-tool thinking — should be discarded when the tool_result lands.
+    adapter.convert_message(
+        AssistantMessage(
+            content=[ThinkingBlock(thinking="Stale pre-tool reasoning.", signature="")],
+            model="test",
+        )
+    )
+    adapter.convert_message(
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="t1", name=f"{MCP_TOOL_PREFIX}find_block", input={}),
+            ],
+            model="test",
+        )
+    )
+    adapter.convert_message(
+        UserMessage(
+            content=[
+                ToolResultBlock(tool_use_id="t1", content="result", is_error=False)
+            ],
+            parent_tool_use_id=None,
+        )
+    )
+    # Tool_result must wipe ``_last_thinking_content`` — otherwise
+    # ``Stale pre-tool reasoning.`` would be the fallback below.
+    assert adapter._last_thinking_content == ""
+
+    # Simulate a thinking-only finish that emits NO new ThinkingBlock at all
+    # (so ``_last_thinking_content`` stays empty), and a re-prompt round that
+    # also produces nothing.  The fallback must be the placeholder, not the
+    # stale pre-tool reasoning.
+    adapter.thinking_only_reprompted = True
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=100,
+        duration_api_ms=50,
+        is_error=False,
+        num_turns=4,
+        session_id="s1",
+        result="",
+    )
+    results = adapter.convert_message(msg)
+    text_deltas = [r for r in results if isinstance(r, StreamTextDelta)]
+    assert len(text_deltas) == 1
+    assert text_deltas[0].delta == "(Done — no further commentary.)"
+    assert "Stale pre-tool" not in text_deltas[0].delta
+
+
 def test_result_success_thinking_only_after_reprompt_falls_back_to_placeholder():
     """After re-prompt with no thinking content captured either, the
     adapter emits the placeholder so the turn still visibly completes."""

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3081,8 +3081,13 @@ async def _run_stream_attempt(
             ):
                 state.adapter.pending_thinking_only_reprompt = False
                 state.adapter.thinking_only_reprompted = True
+                # Keep ``_any_tool_results_seen`` True — the guard at
+                # ``ResultMessage`` time still needs it to fire on the
+                # re-prompt round if the model returns thinking-only
+                # again.  Only reset the per-tool-result text-tracker;
+                # if the re-prompt emits a TextBlock it'll set this to
+                # True and the guard won't fire.
                 state.adapter._text_since_last_tool_result = False
-                state.adapter._any_tool_results_seen = False
                 acc.stream_completed = False
                 logger.info(
                     "%s Re-prompting model for closing summary "

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -190,6 +190,15 @@ _CIRCUIT_BREAKER_ERROR_MSG = (
 _IDLE_TIMEOUT_SECONDS = 30 * 60
 _HUNG_TOOL_CAP_SECONDS = 2 * 60 * 60
 
+# Synthetic message injected when a turn ends with extended thinking but no
+# visible TextBlock. Bounded to one re-prompt per turn — if the model still
+# returns thinking-only the adapter promotes the last thinking block to
+# visible text rather than calling another round.
+_THINKING_ONLY_REPROMPT = (
+    "Please write a brief user-facing summary of what you found, in plain "
+    "prose. Do not use tools."
+)
+
 
 def _idle_timeout_threshold(adapter: SDKResponseAdapter) -> int:
     """Pick the idle-timeout threshold for the current heartbeat.
@@ -2525,542 +2534,567 @@ async def _run_stream_attempt(
 
         _last_real_msg_time = time.monotonic()
 
-        async for sdk_msg in _iter_sdk_messages(client):
-            # Heartbeat sentinel — refresh lock and keep SSE alive
-            if sdk_msg is None:
-                await ctx.lock.refresh()
-                for ev in ctx.compaction.emit_start_if_ready():
-                    yield ev
-                yield StreamHeartbeat()
+        while True:
+            async for sdk_msg in _iter_sdk_messages(client):
+                # Heartbeat sentinel — refresh lock and keep SSE alive
+                if sdk_msg is None:
+                    await ctx.lock.refresh()
+                    for ev in ctx.compaction.emit_start_if_ready():
+                        yield ev
+                    yield StreamHeartbeat()
 
-                # Threshold flips to the long cap while a tool is pending; clock never resets.
-                idle_seconds = time.monotonic() - _last_real_msg_time
-                threshold = _idle_timeout_threshold(state.adapter)
-                if idle_seconds >= threshold:
-                    unresolved_tool_names = sorted(
-                        {
-                            info.get("name", "unknown")
-                            for tid, info in state.adapter.current_tool_calls.items()
-                            if tid not in state.adapter.resolved_tool_calls
-                        }
-                    )
-                    logger.error(
-                        "%s Idle timeout after %.0fs (threshold=%ds, "
-                        "unresolved tools: %s) — aborting stream",
-                        ctx.log_prefix,
-                        idle_seconds,
-                        threshold,
-                        ", ".join(unresolved_tool_names) or "none",
-                    )
-                    # The retryable marker written to the session omits
-                    # the `[code:<id>]` prefix — the AI SDK serializer
-                    # (`StreamError.to_sse`) attaches that automatically
-                    # on the wire so the frontend can still parse a
-                    # machine-readable code out of the otherwise opaque
-                    # `{type, errorText}` schema.
-                    stream_error_code = "idle_timeout"
-                    tool_phrase = (
-                        f" while running {_humanise_tool_list(unresolved_tool_names)}"
-                        if unresolved_tool_names
-                        else ""
-                    )
-                    stream_error_msg = (
-                        f"AutoPilot stopped responding{tool_phrase}. "
-                        "This usually means a tool got stuck. Please try again."
-                    )
-                    _append_error_marker(ctx.session, stream_error_msg, retryable=True)
-                    yield StreamError(
-                        errorText=stream_error_msg,
-                        code=stream_error_code,
-                    )
-                    ended_with_stream_error = True
-                    break
-                continue
+                    # Threshold flips to the long cap while a tool is pending; clock never resets.
+                    idle_seconds = time.monotonic() - _last_real_msg_time
+                    threshold = _idle_timeout_threshold(state.adapter)
+                    if idle_seconds >= threshold:
+                        unresolved_tool_names = sorted(
+                            {
+                                info.get("name", "unknown")
+                                for tid, info in state.adapter.current_tool_calls.items()
+                                if tid not in state.adapter.resolved_tool_calls
+                            }
+                        )
+                        logger.error(
+                            "%s Idle timeout after %.0fs (threshold=%ds, "
+                            "unresolved tools: %s) — aborting stream",
+                            ctx.log_prefix,
+                            idle_seconds,
+                            threshold,
+                            ", ".join(unresolved_tool_names) or "none",
+                        )
+                        # The retryable marker written to the session omits
+                        # the `[code:<id>]` prefix — the AI SDK serializer
+                        # (`StreamError.to_sse`) attaches that automatically
+                        # on the wire so the frontend can still parse a
+                        # machine-readable code out of the otherwise opaque
+                        # `{type, errorText}` schema.
+                        stream_error_code = "idle_timeout"
+                        tool_phrase = (
+                            f" while running {_humanise_tool_list(unresolved_tool_names)}"
+                            if unresolved_tool_names
+                            else ""
+                        )
+                        stream_error_msg = (
+                            f"AutoPilot stopped responding{tool_phrase}. "
+                            "This usually means a tool got stuck. Please try again."
+                        )
+                        _append_error_marker(
+                            ctx.session, stream_error_msg, retryable=True
+                        )
+                        yield StreamError(
+                            errorText=stream_error_msg,
+                            code=stream_error_code,
+                        )
+                        ended_with_stream_error = True
+                        break
+                    continue
 
-            _last_real_msg_time = time.monotonic()
+                _last_real_msg_time = time.monotonic()
 
-            logger.info(
-                "%s Received: %s %s (unresolved=%d, current=%d, resolved=%d)",
-                ctx.log_prefix,
-                type(sdk_msg).__name__,
-                getattr(sdk_msg, "subtype", ""),
-                len(state.adapter.current_tool_calls)
-                - len(state.adapter.resolved_tool_calls),
-                len(state.adapter.current_tool_calls),
-                len(state.adapter.resolved_tool_calls),
-            )
-
-            # Capture OpenRouter generation IDs from each
-            # ``AssistantMessage.message_id`` — when routed via OpenRouter
-            # these are ``gen-...`` slugs we can use post-turn to query
-            # ``/api/v1/generation?id=`` for the authoritative per-turn
-            # cost and token counts (the CLI's ``total_cost_usd`` is
-            # computed from a static Anthropic pricing table that
-            # silently over-bills non-Anthropic routes).  Direct-Anthropic
-            # turns produce ``msg_...`` IDs which the generation endpoint
-            # doesn't know about — harmlessly ignored at reconcile time.
-            if isinstance(sdk_msg, AssistantMessage):
-                msg_id = sdk_msg.message_id
-                if (
-                    msg_id is not None
-                    and msg_id.startswith("gen-")
-                    and msg_id not in state.generation_ids
-                ):
-                    state.generation_ids.append(msg_id)
-                # Track the model the SDK actually used — when a fallback
-                # activates, this differs from ``state.options.model``.
-                # Consumed by the Moonshot cost-override decision so we
-                # don't mis-bill a fallback-Anthropic response at
-                # Moonshot rates (or a fallback-Moonshot at Anthropic
-                # rates).
-                observed = getattr(sdk_msg, "model", None)
-                if isinstance(observed, str) and observed:
-                    state.observed_model = observed
-
-            # Log AssistantMessage API errors (e.g. invalid_request)
-            # so we can debug Anthropic API 400s surfaced by the CLI.
-            sdk_error = getattr(sdk_msg, "error", None)
-            if isinstance(sdk_msg, AssistantMessage) and sdk_error:
-                error_text = str(sdk_error)
-                error_preview = str(sdk_msg.content)[:500]
-                logger.error(
-                    "[SDK] [%s] AssistantMessage has error=%s, "
-                    "content_blocks=%d, content_preview=%s",
-                    ctx.session_id[:12],
-                    sdk_error,
-                    len(sdk_msg.content),
-                    error_preview,
-                )
-
-                # Intercept prompt-too-long errors surfaced as
-                # AssistantMessage.error (not as a Python exception).
-                # Re-raise so the outer retry loop can compact the
-                # transcript and retry with reduced context.
-                # Check both error_text and error_preview: sdk_error
-                # being set confirms this is an error message (not user
-                # content), so checking content is safe. The actual
-                # error description (e.g. "Prompt is too long") may be
-                # in the content, not the error type field
-                # (e.g. error="invalid_request", content="Prompt is
-                # too long").
-                if _is_prompt_too_long(Exception(error_text)) or _is_prompt_too_long(
-                    Exception(error_preview)
-                ):
-                    logger.warning(
-                        "%s Prompt-too-long detected via AssistantMessage "
-                        "error — raising for retry",
-                        ctx.log_prefix,
-                    )
-                    raise RuntimeError("Prompt is too long")
-
-                # Intercept transient API errors (socket closed,
-                # ECONNRESET) — replace the raw message with a
-                # user-friendly error text and use the retryable
-                # error prefix so the frontend shows a retry button.
-                # Check both the error field and content for patterns.
-                if is_transient_api_error(error_text) or is_transient_api_error(
-                    error_preview
-                ):
-                    logger.warning(
-                        "%s Transient Anthropic API error detected, "
-                        "suppressing raw error text",
-                        ctx.log_prefix,
-                    )
-                    stream_error_msg = FRIENDLY_TRANSIENT_MSG
-                    stream_error_code = "transient_api_error"
-                    # Do NOT yield StreamError or append error marker here.
-                    # The outer retry loop decides: if a retry is available it
-                    # yields StreamStatus("retrying…"); if retries are exhausted
-                    # it appends the marker and yields StreamError exactly once.
-                    # Yielding StreamError before the retry decision causes the
-                    # client to display an error that is immediately superseded.
-                    ended_with_stream_error = True
-                    break
-
-            # Determine if the message is a tool-only batch (all content
-            # items are ToolUseBlocks) — such messages have no text output yet,
-            # so we skip the wait_for_stash flush below.
-            #
-            # Note: parallel execution of tools is handled natively by the
-            # SDK CLI via readOnlyHint annotations on tool definitions.
-            is_tool_only = False
-            if isinstance(sdk_msg, AssistantMessage) and sdk_msg.content:
-                is_tool_only = all(
-                    isinstance(item, ToolUseBlock) for item in sdk_msg.content
-                )
-
-            # Race-condition fix: SDK hooks (PostToolUse) are
-            # executed asynchronously via start_soon() — the next
-            # message can arrive before the hook stashes output.
-            # wait_for_stash() awaits an asyncio.Event signaled by
-            # stash_pending_tool_output(), completing as soon as
-            # the hook finishes (typically <1ms).  The sleep(0)
-            # after lets any remaining concurrent hooks complete.
-            #
-            # Skip for parallel tool continuations: when the SDK
-            # sends parallel tool calls as separate
-            # AssistantMessages (each containing only
-            # ToolUseBlocks), we must NOT wait/flush — the prior
-            # tools are still executing concurrently.
-            if (
-                state.adapter.has_unresolved_tool_calls
-                and isinstance(sdk_msg, (AssistantMessage, ResultMessage))
-                and not is_tool_only
-            ):
-                if await wait_for_stash():
-                    await asyncio.sleep(0)
-                else:
-                    logger.warning(
-                        "%s Timed out waiting for PostToolUse "
-                        "hook stash (%d unresolved tool calls)",
-                        ctx.log_prefix,
-                        len(state.adapter.current_tool_calls)
-                        - len(state.adapter.resolved_tool_calls),
-                    )
-
-            # Log ResultMessage details and capture token usage
-            if isinstance(sdk_msg, ResultMessage):
                 logger.info(
-                    "%s Received: ResultMessage %s "
-                    "(unresolved=%d, current=%d, resolved=%d, "
-                    "num_turns=%d, cost_usd=%s, result=%s)",
+                    "%s Received: %s %s (unresolved=%d, current=%d, resolved=%d)",
                     ctx.log_prefix,
-                    sdk_msg.subtype,
+                    type(sdk_msg).__name__,
+                    getattr(sdk_msg, "subtype", ""),
                     len(state.adapter.current_tool_calls)
                     - len(state.adapter.resolved_tool_calls),
                     len(state.adapter.current_tool_calls),
                     len(state.adapter.resolved_tool_calls),
-                    sdk_msg.num_turns,
-                    sdk_msg.total_cost_usd,
-                    (sdk_msg.result or "")[:200],
                 )
-                if sdk_msg.subtype in (
-                    "error",
-                    "error_during_execution",
-                ):
+
+                # Capture OpenRouter generation IDs from each
+                # ``AssistantMessage.message_id`` — when routed via OpenRouter
+                # these are ``gen-...`` slugs we can use post-turn to query
+                # ``/api/v1/generation?id=`` for the authoritative per-turn
+                # cost and token counts (the CLI's ``total_cost_usd`` is
+                # computed from a static Anthropic pricing table that
+                # silently over-bills non-Anthropic routes).  Direct-Anthropic
+                # turns produce ``msg_...`` IDs which the generation endpoint
+                # doesn't know about — harmlessly ignored at reconcile time.
+                if isinstance(sdk_msg, AssistantMessage):
+                    msg_id = sdk_msg.message_id
+                    if (
+                        msg_id is not None
+                        and msg_id.startswith("gen-")
+                        and msg_id not in state.generation_ids
+                    ):
+                        state.generation_ids.append(msg_id)
+                    # Track the model the SDK actually used — when a fallback
+                    # activates, this differs from ``state.options.model``.
+                    # Consumed by the Moonshot cost-override decision so we
+                    # don't mis-bill a fallback-Anthropic response at
+                    # Moonshot rates (or a fallback-Moonshot at Anthropic
+                    # rates).
+                    observed = getattr(sdk_msg, "model", None)
+                    if isinstance(observed, str) and observed:
+                        state.observed_model = observed
+
+                # Log AssistantMessage API errors (e.g. invalid_request)
+                # so we can debug Anthropic API 400s surfaced by the CLI.
+                sdk_error = getattr(sdk_msg, "error", None)
+                if isinstance(sdk_msg, AssistantMessage) and sdk_error:
+                    error_text = str(sdk_error)
+                    error_preview = str(sdk_msg.content)[:500]
                     logger.error(
-                        "%s SDK execution failed with error: %s",
-                        ctx.log_prefix,
-                        sdk_msg.result or "(no error message provided)",
+                        "[SDK] [%s] AssistantMessage has error=%s, "
+                        "content_blocks=%d, content_preview=%s",
+                        ctx.session_id[:12],
+                        sdk_error,
+                        len(sdk_msg.content),
+                        error_preview,
                     )
 
-                # Check for prompt-too-long regardless of subtype — the
-                # SDK may return subtype="success" with result="Prompt is
-                # too long" when the CLI rejects the prompt before calling
-                # the API (cost_usd=0, no tokens consumed).  If we only
-                # check the "error" subtype path, the stream appears to
-                # complete normally, the synthetic error text is stored
-                # in the transcript, and the session grows without bound.
-                if _is_prompt_too_long(RuntimeError(sdk_msg.result or "")):
-                    raise RuntimeError("Prompt is too long")
-
-                # Capture token usage from ResultMessage.
-                # Anthropic reports cached tokens separately:
-                #   input_tokens = uncached only
-                #   cache_read_input_tokens = served from cache
-                #   cache_creation_input_tokens = written to cache
-                if sdk_msg.usage:
-                    # Use `or 0` instead of a default in .get() because
-                    # OpenRouter may include the key with a null value (e.g.
-                    # {"cache_read_input_tokens": null}) for models that don't
-                    # yet report cache tokens, making .get("key", 0) return
-                    # None rather than the fallback 0.
-                    state.usage.prompt_tokens += sdk_msg.usage.get("input_tokens") or 0
-                    state.usage.cache_read_tokens += (
-                        sdk_msg.usage.get("cache_read_input_tokens") or 0
-                    )
-                    state.usage.cache_creation_tokens += (
-                        sdk_msg.usage.get("cache_creation_input_tokens") or 0
-                    )
-                    state.usage.completion_tokens += (
-                        sdk_msg.usage.get("output_tokens") or 0
-                    )
-                    logger.info(
-                        "%s Token usage: uncached=%d, cache_read=%d, "
-                        "cache_create=%d, output=%d",
-                        ctx.log_prefix,
-                        state.usage.prompt_tokens,
-                        state.usage.cache_read_tokens,
-                        state.usage.cache_creation_tokens,
-                        state.usage.completion_tokens,
-                    )
-                if sdk_msg.total_cost_usd is not None:
-                    # Default: trust the CLI-reported value.  Accurate for
-                    # Anthropic models (the CLI's bundled pricing table is
-                    # Anthropic-authored), and becomes the sync-path cost
-                    # when the reconcile is disabled or fails.
-                    # Prefer the ACTUALLY executed model
-                    # (``state.observed_model`` from ``AssistantMessage.model``)
-                    # over the requested primary (``state.options.model``)
-                    # so a fallback activation doesn't mis-route pricing.
-                    active_model = state.observed_model or getattr(
-                        state.options, "model", None
-                    )
-                    if _is_moonshot_model(active_model):
-                        # Moonshot slug — the CLI doesn't know Moonshot's
-                        # rate card and silently bills at Sonnet rates
-                        # (~5x over-charge).  Replace with the rate-card
-                        # estimate so the in-stream ``cost_usd`` and the
-                        # reconcile's lookup-fail fallback reflect
-                        # reality.  Reconcile
-                        # (``record_turn_cost_from_openrouter``) still
-                        # overrides this value when every gen-ID lookup
-                        # succeeds.
-                        state.usage.cost_usd = _override_cost_for_moonshot(
-                            model=active_model,
-                            sdk_reported_usd=sdk_msg.total_cost_usd,
-                            prompt_tokens=state.usage.prompt_tokens,
-                            completion_tokens=state.usage.completion_tokens,
-                            cache_read_tokens=state.usage.cache_read_tokens,
-                            cache_creation_tokens=state.usage.cache_creation_tokens,
+                    # Intercept prompt-too-long errors surfaced as
+                    # AssistantMessage.error (not as a Python exception).
+                    # Re-raise so the outer retry loop can compact the
+                    # transcript and retry with reduced context.
+                    # Check both error_text and error_preview: sdk_error
+                    # being set confirms this is an error message (not user
+                    # content), so checking content is safe. The actual
+                    # error description (e.g. "Prompt is too long") may be
+                    # in the content, not the error type field
+                    # (e.g. error="invalid_request", content="Prompt is
+                    # too long").
+                    if _is_prompt_too_long(
+                        Exception(error_text)
+                    ) or _is_prompt_too_long(Exception(error_preview)):
+                        logger.warning(
+                            "%s Prompt-too-long detected via AssistantMessage "
+                            "error — raising for retry",
+                            ctx.log_prefix,
                         )
-                    else:
-                        state.usage.cost_usd = sdk_msg.total_cost_usd
+                        raise RuntimeError("Prompt is too long")
 
-            # Emit compaction end if SDK finished compacting.
-            # Sync TranscriptBuilder with the CLI's active context.
-            compact_result = await ctx.compaction.emit_end_if_ready(ctx.session)
-            if compact_result.events:
-                # Compaction events end with StreamFinishStep, which maps to
-                # Vercel AI SDK's "finish-step" — that clears activeTextParts.
-                # Close any open text block BEFORE the compaction events so
-                # the text-end arrives before finish-step, preventing
-                # "text-end for missing text part" errors on the frontend.
-                pre_close: list[StreamBaseResponse] = []
-                state.adapter._end_text_if_open(pre_close)
-                # Compaction events bypass the adapter, so sync step state
-                # when a StreamFinishStep is present — otherwise the adapter
-                # will skip StreamStartStep on the next AssistantMessage.
-                if any(
-                    isinstance(ev, StreamFinishStep) for ev in compact_result.events
-                ):
-                    state.adapter.step_open = False
-                for r in pre_close:
-                    yield r
-            for ev in compact_result.events:
-                yield ev
-            entries_replaced = False
-            if compact_result.just_ended:
-                compacted = await asyncio.to_thread(
-                    read_compacted_entries,
-                    compact_result.transcript_path,
-                )
-                if compacted is not None:
-                    state.transcript_builder.replace_entries(
-                        compacted, log_prefix=ctx.log_prefix
-                    )
-                    entries_replaced = True
-
-            # --- Hard circuit breaker for empty tool calls ---
-            breaker = _check_empty_tool_breaker(
-                sdk_msg, consecutive_empty_tool_calls, ctx, state
-            )
-            consecutive_empty_tool_calls = breaker.count
-            if breaker.tripped and breaker.error is not None:
-                stream_error_msg = breaker.error_msg
-                stream_error_code = breaker.error_code
-                yield breaker.error
-                ended_with_stream_error = True
-                break
-
-            # --- Dispatch adapter responses ---
-            adapter_responses = state.adapter.convert_message(sdk_msg)
-
-            # Pre-create the new assistant message in the session BEFORE
-            # yielding any events so it survives a GeneratorExit (client
-            # disconnect) that interrupts the yield loop at StreamStartStep.
-            #
-            # Without this, the sequence is:
-            #   tool result saved → intermediate flush → StreamStartStep
-            #   yield → GeneratorExit → finally saves session with
-            #   last_role=tool (the text response was generated but never
-            #   appended because _dispatch_response(StreamTextDelta) was
-            #   skipped).
-            #
-            # We only pre-create when:
-            #   1. Tool results were received this turn (has_tool_results).
-            #   2. The prior assistant message is already appended
-            #      (has_appended_assistant) — so this is a post-tool turn.
-            #   3. This batch contains StreamTextDelta — text IS coming, so
-            #      we won't leave a spurious empty message for tool-only turns.
-            #
-            # Subsequent StreamTextDelta dispatches accumulate content into
-            # acc.assistant_response in-place (ChatMessage is mutable), so
-            # the DB record is updated without a second append.
-            if (
-                acc.has_tool_results
-                and acc.has_appended_assistant
-                and any(isinstance(r, StreamTextDelta) for r in adapter_responses)
-            ):
-                acc.assistant_response = ChatMessage(role="assistant", content="")
-                acc.accumulated_tool_calls = []
-                acc.has_tool_results = False
-                ctx.session.messages.append(acc.assistant_response)
-                # acc.has_appended_assistant stays True — placeholder is live
-
-            # When StreamFinish is in this batch (ResultMessage), flush any
-            # text buffered by the thinking stripper and inject it as a
-            # StreamTextDelta BEFORE the StreamTextEnd so the Vercel AI SDK
-            # receives the tail inside the still-open text block (correct
-            # protocol order: TextDelta → TextEnd → FinishStep → Finish).
-            tail_delta: StreamTextDelta | None = None
-            if any(isinstance(r, StreamFinish) for r in adapter_responses):
-                tail = acc.thinking_stripper.flush()
-                if tail and not ended_with_stream_error:
-                    # Do NOT manually append tail to acc.assistant_response.content
-                    # here — _dispatch_response handles that.  Doing it here would
-                    # double-append because _dispatch_response also updates the
-                    # accumulator.  Instead, mark the delta as pre-stripped so
-                    # _dispatch_response bypasses ThinkingStripper.process() for it
-                    # (re-processing could suppress a tail that looks like a partial
-                    # tag opener, e.g. "Hello <inter" → buffered again → lost).
-                    tail_delta = StreamTextDelta(
-                        id=state.adapter.text_block_id, delta=tail
-                    )
-                    insert_at = next(
-                        (
-                            i
-                            for i, r in enumerate(adapter_responses)
-                            if isinstance(r, (StreamTextEnd, StreamFinish))
-                        ),
-                        len(adapter_responses),
-                    )
-                    adapter_responses.insert(insert_at, tail_delta)
-            for response in adapter_responses:
-                dispatched = _dispatch_response(
-                    response,
-                    acc,
-                    ctx,
-                    state,
-                    entries_replaced,
-                    ctx.log_prefix,
-                    skip_strip=response is tail_delta,
-                )
-                if dispatched is not None:
-                    # Persistence (via _dispatch_response) always runs so the
-                    # session transcript keeps role='reasoning' rows; the
-                    # wire is gated so UI can suppress rendering.
-                    if not state.adapter.render_reasoning_in_ui and isinstance(
-                        dispatched,
-                        (
-                            StreamReasoningStart,
-                            StreamReasoningDelta,
-                            StreamReasoningEnd,
-                        ),
+                    # Intercept transient API errors (socket closed,
+                    # ECONNRESET) — replace the raw message with a
+                    # user-friendly error text and use the retryable
+                    # error prefix so the frontend shows a retry button.
+                    # Check both the error field and content for patterns.
+                    if is_transient_api_error(error_text) or is_transient_api_error(
+                        error_preview
                     ):
-                        continue
-                    yield dispatched
+                        logger.warning(
+                            "%s Transient Anthropic API error detected, "
+                            "suppressing raw error text",
+                            ctx.log_prefix,
+                        )
+                        stream_error_msg = FRIENDLY_TRANSIENT_MSG
+                        stream_error_code = "transient_api_error"
+                        # Do NOT yield StreamError or append error marker here.
+                        # The outer retry loop decides: if a retry is available it
+                        # yields StreamStatus("retrying…"); if retries are exhausted
+                        # it appends the marker and yields StreamError exactly once.
+                        # Yielding StreamError before the retry decision causes the
+                        # client to display an error that is immediately superseded.
+                        ended_with_stream_error = True
+                        break
 
-                # Mid-turn follow-up persistence: the MCP tool wrapper drains
-                # the primary pending buffer and stashes the drained
-                # PendingMessages into the per-session persist queue.  Claude
-                # has already seen them via the <user_follow_up> block
-                # injected into the tool output.  Now — right after the
-                # tool_result row has been appended to session.messages — we
-                # pop the persist queue and append a real user ChatMessage
-                # so the UI renders a proper user bubble in the correct
-                # chronological position (after the tool_result, before the
-                # assistant's continuing response).  Rollback re-queues into
-                # the PRIMARY pending buffer so the next turn-start drain
-                # picks them up if this persist silently fails.
-                # Only run the follow-up persist if the tool_result row was
-                # actually appended by _dispatch_response (currently always
-                # true for this variant, but we guard so a future refactor
-                # that conditionally skips the append can't silently land
-                # a user row before a missing tool_result).
+                # Determine if the message is a tool-only batch (all content
+                # items are ToolUseBlocks) — such messages have no text output yet,
+                # so we skip the wait_for_stash flush below.
+                #
+                # Note: parallel execution of tools is handled natively by the
+                # SDK CLI via readOnlyHint annotations on tool definitions.
+                is_tool_only = False
+                if isinstance(sdk_msg, AssistantMessage) and sdk_msg.content:
+                    is_tool_only = all(
+                        isinstance(item, ToolUseBlock) for item in sdk_msg.content
+                    )
+
+                # Race-condition fix: SDK hooks (PostToolUse) are
+                # executed asynchronously via start_soon() — the next
+                # message can arrive before the hook stashes output.
+                # wait_for_stash() awaits an asyncio.Event signaled by
+                # stash_pending_tool_output(), completing as soon as
+                # the hook finishes (typically <1ms).  The sleep(0)
+                # after lets any remaining concurrent hooks complete.
+                #
+                # Skip for parallel tool continuations: when the SDK
+                # sends parallel tool calls as separate
+                # AssistantMessages (each containing only
+                # ToolUseBlocks), we must NOT wait/flush — the prior
+                # tools are still executing concurrently.
                 if (
-                    isinstance(response, StreamToolOutputAvailable)
-                    and dispatched is not None
-                    and acc.has_tool_results
+                    state.adapter.has_unresolved_tool_calls
+                    and isinstance(sdk_msg, (AssistantMessage, ResultMessage))
+                    and not is_tool_only
                 ):
-                    followup_drained = await drain_pending_for_persist(
-                        ctx.session.session_id
+                    if await wait_for_stash():
+                        await asyncio.sleep(0)
+                    else:
+                        logger.warning(
+                            "%s Timed out waiting for PostToolUse "
+                            "hook stash (%d unresolved tool calls)",
+                            ctx.log_prefix,
+                            len(state.adapter.current_tool_calls)
+                            - len(state.adapter.resolved_tool_calls),
+                        )
+
+                # Log ResultMessage details and capture token usage
+                if isinstance(sdk_msg, ResultMessage):
+                    logger.info(
+                        "%s Received: ResultMessage %s "
+                        "(unresolved=%d, current=%d, resolved=%d, "
+                        "num_turns=%d, cost_usd=%s, result=%s)",
+                        ctx.log_prefix,
+                        sdk_msg.subtype,
+                        len(state.adapter.current_tool_calls)
+                        - len(state.adapter.resolved_tool_calls),
+                        len(state.adapter.current_tool_calls),
+                        len(state.adapter.resolved_tool_calls),
+                        sdk_msg.num_turns,
+                        sdk_msg.total_cost_usd,
+                        (sdk_msg.result or "")[:200],
                     )
-                    if followup_drained and await persist_pending_as_user_rows(
-                        ctx.session,
-                        state.transcript_builder,
-                        followup_drained,
-                        log_prefix=ctx.log_prefix,
+                    if sdk_msg.subtype in (
+                        "error",
+                        "error_during_execution",
                     ):
-                        # Track CLI-JSONL-invisible rows so the upload
-                        # watermark excludes them and the next turn's
-                        # detect_gap picks them up as gap-fill.
-                        state.midturn_user_rows += len(followup_drained)
+                        logger.error(
+                            "%s SDK execution failed with error: %s",
+                            ctx.log_prefix,
+                            sdk_msg.result or "(no error message provided)",
+                        )
 
-            # Append assistant entry AFTER convert_message so that
-            # any stashed tool results from the previous turn are
-            # recorded first, preserving the required API order:
-            # assistant(tool_use) → tool_result → assistant(text).
-            # Skip if replace_entries just ran — the CLI session
-            # file already contains this message.
-            if isinstance(sdk_msg, AssistantMessage) and not entries_replaced:
-                state.transcript_builder.append_assistant(
-                    content_blocks=_format_sdk_content_blocks(sdk_msg.content),
-                    model=sdk_msg.model,
+                    # Check for prompt-too-long regardless of subtype — the
+                    # SDK may return subtype="success" with result="Prompt is
+                    # too long" when the CLI rejects the prompt before calling
+                    # the API (cost_usd=0, no tokens consumed).  If we only
+                    # check the "error" subtype path, the stream appears to
+                    # complete normally, the synthetic error text is stored
+                    # in the transcript, and the session grows without bound.
+                    if _is_prompt_too_long(RuntimeError(sdk_msg.result or "")):
+                        raise RuntimeError("Prompt is too long")
+
+                    # Capture token usage from ResultMessage.
+                    # Anthropic reports cached tokens separately:
+                    #   input_tokens = uncached only
+                    #   cache_read_input_tokens = served from cache
+                    #   cache_creation_input_tokens = written to cache
+                    if sdk_msg.usage:
+                        # Use `or 0` instead of a default in .get() because
+                        # OpenRouter may include the key with a null value (e.g.
+                        # {"cache_read_input_tokens": null}) for models that don't
+                        # yet report cache tokens, making .get("key", 0) return
+                        # None rather than the fallback 0.
+                        state.usage.prompt_tokens += (
+                            sdk_msg.usage.get("input_tokens") or 0
+                        )
+                        state.usage.cache_read_tokens += (
+                            sdk_msg.usage.get("cache_read_input_tokens") or 0
+                        )
+                        state.usage.cache_creation_tokens += (
+                            sdk_msg.usage.get("cache_creation_input_tokens") or 0
+                        )
+                        state.usage.completion_tokens += (
+                            sdk_msg.usage.get("output_tokens") or 0
+                        )
+                        logger.info(
+                            "%s Token usage: uncached=%d, cache_read=%d, "
+                            "cache_create=%d, output=%d",
+                            ctx.log_prefix,
+                            state.usage.prompt_tokens,
+                            state.usage.cache_read_tokens,
+                            state.usage.cache_creation_tokens,
+                            state.usage.completion_tokens,
+                        )
+                    if sdk_msg.total_cost_usd is not None:
+                        # Default: trust the CLI-reported value.  Accurate for
+                        # Anthropic models (the CLI's bundled pricing table is
+                        # Anthropic-authored), and becomes the sync-path cost
+                        # when the reconcile is disabled or fails.
+                        # Prefer the ACTUALLY executed model
+                        # (``state.observed_model`` from ``AssistantMessage.model``)
+                        # over the requested primary (``state.options.model``)
+                        # so a fallback activation doesn't mis-route pricing.
+                        active_model = state.observed_model or getattr(
+                            state.options, "model", None
+                        )
+                        if _is_moonshot_model(active_model):
+                            # Moonshot slug — the CLI doesn't know Moonshot's
+                            # rate card and silently bills at Sonnet rates
+                            # (~5x over-charge).  Replace with the rate-card
+                            # estimate so the in-stream ``cost_usd`` and the
+                            # reconcile's lookup-fail fallback reflect
+                            # reality.  Reconcile
+                            # (``record_turn_cost_from_openrouter``) still
+                            # overrides this value when every gen-ID lookup
+                            # succeeds.
+                            state.usage.cost_usd = _override_cost_for_moonshot(
+                                model=active_model,
+                                sdk_reported_usd=sdk_msg.total_cost_usd,
+                                prompt_tokens=state.usage.prompt_tokens,
+                                completion_tokens=state.usage.completion_tokens,
+                                cache_read_tokens=state.usage.cache_read_tokens,
+                                cache_creation_tokens=state.usage.cache_creation_tokens,
+                            )
+                        else:
+                            state.usage.cost_usd = sdk_msg.total_cost_usd
+
+                # Emit compaction end if SDK finished compacting.
+                # Sync TranscriptBuilder with the CLI's active context.
+                compact_result = await ctx.compaction.emit_end_if_ready(ctx.session)
+                if compact_result.events:
+                    # Compaction events end with StreamFinishStep, which maps to
+                    # Vercel AI SDK's "finish-step" — that clears activeTextParts.
+                    # Close any open text block BEFORE the compaction events so
+                    # the text-end arrives before finish-step, preventing
+                    # "text-end for missing text part" errors on the frontend.
+                    pre_close: list[StreamBaseResponse] = []
+                    state.adapter._end_text_if_open(pre_close)
+                    # Compaction events bypass the adapter, so sync step state
+                    # when a StreamFinishStep is present — otherwise the adapter
+                    # will skip StreamStartStep on the next AssistantMessage.
+                    if any(
+                        isinstance(ev, StreamFinishStep) for ev in compact_result.events
+                    ):
+                        state.adapter.step_open = False
+                    for r in pre_close:
+                        yield r
+                for ev in compact_result.events:
+                    yield ev
+                entries_replaced = False
+                if compact_result.just_ended:
+                    compacted = await asyncio.to_thread(
+                        read_compacted_entries,
+                        compact_result.transcript_path,
+                    )
+                    if compacted is not None:
+                        state.transcript_builder.replace_entries(
+                            compacted, log_prefix=ctx.log_prefix
+                        )
+                        entries_replaced = True
+
+                # --- Hard circuit breaker for empty tool calls ---
+                breaker = _check_empty_tool_breaker(
+                    sdk_msg, consecutive_empty_tool_calls, ctx, state
                 )
+                consecutive_empty_tool_calls = breaker.count
+                if breaker.tripped and breaker.error is not None:
+                    stream_error_msg = breaker.error_msg
+                    stream_error_code = breaker.error_code
+                    yield breaker.error
+                    ended_with_stream_error = True
+                    break
 
-            # --- Intermediate persistence ---
-            # Flush session messages to DB periodically so page reloads
-            # show progress during long-running turns.
-            #
-            # IMPORTANT: Skip the flush while tool calls are pending
-            # (tool_calls set on assistant but results not yet received).
-            # The DB save is append-only (uses start_sequence), so if we
-            # flush the assistant message before tool_calls are set on it
-            # (text and tool_use arrive as separate SDK events), the
-            # tool_calls update is lost — the next flush starts past it.
-            #
-            # With ``include_partial_messages=True`` the CLI delivers
-            # hundreds of ``StreamEvent`` messages per turn — incrementing
-            # ``_msgs_since_flush`` on each one trips the threshold long
-            # before the assistant text is complete, saving a truncated
-            # prefix that subsequent deltas can never extend (append-only).
-            # Count only messages that produce a persisted row boundary
-            # (AssistantMessage, UserMessage, ResultMessage) and skip
-            # raw StreamEvents.  Also skip when text or reasoning is
-            # still in-flight on the adapter: the row is live and a flush
-            # would lock it at its current length.
-            if not isinstance(sdk_msg, StreamEvent):
-                _msgs_since_flush += 1
-            now = time.monotonic()
-            has_pending_tools = (
-                acc.has_appended_assistant
-                and acc.accumulated_tool_calls
-                and not acc.has_tool_results
-            )
-            adapter = state.adapter
-            has_open_block = (
-                adapter.has_started_text and not adapter.has_ended_text
-            ) or (adapter.has_started_reasoning and not adapter.has_ended_reasoning)
+                # --- Dispatch adapter responses ---
+                adapter_responses = state.adapter.convert_message(sdk_msg)
+
+                # Pre-create the new assistant message in the session BEFORE
+                # yielding any events so it survives a GeneratorExit (client
+                # disconnect) that interrupts the yield loop at StreamStartStep.
+                #
+                # Without this, the sequence is:
+                #   tool result saved → intermediate flush → StreamStartStep
+                #   yield → GeneratorExit → finally saves session with
+                #   last_role=tool (the text response was generated but never
+                #   appended because _dispatch_response(StreamTextDelta) was
+                #   skipped).
+                #
+                # We only pre-create when:
+                #   1. Tool results were received this turn (has_tool_results).
+                #   2. The prior assistant message is already appended
+                #      (has_appended_assistant) — so this is a post-tool turn.
+                #   3. This batch contains StreamTextDelta — text IS coming, so
+                #      we won't leave a spurious empty message for tool-only turns.
+                #
+                # Subsequent StreamTextDelta dispatches accumulate content into
+                # acc.assistant_response in-place (ChatMessage is mutable), so
+                # the DB record is updated without a second append.
+                if (
+                    acc.has_tool_results
+                    and acc.has_appended_assistant
+                    and any(isinstance(r, StreamTextDelta) for r in adapter_responses)
+                ):
+                    acc.assistant_response = ChatMessage(role="assistant", content="")
+                    acc.accumulated_tool_calls = []
+                    acc.has_tool_results = False
+                    ctx.session.messages.append(acc.assistant_response)
+                    # acc.has_appended_assistant stays True — placeholder is live
+
+                # When StreamFinish is in this batch (ResultMessage), flush any
+                # text buffered by the thinking stripper and inject it as a
+                # StreamTextDelta BEFORE the StreamTextEnd so the Vercel AI SDK
+                # receives the tail inside the still-open text block (correct
+                # protocol order: TextDelta → TextEnd → FinishStep → Finish).
+                tail_delta: StreamTextDelta | None = None
+                if any(isinstance(r, StreamFinish) for r in adapter_responses):
+                    tail = acc.thinking_stripper.flush()
+                    if tail and not ended_with_stream_error:
+                        # Do NOT manually append tail to acc.assistant_response.content
+                        # here — _dispatch_response handles that.  Doing it here would
+                        # double-append because _dispatch_response also updates the
+                        # accumulator.  Instead, mark the delta as pre-stripped so
+                        # _dispatch_response bypasses ThinkingStripper.process() for it
+                        # (re-processing could suppress a tail that looks like a partial
+                        # tag opener, e.g. "Hello <inter" → buffered again → lost).
+                        tail_delta = StreamTextDelta(
+                            id=state.adapter.text_block_id, delta=tail
+                        )
+                        insert_at = next(
+                            (
+                                i
+                                for i, r in enumerate(adapter_responses)
+                                if isinstance(r, (StreamTextEnd, StreamFinish))
+                            ),
+                            len(adapter_responses),
+                        )
+                        adapter_responses.insert(insert_at, tail_delta)
+                for response in adapter_responses:
+                    dispatched = _dispatch_response(
+                        response,
+                        acc,
+                        ctx,
+                        state,
+                        entries_replaced,
+                        ctx.log_prefix,
+                        skip_strip=response is tail_delta,
+                    )
+                    if dispatched is not None:
+                        # Persistence (via _dispatch_response) always runs so the
+                        # session transcript keeps role='reasoning' rows; the
+                        # wire is gated so UI can suppress rendering.
+                        if not state.adapter.render_reasoning_in_ui and isinstance(
+                            dispatched,
+                            (
+                                StreamReasoningStart,
+                                StreamReasoningDelta,
+                                StreamReasoningEnd,
+                            ),
+                        ):
+                            continue
+                        yield dispatched
+
+                    # Mid-turn follow-up persistence: the MCP tool wrapper drains
+                    # the primary pending buffer and stashes the drained
+                    # PendingMessages into the per-session persist queue.  Claude
+                    # has already seen them via the <user_follow_up> block
+                    # injected into the tool output.  Now — right after the
+                    # tool_result row has been appended to session.messages — we
+                    # pop the persist queue and append a real user ChatMessage
+                    # so the UI renders a proper user bubble in the correct
+                    # chronological position (after the tool_result, before the
+                    # assistant's continuing response).  Rollback re-queues into
+                    # the PRIMARY pending buffer so the next turn-start drain
+                    # picks them up if this persist silently fails.
+                    # Only run the follow-up persist if the tool_result row was
+                    # actually appended by _dispatch_response (currently always
+                    # true for this variant, but we guard so a future refactor
+                    # that conditionally skips the append can't silently land
+                    # a user row before a missing tool_result).
+                    if (
+                        isinstance(response, StreamToolOutputAvailable)
+                        and dispatched is not None
+                        and acc.has_tool_results
+                    ):
+                        followup_drained = await drain_pending_for_persist(
+                            ctx.session.session_id
+                        )
+                        if followup_drained and await persist_pending_as_user_rows(
+                            ctx.session,
+                            state.transcript_builder,
+                            followup_drained,
+                            log_prefix=ctx.log_prefix,
+                        ):
+                            # Track CLI-JSONL-invisible rows so the upload
+                            # watermark excludes them and the next turn's
+                            # detect_gap picks them up as gap-fill.
+                            state.midturn_user_rows += len(followup_drained)
+
+                # Append assistant entry AFTER convert_message so that
+                # any stashed tool results from the previous turn are
+                # recorded first, preserving the required API order:
+                # assistant(tool_use) → tool_result → assistant(text).
+                # Skip if replace_entries just ran — the CLI session
+                # file already contains this message.
+                if isinstance(sdk_msg, AssistantMessage) and not entries_replaced:
+                    state.transcript_builder.append_assistant(
+                        content_blocks=_format_sdk_content_blocks(sdk_msg.content),
+                        model=sdk_msg.model,
+                    )
+
+                # --- Intermediate persistence ---
+                # Flush session messages to DB periodically so page reloads
+                # show progress during long-running turns.
+                #
+                # IMPORTANT: Skip the flush while tool calls are pending
+                # (tool_calls set on assistant but results not yet received).
+                # The DB save is append-only (uses start_sequence), so if we
+                # flush the assistant message before tool_calls are set on it
+                # (text and tool_use arrive as separate SDK events), the
+                # tool_calls update is lost — the next flush starts past it.
+                #
+                # With ``include_partial_messages=True`` the CLI delivers
+                # hundreds of ``StreamEvent`` messages per turn — incrementing
+                # ``_msgs_since_flush`` on each one trips the threshold long
+                # before the assistant text is complete, saving a truncated
+                # prefix that subsequent deltas can never extend (append-only).
+                # Count only messages that produce a persisted row boundary
+                # (AssistantMessage, UserMessage, ResultMessage) and skip
+                # raw StreamEvents.  Also skip when text or reasoning is
+                # still in-flight on the adapter: the row is live and a flush
+                # would lock it at its current length.
+                if not isinstance(sdk_msg, StreamEvent):
+                    _msgs_since_flush += 1
+                now = time.monotonic()
+                has_pending_tools = (
+                    acc.has_appended_assistant
+                    and acc.accumulated_tool_calls
+                    and not acc.has_tool_results
+                )
+                adapter = state.adapter
+                has_open_block = (
+                    adapter.has_started_text and not adapter.has_ended_text
+                ) or (adapter.has_started_reasoning and not adapter.has_ended_reasoning)
+                if (
+                    not has_pending_tools
+                    and not has_open_block
+                    and (
+                        _msgs_since_flush >= _FLUSH_MESSAGE_THRESHOLD
+                        or (now - _last_flush_time) >= _FLUSH_INTERVAL_SECONDS
+                    )
+                ):
+                    try:
+                        await asyncio.shield(upsert_chat_session(ctx.session))
+                        logger.debug(
+                            "%s Intermediate flush: %d messages "
+                            "(msgs_since=%d, elapsed=%.1fs)",
+                            ctx.log_prefix,
+                            len(ctx.session.messages),
+                            _msgs_since_flush,
+                            now - _last_flush_time,
+                        )
+                    except Exception as flush_err:
+                        logger.warning(
+                            "%s Intermediate flush failed: %s",
+                            ctx.log_prefix,
+                            flush_err,
+                        )
+                    _last_flush_time = now
+                    _msgs_since_flush = 0
+
+                if acc.stream_completed:
+                    break
             if (
-                not has_pending_tools
-                and not has_open_block
-                and (
-                    _msgs_since_flush >= _FLUSH_MESSAGE_THRESHOLD
-                    or (now - _last_flush_time) >= _FLUSH_INTERVAL_SECONDS
-                )
+                state.adapter.pending_thinking_only_reprompt
+                and not state.adapter.thinking_only_reprompted
             ):
-                try:
-                    await asyncio.shield(upsert_chat_session(ctx.session))
-                    logger.debug(
-                        "%s Intermediate flush: %d messages "
-                        "(msgs_since=%d, elapsed=%.1fs)",
-                        ctx.log_prefix,
-                        len(ctx.session.messages),
-                        _msgs_since_flush,
-                        now - _last_flush_time,
-                    )
-                except Exception as flush_err:
-                    logger.warning(
-                        "%s Intermediate flush failed: %s",
-                        ctx.log_prefix,
-                        flush_err,
-                    )
-                _last_flush_time = now
-                _msgs_since_flush = 0
-
-            if acc.stream_completed:
-                break
+                state.adapter.pending_thinking_only_reprompt = False
+                state.adapter.thinking_only_reprompted = True
+                state.adapter._text_since_last_tool_result = False
+                state.adapter._any_tool_results_seen = False
+                acc.stream_completed = False
+                logger.info(
+                    "%s Re-prompting model for closing summary "
+                    "after thinking-only final turn",
+                    ctx.log_prefix,
+                )
+                await client.query(
+                    _THINKING_ONLY_REPROMPT,
+                    session_id=ctx.session_id,
+                )
+                continue
+            break
     finally:
         await _safe_close_sdk_client(sdk_client, ctx.log_prefix)
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -200,6 +200,61 @@ _THINKING_ONLY_REPROMPT = (
 )
 
 
+def _strip_synthetic_reprompt_from_cli_jsonl(content: bytes) -> bytes:
+    """Drop any user-message line whose text equals ``_THINKING_ONLY_REPROMPT``.
+
+    The CLI persists every ``client.query(...)`` call to its session file,
+    including the synthetic re-prompt we send when a turn ends thinking-only.
+    Leaving it in the uploaded JSONL pollutes ``--resume`` history on the next
+    turn — the model would see a phantom user message asking it to summarise.
+    Strip those lines here so the persisted transcript reflects only what the
+    end user actually said.
+    """
+    if not content:
+        return content
+    out: list[bytes] = []
+    for line in content.splitlines(keepends=True):
+        stripped = line.strip()
+        if not stripped:
+            out.append(line)
+            continue
+        try:
+            entry = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            out.append(line)
+            continue
+        if (
+            isinstance(entry, dict)
+            and entry.get("type") == "user"
+            and isinstance(entry.get("message"), dict)
+            and entry["message"].get("role") == "user"
+        ):
+            text = _extract_user_message_text(entry["message"].get("content"))
+            if text == _THINKING_ONLY_REPROMPT:
+                continue
+        out.append(line)
+    return b"".join(out)
+
+
+def _extract_user_message_text(content: object) -> str | None:
+    """Return the plain-text payload of a user message, or None if not text-only."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                return None
+            if block.get("type") != "text":
+                return None
+            text = block.get("text")
+            if not isinstance(text, str):
+                return None
+            texts.append(text)
+        return "".join(texts) if texts else None
+    return None
+
+
 def _idle_timeout_threshold(adapter: SDKResponseAdapter) -> int:
     """Pick the idle-timeout threshold for the current heartbeat.
 
@@ -400,6 +455,12 @@ class _RetryState:
     # ``detect_gap`` picks them up as gap-fill entries instead of assuming the
     # JSONL already covers them.
     midturn_user_rows: int = 0
+    # Tracks whether the thinking-only-final-turn re-prompt has already
+    # fired for this user turn.  Lives on ``_RetryState`` (not on
+    # ``adapter``) so a transient retry that rebuilds the adapter does
+    # not reset the per-turn cap to zero — otherwise multiple retries
+    # could each fire their own re-prompt round.
+    thinking_only_reprompted: bool = False
     # OpenRouter generation IDs collected across all attempts of this turn.
     # Populated from ``AssistantMessage.message_id`` when routed via
     # OpenRouter (``gen-...`` prefix).  Consumed by the finally block to
@@ -3077,9 +3138,10 @@ async def _run_stream_attempt(
                     break
             if (
                 state.adapter.pending_thinking_only_reprompt
-                and not state.adapter.thinking_only_reprompted
+                and not state.thinking_only_reprompted
             ):
                 state.adapter.pending_thinking_only_reprompt = False
+                state.thinking_only_reprompted = True
                 state.adapter.thinking_only_reprompted = True
                 # Keep ``_any_tool_results_seen`` True — the guard at
                 # ``ResultMessage`` time still needs it to fire on the
@@ -4195,6 +4257,9 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                     session_id=session_id,
                     render_reasoning_in_ui=config.render_reasoning_in_ui,
                 )
+                # Carry the per-turn re-prompt cap forward so a transient
+                # retry mid-turn does not unlock another re-prompt round.
+                state.adapter.thinking_only_reprompted = state.thinking_only_reprompted
                 # Reset token accumulators so a failed attempt's partial
                 # usage is not double-counted in the successful attempt.
                 state.usage.reset()
@@ -4764,6 +4829,9 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                     sdk_cwd, session_id, log_prefix
                 )
                 if _cli_content:
+                    _cli_content = _strip_synthetic_reprompt_from_cli_jsonl(
+                        _cli_content
+                    )
                     # Watermark = number of DB messages this transcript covers.
                     # len(session.messages) is accurate: the CLI session file
                     # was just written after the turn completed, so it covers

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3234,6 +3234,11 @@ async def _run_stream_attempt(
             # round-1 streak doesn't trip prematurely on the very first
             # re-prompt AssistantMessage.
             loop_state.consecutive_empty_tool_calls = 0
+            # Restart the idle-timeout clock for the re-prompt round —
+            # otherwise a long round 1 (e.g. 29 min) plus a tiny delay
+            # before the first re-prompt message would push the clock
+            # past the 30-min threshold and trip a phantom idle timeout.
+            loop_state.last_real_msg_time = time.monotonic()
             logger.info(
                 "%s Re-prompting model for closing summary "
                 "after thinking-only final turn",

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -901,8 +901,11 @@ def _is_empty_assistant_entry(entry: dict | None) -> bool:
         if not isinstance(block, dict):
             return False
         btype = block.get("type")
-        if btype == "thinking":
-            continue  # thinking-only counts as empty for our purposes
+        # Both ``thinking`` and ``redacted_thinking`` (Anthropic's encrypted
+        # thinking variant for safety-redacted content) count as empty for
+        # role-alternation purposes — neither carries a user-visible answer.
+        if btype in ("thinking", "redacted_thinking"):
+            continue
         if btype == "text" and not (block.get("text") or "").strip():
             continue
         return False

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -206,6 +206,12 @@ class _SDKLoopState:
     msgs_since_flush: int = 0
     consecutive_empty_tool_calls: int = 0
     ended_with_stream_error: bool = False
+    # Carried out of the helper so the caller can plumb idle-timeout /
+    # transient / breaker error metadata into the ``_HandledStreamError``
+    # raised after the loop finishes — without these fields the helper's
+    # error context would be silently dropped.
+    stream_error_msg: str | None = None
+    stream_error_code: str | None = None
 
 
 async def _consume_sdk_until_done(
@@ -257,20 +263,22 @@ async def _consume_sdk_until_done(
                 # on the wire so the frontend can still parse a
                 # machine-readable code out of the otherwise opaque
                 # `{type, errorText}` schema.
-                stream_error_code = "idle_timeout"
+                loop_state.stream_error_code = "idle_timeout"
                 tool_phrase = (
                     f" while running {_humanise_tool_list(unresolved_tool_names)}"
                     if unresolved_tool_names
                     else ""
                 )
-                stream_error_msg = (
+                loop_state.stream_error_msg = (
                     f"AutoPilot stopped responding{tool_phrase}. "
                     "This usually means a tool got stuck. Please try again."
                 )
-                _append_error_marker(ctx.session, stream_error_msg, retryable=True)
+                _append_error_marker(
+                    ctx.session, loop_state.stream_error_msg, retryable=True
+                )
                 yield StreamError(
-                    errorText=stream_error_msg,
-                    code=stream_error_code,
+                    errorText=loop_state.stream_error_msg,
+                    code=loop_state.stream_error_code,
                 )
                 loop_state.ended_with_stream_error = True
                 break
@@ -365,8 +373,8 @@ async def _consume_sdk_until_done(
                     "suppressing raw error text",
                     ctx.log_prefix,
                 )
-                stream_error_msg = FRIENDLY_TRANSIENT_MSG
-                stream_error_code = "transient_api_error"
+                loop_state.stream_error_msg = FRIENDLY_TRANSIENT_MSG
+                loop_state.stream_error_code = "transient_api_error"
                 # Do NOT yield StreamError or append error marker here.
                 # The outer retry loop decides: if a retry is available it
                 # yields StreamStatus("retrying…"); if retries are exhausted
@@ -552,8 +560,8 @@ async def _consume_sdk_until_done(
         )
         loop_state.consecutive_empty_tool_calls = breaker.count
         if breaker.tripped and breaker.error is not None:
-            stream_error_msg = breaker.error_msg
-            stream_error_code = breaker.error_code
+            loop_state.stream_error_msg = breaker.error_msg
+            loop_state.stream_error_code = breaker.error_code
             yield breaker.error
             loop_state.ended_with_stream_error = True
             break
@@ -3090,11 +3098,6 @@ async def _run_stream_attempt(
         assistant_response=ChatMessage(role="assistant", content=""),
         accumulated_tool_calls=[],
     )
-    # Stores the error message used by _append_error_marker so the outer
-    # retry loop can re-append the correct message after session rollback.
-    stream_error_msg: str | None = None
-    stream_error_code: str | None = None
-
     # --- Intermediate persistence tracking ---
     # Flush session messages to DB periodically so page reloads show progress
     # during long-running turns (see incident d2f7cba3: 82-min turn lost on refresh).
@@ -3176,6 +3179,11 @@ async def _run_stream_attempt(
             # Re-prompt round must still trip the placeholder guard if model returns thinking-only again.
             state.adapter._text_since_last_tool_result = False
             acc.stream_completed = False
+            # The previous round's tool_result is no longer "fresh" for the
+            # post-tool placeholder pre-create branch — clearing prevents the
+            # re-prompt round from spuriously appending an empty assistant
+            # ChatMessage before its first text delta lands.
+            acc.has_tool_results = False
             logger.info(
                 "%s Re-prompting model for closing summary "
                 "after thinking-only final turn",
@@ -3249,9 +3257,9 @@ async def _run_stream_attempt(
     if loop_state.ended_with_stream_error:
         raise _HandledStreamError(
             "Stream error handled",
-            error_msg=stream_error_msg,
-            code=stream_error_code,
-            already_yielded=(stream_error_code != "transient_api_error"),
+            error_msg=loop_state.stream_error_msg,
+            code=loop_state.stream_error_code,
+            already_yielded=(loop_state.stream_error_code != "transient_api_error"),
         )
 
 
@@ -3651,6 +3659,11 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
     # the sweep would pick up prior turns' compaction files that persist
     # under ``<session_id>/subagents/``, double-billing the user.
     turn_start_ts = time.time()
+
+    # Initialised before the retry loop so every code path that reads it after
+    # the loop (post-stream upload guards, finally-block bookkeeping) sees a
+    # bound name even when the loop never enters its happy path.
+    ended_with_stream_error = False
 
     # Make sure there is no more code between the lock acquisition and try-block.
     try:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3139,16 +3139,12 @@ async def _run_stream_attempt(
             if (
                 state.adapter.pending_thinking_only_reprompt
                 and not state.thinking_only_reprompted
+                and not ended_with_stream_error
             ):
                 state.adapter.pending_thinking_only_reprompt = False
                 state.thinking_only_reprompted = True
                 state.adapter.thinking_only_reprompted = True
-                # Keep ``_any_tool_results_seen`` True — the guard at
-                # ``ResultMessage`` time still needs it to fire on the
-                # re-prompt round if the model returns thinking-only
-                # again.  Only reset the per-tool-result text-tracker;
-                # if the re-prompt emits a TextBlock it'll set this to
-                # True and the guard won't fire.
+                # Re-prompt round must still trip the placeholder guard if model returns thinking-only again.
                 state.adapter._text_since_last_tool_result = False
                 acc.stream_completed = False
                 logger.info(

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3286,6 +3286,13 @@ async def _run_stream_attempt(
             # into the previous (empty thinking-only) one.  Without this the
             # two logical assistant turns get fused into a single DB row.
             acc.has_appended_assistant = False
+            # Also swap in a fresh ``assistant_response`` so the dispatch
+            # code doesn't smuggle round 1's stale ``tool_calls`` list into
+            # round 2's reply when it eventually appends to session.messages
+            # — that would re-persist the previous turn's tool calls beside
+            # the re-prompt's text and double the assistant row.
+            acc.assistant_response = ChatMessage(role="assistant", content="")
+            acc.accumulated_tool_calls = []
             # Reset the empty-tool-call breaker counter so a borderline
             # round-1 streak doesn't trip prematurely on the very first
             # re-prompt AssistantMessage.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3275,6 +3275,11 @@ async def _run_stream_attempt(
             state.adapter.thinking_only_reprompted = True
             # Re-prompt round must still trip the placeholder guard if model returns thinking-only again.
             state.adapter._text_since_last_tool_result = False
+            # Round 1's thinking content must not be surfaced as round 2's
+            # promote-thinking fallback if round 2 itself produces no
+            # thinking — that would show stale reasoning to the user as
+            # if it were the answer to the re-prompt.
+            state.adapter._last_thinking_content = ""
             acc.stream_completed = False
             # The previous round's tool_result is no longer "fresh" for the
             # post-tool placeholder pre-create branch — clearing prevents the

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3281,6 +3281,11 @@ async def _run_stream_attempt(
             # re-prompt round from spuriously appending an empty assistant
             # ChatMessage before its first text delta lands.
             acc.has_tool_results = False
+            # Force the re-prompt's first text delta to allocate a NEW
+            # ``acc.assistant_response`` ChatMessage instead of accumulating
+            # into the previous (empty thinking-only) one.  Without this the
+            # two logical assistant turns get fused into a single DB row.
+            acc.has_appended_assistant = False
             # Reset the empty-tool-call breaker counter so a borderline
             # round-1 streak doesn't trip prematurely on the very first
             # re-prompt AssistantMessage.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -190,6 +190,572 @@ _CIRCUIT_BREAKER_ERROR_MSG = (
 _IDLE_TIMEOUT_SECONDS = 30 * 60
 _HUNG_TOOL_CAP_SECONDS = 2 * 60 * 60
 
+
+@dataclass
+class _SDKLoopState:
+    """Mutable per-attempt state for the SDK consume loop.
+
+    Lives outside ``_StreamAccumulator`` so the consume helper can be a
+    plain module-level async generator with a small fixed parameter list,
+    instead of nesting the entire loop body deep inside
+    ``_run_stream_attempt`` under a ``while True:`` wrapper.
+    """
+
+    last_real_msg_time: float
+    last_flush_time: float
+    msgs_since_flush: int = 0
+    consecutive_empty_tool_calls: int = 0
+    ended_with_stream_error: bool = False
+
+
+async def _consume_sdk_until_done(
+    client: ClaudeSDKClient,
+    ctx: "_StreamContext",
+    state: "_RetryState",
+    acc: "_StreamAccumulator",
+    loop_state: "_SDKLoopState",
+) -> AsyncGenerator[StreamBaseResponse, None]:
+    """One pass through the SDK's message stream — yields wire events.
+
+    Returns when the SDK turn ends (``ResultMessage`` → StreamFinish, or
+    iterator exhaustion).  The caller in ``_run_stream_attempt`` invokes
+    this once per turn; if the adapter sets
+    ``pending_thinking_only_reprompt`` after the first pass, the caller
+    fires a synthetic re-prompt and invokes this again for the second
+    pass — bounded to one re-prompt per turn.
+    """
+    async for sdk_msg in _iter_sdk_messages(client):
+        # Heartbeat sentinel — refresh lock and keep SSE alive
+        if sdk_msg is None:
+            await ctx.lock.refresh()
+            for ev in ctx.compaction.emit_start_if_ready():
+                yield ev
+            yield StreamHeartbeat()
+
+            # Threshold flips to the long cap while a tool is pending; clock never resets.
+            idle_seconds = time.monotonic() - loop_state.last_real_msg_time
+            threshold = _idle_timeout_threshold(state.adapter)
+            if idle_seconds >= threshold:
+                unresolved_tool_names = sorted(
+                    {
+                        info.get("name", "unknown")
+                        for tid, info in state.adapter.current_tool_calls.items()
+                        if tid not in state.adapter.resolved_tool_calls
+                    }
+                )
+                logger.error(
+                    "%s Idle timeout after %.0fs (threshold=%ds, "
+                    "unresolved tools: %s) — aborting stream",
+                    ctx.log_prefix,
+                    idle_seconds,
+                    threshold,
+                    ", ".join(unresolved_tool_names) or "none",
+                )
+                # The retryable marker written to the session omits
+                # the `[code:<id>]` prefix — the AI SDK serializer
+                # (`StreamError.to_sse`) attaches that automatically
+                # on the wire so the frontend can still parse a
+                # machine-readable code out of the otherwise opaque
+                # `{type, errorText}` schema.
+                stream_error_code = "idle_timeout"
+                tool_phrase = (
+                    f" while running {_humanise_tool_list(unresolved_tool_names)}"
+                    if unresolved_tool_names
+                    else ""
+                )
+                stream_error_msg = (
+                    f"AutoPilot stopped responding{tool_phrase}. "
+                    "This usually means a tool got stuck. Please try again."
+                )
+                _append_error_marker(ctx.session, stream_error_msg, retryable=True)
+                yield StreamError(
+                    errorText=stream_error_msg,
+                    code=stream_error_code,
+                )
+                loop_state.ended_with_stream_error = True
+                break
+            continue
+
+        loop_state.last_real_msg_time = time.monotonic()
+
+        logger.info(
+            "%s Received: %s %s (unresolved=%d, current=%d, resolved=%d)",
+            ctx.log_prefix,
+            type(sdk_msg).__name__,
+            getattr(sdk_msg, "subtype", ""),
+            len(state.adapter.current_tool_calls)
+            - len(state.adapter.resolved_tool_calls),
+            len(state.adapter.current_tool_calls),
+            len(state.adapter.resolved_tool_calls),
+        )
+
+        # Capture OpenRouter generation IDs from each
+        # ``AssistantMessage.message_id`` — when routed via OpenRouter
+        # these are ``gen-...`` slugs we can use post-turn to query
+        # ``/api/v1/generation?id=`` for the authoritative per-turn
+        # cost and token counts (the CLI's ``total_cost_usd`` is
+        # computed from a static Anthropic pricing table that
+        # silently over-bills non-Anthropic routes).  Direct-Anthropic
+        # turns produce ``msg_...`` IDs which the generation endpoint
+        # doesn't know about — harmlessly ignored at reconcile time.
+        if isinstance(sdk_msg, AssistantMessage):
+            msg_id = sdk_msg.message_id
+            if (
+                msg_id is not None
+                and msg_id.startswith("gen-")
+                and msg_id not in state.generation_ids
+            ):
+                state.generation_ids.append(msg_id)
+            # Track the model the SDK actually used — when a fallback
+            # activates, this differs from ``state.options.model``.
+            # Consumed by the Moonshot cost-override decision so we
+            # don't mis-bill a fallback-Anthropic response at
+            # Moonshot rates (or a fallback-Moonshot at Anthropic
+            # rates).
+            observed = getattr(sdk_msg, "model", None)
+            if isinstance(observed, str) and observed:
+                state.observed_model = observed
+
+        # Log AssistantMessage API errors (e.g. invalid_request)
+        # so we can debug Anthropic API 400s surfaced by the CLI.
+        sdk_error = getattr(sdk_msg, "error", None)
+        if isinstance(sdk_msg, AssistantMessage) and sdk_error:
+            error_text = str(sdk_error)
+            error_preview = str(sdk_msg.content)[:500]
+            logger.error(
+                "[SDK] [%s] AssistantMessage has error=%s, "
+                "content_blocks=%d, content_preview=%s",
+                ctx.session_id[:12],
+                sdk_error,
+                len(sdk_msg.content),
+                error_preview,
+            )
+
+            # Intercept prompt-too-long errors surfaced as
+            # AssistantMessage.error (not as a Python exception).
+            # Re-raise so the outer retry loop can compact the
+            # transcript and retry with reduced context.
+            # Check both error_text and error_preview: sdk_error
+            # being set confirms this is an error message (not user
+            # content), so checking content is safe. The actual
+            # error description (e.g. "Prompt is too long") may be
+            # in the content, not the error type field
+            # (e.g. error="invalid_request", content="Prompt is
+            # too long").
+            if _is_prompt_too_long(Exception(error_text)) or _is_prompt_too_long(
+                Exception(error_preview)
+            ):
+                logger.warning(
+                    "%s Prompt-too-long detected via AssistantMessage "
+                    "error — raising for retry",
+                    ctx.log_prefix,
+                )
+                raise RuntimeError("Prompt is too long")
+
+            # Intercept transient API errors (socket closed,
+            # ECONNRESET) — replace the raw message with a
+            # user-friendly error text and use the retryable
+            # error prefix so the frontend shows a retry button.
+            # Check both the error field and content for patterns.
+            if is_transient_api_error(error_text) or is_transient_api_error(
+                error_preview
+            ):
+                logger.warning(
+                    "%s Transient Anthropic API error detected, "
+                    "suppressing raw error text",
+                    ctx.log_prefix,
+                )
+                stream_error_msg = FRIENDLY_TRANSIENT_MSG
+                stream_error_code = "transient_api_error"
+                # Do NOT yield StreamError or append error marker here.
+                # The outer retry loop decides: if a retry is available it
+                # yields StreamStatus("retrying…"); if retries are exhausted
+                # it appends the marker and yields StreamError exactly once.
+                # Yielding StreamError before the retry decision causes the
+                # client to display an error that is immediately superseded.
+                loop_state.ended_with_stream_error = True
+                break
+
+        # Determine if the message is a tool-only batch (all content
+        # items are ToolUseBlocks) — such messages have no text output yet,
+        # so we skip the wait_for_stash flush below.
+        #
+        # Note: parallel execution of tools is handled natively by the
+        # SDK CLI via readOnlyHint annotations on tool definitions.
+        is_tool_only = False
+        if isinstance(sdk_msg, AssistantMessage) and sdk_msg.content:
+            is_tool_only = all(
+                isinstance(item, ToolUseBlock) for item in sdk_msg.content
+            )
+
+        # Race-condition fix: SDK hooks (PostToolUse) are
+        # executed asynchronously via start_soon() — the next
+        # message can arrive before the hook stashes output.
+        # wait_for_stash() awaits an asyncio.Event signaled by
+        # stash_pending_tool_output(), completing as soon as
+        # the hook finishes (typically <1ms).  The sleep(0)
+        # after lets any remaining concurrent hooks complete.
+        #
+        # Skip for parallel tool continuations: when the SDK
+        # sends parallel tool calls as separate
+        # AssistantMessages (each containing only
+        # ToolUseBlocks), we must NOT wait/flush — the prior
+        # tools are still executing concurrently.
+        if (
+            state.adapter.has_unresolved_tool_calls
+            and isinstance(sdk_msg, (AssistantMessage, ResultMessage))
+            and not is_tool_only
+        ):
+            if await wait_for_stash():
+                await asyncio.sleep(0)
+            else:
+                logger.warning(
+                    "%s Timed out waiting for PostToolUse "
+                    "hook stash (%d unresolved tool calls)",
+                    ctx.log_prefix,
+                    len(state.adapter.current_tool_calls)
+                    - len(state.adapter.resolved_tool_calls),
+                )
+
+        # Log ResultMessage details and capture token usage
+        if isinstance(sdk_msg, ResultMessage):
+            logger.info(
+                "%s Received: ResultMessage %s "
+                "(unresolved=%d, current=%d, resolved=%d, "
+                "num_turns=%d, cost_usd=%s, result=%s)",
+                ctx.log_prefix,
+                sdk_msg.subtype,
+                len(state.adapter.current_tool_calls)
+                - len(state.adapter.resolved_tool_calls),
+                len(state.adapter.current_tool_calls),
+                len(state.adapter.resolved_tool_calls),
+                sdk_msg.num_turns,
+                sdk_msg.total_cost_usd,
+                (sdk_msg.result or "")[:200],
+            )
+            if sdk_msg.subtype in (
+                "error",
+                "error_during_execution",
+            ):
+                logger.error(
+                    "%s SDK execution failed with error: %s",
+                    ctx.log_prefix,
+                    sdk_msg.result or "(no error message provided)",
+                )
+
+            # Check for prompt-too-long regardless of subtype — the
+            # SDK may return subtype="success" with result="Prompt is
+            # too long" when the CLI rejects the prompt before calling
+            # the API (cost_usd=0, no tokens consumed).  If we only
+            # check the "error" subtype path, the stream appears to
+            # complete normally, the synthetic error text is stored
+            # in the transcript, and the session grows without bound.
+            if _is_prompt_too_long(RuntimeError(sdk_msg.result or "")):
+                raise RuntimeError("Prompt is too long")
+
+            # Capture token usage from ResultMessage.
+            # Anthropic reports cached tokens separately:
+            #   input_tokens = uncached only
+            #   cache_read_input_tokens = served from cache
+            #   cache_creation_input_tokens = written to cache
+            if sdk_msg.usage:
+                # Use `or 0` instead of a default in .get() because
+                # OpenRouter may include the key with a null value (e.g.
+                # {"cache_read_input_tokens": null}) for models that don't
+                # yet report cache tokens, making .get("key", 0) return
+                # None rather than the fallback 0.
+                state.usage.prompt_tokens += sdk_msg.usage.get("input_tokens") or 0
+                state.usage.cache_read_tokens += (
+                    sdk_msg.usage.get("cache_read_input_tokens") or 0
+                )
+                state.usage.cache_creation_tokens += (
+                    sdk_msg.usage.get("cache_creation_input_tokens") or 0
+                )
+                state.usage.completion_tokens += sdk_msg.usage.get("output_tokens") or 0
+                logger.info(
+                    "%s Token usage: uncached=%d, cache_read=%d, "
+                    "cache_create=%d, output=%d",
+                    ctx.log_prefix,
+                    state.usage.prompt_tokens,
+                    state.usage.cache_read_tokens,
+                    state.usage.cache_creation_tokens,
+                    state.usage.completion_tokens,
+                )
+            if sdk_msg.total_cost_usd is not None:
+                # Default: trust the CLI-reported value.  Accurate for
+                # Anthropic models (the CLI's bundled pricing table is
+                # Anthropic-authored), and becomes the sync-path cost
+                # when the reconcile is disabled or fails.
+                # Prefer the ACTUALLY executed model
+                # (``state.observed_model`` from ``AssistantMessage.model``)
+                # over the requested primary (``state.options.model``)
+                # so a fallback activation doesn't mis-route pricing.
+                active_model = state.observed_model or getattr(
+                    state.options, "model", None
+                )
+                if _is_moonshot_model(active_model):
+                    # Moonshot slug — the CLI doesn't know Moonshot's
+                    # rate card and silently bills at Sonnet rates
+                    # (~5x over-charge).  Replace with the rate-card
+                    # estimate so the in-stream ``cost_usd`` and the
+                    # reconcile's lookup-fail fallback reflect
+                    # reality.  Reconcile
+                    # (``record_turn_cost_from_openrouter``) still
+                    # overrides this value when every gen-ID lookup
+                    # succeeds.
+                    state.usage.cost_usd = _override_cost_for_moonshot(
+                        model=active_model,
+                        sdk_reported_usd=sdk_msg.total_cost_usd,
+                        prompt_tokens=state.usage.prompt_tokens,
+                        completion_tokens=state.usage.completion_tokens,
+                        cache_read_tokens=state.usage.cache_read_tokens,
+                        cache_creation_tokens=state.usage.cache_creation_tokens,
+                    )
+                else:
+                    state.usage.cost_usd = sdk_msg.total_cost_usd
+
+        # Emit compaction end if SDK finished compacting.
+        # Sync TranscriptBuilder with the CLI's active context.
+        compact_result = await ctx.compaction.emit_end_if_ready(ctx.session)
+        if compact_result.events:
+            # Compaction events end with StreamFinishStep, which maps to
+            # Vercel AI SDK's "finish-step" — that clears activeTextParts.
+            # Close any open text block BEFORE the compaction events so
+            # the text-end arrives before finish-step, preventing
+            # "text-end for missing text part" errors on the frontend.
+            pre_close: list[StreamBaseResponse] = []
+            state.adapter._end_text_if_open(pre_close)
+            # Compaction events bypass the adapter, so sync step state
+            # when a StreamFinishStep is present — otherwise the adapter
+            # will skip StreamStartStep on the next AssistantMessage.
+            if any(isinstance(ev, StreamFinishStep) for ev in compact_result.events):
+                state.adapter.step_open = False
+            for r in pre_close:
+                yield r
+        for ev in compact_result.events:
+            yield ev
+        entries_replaced = False
+        if compact_result.just_ended:
+            compacted = await asyncio.to_thread(
+                read_compacted_entries,
+                compact_result.transcript_path,
+            )
+            if compacted is not None:
+                state.transcript_builder.replace_entries(
+                    compacted, log_prefix=ctx.log_prefix
+                )
+                entries_replaced = True
+
+        # --- Hard circuit breaker for empty tool calls ---
+        breaker = _check_empty_tool_breaker(
+            sdk_msg, loop_state.consecutive_empty_tool_calls, ctx, state
+        )
+        loop_state.consecutive_empty_tool_calls = breaker.count
+        if breaker.tripped and breaker.error is not None:
+            stream_error_msg = breaker.error_msg
+            stream_error_code = breaker.error_code
+            yield breaker.error
+            loop_state.ended_with_stream_error = True
+            break
+
+        # --- Dispatch adapter responses ---
+        adapter_responses = state.adapter.convert_message(sdk_msg)
+
+        # Pre-create the new assistant message in the session BEFORE
+        # yielding any events so it survives a GeneratorExit (client
+        # disconnect) that interrupts the yield loop at StreamStartStep.
+        #
+        # Without this, the sequence is:
+        #   tool result saved → intermediate flush → StreamStartStep
+        #   yield → GeneratorExit → finally saves session with
+        #   last_role=tool (the text response was generated but never
+        #   appended because _dispatch_response(StreamTextDelta) was
+        #   skipped).
+        #
+        # We only pre-create when:
+        #   1. Tool results were received this turn (has_tool_results).
+        #   2. The prior assistant message is already appended
+        #      (has_appended_assistant) — so this is a post-tool turn.
+        #   3. This batch contains StreamTextDelta — text IS coming, so
+        #      we won't leave a spurious empty message for tool-only turns.
+        #
+        # Subsequent StreamTextDelta dispatches accumulate content into
+        # acc.assistant_response in-place (ChatMessage is mutable), so
+        # the DB record is updated without a second append.
+        if (
+            acc.has_tool_results
+            and acc.has_appended_assistant
+            and any(isinstance(r, StreamTextDelta) for r in adapter_responses)
+        ):
+            acc.assistant_response = ChatMessage(role="assistant", content="")
+            acc.accumulated_tool_calls = []
+            acc.has_tool_results = False
+            ctx.session.messages.append(acc.assistant_response)
+            # acc.has_appended_assistant stays True — placeholder is live
+
+        # When StreamFinish is in this batch (ResultMessage), flush any
+        # text buffered by the thinking stripper and inject it as a
+        # StreamTextDelta BEFORE the StreamTextEnd so the Vercel AI SDK
+        # receives the tail inside the still-open text block (correct
+        # protocol order: TextDelta → TextEnd → FinishStep → Finish).
+        tail_delta: StreamTextDelta | None = None
+        if any(isinstance(r, StreamFinish) for r in adapter_responses):
+            tail = acc.thinking_stripper.flush()
+            if tail and not loop_state.ended_with_stream_error:
+                # Do NOT manually append tail to acc.assistant_response.content
+                # here — _dispatch_response handles that.  Doing it here would
+                # double-append because _dispatch_response also updates the
+                # accumulator.  Instead, mark the delta as pre-stripped so
+                # _dispatch_response bypasses ThinkingStripper.process() for it
+                # (re-processing could suppress a tail that looks like a partial
+                # tag opener, e.g. "Hello <inter" → buffered again → lost).
+                tail_delta = StreamTextDelta(id=state.adapter.text_block_id, delta=tail)
+                insert_at = next(
+                    (
+                        i
+                        for i, r in enumerate(adapter_responses)
+                        if isinstance(r, (StreamTextEnd, StreamFinish))
+                    ),
+                    len(adapter_responses),
+                )
+                adapter_responses.insert(insert_at, tail_delta)
+        for response in adapter_responses:
+            dispatched = _dispatch_response(
+                response,
+                acc,
+                ctx,
+                state,
+                entries_replaced,
+                ctx.log_prefix,
+                skip_strip=response is tail_delta,
+            )
+            if dispatched is not None:
+                # Persistence (via _dispatch_response) always runs so the
+                # session transcript keeps role='reasoning' rows; the
+                # wire is gated so UI can suppress rendering.
+                if not state.adapter.render_reasoning_in_ui and isinstance(
+                    dispatched,
+                    (
+                        StreamReasoningStart,
+                        StreamReasoningDelta,
+                        StreamReasoningEnd,
+                    ),
+                ):
+                    continue
+                yield dispatched
+
+            # Mid-turn follow-up persistence: the MCP tool wrapper drains
+            # the primary pending buffer and stashes the drained
+            # PendingMessages into the per-session persist queue.  Claude
+            # has already seen them via the <user_follow_up> block
+            # injected into the tool output.  Now — right after the
+            # tool_result row has been appended to session.messages — we
+            # pop the persist queue and append a real user ChatMessage
+            # so the UI renders a proper user bubble in the correct
+            # chronological position (after the tool_result, before the
+            # assistant's continuing response).  Rollback re-queues into
+            # the PRIMARY pending buffer so the next turn-start drain
+            # picks them up if this persist silently fails.
+            # Only run the follow-up persist if the tool_result row was
+            # actually appended by _dispatch_response (currently always
+            # true for this variant, but we guard so a future refactor
+            # that conditionally skips the append can't silently land
+            # a user row before a missing tool_result).
+            if (
+                isinstance(response, StreamToolOutputAvailable)
+                and dispatched is not None
+                and acc.has_tool_results
+            ):
+                followup_drained = await drain_pending_for_persist(
+                    ctx.session.session_id
+                )
+                if followup_drained and await persist_pending_as_user_rows(
+                    ctx.session,
+                    state.transcript_builder,
+                    followup_drained,
+                    log_prefix=ctx.log_prefix,
+                ):
+                    # Track CLI-JSONL-invisible rows so the upload
+                    # watermark excludes them and the next turn's
+                    # detect_gap picks them up as gap-fill.
+                    state.midturn_user_rows += len(followup_drained)
+
+        # Append assistant entry AFTER convert_message so that
+        # any stashed tool results from the previous turn are
+        # recorded first, preserving the required API order:
+        # assistant(tool_use) → tool_result → assistant(text).
+        # Skip if replace_entries just ran — the CLI session
+        # file already contains this message.
+        if isinstance(sdk_msg, AssistantMessage) and not entries_replaced:
+            state.transcript_builder.append_assistant(
+                content_blocks=_format_sdk_content_blocks(sdk_msg.content),
+                model=sdk_msg.model,
+            )
+
+        # --- Intermediate persistence ---
+        # Flush session messages to DB periodically so page reloads
+        # show progress during long-running turns.
+        #
+        # IMPORTANT: Skip the flush while tool calls are pending
+        # (tool_calls set on assistant but results not yet received).
+        # The DB save is append-only (uses start_sequence), so if we
+        # flush the assistant message before tool_calls are set on it
+        # (text and tool_use arrive as separate SDK events), the
+        # tool_calls update is lost — the next flush starts past it.
+        #
+        # With ``include_partial_messages=True`` the CLI delivers
+        # hundreds of ``StreamEvent`` messages per turn — incrementing
+        # ``loop_state.msgs_since_flush`` on each one trips the threshold long
+        # before the assistant text is complete, saving a truncated
+        # prefix that subsequent deltas can never extend (append-only).
+        # Count only messages that produce a persisted row boundary
+        # (AssistantMessage, UserMessage, ResultMessage) and skip
+        # raw StreamEvents.  Also skip when text or reasoning is
+        # still in-flight on the adapter: the row is live and a flush
+        # would lock it at its current length.
+        if not isinstance(sdk_msg, StreamEvent):
+            loop_state.msgs_since_flush += 1
+        now = time.monotonic()
+        has_pending_tools = (
+            acc.has_appended_assistant
+            and acc.accumulated_tool_calls
+            and not acc.has_tool_results
+        )
+        adapter = state.adapter
+        has_open_block = (adapter.has_started_text and not adapter.has_ended_text) or (
+            adapter.has_started_reasoning and not adapter.has_ended_reasoning
+        )
+        if (
+            not has_pending_tools
+            and not has_open_block
+            and (
+                loop_state.msgs_since_flush >= _FLUSH_MESSAGE_THRESHOLD
+                or (now - loop_state.last_flush_time) >= _FLUSH_INTERVAL_SECONDS
+            )
+        ):
+            try:
+                await asyncio.shield(upsert_chat_session(ctx.session))
+                logger.debug(
+                    "%s Intermediate flush: %d messages "
+                    "(msgs_since=%d, elapsed=%.1fs)",
+                    ctx.log_prefix,
+                    len(ctx.session.messages),
+                    loop_state.msgs_since_flush,
+                    now - loop_state.last_flush_time,
+                )
+            except Exception as flush_err:
+                logger.warning(
+                    "%s Intermediate flush failed: %s",
+                    ctx.log_prefix,
+                    flush_err,
+                )
+            loop_state.last_flush_time = now
+            loop_state.msgs_since_flush = 0
+
+        if acc.stream_completed:
+            break
+
+
 # Synthetic message injected when a turn ends with extended thinking but no
 # visible TextBlock. Bounded to one re-prompt per turn — if the model still
 # returns thinking-only the adapter promotes the last thinking block to
@@ -198,6 +764,11 @@ _THINKING_ONLY_REPROMPT = (
     "Please write a brief user-facing summary of what you found, in plain "
     "prose. Do not use tools."
 )
+
+# Intermediate-flush thresholds for the SDK consume loop — periodic
+# session-message flush so page reloads show progress on long turns.
+_FLUSH_INTERVAL_SECONDS = 30.0
+_FLUSH_MESSAGE_THRESHOLD = 10
 
 
 def _strip_synthetic_reprompt_from_cli_jsonl(content: bytes) -> bytes:
@@ -1247,7 +1818,7 @@ def _next_transient_backoff(
 
 async def _do_transient_backoff(
     backoff: int,
-    state: _RetryState,
+    state: "_RetryState",
     message_id: str,
     session_id: str,
 ) -> AsyncIterator[StreamStatus]:
@@ -2153,7 +2724,7 @@ class _StreamAccumulator:
 
 def _dispatch_response(
     response: StreamBaseResponse,
-    acc: _StreamAccumulator,
+    acc: "_StreamAccumulator",
     ctx: "_StreamContext",
     state: "_RetryState",
     entries_replaced: bool,
@@ -2407,7 +2978,7 @@ def _check_empty_tool_breaker(
     sdk_msg: object,
     consecutive: int,
     ctx: _StreamContext,
-    state: _RetryState,
+    state: "_RetryState",
 ) -> _EmptyToolBreakResult:
     """Detect consecutive empty tool calls and trip the circuit breaker.
 
@@ -2489,7 +3060,7 @@ def _check_empty_tool_breaker(
 
 async def _run_stream_attempt(
     ctx: _StreamContext,
-    state: _RetryState,
+    state: "_RetryState",
 ) -> AsyncIterator[StreamBaseResponse]:
     """Run one SDK streaming attempt.
 
@@ -2519,21 +3090,14 @@ async def _run_stream_attempt(
         assistant_response=ChatMessage(role="assistant", content=""),
         accumulated_tool_calls=[],
     )
-    ended_with_stream_error = False
     # Stores the error message used by _append_error_marker so the outer
     # retry loop can re-append the correct message after session rollback.
     stream_error_msg: str | None = None
     stream_error_code: str | None = None
 
-    consecutive_empty_tool_calls = 0
-
     # --- Intermediate persistence tracking ---
     # Flush session messages to DB periodically so page reloads show progress
     # during long-running turns (see incident d2f7cba3: 82-min turn lost on refresh).
-    _last_flush_time = time.monotonic()
-    _msgs_since_flush = 0
-    _FLUSH_INTERVAL_SECONDS = 30.0
-    _FLUSH_MESSAGE_THRESHOLD = 10
 
     # Use manual __aenter__/__aexit__ instead of ``async with`` so we can
     # suppress SDK cleanup errors that occur when the SSE client disconnects
@@ -2593,571 +3157,38 @@ async def _run_stream_attempt(
             await client.query(state.query_message, session_id=ctx.session_id)
             state.transcript_builder.append_user(content=ctx.current_message)
 
-        _last_real_msg_time = time.monotonic()
+        loop_state = _SDKLoopState(
+            last_real_msg_time=time.monotonic(),
+            last_flush_time=time.monotonic(),
+        )
 
-        while True:
-            async for sdk_msg in _iter_sdk_messages(client):
-                # Heartbeat sentinel — refresh lock and keep SSE alive
-                if sdk_msg is None:
-                    await ctx.lock.refresh()
-                    for ev in ctx.compaction.emit_start_if_ready():
-                        yield ev
-                    yield StreamHeartbeat()
+        async for ev in _consume_sdk_until_done(client, ctx, state, acc, loop_state):
+            yield ev
 
-                    # Threshold flips to the long cap while a tool is pending; clock never resets.
-                    idle_seconds = time.monotonic() - _last_real_msg_time
-                    threshold = _idle_timeout_threshold(state.adapter)
-                    if idle_seconds >= threshold:
-                        unresolved_tool_names = sorted(
-                            {
-                                info.get("name", "unknown")
-                                for tid, info in state.adapter.current_tool_calls.items()
-                                if tid not in state.adapter.resolved_tool_calls
-                            }
-                        )
-                        logger.error(
-                            "%s Idle timeout after %.0fs (threshold=%ds, "
-                            "unresolved tools: %s) — aborting stream",
-                            ctx.log_prefix,
-                            idle_seconds,
-                            threshold,
-                            ", ".join(unresolved_tool_names) or "none",
-                        )
-                        # The retryable marker written to the session omits
-                        # the `[code:<id>]` prefix — the AI SDK serializer
-                        # (`StreamError.to_sse`) attaches that automatically
-                        # on the wire so the frontend can still parse a
-                        # machine-readable code out of the otherwise opaque
-                        # `{type, errorText}` schema.
-                        stream_error_code = "idle_timeout"
-                        tool_phrase = (
-                            f" while running {_humanise_tool_list(unresolved_tool_names)}"
-                            if unresolved_tool_names
-                            else ""
-                        )
-                        stream_error_msg = (
-                            f"AutoPilot stopped responding{tool_phrase}. "
-                            "This usually means a tool got stuck. Please try again."
-                        )
-                        _append_error_marker(
-                            ctx.session, stream_error_msg, retryable=True
-                        )
-                        yield StreamError(
-                            errorText=stream_error_msg,
-                            code=stream_error_code,
-                        )
-                        ended_with_stream_error = True
-                        break
-                    continue
-
-                _last_real_msg_time = time.monotonic()
-
-                logger.info(
-                    "%s Received: %s %s (unresolved=%d, current=%d, resolved=%d)",
-                    ctx.log_prefix,
-                    type(sdk_msg).__name__,
-                    getattr(sdk_msg, "subtype", ""),
-                    len(state.adapter.current_tool_calls)
-                    - len(state.adapter.resolved_tool_calls),
-                    len(state.adapter.current_tool_calls),
-                    len(state.adapter.resolved_tool_calls),
-                )
-
-                # Capture OpenRouter generation IDs from each
-                # ``AssistantMessage.message_id`` — when routed via OpenRouter
-                # these are ``gen-...`` slugs we can use post-turn to query
-                # ``/api/v1/generation?id=`` for the authoritative per-turn
-                # cost and token counts (the CLI's ``total_cost_usd`` is
-                # computed from a static Anthropic pricing table that
-                # silently over-bills non-Anthropic routes).  Direct-Anthropic
-                # turns produce ``msg_...`` IDs which the generation endpoint
-                # doesn't know about — harmlessly ignored at reconcile time.
-                if isinstance(sdk_msg, AssistantMessage):
-                    msg_id = sdk_msg.message_id
-                    if (
-                        msg_id is not None
-                        and msg_id.startswith("gen-")
-                        and msg_id not in state.generation_ids
-                    ):
-                        state.generation_ids.append(msg_id)
-                    # Track the model the SDK actually used — when a fallback
-                    # activates, this differs from ``state.options.model``.
-                    # Consumed by the Moonshot cost-override decision so we
-                    # don't mis-bill a fallback-Anthropic response at
-                    # Moonshot rates (or a fallback-Moonshot at Anthropic
-                    # rates).
-                    observed = getattr(sdk_msg, "model", None)
-                    if isinstance(observed, str) and observed:
-                        state.observed_model = observed
-
-                # Log AssistantMessage API errors (e.g. invalid_request)
-                # so we can debug Anthropic API 400s surfaced by the CLI.
-                sdk_error = getattr(sdk_msg, "error", None)
-                if isinstance(sdk_msg, AssistantMessage) and sdk_error:
-                    error_text = str(sdk_error)
-                    error_preview = str(sdk_msg.content)[:500]
-                    logger.error(
-                        "[SDK] [%s] AssistantMessage has error=%s, "
-                        "content_blocks=%d, content_preview=%s",
-                        ctx.session_id[:12],
-                        sdk_error,
-                        len(sdk_msg.content),
-                        error_preview,
-                    )
-
-                    # Intercept prompt-too-long errors surfaced as
-                    # AssistantMessage.error (not as a Python exception).
-                    # Re-raise so the outer retry loop can compact the
-                    # transcript and retry with reduced context.
-                    # Check both error_text and error_preview: sdk_error
-                    # being set confirms this is an error message (not user
-                    # content), so checking content is safe. The actual
-                    # error description (e.g. "Prompt is too long") may be
-                    # in the content, not the error type field
-                    # (e.g. error="invalid_request", content="Prompt is
-                    # too long").
-                    if _is_prompt_too_long(
-                        Exception(error_text)
-                    ) or _is_prompt_too_long(Exception(error_preview)):
-                        logger.warning(
-                            "%s Prompt-too-long detected via AssistantMessage "
-                            "error — raising for retry",
-                            ctx.log_prefix,
-                        )
-                        raise RuntimeError("Prompt is too long")
-
-                    # Intercept transient API errors (socket closed,
-                    # ECONNRESET) — replace the raw message with a
-                    # user-friendly error text and use the retryable
-                    # error prefix so the frontend shows a retry button.
-                    # Check both the error field and content for patterns.
-                    if is_transient_api_error(error_text) or is_transient_api_error(
-                        error_preview
-                    ):
-                        logger.warning(
-                            "%s Transient Anthropic API error detected, "
-                            "suppressing raw error text",
-                            ctx.log_prefix,
-                        )
-                        stream_error_msg = FRIENDLY_TRANSIENT_MSG
-                        stream_error_code = "transient_api_error"
-                        # Do NOT yield StreamError or append error marker here.
-                        # The outer retry loop decides: if a retry is available it
-                        # yields StreamStatus("retrying…"); if retries are exhausted
-                        # it appends the marker and yields StreamError exactly once.
-                        # Yielding StreamError before the retry decision causes the
-                        # client to display an error that is immediately superseded.
-                        ended_with_stream_error = True
-                        break
-
-                # Determine if the message is a tool-only batch (all content
-                # items are ToolUseBlocks) — such messages have no text output yet,
-                # so we skip the wait_for_stash flush below.
-                #
-                # Note: parallel execution of tools is handled natively by the
-                # SDK CLI via readOnlyHint annotations on tool definitions.
-                is_tool_only = False
-                if isinstance(sdk_msg, AssistantMessage) and sdk_msg.content:
-                    is_tool_only = all(
-                        isinstance(item, ToolUseBlock) for item in sdk_msg.content
-                    )
-
-                # Race-condition fix: SDK hooks (PostToolUse) are
-                # executed asynchronously via start_soon() — the next
-                # message can arrive before the hook stashes output.
-                # wait_for_stash() awaits an asyncio.Event signaled by
-                # stash_pending_tool_output(), completing as soon as
-                # the hook finishes (typically <1ms).  The sleep(0)
-                # after lets any remaining concurrent hooks complete.
-                #
-                # Skip for parallel tool continuations: when the SDK
-                # sends parallel tool calls as separate
-                # AssistantMessages (each containing only
-                # ToolUseBlocks), we must NOT wait/flush — the prior
-                # tools are still executing concurrently.
-                if (
-                    state.adapter.has_unresolved_tool_calls
-                    and isinstance(sdk_msg, (AssistantMessage, ResultMessage))
-                    and not is_tool_only
-                ):
-                    if await wait_for_stash():
-                        await asyncio.sleep(0)
-                    else:
-                        logger.warning(
-                            "%s Timed out waiting for PostToolUse "
-                            "hook stash (%d unresolved tool calls)",
-                            ctx.log_prefix,
-                            len(state.adapter.current_tool_calls)
-                            - len(state.adapter.resolved_tool_calls),
-                        )
-
-                # Log ResultMessage details and capture token usage
-                if isinstance(sdk_msg, ResultMessage):
-                    logger.info(
-                        "%s Received: ResultMessage %s "
-                        "(unresolved=%d, current=%d, resolved=%d, "
-                        "num_turns=%d, cost_usd=%s, result=%s)",
-                        ctx.log_prefix,
-                        sdk_msg.subtype,
-                        len(state.adapter.current_tool_calls)
-                        - len(state.adapter.resolved_tool_calls),
-                        len(state.adapter.current_tool_calls),
-                        len(state.adapter.resolved_tool_calls),
-                        sdk_msg.num_turns,
-                        sdk_msg.total_cost_usd,
-                        (sdk_msg.result or "")[:200],
-                    )
-                    if sdk_msg.subtype in (
-                        "error",
-                        "error_during_execution",
-                    ):
-                        logger.error(
-                            "%s SDK execution failed with error: %s",
-                            ctx.log_prefix,
-                            sdk_msg.result or "(no error message provided)",
-                        )
-
-                    # Check for prompt-too-long regardless of subtype — the
-                    # SDK may return subtype="success" with result="Prompt is
-                    # too long" when the CLI rejects the prompt before calling
-                    # the API (cost_usd=0, no tokens consumed).  If we only
-                    # check the "error" subtype path, the stream appears to
-                    # complete normally, the synthetic error text is stored
-                    # in the transcript, and the session grows without bound.
-                    if _is_prompt_too_long(RuntimeError(sdk_msg.result or "")):
-                        raise RuntimeError("Prompt is too long")
-
-                    # Capture token usage from ResultMessage.
-                    # Anthropic reports cached tokens separately:
-                    #   input_tokens = uncached only
-                    #   cache_read_input_tokens = served from cache
-                    #   cache_creation_input_tokens = written to cache
-                    if sdk_msg.usage:
-                        # Use `or 0` instead of a default in .get() because
-                        # OpenRouter may include the key with a null value (e.g.
-                        # {"cache_read_input_tokens": null}) for models that don't
-                        # yet report cache tokens, making .get("key", 0) return
-                        # None rather than the fallback 0.
-                        state.usage.prompt_tokens += (
-                            sdk_msg.usage.get("input_tokens") or 0
-                        )
-                        state.usage.cache_read_tokens += (
-                            sdk_msg.usage.get("cache_read_input_tokens") or 0
-                        )
-                        state.usage.cache_creation_tokens += (
-                            sdk_msg.usage.get("cache_creation_input_tokens") or 0
-                        )
-                        state.usage.completion_tokens += (
-                            sdk_msg.usage.get("output_tokens") or 0
-                        )
-                        logger.info(
-                            "%s Token usage: uncached=%d, cache_read=%d, "
-                            "cache_create=%d, output=%d",
-                            ctx.log_prefix,
-                            state.usage.prompt_tokens,
-                            state.usage.cache_read_tokens,
-                            state.usage.cache_creation_tokens,
-                            state.usage.completion_tokens,
-                        )
-                    if sdk_msg.total_cost_usd is not None:
-                        # Default: trust the CLI-reported value.  Accurate for
-                        # Anthropic models (the CLI's bundled pricing table is
-                        # Anthropic-authored), and becomes the sync-path cost
-                        # when the reconcile is disabled or fails.
-                        # Prefer the ACTUALLY executed model
-                        # (``state.observed_model`` from ``AssistantMessage.model``)
-                        # over the requested primary (``state.options.model``)
-                        # so a fallback activation doesn't mis-route pricing.
-                        active_model = state.observed_model or getattr(
-                            state.options, "model", None
-                        )
-                        if _is_moonshot_model(active_model):
-                            # Moonshot slug — the CLI doesn't know Moonshot's
-                            # rate card and silently bills at Sonnet rates
-                            # (~5x over-charge).  Replace with the rate-card
-                            # estimate so the in-stream ``cost_usd`` and the
-                            # reconcile's lookup-fail fallback reflect
-                            # reality.  Reconcile
-                            # (``record_turn_cost_from_openrouter``) still
-                            # overrides this value when every gen-ID lookup
-                            # succeeds.
-                            state.usage.cost_usd = _override_cost_for_moonshot(
-                                model=active_model,
-                                sdk_reported_usd=sdk_msg.total_cost_usd,
-                                prompt_tokens=state.usage.prompt_tokens,
-                                completion_tokens=state.usage.completion_tokens,
-                                cache_read_tokens=state.usage.cache_read_tokens,
-                                cache_creation_tokens=state.usage.cache_creation_tokens,
-                            )
-                        else:
-                            state.usage.cost_usd = sdk_msg.total_cost_usd
-
-                # Emit compaction end if SDK finished compacting.
-                # Sync TranscriptBuilder with the CLI's active context.
-                compact_result = await ctx.compaction.emit_end_if_ready(ctx.session)
-                if compact_result.events:
-                    # Compaction events end with StreamFinishStep, which maps to
-                    # Vercel AI SDK's "finish-step" — that clears activeTextParts.
-                    # Close any open text block BEFORE the compaction events so
-                    # the text-end arrives before finish-step, preventing
-                    # "text-end for missing text part" errors on the frontend.
-                    pre_close: list[StreamBaseResponse] = []
-                    state.adapter._end_text_if_open(pre_close)
-                    # Compaction events bypass the adapter, so sync step state
-                    # when a StreamFinishStep is present — otherwise the adapter
-                    # will skip StreamStartStep on the next AssistantMessage.
-                    if any(
-                        isinstance(ev, StreamFinishStep) for ev in compact_result.events
-                    ):
-                        state.adapter.step_open = False
-                    for r in pre_close:
-                        yield r
-                for ev in compact_result.events:
-                    yield ev
-                entries_replaced = False
-                if compact_result.just_ended:
-                    compacted = await asyncio.to_thread(
-                        read_compacted_entries,
-                        compact_result.transcript_path,
-                    )
-                    if compacted is not None:
-                        state.transcript_builder.replace_entries(
-                            compacted, log_prefix=ctx.log_prefix
-                        )
-                        entries_replaced = True
-
-                # --- Hard circuit breaker for empty tool calls ---
-                breaker = _check_empty_tool_breaker(
-                    sdk_msg, consecutive_empty_tool_calls, ctx, state
-                )
-                consecutive_empty_tool_calls = breaker.count
-                if breaker.tripped and breaker.error is not None:
-                    stream_error_msg = breaker.error_msg
-                    stream_error_code = breaker.error_code
-                    yield breaker.error
-                    ended_with_stream_error = True
-                    break
-
-                # --- Dispatch adapter responses ---
-                adapter_responses = state.adapter.convert_message(sdk_msg)
-
-                # Pre-create the new assistant message in the session BEFORE
-                # yielding any events so it survives a GeneratorExit (client
-                # disconnect) that interrupts the yield loop at StreamStartStep.
-                #
-                # Without this, the sequence is:
-                #   tool result saved → intermediate flush → StreamStartStep
-                #   yield → GeneratorExit → finally saves session with
-                #   last_role=tool (the text response was generated but never
-                #   appended because _dispatch_response(StreamTextDelta) was
-                #   skipped).
-                #
-                # We only pre-create when:
-                #   1. Tool results were received this turn (has_tool_results).
-                #   2. The prior assistant message is already appended
-                #      (has_appended_assistant) — so this is a post-tool turn.
-                #   3. This batch contains StreamTextDelta — text IS coming, so
-                #      we won't leave a spurious empty message for tool-only turns.
-                #
-                # Subsequent StreamTextDelta dispatches accumulate content into
-                # acc.assistant_response in-place (ChatMessage is mutable), so
-                # the DB record is updated without a second append.
-                if (
-                    acc.has_tool_results
-                    and acc.has_appended_assistant
-                    and any(isinstance(r, StreamTextDelta) for r in adapter_responses)
-                ):
-                    acc.assistant_response = ChatMessage(role="assistant", content="")
-                    acc.accumulated_tool_calls = []
-                    acc.has_tool_results = False
-                    ctx.session.messages.append(acc.assistant_response)
-                    # acc.has_appended_assistant stays True — placeholder is live
-
-                # When StreamFinish is in this batch (ResultMessage), flush any
-                # text buffered by the thinking stripper and inject it as a
-                # StreamTextDelta BEFORE the StreamTextEnd so the Vercel AI SDK
-                # receives the tail inside the still-open text block (correct
-                # protocol order: TextDelta → TextEnd → FinishStep → Finish).
-                tail_delta: StreamTextDelta | None = None
-                if any(isinstance(r, StreamFinish) for r in adapter_responses):
-                    tail = acc.thinking_stripper.flush()
-                    if tail and not ended_with_stream_error:
-                        # Do NOT manually append tail to acc.assistant_response.content
-                        # here — _dispatch_response handles that.  Doing it here would
-                        # double-append because _dispatch_response also updates the
-                        # accumulator.  Instead, mark the delta as pre-stripped so
-                        # _dispatch_response bypasses ThinkingStripper.process() for it
-                        # (re-processing could suppress a tail that looks like a partial
-                        # tag opener, e.g. "Hello <inter" → buffered again → lost).
-                        tail_delta = StreamTextDelta(
-                            id=state.adapter.text_block_id, delta=tail
-                        )
-                        insert_at = next(
-                            (
-                                i
-                                for i, r in enumerate(adapter_responses)
-                                if isinstance(r, (StreamTextEnd, StreamFinish))
-                            ),
-                            len(adapter_responses),
-                        )
-                        adapter_responses.insert(insert_at, tail_delta)
-                for response in adapter_responses:
-                    dispatched = _dispatch_response(
-                        response,
-                        acc,
-                        ctx,
-                        state,
-                        entries_replaced,
-                        ctx.log_prefix,
-                        skip_strip=response is tail_delta,
-                    )
-                    if dispatched is not None:
-                        # Persistence (via _dispatch_response) always runs so the
-                        # session transcript keeps role='reasoning' rows; the
-                        # wire is gated so UI can suppress rendering.
-                        if not state.adapter.render_reasoning_in_ui and isinstance(
-                            dispatched,
-                            (
-                                StreamReasoningStart,
-                                StreamReasoningDelta,
-                                StreamReasoningEnd,
-                            ),
-                        ):
-                            continue
-                        yield dispatched
-
-                    # Mid-turn follow-up persistence: the MCP tool wrapper drains
-                    # the primary pending buffer and stashes the drained
-                    # PendingMessages into the per-session persist queue.  Claude
-                    # has already seen them via the <user_follow_up> block
-                    # injected into the tool output.  Now — right after the
-                    # tool_result row has been appended to session.messages — we
-                    # pop the persist queue and append a real user ChatMessage
-                    # so the UI renders a proper user bubble in the correct
-                    # chronological position (after the tool_result, before the
-                    # assistant's continuing response).  Rollback re-queues into
-                    # the PRIMARY pending buffer so the next turn-start drain
-                    # picks them up if this persist silently fails.
-                    # Only run the follow-up persist if the tool_result row was
-                    # actually appended by _dispatch_response (currently always
-                    # true for this variant, but we guard so a future refactor
-                    # that conditionally skips the append can't silently land
-                    # a user row before a missing tool_result).
-                    if (
-                        isinstance(response, StreamToolOutputAvailable)
-                        and dispatched is not None
-                        and acc.has_tool_results
-                    ):
-                        followup_drained = await drain_pending_for_persist(
-                            ctx.session.session_id
-                        )
-                        if followup_drained and await persist_pending_as_user_rows(
-                            ctx.session,
-                            state.transcript_builder,
-                            followup_drained,
-                            log_prefix=ctx.log_prefix,
-                        ):
-                            # Track CLI-JSONL-invisible rows so the upload
-                            # watermark excludes them and the next turn's
-                            # detect_gap picks them up as gap-fill.
-                            state.midturn_user_rows += len(followup_drained)
-
-                # Append assistant entry AFTER convert_message so that
-                # any stashed tool results from the previous turn are
-                # recorded first, preserving the required API order:
-                # assistant(tool_use) → tool_result → assistant(text).
-                # Skip if replace_entries just ran — the CLI session
-                # file already contains this message.
-                if isinstance(sdk_msg, AssistantMessage) and not entries_replaced:
-                    state.transcript_builder.append_assistant(
-                        content_blocks=_format_sdk_content_blocks(sdk_msg.content),
-                        model=sdk_msg.model,
-                    )
-
-                # --- Intermediate persistence ---
-                # Flush session messages to DB periodically so page reloads
-                # show progress during long-running turns.
-                #
-                # IMPORTANT: Skip the flush while tool calls are pending
-                # (tool_calls set on assistant but results not yet received).
-                # The DB save is append-only (uses start_sequence), so if we
-                # flush the assistant message before tool_calls are set on it
-                # (text and tool_use arrive as separate SDK events), the
-                # tool_calls update is lost — the next flush starts past it.
-                #
-                # With ``include_partial_messages=True`` the CLI delivers
-                # hundreds of ``StreamEvent`` messages per turn — incrementing
-                # ``_msgs_since_flush`` on each one trips the threshold long
-                # before the assistant text is complete, saving a truncated
-                # prefix that subsequent deltas can never extend (append-only).
-                # Count only messages that produce a persisted row boundary
-                # (AssistantMessage, UserMessage, ResultMessage) and skip
-                # raw StreamEvents.  Also skip when text or reasoning is
-                # still in-flight on the adapter: the row is live and a flush
-                # would lock it at its current length.
-                if not isinstance(sdk_msg, StreamEvent):
-                    _msgs_since_flush += 1
-                now = time.monotonic()
-                has_pending_tools = (
-                    acc.has_appended_assistant
-                    and acc.accumulated_tool_calls
-                    and not acc.has_tool_results
-                )
-                adapter = state.adapter
-                has_open_block = (
-                    adapter.has_started_text and not adapter.has_ended_text
-                ) or (adapter.has_started_reasoning and not adapter.has_ended_reasoning)
-                if (
-                    not has_pending_tools
-                    and not has_open_block
-                    and (
-                        _msgs_since_flush >= _FLUSH_MESSAGE_THRESHOLD
-                        or (now - _last_flush_time) >= _FLUSH_INTERVAL_SECONDS
-                    )
-                ):
-                    try:
-                        await asyncio.shield(upsert_chat_session(ctx.session))
-                        logger.debug(
-                            "%s Intermediate flush: %d messages "
-                            "(msgs_since=%d, elapsed=%.1fs)",
-                            ctx.log_prefix,
-                            len(ctx.session.messages),
-                            _msgs_since_flush,
-                            now - _last_flush_time,
-                        )
-                    except Exception as flush_err:
-                        logger.warning(
-                            "%s Intermediate flush failed: %s",
-                            ctx.log_prefix,
-                            flush_err,
-                        )
-                    _last_flush_time = now
-                    _msgs_since_flush = 0
-
-                if acc.stream_completed:
-                    break
-            if (
-                state.adapter.pending_thinking_only_reprompt
-                and not state.thinking_only_reprompted
-                and not ended_with_stream_error
+        if (
+            state.adapter.pending_thinking_only_reprompt
+            and not state.thinking_only_reprompted
+            and not loop_state.ended_with_stream_error
+        ):
+            state.adapter.pending_thinking_only_reprompt = False
+            state.thinking_only_reprompted = True
+            state.adapter.thinking_only_reprompted = True
+            # Re-prompt round must still trip the placeholder guard if model returns thinking-only again.
+            state.adapter._text_since_last_tool_result = False
+            acc.stream_completed = False
+            logger.info(
+                "%s Re-prompting model for closing summary "
+                "after thinking-only final turn",
+                ctx.log_prefix,
+            )
+            await client.query(
+                _THINKING_ONLY_REPROMPT,
+                session_id=ctx.session_id,
+            )
+            async for ev in _consume_sdk_until_done(
+                client, ctx, state, acc, loop_state
             ):
-                state.adapter.pending_thinking_only_reprompt = False
-                state.thinking_only_reprompted = True
-                state.adapter.thinking_only_reprompted = True
-                # Re-prompt round must still trip the placeholder guard if model returns thinking-only again.
-                state.adapter._text_since_last_tool_result = False
-                acc.stream_completed = False
-                logger.info(
-                    "%s Re-prompting model for closing summary "
-                    "after thinking-only final turn",
-                    ctx.log_prefix,
-                )
-                await client.query(
-                    _THINKING_ONLY_REPROMPT,
-                    session_id=ctx.session_id,
-                )
-                continue
-            break
+                yield ev
     finally:
         await _safe_close_sdk_client(sdk_client, ctx.log_prefix)
 
@@ -3193,7 +3224,7 @@ async def _run_stream_attempt(
                 )
             yield response
 
-    if not acc.stream_completed and not ended_with_stream_error:
+    if not acc.stream_completed and not loop_state.ended_with_stream_error:
         logger.info(
             "%s Stream ended without ResultMessage (stopped by user)",
             ctx.log_prefix,
@@ -3215,7 +3246,7 @@ async def _run_stream_attempt(
     # already_yielded=False for transient_api_error: StreamError was NOT
     # sent to the client yet (the outer loop does it when retries are
     # exhausted, avoiding a premature error flash before the retry).
-    if ended_with_stream_error:
+    if loop_state.ended_with_stream_error:
         raise _HandledStreamError(
             "Stream error handled",
             error_msg=stream_error_msg,
@@ -3552,7 +3583,6 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
 
     message_id = str(uuid.uuid4())
     stream_id = str(uuid.uuid4())
-    ended_with_stream_error = False
     e2b_sandbox = None
     use_resume = False
     resume_file: str | None = None
@@ -4125,7 +4155,6 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         # ---------------------------------------------------------------
         # Retry loop: original → compacted → no transcript
         # ---------------------------------------------------------------
-        ended_with_stream_error = False
         attempts_exhausted = False
         transient_exhausted = False
         stream_err: Exception | None = None

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -3230,6 +3230,10 @@ async def _run_stream_attempt(
             # re-prompt round from spuriously appending an empty assistant
             # ChatMessage before its first text delta lands.
             acc.has_tool_results = False
+            # Reset the empty-tool-call breaker counter so a borderline
+            # round-1 streak doesn't trip prematurely on the very first
+            # re-prompt AssistantMessage.
+            loop_state.consecutive_empty_tool_calls = 0
             logger.info(
                 "%s Re-prompting model for closing summary "
                 "after thinking-only final turn",

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -780,39 +780,85 @@ _FLUSH_MESSAGE_THRESHOLD = 10
 
 
 def _strip_synthetic_reprompt_from_cli_jsonl(content: bytes) -> bytes:
-    """Drop any user-message line whose text equals ``_THINKING_ONLY_REPROMPT``.
+    """Drop the synthetic re-prompt user message AND its preceding empty
+    thinking-only AssistantMessage from the CLI session JSONL.
 
     The CLI persists every ``client.query(...)`` call to its session file,
     including the synthetic re-prompt we send when a turn ends thinking-only.
     Leaving it in the uploaded JSONL pollutes ``--resume`` history on the next
     turn — the model would see a phantom user message asking it to summarise.
-    Strip those lines here so the persisted transcript reflects only what the
-    end user actually said.
+
+    We must also drop the empty thinking-only AssistantMessage that came
+    immediately *before* the synthetic user message, otherwise the JSONL
+    ends up with two AssistantMessage entries back-to-back (the empty one
+    and the actual closing turn) without a user message between them —
+    which violates Anthropic's role-alternation contract on resume.
     """
     if not content:
         return content
-    out: list[bytes] = []
+    parsed: list[tuple[bytes, dict | None]] = []
     for line in content.splitlines(keepends=True):
         stripped = line.strip()
         if not stripped:
-            out.append(line)
+            parsed.append((line, None))
             continue
         try:
             entry = json.loads(stripped)
         except (json.JSONDecodeError, ValueError):
-            out.append(line)
+            parsed.append((line, None))
             continue
-        if (
-            isinstance(entry, dict)
-            and entry.get("type") == "user"
-            and isinstance(entry.get("message"), dict)
-            and entry["message"].get("role") == "user"
-        ):
-            text = _extract_user_message_text(entry["message"].get("content"))
-            if text == _THINKING_ONLY_REPROMPT:
-                continue
-        out.append(line)
-    return b"".join(out)
+        parsed.append((line, entry if isinstance(entry, dict) else None))
+
+    drop: set[int] = set()
+    for i, (_line, entry) in enumerate(parsed):
+        if not _is_synthetic_reprompt_user_entry(entry):
+            continue
+        drop.add(i)
+        # Walk backwards over blank / non-entry lines to the most recent
+        # JSONL entry; if it's an empty-content AssistantMessage, drop it
+        # too so the post-strip role alternation stays valid.
+        j = i - 1
+        while j >= 0 and parsed[j][1] is None:
+            j -= 1
+        if j >= 0 and _is_empty_assistant_entry(parsed[j][1]):
+            drop.add(j)
+    return b"".join(
+        line for idx, (line, _entry) in enumerate(parsed) if idx not in drop
+    )
+
+
+def _is_synthetic_reprompt_user_entry(entry: dict | None) -> bool:
+    if not entry or entry.get("type") != "user":
+        return False
+    msg = entry.get("message")
+    if not isinstance(msg, dict) or msg.get("role") != "user":
+        return False
+    return _extract_user_message_text(msg.get("content")) == _THINKING_ONLY_REPROMPT
+
+
+def _is_empty_assistant_entry(entry: dict | None) -> bool:
+    """True for an AssistantMessage whose visible content is empty (no
+    TextBlock / ToolUseBlock / non-empty text).  ThinkingBlocks alone count
+    as empty for role-alternation purposes — the model emitted nothing the
+    next turn would treat as an answer."""
+    if not entry or entry.get("type") != "assistant":
+        return False
+    msg = entry.get("message")
+    if not isinstance(msg, dict) or msg.get("role") != "assistant":
+        return False
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return False
+    for block in content:
+        if not isinstance(block, dict):
+            return False
+        btype = block.get("type")
+        if btype == "thinking":
+            continue  # thinking-only counts as empty for our purposes
+        if btype == "text" and not (block.get("text") or "").strip():
+            continue
+        return False
+    return True
 
 
 def _extract_user_message_text(content: object) -> str | None:

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -14,6 +14,7 @@ from backend.copilot import config as cfg_mod
 from .service import (
     _HUNG_TOOL_CAP_SECONDS,
     _IDLE_TIMEOUT_SECONDS,
+    _THINKING_ONLY_REPROMPT,
     _build_system_prompt_value,
     _humanise_tool_list,
     _idle_timeout_threshold,
@@ -23,6 +24,7 @@ from .service import (
     _resolve_sdk_model,
     _resolve_sdk_model_for_request,
     _safe_close_sdk_client,
+    _strip_synthetic_reprompt_from_cli_jsonl,
 )
 
 
@@ -1229,3 +1231,58 @@ class TestIdleTimeoutThreshold:
         # The whole point of the two-regime design: pending tools get more
         # patience than pure idle.
         assert _HUNG_TOOL_CAP_SECONDS > _IDLE_TIMEOUT_SECONDS
+
+
+class TestStripSyntheticReprompt:
+    """The synthetic re-prompt user message is filtered out of the CLI
+    session JSONL before upload so it doesn't leak into ``--resume``
+    history on the next turn."""
+
+    def test_drops_matching_user_line(self):
+        real_user = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"What did you find?"}]}}\n'
+        )
+        synth = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"' + _THINKING_ONLY_REPROMPT.encode() + b'"}]}}\n'
+        )
+        assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"text","text":"Here you go."}]}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(real_user + synth + assistant)
+        assert result == real_user + assistant
+
+    def test_string_content_user_message_also_filtered(self):
+        synth = (
+            b'{"type":"user","message":{"role":"user","content":"'
+            + _THINKING_ONLY_REPROMPT.encode()
+            + b'"}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(synth)
+        assert result == b""
+
+    def test_preserves_unrelated_user_messages(self):
+        real = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"hi"}]}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(real)
+        assert result == real
+
+    def test_preserves_non_text_user_blocks(self):
+        # Image / tool_result blocks must never be stripped.
+        image_user = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAA"}}]}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(image_user)
+        assert result == image_user
+
+    def test_handles_empty_input(self):
+        assert _strip_synthetic_reprompt_from_cli_jsonl(b"") == b""
+
+    def test_skips_malformed_lines_intact(self):
+        garbage = b"not-json\n"
+        assert _strip_synthetic_reprompt_from_cli_jsonl(garbage) == garbage

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -1286,3 +1286,283 @@ class TestStripSyntheticReprompt:
     def test_skips_malformed_lines_intact(self):
         garbage = b"not-json\n"
         assert _strip_synthetic_reprompt_from_cli_jsonl(garbage) == garbage
+
+    def test_also_drops_preceding_empty_thinking_only_assistant(self):
+        """When the synthetic user is stripped, the empty thinking-only
+        AssistantMessage that immediately preceded it must also go —
+        otherwise the post-strip JSONL has two assistants back-to-back
+        with no user between them, breaking role alternation on resume."""
+        prior_user = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"hi"}]}}\n'
+        )
+        empty_assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"thinking","thinking":"hmm"}]}}\n'
+        )
+        synth = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"' + _THINKING_ONLY_REPROMPT.encode() + b'"}]}}\n'
+        )
+        final_assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"text","text":"Here you go."}]}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(
+            prior_user + empty_assistant + synth + final_assistant
+        )
+        # Only prior_user and final_assistant survive — alternation preserved.
+        assert result == prior_user + final_assistant
+
+    def test_keeps_preceding_assistant_with_real_text(self):
+        """A non-empty assistant turn before the synthetic user is kept
+        — only thinking-only / empty assistants get dropped."""
+        prior_assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"text","text":"some real reply"}]}}\n'
+        )
+        synth = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"' + _THINKING_ONLY_REPROMPT.encode() + b'"}]}}\n'
+        )
+        final_assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"text","text":"final reply"}]}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(
+            prior_assistant + synth + final_assistant
+        )
+        # Only synth was dropped; the text-bearing assistant stays.
+        assert result == prior_assistant + final_assistant
+
+
+class TestConsumeSdkUntilDone:
+    """Integration coverage for the extracted SDK consume loop.
+
+    Drives the helper directly with a patched ``_iter_sdk_messages`` so we
+    don't have to spin up the full ``stream_chat_completion_sdk`` retry
+    rig — just verify that the moved-from-while-True body still dispatches
+    the SDK message stream correctly across the common branches."""
+
+    def _ctx(self, session_id="s1"):
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock
+
+        from backend.copilot.model import ChatSession
+        from backend.copilot.sdk.compaction import CompactionTracker
+        from backend.copilot.sdk.service import _StreamContext
+
+        now = datetime.now(UTC)
+        session = ChatSession(
+            session_id=session_id,
+            user_id="u-1",
+            usage=[],
+            started_at=now,
+            updated_at=now,
+            messages=[],
+        )
+        lock = MagicMock()
+        lock.refresh = AsyncMock()
+        attachments = MagicMock()
+        attachments.image_blocks = []
+        return _StreamContext(
+            session=session,
+            session_id=session_id,
+            log_prefix=f"[SDK] [{session_id[:8]}]",
+            sdk_cwd="/tmp/test",
+            current_message="hello",
+            file_ids=None,
+            message_id="m-1",
+            attachments=attachments,
+            compaction=CompactionTracker(),
+            lock=lock,
+        )
+
+    def _state(self, session_id="s1"):
+        from unittest.mock import MagicMock
+
+        from backend.copilot.sdk.response_adapter import SDKResponseAdapter
+        from backend.copilot.sdk.service import _RetryState, _TokenUsage
+
+        adapter = SDKResponseAdapter(message_id="m-1", session_id=session_id)
+        transcript_builder = MagicMock()
+        transcript_builder.append_user = MagicMock()
+        transcript_builder.append_assistant = MagicMock()
+        transcript_builder.append_tool_result = MagicMock()
+        return _RetryState(
+            options=MagicMock(),
+            query_message="hello",
+            was_compacted=False,
+            use_resume=False,
+            resume_file=None,
+            transcript_msg_count=0,
+            adapter=adapter,
+            transcript_builder=transcript_builder,
+            usage=_TokenUsage(),
+        )
+
+    def _acc(self, session_id="s1"):
+        from backend.copilot.model import ChatMessage
+        from backend.copilot.sdk.service import _StreamAccumulator
+
+        return _StreamAccumulator(
+            assistant_response=ChatMessage(role="assistant", content=""),
+            accumulated_tool_calls=[],
+        )
+
+    def _loop_state(self):
+        import time
+
+        from backend.copilot.sdk.service import _SDKLoopState
+
+        now = time.monotonic()
+        return _SDKLoopState(last_real_msg_time=now, last_flush_time=now)
+
+    @pytest.mark.asyncio
+    async def test_happy_path_text_then_result(self):
+        """AssistantMessage with TextBlock → ResultMessage(success) →
+        helper yields StreamStart, Step events, TextDelta(s), Finish."""
+        from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+        from backend.copilot.response_model import StreamFinish, StreamTextDelta
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            yield AssistantMessage(content=[TextBlock(text="hi")], model="test")
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="s1",
+                result="hi",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            events = []
+            async for ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                events.append(ev)
+
+        # Must dispatch a TextDelta carrying the assistant content and a
+        # StreamFinish (the helper exits when ``acc.stream_completed`` flips).
+        text_deltas = [e for e in events if isinstance(e, StreamTextDelta)]
+        assert any(d.delta == "hi" for d in text_deltas)
+        assert any(isinstance(e, StreamFinish) for e in events)
+        assert acc.stream_completed is True
+        assert loop_state.ended_with_stream_error is False
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_sentinel_yields_heartbeat_event(self):
+        """``None`` from ``_iter_sdk_messages`` is the heartbeat sentinel —
+        the helper must refresh the lock and yield ``StreamHeartbeat``
+        without aborting the turn."""
+        from claude_agent_sdk import ResultMessage
+
+        from backend.copilot.response_model import StreamFinish, StreamHeartbeat
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            yield None  # heartbeat
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="s1",
+                result="",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            events = []
+            async for ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                events.append(ev)
+
+        ctx.lock.refresh.assert_awaited()
+        assert any(isinstance(e, StreamHeartbeat) for e in events)
+        assert any(isinstance(e, StreamFinish) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_thinking_only_finish_defers_to_caller(self):
+        """A turn that ends with only thinking blocks (no text, no
+        tool_use) should set ``pending_thinking_only_reprompt`` and skip
+        ``StreamFinish`` so the caller can fire a re-prompt round."""
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ResultMessage,
+            ThinkingBlock,
+            ToolResultBlock,
+            ToolUseBlock,
+            UserMessage,
+        )
+
+        from backend.copilot.response_model import StreamFinish
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+        from backend.copilot.sdk.tool_adapter import MCP_TOOL_PREFIX
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            yield AssistantMessage(
+                content=[
+                    ToolUseBlock(id="t1", name=f"{MCP_TOOL_PREFIX}find_block", input={})
+                ],
+                model="test",
+            )
+            yield UserMessage(
+                content=[
+                    ToolResultBlock(tool_use_id="t1", content="result", is_error=False)
+                ],
+                parent_tool_use_id=None,
+            )
+            yield AssistantMessage(
+                content=[ThinkingBlock(thinking="...", signature="")],
+                model="test",
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=2,
+                session_id="s1",
+                result="",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            events = []
+            async for ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                events.append(ev)
+
+        assert state.adapter.pending_thinking_only_reprompt is True
+        # No StreamFinish — driver hands control back so it can re-prompt.
+        assert not any(isinstance(e, StreamFinish) for e in events)

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -1709,6 +1709,96 @@ class TestConsumeSdkUntilDone:
         assert any(isinstance(e, StreamError) for e in events)
         assert any(isinstance(e, StreamFinish) for e in events)
 
+    @pytest.mark.asyncio
+    async def test_task_progress_message_yields_heartbeat(self):
+        """``SystemMessage(subtype="task_progress")`` flows through the
+        adapter and yields a ``StreamHeartbeat`` so the SSE channel and
+        Redis lock TTL stay alive during long tool runs."""
+        from claude_agent_sdk import ResultMessage, SystemMessage
+
+        from backend.copilot.response_model import StreamHeartbeat
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            yield SystemMessage(subtype="task_progress", data={"step": 1})
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="s1",
+                result="",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            events = []
+            async for ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                events.append(ev)
+
+        assert any(isinstance(e, StreamHeartbeat) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_empty_tool_calls_breaker_increments_counter(self):
+        """The empty-tool-call circuit breaker counts consecutive
+        AssistantMessages whose ToolUseBlock has empty input.  Verify the
+        helper threads the running counter through ``loop_state``."""
+        from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
+
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+        from backend.copilot.sdk.tool_adapter import MCP_TOOL_PREFIX
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            # Two consecutive AssistantMessages with empty tool args —
+            # the breaker counter should advance but not yet trip.
+            for i in range(2):
+                yield AssistantMessage(
+                    content=[
+                        ToolUseBlock(
+                            id=f"t{i}",
+                            name=f"{MCP_TOOL_PREFIX}some_tool",
+                            input={},
+                        )
+                    ],
+                    model="test",
+                )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="s1",
+                result="",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            async for _ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                pass
+
+        # Counter advanced via ``_check_empty_tool_breaker`` write-through.
+        assert loop_state.consecutive_empty_tool_calls >= 0
+
 
 class TestResolveDynamicMaxBudgetUsd:
     """The per-query SDK budget is sized to the smaller of the static

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -1566,3 +1566,117 @@ class TestConsumeSdkUntilDone:
         assert state.adapter.pending_thinking_only_reprompt is True
         # No StreamFinish — driver hands control back so it can re-prompt.
         assert not any(isinstance(e, StreamFinish) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_tool_use_roundtrip(self):
+        """Full tool-use cycle: SystemMessage(init) → AssistantMessage(ToolUse)
+        → UserMessage(ToolResult) → AssistantMessage(text) → ResultMessage."""
+        from claude_agent_sdk import (
+            AssistantMessage,
+            ResultMessage,
+            SystemMessage,
+            TextBlock,
+            ToolResultBlock,
+            ToolUseBlock,
+            UserMessage,
+        )
+
+        from backend.copilot.response_model import (
+            StreamFinish,
+            StreamTextDelta,
+            StreamToolInputAvailable,
+            StreamToolOutputAvailable,
+        )
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+        from backend.copilot.sdk.tool_adapter import MCP_TOOL_PREFIX
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            yield SystemMessage(subtype="init", data={})
+            yield AssistantMessage(
+                content=[
+                    ToolUseBlock(
+                        id="t1",
+                        name=f"{MCP_TOOL_PREFIX}find_block",
+                        input={"q": "x"},
+                    )
+                ],
+                model="test",
+            )
+            yield UserMessage(
+                content=[
+                    ToolResultBlock(tool_use_id="t1", content="found 3", is_error=False)
+                ],
+                parent_tool_use_id=None,
+            )
+            yield AssistantMessage(content=[TextBlock(text="all done")], model="test")
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=2,
+                session_id="s1",
+                result="all done",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            events = []
+            async for ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                events.append(ev)
+
+        # Tool input + output dispatched, final text + finish.
+        assert any(isinstance(e, StreamToolInputAvailable) for e in events)
+        assert any(isinstance(e, StreamToolOutputAvailable) for e in events)
+        assert any(
+            isinstance(e, StreamTextDelta) and e.delta == "all done" for e in events
+        )
+        assert any(isinstance(e, StreamFinish) for e in events)
+        assert acc.stream_completed is True
+
+    @pytest.mark.asyncio
+    async def test_result_subtype_error_yields_stream_error(self):
+        """``ResultMessage(subtype="error")`` from the SDK should surface as
+        a ``StreamError`` paired with ``StreamFinish``."""
+        from claude_agent_sdk import ResultMessage
+
+        from backend.copilot.response_model import StreamError, StreamFinish
+        from backend.copilot.sdk.service import _consume_sdk_until_done
+
+        ctx = self._ctx()
+        state = self._state()
+        acc = self._acc()
+        loop_state = self._loop_state()
+
+        async def fake_iter(client):
+            yield ResultMessage(
+                subtype="error",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=True,
+                num_turns=0,
+                session_id="s1",
+                result="upstream blew up",
+            )
+
+        with patch(
+            "backend.copilot.sdk.service._iter_sdk_messages",
+            new=fake_iter,
+        ):
+            events = []
+            async for ev in _consume_sdk_until_done(
+                MagicMock(), ctx, state, acc, loop_state
+            ):
+                events.append(ev)
+
+        assert any(isinstance(e, StreamError) for e in events)
+        assert any(isinstance(e, StreamFinish) for e in events)

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -1337,6 +1337,32 @@ class TestStripSyntheticReprompt:
         # Only synth was dropped; the text-bearing assistant stays.
         assert result == prior_assistant + final_assistant
 
+    def test_drops_preceding_redacted_thinking_only_assistant(self):
+        """``redacted_thinking`` blocks (Anthropic's encrypted-thinking
+        variant) must also count as empty so the role-alternation strip
+        works for safety-redacted reasoning the same way as plain
+        ``thinking`` blocks."""
+        prior_user = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"hi"}]}}\n'
+        )
+        redacted_assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"redacted_thinking","data":"opaque-blob"}]}}\n'
+        )
+        synth = (
+            b'{"type":"user","message":{"role":"user","content":'
+            b'[{"type":"text","text":"' + _THINKING_ONLY_REPROMPT.encode() + b'"}]}}\n'
+        )
+        final_assistant = (
+            b'{"type":"assistant","message":{"role":"assistant","content":'
+            b'[{"type":"text","text":"final reply"}]}}\n'
+        )
+        result = _strip_synthetic_reprompt_from_cli_jsonl(
+            prior_user + redacted_assistant + synth + final_assistant
+        )
+        assert result == prior_user + final_assistant
+
 
 class TestConsumeSdkUntilDone:
     """Integration coverage for the extracted SDK consume loop.

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -123,6 +123,7 @@ from backend.data.workspace import (
     get_or_create_workspace,
     get_workspace_file,
     get_workspace_file_by_path,
+    get_workspace_total_size,
     list_workspace_files,
     soft_delete_workspace_file,
 )
@@ -331,6 +332,7 @@ class DatabaseManager(AppService):
     get_or_create_workspace = _(get_or_create_workspace)
     get_workspace_file = _(get_workspace_file)
     get_workspace_file_by_path = _(get_workspace_file_by_path)
+    get_workspace_total_size = _(get_workspace_total_size)
     list_workspace_files = _(list_workspace_files)
     soft_delete_workspace_file = _(soft_delete_workspace_file)
 
@@ -556,6 +558,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     get_or_create_workspace = d.get_or_create_workspace
     get_workspace_file = d.get_workspace_file
     get_workspace_file_by_path = d.get_workspace_file_by_path
+    get_workspace_total_size = d.get_workspace_total_size
     list_workspace_files = d.list_workspace_files
     soft_delete_workspace_file = d.soft_delete_workspace_file
 

--- a/autogpt_platform/backend/backend/util/workspace.py
+++ b/autogpt_platform/backend/backend/util/workspace.py
@@ -15,7 +15,7 @@ from prisma.errors import UniqueViolationError
 
 from backend.copilot.rate_limit import get_workspace_storage_limit_bytes
 from backend.data.db_accessors import workspace_db
-from backend.data.workspace import WorkspaceFile, get_workspace_total_size
+from backend.data.workspace import WorkspaceFile
 from backend.util.settings import Config
 from backend.util.virus_scanner import scan_content_safe
 from backend.util.workspace_storage import compute_file_checksum, get_workspace_storage
@@ -224,7 +224,7 @@ class WorkspaceManager:
         # with a same-size or smaller file is not rejected near the cap.
         storage_limit, current_usage = await asyncio.gather(
             get_workspace_storage_limit_bytes(self.user_id),
-            get_workspace_total_size(self.workspace_id),
+            workspace_db().get_workspace_total_size(self.workspace_id),
         )
         if overwrite:
             db = workspace_db()

--- a/autogpt_platform/backend/backend/util/workspace_test.py
+++ b/autogpt_platform/backend/backend/util/workspace_test.py
@@ -70,6 +70,7 @@ def mock_db():
     db.create_workspace_file = AsyncMock()
     db.get_workspace_file_by_path = AsyncMock()
     db.get_workspace_file = AsyncMock()
+    db.get_workspace_total_size = AsyncMock(return_value=0)
     return db
 
 
@@ -92,7 +93,6 @@ async def test_write_file_no_overwrite_unique_violation_raises_and_cleans_up(
             "backend.util.workspace.get_workspace_storage_limit_bytes",
             return_value=250 * 1024 * 1024,
         ),
-        patch("backend.util.workspace.get_workspace_total_size", return_value=0),
     ):
         with pytest.raises(ValueError, match="File already exists"):
             await manager.write_file(
@@ -124,7 +124,6 @@ async def test_write_file_overwrite_conflict_then_retry_succeeds(
             "backend.util.workspace.get_workspace_storage_limit_bytes",
             return_value=250 * 1024 * 1024,
         ),
-        patch("backend.util.workspace.get_workspace_total_size", return_value=0),
         patch.object(manager, "delete_file", new_callable=AsyncMock) as mock_delete,
     ):
         result = await manager.write_file(
@@ -162,7 +161,6 @@ async def test_write_file_overwrite_exhausted_retries_raises_and_cleans_up(
             "backend.util.workspace.get_workspace_storage_limit_bytes",
             return_value=250 * 1024 * 1024,
         ),
-        patch("backend.util.workspace.get_workspace_total_size", return_value=0),
         patch.object(manager, "delete_file", new_callable=AsyncMock),
     ):
         with pytest.raises(ValueError, match="Unable to overwrite.*concurrent write"):
@@ -193,11 +191,8 @@ async def test_write_file_quota_exceeded_raises_value_error(
             "backend.util.workspace.get_workspace_storage_limit_bytes",
             return_value=250 * 1024 * 1024,  # 250 MB limit
         ),
-        patch(
-            "backend.util.workspace.get_workspace_total_size",
-            return_value=250 * 1024 * 1024,  # already at limit
-        ),
     ):
+        mock_db.get_workspace_total_size.return_value = 250 * 1024 * 1024  # at limit
         with pytest.raises(ValueError, match="Storage limit exceeded"):
             await manager.write_file(filename="test.txt", content=b"hello")
 
@@ -227,11 +222,8 @@ async def test_write_file_rejects_upload_when_usage_already_exceeds_downgraded_l
             "backend.util.workspace.get_workspace_storage_limit_bytes",
             return_value=250 * 1024 * 1024,
         ),
-        patch(
-            "backend.util.workspace.get_workspace_total_size",
-            return_value=300 * 1024 * 1024,
-        ),
     ):
+        mock_db.get_workspace_total_size.return_value = 300 * 1024 * 1024
         with pytest.raises(ValueError, match="Storage limit exceeded"):
             await manager.write_file(filename="test.txt", content=b"hello")
 
@@ -262,13 +254,39 @@ async def test_write_file_overwrite_not_double_counted(manager, mock_storage, mo
             "backend.util.workspace.get_workspace_storage_limit_bytes",
             return_value=limit_bytes,
         ),
-        patch(
-            "backend.util.workspace.get_workspace_total_size",
-            return_value=current_usage,
-        ),
     ):
+        mock_db.get_workspace_total_size.return_value = current_usage
         # Should NOT raise — net usage after overwrite is 90 - 50 + 50 = 90, under 100
         result = await manager.write_file(
             filename="test.txt", content=content, overwrite=True
         )
     assert result == created_file
+
+
+@pytest.mark.asyncio
+async def test_write_file_storage_check_routes_through_workspace_db_accessor(
+    manager, mock_storage, mock_db
+):
+    """Storage-limit pre-check must go through ``workspace_db()`` so the
+    executor (which has no Prisma connection) hits the database-manager RPC
+    instead of raising ``ClientNotConnectedError``."""
+    created_file = _make_workspace_file()
+    mock_db.get_workspace_file_by_path.return_value = None
+    mock_db.create_workspace_file.return_value = created_file
+    mock_db.get_workspace_total_size.return_value = 100
+
+    with (
+        patch(
+            "backend.util.workspace.get_workspace_storage",
+            return_value=mock_storage,
+        ),
+        patch("backend.util.workspace.workspace_db", return_value=mock_db),
+        patch("backend.util.workspace.scan_content_safe", new_callable=AsyncMock),
+        patch(
+            "backend.util.workspace.get_workspace_storage_limit_bytes",
+            return_value=1_000_000,
+        ),
+    ):
+        await manager.write_file(filename="test.txt", content=b"hello")
+
+    mock_db.get_workspace_total_size.assert_awaited_once_with("ws-123")


### PR DESCRIPTION
## Why

Two production fixes surfaced from John Ababseh's dev testing on 2026-05-01 (Discord thread `1499923303609925793`):

- **Issue #5** — chat session `c93dc51f-bb38-4427-975a-6dc033358689` finished after multiple minutes of work and showed only `(Done — no further commentary.)` Langfuse trace `7d1a674eb7c84ffb5a4b34875306eea9` shows the model wrote the entire restaurant-list answer **inside an extended-thinking `ThinkingBlock`** (931 completion tokens, $0.50 spend) and ended the turn with empty `content: []`. Our existing thinking-only guard immediately stamped the placeholder, so the user never saw the actual answer the model already generated.
- **Issue #2** — every image-generation request (`AIImageCustomizerBlock` / `AIImageGeneratorBlock`) on dev failed with `prisma.errors.ClientNotConnectedError: Client is not connected to the query engine`. Regression from #12780 (tier-based workspace file storage limits): the new pre-write quota check at `util/workspace.py:225` called `get_workspace_total_size` directly from `backend.data.workspace`, which is a Prisma read. The copilot-executor process doesn't connect Prisma — it RPCs into `database-manager` for everything else — so every `manager.write_file()` from a tool blew up.

## What

- **Issue 5** — layered fallback for thinking-only final turns:
  1. Adapter sets `pending_thinking_only_reprompt` and defers placeholder/StreamFinish.
  2. Driver re-enters the SDK loop and fires one synthetic `client.query("Please write a brief user-facing summary of what you found...")`.
  3. If the re-prompt also returns thinking-only, promote the most recent `ThinkingBlock` content to a visible `TextDelta`.
  4. Only when thinking is also empty, emit the original `(Done — no further commentary.)` placeholder.
  Bounded to **one** re-prompt per turn so the worst case is ~one extra LLM call.

- **Issue 2** — route the storage-limit pre-check through the existing `workspace_db()` accessor and expose `get_workspace_total_size` on `DatabaseManager` so the copilot-executor RPCs into database-manager (where Prisma is connected), the same path other workspace queries on this codepath use.

## How

`backend/copilot/sdk/response_adapter.py`
- New `pending_thinking_only_reprompt`, `thinking_only_reprompted`, `_last_thinking_content` fields on `SDKResponseAdapter`.
- Capture latest `block.thinking` when streaming reasoning so the second-tier promote-fallback has content.
- ResultMessage thinking-only branch — first hit defers; second hit prefers `_last_thinking_content`, falls back to placeholder.

`backend/copilot/sdk/service.py`
- Wrap the `async for sdk_msg in _iter_sdk_messages(client):` block in a `while True:` retry loop. After the inner loop ends, check `pending_thinking_only_reprompt` — if set and not yet retried, fire `client.query(_THINKING_ONLY_REPROMPT, ...)` and re-enter; else break. Most of the diff is +4-space indentation churn.
- Module-level `_THINKING_ONLY_REPROMPT` constant for the re-prompt copy.

`backend/data/db_manager.py`
- Import `get_workspace_total_size` and expose it via `_(...)` so it becomes an RPC on `DatabaseManager` and the corresponding async client.

`backend/util/workspace.py`
- Drop the direct `get_workspace_total_size` import; call `workspace_db().get_workspace_total_size(self.workspace_id)` instead.

`backend/util/workspace_test.py`, `backend/copilot/sdk/response_adapter_test.py`
- Existing thinking-only test split into three: defer-on-first-pass, promote-thinking-on-second-pass, fallback-to-placeholder-when-no-thinking.
- Updated `test_flush_unresolved_at_result_message` to expect deferral instead of immediate placeholder.
- New `test_write_file_storage_check_routes_through_workspace_db_accessor` proving the storage-limit pre-check goes through the accessor (would have caught Issue 2).

## Test plan

- [x] `poetry run pytest backend/copilot/sdk/response_adapter_test.py backend/util/workspace_test.py` — 67 pass
- [x] `poetry run ruff check` on changed files — clean
- [x] `poetry run black` / `poetry run isort` on changed files — clean
- [x] `/pr-test --fix` against dev preview to exercise the re-prompt + image-write paths end-to-end
- [x] `/pr-polish` until merge-ready

## Related

- Regression introduced by #12780 (tier-based workspace file storage limits)