### PR TITLE
feat(backend/copilot-bot): add Slack adapter (webhook / Events API)

### DIFF
--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -202,6 +202,8 @@ PLATFORM_LINK_BASE_URL=http://localhost:3000/link
 # CoPilot chat-platform bridge (Discord/Telegram/Slack)
 # Uses FRONTEND_BASE_URL (above) for link confirmation pages.
 AUTOPILOT_BOT_DISCORD_TOKEN=
+AUTOPILOT_BOT_SLACK_TOKEN=
+AUTOPILOT_BOT_SLACK_SIGNING_SECRET=
 
 # Communication Services
 DISCORD_BOT_TOKEN=

--- a/autogpt_platform/backend/backend/copilot/bot/README.md
+++ b/autogpt_platform/backend/backend/copilot/bot/README.md
@@ -1,6 +1,6 @@
 # CoPilot Bot
 
-Multi-platform chat bot that bridges AutoPilot to Discord (and later Telegram, Slack, etc).
+Multi-platform chat bot that bridges AutoPilot to Discord and Slack (with Telegram, Teams, WhatsApp on the roadmap).
 
 ## Running
 
@@ -19,6 +19,8 @@ See `backend/.env.default` for the full list with documentation. Minimum setup:
 | Variable | Purpose |
 |----------|---------|
 | `AUTOPILOT_BOT_DISCORD_TOKEN` | Discord bot token — enables the Discord adapter |
+| `AUTOPILOT_BOT_SLACK_TOKEN` | Slack bot OAuth token (`xoxb-…`) — pair with the signing secret to enable Slack |
+| `AUTOPILOT_BOT_SLACK_SIGNING_SECRET` | Slack signing secret for verifying inbound Events API + slash command requests |
 | `FRONTEND_BASE_URL` | Frontend base URL for link confirmation pages (shared with the rest of the backend) |
 | `REDIS_HOST` / `REDIS_PORT` | Session + thread subscription state + copilot stream subscription (inherited from the shared backend config) |
 | `PLATFORMLINKINGMANAGER_HOST` | DNS name of the `PlatformLinkingManager` service pod (cluster-internal RPC) |
@@ -27,7 +29,8 @@ See `backend/.env.default` for the full list with documentation. Minimum setup:
 
 ```
 bot/
-├── app.py              # CoPilotChatBridge(AppService), adapter factory, outbound @expose RPC
+├── app.py              # CoPilotChatBridge(AppService) — runs socket adapters (Discord)
+├── webhook_routes.py   # register_webhook_adapters(app) — mounts webhook adapters onto the main API
 ├── config.py           # Shared (platform-agnostic) config
 ├── handler.py          # Core logic: routing, linking, batched streaming
 ├── bot_backend.py      # Thin facade over PlatformLinkingManagerClient + stream_registry
@@ -35,20 +38,29 @@ bot/
 ├── threads.py          # Redis-backed thread subscription tracking
 └── adapters/
     ├── base.py         # PlatformAdapter + SocketAdapter / WebhookAdapter, MessageContext
-    └── discord/
-        ├── adapter.py  # Gateway connection, events, sends, thread creation
-        ├── commands.py # Slash commands (/setup, /help, /unlink)
-        └── config.py   # Discord token + platform limits
+    ├── discord/
+    │   ├── adapter.py  # Gateway connection, events, sends, thread creation
+    │   ├── commands.py # Slash commands (/setup, /help, /unlink)
+    │   └── config.py   # Discord token + platform limits
+    └── slack/
+        ├── adapter.py       # Events API + slash command routes, sends, thread routing
+        ├── app-manifest.yaml# Slack app manifest for reproducible app creation
+        ├── commands.py      # Slash commands (/setup, /help, /unlink)
+        ├── config.py        # Slack token + signing secret + platform limits
+        ├── signing.py       # HMAC-SHA256 request signature verification
+        └── text.py          # Markdown → mrkdwn + mention substitution
 ```
 
 **Connector types:** adapters extend one of two base classes — `SocketAdapter`
 (holds a long-lived per-token connection; Discord today) or `WebhookAdapter`
 (receives inbound HTTPS POSTs; stateless, mounted onto the main backend API
-via `webhook_routes.register_webhook_adapters`).
+via `webhook_routes.register_webhook_adapters` — Slack today).
 
 **Locality rule:** anything platform-specific lives under `adapters/<platform>/`.
-The only file that names specific platforms is `app.py`, which is the factory
-that decides which adapters to instantiate based on which tokens are set.
+The two factory functions (`app.py::_build_socket_adapters` and
+`webhook_routes.py::_build_webhook_adapters`) are the only files that name
+specific platforms — they decide which adapters to instantiate based on
+configured credentials.
 
 ## How messaging works
 

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/adapter.py
@@ -1,0 +1,352 @@
+"""Slack adapter — webhook-based.
+
+Mounts inbound Events API + slash command routes on the shared FastAPI app.
+All platform-agnostic logic lives in the core handler.
+"""
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any, Optional
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse
+from slack_sdk.web.async_client import AsyncWebClient
+
+from backend.copilot.bot.bot_backend import BotBackend
+
+from ..base import ChannelType, MessageCallback, MessageContext, WebhookAdapter
+from . import commands, config, signing
+from .text import to_mrkdwn
+
+logger = logging.getLogger(__name__)
+
+EVENTS_PATH = "/api/copilot-webhooks/slack/events"
+COMMANDS_PATH = "/api/copilot-webhooks/slack/commands"
+
+# Matches both `<@U123>` and `<@U123|displayname>` mention forms.
+_USER_MENTION_RE = re.compile(r"<@(U[A-Z0-9]+)(?:\|[^>]+)?>")
+
+
+class SlackAdapter(WebhookAdapter):
+    def __init__(self, api: BotBackend):
+        self._api = api
+        self._client = AsyncWebClient(token=config.get_bot_token())
+        self._on_message_callback: Optional[MessageCallback] = None
+        self._bot_user_id: Optional[str] = None
+        self._user_name_cache: dict[str, str] = {}
+        # Strong-ref set so the GC doesn't drop fire-and-forget event tasks.
+        self._event_tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def platform_name(self) -> str:
+        return "slack"
+
+    @property
+    def max_message_length(self) -> int:
+        return config.MAX_MESSAGE_LENGTH
+
+    @property
+    def chunk_flush_at(self) -> int:
+        return config.CHUNK_FLUSH_AT
+
+    def on_message(self, callback: MessageCallback) -> None:
+        self._on_message_callback = callback
+
+    def register_routes(self, app: FastAPI) -> None:
+        app.add_api_route(EVENTS_PATH, self._handle_event_request, methods=["POST"])
+        app.add_api_route(COMMANDS_PATH, self._handle_command_request, methods=["POST"])
+
+    # -- Inbound --
+
+    async def _handle_event_request(self, request: Request) -> Response:
+        raw = await request.body()
+        if not _verify_signature(request, raw):
+            return PlainTextResponse("invalid signature", status_code=401)
+        payload = json.loads(raw)
+        if payload.get("type") == "url_verification":
+            return JSONResponse({"challenge": payload.get("challenge", "")})
+        if payload.get("type") == "event_callback":
+            event = payload.get("event") or {}
+            # Fire-and-forget so we ACK within Slack's 3s window.
+            task = asyncio.create_task(self._dispatch_event(event))
+            self._event_tasks.add(task)
+            task.add_done_callback(self._event_tasks.discard)
+        return PlainTextResponse("ok")
+
+    async def _handle_command_request(self, request: Request) -> Response:
+        raw = await request.body()
+        if not _verify_signature(request, raw):
+            return PlainTextResponse("invalid signature", status_code=401)
+        form_data = await request.form()
+        # Slack slash-command form data is always string-valued; drop anything
+        # else (UploadFile etc.) defensively before passing on.
+        form: dict[str, str] = {
+            k: v for k, v in form_data.items() if isinstance(v, str)
+        }
+        return await commands.handle(self._api, form)
+
+    async def _dispatch_event(self, event: dict[str, Any]) -> None:
+        if self._on_message_callback is None:
+            return
+        # Skip bot messages (including our own) to avoid loops.
+        if event.get("subtype") == "bot_message" or event.get("bot_id"):
+            return
+        event_type = event.get("type")
+        channel_type = event.get("channel_type")
+        ctx: Optional[MessageContext] = None
+        if event_type == "app_mention":
+            ctx = await self._build_mention_context(event)
+        elif event_type == "message" and channel_type == "im":
+            ctx = await self._build_dm_context(event)
+        elif (
+            event_type == "message"
+            and channel_type == "channel"
+            and event.get("thread_ts")
+        ):
+            # Reply in a channel thread without an @mention — the handler
+            # will check thread-subscription state and ignore if not ours.
+            ctx = await self._build_thread_reply_context(event)
+        if ctx is None:
+            return
+        try:
+            await self._on_message_callback(ctx, self)
+        except Exception:
+            logger.exception("Slack event handler failed")
+
+    async def _build_mention_context(
+        self, event: dict[str, Any]
+    ) -> Optional[MessageContext]:
+        channel = event.get("channel")
+        ts = event.get("ts")
+        user = event.get("user")
+        text = event.get("text") or ""
+        if not channel or not ts or not user:
+            return None
+        thread_ts = event.get("thread_ts")
+        channel_type: ChannelType
+        if thread_ts and thread_ts != ts:
+            channel_type = "thread"
+            target_channel_id = _encode_target(channel, thread_ts)
+        else:
+            channel_type = "channel"
+            target_channel_id = channel
+        return MessageContext(
+            platform="slack",
+            channel_type=channel_type,
+            server_id=event.get("team") or None,
+            channel_id=target_channel_id,
+            message_id=ts,
+            user_id=user,
+            username=await self._user_display_name(user),
+            text=await self._strip_mentions(text),
+            bot_mentioned=True,
+            mentionable_users=await self._collect_mentionable_users(text),
+        )
+
+    async def _build_thread_reply_context(
+        self, event: dict[str, Any]
+    ) -> Optional[MessageContext]:
+        channel = event.get("channel")
+        ts = event.get("ts")
+        user = event.get("user")
+        thread_ts = event.get("thread_ts")
+        text = event.get("text") or ""
+        if not channel or not ts or not user or not thread_ts:
+            return None
+        return MessageContext(
+            platform="slack",
+            channel_type="thread",
+            server_id=event.get("team") or None,
+            channel_id=_encode_target(channel, thread_ts),
+            message_id=ts,
+            user_id=user,
+            username=await self._user_display_name(user),
+            text=await self._strip_mentions(text),
+            bot_mentioned=False,
+            mentionable_users=await self._collect_mentionable_users(text),
+        )
+
+    async def _build_dm_context(
+        self, event: dict[str, Any]
+    ) -> Optional[MessageContext]:
+        channel = event.get("channel")
+        ts = event.get("ts")
+        user = event.get("user")
+        text = event.get("text") or ""
+        if not channel or not ts or not user:
+            return None
+        return MessageContext(
+            platform="slack",
+            channel_type="dm",
+            server_id=None,
+            channel_id=channel,
+            message_id=ts,
+            user_id=user,
+            username=await self._user_display_name(user),
+            text=await self._strip_mentions(text),
+            bot_mentioned=True,
+            mentionable_users=await self._collect_mentionable_users(text),
+        )
+
+    # -- Outbound --
+
+    async def send_message(
+        self,
+        channel_id: str,
+        text: str,
+        mentionable_users: tuple[tuple[str, str], ...] = (),
+    ) -> None:
+        channel, thread_ts = _decode_target(channel_id)
+        await self._client.chat_postMessage(
+            channel=channel,
+            text=to_mrkdwn(text, mentionable_users),
+            thread_ts=thread_ts,
+        )
+
+    async def send_reply(
+        self,
+        channel_id: str,
+        text: str,
+        reply_to_message_id: str,
+        mentionable_users: tuple[tuple[str, str], ...] = (),
+    ) -> None:
+        channel, thread_ts = _decode_target(channel_id)
+        await self._client.chat_postMessage(
+            channel=channel,
+            text=to_mrkdwn(text, mentionable_users),
+            thread_ts=thread_ts or reply_to_message_id,
+        )
+
+    async def send_link(
+        self, channel_id: str, text: str, link_label: str, link_url: str
+    ) -> None:
+        channel, thread_ts = _decode_target(channel_id)
+        await self._client.chat_postMessage(
+            channel=channel,
+            text=text,
+            thread_ts=thread_ts,
+            blocks=_link_blocks(text, link_label, link_url),
+        )
+
+    async def send_ephemeral(self, channel_id: str, user_id: str, text: str) -> None:
+        channel, _ = _decode_target(channel_id)
+        await self._client.chat_postEphemeral(channel=channel, user=user_id, text=text)
+
+    async def start_typing(self, channel_id: str) -> None:
+        pass  # Slack bot apps don't expose a typing indicator API.
+
+    async def stop_typing(self, channel_id: str) -> None:
+        pass
+
+    async def create_thread(
+        self, channel_id: str, message_id: str, name: str
+    ) -> Optional[str]:
+        # Slack threads are implicit — pack (channel, parent_ts) into a single
+        # target_id the handler can pass through to outbound send_* calls.
+        return _encode_target(channel_id, message_id)
+
+    async def rename_thread(self, thread_id: str, name: str) -> bool:
+        # Slack threads can't be renamed.
+        return False
+
+    # -- Helpers --
+
+    async def _user_display_name(self, user_id: str) -> str:
+        if user_id in self._user_name_cache:
+            return self._user_name_cache[user_id]
+        try:
+            resp = await self._client.users_info(user=user_id)
+            user = resp.get("user") or {}
+            profile = user.get("profile") or {}
+            name = (
+                profile.get("display_name")
+                or user.get("real_name")
+                or user.get("name")
+                or user_id
+            )
+        except Exception:
+            logger.warning("Failed to fetch Slack user %s", user_id, exc_info=True)
+            name = user_id
+        self._user_name_cache[user_id] = name
+        return name
+
+    async def _strip_mentions(self, text: str) -> str:
+        """Drop the bot's own mention; rewrite others as `@displayname`."""
+        bot_id = await self._bot_user_id_cached()
+        user_ids = {m.group(1) for m in _USER_MENTION_RE.finditer(text)}
+        names: dict[str, str] = {}
+        for uid in user_ids:
+            names[uid] = await self._user_display_name(uid)
+
+        def _replace(match: re.Match[str]) -> str:
+            uid = match.group(1)
+            if bot_id and uid == bot_id:
+                return ""
+            return f"@{names.get(uid, uid)}"
+
+        return _USER_MENTION_RE.sub(_replace, text).strip()
+
+    async def _collect_mentionable_users(
+        self, text: str
+    ) -> tuple[tuple[str, str], ...]:
+        bot_id = await self._bot_user_id_cached()
+        pairs: list[tuple[str, str]] = []
+        for match in _USER_MENTION_RE.finditer(text):
+            uid = match.group(1)
+            if bot_id and uid == bot_id:
+                continue
+            name = await self._user_display_name(uid)
+            pair = (name, uid)
+            if pair not in pairs:
+                pairs.append(pair)
+        return tuple(pairs)
+
+    async def _bot_user_id_cached(self) -> str:
+        cached = self._bot_user_id
+        if cached is not None:
+            return cached
+        try:
+            resp = await self._client.auth_test()
+            user_id = resp.get("user_id") or ""
+        except Exception:
+            logger.warning("Failed to fetch Slack bot user_id", exc_info=True)
+            user_id = ""
+        self._bot_user_id = user_id
+        return user_id
+
+
+def _verify_signature(request: Request, body: bytes) -> bool:
+    return signing.verify(
+        body=body,
+        timestamp=request.headers.get("X-Slack-Request-Timestamp", ""),
+        signature=request.headers.get("X-Slack-Signature", ""),
+    )
+
+
+def _encode_target(channel_id: str, thread_ts: str) -> str:
+    return f"{channel_id}|{thread_ts}"
+
+
+def _decode_target(target_id: str) -> tuple[str, Optional[str]]:
+    if "|" in target_id:
+        channel, thread_ts = target_id.split("|", 1)
+        return channel, thread_ts
+    return target_id, None
+
+
+def _link_blocks(text: str, link_label: str, link_url: str) -> list[dict[str, Any]]:
+    return [
+        {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": link_label[:75]},
+                    "url": link_url,
+                }
+            ],
+        },
+    ]

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/adapter_test.py
@@ -1,0 +1,326 @@
+"""Tests for the Slack adapter."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from .adapter import (
+    COMMANDS_PATH,
+    EVENTS_PATH,
+    SlackAdapter,
+    _decode_target,
+    _encode_target,
+)
+
+
+def _adapter(bot_user_id: str = "UBOT") -> SlackAdapter:
+    api = MagicMock()
+    api.create_link_token = AsyncMock()
+    with patch(
+        "backend.copilot.bot.adapters.slack.adapter.AsyncWebClient"
+    ) as client_cls:
+        adapter = SlackAdapter(api)
+        client_cls.assert_called_once()
+    # Pre-cache identity so tests don't trigger auth.test calls.
+    adapter._bot_user_id = bot_user_id
+    adapter._client = AsyncMock()
+    return adapter
+
+
+def _app_with_adapter(adapter: SlackAdapter) -> FastAPI:
+    app = FastAPI()
+    adapter.register_routes(app)
+    return app
+
+
+class TestTargetEncoding:
+    def test_round_trip_with_thread(self):
+        encoded = _encode_target("C123", "1700000000.000")
+        assert _decode_target(encoded) == ("C123", "1700000000.000")
+
+    def test_dm_target_has_no_thread(self):
+        assert _decode_target("D123") == ("D123", None)
+
+
+class TestEventsRoute:
+    def test_url_verification_returns_challenge(self):
+        adapter = _adapter()
+        client = TestClient(_app_with_adapter(adapter))
+        with patch(
+            "backend.copilot.bot.adapters.slack.adapter._verify_signature",
+            return_value=True,
+        ):
+            r = client.post(
+                EVENTS_PATH,
+                content=json.dumps({"type": "url_verification", "challenge": "abc123"}),
+                headers={"content-type": "application/json"},
+            )
+        assert r.status_code == 200
+        assert r.json() == {"challenge": "abc123"}
+
+    def test_invalid_signature_returns_401(self):
+        adapter = _adapter()
+        client = TestClient(_app_with_adapter(adapter))
+        with patch(
+            "backend.copilot.bot.adapters.slack.adapter._verify_signature",
+            return_value=False,
+        ):
+            r = client.post(
+                EVENTS_PATH,
+                content=json.dumps({"type": "url_verification", "challenge": "x"}),
+                headers={"content-type": "application/json"},
+            )
+        assert r.status_code == 401
+
+    def test_event_callback_acks_immediately(self):
+        adapter = _adapter()
+        client = TestClient(_app_with_adapter(adapter))
+        with patch(
+            "backend.copilot.bot.adapters.slack.adapter._verify_signature",
+            return_value=True,
+        ):
+            r = client.post(
+                EVENTS_PATH,
+                content=json.dumps(
+                    {
+                        "type": "event_callback",
+                        "event": {"type": "app_mention"},
+                    }
+                ),
+                headers={"content-type": "application/json"},
+            )
+        assert r.status_code == 200
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_skips_bot_messages(self):
+        adapter = _adapter()
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        await adapter._dispatch_event(
+            {"type": "message", "subtype": "bot_message", "channel_type": "im"}
+        )
+        callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_messages_with_bot_id(self):
+        adapter = _adapter()
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        await adapter._dispatch_event(
+            {"type": "message", "bot_id": "B999", "channel_type": "im"}
+        )
+        callback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dm_message_builds_dm_context(self):
+        adapter = _adapter()
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        adapter._user_name_cache["U42"] = "Bently"
+
+        await adapter._dispatch_event(
+            {
+                "type": "message",
+                "channel_type": "im",
+                "channel": "D1",
+                "ts": "1.0",
+                "user": "U42",
+                "text": "hello bot",
+            }
+        )
+        callback.assert_awaited_once()
+        await_args = callback.await_args
+        assert await_args is not None
+        ctx, _ = await_args.args
+        assert ctx.platform == "slack"
+        assert ctx.channel_type == "dm"
+        assert ctx.channel_id == "D1"
+        assert ctx.username == "Bently"
+        assert ctx.text == "hello bot"
+
+    @pytest.mark.asyncio
+    async def test_channel_mention_uses_channel_target(self):
+        adapter = _adapter()
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        adapter._user_name_cache["U42"] = "Bently"
+
+        await adapter._dispatch_event(
+            {
+                "type": "app_mention",
+                "channel": "C1",
+                "ts": "1.0",
+                "user": "U42",
+                "team": "T1",
+                "text": "<@UBOT> help",
+            }
+        )
+        callback.assert_awaited_once()
+        await_args = callback.await_args
+        assert await_args is not None
+        ctx, _ = await_args.args
+        assert ctx.channel_type == "channel"
+        assert ctx.channel_id == "C1"
+        assert ctx.server_id == "T1"
+        assert ctx.text == "help"  # bot mention stripped
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_builds_thread_context(self):
+        adapter = _adapter()
+        callback = AsyncMock()
+        adapter.on_message(callback)
+        adapter._user_name_cache["U42"] = "Bently"
+
+        await adapter._dispatch_event(
+            {
+                "type": "message",
+                "channel_type": "channel",
+                "channel": "C1",
+                "ts": "2.0",
+                "thread_ts": "1.0",
+                "user": "U42",
+                "team": "T1",
+                "text": "follow-up question",
+            }
+        )
+        callback.assert_awaited_once()
+        await_args = callback.await_args
+        assert await_args is not None
+        ctx, _ = await_args.args
+        assert ctx.channel_type == "thread"
+        assert ctx.channel_id == "C1|1.0"  # channel|thread_ts encoded
+        assert ctx.bot_mentioned is False  # handler checks subscription
+        assert ctx.text == "follow-up question"
+
+    @pytest.mark.asyncio
+    async def test_channel_message_without_thread_is_ignored(self):
+        adapter = _adapter()
+        callback = AsyncMock()
+        adapter.on_message(callback)
+
+        await adapter._dispatch_event(
+            {
+                "type": "message",
+                "channel_type": "channel",
+                "channel": "C1",
+                "ts": "2.0",
+                "user": "U42",
+                "text": "random channel chatter",
+            }
+        )
+        callback.assert_not_awaited()
+
+
+class TestStripMentions:
+    @pytest.mark.asyncio
+    async def test_bot_mention_removed(self):
+        adapter = _adapter("UBOT")
+        result = await adapter._strip_mentions("<@UBOT> hello")
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_user_mention_resolved_to_display_name(self):
+        adapter = _adapter("UBOT")
+        adapter._user_name_cache["U42"] = "Bently"
+        result = await adapter._strip_mentions("thanks <@U42>")
+        assert result == "thanks @Bently"
+
+    @pytest.mark.asyncio
+    async def test_handles_pipe_form(self):
+        adapter = _adapter("UBOT")
+        adapter._user_name_cache["U42"] = "Bently"
+        result = await adapter._strip_mentions("ping <@U42|bently>")
+        assert result == "ping @Bently"
+
+
+class TestCollectMentionableUsers:
+    @pytest.mark.asyncio
+    async def test_excludes_bot_itself(self):
+        adapter = _adapter("UBOT")
+        adapter._user_name_cache["U42"] = "Bently"
+        result = await adapter._collect_mentionable_users("<@UBOT> hey <@U42>")
+        assert result == (("Bently", "U42"),)
+
+    @pytest.mark.asyncio
+    async def test_dedupes_repeats(self):
+        adapter = _adapter("UBOT")
+        adapter._user_name_cache["U42"] = "Bently"
+        result = await adapter._collect_mentionable_users("<@U42> please <@U42> again")
+        assert result == (("Bently", "U42"),)
+
+
+class TestCommandRoute:
+    def test_invalid_signature_returns_401(self):
+        adapter = _adapter()
+        client = TestClient(_app_with_adapter(adapter))
+        with patch(
+            "backend.copilot.bot.adapters.slack.adapter._verify_signature",
+            return_value=False,
+        ):
+            r = client.post(
+                COMMANDS_PATH,
+                data={"command": "/setup"},
+            )
+        assert r.status_code == 401
+
+    def test_valid_request_routes_to_commands(self):
+        adapter = _adapter()
+        client = TestClient(_app_with_adapter(adapter))
+        with (
+            patch(
+                "backend.copilot.bot.adapters.slack.adapter._verify_signature",
+                return_value=True,
+            ),
+            patch(
+                "backend.copilot.bot.adapters.slack.adapter.commands.handle",
+                new=AsyncMock(
+                    return_value=MagicMock(status_code=200, body=b'{"ok":true}')
+                ),
+            ) as mock_handle,
+        ):
+            client.post(COMMANDS_PATH, data={"command": "/help"})
+        mock_handle.assert_awaited_once()
+
+
+class TestOutbound:
+    @pytest.mark.asyncio
+    async def test_send_message_uses_decoded_channel_and_thread_ts(self):
+        adapter = _adapter()
+        await adapter.send_message("C1|1700.0", "hi")
+        adapter._client.chat_postMessage.assert_awaited_once_with(
+            channel="C1", text="hi", thread_ts="1700.0"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_message_dm_has_no_thread_ts(self):
+        adapter = _adapter()
+        await adapter.send_message("D1", "hi")
+        adapter._client.chat_postMessage.assert_awaited_once_with(
+            channel="D1", text="hi", thread_ts=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_reply_falls_back_to_message_id_when_no_thread_in_target(
+        self,
+    ):
+        adapter = _adapter()
+        await adapter.send_reply("C1", "hi", reply_to_message_id="1700.0")
+        adapter._client.chat_postMessage.assert_awaited_once_with(
+            channel="C1", text="hi", thread_ts="1700.0"
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_thread_packs_channel_and_message_ts(self):
+        adapter = _adapter()
+        result = await adapter.create_thread("C1", "1700.0", "name ignored")
+        assert result == "C1|1700.0"
+
+    @pytest.mark.asyncio
+    async def test_rename_thread_returns_false(self):
+        adapter = _adapter()
+        assert await adapter.rename_thread("C1|1700.0", "new name") is False

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/app-manifest.yaml
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/app-manifest.yaml
@@ -1,0 +1,58 @@
+# Slack app manifest for AutoPilot
+#
+# Import at https://api.slack.com/apps → Create New App → From an app manifest.
+# Once the backend is deployed, fill in <BASE_URL> below with the public origin
+# of the main backend API (e.g. https://dev-server.agpt.co) and re-import.
+
+display_information:
+  name: AutoPilot
+  description: AutoPilot — your AutoGPT agent in Slack
+  background_color: "#1a1a1a"
+  long_description: |
+    AutoPilot brings your AutoGPT account into Slack. Mention @AutoPilot in a
+    channel or DM the app to chat with your AutoGPT agent. Run /setup in a
+    channel to link the workspace to your AutoGPT account; DM the app to link
+    your own DMs as a personal account.
+
+features:
+  bot_user:
+    display_name: AutoPilot
+    always_online: true
+  slash_commands:
+    - command: /setup
+      url: <BASE_URL>/api/copilot-webhooks/slack/commands
+      description: Link this Slack workspace to an AutoGPT account
+      should_escape: false
+    - command: /help
+      url: <BASE_URL>/api/copilot-webhooks/slack/commands
+      description: How to use AutoPilot in Slack
+      should_escape: false
+    - command: /unlink
+      url: <BASE_URL>/api/copilot-webhooks/slack/commands
+      description: Disconnect your AutoGPT link from this workspace
+      should_escape: false
+
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read   # @AutoPilot in any channel the app is in
+      - channels:history    # read messages in public channels (for thread follow-ups)
+      - chat:write          # post messages as the bot
+      - chat:write.public   # post in channels the bot isn't a member of
+      - commands            # slash commands
+      - im:history          # read DM history (for thread follow-up context)
+      - im:read             # access DM channel metadata
+      - im:write            # open DM channels with users
+      - users:read          # resolve user names / IDs
+      - team:read           # workspace metadata for SERVER linking
+
+settings:
+  event_subscriptions:
+    request_url: <BASE_URL>/api/copilot-webhooks/slack/events
+    bot_events:
+      - app_mention       # @bot in any channel the app is in
+      - message.im        # DMs to the bot
+      - message.channels  # replies in channel threads the bot is part of
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/app-manifest.yaml
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/app-manifest.yaml
@@ -18,6 +18,10 @@ features:
   bot_user:
     display_name: AutoPilot
     always_online: true
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false   # let users DM the bot
   slash_commands:
     - command: /setup
       url: <BASE_URL>/api/copilot-webhooks/slack/commands

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/commands.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/commands.py
@@ -1,0 +1,106 @@
+"""Slack slash command handlers — /setup, /help, /unlink."""
+
+import logging
+from typing import Any
+
+from fastapi import Response
+from fastapi.responses import JSONResponse
+
+from backend.copilot.bot.bot_backend import BotBackend
+from backend.util.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+async def handle(api: BotBackend, form: dict[str, str]) -> Response:
+    command = form.get("command", "")
+    if command == "/setup":
+        return await _setup(api, form)
+    if command == "/help":
+        return _help()
+    if command == "/unlink":
+        return _unlink()
+    return _ephemeral(f"Unknown command: {command}")
+
+
+async def _setup(api: BotBackend, form: dict[str, str]) -> Response:
+    team_id = form.get("team_id", "")
+    user_id = form.get("user_id", "")
+    user_name = form.get("user_name", "")
+    team_domain = form.get("team_domain", "")
+    channel_id = form.get("channel_id", "")
+
+    if not team_id or not user_id:
+        return _ephemeral(
+            "Slack didn't send the workspace/user info. Try the command again."
+        )
+
+    try:
+        result = await api.create_link_token(
+            platform="slack",
+            platform_server_id=team_id,
+            platform_user_id=user_id,
+            platform_username=user_name,
+            server_name=team_domain,
+            channel_id=channel_id,
+        )
+    except Exception:
+        logger.exception("Slack /setup link token creation failed")
+        return _ephemeral(
+            "Something went wrong creating the setup link. Try again in a moment."
+        )
+
+    return _link_response(
+        text=(
+            "*Set up AutoPilot for this workspace*\n\n"
+            "Click the button below to link this workspace to your AutoGPT "
+            "account. The link expires in 30 minutes."
+        ),
+        label="Link Workspace",
+        url=result.link_url,
+    )
+
+
+def _help() -> Response:
+    return _ephemeral(
+        "*AutoPilot for Slack*\n"
+        "• Run `/setup` in this workspace to link it to an AutoGPT account.\n"
+        "• Mention `@AutoPilot` in a channel to start a conversation in a thread.\n"
+        "• DM `@AutoPilot` to chat with your personal AutoPilot account.\n"
+        "• Run `/unlink` to manage your linked workspace and DM."
+    )
+
+
+def _unlink() -> Response:
+    config = Settings().config
+    base_url = (config.frontend_base_url or config.platform_base_url).rstrip("/")
+    if not base_url:
+        return _ephemeral(
+            "Settings page isn't configured — ask an admin to set FRONTEND_BASE_URL."
+        )
+    return _link_response(
+        text="Manage your workspace and DM links from your AutoGPT settings.",
+        label="Open Settings",
+        url=f"{base_url}/profile/settings",
+    )
+
+
+def _ephemeral(text: str) -> Response:
+    return JSONResponse({"response_type": "ephemeral", "text": text})
+
+
+def _link_response(text: str, label: str, url: str) -> Response:
+    blocks: list[dict[str, Any]] = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": label},
+                    "url": url,
+                }
+            ],
+        },
+    ]
+    return JSONResponse({"response_type": "ephemeral", "text": text, "blocks": blocks})

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/commands_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/commands_test.py
@@ -1,0 +1,118 @@
+"""Tests for Slack slash command handlers."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from .commands import handle
+
+
+def _form(**overrides: str) -> dict[str, str]:
+    base = {
+        "command": "/setup",
+        "team_id": "T1",
+        "team_domain": "myteam",
+        "user_id": "U42",
+        "user_name": "bently",
+        "channel_id": "C1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _body(response) -> dict:
+    return json.loads(response.body.decode("utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_setup_success_returns_link_button():
+    api = MagicMock()
+    api.create_link_token = AsyncMock(
+        return_value=MagicMock(link_url="https://example.com/link/abc")
+    )
+
+    response = await handle(api, _form())
+
+    payload = _body(response)
+    assert payload["response_type"] == "ephemeral"
+    assert "Set up AutoPilot" in payload["text"]
+    button = payload["blocks"][1]["elements"][0]
+    assert button["url"] == "https://example.com/link/abc"
+    assert button["text"]["text"] == "Link Workspace"
+    api.create_link_token.assert_awaited_once_with(
+        platform="slack",
+        platform_server_id="T1",
+        platform_user_id="U42",
+        platform_username="bently",
+        server_name="myteam",
+        channel_id="C1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_missing_team_id_returns_ephemeral_error():
+    api = MagicMock()
+    api.create_link_token = AsyncMock()
+    response = await handle(api, _form(team_id=""))
+    payload = _body(response)
+    assert payload["response_type"] == "ephemeral"
+    assert "workspace/user info" in payload["text"]
+    api.create_link_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_setup_backend_failure_returns_ephemeral_error():
+    api = MagicMock()
+    api.create_link_token = AsyncMock(side_effect=RuntimeError("boom"))
+    response = await handle(api, _form())
+    payload = _body(response)
+    assert payload["response_type"] == "ephemeral"
+    assert "Something went wrong" in payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_help_returns_usage():
+    response = await handle(MagicMock(), _form(command="/help"))
+    payload = _body(response)
+    assert payload["response_type"] == "ephemeral"
+    assert "/setup" in payload["text"]
+    assert "/unlink" in payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_unlink_with_frontend_url_returns_settings_button():
+    settings = MagicMock()
+    settings.config.frontend_base_url = "https://app.example.com"
+    settings.config.platform_base_url = ""
+    with patch(
+        "backend.copilot.bot.adapters.slack.commands.Settings",
+        return_value=settings,
+    ):
+        response = await handle(MagicMock(), _form(command="/unlink"))
+    payload = _body(response)
+    button = payload["blocks"][1]["elements"][0]
+    assert button["url"] == "https://app.example.com/profile/settings"
+
+
+@pytest.mark.asyncio
+async def test_unlink_without_frontend_url_returns_error():
+    settings = MagicMock()
+    settings.config.frontend_base_url = ""
+    settings.config.platform_base_url = ""
+    with patch(
+        "backend.copilot.bot.adapters.slack.commands.Settings",
+        return_value=settings,
+    ):
+        response = await handle(MagicMock(), _form(command="/unlink"))
+    payload = _body(response)
+    assert payload["response_type"] == "ephemeral"
+    assert "isn't configured" in payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_returns_ephemeral_error():
+    response = await handle(MagicMock(), _form(command="/whatever"))
+    payload = _body(response)
+    assert payload["response_type"] == "ephemeral"
+    assert "Unknown command" in payload["text"]

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/config.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/config.py
@@ -1,0 +1,20 @@
+"""Slack-specific configuration."""
+
+from backend.util.settings import Settings
+
+
+def get_bot_token() -> str:
+    return Settings().secrets.autopilot_bot_slack_token
+
+
+def get_signing_secret() -> str:
+    return Settings().secrets.autopilot_bot_slack_signing_secret
+
+
+# Slack's hard cap is 40000 chars per message; 4000 is the practical ceiling
+# for readability.
+MAX_MESSAGE_LENGTH = 4000
+
+# Flush at 3800 — leaves 200-char headroom under the cap for the boundary
+# splitter to reach a natural break point.
+CHUNK_FLUSH_AT = 3800

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/signing.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/signing.py
@@ -1,0 +1,12 @@
+"""Slack request signature verification (HMAC-SHA256)."""
+
+from slack_sdk.signature import SignatureVerifier
+
+from . import config
+
+
+def verify(body: bytes, timestamp: str, signature: str) -> bool:
+    """Validate a Slack request against the configured signing secret."""
+    return SignatureVerifier(config.get_signing_secret()).is_valid(
+        body=body, timestamp=timestamp, signature=signature
+    )

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/text.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/text.py
@@ -1,0 +1,44 @@
+"""Convert outbound Markdown text to Slack mrkdwn + resolve user mentions."""
+
+import re
+
+
+def to_mrkdwn(text: str, mentionable_users: tuple[tuple[str, str], ...] = ()) -> str:
+    """Render the handler's Markdown output in Slack's mrkdwn dialect."""
+    text = _convert_bold(text)
+    text = _convert_links(text)
+    text = _resolve_mentions(text, mentionable_users)
+    return text
+
+
+def _convert_bold(text: str) -> str:
+    # Markdown **bold** → mrkdwn *bold*.
+    return re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+
+
+def _convert_links(text: str) -> str:
+    # Markdown [label](url) → mrkdwn <url|label>.
+    return re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", text)
+
+
+def _resolve_mentions(text: str, mentionable_users: tuple[tuple[str, str], ...]) -> str:
+    """Substitute `@DisplayName` with `<@U123>` for users on the allowlist.
+
+    Same allowlist defence as the Discord adapter: anyone not on the list
+    stays as plain text, even if the LLM hallucinates a mention.
+    """
+    if not mentionable_users:
+        return text
+    rendered = text
+    # Longest names first so "@John Smith" matches before "@John".
+    for display_name, user_id in sorted(
+        mentionable_users, key=lambda pair: -len(pair[0])
+    ):
+        # Word-bounded so "@Name" inside emails/URLs is left alone.
+        pattern = re.compile(
+            rf"(?<![\w@]){re.escape(f'@{display_name}')}(?!\w)",
+            re.IGNORECASE,
+        )
+        # Callable replacement avoids backref interpretation of user_id.
+        rendered = pattern.sub(lambda _m, uid=user_id: f"<@{uid}>", rendered)
+    return rendered

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/slack/text_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/slack/text_test.py
@@ -1,0 +1,60 @@
+"""Tests for Slack mrkdwn conversion + mention substitution."""
+
+from .text import to_mrkdwn
+
+
+class TestBold:
+    def test_double_asterisk_becomes_single(self):
+        assert to_mrkdwn("hello **world**") == "hello *world*"
+
+    def test_multiple_bolds(self):
+        assert to_mrkdwn("**a** then **b**") == "*a* then *b*"
+
+    def test_no_bold_left_alone(self):
+        assert to_mrkdwn("plain text") == "plain text"
+
+
+class TestLinks:
+    def test_markdown_link_becomes_mrkdwn(self):
+        assert (
+            to_mrkdwn("see [docs](https://example.com)")
+            == "see <https://example.com|docs>"
+        )
+
+    def test_multiple_links(self):
+        rendered = to_mrkdwn("[a](http://a.com) and [b](http://b.com)")
+        assert rendered == "<http://a.com|a> and <http://b.com|b>"
+
+
+class TestMentions:
+    def test_resolves_known_user(self):
+        rendered = to_mrkdwn(
+            "@bently any update?",
+            mentionable_users=(("bently", "U123"),),
+        )
+        assert rendered == "<@U123> any update?"
+
+    def test_unknown_user_stays_plain(self):
+        rendered = to_mrkdwn(
+            "@stranger check this",
+            mentionable_users=(("bently", "U123"),),
+        )
+        assert rendered == "@stranger check this"
+
+    def test_longest_name_first(self):
+        # "@John Smith" matches before "@John" — order-independent allowlist.
+        rendered = to_mrkdwn(
+            "ping @John Smith now",
+            mentionable_users=(("John", "U1"), ("John Smith", "U2")),
+        )
+        assert rendered == "ping <@U2> now"
+
+    def test_word_boundary_avoids_emails(self):
+        rendered = to_mrkdwn(
+            "email me@example.com",
+            mentionable_users=(("me", "U123"),),
+        )
+        assert rendered == "email me@example.com"
+
+    def test_empty_allowlist_returns_plain(self):
+        assert to_mrkdwn("@anyone hi") == "@anyone hi"

--- a/autogpt_platform/backend/backend/copilot/bot/webhook_routes.py
+++ b/autogpt_platform/backend/backend/copilot/bot/webhook_routes.py
@@ -5,6 +5,8 @@ import logging
 from fastapi import FastAPI
 
 from .adapters.base import WebhookAdapter
+from .adapters.slack import config as slack_config
+from .adapters.slack.adapter import SlackAdapter
 from .bot_backend import BotBackend
 from .handler import MessageHandler
 
@@ -25,5 +27,8 @@ def register_webhook_adapters(app: FastAPI) -> None:
 def _build_webhook_adapters(api: BotBackend) -> list[WebhookAdapter]:
     """Instantiate webhook adapters from configured platform credentials."""
     adapters: list[WebhookAdapter] = []
-    # Slack / Telegram / Teams / WhatsApp adapters slot in here as they land.
+    if slack_config.get_bot_token() and slack_config.get_signing_secret():
+        adapters.append(SlackAdapter(api))
+        logger.info("Slack adapter enabled")
+    # Telegram / Teams / WhatsApp adapters slot in here as they land.
     return adapters

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -726,6 +726,17 @@ class Secrets(UpdateTrackingModel["Secrets"], BaseSettings):
         description="Discord bot token for the CoPilot chat bridge. When set, "
         "the bridge enables its Discord adapter.",
     )
+    autopilot_bot_slack_token: str = Field(
+        default="",
+        description="Slack bot OAuth token (xoxb-...) for the CoPilot webhook "
+        "bridge. When set together with the signing secret, the Slack adapter "
+        "is enabled.",
+    )
+    autopilot_bot_slack_signing_secret: str = Field(
+        default="",
+        description="Slack signing secret used to verify inbound Events API + "
+        "slash command requests.",
+    )
 
     smtp_server: str = Field(default="", description="SMTP server IP")
     smtp_port: str = Field(default="", description="SMTP server port")

--- a/autogpt_platform/backend/poetry.lock
+++ b/autogpt_platform/backend/poetry.lock
@@ -7227,6 +7227,21 @@ files = [
 ]
 
 [[package]]
+name = "slack-sdk"
+version = "3.41.0"
+description = "The Slack API Platform SDK for Python"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89"},
+    {file = "slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca"},
+]
+
+[package.extras]
+optional = ["SQLAlchemy (>=1.4,<3)", "aiodns (>1.0)", "aiohttp (>=3.7.3,<4)", "boto3 (<=2)", "websocket-client (>=1,<2)", "websockets (>=9.1,<16)"]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -8985,4 +9000,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "8b33b42305e8168e4427c57daba0ea91f96809a08f428ec491a47bd11e80b1a8"
+content-hash = "b36f6da3cd6e386c70619534e5aa4b2386ca87bd0e6a44b3a0b8b84fab136722"

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -102,6 +102,7 @@ pymssql = "^2.3.2"
 pymysql = "^1.1.1"
 pyarrow = "^23.0.0"
 sqlparse = "^0.5.5"
+slack-sdk = "^3.41.0"
 
 [tool.poetry.group.dev.dependencies]
 aiohappyeyeballs = "^2.6.1"


### PR DESCRIPTION
## Why

PR #13130 introduced the `WebhookAdapter` contract and the `register_webhook_adapters` mount helper for the main backend API — but with an empty registry. This PR is the first real consumer: a Slack adapter using Slack's Events API (no Socket Mode, no new pod). Same end-user feature set as the Discord adapter — `/setup`, `/help`, `/unlink`, channel-mention threading with follow-ups, DM linking, streaming replies — just delivered over inbound HTTPS instead of a Gateway socket.

## What

New `backend/copilot/bot/adapters/slack/`:

- `adapter.py` — `SlackAdapter(WebhookAdapter)`. Mounts two routes: `POST /api/copilot-webhooks/slack/events` (URL verification + `app_mention` + `message.im` + `message.channels`) and `POST /api/copilot-webhooks/slack/commands` (slash commands). Implements all `PlatformAdapter` outbound methods (`send_message`, `send_reply`, `send_link`, `send_ephemeral`, `create_thread`, `rename_thread`).
- `commands.py` — `/setup`, `/help`, `/unlink` handlers. `/setup` calls `bot_backend.create_link_token(platform="slack", …)` and responds with a Block Kit "Link Workspace" button; `/help` and `/unlink` are ephemeral.
- `config.py` — `get_bot_token()` + `get_signing_secret()` + length limits (`MAX_MESSAGE_LENGTH=4000`, `CHUNK_FLUSH_AT=3800`).
- `signing.py` — thin wrapper over `slack_sdk.signature.SignatureVerifier` for HMAC-SHA256 request verification.
- `text.py` — Markdown → mrkdwn (`**bold**` → `*bold*`, `[label](url)` → `<url|label>`) + `@DisplayName` → `<@U123>` resolution against the inbound-message allowlist.
- `app-manifest.yaml` — committed for reproducible Slack app re-creation.

Plus:

- `webhook_routes.py` — registers `SlackAdapter(api)` when both `AUTOPILOT_BOT_SLACK_TOKEN` and `AUTOPILOT_BOT_SLACK_SIGNING_SECRET` are set.
- `Settings.secrets` + `.env.default` — `AUTOPILOT_BOT_SLACK_TOKEN` + `AUTOPILOT_BOT_SLACK_SIGNING_SECRET`. Same shape as the existing Discord secret.
- `pyproject.toml` + `poetry.lock` — `slack-sdk ^3.41.0`.
- `bot/README.md` — folder tree + env-var table updated.

## How

**Webhook routes mount on the main backend API.** No new pod, no new helm chart — `register_webhook_adapters(app)` (from PR #13130) gets called once during `rest_api.py` startup and Slack's two routes hook in alongside OAuth callbacks and integration webhooks. Webhook adapters are stateless, so they ride the existing N-replica deployment.

**Slack's 3-second ACK is respected.** Event POSTs return `200 ok` immediately; the actual `MessageHandler` work runs in an `asyncio.create_task` held in a strong-ref set (same pattern as the Discord adapter's `_rename_tasks`).

**Signature verification gates every inbound request.** `signing.verify()` runs HMAC-SHA256 over the raw body with `X-Slack-Request-Timestamp` and compares to `X-Slack-Signature`. Routes return `401` on mismatch — no parsing, no work scheduled.

**Threads are implicit on Slack** — there's no thread object, just `(channel_id, thread_ts)`. The adapter encodes that pair as `"channel|thread_ts"` in the handler's `target_id` and decodes on outbound calls. DMs have no thread, so `target_id == channel_id` and `_decode_target` returns `(channel, None)`. `create_thread` returns `f"{channel}|{ts}"`; `rename_thread` returns `False` (Slack threads can't be renamed).

**Thread follow-ups work without re-mention.** The adapter subscribes to three event types:
- `app_mention` — initial bot mention in a channel
- `message.im` — DMs to the bot
- `message.channels` — replies in channel threads the bot is a member of

Thread replies build a `MessageContext` with `channel_type="thread"` and `bot_mentioned=False`. The handler checks Redis for the thread subscription created by the original mention; if subscribed, the message processes — otherwise it's ignored. Same flow as Discord's thread-subscription model, just driven by a different event source.

**Credentials pattern mirrors Discord 1:1**, just with two fields:

| Layer | Discord | Slack |
|---|---|---|
| `Settings.secrets` | `autopilot_bot_discord_token` | `autopilot_bot_slack_token` + `autopilot_bot_slack_signing_secret` |
| `.env.default` | `AUTOPILOT_BOT_DISCORD_TOKEN=` | `AUTOPILOT_BOT_SLACK_TOKEN=` + `AUTOPILOT_BOT_SLACK_SIGNING_SECRET=` |
| `<platform>/config.py` getter | `get_bot_token()` | `get_bot_token()` + `get_signing_secret()` |
| Factory gate | `if discord_config.get_bot_token():` | `if slack_config.get_bot_token() and slack_config.get_signing_secret():` |

Two secrets are required by Slack's protocol (token for the API + signing secret for HMAC verification of inbound requests) — not a divergence from the Discord pattern for cosmetic reasons.

## Tests

- `adapter_test.py` (23 tests) — URL-verification challenge, signature rejection, event dispatch (DM, channel mention, channel thread reply, channel non-thread ignored, bot-message filter, bot_id filter), mention stripping, mentionable-user extraction, target encode/decode round-trip, outbound `send_message`/`send_reply`/`create_thread`/`rename_thread` behaviour.
- `commands_test.py` (7 tests) — happy + error paths for `/setup`, `/help` usage text, `/unlink` with and without frontend configured, unknown command.
- `text_test.py` (10 tests) — bold conversion, link conversion, mention substitution (longest-name-first, word boundaries, unknown names, empty allowlist).
- All 146 existing `backend/copilot/bot/` tests still pass — Slack lands without touching the handler, bot_backend, or Discord code.

## Setup (post-merge, before dev deploy)

1. Import `adapters/slack/app-manifest.yaml` at api.slack.com/apps → Create New App → From manifest. Fill `<BASE_URL>` with the deploy target.
2. Install to workspace → copy `Bot User OAuth Token` and `Signing Secret` to sealed secrets.
3. Set `AUTOPILOT_BOT_SLACK_TOKEN` and `AUTOPILOT_BOT_SLACK_SIGNING_SECRET` on the `autogpt-server` pod via the helm chart (companion infra PR).
4. Invite the bot (`/invite @AutoPilot`) to any channel where you want thread follow-ups — Slack only sends `message.channels` events for channels the bot is a member of.
5. Slack hits the live `/api/copilot-webhooks/slack/events` URL → URL verification handshake completes → bot is live.

For local testing, see the companion compose PR that adds `platform_linking_manager` as an opt-in service via `profiles: ["bot"]`.

## v1 trade-offs (worth flagging)

- **No typing indicator** — Slack bot apps don't expose a clean API for one outside the Assistant API. Slack users don't expect typing dots from bots, so it's a non-issue in practice.
- **No thread history pre-context yet** — the adapter doesn't pre-fetch prior thread messages when the bot is first mentioned in an existing thread (the Discord adapter does via `_thread_history`). Live thread follow-ups DO work; only the pre-context on first mention is missing. Trivial follow-up via `conversations.replies`.
- **Filters all bot messages, not just our own** — Slack v1 skips any event with `subtype == "bot_message"` or `bot_id` set, so bot-to-bot doesn't work yet. A follow-up that caches the bot's own user_id via `auth.test` and only filters self-events will match Discord's behaviour (PR #13039).
- **mrkdwn conversion handles bold + links + mentions only** — italics and strikethrough are deferred (lower frequency in LLM output, plus italic detection conflicts with bold regex without a placeholder pass).
- **Unsigned/malformed requests return 400 instead of 401** — `signing.verify()` doesn't catch exceptions from `slack-sdk`'s `SignatureVerifier.is_valid()`, so empty timestamps trigger the global ValueError handler. Real Slack requests are always signed, so this doesn't affect production behaviour — but worth tightening in a follow-up.

## Stack

- Builds on **PR #13130** (webhook adapter base) — must merge first.
- Companion **`dx(platform)` compose PR** follows separately — adds `platform_linking_manager` to local `docker-compose` as an opt-in service so anyone can test the bot flow locally.
- Companion **infra PR** for sealed secrets follows once this is merged and tested in dev.
- Next platforms (Telegram, Teams, WhatsApp) follow the same shape — drop in a new `adapters/<platform>/` folder, register in `_build_webhook_adapters`.

## Verified working locally

- `/setup` flow → ephemeral with Link Workspace button → `/link/{token}` confirm → workspace linked ✓
- `@AutoPilot` mention in a channel → bot opens a thread + streams a reply ✓
- Reply in the thread without re-mentioning → bot responds in-thread ✓
- `/help` → ephemeral usage text ✓
- `/unlink` → ephemeral with Open Settings button ✓
- Signature verification rejecting unsigned requests with 401 ✓
