### PR TITLE
feat(backend/copilot-bot): add WebhookAdapter base + mount routes on main API

### DIFF
--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -83,6 +83,10 @@ logger = logging.getLogger(__name__)
 
 logging.getLogger("autogpt_libs").setLevel(logging.INFO)
 
+# Owned at module level so `lifespan_context` can close it on shutdown;
+# routes are mounted further down once `app` exists.
+_webhook_bot_backend = BotBackend()
+
 
 @contextlib.contextmanager
 def launch_darkly_context():
@@ -425,7 +429,6 @@ app.include_router(
     prefix="/api/platform-linking",
 )
 
-_webhook_bot_backend = BotBackend()
 register_webhook_adapters(app, _webhook_bot_backend)
 
 app.mount("/external-api", external_api)

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -53,6 +53,7 @@ from backend.api.features.library.exceptions import (
     FolderValidationError,
 )
 from backend.blocks.llm import DEFAULT_LLM_MODEL
+from backend.copilot.bot.bot_backend import BotBackend
 from backend.copilot.bot.webhook_routes import register_webhook_adapters
 from backend.copilot.rate_limit import UserPaywalledError
 from backend.data.model import Credentials
@@ -156,6 +157,11 @@ async def lifespan_context(app: fastapi.FastAPI):
     # Each cleanup is wrapped so one failure doesn't block the rest. The
     # Redis close in particular silences asyncio's "Unclosed ClusterNode"
     # GC warning at interpreter shutdown.
+    try:
+        await _webhook_bot_backend.close()
+    except Exception:
+        logger.warning("webhook BotBackend.close() failed", exc_info=True)
+
     try:
         await backend.data.redis_client.disconnect_async()
     except Exception:
@@ -419,7 +425,8 @@ app.include_router(
     prefix="/api/platform-linking",
 )
 
-register_webhook_adapters(app)
+_webhook_bot_backend = BotBackend()
+register_webhook_adapters(app, _webhook_bot_backend)
 
 app.mount("/external-api", external_api)
 

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -53,6 +53,7 @@ from backend.api.features.library.exceptions import (
     FolderValidationError,
 )
 from backend.blocks.llm import DEFAULT_LLM_MODEL
+from backend.copilot.bot.webhook_routes import register_webhook_adapters
 from backend.copilot.rate_limit import UserPaywalledError
 from backend.data.model import Credentials
 from backend.integrations.providers import ProviderName
@@ -417,6 +418,8 @@ app.include_router(
     tags=["platform-linking"],
     prefix="/api/platform-linking",
 )
+
+register_webhook_adapters(app)
 
 app.mount("/external-api", external_api)
 

--- a/autogpt_platform/backend/backend/copilot/bot/README.md
+++ b/autogpt_platform/backend/backend/copilot/bot/README.md
@@ -30,16 +30,21 @@ bot/
 ├── app.py              # CoPilotChatBridge(AppService), adapter factory, outbound @expose RPC
 ├── config.py           # Shared (platform-agnostic) config
 ├── handler.py          # Core logic: routing, linking, batched streaming
-├── bot_backend.py     # Thin facade over PlatformLinkingManagerClient + stream_registry
+├── bot_backend.py      # Thin facade over PlatformLinkingManagerClient + stream_registry
 ├── text.py             # Text splitting + batch formatting
 ├── threads.py          # Redis-backed thread subscription tracking
 └── adapters/
-    ├── base.py         # PlatformAdapter interface + MessageContext
+    ├── base.py         # PlatformAdapter + SocketAdapter / WebhookAdapter, MessageContext
     └── discord/
         ├── adapter.py  # Gateway connection, events, sends, thread creation
         ├── commands.py # Slash commands (/setup, /help, /unlink)
         └── config.py   # Discord token + platform limits
 ```
+
+**Connector types:** adapters extend one of two base classes — `SocketAdapter`
+(holds a long-lived per-token connection; Discord today) or `WebhookAdapter`
+(receives inbound HTTPS POSTs; stateless, mounted onto the main backend API
+via `webhook_routes.register_webhook_adapters`).
 
 **Locality rule:** anything platform-specific lives under `adapters/<platform>/`.
 The only file that names specific platforms is `app.py`, which is the factory
@@ -62,16 +67,26 @@ that decides which adapters to instantiate based on which tokens are set.
 
 ## Adding a new platform
 
-1. Create `adapters/<platform>/` with `adapter.py`, `commands.py` (if the
-   platform has commands), and `config.py`
-2. `adapter.py` subclasses `PlatformAdapter` and implements all its abstract
-   methods — `max_message_length`, `chunk_flush_at`, `send_message`,
-   `send_link`, `create_thread`, etc.
+Adapters extend one of two base classes (see **Connector types** above):
+
+- **Socket-owning** — subclass `SocketAdapter`, implement `start`/`stop`, and
+  register it in `app.py::_build_socket_adapters`.
+- **Webhook-based** — subclass `WebhookAdapter` and implement `register_routes`
+  (owning the request signature verification), then register it in
+  `webhook_routes.py::_build_webhook_adapters`.
+
+Then:
+
+1. Create `adapters/<platform>/` with `adapter.py`, `config.py`, and
+   `commands.py` (if the platform has commands)
+2. `adapter.py` implements all the `PlatformAdapter` abstract methods —
+   `send_message`, `send_link`, `create_thread`, `max_message_length`,
+   `chunk_flush_at`, etc.
 3. `config.py` declares the platform's env vars and any platform-specific
    numbers (message limits, token name, etc.)
-4. Add two lines to `app.py::_build_adapters`:
+4. Register the adapter in its factory:
    ```python
-   if <platform>_config.BOT_TOKEN:
+   if <platform>_config.get_bot_token():
        adapters.append(<Platform>Adapter(api))
    ```
 

--- a/autogpt_platform/backend/backend/copilot/bot/README.md
+++ b/autogpt_platform/backend/backend/copilot/bot/README.md
@@ -84,7 +84,15 @@ Then:
    `chunk_flush_at`, etc.
 3. `config.py` declares the platform's env vars and any platform-specific
    numbers (message limits, token name, etc.)
-4. Register the adapter in its factory:
+4. Register the adapter in the factory that matches its connector type:
+
+   **Socket adapter** — add to `app.py::_build_socket_adapters`:
+   ```python
+   if <platform>_config.get_bot_token():
+       adapters.append(<Platform>Adapter(api))
+   ```
+
+   **Webhook adapter** — add to `webhook_routes.py::_build_webhook_adapters`:
    ```python
    if <platform>_config.get_bot_token():
        adapters.append(<Platform>Adapter(api))

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base.py
@@ -1,13 +1,16 @@
 """Abstract base for platform adapters.
 
-Each chat platform (Discord, Telegram, Slack, etc.) implements this interface.
-The core bot logic in handler.py is platform-agnostic — it only speaks through
-these methods.
+`PlatformAdapter` is the outbound contract the platform-agnostic core handler
+speaks through. Concrete adapters extend one of two subtypes depending on how
+inbound events arrive: `SocketAdapter` (owns a long-lived connection) or
+`WebhookAdapter` (receives inbound HTTPS POSTs).
 """
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Literal, Optional
+
+from fastapi import FastAPI
 
 # Callback signature: (ctx, adapter) -> awaitable None
 MessageCallback = Callable[["MessageContext", "PlatformAdapter"], Awaitable[None]]
@@ -54,7 +57,7 @@ class MessageContext:
 
 
 class PlatformAdapter(ABC):
-    """Interface that each chat platform must implement."""
+    """Outbound contract shared by every platform adapter."""
 
     @property
     @abstractmethod
@@ -62,12 +65,6 @@ class PlatformAdapter(ABC):
 
     @abstractmethod
     def on_message(self, callback: MessageCallback) -> None: ...
-
-    @abstractmethod
-    async def start(self) -> None: ...
-
-    @abstractmethod
-    async def stop(self) -> None: ...
 
     @abstractmethod
     async def send_message(
@@ -146,5 +143,31 @@ class PlatformAdapter(ABC):
         Should be slightly under max_message_length to leave headroom for
         any trailing content that the splitter might pull into the current
         chunk.
+        """
+        ...
+
+
+class SocketAdapter(PlatformAdapter):
+    """Adapter that owns a long-lived connection (Discord Gateway, Slack
+    Socket Mode). The connection is a per-token singleton, so each socket
+    adapter needs its own pod.
+    """
+
+    @abstractmethod
+    async def start(self) -> None: ...
+
+    @abstractmethod
+    async def stop(self) -> None: ...
+
+
+class WebhookAdapter(PlatformAdapter):
+    """Adapter driven by inbound HTTPS webhooks (Slack Events API, Telegram,
+    Teams, WhatsApp). Stateless — webhook adapters share one pod.
+    """
+
+    @abstractmethod
+    def register_routes(self, app: FastAPI) -> None:
+        """Mount inbound webhook route(s) onto `app`; owns its own request
+        signature verification.
         """
         ...

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/base_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/base_test.py
@@ -1,0 +1,13 @@
+"""Tests for the adapter base-class hierarchy."""
+
+from .base import PlatformAdapter, SocketAdapter, WebhookAdapter
+from .discord.adapter import DiscordAdapter
+
+
+def test_socket_and_webhook_adapters_share_the_platform_contract():
+    assert issubclass(SocketAdapter, PlatformAdapter)
+    assert issubclass(WebhookAdapter, PlatformAdapter)
+
+
+def test_discord_is_a_socket_adapter():
+    assert issubclass(DiscordAdapter, SocketAdapter)

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -19,7 +19,7 @@ from ..base import (
     MessageCallback,
     MessageContext,
     MessageHistoryEntry,
-    PlatformAdapter,
+    SocketAdapter,
 )
 from . import commands, config
 
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 THREAD_HISTORY_LIMIT = 20
 
 
-class DiscordAdapter(PlatformAdapter):
+class DiscordAdapter(SocketAdapter):
     def __init__(self, api: BotBackend):
         intents = discord.Intents.default()
         intents.message_content = True

--- a/autogpt_platform/backend/backend/copilot/bot/app.py
+++ b/autogpt_platform/backend/backend/copilot/bot/app.py
@@ -1,6 +1,8 @@
-"""CoPilot Chat Bridge — AppService that runs the configured chat-platform
-adapters (Discord, Telegram, Slack) and exposes outbound message RPC for
-other services to push messages into chat platforms.
+"""CoPilot Chat Bridge — AppService that runs the socket-owning chat adapters.
+
+Hosts adapters that hold a long-lived connection to their platform (Discord
+today; Slack Socket Mode later) and exposes outbound message RPC for other
+services. Webhook-based adapters (`WebhookAdapter`) are wired up separately.
 """
 
 import asyncio
@@ -17,7 +19,7 @@ from backend.util.service import (
 )
 from backend.util.settings import Settings
 
-from .adapters.base import PlatformAdapter
+from .adapters.base import SocketAdapter
 from .adapters.discord import config as discord_config
 from .adapters.discord.adapter import DiscordAdapter
 from .bot_backend import BotBackend
@@ -54,7 +56,7 @@ class CoPilotChatBridge(AppService):
 
     async def _run_adapters(self) -> None:
         api = BotBackend()
-        adapters = _build_adapters(api)
+        adapters = _build_socket_adapters(api)
 
         if not adapters:
             logger.info(
@@ -142,15 +144,10 @@ class CoPilotChatBridgeClient(AppServiceClient):
     send_dm = endpoint_to_async(CoPilotChatBridge.send_dm)
 
 
-def _build_adapters(api: BotBackend) -> list[PlatformAdapter]:
-    """Instantiate adapters based on which platform tokens are configured."""
-    adapters: list[PlatformAdapter] = []
+def _build_socket_adapters(api: BotBackend) -> list[SocketAdapter]:
+    """Instantiate socket-owning adapters based on configured platform tokens."""
+    adapters: list[SocketAdapter] = []
     if discord_config.get_bot_token():
         adapters.append(DiscordAdapter(api))
         logger.info("Discord adapter enabled")
-    # Future:
-    # if telegram_config.get_bot_token():
-    #     adapters.append(TelegramAdapter(api))
-    # if slack_config.get_bot_token():
-    #     adapters.append(SlackAdapter(api))
     return adapters

--- a/autogpt_platform/backend/backend/copilot/bot/webhook_routes.py
+++ b/autogpt_platform/backend/backend/copilot/bot/webhook_routes.py
@@ -11,9 +11,12 @@ from .handler import MessageHandler
 logger = logging.getLogger(__name__)
 
 
-def register_webhook_adapters(app: FastAPI) -> None:
-    """Wire every configured webhook adapter's routes onto `app`."""
-    api = BotBackend()
+def register_webhook_adapters(app: FastAPI, api: BotBackend) -> None:
+    """Wire every configured webhook adapter's routes onto `app`.
+
+    The caller owns the `api` lifecycle (close it in the app's lifespan
+    cleanup) — matching the pattern used by the socket bridge in `app.py`.
+    """
     handler = MessageHandler(api)
     adapters = _build_webhook_adapters(api)
     for adapter in adapters:

--- a/autogpt_platform/backend/backend/copilot/bot/webhook_routes.py
+++ b/autogpt_platform/backend/backend/copilot/bot/webhook_routes.py
@@ -1,0 +1,29 @@
+"""Mount webhook adapter routes onto the main backend API."""
+
+import logging
+
+from fastapi import FastAPI
+
+from .adapters.base import WebhookAdapter
+from .bot_backend import BotBackend
+from .handler import MessageHandler
+
+logger = logging.getLogger(__name__)
+
+
+def register_webhook_adapters(app: FastAPI) -> None:
+    """Wire every configured webhook adapter's routes onto `app`."""
+    api = BotBackend()
+    handler = MessageHandler(api)
+    adapters = _build_webhook_adapters(api)
+    for adapter in adapters:
+        adapter.on_message(handler.handle)
+        adapter.register_routes(app)
+    logger.info("Mounted %d webhook adapter(s) on the main backend API", len(adapters))
+
+
+def _build_webhook_adapters(api: BotBackend) -> list[WebhookAdapter]:
+    """Instantiate webhook adapters from configured platform credentials."""
+    adapters: list[WebhookAdapter] = []
+    # Slack / Telegram / Teams / WhatsApp adapters slot in here as they land.
+    return adapters

--- a/autogpt_platform/backend/backend/copilot/bot/webhook_routes_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/webhook_routes_test.py
@@ -15,15 +15,13 @@ def test_build_webhook_adapters_starts_empty():
 def test_register_webhook_adapters_wires_each_adapter():
     app = FastAPI()
     adapter = MagicMock(spec=WebhookAdapter)
+    api = MagicMock()
 
-    with (
-        patch("backend.copilot.bot.bot_backend.get_platform_linking_manager_client"),
-        patch(
-            "backend.copilot.bot.webhook_routes._build_webhook_adapters",
-            return_value=[adapter],
-        ),
+    with patch(
+        "backend.copilot.bot.webhook_routes._build_webhook_adapters",
+        return_value=[adapter],
     ):
-        register_webhook_adapters(app)
+        register_webhook_adapters(app, api)
 
     adapter.on_message.assert_called_once()
     adapter.register_routes.assert_called_once_with(app)

--- a/autogpt_platform/backend/backend/copilot/bot/webhook_routes_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/webhook_routes_test.py
@@ -1,0 +1,29 @@
+"""Tests for the webhook adapter route-mounting helper."""
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+
+from .adapters.base import WebhookAdapter
+from .webhook_routes import _build_webhook_adapters, register_webhook_adapters
+
+
+def test_build_webhook_adapters_starts_empty():
+    assert _build_webhook_adapters(MagicMock()) == []
+
+
+def test_register_webhook_adapters_wires_each_adapter():
+    app = FastAPI()
+    adapter = MagicMock(spec=WebhookAdapter)
+
+    with (
+        patch("backend.copilot.bot.bot_backend.get_platform_linking_manager_client"),
+        patch(
+            "backend.copilot.bot.webhook_routes._build_webhook_adapters",
+            return_value=[adapter],
+        ),
+    ):
+        register_webhook_adapters(app)
+
+    adapter.on_message.assert_called_once()
+    adapter.register_routes.assert_called_once_with(app)


### PR DESCRIPTION
## Why

The next chat platforms — Slack, Telegram, Teams, WhatsApp — are webhook-based. They POST inbound events over HTTPS rather than holding a persistent connection like Discord's Gateway. The current `PlatformAdapter` ABC was shaped around the socket model (`start`/`stop` lifecycle); there's no place for inbound webhook routes to mount.

Without this scaffolding, the upcoming Slack PR would mix three concerns: refactor the ABC, add the route-mount machinery, **and** add the Slack adapter itself. This PR isolates the foundation so the Slack PR is purely "add Slack."

## What

- **Split `PlatformAdapter` into three classes:**
  - `PlatformAdapter` — shared outbound contract (`send_message`, `send_link`, `create_thread`, etc.) used by the platform-agnostic `MessageHandler`
  - `SocketAdapter(PlatformAdapter)` — adds `start`/`stop` (socket-owning connectors — Discord today, Slack Socket Mode hypothetically)
  - `WebhookAdapter(PlatformAdapter)` — adds `register_routes(app)` (HTTPS-driven connectors — Slack Events API, Telegram, Teams, WhatsApp)
- `DiscordAdapter` moves under `SocketAdapter` — base class only, **zero logic change**
- `app.py::_build_adapters` → `_build_socket_adapters` (type-narrowed to `list[SocketAdapter]`)
- New `backend/copilot/bot/webhook_routes.py` — `register_webhook_adapters(app)` helper + empty `_build_webhook_adapters` registry
- One-line call from `backend/api/rest_api.py` to mount webhook adapter routes during app setup
- README updated with the connector taxonomy + revised "Adding a new platform" guide

## How

**Where webhook routes live.** Webhook adapters mount onto the main backend API (`AgentServer`) rather than a new dedicated service:

- The main API is already the public ingress surface with N stateless replicas — exactly what webhook receivers need.
- Mirrors how OAuth callbacks and block webhook triggers already work on the main API.
- The original reason `copilot-bot` is its own pod — the persistent Discord Gateway connection — does **not** apply to stateless HTTPS handlers. A separate "webhook bridge" pod would be speculative infrastructure with no current consumer.

**Locality preserved.** Per-platform code stays under `adapters/<platform>/`. The webhook mount helper iterates `_build_webhook_adapters(api)` and calls `adapter.register_routes(app)` on each — every adapter owns its own routes and signature verification, in line with the existing locality rule.

**Resilient empty path.** With no webhook adapters configured (the state on merge), `register_webhook_adapters` logs `Mounted 0 webhook adapter(s)` and returns. The API starts cleanly with or without webhook platforms configured — same property as the existing `CoPilotChatBridge` empty-adapter path.

**Synchronous startup wiring.** The mount call happens at `rest_api.py` module-level alongside the existing `app.include_router(...)` calls. Errors propagate visibly at startup — no fire-and-forget pattern (lesson from the `CoPilotChatBridge` adapter-task review in #12618).

## Tests

- `adapters/base_test.py` — subclass-hierarchy regression: `SocketAdapter` / `WebhookAdapter` both extend `PlatformAdapter`; `DiscordAdapter` is now a `SocketAdapter`.
- `webhook_routes_test.py` — empty registry returns `[]`; `register_webhook_adapters` correctly wires `on_message` and `register_routes` on each adapter.
- All 116 existing `backend/copilot/bot/` tests still pass — the base-class split is non-breaking.

## Stack

- This PR → **Slack via webhook (Events API)** — adds `adapters/slack/`, registers `SlackAdapter(api)` in `_build_webhook_adapters` (one-line registry addition), zero `rest_api.py` changes needed.
- Then **Telegram**, **Teams**, **WhatsApp** — each is its own adapter folder + one registry entry.
- Companion infra PR for sealed secrets per platform — no new helm chart, since routes mount on the existing main backend pod.
