### PR TITLE
perf(backend/copilot): metadata-only fetch for chat ownership checks

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -19,12 +19,12 @@ from backend.copilot.db import get_chat_messages_paginated
 from backend.copilot.executor.utils import enqueue_cancel_task, enqueue_copilot_turn
 from backend.copilot.model import (
     ChatMessage,
-    ChatSession,
+    ChatSessionInfo,
     ChatSessionMetadata,
     append_and_save_message,
     create_chat_session,
     delete_chat_session,
-    get_chat_session,
+    get_chat_session_metadata,
     get_or_create_builder_session,
     get_user_sessions,
     update_session_title,
@@ -109,9 +109,14 @@ config = ChatConfig()
 async def _validate_and_get_session(
     session_id: str,
     user_id: str | None,
-) -> ChatSession:
-    """Validate session exists and belongs to user."""
-    session = await get_chat_session(session_id, user_id)
+) -> ChatSessionInfo:
+    """Validate session exists and belongs to user.
+
+    Returns metadata-only — callers needing the message history must use
+    ``get_chat_session`` directly. Bypassing the message-loading path
+    avoids a multi-KB cache deserialisation per ownership check.
+    """
+    session = await get_chat_session_metadata(session_id, user_id)
     if not session:
         raise NotFoundError(f"Session {session_id} not found.")
     return session
@@ -491,7 +496,7 @@ async def disconnect_session_stream(
     backend releases XREAD listeners immediately rather than waiting for
     the 5-10 s timeout.
     """
-    session = await get_chat_session(session_id, user_id)
+    session = await get_chat_session_metadata(session_id, user_id)
     if not session:
         raise HTTPException(
             status_code=404,
@@ -1538,7 +1543,7 @@ async def health_check() -> dict:
 
     # Create and retrieve session to verify full data layer
     session = await create_chat_session(health_check_user_id, dry_run=False)
-    await get_chat_session(session.session_id, health_check_user_id)
+    await get_chat_session_metadata(session.session_id, health_check_user_id)
 
     return {
         "status": "healthy",

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -1538,7 +1538,12 @@ async def health_check() -> dict:
 
     # Create and retrieve session to verify full data layer
     session = await create_chat_session(health_check_user_id, dry_run=False)
-    await get_chat_session_metadata(session.session_id, health_check_user_id)
+    fetched = await get_chat_session_metadata(session.session_id, health_check_user_id)
+    if fetched is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Chat read path unhealthy: session not found after create",
+        )
 
     return {
         "status": "healthy",

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -496,12 +496,7 @@ async def disconnect_session_stream(
     backend releases XREAD listeners immediately rather than waiting for
     the 5-10 s timeout.
     """
-    session = await get_chat_session_metadata(session_id, user_id)
-    if not session:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session {session_id} not found or access denied",
-        )
+    await _validate_and_get_session(session_id, user_id)
     await stream_registry.disconnect_all_listeners(session_id)
     return Response(status_code=204)
 

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1734,7 +1734,7 @@ def test_disconnect_stream_returns_204_and_awaits_registry(
 ) -> None:
     mock_session = MagicMock()
     mocker.patch(
-        "backend.api.features.chat.routes.get_chat_session",
+        "backend.api.features.chat.routes.get_chat_session_metadata",
         new_callable=AsyncMock,
         return_value=mock_session,
     )
@@ -1755,7 +1755,7 @@ def test_disconnect_stream_returns_404_when_session_missing(
     test_user_id: str,
 ) -> None:
     mocker.patch(
-        "backend.api.features.chat.routes.get_chat_session",
+        "backend.api.features.chat.routes.get_chat_session_metadata",
         new_callable=AsyncMock,
         return_value=None,
     )

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1917,6 +1917,34 @@ def test_create_session_rejects_unknown_fields(
     assert response.status_code == 422
 
 
+def test_health_check_returns_503_when_metadata_read_returns_none(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    # Round-trips create-then-read; if the read path returns None despite
+    # a successful create, the health endpoint must surface the failure.
+    from backend.copilot.model import ChatSession
+
+    mocker.patch(
+        "backend.data.user.get_or_create_user",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.create_chat_session",
+        new_callable=AsyncMock,
+        side_effect=lambda uid, *, dry_run: ChatSession.new(uid, dry_run=dry_run),
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.get_chat_session_metadata",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+
+    response = client.get("/health")
+    assert response.status_code == 503
+    assert "unhealthy" in response.json()["detail"].lower()
+
+
 def test_resolve_session_permissions_blocks_out_of_scope_tools() -> None:
     """Builder-bound sessions return a blacklist of the three tools that
     conflict with the panel's graph-bound scope. Regular sessions return

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1945,6 +1945,38 @@ def test_health_check_returns_503_when_metadata_read_returns_none(
     assert "unhealthy" in response.json()["detail"].lower()
 
 
+def test_health_check_returns_healthy_on_round_trip_success(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    # Happy path: create + read both succeed → 200 with healthy body.
+    from backend.copilot.model import ChatSession, ChatSessionInfo
+
+    mocker.patch(
+        "backend.data.user.get_or_create_user",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+    fake_session = ChatSession.new("health-check-user", dry_run=False)
+    mocker.patch(
+        "backend.api.features.chat.routes.create_chat_session",
+        new_callable=AsyncMock,
+        return_value=fake_session,
+    )
+    mocker.patch(
+        "backend.api.features.chat.routes.get_chat_session_metadata",
+        new_callable=AsyncMock,
+        return_value=ChatSessionInfo(
+            **{**fake_session.model_dump(exclude={"messages"})}
+        ),
+    )
+
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "healthy"
+    assert body["service"] == "chat"
+
+
 def test_resolve_session_permissions_blocks_out_of_scope_tools() -> None:
     """Builder-bound sessions return a blacklist of the three tools that
     conflict with the panel's graph-bound scope. Regular sessions return

--- a/autogpt_platform/backend/backend/copilot/builder_context.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from backend.copilot.model import ChatSession
+from backend.copilot.model import ChatSession, ChatSessionInfo
 from backend.copilot.permissions import CopilotPermissions
 from backend.copilot.tools.agent_generator import get_agent_as_json
 from backend.copilot.tools.get_agent_building_guide import _load_guide
@@ -31,10 +31,14 @@ BUILDER_BLOCKED_TOOLS: tuple[str, ...] = (
 
 
 def resolve_session_permissions(
-    session: ChatSession | None,
+    session: ChatSessionInfo | None,
 ) -> CopilotPermissions | None:
     """Blacklist :data:`BUILDER_BLOCKED_TOOLS` for builder-bound sessions,
-    return ``None`` (unrestricted) otherwise."""
+    return ``None`` (unrestricted) otherwise.
+
+    Reads ``metadata.builder_graph_id`` only — works on either the bare
+    ``ChatSessionInfo`` (no messages) or the full ``ChatSession``.
+    """
     if session is None or not session.metadata.builder_graph_id:
         return None
     return CopilotPermissions(

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -555,6 +555,30 @@ async def get_chat_session(
     return session
 
 
+async def get_chat_session_metadata(
+    session_id: str,
+    user_id: str | None = None,
+) -> ChatSessionInfo | None:
+    """Get chat session metadata only (no messages).
+
+    Goes directly to the DB by primary key — bypasses the Redis cache,
+    which stores the full session and would deserialize the entire message
+    history just to read ``user_id``. Use this for ownership/existence
+    checks; use ``get_chat_session`` when the message history is actually
+    needed.
+    """
+    session_meta = await chat_db().get_chat_session_metadata(session_id)
+    if session_meta is None:
+        return None
+    if user_id is not None and session_meta.user_id != user_id:
+        logger.warning(
+            f"Session {session_id} user id mismatch: "
+            f"{session_meta.user_id} != {user_id}"
+        )
+        return None
+    return session_meta
+
+
 async def _get_session_from_cache(session_id: str) -> ChatSession | None:
     """Get a chat session from Redis cache."""
     redis_key = _get_session_cache_key(session_id)

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -375,6 +375,7 @@ class DatabaseManager(AppService):
 
     # ============ CoPilot Chat Sessions ============ #
     get_chat_session = _(chat_db.get_chat_session)
+    get_chat_session_metadata = _(chat_db.get_chat_session_metadata)
     create_chat_session = _(chat_db.create_chat_session)
     update_chat_session = _(chat_db.update_chat_session)
     add_chat_message = _(chat_db.add_chat_message)
@@ -600,6 +601,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
 
     # ============ CoPilot Chat Sessions ============ #
     get_chat_session = d.get_chat_session
+    get_chat_session_metadata = d.get_chat_session_metadata
     create_chat_session = d.create_chat_session
     update_chat_session = d.update_chat_session
     add_chat_message = d.add_chat_message


### PR DESCRIPTION
## Why

Follow-up to #13033. Five chat routes only need session existence + ownership for their work, but they were calling `get_chat_session` which:

1. **DB path (cache miss)**: loads the full session with `include={"Messages": True}` — same eager-include pattern that #13033 fixed for `update_chat_session`.
2. **Cache path (cache hit)**: pulls a multi-KB JSON blob from Redis just to read `.user_id`.

Per `pg_stat_statements` on prod the `ChatMessage WHERE sessionId IN ($1) ORDER BY sequence ASC OFFSET $2` query was hit 84,821 times returning 75 M rows (887 rpc). A meaningful fraction of those calls came from these ownership-check routes, where the message history is never read.

## What

- New `get_chat_session_metadata(session_id, user_id)` wrapper in [copilot/model.py](autogpt_platform/backend/backend/copilot/model.py) — goes directly to `db.get_chat_session_metadata` by PK, validates `user_id`, returns `ChatSessionInfo`. **No Redis cache, no Messages include.**
- `_validate_and_get_session` switched to use it; return type narrowed `ChatSession` → `ChatSessionInfo`.
- Affected routes: `_validate_and_get_session` (used by `/cancel`, `/messages/pending` peek, `/messages/pending` queue, `/stream` POST), `disconnect_session_stream`, `chat_health_check`.
- `resolve_session_permissions` widened to accept `ChatSessionInfo | None` (it only reads `.metadata.builder_graph_id`).
- `data/db_manager.py` exposes `get_chat_session_metadata` on the DB-manager client surface.

## How

Bypassing the cache for ownership checks is intentional. The cache stores the full session JSON (including every message), and deserialising it just to read `.user_id` was already costing more than the metadata-only PK lookup it replaces. Profile-wise:

- **Before**: cache hit → multi-KB JSON deserialise → read `.user_id`
- **After**: 1 SQL row by PK → read `.user_id`

The DB query is `SELECT * FROM "ChatSession" WHERE id = $1 LIMIT 1`, indexed PK lookup, sub-millisecond. Net latency is roughly equal; egress drops by the size of the cached JSON (which scales with conversation length).

## What this does NOT touch

The `/stream` LLM-turn path in `baseline/service.py` and `sdk/service.py` still calls `get_chat_session` because the LLM needs the prior conversation context. That's a bigger refactor (watermark-aware gap fetch — only load messages after the transcript checkpoint) and will land as a separate PR.

## Tests

Existing route tests in `routes_test.py` updated to mock `get_chat_session_metadata` instead of `get_chat_session` for the disconnect path. All other route mocks point at `_validate_and_get_session` (the helper) and need no change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings (black/ruff clean)
- [x] I have added tests that prove my fix is effective (existing tests updated)
- [x] New and existing unit tests pass locally with my changes (CI runs against the test DB)
- [x] Any dependent changes have been merged and published in downstream modules
