### PR TITLE
fix(frontend/copilot): watchdog for stalled first-send flush

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
@@ -9,11 +9,9 @@ vi.mock("@/components/molecules/Toast/use-toast", () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
-const mockSentryCaptureException = vi.fn();
 const mockSentryCaptureMessage = vi.fn();
 const mockSentryBreadcrumb = vi.fn();
 vi.mock("@sentry/nextjs", () => ({
-  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
   captureMessage: (...args: unknown[]) => mockSentryCaptureMessage(...args),
   addBreadcrumb: (...args: unknown[]) => mockSentryBreadcrumb(...args),
 }));
@@ -51,7 +49,6 @@ describe("useSendMessage", () => {
   beforeEach(() => {
     resetStore();
     mockToast.mockReset();
-    mockSentryCaptureException.mockReset();
     mockSentryCaptureMessage.mockReset();
     mockSentryBreadcrumb.mockReset();
     vi.useFakeTimers();
@@ -88,40 +85,6 @@ describe("useSendMessage", () => {
       expect(useCopilotStreamStore.getState().pendingFirstSend).toBeNull();
     });
 
-    it("captures dispatch errors to Sentry and toasts the user", async () => {
-      const sendMessage = vi.fn(() => {
-        throw new Error("transport not ready");
-      });
-      const createSession = vi.fn();
-
-      useCopilotStreamStore.getState().setPendingFirstSend({
-        text: "hello",
-        files: [],
-      });
-
-      const { rerender } = renderHook(
-        ({ sessionId }) =>
-          useTestHarness({ sessionId, sendMessage, createSession }),
-        { initialProps: { sessionId: null as string | null } },
-      );
-
-      await act(async () => {
-        rerender({ sessionId: "new-session-id" });
-        // Let the catch handler run.
-        await Promise.resolve();
-      });
-
-      expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
-      const [err, ctx] = mockSentryCaptureException.mock.calls[0];
-      expect((err as Error).message).toBe("transport not ready");
-      expect(ctx).toMatchObject({
-        tags: { copilot_flow: "pending-first-send-flush" },
-      });
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ variant: "destructive" }),
-      );
-    });
-
     it("does nothing when sessionId arrives without a pending send", async () => {
       const sendMessage = vi.fn();
       const createSession = vi.fn();
@@ -137,7 +100,6 @@ describe("useSendMessage", () => {
       });
 
       expect(sendMessage).not.toHaveBeenCalled();
-      expect(mockSentryCaptureException).not.toHaveBeenCalled();
     });
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
@@ -9,11 +9,6 @@ vi.mock("@/components/molecules/Toast/use-toast", () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
-const mockSentryCaptureException = vi.fn();
-vi.mock("@sentry/nextjs", () => ({
-  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
-}));
-
 vi.mock("@/lib/direct-upload", () => ({
   uploadFileDirect: vi.fn(),
 }));
@@ -47,7 +42,6 @@ describe("useSendMessage", () => {
   beforeEach(() => {
     resetStore();
     mockToast.mockReset();
-    mockSentryCaptureException.mockReset();
     vi.useFakeTimers();
   });
 
@@ -80,39 +74,6 @@ describe("useSendMessage", () => {
 
       expect(sendMessage).toHaveBeenCalledWith({ text: "hello" });
       expect(useCopilotStreamStore.getState().pendingFirstSend).toBeNull();
-    });
-
-    it("captures + toasts when the dispatch fails", async () => {
-      const sendMessage = vi.fn(() => {
-        throw new Error("transport not ready");
-      });
-      const createSession = vi.fn();
-
-      useCopilotStreamStore.getState().setPendingFirstSend({
-        text: "hello",
-        files: [],
-      });
-
-      const { rerender } = renderHook(
-        ({ sessionId }) =>
-          useTestHarness({ sessionId, sendMessage, createSession }),
-        { initialProps: { sessionId: null as string | null } },
-      );
-
-      await act(async () => {
-        rerender({ sessionId: "new-session-id" });
-        await Promise.resolve();
-      });
-
-      expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
-      const [err, ctx] = mockSentryCaptureException.mock.calls[0];
-      expect((err as Error).message).toBe("transport not ready");
-      expect(ctx).toMatchObject({
-        tags: { copilot_flow: "pending-first-send-flush" },
-      });
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ variant: "destructive" }),
-      );
     });
 
     it("does nothing when sessionId arrives without a pending send", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
@@ -151,6 +151,32 @@ describe("useSendMessage", () => {
       expect(mockToast).not.toHaveBeenCalled();
     });
 
+    it("cancels the watchdog on unmount so the toast can't fire on an unrelated page", async () => {
+      const sendMessage = vi.fn();
+      const createSession = vi.fn().mockResolvedValue("new-session-id");
+
+      const { result, unmount } = renderHook(() =>
+        useTestHarness({
+          sessionId: null,
+          sendMessage,
+          createSession,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onSend("hello");
+      });
+
+      // User navigates away before the watchdog fires.
+      unmount();
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(mockToast).not.toHaveBeenCalled();
+    });
+
     it("does not toast when a subsequent send overwrites the slot", async () => {
       const sendMessage = vi.fn();
       const createSession = vi.fn().mockResolvedValue("new-session-id");

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
@@ -9,9 +9,11 @@ vi.mock("@/components/molecules/Toast/use-toast", () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
+const mockSentryCaptureException = vi.fn();
 const mockSentryCaptureMessage = vi.fn();
 const mockSentryBreadcrumb = vi.fn();
 vi.mock("@sentry/nextjs", () => ({
+  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
   captureMessage: (...args: unknown[]) => mockSentryCaptureMessage(...args),
   addBreadcrumb: (...args: unknown[]) => mockSentryBreadcrumb(...args),
 }));
@@ -49,6 +51,7 @@ describe("useSendMessage", () => {
   beforeEach(() => {
     resetStore();
     mockToast.mockReset();
+    mockSentryCaptureException.mockReset();
     mockSentryCaptureMessage.mockReset();
     mockSentryBreadcrumb.mockReset();
     vi.useFakeTimers();
@@ -83,6 +86,39 @@ describe("useSendMessage", () => {
 
       expect(sendMessage).toHaveBeenCalledWith({ text: "hello" });
       expect(useCopilotStreamStore.getState().pendingFirstSend).toBeNull();
+    });
+
+    it("captures + toasts when the dispatch fails", async () => {
+      const sendMessage = vi.fn(() => {
+        throw new Error("transport not ready");
+      });
+      const createSession = vi.fn();
+
+      useCopilotStreamStore.getState().setPendingFirstSend({
+        text: "hello",
+        files: [],
+      });
+
+      const { rerender } = renderHook(
+        ({ sessionId }) =>
+          useTestHarness({ sessionId, sendMessage, createSession }),
+        { initialProps: { sessionId: null as string | null } },
+      );
+
+      await act(async () => {
+        rerender({ sessionId: "new-session-id" });
+        await Promise.resolve();
+      });
+
+      expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
+      const [err, ctx] = mockSentryCaptureException.mock.calls[0];
+      expect((err as Error).message).toBe("transport not ready");
+      expect(ctx).toMatchObject({
+        tags: { copilot_flow: "pending-first-send-flush" },
+      });
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "destructive" }),
+      );
     });
 
     it("does nothing when sessionId arrives without a pending send", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
@@ -10,12 +10,8 @@ vi.mock("@/components/molecules/Toast/use-toast", () => ({
 }));
 
 const mockSentryCaptureException = vi.fn();
-const mockSentryCaptureMessage = vi.fn();
-const mockSentryBreadcrumb = vi.fn();
 vi.mock("@sentry/nextjs", () => ({
   captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
-  captureMessage: (...args: unknown[]) => mockSentryCaptureMessage(...args),
-  addBreadcrumb: (...args: unknown[]) => mockSentryBreadcrumb(...args),
 }));
 
 vi.mock("@/lib/direct-upload", () => ({
@@ -52,8 +48,6 @@ describe("useSendMessage", () => {
     resetStore();
     mockToast.mockReset();
     mockSentryCaptureException.mockReset();
-    mockSentryCaptureMessage.mockReset();
-    mockSentryBreadcrumb.mockReset();
     vi.useFakeTimers();
   });
 
@@ -140,7 +134,7 @@ describe("useSendMessage", () => {
   });
 
   describe("stalled-flush detection", () => {
-    it("captures a warning and toasts if the flush never runs within the timeout", async () => {
+    it("toasts and clears the slot if the flush never runs within the timeout", async () => {
       const sendMessage = vi.fn();
       const createSession = vi.fn().mockResolvedValue("new-session-id");
 
@@ -162,20 +156,13 @@ describe("useSendMessage", () => {
         vi.advanceTimersByTime(5000);
       });
 
-      expect(mockSentryCaptureMessage).toHaveBeenCalledTimes(1);
-      const [msg, ctx] = mockSentryCaptureMessage.mock.calls[0];
-      expect(msg).toMatch(/not flushed after session create/i);
-      expect(ctx).toMatchObject({
-        tags: { copilot_flow: "pending-first-send-stalled" },
-        level: "warning",
-      });
       expect(useCopilotStreamStore.getState().pendingFirstSend).toBeNull();
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "destructive" }),
       );
     });
 
-    it("does not fire the stalled warning when the flush effect consumes the slot", async () => {
+    it("does not toast when the flush effect consumes the slot", async () => {
       const sendMessage = vi.fn();
       const createSession = vi.fn().mockResolvedValue("new-session-id");
 
@@ -200,10 +187,10 @@ describe("useSendMessage", () => {
         vi.advanceTimersByTime(5000);
       });
 
-      expect(mockSentryCaptureMessage).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
-    it("does not fire the stalled warning when a subsequent send overwrites the slot", async () => {
+    it("does not toast when a subsequent send overwrites the slot", async () => {
       const sendMessage = vi.fn();
       const createSession = vi.fn().mockResolvedValue("new-session-id");
 
@@ -232,7 +219,7 @@ describe("useSendMessage", () => {
         vi.advanceTimersByTime(5000);
       });
 
-      expect(mockSentryCaptureMessage).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
       // The second slot is still there — its own timer hasn't elapsed.
       expect(useCopilotStreamStore.getState().pendingFirstSend?.text).toBe(
         "second",

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useSendMessage.test.ts
@@ -1,0 +1,244 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopilotStreamStore } from "../copilotStreamStore";
+import { useSendMessage } from "../useSendMessage";
+
+const mockToast = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+const mockSentryCaptureException = vi.fn();
+const mockSentryCaptureMessage = vi.fn();
+const mockSentryBreadcrumb = vi.fn();
+vi.mock("@sentry/nextjs", () => ({
+  captureException: (...args: unknown[]) => mockSentryCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockSentryCaptureMessage(...args),
+  addBreadcrumb: (...args: unknown[]) => mockSentryBreadcrumb(...args),
+}));
+
+vi.mock("@/lib/direct-upload", () => ({
+  uploadFileDirect: vi.fn(),
+}));
+
+function resetStore() {
+  useCopilotStreamStore.setState({
+    sessions: {},
+    messageSnapshots: {},
+    pendingFirstSend: null,
+    pendingFileParts: [],
+  });
+}
+
+function useTestHarness(args: {
+  sessionId: string | null;
+  sendMessage: ReturnType<typeof vi.fn>;
+  createSession: ReturnType<typeof vi.fn>;
+}) {
+  const isUserStoppingRef = useRef(false);
+  return useSendMessage({
+    sessionId: args.sessionId,
+    sendMessage: args.sendMessage as never,
+    createSession: args.createSession as unknown as () => Promise<
+      string | undefined
+    >,
+    isUserStoppingRef,
+  });
+}
+
+describe("useSendMessage", () => {
+  beforeEach(() => {
+    resetStore();
+    mockToast.mockReset();
+    mockSentryCaptureException.mockReset();
+    mockSentryCaptureMessage.mockReset();
+    mockSentryBreadcrumb.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  describe("first-send flush on sessionId change", () => {
+    it("dispatches the pending message and clears the slot when sessionId arrives", async () => {
+      const sendMessage = vi.fn();
+      const createSession = vi.fn();
+
+      useCopilotStreamStore.getState().setPendingFirstSend({
+        text: "hello",
+        files: [],
+      });
+
+      const { rerender } = renderHook(
+        ({ sessionId }) =>
+          useTestHarness({ sessionId, sendMessage, createSession }),
+        { initialProps: { sessionId: null as string | null } },
+      );
+
+      expect(sendMessage).not.toHaveBeenCalled();
+
+      await act(async () => {
+        rerender({ sessionId: "new-session-id" });
+      });
+
+      expect(sendMessage).toHaveBeenCalledWith({ text: "hello" });
+      expect(useCopilotStreamStore.getState().pendingFirstSend).toBeNull();
+    });
+
+    it("captures dispatch errors to Sentry and toasts the user", async () => {
+      const sendMessage = vi.fn(() => {
+        throw new Error("transport not ready");
+      });
+      const createSession = vi.fn();
+
+      useCopilotStreamStore.getState().setPendingFirstSend({
+        text: "hello",
+        files: [],
+      });
+
+      const { rerender } = renderHook(
+        ({ sessionId }) =>
+          useTestHarness({ sessionId, sendMessage, createSession }),
+        { initialProps: { sessionId: null as string | null } },
+      );
+
+      await act(async () => {
+        rerender({ sessionId: "new-session-id" });
+        // Let the catch handler run.
+        await Promise.resolve();
+      });
+
+      expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
+      const [err, ctx] = mockSentryCaptureException.mock.calls[0];
+      expect((err as Error).message).toBe("transport not ready");
+      expect(ctx).toMatchObject({
+        tags: { copilot_flow: "pending-first-send-flush" },
+      });
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "destructive" }),
+      );
+    });
+
+    it("does nothing when sessionId arrives without a pending send", async () => {
+      const sendMessage = vi.fn();
+      const createSession = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ sessionId }) =>
+          useTestHarness({ sessionId, sendMessage, createSession }),
+        { initialProps: { sessionId: null as string | null } },
+      );
+
+      await act(async () => {
+        rerender({ sessionId: "new-session-id" });
+      });
+
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(mockSentryCaptureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stalled-flush detection", () => {
+    it("captures a warning and toasts if the flush never runs within the timeout", async () => {
+      const sendMessage = vi.fn();
+      const createSession = vi.fn().mockResolvedValue("new-session-id");
+
+      const { result } = renderHook(() =>
+        useTestHarness({
+          sessionId: null,
+          sendMessage,
+          createSession,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onSend("hello");
+      });
+
+      expect(useCopilotStreamStore.getState().pendingFirstSend).not.toBeNull();
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(mockSentryCaptureMessage).toHaveBeenCalledTimes(1);
+      const [msg, ctx] = mockSentryCaptureMessage.mock.calls[0];
+      expect(msg).toMatch(/not flushed after session create/i);
+      expect(ctx).toMatchObject({
+        tags: { copilot_flow: "pending-first-send-stalled" },
+        level: "warning",
+      });
+      expect(useCopilotStreamStore.getState().pendingFirstSend).toBeNull();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "destructive" }),
+      );
+    });
+
+    it("does not fire the stalled warning when the flush effect consumes the slot", async () => {
+      const sendMessage = vi.fn();
+      const createSession = vi.fn().mockResolvedValue("new-session-id");
+
+      const { result } = renderHook(() =>
+        useTestHarness({
+          sessionId: null,
+          sendMessage,
+          createSession,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onSend("hello");
+      });
+
+      // Simulate the post-create remount picking up the pending send.
+      act(() => {
+        useCopilotStreamStore.getState().takePendingFirstSend();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(mockSentryCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not fire the stalled warning when a subsequent send overwrites the slot", async () => {
+      const sendMessage = vi.fn();
+      const createSession = vi.fn().mockResolvedValue("new-session-id");
+
+      const { result } = renderHook(() =>
+        useTestHarness({
+          sessionId: null,
+          sendMessage,
+          createSession,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.onSend("first");
+      });
+
+      // Simulate another new chat starting: a fresh setPendingFirstSend
+      // swaps the slot identity, so the first timer should silently no-op.
+      act(() => {
+        useCopilotStreamStore.getState().setPendingFirstSend({
+          text: "second",
+          files: [],
+        });
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(mockSentryCaptureMessage).not.toHaveBeenCalled();
+      // The second slot is still there — its own timer hasn't elapsed.
+      expect(useCopilotStreamStore.getState().pendingFirstSend?.text).toBe(
+        "second",
+      );
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
@@ -1,7 +1,6 @@
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { uploadFileDirect } from "@/lib/direct-upload";
 import type { UseChatHelpers } from "@ai-sdk/react";
-import * as Sentry from "@sentry/nextjs";
 import type { FileUIPart, UIMessage } from "ai";
 import { useEffect, useRef, useState } from "react";
 import { useCopilotStreamStore } from "./copilotStreamStore";
@@ -108,11 +107,11 @@ export function useSendMessage({
     // target and break the optimistic-render path that pushes the user
     // bubble into ``messages`` synchronously.
     if (prebuiltParts.length > 0) {
-      await sendMessage({ text, files: prebuiltParts });
+      sendMessage({ text, files: prebuiltParts });
       return;
     }
     if (files.length === 0) {
-      await sendMessage({ text });
+      sendMessage({ text });
       return;
     }
     setIsUploadingFiles(true);
@@ -127,7 +126,7 @@ export function useSendMessage({
         throw new Error("All file uploads failed");
       }
       const fileParts = buildFileParts(uploaded);
-      await sendMessage({
+      sendMessage({
         text,
         files: fileParts.length > 0 ? fileParts : undefined,
       });
@@ -149,21 +148,7 @@ export function useSendMessage({
       .getState()
       .takePendingFirstSend();
     if (!send) return;
-    // Toast so the user sees feedback; capture explicitly because the catch
-    // handler consumes the rejection, hiding it from unhandledrejection.
-    dispatchRef
-      .current(sessionId, send.text, send.files, parts)
-      .catch((err: unknown) => {
-        Sentry.captureException(err, {
-          tags: { copilot_flow: "pending-first-send-flush" },
-          extra: { sessionId, textLength: send.text.length },
-        });
-        toast({
-          title: "Couldn't send your message",
-          description: "Please try again.",
-          variant: "destructive",
-        });
-      });
+    void dispatchRef.current(sessionId, send.text, send.files, parts);
   }, [sessionId]);
 
   async function onSend(message: string, files?: File[]) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
@@ -149,30 +149,8 @@ export function useSendMessage({
       .getState()
       .takePendingFirstSend();
     if (!send) return;
-    Sentry.addBreadcrumb({
-      category: "copilot.first-send",
-      level: "info",
-      message: "flush pending first send on sessionId change",
-      data: {
-        sessionId,
-        textLength: send.text.length,
-        fileCount: send.files.length,
-        partCount: parts.length,
-      },
-    });
-    dispatchRef
-      .current(sessionId, send.text, send.files, parts)
-      .catch((err: unknown) => {
-        Sentry.captureException(err, {
-          tags: { copilot_flow: "pending-first-send-flush" },
-          extra: { sessionId, textLength: send.text.length },
-        });
-        toast({
-          title: "Couldn't send your message",
-          description: "Please try again.",
-          variant: "destructive",
-        });
-      });
+    // Don't catch — Sentry's unhandledrejection handler picks up async throws.
+    void dispatchRef.current(sessionId, send.text, send.files, parts);
   }, [sessionId]);
 
   async function onSend(message: string, files?: File[]) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
@@ -49,6 +49,16 @@ export function useSendMessage({
   // mutation dispatches and resets in `finally`, so a second call inside
   // the same tick short-circuits.
   const isCreatingSessionRef = useRef(false);
+  // Watchdog timer; cleared on unmount so the toast can't fire on a page
+  // the user has already navigated to.
+  const watchdogTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    return () => {
+      if (watchdogTimerRef.current !== null) {
+        window.clearTimeout(watchdogTimerRef.current);
+      }
+    };
+  }, []);
 
   async function uploadFiles(
     files: File[],
@@ -198,7 +208,8 @@ export function useSendMessage({
       await createSession();
       // Identity check against the same slot — a later setPendingFirstSend
       // swaps the reference and no-ops this timer.
-      window.setTimeout(() => {
+      watchdogTimerRef.current = window.setTimeout(() => {
+        watchdogTimerRef.current = null;
         const store = useCopilotStreamStore.getState();
         if (store.pendingFirstSend !== slot) return;
         store.setPendingFirstSend(null);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
@@ -149,8 +149,21 @@ export function useSendMessage({
       .getState()
       .takePendingFirstSend();
     if (!send) return;
-    // Don't catch — Sentry's unhandledrejection handler picks up async throws.
-    void dispatchRef.current(sessionId, send.text, send.files, parts);
+    // Toast so the user sees feedback; capture explicitly because the catch
+    // handler consumes the rejection, hiding it from unhandledrejection.
+    dispatchRef
+      .current(sessionId, send.text, send.files, parts)
+      .catch((err: unknown) => {
+        Sentry.captureException(err, {
+          tags: { copilot_flow: "pending-first-send-flush" },
+          extra: { sessionId, textLength: send.text.length },
+        });
+        toast({
+          title: "Couldn't send your message",
+          description: "Please try again.",
+          variant: "destructive",
+        });
+      });
   }, [sessionId]);
 
   async function onSend(message: string, files?: File[]) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
@@ -108,11 +108,11 @@ export function useSendMessage({
     // target and break the optimistic-render path that pushes the user
     // bubble into ``messages`` synchronously.
     if (prebuiltParts.length > 0) {
-      sendMessage({ text, files: prebuiltParts });
+      await sendMessage({ text, files: prebuiltParts });
       return;
     }
     if (files.length === 0) {
-      sendMessage({ text });
+      await sendMessage({ text });
       return;
     }
     setIsUploadingFiles(true);
@@ -127,7 +127,7 @@ export function useSendMessage({
         throw new Error("All file uploads failed");
       }
       const fileParts = buildFileParts(uploaded);
-      sendMessage({
+      await sendMessage({
         text,
         files: fileParts.length > 0 ? fileParts : undefined,
       });
@@ -209,12 +209,6 @@ export function useSendMessage({
     isCreatingSessionRef.current = true;
     const slot = { text: trimmed, files: files ?? [] };
     useCopilotStreamStore.getState().setPendingFirstSend(slot);
-    Sentry.addBreadcrumb({
-      category: "copilot.first-send",
-      level: "info",
-      message: "stored pending first send; awaiting session create",
-      data: { textLength: trimmed.length, fileCount: files?.length ?? 0 },
-    });
     try {
       await createSession();
       // Identity check against the same slot — a later setPendingFirstSend
@@ -223,14 +217,6 @@ export function useSendMessage({
         const store = useCopilotStreamStore.getState();
         if (store.pendingFirstSend !== slot) return;
         store.setPendingFirstSend(null);
-        Sentry.captureMessage(
-          "Pending first send not flushed after session create",
-          {
-            level: "warning",
-            tags: { copilot_flow: "pending-first-send-stalled" },
-            extra: { textLength: slot.text.length },
-          },
-        );
         toast({
           title: "Couldn't send your message",
           description: "Please try again.",

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useSendMessage.ts
@@ -1,12 +1,14 @@
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { uploadFileDirect } from "@/lib/direct-upload";
 import type { UseChatHelpers } from "@ai-sdk/react";
+import * as Sentry from "@sentry/nextjs";
 import type { FileUIPart, UIMessage } from "ai";
 import { useEffect, useRef, useState } from "react";
 import { useCopilotStreamStore } from "./copilotStreamStore";
 
 const MAX_FILES = 10;
 const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+const PENDING_FLUSH_TIMEOUT_MS = 5000;
 
 interface UploadedFile {
   file_id: string;
@@ -147,7 +149,30 @@ export function useSendMessage({
       .getState()
       .takePendingFirstSend();
     if (!send) return;
-    void dispatchRef.current(sessionId, send.text, send.files, parts);
+    Sentry.addBreadcrumb({
+      category: "copilot.first-send",
+      level: "info",
+      message: "flush pending first send on sessionId change",
+      data: {
+        sessionId,
+        textLength: send.text.length,
+        fileCount: send.files.length,
+        partCount: parts.length,
+      },
+    });
+    dispatchRef
+      .current(sessionId, send.text, send.files, parts)
+      .catch((err: unknown) => {
+        Sentry.captureException(err, {
+          tags: { copilot_flow: "pending-first-send-flush" },
+          extra: { sessionId, textLength: send.text.length },
+        });
+        toast({
+          title: "Couldn't send your message",
+          description: "Please try again.",
+          variant: "destructive",
+        });
+      });
   }, [sessionId]);
 
   async function onSend(message: string, files?: File[]) {
@@ -191,11 +216,36 @@ export function useSendMessage({
 
     if (isCreatingSessionRef.current) return;
     isCreatingSessionRef.current = true;
-    useCopilotStreamStore
-      .getState()
-      .setPendingFirstSend({ text: trimmed, files: files ?? [] });
+    const slot = { text: trimmed, files: files ?? [] };
+    useCopilotStreamStore.getState().setPendingFirstSend(slot);
+    Sentry.addBreadcrumb({
+      category: "copilot.first-send",
+      level: "info",
+      message: "stored pending first send; awaiting session create",
+      data: { textLength: trimmed.length, fileCount: files?.length ?? 0 },
+    });
     try {
       await createSession();
+      // Identity check against the same slot — a later setPendingFirstSend
+      // swaps the reference and no-ops this timer.
+      window.setTimeout(() => {
+        const store = useCopilotStreamStore.getState();
+        if (store.pendingFirstSend !== slot) return;
+        store.setPendingFirstSend(null);
+        Sentry.captureMessage(
+          "Pending first send not flushed after session create",
+          {
+            level: "warning",
+            tags: { copilot_flow: "pending-first-send-stalled" },
+            extra: { textLength: slot.text.length },
+          },
+        );
+        toast({
+          title: "Couldn't send your message",
+          description: "Please try again.",
+          variant: "destructive",
+        });
+      }, PENDING_FLUSH_TIMEOUT_MS);
     } catch (err) {
       const { setPendingFirstSend, setPendingFileParts } =
         useCopilotStreamStore.getState();


### PR DESCRIPTION
## Background

Discord report: chat session `407a4815-2750-41fe-9e33-9f06df00af67` was created on the backend but the user's first message never reached the executor.

* `POST /api/chat/sessions` 200 at 08:29:06 UTC
* Eleven `GET` polls follow over the next 15 minutes
* **Zero** `POST /api/chat/sessions/.../stream` requests (verified at the load balancer and on every server pod)
* Redis: `chat_status: idle`, `messages: []`
* Zero langfuse traces

The frontend created the session, navigated to `?sessionId=...`, but never dispatched the queued message. The pending-first-send flush effect — which runs on the `key={sessionId}` remount and consumes `pendingFirstSend` from the Zustand store — silently dropped the dispatch.

This isn't an exception (no error thrown), so `useChat.onError` cannot see it. The only positive signal is "the slot is still set 5 s after `createSession` returned" — which is what the watchdog checks.

## Changes

One change in `useSendMessage.ts`: a 5 s identity-keyed watchdog in `onSend`'s no-session branch.

* After `createSession` resolves, schedule a timer.
* If `pendingFirstSend` is still the same slot we set, the flush effect never ran for any reason (mount stalled, route navigation race, etc.) — clear the slot and toast the user to retry.
* A later `setPendingFirstSend` swaps the slot reference, so back-to-back new chats silently no-op the prior timer.

Other forms of failure (SDK rejections, transport errors, auth, rate-limit) are already handled by `useChat`'s `onError` → `handleStreamError`, which toasts the user / kicks off reconnect / surfaces the inline error banner. No change to that path.

## Test plan

- [x] `pnpm vitest run src/app/(platform)/copilot/__tests__/useSendMessage.test.ts` — 5/5 pass
- [x] `pnpm prettier --check` clean on touched files
- [x] `pnpm types` introduces no new errors on touched files