### PR TITLE
refactor(backend): use shared get_openai_client in tally extraction

### DIFF
--- a/autogpt_platform/backend/backend/data/tally.py
+++ b/autogpt_platform/backend/backend/data/tally.py
@@ -6,15 +6,13 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
-from openai import AsyncOpenAI
-
 from backend.data.redis_client import get_redis_async
 from backend.data.understanding import (
     BusinessUnderstandingInput,
     get_business_understanding,
     upsert_business_understanding,
 )
-from backend.util.clients import OPENROUTER_BASE_URL
+from backend.util.clients import get_openai_client
 from backend.util.request import Requests
 from backend.util.settings import Settings
 
@@ -354,9 +352,11 @@ async def extract_business_understanding(
 
     Raises on timeout or unparseable response so the caller can handle it.
     """
-    settings = Settings()
-    api_key = settings.secrets.open_router_api_key
-    client = AsyncOpenAI(api_key=api_key, base_url=OPENROUTER_BASE_URL)
+    client = get_openai_client(prefer_openrouter=True)
+    if client is None:
+        raise RuntimeError(
+            "open_router_api_key not set, cannot extract business understanding"
+        )
 
     try:
         response = await asyncio.wait_for(

--- a/autogpt_platform/backend/backend/data/tally_test.py
+++ b/autogpt_platform/backend/backend/data/tally_test.py
@@ -425,7 +425,7 @@ async def test_extract_business_understanding_themed_prompts():
     mock_client = AsyncMock()
     mock_client.chat.completions.create.return_value = mock_response
 
-    with patch("backend.data.tally.AsyncOpenAI", return_value=mock_client):
+    with patch("backend.data.tally.get_openai_client", return_value=mock_client):
         result = await extract_business_understanding("Q: Name?\nA: Alice")
 
     assert result.user_name == "Alice"
@@ -455,7 +455,7 @@ async def test_extract_themed_prompts_filters_long_and_unknown_keys():
     mock_client = AsyncMock()
     mock_client.chat.completions.create.return_value = mock_response
 
-    with patch("backend.data.tally.AsyncOpenAI", return_value=mock_client):
+    with patch("backend.data.tally.get_openai_client", return_value=mock_client):
         result = await extract_business_understanding("Q: Name?\nA: Alice")
 
     assert result.suggested_prompts is not None
@@ -480,7 +480,7 @@ async def test_extract_business_understanding_filters_nulls():
     mock_client = AsyncMock()
     mock_client.chat.completions.create.return_value = mock_response
 
-    with patch("backend.data.tally.AsyncOpenAI", return_value=mock_client):
+    with patch("backend.data.tally.get_openai_client", return_value=mock_client):
         result = await extract_business_understanding("Q: Name?\nA: Alice")
 
     assert result.user_name == "Alice"
@@ -500,7 +500,7 @@ async def test_extract_business_understanding_invalid_json():
     mock_client.chat.completions.create.return_value = mock_response
 
     with (
-        patch("backend.data.tally.AsyncOpenAI", return_value=mock_client),
+        patch("backend.data.tally.get_openai_client", return_value=mock_client),
         pytest.raises(json.JSONDecodeError),
     ):
         await extract_business_understanding("Q: Name?\nA: Alice")
@@ -513,9 +513,19 @@ async def test_extract_business_understanding_timeout():
     mock_client.chat.completions.create.side_effect = asyncio.TimeoutError()
 
     with (
-        patch("backend.data.tally.AsyncOpenAI", return_value=mock_client),
+        patch("backend.data.tally.get_openai_client", return_value=mock_client),
         patch("backend.data.tally._LLM_TIMEOUT", 0.001),
         pytest.raises(asyncio.TimeoutError),
+    ):
+        await extract_business_understanding("Q: Name?\nA: Alice")
+
+
+@pytest.mark.asyncio
+async def test_extract_business_understanding_missing_openrouter_key():
+    """When OpenRouter is not configured, raise a clear RuntimeError."""
+    with (
+        patch("backend.data.tally.get_openai_client", return_value=None),
+        pytest.raises(RuntimeError, match="open_router_api_key not set"),
     ):
         await extract_business_understanding("Q: Name?\nA: Alice")
 

--- a/autogpt_platform/backend/backend/data/tally_test.py
+++ b/autogpt_platform/backend/backend/data/tally_test.py
@@ -524,10 +524,13 @@ async def test_extract_business_understanding_timeout():
 async def test_extract_business_understanding_missing_openrouter_key():
     """When OpenRouter is not configured, raise a clear RuntimeError."""
     with (
-        patch("backend.data.tally.get_openai_client", return_value=None),
+        patch(
+            "backend.data.tally.get_openai_client", return_value=None
+        ) as mock_get_client,
         pytest.raises(RuntimeError, match="open_router_api_key not set"),
     ):
         await extract_business_understanding("Q: Name?\nA: Alice")
+    mock_get_client.assert_called_once_with(prefer_openrouter=True)
 
 
 # ── _refresh_cache ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`backend/data/tally.py::extract_business_understanding` was instantiating its OpenRouter client by hand:

```python
api_key = settings.secrets.open_router_api_key
client = AsyncOpenAI(api_key=api_key, base_url=OPENROUTER_BASE_URL)
```

This duplicates the `get_openai_client(prefer_openrouter=True)` helper in `backend/util/clients.py` and skips the process-level caching the helper provides. It also silently passed `api_key=None` to `AsyncOpenAI` when the OpenRouter key was unset, deferring the failure to request time.

Other platform-internal OpenAI/OpenRouter callers — `backend/executor/simulator.py`, `backend/api/features/store/embeddings.py` — already go through `get_openai_client`. Tally was the last platform-internal manual call left.

## What

- Replace manual `AsyncOpenAI(...)` + `OPENROUTER_BASE_URL` import with `get_openai_client(prefer_openrouter=True)` in `extract_business_understanding`.
- Raise a clear `RuntimeError("open_router_api_key not set, ...")` when the helper returns `None`, matching the pattern in `embeddings.py:74`.
- Update existing tests to patch `backend.data.tally.get_openai_client` instead of `AsyncOpenAI`.
- Add `test_extract_business_understanding_missing_openrouter_key` for the new fast-fail branch.

## How

`get_openai_client(prefer_openrouter=True)` returns an `AsyncOpenAI` client wired to OpenRouter when `open_router_api_key` is set, and `None` otherwise — exactly the shape Tally needed. The helper is `@cached(ttl_seconds=3600)` so the extracted client is reused across invocations within the same process.

Behavior is unchanged when OpenRouter is configured. The only observable change is the missing-key path: previously the call would attempt the request with `api_key=None` and fail with an opaque OpenAI SDK error; now it fails fast with a `RuntimeError` whose message names the missing secret.

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `dev` branch of the repository
- [x] My commit messages follow the Conventional Commits standard
- [x] My code adheres to the project's linting and formatting standards
- [x] I have ran the pre-commit hooks before committing my changes
- [x] I have added tests
- [ ] My PR is ready to review, and I have requested a review by tagging an appropriate person