### PR TITLE
fix(backend/copilot): hide builder-blocked MCP tools so the SDK can't auto-deny them

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -43,7 +43,6 @@ from backend.copilot.pending_message_helpers import (
     queue_pending_for_http,
 )
 from backend.copilot.pending_messages import peek_pending_messages
-from backend.copilot.permissions import CopilotPermissions
 from backend.copilot.rate_limit import (
     CoPilotUsagePublic,
     RateLimitExceeded,

--- a/autogpt_platform/backend/backend/copilot/builder_context.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context.py
@@ -72,6 +72,22 @@ _BUILDER_RUN_AGENT_GUIDANCE = (
     "in the same turn."
 )
 
+# Steers the model toward edit_agent on the bound graph. Empty builder
+# graphs (version=1, no nodes) tempt the model to reach for create_agent;
+# that tool is hidden in builder sessions and the model has no UI to ask
+# the user for permission — without explicit guidance it would otherwise
+# narrate a phantom Claude-Code-style approval prompt.
+_BUILDER_TOOL_GUIDANCE = (
+    "This builder panel is already bound to the graph shown in "
+    "<builder_context>. Use `edit_agent` against that graph id to add, "
+    "modify, or remove nodes and links — even when the graph is empty "
+    "(version=1, no nodes). Never ask the user to approve a tool: there "
+    "is no permission prompt UI in the builder chat, and the tools "
+    "`create_agent`, `customize_agent`, and `get_agent_building_guide` "
+    "are intentionally unavailable here (the building guide is already "
+    "included in <building_guide> below)."
+)
+
 
 def _sanitize_for_xml(value: Any) -> str:
     """Escape XML special chars — mirrors ``sanitizeForXml`` in
@@ -164,6 +180,9 @@ async def build_builder_system_prompt_suffix(session: ChatSession) -> str:
     # code fences, and example JSON.
     return (
         f"\n\n<{BUILDER_SESSION_TAG}>\n"
+        f"<tool_usage>\n"
+        f"{_BUILDER_TOOL_GUIDANCE}\n"
+        f"</tool_usage>\n"
         f"<run_agent_dispatch_mode>\n"
         f"{_BUILDER_RUN_AGENT_GUIDANCE}\n"
         f"</run_agent_dispatch_mode>\n"

--- a/autogpt_platform/backend/backend/copilot/builder_context.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context.py
@@ -78,14 +78,20 @@ _BUILDER_RUN_AGENT_GUIDANCE = (
 # the user for permission — without explicit guidance it would otherwise
 # narrate a phantom Claude-Code-style approval prompt.
 _BUILDER_TOOL_GUIDANCE = (
-    "This builder panel is already bound to the graph shown in "
-    "<builder_context>. Use `edit_agent` against that graph id to add, "
-    "modify, or remove nodes and links — even when the graph is empty "
-    "(version=1, no nodes). Never ask the user to approve a tool: there "
-    "is no permission prompt UI in the builder chat, and the tools "
-    "`create_agent`, `customize_agent`, and `get_agent_building_guide` "
-    "are intentionally unavailable here (the building guide is already "
-    "included in <building_guide> below)."
+    "This builder panel is bound to the graph shown in <builder_context>. "
+    "Use `edit_agent` against that graph id for every modification, "
+    "including populating an empty graph (version=1, no nodes) — "
+    "`edit_agent` accepts the same node/link payload that `create_agent` "
+    "would, so there is no reason to reach for `create_agent` here. "
+    "Typical sequence for a new request: call `find_block` to discover "
+    "the block ids and input schemas you need, then call `edit_agent` "
+    "once with the full set of nodes and links. "
+    "Never ask the user to approve or allow a tool — there is no "
+    "permission prompt UI in the builder chat, so any 'click Allow' "
+    "narration will leave the user stuck. The tools `create_agent`, "
+    "`customize_agent`, and `get_agent_building_guide` are intentionally "
+    "unavailable in builder sessions (the building guide is already "
+    "embedded in <building_guide> below)."
 )
 
 

--- a/autogpt_platform/backend/backend/copilot/builder_context.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context.py
@@ -72,11 +72,23 @@ _BUILDER_RUN_AGENT_GUIDANCE = (
     "in the same turn."
 )
 
+
 # Steers the model toward edit_agent on the bound graph. Empty builder
 # graphs (version=1, no nodes) tempt the model to reach for create_agent;
 # that tool is hidden in builder sessions and the model has no UI to ask
 # the user for permission — without explicit guidance it would otherwise
 # narrate a phantom Claude-Code-style approval prompt.
+def _format_blocked_tool_list(tools: tuple[str, ...]) -> str:
+    """Render BUILDER_BLOCKED_TOOLS as ``a`, ``b`, and ``c``
+    so the prose stays in sync with the tuple."""
+    quoted = [f"`{name}`" for name in tools]
+    if len(quoted) <= 1:
+        return quoted[0] if quoted else ""
+    if len(quoted) == 2:
+        return f"{quoted[0]} and {quoted[1]}"
+    return f"{', '.join(quoted[:-1])}, and {quoted[-1]}"
+
+
 _BUILDER_TOOL_GUIDANCE = (
     "This builder panel is bound to the graph shown in <builder_context>. "
     "Use `edit_agent` against that graph id for every modification, "
@@ -88,10 +100,10 @@ _BUILDER_TOOL_GUIDANCE = (
     "once with the full set of nodes and links. "
     "Never ask the user to approve or allow a tool — there is no "
     "permission prompt UI in the builder chat, so any 'click Allow' "
-    "narration will leave the user stuck. The tools `create_agent`, "
-    "`customize_agent`, and `get_agent_building_guide` are intentionally "
-    "unavailable in builder sessions (the building guide is already "
-    "embedded in <building_guide> below)."
+    "narration will leave the user stuck. "
+    f"The tools {_format_blocked_tool_list(BUILDER_BLOCKED_TOOLS)} are "
+    "intentionally unavailable in builder sessions (the building guide "
+    "is already embedded in <building_guide> below)."
 )
 
 

--- a/autogpt_platform/backend/backend/copilot/builder_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context_test.py
@@ -95,6 +95,28 @@ async def test_system_prompt_suffix_contains_only_static_content():
 
 
 @pytest.mark.asyncio
+async def test_system_prompt_suffix_steers_to_edit_agent():
+    """The suffix must tell the model to use edit_agent on the bound
+    graph and forbid calling the blocked tools — production traces
+    showed the model hallucinating a Claude-Code permission prompt when
+    it reached for create_agent / get_agent_building_guide instead."""
+    session = _session("graph-1")
+    with patch(
+        "backend.copilot.builder_context._load_guide",
+        return_value="# Guide body",
+    ):
+        suffix = await build_builder_system_prompt_suffix(session)
+
+    assert "<tool_usage>" in suffix
+    assert "edit_agent" in suffix
+    assert "create_agent" in suffix
+    assert "get_agent_building_guide" in suffix
+    # The "no permission prompt UI" framing is what stops the model from
+    # asking the user to "click Allow" when a tool is unavailable.
+    assert "no permission prompt UI" in suffix
+
+
+@pytest.mark.asyncio
 async def test_system_prompt_suffix_identical_across_graphs():
     """The suffix must be byte-identical regardless of which graph the
     session is bound to — that's what keeps the cacheable prefix warm

--- a/autogpt_platform/backend/backend/copilot/builder_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context_test.py
@@ -110,6 +110,7 @@ async def test_system_prompt_suffix_steers_to_edit_agent():
     assert "<tool_usage>" in suffix
     assert "edit_agent" in suffix
     assert "create_agent" in suffix
+    assert "customize_agent" in suffix
     assert "get_agent_building_guide" in suffix
     # The "no permission prompt UI" framing is what stops the model from
     # asking the user to "click Allow" when a tool is unavailable.

--- a/autogpt_platform/backend/backend/copilot/builder_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context_test.py
@@ -115,6 +115,9 @@ async def test_system_prompt_suffix_steers_to_edit_agent():
     # The "no permission prompt UI" framing is what stops the model from
     # asking the user to "click Allow" when a tool is unavailable.
     assert "no permission prompt UI" in suffix
+    # Concrete sequence (find_block → edit_agent) gives the model a
+    # template to follow instead of reaching for the blocked tools.
+    assert "find_block" in suffix
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/builder_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/builder_context_test.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from backend.copilot.builder_context import (
+    BUILDER_BLOCKED_TOOLS,
     BUILDER_CONTEXT_TAG,
     BUILDER_SESSION_TAG,
     build_builder_context_turn_prefix,
@@ -109,9 +110,15 @@ async def test_system_prompt_suffix_steers_to_edit_agent():
 
     assert "<tool_usage>" in suffix
     assert "edit_agent" in suffix
-    assert "create_agent" in suffix
-    assert "customize_agent" in suffix
-    assert "get_agent_building_guide" in suffix
+    # Every blocked tool must be named in the prose (drift guard: if
+    # BUILDER_BLOCKED_TOOLS grows, the prose must grow with it).
+    for blocked in BUILDER_BLOCKED_TOOLS:
+        assert blocked in suffix
+    # "intentionally unavailable" is the prohibitive framing — a bare
+    # "create_agent in suffix" check would pass even if the prose said
+    # "create_agent is available". This anchors the assertion to the
+    # exclusion semantics.
+    assert "intentionally unavailable" in suffix
     # The "no permission prompt UI" framing is what stops the model from
     # asking the user to "click Allow" when a tool is unavailable.
     assert "no permission prompt UI" in suffix

--- a/autogpt_platform/backend/backend/copilot/context.py
+++ b/autogpt_platform/backend/backend/copilot/context.py
@@ -69,7 +69,7 @@ _encode_cwd_for_cli = encode_cwd_for_cli
 
 def set_execution_context(
     user_id: str | None,
-    session: ChatSession,
+    session: ChatSession | None,
     sandbox: "AsyncSandbox | None" = None,
     sdk_cwd: str | None = None,
     permissions: "CopilotPermissions | None" = None,

--- a/autogpt_platform/backend/backend/copilot/sdk/security_hooks_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/security_hooks_test.py
@@ -829,7 +829,7 @@ async def test_post_tool_use_no_session_skips_drain(monkeypatch):
 
     ctx_mod.set_execution_context(
         user_id=None,
-        session=None,  # type: ignore[arg-type]
+        session=None,
         sandbox=None,
         sdk_cwd=SDK_CWD,
     )

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -128,7 +128,7 @@ from ..service import (
 )
 from ..thinking_stripper import ThinkingStripper
 from ..token_tracking import persist_and_record_usage
-from ..tools import ToolGroup
+from ..tools import ToolGroup, tool_names_in_groups
 from ..tools.e2b_sandbox import get_or_create_sandbox, pause_sandbox_direct
 from ..tools.sandbox import WORKSPACE_PREFIX, make_session_path
 from ..tracking import track_user_message
@@ -4011,7 +4011,19 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 "Claude Code CLI subscription (requires `claude login`)."
             )
 
-        hidden_tools = _hidden_short_names_for_permissions(permissions)
+        disabled_tool_groups: list[ToolGroup] = []
+        if not graphiti_enabled:
+            disabled_tool_groups.append("graphiti")
+
+        # Hide both permission-denied tools AND group-disabled tools at
+        # registration. ``allowed_tools`` filtering alone routes group-
+        # disabled calls through the same auto-deny path the per-permission
+        # hiding is meant to eliminate (CLI returns "Permission to use ...
+        # has been denied", which the model narrates as a fake Allow/Deny
+        # prompt).
+        hidden_tools = _hidden_short_names_for_permissions(
+            permissions
+        ) | tool_names_in_groups(disabled_tool_groups)
         mcp_server = create_copilot_mcp_server(
             use_e2b=use_e2b, hidden_tool_names=hidden_tools
         )
@@ -4040,10 +4052,6 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             max_subtasks=config.claude_agent_max_subtasks,
             on_compact=compaction.on_compact,
         )
-
-        disabled_tool_groups: list[ToolGroup] = []
-        if not graphiti_enabled:
-            disabled_tool_groups.append("graphiti")
 
         if permissions is not None:
             allowed, disallowed = apply_tool_permissions(

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -84,7 +84,11 @@ from ..pending_messages import (
     drain_pending_for_persist,
     push_pending_message,
 )
-from ..permissions import apply_tool_permissions
+from ..permissions import (
+    CopilotPermissions,
+    all_known_tool_names,
+    apply_tool_permissions,
+)
 from ..prompting import get_graphiti_supplement, get_sdk_supplement
 from ..rate_limit import (
     get_global_rate_limits,
@@ -831,6 +835,24 @@ _THINKING_ONLY_REPROMPT = (
 # session-message flush so page reloads show progress on long turns.
 _FLUSH_INTERVAL_SECONDS = 30.0
 _FLUSH_MESSAGE_THRESHOLD = 10
+
+
+def _hidden_short_names_for_permissions(
+    permissions: CopilotPermissions | None,
+) -> frozenset[str]:
+    """Short tool names that should not be registered on the MCP server.
+
+    ``allowed_tools``/``disallowed_tools`` only gate execution — denied
+    calls still come back to the model with the CLI's canned "Permission
+    to use ... has been denied" string, which the model then narrates as a
+    Claude-Code-style approval prompt that doesn't exist in copilot.
+    Hiding the tool from the MCP server removes it from the model's tool
+    list entirely so it never reaches for the blocked name.
+    """
+    if permissions is None or permissions.is_empty():
+        return frozenset()
+    all_tools = all_known_tool_names()
+    return all_tools - permissions.effective_allowed_tools(all_tools)
 
 
 def _strip_synthetic_reprompt_from_cli_jsonl(content: bytes) -> bytes:
@@ -3989,7 +4011,10 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 "Claude Code CLI subscription (requires `claude login`)."
             )
 
-        mcp_server = create_copilot_mcp_server(use_e2b=use_e2b)
+        hidden_tools = _hidden_short_names_for_permissions(permissions)
+        mcp_server = create_copilot_mcp_server(
+            use_e2b=use_e2b, hidden_tool_names=hidden_tools
+        )
 
         # Resolve model (request tier → LD per-user override → config default).
         # Done BEFORE build_sdk_env so model-aware env vars (e.g. the

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.copilot import config as cfg_mod
+from backend.copilot.builder_context import BUILDER_BLOCKED_TOOLS
+from backend.copilot.permissions import CopilotPermissions, all_known_tool_names
 
 from .service import (
     _HUNG_TOOL_CAP_SECONDS,
@@ -17,6 +19,7 @@ from .service import (
     _MAX_BUDGET_USD_FLOOR,
     _THINKING_ONLY_REPROMPT,
     _build_system_prompt_value,
+    _hidden_short_names_for_permissions,
     _humanise_tool_list,
     _idle_timeout_threshold,
     _is_sdk_disconnect_error,
@@ -2164,3 +2167,56 @@ class TestStreamEndedWithoutResultMessage:
 
         contents = [m.content for m in ctx.session.messages]
         assert STREAM_ERROR_MARKER not in contents, contents
+
+
+class TestHiddenShortNamesForPermissions:
+    """``_hidden_short_names_for_permissions`` is the pure function that
+    decides which MCP tools to skip at registration so the model never sees
+    permission-denied names — direct fix for the production trace where the
+    SDK's auto-deny string was narrated as a fake Allow/Deny UI."""
+
+    def test_none_permissions_hides_nothing(self):
+        assert _hidden_short_names_for_permissions(None) == frozenset()
+
+    def test_empty_permissions_hides_nothing(self):
+        # tools=[] makes is_empty() true regardless of the *_exclude flags.
+        perms = CopilotPermissions(tools=[], blocks=[])
+        assert _hidden_short_names_for_permissions(perms) == frozenset()
+
+    def test_blacklist_hides_listed_tools(self):
+        perms = CopilotPermissions(
+            tools=list(BUILDER_BLOCKED_TOOLS),
+            tools_exclude=True,
+        )
+        hidden = _hidden_short_names_for_permissions(perms)
+        assert set(BUILDER_BLOCKED_TOOLS) <= hidden
+        # Everything else stays visible.
+        assert hidden == all_known_tool_names() - (
+            all_known_tool_names() - set(BUILDER_BLOCKED_TOOLS)
+        )
+
+    def test_whitelist_hides_everything_not_listed(self):
+        all_tools = all_known_tool_names()
+        # Pick one stable, well-known tool as the whitelist.
+        keep = "find_block"
+        assert keep in all_tools, "test relies on find_block being registered"
+        perms = CopilotPermissions(
+            tools=[keep],
+            tools_exclude=False,
+        )
+        hidden = _hidden_short_names_for_permissions(perms)
+        assert keep not in hidden
+        assert hidden == all_tools - {keep}
+
+    def test_unknown_tool_in_blacklist_is_ignored(self):
+        """Typos in the blacklist must not phantom-hide real tools — the
+        function operates on the intersection with the known-tool set."""
+        perms = CopilotPermissions(
+            tools=["this_tool_does_not_exist"],
+            tools_exclude=True,
+        )
+        hidden = _hidden_short_names_for_permissions(perms)
+        # No real tool gets hidden by an unknown name.
+        assert hidden == frozenset()
+        # Sanity: all real tools remain visible.
+        assert all_known_tool_names() - hidden == all_known_tool_names()

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
@@ -709,6 +709,8 @@ def create_copilot_mcp_server(
     _MUTATING_E2B_TOOLS = {"write_file", "edit_file"}
     if use_e2b:
         for name, desc, schema, handler in E2B_FILE_TOOLS:
+            if name in hidden:
+                continue
             ann = (
                 _MUTATING_ANNOTATION
                 if name in _MUTATING_E2B_TOOLS
@@ -728,53 +730,57 @@ def create_copilot_mcp_server(
     # "read_file", and "edit_file".  Registering both would give the LLM
     # duplicate tools per operation.
     if not use_e2b:
-        write_handler = get_write_tool_handler()
-        write_tool = tool(
-            WRITE_TOOL_NAME,
-            WRITE_TOOL_DESCRIPTION,
-            WRITE_TOOL_SCHEMA,
-            annotations=_MUTATING_ANNOTATION,
-        )(
-            _make_truncating_wrapper(
-                write_handler, WRITE_TOOL_NAME, input_schema=WRITE_TOOL_SCHEMA
+        if WRITE_TOOL_NAME not in hidden:
+            write_handler = get_write_tool_handler()
+            write_tool = tool(
+                WRITE_TOOL_NAME,
+                WRITE_TOOL_DESCRIPTION,
+                WRITE_TOOL_SCHEMA,
+                annotations=_MUTATING_ANNOTATION,
+            )(
+                _make_truncating_wrapper(
+                    write_handler, WRITE_TOOL_NAME, input_schema=WRITE_TOOL_SCHEMA
+                )
             )
-        )
-        sdk_tools.append(write_tool)
+            sdk_tools.append(write_tool)
 
-        read_file_handler = get_read_tool_handler()
-        read_file_tool = tool(
-            READ_TOOL_NAME,
-            READ_TOOL_DESCRIPTION,
-            READ_TOOL_SCHEMA,
-            annotations=_PARALLEL_ANNOTATION,
-        )(
-            _make_truncating_wrapper(
-                read_file_handler, READ_TOOL_NAME, input_schema=READ_TOOL_SCHEMA
+        if READ_TOOL_NAME not in hidden:
+            read_file_handler = get_read_tool_handler()
+            read_file_tool = tool(
+                READ_TOOL_NAME,
+                READ_TOOL_DESCRIPTION,
+                READ_TOOL_SCHEMA,
+                annotations=_PARALLEL_ANNOTATION,
+            )(
+                _make_truncating_wrapper(
+                    read_file_handler, READ_TOOL_NAME, input_schema=READ_TOOL_SCHEMA
+                )
             )
-        )
-        sdk_tools.append(read_file_tool)
+            sdk_tools.append(read_file_tool)
 
-        edit_handler = get_edit_tool_handler()
-        edit_tool = tool(
-            EDIT_TOOL_NAME,
-            EDIT_TOOL_DESCRIPTION,
-            EDIT_TOOL_SCHEMA,
-            annotations=_MUTATING_ANNOTATION,
-        )(
-            _make_truncating_wrapper(
-                edit_handler, EDIT_TOOL_NAME, input_schema=EDIT_TOOL_SCHEMA
+        if EDIT_TOOL_NAME not in hidden:
+            edit_handler = get_edit_tool_handler()
+            edit_tool = tool(
+                EDIT_TOOL_NAME,
+                EDIT_TOOL_DESCRIPTION,
+                EDIT_TOOL_SCHEMA,
+                annotations=_MUTATING_ANNOTATION,
+            )(
+                _make_truncating_wrapper(
+                    edit_handler, EDIT_TOOL_NAME, input_schema=EDIT_TOOL_SCHEMA
+                )
             )
-        )
-        sdk_tools.append(edit_tool)
+            sdk_tools.append(edit_tool)
 
     # Read tool for SDK-truncated tool results (always needed, read-only).
-    read_tool = tool(
-        _READ_TOOL_NAME,
-        _READ_TOOL_DESCRIPTION,
-        _READ_TOOL_SCHEMA,
-        annotations=_PARALLEL_ANNOTATION,
-    )(_make_truncating_wrapper(_read_file_handler, _READ_TOOL_NAME))
-    sdk_tools.append(read_tool)
+    if _READ_TOOL_NAME not in hidden:
+        read_tool = tool(
+            _READ_TOOL_NAME,
+            _READ_TOOL_DESCRIPTION,
+            _READ_TOOL_SCHEMA,
+            annotations=_PARALLEL_ANNOTATION,
+        )(_make_truncating_wrapper(_read_file_handler, _READ_TOOL_NAME))
+        sdk_tools.append(read_tool)
 
     return create_sdk_mcp_server(
         name=MCP_SERVER_NAME,

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
@@ -658,7 +658,11 @@ def _make_truncating_wrapper(
     return wrapper
 
 
-def create_copilot_mcp_server(*, use_e2b: bool = False):
+def create_copilot_mcp_server(
+    *,
+    use_e2b: bool = False,
+    hidden_tool_names: Iterable[str] = (),
+):
     """Create an in-process MCP server configuration for CoPilot tools.
 
     All tools are annotated with ``readOnlyHint=True`` so the SDK CLI
@@ -672,11 +676,21 @@ def create_copilot_mcp_server(*, use_e2b: bool = False):
     that route directly to the E2B sandbox filesystem, and the caller should
     disable the corresponding SDK built-in tools via
     :func:`get_sdk_disallowed_tools`.
+
+    Short tool names in *hidden_tool_names* are not registered at all — the
+    model never sees them.  ``allowed_tools``/``disallowed_tools`` alone are
+    insufficient because the CLI auto-rejects calls to denied tools with a
+    canned "Permission to use ... has been denied" string that the model
+    then narrates as a Claude-Code-style approval prompt (no such UI exists
+    in copilot).  Hiding the tool removes the temptation entirely.
     """
 
+    hidden = frozenset(hidden_tool_names)
     sdk_tools = []
 
     for tool_name, base_tool in TOOL_REGISTRY.items():
+        if tool_name in hidden:
+            continue
         handler = create_tool_handler(base_tool)
         schema = _build_input_schema(base_tool)
         # All tools annotated readOnlyHint=True to enable parallel dispatch.

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -9,6 +9,7 @@ from mcp.types import ToolAnnotations
 
 from backend.copilot.context import get_sdk_cwd
 from backend.copilot.response_model import StreamToolOutputAvailable
+from backend.copilot.tools import TOOL_REGISTRY
 from backend.util.truncate import truncate
 
 from .tool_adapter import (
@@ -18,6 +19,7 @@ from .tool_adapter import (
     _make_truncating_wrapper,
     _strip_llm_fields,
     _text_from_mcp_result,
+    create_copilot_mcp_server,
     create_tool_handler,
     pop_pending_tool_output,
     reset_stash_event,
@@ -458,9 +460,9 @@ class TestBug1DuplicateExecution:
         await _buggy_prelaunch_handler(mock_tool, pre_launch_args, dispatch_args)
 
         # BUG: pre-launch executed once + fallback executed again = 2
-        assert (
-            len(call_log) == 1
-        ), f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
+        assert len(call_log) == 1, (
+            f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
+        )
 
     @pytest.mark.asyncio
     async def test_current_code_no_duplicate(self):
@@ -980,7 +982,9 @@ class TestTruncatingWrapperLeavesOutputUntouched:
         session = MagicMock()
         session.dry_run = False
         session.session_id = "sess-no-inject"
-        set_execution_context(user_id="u", session=session, sandbox=None, sdk_cwd="/tmp/test")  # type: ignore[arg-type]
+        set_execution_context(
+            user_id="u", session=session, sandbox=None, sdk_cwd="/tmp/test"
+        )  # type: ignore[arg-type]
 
         async def fake_tool_fn(_args: dict) -> dict:
             return {
@@ -1002,7 +1006,9 @@ class TestTruncatingWrapperLeavesOutputUntouched:
         session = MagicMock()
         session.dry_run = False
         session.session_id = "sess-stash"
-        set_execution_context(user_id="u", session=session, sandbox=None, sdk_cwd="/tmp/test")  # type: ignore[arg-type]
+        set_execution_context(
+            user_id="u", session=session, sandbox=None, sdk_cwd="/tmp/test"
+        )  # type: ignore[arg-type]
 
         clean_json = '{"stdout": "hello\\n", "exit_code": 0}'
 
@@ -1018,3 +1024,48 @@ class TestTruncatingWrapperLeavesOutputUntouched:
         stashed = pop_pending_tool_output("fake_tool_stash_pure")
         assert stashed == clean_json
         assert "<user_follow_up>" not in (stashed or "")
+
+
+class TestCreateCopilotMcpServerHidden:
+    """``hidden_tool_names`` removes tools from MCP registration entirely
+    so the model never sees them — guards against the production bug
+    where builder-blocked tools were still advertised, the model called
+    them anyway, and the CLI returned its canned "Permission to use ...
+    has been denied" string that the model then narrated as a fake
+    Allow/Deny UI."""
+
+    @pytest.mark.asyncio
+    async def test_hidden_tools_not_registered(self):
+        sample = next(iter(TOOL_REGISTRY.keys()))
+        server = create_copilot_mcp_server(hidden_tool_names=[sample])
+        registered = await self._registered_tool_names(server)
+        assert sample not in registered
+        # Other tools still register.
+        assert len(registered) >= len(TOOL_REGISTRY) - 1
+
+    @pytest.mark.asyncio
+    async def test_no_hidden_tools_registers_all(self):
+        server = create_copilot_mcp_server()
+        registered = await self._registered_tool_names(server)
+        for short in TOOL_REGISTRY:
+            assert short in registered
+
+    @pytest.mark.asyncio
+    async def test_builder_blocked_tools_hidden(self):
+        from backend.copilot.builder_context import BUILDER_BLOCKED_TOOLS
+
+        server = create_copilot_mcp_server(hidden_tool_names=BUILDER_BLOCKED_TOOLS)
+        registered = await self._registered_tool_names(server)
+        for blocked in BUILDER_BLOCKED_TOOLS:
+            assert blocked not in registered
+        # edit_agent must remain so the model can populate the bound graph.
+        assert "edit_agent" in registered
+
+    @staticmethod
+    async def _registered_tool_names(server) -> set[str]:
+        from mcp.types import ListToolsRequest
+
+        instance = server["instance"]
+        handler = instance.request_handlers[ListToolsRequest]
+        result = await handler(ListToolsRequest(method="tools/list"))
+        return {t.name for t in result.root.tools}

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -463,9 +463,9 @@ class TestBug1DuplicateExecution:
         await _buggy_prelaunch_handler(mock_tool, pre_launch_args, dispatch_args)
 
         # BUG: pre-launch executed once + fallback executed again = 2
-        assert len(call_log) == 1, (
-            f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
-        )
+        assert (
+            len(call_log) == 1
+        ), f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
 
     @pytest.mark.asyncio
     async def test_current_code_no_duplicate(self):
@@ -1033,10 +1033,14 @@ class TestCreateCopilotMcpServerHidden:
 
     @pytest.mark.asyncio
     async def test_hidden_tools_not_registered(self):
-        sample = next(iter(TOOL_REGISTRY.keys()))
-        server = create_copilot_mcp_server(hidden_tool_names=[sample])
+        # Use a named tool (find_block is stable + load-bearing in the
+        # builder flow) so the test reads as a real scenario instead of
+        # "the first key in dict insertion order".
+        hidden_name = "find_block"
+        assert hidden_name in TOOL_REGISTRY, "fixture relies on find_block"
+        server = create_copilot_mcp_server(hidden_tool_names=[hidden_name])
         registered = await self._registered_tool_names(server)
-        assert sample not in registered
+        assert hidden_name not in registered
         # Other tools still register.
         assert len(registered) >= len(TOOL_REGISTRY) - 1
 
@@ -1055,6 +1059,19 @@ class TestCreateCopilotMcpServerHidden:
             assert blocked not in registered
         # edit_agent must remain so the model can populate the bound graph.
         assert "edit_agent" in registered
+
+    @pytest.mark.asyncio
+    async def test_unknown_hidden_name_is_silently_ignored(self):
+        """A typo in ``hidden_tool_names`` must not phantom-hide a real
+        tool or raise — the registration loop intersects with
+        TOOL_REGISTRY keys, so unknown names are a no-op."""
+        server = create_copilot_mcp_server(
+            hidden_tool_names=["this_tool_does_not_exist"]
+        )
+        registered = await self._registered_tool_names(server)
+        # All real tools still register.
+        for short in TOOL_REGISTRY:
+            assert short in registered
 
     @staticmethod
     async def _registered_tool_names(server) -> set[str]:

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,7 @@ from mcp.types import ListToolsRequest, ToolAnnotations
 
 from backend.copilot.builder_context import BUILDER_BLOCKED_TOOLS
 from backend.copilot.context import get_sdk_cwd
+from backend.copilot.model import ChatSession
 from backend.copilot.response_model import StreamToolOutputAvailable
 from backend.copilot.tools import TOOL_REGISTRY
 from backend.util.truncate import truncate
@@ -80,7 +82,7 @@ class TestGetSdkCwd:
     def test_returns_empty_string_by_default(self):
         set_execution_context(
             user_id="test",
-            session=None,  # type: ignore[arg-type]
+            session=None,
             sandbox=None,
         )
         assert get_sdk_cwd() == ""
@@ -88,7 +90,7 @@ class TestGetSdkCwd:
     def test_returns_set_value(self):
         set_execution_context(
             user_id="test",
-            session=None,  # type: ignore[arg-type]
+            session=None,
             sandbox=None,
             sdk_cwd="/tmp/copilot-test-123",
         )
@@ -106,7 +108,7 @@ class TestToolOutputStash:
         """Initialise the context vars that stash_pending_tool_output needs."""
         set_execution_context(
             user_id="test",
-            session=None,  # type: ignore[arg-type]
+            session=None,
             sandbox=None,
             sdk_cwd="/tmp/test",
         )
@@ -148,7 +150,7 @@ class TestResetStashEvent:
     def _init_context(self):
         set_execution_context(
             user_id="test",
-            session=None,  # type: ignore[arg-type]
+            session=None,
             sandbox=None,
         )
 
@@ -211,7 +213,7 @@ class TestTruncationAndStashIntegration:
     def _init_context(self):
         set_execution_context(
             user_id="test",
-            session=None,  # type: ignore[arg-type]
+            session=None,
             sandbox=None,
             sdk_cwd="/tmp/test",
         )
@@ -273,15 +275,15 @@ def _make_mock_tool(
     return tool
 
 
-def _make_mock_session() -> MagicMock:
-    """Return a minimal ChatSession mock."""
-    return MagicMock()
+def _make_test_session(*, dry_run: bool = False) -> ChatSession:
+    """Return a minimal real ``ChatSession`` for tool-context tests."""
+    return ChatSession.new(user_id="test-user", dry_run=dry_run)
 
 
-def _init_ctx(session=None):
+def _init_ctx(session: ChatSession | None = None):
     set_execution_context(
         user_id="user-1",
-        session=session,  # type: ignore[arg-type]
+        session=session,
         sandbox=None,
     )
 
@@ -291,7 +293,7 @@ class TestCreateToolHandler:
 
     @pytest.fixture(autouse=True)
     def _init(self):
-        _init_ctx(session=_make_mock_session())
+        _init_ctx(session=_make_test_session())
 
     @pytest.mark.asyncio
     async def test_handler_executes_tool_directly(self):
@@ -310,7 +312,7 @@ class TestCreateToolHandler:
     async def test_handler_returns_error_on_no_session(self):
         """When session is None, handler returns MCP error."""
         mock_tool = _make_mock_tool("run_block")
-        set_execution_context(user_id="u", session=None, sandbox=None)  # type: ignore[arg-type]
+        set_execution_context(user_id="u", session=None, sandbox=None)
 
         handler = create_tool_handler(mock_tool)
         result = await handler({"block_id": "b1"})
@@ -347,7 +349,7 @@ class TestToolInlineExecution:
 
     @pytest.fixture(autouse=True)
     def _init(self):
-        _init_ctx(session=_make_mock_session())
+        _init_ctx(session=_make_test_session())
 
     @pytest.mark.asyncio
     async def test_tool_runs_to_completion_regardless_of_duration(self):
@@ -410,7 +412,7 @@ async def _buggy_prelaunch_handler(mock_tool, pre_launch_args, dispatch_args):
     """
     from backend.copilot.sdk.tool_adapter import _execute_tool_sync
 
-    user_id, session = "user-1", _make_mock_session()
+    user_id, session = "user-1", _make_test_session()
 
     # Step 1: pre-launch fires immediately (speculative)
     task = asyncio.create_task(
@@ -442,7 +444,7 @@ class TestBug1DuplicateExecution:
 
     @pytest.fixture(autouse=True)
     def _init(self):
-        _init_ctx(session=_make_mock_session())
+        _init_ctx(session=_make_test_session())
 
     @pytest.mark.xfail(reason="Old pre-launch code causes duplicate execution")
     @pytest.mark.asyncio
@@ -461,9 +463,9 @@ class TestBug1DuplicateExecution:
         await _buggy_prelaunch_handler(mock_tool, pre_launch_args, dispatch_args)
 
         # BUG: pre-launch executed once + fallback executed again = 2
-        assert (
-            len(call_log) == 1
-        ), f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
+        assert len(call_log) == 1, (
+            f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
+        )
 
     @pytest.mark.asyncio
     async def test_current_code_no_duplicate(self):
@@ -487,7 +489,7 @@ class TestBug2FIFODesync:
 
     @pytest.fixture(autouse=True)
     def _init(self):
-        _init_ctx(session=_make_mock_session())
+        _init_ctx(session=_make_test_session())
 
     @pytest.mark.xfail(reason="Old FIFO queue returns wrong result on denial")
     @pytest.mark.asyncio
@@ -509,7 +511,7 @@ class TestBug2FIFODesync:
 
         mock_tool = _make_mock_tool("run_block")
         mock_tool.execute = AsyncMock(side_effect=tagged_execute)
-        user_id, session = "user-1", _make_mock_session()
+        user_id, session = "user-1", _make_test_session()
 
         # Simulate old FIFO queue
         queue: asyncio.Queue = asyncio.Queue()
@@ -574,7 +576,7 @@ class TestBug3CancelRace:
 
     @pytest.fixture(autouse=True)
     def _init(self):
-        _init_ctx(session=_make_mock_session())
+        _init_ctx(session=_make_test_session())
 
     @pytest.mark.xfail(reason="Old code: cancel arrives after task completes")
     @pytest.mark.asyncio
@@ -674,7 +676,7 @@ class TestReadFileHandlerBridge:
     def _init_context(self):
         set_execution_context(
             user_id="test",
-            session=None,  # type: ignore[arg-type]
+            session=None,
             sandbox=None,
             sdk_cwd="/tmp/copilot-bridge-test",
         )
@@ -695,8 +697,8 @@ class TestReadFileHandlerBridge:
             lambda path: True,
         )
 
-        fake_sandbox = object()
-        token = _current_sandbox.set(fake_sandbox)  # type: ignore[arg-type]
+        fake_sandbox: Any = object()
+        token = _current_sandbox.set(fake_sandbox)
         try:
             bridge_calls: list[tuple] = []
 
@@ -829,7 +831,7 @@ class TestStripLlmFields:
 
     def test_strip_after_stash_ordering(self):
         """Stash receives full payload (with is_dry_run); LLM result does not."""
-        set_execution_context(user_id="test", session=None, sandbox=None)  # type: ignore[arg-type]
+        set_execution_context(user_id="test", session=None, sandbox=None)
 
         full_text = '{"message": "ok", "is_dry_run": true}'
         result = {
@@ -909,11 +911,10 @@ class TestStripLlmFields:
         the stash/strip lines in production code causes this test to fail.
         Uses a session with dry_run=True so that stripping is active.
         """
-        dry_run_session = MagicMock()
-        dry_run_session.dry_run = True
+        dry_run_session = _make_test_session(dry_run=True)
         set_execution_context(
             user_id="test", session=dry_run_session, sandbox=None, sdk_cwd="/tmp/test"
-        )  # type: ignore[arg-type]
+        )
 
         full_payload = '{"message": "done", "is_dry_run": true}'
 
@@ -944,11 +945,10 @@ class TestStripLlmFields:
         dry_run mode, the LLM should see is_dry_run=True so it knows that
         specific tool result was simulated.
         """
-        normal_session = MagicMock()
-        normal_session.dry_run = False
+        normal_session = _make_test_session(dry_run=False)
         set_execution_context(
             user_id="test", session=normal_session, sandbox=None, sdk_cwd="/tmp/test"
-        )  # type: ignore[arg-type]
+        )
 
         full_payload = '{"message": "simulated", "is_dry_run": true}'
 
@@ -980,12 +980,10 @@ class TestTruncatingWrapperLeavesOutputUntouched:
 
     @pytest.mark.asyncio
     async def test_wrapper_does_not_inject_followup(self):
-        session = MagicMock()
-        session.dry_run = False
-        session.session_id = "sess-no-inject"
+        session = _make_test_session(dry_run=False)
         set_execution_context(
             user_id="u", session=session, sandbox=None, sdk_cwd="/tmp/test"
-        )  # type: ignore[arg-type]
+        )
 
         async def fake_tool_fn(_args: dict) -> dict:
             return {
@@ -1004,12 +1002,10 @@ class TestTruncatingWrapperLeavesOutputUntouched:
     async def test_stash_stays_clean(self):
         """The frontend-facing stash must be a byte-for-byte copy of the
         raw tool output (needed for JSON.parse in the bash widget)."""
-        session = MagicMock()
-        session.dry_run = False
-        session.session_id = "sess-stash"
+        session = _make_test_session(dry_run=False)
         set_execution_context(
             user_id="u", session=session, sandbox=None, sdk_cwd="/tmp/test"
-        )  # type: ignore[arg-type]
+        )
 
         clean_json = '{"stdout": "hello\\n", "exit_code": 0}'
 

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter_test.py
@@ -5,8 +5,9 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from mcp.types import ToolAnnotations
+from mcp.types import ListToolsRequest, ToolAnnotations
 
+from backend.copilot.builder_context import BUILDER_BLOCKED_TOOLS
 from backend.copilot.context import get_sdk_cwd
 from backend.copilot.response_model import StreamToolOutputAvailable
 from backend.copilot.tools import TOOL_REGISTRY
@@ -460,9 +461,9 @@ class TestBug1DuplicateExecution:
         await _buggy_prelaunch_handler(mock_tool, pre_launch_args, dispatch_args)
 
         # BUG: pre-launch executed once + fallback executed again = 2
-        assert len(call_log) == 1, (
-            f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
-        )
+        assert (
+            len(call_log) == 1
+        ), f"Expected 1 execution but got {len(call_log)} — duplicate execution bug!"
 
     @pytest.mark.asyncio
     async def test_current_code_no_duplicate(self):
@@ -1052,8 +1053,6 @@ class TestCreateCopilotMcpServerHidden:
 
     @pytest.mark.asyncio
     async def test_builder_blocked_tools_hidden(self):
-        from backend.copilot.builder_context import BUILDER_BLOCKED_TOOLS
-
         server = create_copilot_mcp_server(hidden_tool_names=BUILDER_BLOCKED_TOOLS)
         registered = await self._registered_tool_names(server)
         for blocked in BUILDER_BLOCKED_TOOLS:
@@ -1063,8 +1062,6 @@ class TestCreateCopilotMcpServerHidden:
 
     @staticmethod
     async def _registered_tool_names(server) -> set[str]:
-        from mcp.types import ListToolsRequest
-
         instance = server["instance"]
         handler = instance.request_handlers[ListToolsRequest]
         result = await handler(ListToolsRequest(method="tools/list"))


### PR DESCRIPTION
## Why

Production AutoPilot/Copilot chats that originate from the **builder panel** (a chat embedded inside `/build` that is bound to a specific graph via `session.metadata.builder_graph_id`) have been completely stalling out for some users. Symptom from three reproduced sessions:

- Model reaches for `mcp__copilot__get_agent_building_guide` (or `mcp__copilot__create_agent`).
- Tool result comes back as the literal string `Permission to use mcp__copilot__... has been denied.` (length 73 / 61 — exact match for the canned string baked into the Claude Code CLI binary).
- Model then narrates a Claude-Code-style Allow/Deny prompt to the user ("click Allow…") — UI that **does not exist** in the builder chat.
- User can't unstuck it. Churn.

Root cause is two-fold:

1. `BUILDER_BLOCKED_TOOLS = ("create_agent", "customize_agent", "get_agent_building_guide")` is correct — the panel is already bound to a graph, so minting a new one is wrong and the building guide is already in the cacheable system-prompt suffix. But these tools were only added to `disallowed_tools` while the MCP server kept advertising them, so the model kept reaching for them and the SDK kept synthesising the deny string.
2. The system prompt for builder mode never explicitly said "use `edit_agent` against the bound graph, even when it's empty" — so on empty (v1, 0 nodes) graphs the model picked `create_agent` instead of `edit_agent`.

## What

- `create_copilot_mcp_server` now accepts `hidden_tool_names`; tools in that set are not registered at all, so the model never sees them.
- `stream_chat_completion_sdk` derives the hidden set from the active `CopilotPermissions` and passes it through.
- `build_builder_system_prompt_suffix` gains a `<tool_usage>` block telling the model to use `edit_agent` on the bound graph, that `create_agent`/`customize_agent`/`get_agent_building_guide` are unavailable, and explicitly that **there is no permission prompt UI** in the builder chat (so don't ask the user to "click Allow").

## How

- `tool_adapter.create_copilot_mcp_server(hidden_tool_names=...)` filters `TOOL_REGISTRY` at MCP registration time. `allowed_tools`/`disallowed_tools` alone are insufficient because the CLI auto-rejects denied calls with a hardcoded "Permission to use ... has been denied" string that the model misreads as an interactive permission gate.
- `sdk/service._hidden_short_names_for_permissions` computes `ALL_TOOL_NAMES - effective_allowed_tools(...)` — anything excluded by the active permissions is hidden from the MCP server too. Non-permissioned sessions get an empty hidden set (no behaviour change).
- `builder_context._BUILDER_TOOL_GUIDANCE` is appended inside the existing `<builder_session>` suffix (still cacheable; no per-turn variability), keeping the prompt cache warm.

## Test plan

- [x] `pytest backend/copilot/sdk/tool_adapter_test.py backend/copilot/builder_context_test.py backend/copilot/permissions_test.py backend/copilot/sdk/service_test.py` — 223 pass
- [x] New tests: `TestCreateCopilotMcpServerHidden` (3 cases, including a regression for `BUILDER_BLOCKED_TOOLS`) and `test_system_prompt_suffix_steers_to_edit_agent`
- [ ] `/pr-test` against the consolidated preview to confirm a builder-bound empty graph no longer churns when the user asks for help building
