### PR TITLE
feat(platform): copilot followups UI

### DIFF
--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -2317,6 +2317,28 @@ async def list_all_graphs_execution_schedules(
     return await get_scheduler_client().get_graph_execution_schedules(user_id=user_id)
 
 
+@v1_router.get(
+    path="/schedules/followups",
+    summary="List copilot follow-up schedules for a user",
+    operation_id="listCopilotFollowupSchedules",
+    tags=["schedules"],
+    dependencies=[Security(requires_user)],
+)
+async def list_copilot_turn_schedules(
+    user_id: Annotated[str, Security(get_user_id)],
+) -> list[scheduler.CopilotTurnJobInfo]:
+    """Return only copilot-turn schedules for the current user.
+
+    Sibling of :func:`list_all_graphs_execution_schedules`; one route per kind
+    keeps the generated frontend client typed to a single concrete return type
+    instead of a discriminated union.
+    """
+    schedules = await get_scheduler_client().get_execution_schedules(
+        user_id=user_id, kind="copilot_turn"
+    )
+    return [s for s in schedules if isinstance(s, scheduler.CopilotTurnJobInfo)]
+
+
 @v1_router.delete(
     path="/schedules/{schedule_id}",
     summary="Delete execution schedule",

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -2336,7 +2336,12 @@ async def list_copilot_turn_schedules(
     schedules = await get_scheduler_client().get_execution_schedules(
         user_id=user_id, kind="copilot_turn"
     )
-    return [s for s in schedules if isinstance(s, scheduler.CopilotTurnJobInfo)]
+    # The ``kind="copilot_turn"`` filter is the source of truth — every row in
+    # the result IS a ``CopilotTurnJobInfo``. The cast narrows the static type
+    # from the polymorphic ``list[GraphExecutionJobInfo | CopilotTurnJobInfo]``
+    # without an at-runtime second filter that would silently drop rows if the
+    # discriminator ever drifted.
+    return cast(list[scheduler.CopilotTurnJobInfo], schedules)
 
 
 @v1_router.delete(

--- a/autogpt_platform/backend/backend/api/features/v1_test.py
+++ b/autogpt_platform/backend/backend/api/features/v1_test.py
@@ -1037,3 +1037,60 @@ async def test_upload_file_gcs_not_configured_fallback(test_user_id: str):
 
         # Verify cloud storage methods were NOT called
         mock_handler.store_file.assert_not_called()
+
+
+def test_list_copilot_turn_schedules_filters_to_copilot_kind(
+    mocker: pytest_mock.MockFixture,
+    test_user_id: str,
+) -> None:
+    """GET /schedules/followups returns only CopilotTurnJobInfo items for the user.
+
+    The route delegates to ``Scheduler.get_execution_schedules(kind="copilot_turn")``;
+    we mock the client to make sure (a) the kind filter is forwarded and
+    (b) any non-copilot rows are dropped from the response.
+    """
+    from backend.executor.scheduler import CopilotTurnJobInfo, GraphExecutionJobInfo
+
+    copilot_info = CopilotTurnJobInfo(
+        id="sched-1",
+        name="copilot followup",
+        next_run_time="2026-05-22T10:00:00+00:00",
+        timezone="UTC",
+        user_id=test_user_id,
+        session_id="sess-1",
+        message="check status",
+        cron="0 9 * * *",
+    )
+    graph_info = GraphExecutionJobInfo(
+        id="sched-2",
+        name="graph run",
+        next_run_time="2026-05-22T11:00:00+00:00",
+        timezone="UTC",
+        user_id=test_user_id,
+        graph_id="g-1",
+        graph_version=1,
+        cron="0 10 * * *",
+        input_data={},
+    )
+
+    mock_client = Mock()
+    mock_client.get_execution_schedules = AsyncMock(
+        return_value=[copilot_info, graph_info]
+    )
+    mocker.patch(
+        "backend.api.features.v1.get_scheduler_client",
+        return_value=mock_client,
+    )
+
+    response = client.get("/schedules/followups")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["id"] == "sched-1"
+    assert body[0]["kind"] == "copilot_turn"
+    assert body[0]["session_id"] == "sess-1"
+
+    mock_client.get_execution_schedules.assert_awaited_once_with(
+        user_id=test_user_id, kind="copilot_turn"
+    )

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -1,0 +1,149 @@
+import {
+  getDeleteV1DeleteExecutionScheduleMockHandler,
+  getDeleteV1DeleteExecutionScheduleMockHandler422,
+  getListCopilotFollowupSchedulesMockHandler,
+} from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+import { server } from "@/mocks/mock-server";
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@/tests/integrations/test-utils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import FollowupsPage from "../page";
+
+const toastMock = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+function makeFollowup(
+  overrides: Partial<CopilotTurnJobInfo>,
+): CopilotTurnJobInfo {
+  const runAt = new Date(Date.now() + 60 * 60 * 1000);
+  return {
+    id: "sched-1",
+    name: "copilot-followup",
+    user_id: "user-1",
+    session_id: "session-abcdef0123",
+    message: "Check the build status and report back",
+    cron: null,
+    run_at: runAt,
+    next_run_time: runAt.toISOString(),
+    kind: "copilot_turn",
+    timezone: "UTC",
+    cap_retry_count: 0,
+    ...overrides,
+  };
+}
+
+describe("FollowupsPage", () => {
+  beforeEach(() => {
+    toastMock.mockClear();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  test("renders empty state when no follow-ups exist", async () => {
+    server.use(getListCopilotFollowupSchedulesMockHandler([]));
+
+    render(<FollowupsPage />);
+
+    expect(await screen.findByTestId("followups-empty")).toBeDefined();
+    expect(screen.queryByTestId("followups-list")).toBeNull();
+  });
+
+  test("renders one row per follow-up returned by the API", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([
+        makeFollowup({ id: "f1", message: "First follow-up message" }),
+        makeFollowup({
+          id: "f2",
+          message: "Second follow-up message",
+          session_id: "session-zzzzzzzzzz",
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const rows = await screen.findAllByTestId("followup-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute("data-followup-id")).toBe("f1");
+    expect(rows[1].getAttribute("data-followup-id")).toBe("f2");
+    expect(screen.getByText("First follow-up message")).toBeDefined();
+    expect(screen.getByText("Second follow-up message")).toBeDefined();
+  });
+
+  test("session link points to /copilot with the session id query param", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([
+        makeFollowup({ id: "f1", session_id: "session-abcdef0123" }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const row = await screen.findByTestId("followup-row");
+    const link = within(row).getByTestId("followup-open-session");
+    expect(link.getAttribute("href")).toBe(
+      "/copilot?sessionId=session-abcdef0123",
+    );
+  });
+
+  test("Cancel button opens the confirmation dialog and calls the delete API", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([makeFollowup({ id: "f1" })]),
+      getDeleteV1DeleteExecutionScheduleMockHandler(),
+    );
+
+    render(<FollowupsPage />);
+
+    const cancelButton = await screen.findByTestId("followup-cancel-button");
+    fireEvent.click(cancelButton);
+
+    const confirmButton = await screen.findByTestId("followup-confirm-cancel");
+    fireEvent.click(confirmButton);
+
+    await vi.waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Follow-up cancelled" }),
+      );
+    });
+  });
+
+  test("shows a destructive toast when the delete API fails", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([makeFollowup({ id: "f1" })]),
+      getDeleteV1DeleteExecutionScheduleMockHandler422(),
+    );
+
+    render(<FollowupsPage />);
+
+    const cancelButton = await screen.findByTestId("followup-cancel-button");
+    fireEvent.click(cancelButton);
+
+    const confirmButton = await screen.findByTestId("followup-confirm-cancel");
+    fireEvent.click(confirmButton);
+
+    await vi.waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to cancel follow-up",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -118,7 +118,7 @@ describe("FollowupsPage", () => {
 
     await vi.waitFor(() => {
       expect(toastMock).toHaveBeenCalledWith(
-        expect.objectContaining({ title: "Follow-up cancelled" }),
+        expect.objectContaining({ title: "Follow-up deleted" }),
       );
     });
   });
@@ -140,7 +140,7 @@ describe("FollowupsPage", () => {
     await vi.waitFor(() => {
       expect(toastMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "Failed to cancel follow-up",
+          title: "Failed to delete follow-up",
           variant: "destructive",
         }),
       );

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/EmptyFollowups/EmptyFollowups.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/EmptyFollowups/EmptyFollowups.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@/components/atoms/Text/Text";
+import { ClockClockwiseIcon } from "@phosphor-icons/react";
+
+export function EmptyFollowups() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-3 rounded-large border border-dashed border-zinc-200 px-6 py-16 text-center"
+      data-testid="followups-empty"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-yellow-50">
+        <ClockClockwiseIcon size={24} className="text-yellow-700" />
+      </div>
+      <Text variant="h4" className="text-zinc-900">
+        No copilot follow-ups
+      </Text>
+      <Text variant="body" className="max-w-md !text-zinc-500">
+        Ask your copilot to schedule something for later and it will show up
+        here so you can edit or cancel it.
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/FollowupListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/FollowupListItem.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { ChatCircleTextIcon, TrashIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+import { useFollowupListItem } from "./useFollowupListItem";
+
+interface Props {
+  followup: CopilotTurnJobInfo;
+  onDeleted?: () => void;
+}
+
+export function FollowupListItem({ followup, onDeleted }: Props) {
+  const {
+    sessionHref,
+    nextRunLabel,
+    nextRunTitle,
+    recurrenceLabel,
+    messagePreview,
+    isDeleteOpen,
+    openDelete,
+    closeDelete,
+    isDeleting,
+    handleDelete,
+  } = useFollowupListItem({ followup, onDeleted });
+
+  return (
+    <div
+      className="flex w-full flex-col gap-3 rounded-large border border-zinc-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
+      data-testid="followup-row"
+      data-followup-id={followup.id}
+    >
+      <Link
+        href={sessionHref}
+        className="flex min-w-0 flex-1 items-start gap-3 hover:opacity-80"
+        data-testid="followup-open-session"
+      >
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-large border border-slate-50 bg-yellow-50">
+          <ChatCircleTextIcon
+            size={18}
+            className="text-yellow-700"
+            weight="bold"
+          />
+        </div>
+        <div className="flex min-w-0 flex-col gap-1">
+          <Text
+            variant="body-medium"
+            className="block w-full truncate text-ellipsis"
+          >
+            {messagePreview}
+          </Text>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <Text
+              variant="small"
+              className="!text-zinc-500"
+              title={nextRunTitle}
+            >
+              {nextRunLabel}
+            </Text>
+            <span className="text-zinc-300">•</span>
+            <Text variant="small" className="!text-zinc-500">
+              {recurrenceLabel}
+            </Text>
+            <span className="text-zinc-300">•</span>
+            <Text variant="small" className="!text-zinc-400">
+              Session {followup.session_id.slice(0, 8)}
+            </Text>
+          </div>
+        </div>
+      </Link>
+
+      <div className="flex flex-shrink-0 items-center gap-2">
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={openDelete}
+          data-testid="followup-cancel-button"
+          aria-label="Cancel follow-up"
+        >
+          <TrashIcon className="mr-1 h-4 w-4" />
+          Cancel
+        </Button>
+      </div>
+
+      <Dialog
+        controlled={{ isOpen: isDeleteOpen, set: closeDelete }}
+        styling={{ maxWidth: "32rem" }}
+        title="Cancel follow-up"
+      >
+        <Dialog.Content>
+          <div className="flex flex-col gap-4">
+            <Text variant="large">
+              Cancel this scheduled follow-up? The copilot will not send the
+              message and you can recreate it from chat if needed.
+            </Text>
+            <Dialog.Footer>
+              <Button
+                variant="secondary"
+                disabled={isDeleting}
+                onClick={() => closeDelete(false)}
+              >
+                Keep follow-up
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                loading={isDeleting}
+                data-testid="followup-confirm-cancel"
+              >
+                Cancel follow-up
+              </Button>
+            </Dialog.Footer>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/FollowupListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/FollowupListItem.tsx
@@ -10,10 +10,9 @@ import { useFollowupListItem } from "./useFollowupListItem";
 
 interface Props {
   followup: CopilotTurnJobInfo;
-  onDeleted?: () => void;
 }
 
-export function FollowupListItem({ followup, onDeleted }: Props) {
+export function FollowupListItem({ followup }: Props) {
   const {
     sessionHref,
     nextRunLabel,
@@ -25,7 +24,7 @@ export function FollowupListItem({ followup, onDeleted }: Props) {
     closeDelete,
     isDeleting,
     handleDelete,
-  } = useFollowupListItem({ followup, onDeleted });
+  } = useFollowupListItem({ followup });
 
   return (
     <div
@@ -78,22 +77,22 @@ export function FollowupListItem({ followup, onDeleted }: Props) {
           size="small"
           onClick={openDelete}
           data-testid="followup-cancel-button"
-          aria-label="Cancel follow-up"
+          aria-label="Delete follow-up"
         >
           <TrashIcon className="mr-1 h-4 w-4" />
-          Cancel
+          Delete
         </Button>
       </div>
 
       <Dialog
         controlled={{ isOpen: isDeleteOpen, set: closeDelete }}
         styling={{ maxWidth: "32rem" }}
-        title="Cancel follow-up"
+        title="Delete follow-up"
       >
         <Dialog.Content>
           <div className="flex flex-col gap-4">
             <Text variant="large">
-              Cancel this scheduled follow-up? The copilot will not send the
+              Delete this scheduled follow-up? The copilot will not send the
               message and you can recreate it from chat if needed.
             </Text>
             <Dialog.Footer>
@@ -102,7 +101,7 @@ export function FollowupListItem({ followup, onDeleted }: Props) {
                 disabled={isDeleting}
                 onClick={() => closeDelete(false)}
               >
-                Keep follow-up
+                Keep it
               </Button>
               <Button
                 variant="destructive"
@@ -110,7 +109,7 @@ export function FollowupListItem({ followup, onDeleted }: Props) {
                 loading={isDeleting}
                 data-testid="followup-confirm-cancel"
               >
-                Cancel follow-up
+                Yes, delete
               </Button>
             </Dialog.Footer>
           </div>

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/helpers.ts
@@ -1,0 +1,17 @@
+import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+
+const MESSAGE_PREVIEW_MAX_LEN = 140;
+
+export function describeFollowup(followup: CopilotTurnJobInfo) {
+  const message = (followup.message ?? "").trim();
+  const messagePreview =
+    message.length === 0
+      ? "(no message)"
+      : message.length > MESSAGE_PREVIEW_MAX_LEN
+        ? `${message.slice(0, MESSAGE_PREVIEW_MAX_LEN).trimEnd()}…`
+        : message;
+
+  const sessionHref = `/copilot?sessionId=${encodeURIComponent(followup.session_id)}`;
+
+  return { messagePreview, sessionHref };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/useFollowupListItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/useFollowupListItem.ts
@@ -12,10 +12,9 @@ import { describeFollowup } from "./helpers";
 
 interface Args {
   followup: CopilotTurnJobInfo;
-  onDeleted?: () => void;
 }
 
-export function useFollowupListItem({ followup, onDeleted }: Args) {
+export function useFollowupListItem({ followup }: Args) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -49,15 +48,17 @@ export function useFollowupListItem({ followup, onDeleted }: Args) {
   async function handleDelete() {
     try {
       await deleteSchedule({ scheduleId: followup.id });
-      toast({ title: "Follow-up cancelled" });
+      toast({ title: "Follow-up deleted" });
       setIsDeleteOpen(false);
-      onDeleted?.();
+      // Invalidation is the single source of truth — React Query will
+      // refetch the list automatically. No need for a parent-supplied
+      // `onDeleted` callback that would race the toast.
       queryClient.invalidateQueries({
         queryKey: getListCopilotFollowupSchedulesQueryKey(),
       });
     } catch (error) {
       toast({
-        title: "Failed to cancel follow-up",
+        title: "Failed to delete follow-up",
         description:
           error instanceof Error
             ? error.message

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/useFollowupListItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/useFollowupListItem.ts
@@ -1,0 +1,90 @@
+import {
+  getListCopilotFollowupSchedulesQueryKey,
+  useDeleteV1DeleteExecutionSchedule,
+} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { humanizeCronExpression } from "@/lib/cron-expression-utils";
+import { useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { useState } from "react";
+import { describeFollowup } from "./helpers";
+
+interface Args {
+  followup: CopilotTurnJobInfo;
+  onDeleted?: () => void;
+}
+
+export function useFollowupListItem({ followup, onDeleted }: Args) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  const { mutateAsync: deleteSchedule, isPending: isDeleting } =
+    useDeleteV1DeleteExecutionSchedule();
+
+  const { messagePreview, sessionHref } = describeFollowup(followup);
+
+  const nextRunDate = followup.next_run_time
+    ? new Date(followup.next_run_time)
+    : null;
+  const nextRunLabel =
+    nextRunDate && !Number.isNaN(nextRunDate.valueOf())
+      ? `Next ${formatDistanceToNow(nextRunDate, { addSuffix: true })}`
+      : "Pending";
+  const nextRunTitle = nextRunDate ? nextRunDate.toString() : undefined;
+
+  const recurrenceLabel = followup.cron
+    ? safeHumanizeCron(followup.cron)
+    : "Runs once";
+
+  function openDelete() {
+    setIsDeleteOpen(true);
+  }
+
+  function closeDelete(open: boolean) {
+    setIsDeleteOpen(open);
+  }
+
+  async function handleDelete() {
+    try {
+      await deleteSchedule({ scheduleId: followup.id });
+      toast({ title: "Follow-up cancelled" });
+      setIsDeleteOpen(false);
+      onDeleted?.();
+      queryClient.invalidateQueries({
+        queryKey: getListCopilotFollowupSchedulesQueryKey(),
+      });
+    } catch (error) {
+      toast({
+        title: "Failed to cancel follow-up",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred.",
+        variant: "destructive",
+      });
+    }
+  }
+
+  return {
+    sessionHref,
+    messagePreview,
+    nextRunLabel,
+    nextRunTitle,
+    recurrenceLabel,
+    isDeleteOpen,
+    openDelete,
+    closeDelete,
+    isDeleting,
+    handleDelete,
+  };
+}
+
+function safeHumanizeCron(cron: string): string {
+  try {
+    return humanizeCronExpression(cron);
+  } catch {
+    return cron;
+  }
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+import { Text } from "@/components/atoms/Text/Text";
+import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
+import { EmptyFollowups } from "./components/EmptyFollowups/EmptyFollowups";
+import { FollowupListItem } from "./components/FollowupListItem/FollowupListItem";
+import { useFollowupsPage } from "./useFollowupsPage";
+
+export default function FollowupsPage() {
+  const { followups, isLoading, error, refetchFollowups } = useFollowupsPage();
+
+  useEffect(() => {
+    document.title = "Copilot follow-ups – AutoGPT Platform";
+  }, []);
+
+  return (
+    <main className="container min-h-screen space-y-6 pb-20 pt-16 sm:px-8 md:px-12">
+      <header className="flex flex-col gap-2">
+        <Text variant="h2">Copilot follow-ups</Text>
+        <Text variant="body" className="!text-zinc-500">
+          Scheduled messages your copilot sessions will send themselves. Open a
+          row to jump into the session, or cancel one you no longer need.
+        </Text>
+      </header>
+
+      {error ? (
+        <ErrorCard
+          responseError={{
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to load follow-ups",
+          }}
+          context="copilot follow-ups"
+        />
+      ) : isLoading ? (
+        <div
+          className="flex items-center justify-center py-16"
+          data-testid="followups-loading"
+        >
+          <LoadingSpinner />
+        </div>
+      ) : followups.length === 0 ? (
+        <EmptyFollowups />
+      ) : (
+        <ul
+          className="flex flex-col gap-3"
+          data-testid="followups-list"
+          aria-label="Copilot follow-ups"
+        >
+          {followups.map((followup) => (
+            <li key={followup.id}>
+              <FollowupListItem
+                followup={followup}
+                onDeleted={refetchFollowups}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
@@ -9,7 +9,7 @@ import { FollowupListItem } from "./components/FollowupListItem/FollowupListItem
 import { useFollowupsPage } from "./useFollowupsPage";
 
 export default function FollowupsPage() {
-  const { followups, isLoading, error, refetchFollowups } = useFollowupsPage();
+  const { followups, isLoading, error } = useFollowupsPage();
 
   useEffect(() => {
     document.title = "Copilot follow-ups – AutoGPT Platform";

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/useFollowupsPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/useFollowupsPage.ts
@@ -1,0 +1,17 @@
+import { useListCopilotFollowupSchedules } from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { okData } from "@/app/api/helpers";
+
+export function useFollowupsPage() {
+  const query = useListCopilotFollowupSchedules({
+    query: {
+      select: (res) => okData(res) ?? [],
+    },
+  });
+
+  return {
+    followups: query.data ?? [],
+    isLoading: query.isLoading,
+    error: query.error,
+    refetchFollowups: query.refetch,
+  };
+}

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -8079,6 +8079,34 @@
         "security": [{ "HTTPBearerJWT": [] }]
       }
     },
+    "/api/schedules/followups": {
+      "get": {
+        "tags": ["v1", "schedules"],
+        "summary": "List copilot follow-up schedules for a user",
+        "description": "Return only copilot-turn schedules for the current user.\n\nSibling of :func:`list_all_graphs_execution_schedules`; one route per kind\nkeeps the generated frontend client typed to a single concrete return type\ninstead of a discriminated union.",
+        "operationId": "listCopilotFollowupSchedules",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CopilotTurnJobInfo"
+                  },
+                  "type": "array",
+                  "title": "Response Listcopilotfollowupschedules"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
     "/api/schedules/{schedule_id}": {
       "delete": {
         "tags": ["v1", "schedules"],
@@ -11082,6 +11110,58 @@
           "LIBRARY_AGENT"
         ],
         "title": "ContentType"
+      },
+      "CopilotTurnJobInfo": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "copilot_turn",
+            "title": "Kind",
+            "default": "copilot_turn"
+          },
+          "schedule_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Schedule Id"
+          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "session_id": { "type": "string", "title": "Session Id" },
+          "message": { "type": "string", "title": "Message" },
+          "cron": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Cron"
+          },
+          "run_at": {
+            "anyOf": [
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
+            ],
+            "title": "Run At"
+          },
+          "cap_retry_count": {
+            "type": "integer",
+            "title": "Cap Retry Count",
+            "default": 0
+          },
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "next_run_time": { "type": "string", "title": "Next Run Time" },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "Timezone used for scheduling",
+            "default": "UTC"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id",
+          "session_id",
+          "message",
+          "id",
+          "name",
+          "next_run_time"
+        ],
+        "title": "CopilotTurnJobInfo"
       },
       "CopilotUsageExportResponse": {
         "properties": {


### PR DESCRIPTION
## Why
Copilot can already schedule follow-up turns for itself (#13190), but there is no surface for the user to see what's pending or cancel one — they only see the side-effect when the copilot speaks up later. This adds the minimal Library page that lists them and lets the user cancel.

Stacked on top of #13190 — this PR's diff will collapse to just the UI commit once that lands.

## What
- New page at `/library/followups` listing the current user's pending copilot follow-ups, with:
  - Empty state when the user has none.
  - One row per scheduled turn showing message preview, next-run label (relative), recurrence label (humanised cron) and a session-id tag. Clicking the row deep-links to the originating `/copilot?sessionId=...`.
  - A `Cancel` action that opens a confirmation dialog and calls the existing `DELETE /api/schedules/{id}` route; success toasts and refetches, failure toasts destructively.
- New backend route `GET /api/schedules/followups` returning only `CopilotTurnJobInfo` rows for the caller. Split out from the polymorphic `GET /api/schedules` so the OpenAPI-generated client gets a single concrete return type per route instead of a discriminated union.

## How
- Backend: thin wrapper around `Scheduler.get_execution_schedules(kind="copilot_turn")` plus an explicit `operation_id="listCopilotFollowupSchedules"` to keep the generated TS client tidy.
- Frontend: page + sub-components (`EmptyFollowups`, `FollowupListItem`) following the `page.tsx + usePageName.ts + helpers.ts` pattern in `frontend/AGENTS.md`. Design-system atoms/molecules only (`Text`, `Button`, `Dialog`, `LoadingSpinner`, `ErrorCard`), Phosphor icons only.
- Data fetching via the Orval-generated `useListCopilotFollowupSchedules` hook; delete reuses `useDeleteV1DeleteExecutionSchedule` and invalidates the followups query key on success.
- Tests:
  - Backend route test mocks the scheduler client and asserts the `kind="copilot_turn"` filter is forwarded and non-copilot rows are dropped.
  - Frontend integration tests (Vitest + RTL + MSW with Orval-generated handlers) cover: empty list, one row per followup, deep link href, delete success toast, delete failure toast.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests for my changes
- [x] My changes generate no new warnings
- [x] I have ensured that my changes are backwards compatible