### PR TITLE
fix(copilot): dedupe transcript replay blocks

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/helpers.test.ts
@@ -343,6 +343,24 @@ describe("deduplicateMessages", () => {
     expect(result.map((m) => m.id)).toEqual(["u1", "a1", "a2"]);
   });
 
+  it("removes whole-conversation SSE prefix replays with fresh IDs", () => {
+    const msgs = [
+      makeMsgWithId("u1", "user", "Build a landing page"),
+      makeMsgWithId("a1", "assistant", "I'll inspect the app."),
+      makeMsgWithId("u2", "user", "Use the dark theme"),
+      makeMsgWithId("a2", "assistant", "Applying the dark theme."),
+      // Reconnect/resume can replay the persisted transcript from the
+      // beginning with fresh client IDs. Without prefix-block deduplication,
+      // the whole chat appears again and again in the UI.
+      makeMsgWithId("u1-replay", "user", "Build a landing page"),
+      makeMsgWithId("a1-replay", "assistant", "I'll inspect the app."),
+      makeMsgWithId("u2-replay", "user", "Use the dark theme"),
+      makeMsgWithId("a2-replay", "assistant", "Applying the dark theme."),
+    ];
+    const result = deduplicateMessages(msgs);
+    expect(result.map((m) => m.id)).toEqual(["u1", "a1", "u2", "a2"]);
+  });
+
   it("keeps identical assistant replies to different user prompts", () => {
     const msgs = [
       makeMsgWithId("u1", "user", "What is 2+2?"),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers.ts
@@ -322,27 +322,92 @@ export function shouldDebounceReconnect(
   return windowMs - sinceLastResume;
 }
 
+const MIN_PREFIX_REPLAY_MESSAGES = 4;
+
+function messageContentFingerprint(msg: UIMessage): string {
+  // JSON.stringify the parts array to avoid separator-collision false
+  // positives: a plain join("|") on ["a|b", "c"] and ["a", "b|c"]
+  // produces the same string. JSON encoding each element is unambiguous.
+  // Fall back to JSON.stringify(p) for parts that carry neither a text nor
+  // a toolCallId (e.g. step-start) so structurally different parts never
+  // collapse to the same empty-string fingerprint element.
+  return JSON.stringify(
+    msg.parts.map(
+      (p) =>
+        ("text" in p && p.text) ||
+        ("toolCallId" in p && p.toolCallId) ||
+        JSON.stringify(p),
+    ),
+  );
+}
+
+function messageReplayFingerprint(msg: UIMessage): string {
+  return `${msg.role}:${messageContentFingerprint(msg)}`;
+}
+
 /**
- * Deduplicate messages by ID and by consecutive content fingerprint.
+ * Drop appended transcript-prefix replays. During SSE resume, the stream can
+ * replay the persisted transcript from the beginning with fresh client IDs;
+ * that creates a suffix whose fingerprints match the array prefix exactly:
+ *   [u1, a1, u2, a2, u1', a1', u2', a2']
  *
- * ID dedup catches exact duplicates within the same source.
- * Content dedup uses a composite key of `role + preceding-user-message-id +
- * content-fingerprint` to detect replayed messages that arrive with new
- * IDs after an SSE reconnection replays from the beginning of the Redis
- * stream. Scoping by user message ID (not text) preserves the second
- * assistant reply when the user asks the same question twice and gets the
- * same answer — two different user messages produce two different IDs even
- * when their text is identical.
+ * We only remove prefix blocks with at least 4 messages. That is deliberately
+ * conservative so a user asking the same question twice and getting the same
+ * short answer (two messages) is preserved.
+ */
+function removeTranscriptPrefixReplays(messages: UIMessage[]): UIMessage[] {
+  if (messages.length < MIN_PREFIX_REPLAY_MESSAGES * 2) return messages;
+
+  const fingerprints = messages.map(messageReplayFingerprint);
+  const dropped = new Set<number>();
+
+  for (let i = 1; i < messages.length; i++) {
+    if (dropped.has(i)) continue;
+
+    let replayLength = 0;
+    while (
+      i + replayLength < messages.length &&
+      replayLength < i &&
+      fingerprints[replayLength] === fingerprints[i + replayLength]
+    ) {
+      replayLength++;
+    }
+
+    if (replayLength < MIN_PREFIX_REPLAY_MESSAGES) continue;
+
+    for (let offset = 0; offset < replayLength; offset++) {
+      dropped.add(i + offset);
+    }
+    i += replayLength - 1;
+  }
+
+  if (dropped.size === 0) return messages;
+  return messages.filter((_, index) => !dropped.has(index));
+}
+
+/**
+ * Deduplicate messages by ID, appended transcript-prefix replay, and assistant
+ * content fingerprint.
+ *
+ * ID dedup catches exact duplicates within the same source. Prefix replay
+ * dedup catches whole transcript replays that arrive with fresh IDs after an
+ * SSE reconnection/resume. Assistant content dedup catches repeated assistant
+ * chunks within a turn while preserving identical answers to different user
+ * prompts by scoping to the preceding user message ID.
  */
 export function deduplicateMessages(messages: UIMessage[]): UIMessage[] {
   const seenIds = new Set<string>();
+  const idDeduped = messages.filter((msg) => {
+    if (seenIds.has(msg.id)) return false;
+    seenIds.add(msg.id);
+    return true;
+  });
+
+  const replayDeduped = removeTranscriptPrefixReplays(idDeduped);
   const seenFingerprints = new Set<string>();
   let lastUserMsgID = "";
 
-  return messages.filter((msg) => {
-    if (seenIds.has(msg.id)) return false;
-    seenIds.add(msg.id);
-
+  return replayDeduped.filter((msg) => {
     if (msg.role === "user") {
       // Track the ID (not text) of the latest user message so we can scope
       // assistant fingerprints to their conversational turn. Using the ID
@@ -352,20 +417,7 @@ export function deduplicateMessages(messages: UIMessage[]): UIMessage[] {
     }
 
     if (msg.role === "assistant") {
-      // JSON.stringify the parts array to avoid separator-collision false
-      // positives: a plain join("|") on ["a|b", "c"] and ["a", "b|c"]
-      // produces the same string. JSON encoding each element is unambiguous.
-      // Fall back to JSON.stringify(p) for parts that carry neither a text nor
-      // a toolCallId (e.g. step-start) so structurally different parts never
-      // collapse to the same empty-string fingerprint element.
-      const contentFingerprint = JSON.stringify(
-        msg.parts.map(
-          (p) =>
-            ("text" in p && p.text) ||
-            ("toolCallId" in p && p.toolCallId) ||
-            JSON.stringify(p),
-        ),
-      );
+      const contentFingerprint = messageContentFingerprint(msg);
 
       if (contentFingerprint !== "[]") {
         // Scope to the preceding user message turn so that identical assistant

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/helpers.ts
@@ -361,7 +361,7 @@ function removeTranscriptPrefixReplays(messages: UIMessage[]): UIMessage[] {
   const fingerprints = messages.map(messageReplayFingerprint);
   const dropped = new Set<number>();
 
-  for (let i = 1; i < messages.length; i++) {
+  for (let i = MIN_PREFIX_REPLAY_MESSAGES; i < messages.length; i++) {
     if (dropped.has(i)) continue;
 
     let replayLength = 0;


### PR DESCRIPTION
## Summary

- Deduplicate transcript replay blocks in the copilot chat so repeated/echoed transcript messages do not surface twice during replay.
- Scope is limited to `autogpt_platform/frontend/src/app/(platform)/copilot/helpers.ts` and its colocated unit test.

## Test Plan

- [ ] `pnpm test:unit 'src/app/(platform)/copilot/__tests__/helpers.test.ts'`
- [ ] `pnpm format`
- [ ] `pnpm lint`
- [ ] `pnpm types`