### PR TITLE
fix(frontend): hide delete control on AutoGPT-managed credentials

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/__tests__/main.test.tsx
@@ -184,6 +184,31 @@ describe("SettingsIntegrationsPage — delete", () => {
       expect(screen.queryByText("Personal")).toBeNull();
     });
   });
+
+  test("managed credentials hide the trash button and select checkbox", async () => {
+    server.use(
+      getGetV1ListCredentialsMockHandler([
+        makeCred({
+          id: "a1",
+          provider: "ayrshare",
+          title: "Ayrshare (managed by AutoGPT)",
+          is_managed: true,
+        }),
+      ]),
+    );
+
+    render(<SettingsIntegrationsPage />);
+
+    expect(
+      await screen.findByText("Ayrshare (managed by AutoGPT)"),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: /delete ayrshare/i }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("checkbox", { name: /select ayrshare/i }),
+    ).toBeNull();
+  });
 });
 
 describe("SettingsIntegrationsPage — selection bar", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/CredentialRow/CredentialRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/CredentialRow/CredentialRow.tsx
@@ -34,24 +34,28 @@ export function CredentialRow({
       className="flex w-full items-center justify-between py-3 pl-3 pr-5 transition-colors data-[selected=true]:bg-zinc-100"
     >
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          role="checkbox"
-          aria-checked={selected}
-          aria-label={`Select ${credential.title}`}
-          onClick={onToggleSelected}
-          className={`shrink-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-800 ${
-            selected
-              ? "text-zinc-800 hover:text-zinc-900"
-              : "text-zinc-500 hover:text-zinc-700"
-          }`}
-        >
-          {selected ? (
-            <CheckSquareIcon size={20} weight="fill" />
-          ) : (
-            <SquareIcon size={20} />
-          )}
-        </button>
+        {credential.isManaged ? (
+          <div className="size-5 shrink-0" aria-hidden="true" />
+        ) : (
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={selected}
+            aria-label={`Select ${credential.title}`}
+            onClick={onToggleSelected}
+            className={`shrink-0 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-800 ${
+              selected
+                ? "text-zinc-800 hover:text-zinc-900"
+                : "text-zinc-500 hover:text-zinc-700"
+            }`}
+          >
+            {selected ? (
+              <CheckSquareIcon size={20} weight="fill" />
+            ) : (
+              <SquareIcon size={20} />
+            )}
+          </button>
+        )}
 
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-3">
@@ -70,20 +74,29 @@ export function CredentialRow({
         </div>
       </div>
 
-      <button
-        type="button"
-        onClick={onDelete}
-        disabled={isDeleting}
-        aria-busy={isDeleting}
-        aria-label={`Delete ${credential.title}`}
-        className="inline-flex size-5 items-center justify-center text-[#1F1F20] transition-colors hover:text-red-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-purple-400 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-[#1F1F20]"
-      >
-        {isDeleting ? (
-          <SpinnerIcon size={20} className="animate-spin" />
-        ) : (
-          <TrashIcon size={20} />
-        )}
-      </button>
+      {credential.isManaged ? (
+        <span
+          title="Managed by AutoGPT — cannot be removed"
+          className="text-[11px] font-medium uppercase tracking-[1.1px] text-[#505057]"
+        >
+          Managed
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={isDeleting}
+          aria-busy={isDeleting}
+          aria-label={`Delete ${credential.title}`}
+          className="inline-flex size-5 items-center justify-center text-[#1F1F20] transition-colors hover:text-red-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-purple-400 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-[#1F1F20]"
+        >
+          {isDeleting ? (
+            <SpinnerIcon size={20} className="animate-spin" />
+          ) : (
+            <TrashIcon size={20} />
+          )}
+        </button>
+      )}
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/CredentialRow/CredentialRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/CredentialRow/CredentialRow.tsx
@@ -8,6 +8,13 @@ import {
 } from "@phosphor-icons/react";
 
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/atoms/Tooltip/BaseTooltip";
+
+import {
   formatMaskedValue,
   typeBadgeLabel,
   type CredentialView,
@@ -75,12 +82,21 @@ export function CredentialRow({
       </div>
 
       {credential.isManaged ? (
-        <span
-          title="Managed by AutoGPT — cannot be removed"
-          className="text-[11px] font-medium uppercase tracking-[1.1px] text-[#505057]"
-        >
-          Managed
-        </span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                tabIndex={0}
+                className="text-[11px] font-medium uppercase tracking-[1.1px] text-[#505057] focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-800"
+              >
+                Managed
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              Managed by AutoGPT — cannot be removed
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       ) : (
         <button
           type="button"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/useIntegrationsList.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/integrations/components/IntegrationsList/useIntegrationsList.ts
@@ -34,7 +34,7 @@ export function useIntegrationsList() {
   const providers = filterProviders(allProviders, debouncedQuery);
 
   const allCredentialIds = allProviders.flatMap((p) =>
-    p.credentials.map((c) => c.id),
+    p.credentials.filter((c) => !c.isManaged).map((c) => c.id),
   );
   const selection = useIntegrationsSelection(allCredentialIds);
   const {


### PR DESCRIPTION
## Why

Deleting an "Ayrshare (managed by AutoGPT)" credential from `Settings → Integrations` on dev fails with the toast "Failed to remove integration ... Try again to retry the failed ones." This isn't a transient failure — the backend deliberately rejects deletes of `is_managed=True` credentials with `HTTP 403 "AutoGPT-managed credentials cannot be deleted"` ([router.py:518-522](https://github.com/Significant-Gravitas/AutoGPT/blob/dev/autogpt_platform/backend/backend/api/features/integrations/router.py#L518-L522)). For Ayrshare specifically there's no upstream profile-delete API anyway, and the managed-credentials sweep would just re-provision on the next list call.

The frontend `CredentialRow` rendered the trash button + select checkbox unconditionally, leading users to attempt an action the platform doesn't support and get a generic error.

## What

- `CredentialRow`: hide the per-row select checkbox and trash button when `credential.isManaged === true`; show a small "Managed" tag in their place.
- `useIntegrationsList`: exclude managed credentials from the `allCredentialIds` list that feeds "select all", so bulk-delete also skips them.
- Add an integration test asserting both controls are absent for managed credentials.

## How

The `isManaged` flag is already on `CredentialView` (mapped from backend `is_managed`). The fix is purely a render-time gate plus a filter in the select-all id collection; no API or store changes.

Note: linking/unlinking the individual social networks inside the managed Ayrshare profile happens on the Ayrshare-hosted page reached via `GET /ayrshare/sso_url` (already wired through the Connect flow in the block UI) — not from this settings page.

## Checklist

- [x] Integration test covers the new behavior
- [x] `pnpm format` / `pnpm types` clean for changed files
- [x] No backend changes required
