### PR TITLE
feat(copilot): autopilot UX polish + skills/followups LD kill-switches + unified Scheduled page

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/schedule_followup.py
+++ b/autogpt_platform/backend/backend/copilot/tools/schedule_followup.py
@@ -31,6 +31,7 @@ from typing import Any
 from apscheduler.triggers.cron import CronTrigger
 
 from backend.copilot.model import ChatSession, get_chat_session
+from backend.copilot.tools.session_context import is_followups_feature_enabled
 from backend.copilot.tracking import track_followup_scheduled
 from backend.data.db_accessors import user_db
 from backend.util.clients import get_scheduler_client
@@ -149,13 +150,6 @@ class ScheduleFollowupTool(BaseTool):
                 error="auth_required",
                 session_id=current_session_id,
             )
-        # Per-user kill-switch — ``COPILOT_SCHEDULED_FOLLOWUPS`` LD
-        # flag.  Default-on; flip off in LaunchDarkly to disable the
-        # tool without a redeploy.
-        from backend.copilot.tools.session_context import (
-            is_followups_feature_enabled,
-        )
-
         if not await is_followups_feature_enabled(user_id):
             return ErrorResponse(
                 message=(

--- a/autogpt_platform/backend/backend/copilot/tools/schedule_followup.py
+++ b/autogpt_platform/backend/backend/copilot/tools/schedule_followup.py
@@ -149,6 +149,23 @@ class ScheduleFollowupTool(BaseTool):
                 error="auth_required",
                 session_id=current_session_id,
             )
+        # Per-user kill-switch — ``COPILOT_SCHEDULED_FOLLOWUPS`` LD
+        # flag.  Default-on; flip off in LaunchDarkly to disable the
+        # tool without a redeploy.
+        from backend.copilot.tools.session_context import (
+            is_followups_feature_enabled,
+        )
+
+        if not await is_followups_feature_enabled(user_id):
+            return ErrorResponse(
+                message=(
+                    "Scheduled followups are currently disabled for this "
+                    "user. Re-enable the ``copilot-scheduled-followups`` "
+                    "LaunchDarkly flag to use ``schedule_followup``."
+                ),
+                error="feature_disabled",
+                session_id=current_session_id,
+            )
 
         message: str | None = kwargs.get("message")
         if not message or not message.strip():

--- a/autogpt_platform/backend/backend/copilot/tools/schedule_followup_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/schedule_followup_test.py
@@ -284,7 +284,7 @@ async def test_returns_feature_disabled_when_flag_off(tool):
     )
 
     with patch(
-        "backend.copilot.tools.session_context.is_followups_feature_enabled",
+        f"{_TOOL_PATH}.is_followups_feature_enabled",
         new=AsyncMock(return_value=False),
     ), patch(f"{_TOOL_PATH}.get_scheduler_client", return_value=scheduler_client):
         result = await tool._execute(

--- a/autogpt_platform/backend/backend/copilot/tools/schedule_followup_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/schedule_followup_test.py
@@ -263,3 +263,37 @@ async def test_cron_schedules_recurring(tool, session):
     assert call_kwargs["cron"] == "0 9 * * 1"
     assert call_kwargs["run_at"] is None
     assert call_kwargs["user_timezone"] == "UTC"
+
+
+# ---------------------------------------------------------------------------
+# COPILOT_SCHEDULED_FOLLOWUPS LaunchDarkly kill-switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_feature_disabled_when_flag_off(tool):
+    """When the per-user LD flag is off, ``_execute`` short-circuits to a
+    structured ``feature_disabled`` error WITHOUT touching the scheduler
+    client.  This is the rollback story — flipping the flag has to make
+    new schedules impossible without a redeploy."""
+    session = make_session(_USER)
+
+    scheduler_client = MagicMock()
+    scheduler_client.add_copilot_turn_schedule = AsyncMock(
+        side_effect=AssertionError("scheduler must not be touched when flag off")
+    )
+
+    with patch(
+        "backend.copilot.tools.session_context.is_followups_feature_enabled",
+        new=AsyncMock(return_value=False),
+    ), patch(f"{_TOOL_PATH}.get_scheduler_client", return_value=scheduler_client):
+        result = await tool._execute(
+            user_id=_USER,
+            session=session,
+            message="ping me later",
+            delay_seconds=120,
+        )
+
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "feature_disabled"
+    scheduler_client.add_copilot_turn_schedule.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/tools/session_context.py
+++ b/autogpt_platform/backend/backend/copilot/tools/session_context.py
@@ -27,6 +27,7 @@ import logging
 
 from backend.executor.scheduler import CopilotTurnJobInfo
 from backend.util.clients import get_scheduler_client
+from backend.util.feature_flag import Flag, is_feature_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +79,6 @@ async def is_followups_feature_enabled(user_id: str | None) -> bool:
     """
     if not user_id:
         return True
-    from backend.util.feature_flag import Flag, is_feature_enabled
-
     return await is_feature_enabled(
         Flag.COPILOT_SCHEDULED_FOLLOWUPS, user_id, default=True
     )

--- a/autogpt_platform/backend/backend/copilot/tools/session_context.py
+++ b/autogpt_platform/backend/backend/copilot/tools/session_context.py
@@ -70,6 +70,21 @@ def _format_followup_list(jobs: list[CopilotTurnJobInfo]) -> list[str]:
     return lines
 
 
+async def is_followups_feature_enabled(user_id: str | None) -> bool:
+    """Per-user kill-switch for the scheduled-followups feature
+    (``COPILOT_SCHEDULED_FOLLOWUPS`` LD flag).  Default-on.  Anonymous
+    calls (no ``user_id``) treat as enabled so unauthenticated paths
+    don't surprise-break.
+    """
+    if not user_id:
+        return True
+    from backend.util.feature_flag import Flag, is_feature_enabled
+
+    return await is_feature_enabled(
+        Flag.COPILOT_SCHEDULED_FOLLOWUPS, user_id, default=True
+    )
+
+
 async def build_session_context(session_id: str, user_id: str) -> str:
     """Return the body of the ``<session_context>`` block for this turn.
 
@@ -86,7 +101,14 @@ async def build_session_context(session_id: str, user_id: str) -> str:
 
     The return value is the **body** of the block (no surrounding
     ``<session_context>`` tags); the caller wraps it.
+
+    When the ``COPILOT_SCHEDULED_FOLLOWUPS`` LD flag is off for this
+    user, the followup awareness collapses to just ``pending_followups:
+    0`` — we keep the ``session_id`` line so the model still knows
+    which session it is in, and we skip the scheduler RPC entirely.
     """
+    if not await is_followups_feature_enabled(user_id):
+        return f"session_id: {session_id}; pending_followups: 0"
     try:
         raw_jobs = await get_scheduler_client().get_execution_schedules(
             user_id=user_id,

--- a/autogpt_platform/backend/backend/copilot/tools/session_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/session_context_test.py
@@ -331,3 +331,34 @@ def test_malformed_nested_session_context_fully_consumed():
     assert SESSION_CONTEXT_TAG not in cleaned
     assert "extra</session_context>" not in cleaned
     assert "hello" in cleaned
+
+
+# ---------------------------------------------------------------------------
+# COPILOT_SCHEDULED_FOLLOWUPS LaunchDarkly kill-switch — default-on; LD-off
+# must collapse ``<session_context>`` to the bare session_id line AND skip
+# the scheduler RPC entirely (cost half of the kill-switch).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_session_context_skips_scheduler_when_followups_disabled():
+    from backend.copilot.tools.session_context import build_session_context
+
+    scheduler_spy = AsyncMock(
+        side_effect=AssertionError("scheduler must not be called when flag off")
+    )
+
+    class _FakeClient:
+        get_execution_schedules = scheduler_spy
+
+    with patch(
+        "backend.copilot.tools.session_context.is_followups_feature_enabled",
+        new=AsyncMock(return_value=False),
+    ), patch(
+        "backend.copilot.tools.session_context.get_scheduler_client",
+        return_value=_FakeClient(),
+    ):
+        result = await build_session_context(session_id="sess-1", user_id="user-1")
+
+    assert result == "session_id: sess-1; pending_followups: 0"
+    scheduler_spy.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/tools/session_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/session_context_test.py
@@ -342,8 +342,6 @@ def test_malformed_nested_session_context_fully_consumed():
 
 @pytest.mark.asyncio
 async def test_build_session_context_skips_scheduler_when_followups_disabled():
-    from backend.copilot.tools.session_context import build_session_context
-
     scheduler_spy = AsyncMock(
         side_effect=AssertionError("scheduler must not be called when flag off")
     )

--- a/autogpt_platform/backend/backend/copilot/tools/skills.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills.py
@@ -671,12 +671,32 @@ def render_skills_index(skills: list[ParsedSkill]) -> str:
     return "\n".join(lines)
 
 
+async def is_skills_feature_enabled(user_id: str | None) -> bool:
+    """Per-user kill-switch for the skills feature (``COPILOT_SKILLS``
+    LaunchDarkly flag).  Default-on; the flag exists only so we can
+    disable the feature without a redeploy.  Anonymous calls
+    (no ``user_id``) treat as enabled so unauthenticated paths don't
+    surprise-break.
+    """
+    if not user_id:
+        return True
+    from backend.util.feature_flag import Flag, is_feature_enabled
+
+    return await is_feature_enabled(Flag.COPILOT_SKILLS, user_id, default=True)
+
+
 async def build_skills_context(user_id: str | None) -> str:
     """Build the body of the ``<available_skills>`` block injected into
     the first user message.  Returns ``""`` if there are no skills to
     show — :func:`inject_user_context` then omits the block entirely so
     sessions with no skill state don't pay the tag overhead.
+
+    Also returns ``""`` when the ``COPILOT_SKILLS`` LD flag is off for
+    this user, so the kill-switch fully suppresses the per-turn index
+    cost (no list query, no Redis hit, nothing to cache).
     """
+    if not await is_skills_feature_enabled(user_id):
+        return ""
     skills = await list_all_skills(user_id)
     index = render_skills_index(skills)
     if not index:
@@ -790,6 +810,17 @@ class StoreSkillTool(BaseTool):
         if not user_id:
             return ErrorResponse(
                 message="Authentication required", session_id=session_id
+            )
+        if not await is_skills_feature_enabled(user_id):
+            return ErrorResponse(
+                message=(
+                    "Skill registry is currently disabled for this user. "
+                    "Re-enable the ``copilot-skills`` LaunchDarkly flag to "
+                    "use ``store_skill`` / ``read_skill`` / ``delete_skill`` "
+                    "/ ``list_skills``."
+                ),
+                error="feature_disabled",
+                session_id=session_id,
             )
 
         name = name.strip().lower()
@@ -1013,6 +1044,12 @@ class ReadSkillTool(BaseTool):
         **kwargs,
     ) -> ToolResponseBase:
         session_id = session.session_id
+        if not await is_skills_feature_enabled(user_id):
+            return ErrorResponse(
+                message="Skill registry is currently disabled for this user.",
+                error="feature_disabled",
+                session_id=session_id,
+            )
         name = name.strip().lower()
         if not name:
             return ErrorResponse(message="name is required", session_id=session_id)
@@ -1149,6 +1186,12 @@ class DeleteSkillTool(BaseTool):
             return ErrorResponse(
                 message="Authentication required", session_id=session_id
             )
+        if not await is_skills_feature_enabled(user_id):
+            return ErrorResponse(
+                message="Skill registry is currently disabled for this user.",
+                error="feature_disabled",
+                session_id=session_id,
+            )
         try:
             slug = await delete_user_skill(user_id, name)
         except ValueError as exc:
@@ -1199,6 +1242,12 @@ class ListSkillsTool(BaseTool):
         session: ChatSession,
         **kwargs,
     ) -> ToolResponseBase:
+        if not await is_skills_feature_enabled(user_id):
+            return ErrorResponse(
+                message="Skill registry is currently disabled for this user.",
+                error="feature_disabled",
+                session_id=session.session_id,
+            )
         skills = await list_all_skills(user_id)
         payload = [
             {

--- a/autogpt_platform/backend/backend/copilot/tools/skills.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills.py
@@ -38,6 +38,7 @@ from backend.copilot.service import strip_server_injected_tags
 from backend.data.db_accessors import workspace_db
 from backend.data.redis_client import get_redis_async
 from backend.executor.cluster_lock import AsyncClusterLock
+from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.workspace import WorkspaceManager
 
 from .base import BaseTool
@@ -680,8 +681,6 @@ async def is_skills_feature_enabled(user_id: str | None) -> bool:
     """
     if not user_id:
         return True
-    from backend.util.feature_flag import Flag, is_feature_enabled
-
     return await is_feature_enabled(Flag.COPILOT_SKILLS, user_id, default=True)
 
 

--- a/autogpt_platform/backend/backend/copilot/tools/skills_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills_test.py
@@ -1169,8 +1169,6 @@ async def test_read_user_skill_with_body_returns_full_text():
 
 @pytest.mark.asyncio
 async def test_build_skills_context_empty_when_flag_disabled():
-    from backend.copilot.tools.skills import build_skills_context
-
     with patch(
         "backend.copilot.tools.skills.is_skills_feature_enabled",
         new=AsyncMock(return_value=False),
@@ -1182,8 +1180,6 @@ async def test_build_skills_context_empty_when_flag_disabled():
 
 @pytest.mark.asyncio
 async def test_build_skills_context_normal_when_flag_enabled():
-    from backend.copilot.tools.skills import build_skills_context
-
     fake_manager = _FakeWorkspaceManager()
     fake_manager.files["/skills/x/SKILL.md"] = render_skill_markdown(
         ParsedSkill(name="x", description="ok", body="b")
@@ -1205,8 +1201,6 @@ async def test_build_skills_context_normal_when_flag_enabled():
 
 @pytest.mark.asyncio
 async def test_store_skill_returns_feature_disabled_when_flag_off():
-    from backend.copilot.tools.skills import StoreSkillTool
-
     tool = StoreSkillTool()
     session = _make_session()
     with patch(
@@ -1227,8 +1221,6 @@ async def test_store_skill_returns_feature_disabled_when_flag_off():
 
 @pytest.mark.asyncio
 async def test_list_skills_returns_feature_disabled_when_flag_off():
-    from backend.copilot.tools.skills import ListSkillsTool
-
     tool = ListSkillsTool()
     session = _make_session()
     with patch(

--- a/autogpt_platform/backend/backend/copilot/tools/skills_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/skills_test.py
@@ -1157,3 +1157,85 @@ async def test_read_user_skill_with_body_returns_full_text():
     assert result is not None
     assert result.name == "myskill"
     assert "# Body" in result.body
+
+
+# ---------------------------------------------------------------------------
+# COPILOT_SKILLS LaunchDarkly kill-switch — default-on; LD-off must collapse
+# the per-turn ``<available_skills>`` block to empty AND make every MCP tool
+# return a structured ``feature_disabled`` error.  This is the rollback story
+# if the feature regresses in prod.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_skills_context_empty_when_flag_disabled():
+    from backend.copilot.tools.skills import build_skills_context
+
+    with patch(
+        "backend.copilot.tools.skills.is_skills_feature_enabled",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await build_skills_context("user-1")
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_build_skills_context_normal_when_flag_enabled():
+    from backend.copilot.tools.skills import build_skills_context
+
+    fake_manager = _FakeWorkspaceManager()
+    fake_manager.files["/skills/x/SKILL.md"] = render_skill_markdown(
+        ParsedSkill(name="x", description="ok", body="b")
+    ).encode()
+    with _patch_skills_path(fake_manager), patch(
+        "backend.copilot.tools.skills.is_skills_feature_enabled",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "backend.copilot.tools.skills._read_skills_cache",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "backend.copilot.tools.skills._write_skills_cache",
+        new=AsyncMock(),
+    ):
+        result = await build_skills_context("user-1")
+
+    assert "name: x" in result
+
+
+@pytest.mark.asyncio
+async def test_store_skill_returns_feature_disabled_when_flag_off():
+    from backend.copilot.tools.skills import StoreSkillTool
+
+    tool = StoreSkillTool()
+    session = _make_session()
+    with patch(
+        "backend.copilot.tools.skills.is_skills_feature_enabled",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await tool._execute(
+            user_id="user-1",
+            session=session,
+            name="x",
+            description="d",
+            body="b",
+        )
+
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "feature_disabled"
+
+
+@pytest.mark.asyncio
+async def test_list_skills_returns_feature_disabled_when_flag_off():
+    from backend.copilot.tools.skills import ListSkillsTool
+
+    tool = ListSkillsTool()
+    session = _make_session()
+    with patch(
+        "backend.copilot.tools.skills.is_skills_feature_enabled",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await tool._execute(user_id="user-1", session=session)
+
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "feature_disabled"

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -43,6 +43,16 @@ class Flag(str, Enum):
     CHAT_MODE_OPTION = "chat-mode-option"
     COPILOT_SDK = "copilot-sdk"
     COPILOT_COST_LIMITS = "copilot-cost-limits"
+    # Self-distilled skills registry (store_skill / read_skill /
+    # delete_skill / list_skills + the per-turn <available_skills>
+    # context block).  Default-on — flip off in LaunchDarkly to disable
+    # the feature without a redeploy.
+    COPILOT_SKILLS = "copilot-skills"
+    # Scheduled copilot turn followups (schedule_followup MCP tool +
+    # the pending_followups awareness inside <session_context>).  The
+    # current_session_id line stays regardless — only the followup
+    # surface is gated.  Default-on.
+    COPILOT_SCHEDULED_FOLLOWUPS = "copilot-scheduled-followups"
     COPILOT_TIER_MULTIPLIERS = "copilot-tier-multipliers"
     COPILOT_TIER_WORKSPACE_STORAGE_LIMITS = "copilot-tier-workspace-storage-limits"
     COPILOT_TIER_STRIPE_PRICES = "copilot-tier-stripe-prices"

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/BriefingTabContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/BriefingTabContent.tsx
@@ -4,7 +4,10 @@ import type { CoPilotUsagePublic } from "@/app/api/__generated__/models/coPilotU
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { useGetV2GetCopilotUsage } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useListCopilotSkills } from "@/app/api/__generated__/endpoints/skills/skills";
-import { useListCopilotFollowupSchedules } from "@/app/api/__generated__/endpoints/schedules/schedules";
+import {
+  useGetV1ListExecutionSchedulesForAUser,
+  useListCopilotFollowupSchedules,
+} from "@/app/api/__generated__/endpoints/schedules/schedules";
 import {
   formatResetTime,
   formatTierLabel,
@@ -119,20 +122,35 @@ function CopilotLibrarySummary() {
   const { data: followupsRes } = useListCopilotFollowupSchedules({
     query: { staleTime: 30_000 },
   });
+  // Graph schedules (recurring agent runs) live alongside followups in
+  // the unified Scheduled page — count them together so the briefing
+  // pill mirrors what the user sees there.
+  const { data: graphsRes } = useGetV1ListExecutionSchedulesForAUser({
+    query: { staleTime: 30_000 },
+  });
 
   const skillsCount =
     skillsRes && skillsRes.status === 200 ? skillsRes.data.length : 0;
-  const followupsCount =
+  const copilotFollowupsCount =
     followupsRes && followupsRes.status === 200 ? followupsRes.data.length : 0;
+  const graphSchedulesCount =
+    graphsRes && graphsRes.status === 200 ? graphsRes.data.length : 0;
+  const scheduledCount = copilotFollowupsCount + graphSchedulesCount;
 
-  // Suppress the pill entirely when the user has no copilot library
-  // content yet — surfacing "0 skills · 0 follow-ups" is noise, not
+  // Suppress the pill entirely when the user has no autopilot library
+  // content yet — surfacing "0 skills · 0 scheduled" is noise, not a
   // discovery affordance.  The pill reappears the moment either count
   // turns positive (e.g. on the next refetch after a store_skill /
-  // schedule_followup tool call).
-  if (skillsCount === 0 && followupsCount === 0) {
+  // schedule_followup / add_graph_execution_schedule tool call).
+  if (skillsCount === 0 && scheduledCount === 0) {
     return null;
   }
+
+  // Per-link hide: surface only the counts that are non-zero.  We
+  // already returned ``null`` above when both are zero, so at least
+  // one of these two branches always renders.
+  const showSkills = skillsCount > 0;
+  const showScheduled = scheduledCount > 0;
 
   return (
     <div
@@ -140,23 +158,29 @@ function CopilotLibrarySummary() {
       data-testid="copilot-library-summary"
     >
       <Text variant="small" className="!text-zinc-500">
-        Copilot library
+        Autopilot library
       </Text>
-      <Link
-        href="/library/skills"
-        className="text-sm text-violet-700 hover:underline"
-        data-testid="copilot-library-skills-link"
-      >
-        {skillsCount} skill{skillsCount === 1 ? "" : "s"}
-      </Link>
-      <span className="text-zinc-300">•</span>
-      <Link
-        href="/library/followups"
-        className="text-sm text-yellow-700 hover:underline"
-        data-testid="copilot-library-followups-link"
-      >
-        {followupsCount} follow-up{followupsCount === 1 ? "" : "s"}
-      </Link>
+      {showSkills ? (
+        <Link
+          href="/library/skills"
+          className="text-sm text-violet-700 hover:underline"
+          data-testid="copilot-library-skills-link"
+        >
+          {skillsCount} skill{skillsCount === 1 ? "" : "s"}
+        </Link>
+      ) : null}
+      {showSkills && showScheduled ? (
+        <span className="text-zinc-300">•</span>
+      ) : null}
+      {showScheduled ? (
+        <Link
+          href="/library/followups"
+          className="text-sm text-yellow-700 hover:underline"
+          data-testid="copilot-library-followups-link"
+        >
+          {scheduledCount} scheduled
+        </Link>
+      ) : null}
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
@@ -3,6 +3,9 @@ import {
   getGetV1ListExecutionSchedulesForAUserMockHandler,
   getListCopilotFollowupSchedulesMockHandler,
 } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import type { CopilotSkillInfo } from "@/app/api/__generated__/models/copilotSkillInfo";
+import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { server } from "@/mocks/mock-server";
 import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
@@ -422,17 +425,17 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
     mockUseGetFlag.mockReturnValue(false);
   }
 
-  function makeSkill(overrides: { name?: string } = {}) {
+  function makeSkill(overrides: { name?: string } = {}): CopilotSkillInfo {
     return {
       name: overrides.name ?? "skill-1",
       description: "test skill",
       triggers: [],
       version: "1.0.0",
       updated_at: new Date().toISOString(),
-    };
+    } as unknown as CopilotSkillInfo;
   }
 
-  function makeFollowup(overrides: { id?: string } = {}) {
+  function makeFollowup(overrides: { id?: string } = {}): CopilotTurnJobInfo {
     const runAt = new Date(Date.now() + 60 * 60 * 1000);
     return {
       id: overrides.id ?? "f-1",
@@ -443,13 +446,15 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
       cron: null,
       run_at: runAt,
       next_run_time: runAt.toISOString(),
-      kind: "copilot_turn",
+      kind: "copilot_turn" as const,
       timezone: "UTC",
       cap_retry_count: 0,
     };
   }
 
-  function makeGraphSchedule(overrides: { id?: string } = {}) {
+  function makeGraphSchedule(
+    overrides: { id?: string } = {},
+  ): GraphExecutionJobInfo {
     return {
       id: overrides.id ?? "g-1",
       name: "daily",
@@ -460,7 +465,7 @@ describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => 
       cron: "0 9 * * *",
       input_data: {},
       next_run_time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
-      kind: "graph",
+      kind: "graph" as const,
       timezone: "UTC",
     };
   }

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentBriefingPanel/__tests__/BriefingTabContent.test.tsx
@@ -1,4 +1,10 @@
+import { getListCopilotSkillsMockHandler } from "@/app/api/__generated__/endpoints/skills/skills.msw";
+import {
+  getGetV1ListExecutionSchedulesForAUserMockHandler,
+  getListCopilotFollowupSchedulesMockHandler,
+} from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { server } from "@/mocks/mock-server";
 import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BriefingTabContent } from "../BriefingTabContent";
@@ -57,6 +63,7 @@ afterEach(() => {
   mockUseGetV2GetCopilotUsage.mockReset();
   mockUseGetV1UserCostSummary.mockReset();
   mockUseGetFlag.mockReset();
+  server.resetHandlers();
 });
 
 function makeUsage({
@@ -402,5 +409,142 @@ describe("BriefingTabContent — CostsBreakdown", () => {
 
     expect(screen.getByText("$5.00")).toBeDefined();
     expect(screen.queryByText("$1.67")).toBeNull();
+  });
+});
+
+describe("BriefingTabContent — CopilotLibrarySummary (Autopilot pill)", () => {
+  function setupBriefingMocks() {
+    mockUseGetV2GetCopilotUsage.mockReturnValue({
+      data: undefined,
+      isSuccess: false,
+    });
+    mockUseGetV1UserCostSummary.mockReturnValue(emptyCostSummary());
+    mockUseGetFlag.mockReturnValue(false);
+  }
+
+  function makeSkill(overrides: { name?: string } = {}) {
+    return {
+      name: overrides.name ?? "skill-1",
+      description: "test skill",
+      triggers: [],
+      version: "1.0.0",
+      updated_at: new Date().toISOString(),
+    };
+  }
+
+  function makeFollowup(overrides: { id?: string } = {}) {
+    const runAt = new Date(Date.now() + 60 * 60 * 1000);
+    return {
+      id: overrides.id ?? "f-1",
+      name: "copilot-followup",
+      user_id: "user-1",
+      session_id: "session-abcdef0123",
+      message: "ping",
+      cron: null,
+      run_at: runAt,
+      next_run_time: runAt.toISOString(),
+      kind: "copilot_turn",
+      timezone: "UTC",
+      cap_retry_count: 0,
+    };
+  }
+
+  function makeGraphSchedule(overrides: { id?: string } = {}) {
+    return {
+      id: overrides.id ?? "g-1",
+      name: "daily",
+      user_id: "user-1",
+      graph_id: "graph-abc",
+      graph_version: 1,
+      agent_name: "Daily agent",
+      cron: "0 9 * * *",
+      input_data: {},
+      next_run_time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+      kind: "graph",
+      timezone: "UTC",
+    };
+  }
+
+  it("renders nothing when there are zero skills AND zero scheduled items", async () => {
+    setupBriefingMocks();
+    server.use(
+      getListCopilotSkillsMockHandler([]),
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([]),
+    );
+
+    render(<BriefingTabContent activeTab="all" agents={[]} />);
+
+    // The pill suppresses entirely when both counts are zero — surfacing
+    // "0 skills · 0 scheduled" would be noise, not a discovery affordance.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId("copilot-library-summary")).toBeNull();
+    expect(screen.queryByText("Autopilot library")).toBeNull();
+  });
+
+  it("shows only the skills link when scheduled count is zero", async () => {
+    setupBriefingMocks();
+    server.use(
+      getListCopilotSkillsMockHandler([
+        makeSkill({ name: "alpha" }),
+        makeSkill({ name: "beta" }),
+      ]),
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([]),
+    );
+
+    render(<BriefingTabContent activeTab="all" agents={[]} />);
+
+    expect(await screen.findByText("Autopilot library")).toBeDefined();
+    expect(screen.getByTestId("copilot-library-skills-link").textContent).toBe(
+      "2 skills",
+    );
+    expect(screen.queryByTestId("copilot-library-followups-link")).toBeNull();
+  });
+
+  it("shows only the scheduled link when skills count is zero (sums followups + graph schedules)", async () => {
+    setupBriefingMocks();
+    server.use(
+      getListCopilotSkillsMockHandler([]),
+      getListCopilotFollowupSchedulesMockHandler([
+        makeFollowup({ id: "f1" }),
+        makeFollowup({ id: "f2" }),
+      ]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({ id: "g1" }),
+      ]),
+    );
+
+    render(<BriefingTabContent activeTab="all" agents={[]} />);
+
+    expect(await screen.findByText("Autopilot library")).toBeDefined();
+    // 2 followups + 1 graph schedule = 3 total scheduled.
+    expect(
+      screen.getByTestId("copilot-library-followups-link").textContent,
+    ).toBe("3 scheduled");
+    expect(screen.queryByTestId("copilot-library-skills-link")).toBeNull();
+  });
+
+  it("shows both links with a separator when both counts are positive", async () => {
+    setupBriefingMocks();
+    server.use(
+      getListCopilotSkillsMockHandler([makeSkill({ name: "only-one" })]),
+      getListCopilotFollowupSchedulesMockHandler([makeFollowup({ id: "f1" })]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([]),
+    );
+
+    render(<BriefingTabContent activeTab="all" agents={[]} />);
+
+    expect(await screen.findByText("Autopilot library")).toBeDefined();
+    // Singular form when count is 1 — verifies the pluralization branch.
+    expect(screen.getByTestId("copilot-library-skills-link").textContent).toBe(
+      "1 skill",
+    );
+    expect(
+      screen.getByTestId("copilot-library-followups-link").textContent,
+    ).toBe("1 scheduled");
+    // Separator dot is only rendered when BOTH links are visible.
+    const pill = screen.getByTestId("copilot-library-summary");
+    expect(pill.textContent).toContain("•");
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -1,9 +1,11 @@
 import {
   getDeleteV1DeleteExecutionScheduleMockHandler,
   getDeleteV1DeleteExecutionScheduleMockHandler422,
+  getGetV1ListExecutionSchedulesForAUserMockHandler,
   getListCopilotFollowupSchedulesMockHandler,
 } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
 import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { server } from "@/mocks/mock-server";
 import {
   fireEvent,
@@ -46,6 +48,32 @@ function makeFollowup(
   };
 }
 
+function makeGraphSchedule(
+  overrides: Partial<GraphExecutionJobInfo>,
+): GraphExecutionJobInfo {
+  return {
+    id: "graph-sched-1",
+    name: "Daily summary",
+    user_id: "user-1",
+    graph_id: "graph-abc",
+    graph_version: 1,
+    agent_name: "Daily summary agent",
+    cron: "0 9 * * *",
+    input_data: {},
+    next_run_time: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
+    kind: "graph",
+    timezone: "UTC",
+    ...overrides,
+  };
+}
+
+// Default zero-graph-schedules handler so tests that only care about
+// followups don't have to mock the graph-schedules endpoint too.  The
+// page now fetches BOTH on mount (unified Scheduled view).
+function defaultGraphSchedulesHandler() {
+  return getGetV1ListExecutionSchedulesForAUserMockHandler([]);
+}
+
 describe("FollowupsPage", () => {
   beforeEach(() => {
     toastMock.mockClear();
@@ -56,7 +84,10 @@ describe("FollowupsPage", () => {
   });
 
   test("renders empty state when no follow-ups exist", async () => {
-    server.use(getListCopilotFollowupSchedulesMockHandler([]));
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      defaultGraphSchedulesHandler(),
+    );
 
     render(<FollowupsPage />);
 
@@ -74,6 +105,7 @@ describe("FollowupsPage", () => {
           session_id: "session-zzzzzzzzzz",
         }),
       ]),
+      defaultGraphSchedulesHandler(),
     );
 
     render(<FollowupsPage />);
@@ -91,6 +123,7 @@ describe("FollowupsPage", () => {
       getListCopilotFollowupSchedulesMockHandler([
         makeFollowup({ id: "f1", session_id: "session-abcdef0123" }),
       ]),
+      defaultGraphSchedulesHandler(),
     );
 
     render(<FollowupsPage />);
@@ -107,6 +140,7 @@ describe("FollowupsPage", () => {
       getListCopilotFollowupSchedulesMockHandler([
         makeFollowup({ id: "f1", session_id: null as unknown as string }),
       ]),
+      defaultGraphSchedulesHandler(),
     );
 
     render(<FollowupsPage />);
@@ -124,6 +158,7 @@ describe("FollowupsPage", () => {
   test("Cancel button opens the confirmation dialog and calls the delete API", async () => {
     server.use(
       getListCopilotFollowupSchedulesMockHandler([makeFollowup({ id: "f1" })]),
+      defaultGraphSchedulesHandler(),
       getDeleteV1DeleteExecutionScheduleMockHandler(),
     );
 
@@ -142,9 +177,33 @@ describe("FollowupsPage", () => {
     });
   });
 
+  test("unified page renders graph schedule rows alongside copilot followups", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([
+        makeFollowup({ id: "f1", message: "First follow-up message" }),
+      ]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({ id: "g1", agent_name: "Nightly cleanup" }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    // Followup row still renders.
+    expect(await screen.findByText("First follow-up message")).toBeDefined();
+    // Graph-kind row renders with its agent name + the "Agent run" badge.
+    expect(screen.getByText("Nightly cleanup")).toBeDefined();
+    const graphRow = screen.getByTestId("schedule-row");
+    expect(graphRow.getAttribute("data-schedule-kind")).toBe("graph");
+    expect(within(graphRow).getByTestId("schedule-kind-badge").textContent).toBe(
+      "Agent run",
+    );
+  });
+
   test("shows a destructive toast when the delete API fails", async () => {
     server.use(
       getListCopilotFollowupSchedulesMockHandler([makeFollowup({ id: "f1" })]),
+      defaultGraphSchedulesHandler(),
       getDeleteV1DeleteExecutionScheduleMockHandler422(),
     );
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -237,7 +237,10 @@ describe("FollowupsPage", () => {
         makeGraphSchedule({
           id: "g-once",
           agent_name: "One shot",
-          cron: null,
+          // Backend returns null for one-shot graph schedules; the
+          // generated type says ``string`` but we exercise the runtime
+          // null-guard in `useGraphScheduleListItem` so cast through.
+          cron: null as unknown as string,
         }),
       ]),
     );

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -274,12 +274,21 @@ describe("FollowupsPage", () => {
           agent_name: "" as unknown as string,
           name: "My schedule name",
         }),
+        makeGraphSchedule({
+          id: "g-fallback-default",
+          agent_name: "" as unknown as string,
+          name: "",
+        }),
       ]),
     );
 
     render(<FollowupsPage />);
 
+    // Second-tier fallback: schedule name renders when agent_name is empty.
     expect(await screen.findByText("My schedule name")).toBeDefined();
+    // Final fallback: the literal "Scheduled agent" renders when BOTH
+    // agent_name and name are empty.
+    expect(screen.getByText("Scheduled agent")).toBeDefined();
   });
 
   test("graph row: clicking View opens the dialog with graph metadata", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -195,9 +195,9 @@ describe("FollowupsPage", () => {
     expect(screen.getByText("Nightly cleanup")).toBeDefined();
     const graphRow = screen.getByTestId("schedule-row");
     expect(graphRow.getAttribute("data-schedule-kind")).toBe("graph");
-    expect(within(graphRow).getByTestId("schedule-kind-badge").textContent).toBe(
-      "Agent run",
-    );
+    expect(
+      within(graphRow).getByTestId("schedule-kind-badge").textContent,
+    ).toBe("Agent run");
   });
 
   test("shows a destructive toast when the delete API fails", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/__tests__/main.test.tsx
@@ -224,4 +224,162 @@ describe("FollowupsPage", () => {
       );
     });
   });
+
+  test("graph row: cron is humanized when present, falls back to 'Runs once' when null", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({
+          id: "g-cron",
+          agent_name: "Daily summary",
+          cron: "0 9 * * *",
+        }),
+        makeGraphSchedule({
+          id: "g-once",
+          agent_name: "One shot",
+          cron: null,
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const rows = await screen.findAllByTestId("schedule-row");
+    expect(rows).toHaveLength(2);
+    // Recurring schedule humanizes the cron expression — the cron lib
+    // turns ``0 9 * * *`` into a phrase starting with "At 9:00 AM" or
+    // similar. We only assert the row does NOT render the raw cron
+    // string or "Runs once".
+    const cronRow = rows.find(
+      (r) => r.getAttribute("data-schedule-id") === "g-cron",
+    )!;
+    expect(within(cronRow).queryByText("Runs once")).toBeNull();
+    expect(within(cronRow).queryByText("0 9 * * *")).toBeNull();
+    // One-shot (cron=null) renders the "Runs once" label.
+    const onceRow = rows.find(
+      (r) => r.getAttribute("data-schedule-id") === "g-once",
+    )!;
+    expect(within(onceRow).getByText("Runs once")).toBeDefined();
+  });
+
+  test("graph row: agentLabel falls back to schedule name then 'Scheduled agent' when agent_name missing", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({
+          id: "g-fallback-name",
+          agent_name: "" as unknown as string,
+          name: "My schedule name",
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    expect(await screen.findByText("My schedule name")).toBeDefined();
+  });
+
+  test("graph row: clicking View opens the dialog with graph metadata", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({
+          id: "g-view",
+          agent_name: "Nightly cleanup",
+          graph_id: "graph-xyz",
+          graph_version: 7,
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const row = await screen.findByTestId("schedule-row");
+    fireEvent.click(within(row).getByTestId("schedule-view-button"));
+
+    // Dialog renders graph_id + version line.
+    expect(await screen.findByText(/graph-xyz/)).toBeDefined();
+    expect(screen.getByText(/v7/)).toBeDefined();
+  });
+
+  test("graph row: delete success path shows the success toast", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({ id: "g-del" }),
+      ]),
+      getDeleteV1DeleteExecutionScheduleMockHandler(),
+    );
+
+    render(<FollowupsPage />);
+
+    const row = await screen.findByTestId("schedule-row");
+    fireEvent.click(within(row).getByTestId("schedule-delete-button"));
+
+    const confirmButton = await screen.findByTestId("schedule-confirm-delete");
+    fireEvent.click(confirmButton);
+
+    await vi.waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Schedule deleted" }),
+      );
+    });
+  });
+
+  test("graph row: delete error path shows the destructive toast", async () => {
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({ id: "g-del-err" }),
+      ]),
+      getDeleteV1DeleteExecutionScheduleMockHandler422(),
+    );
+
+    render(<FollowupsPage />);
+
+    const row = await screen.findByTestId("schedule-row");
+    fireEvent.click(within(row).getByTestId("schedule-delete-button"));
+
+    const confirmButton = await screen.findByTestId("schedule-confirm-delete");
+    fireEvent.click(confirmButton);
+
+    await vi.waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to delete schedule",
+          variant: "destructive",
+        }),
+      );
+    });
+  });
+
+  test("unified page sorts items by next_run_time ascending", async () => {
+    const soon = new Date(Date.now() + 5 * 60 * 1000).toISOString(); // 5 min
+    const later = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(); // 2 h
+    server.use(
+      getListCopilotFollowupSchedulesMockHandler([
+        makeFollowup({
+          id: "f-later",
+          message: "Later followup",
+          next_run_time: later,
+        }),
+      ]),
+      getGetV1ListExecutionSchedulesForAUserMockHandler([
+        makeGraphSchedule({
+          id: "g-soon",
+          agent_name: "Sooner agent",
+          next_run_time: soon,
+        }),
+      ]),
+    );
+
+    render(<FollowupsPage />);
+
+    const list = await screen.findByTestId("followups-list");
+    const items = within(list).getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    // Sooner graph schedule comes first; later followup second.
+    expect(within(items[0]).getByText("Sooner agent")).toBeDefined();
+    expect(within(items[1]).getByText("Later followup")).toBeDefined();
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/EmptyFollowups/EmptyFollowups.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/EmptyFollowups/EmptyFollowups.tsx
@@ -14,9 +14,9 @@ export function EmptyFollowups() {
         Nothing scheduled
       </Text>
       <Text variant="body" className="max-w-md !text-zinc-500">
-        Ask your copilot to schedule a follow-up, or add a recurring schedule
-        to an agent from the builder — both will show up here so you can
-        review or cancel them.
+        Ask your copilot to schedule a follow-up, or add a recurring schedule to
+        an agent from the builder — both will show up here so you can review or
+        cancel them.
       </Text>
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/EmptyFollowups/EmptyFollowups.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/EmptyFollowups/EmptyFollowups.tsx
@@ -11,12 +11,12 @@ export function EmptyFollowups() {
         <ClockClockwiseIcon size={24} className="text-yellow-700" />
       </div>
       <Text variant="h4" className="text-zinc-900">
-        No copilot follow-ups
+        Nothing scheduled
       </Text>
       <Text variant="body" className="max-w-md !text-zinc-500">
-        Ask your copilot to schedule something for later and it will show up
-        here so you can cancel it. To change a follow-up, cancel and ask the
-        copilot to schedule a new one.
+        Ask your copilot to schedule a follow-up, or add a recurring schedule
+        to an agent from the builder — both will show up here so you can
+        review or cancel them.
       </Text>
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/GraphScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/GraphScheduleListItem.tsx
@@ -141,8 +141,7 @@ export function GraphScheduleListItem({ schedule }: Props) {
           <div className="flex flex-col gap-4">
             <Text variant="large">
               Delete this scheduled agent run? The agent will stop running on
-              this schedule and you can recreate it from the builder if
-              needed.
+              this schedule and you can recreate it from the builder if needed.
             </Text>
             <Dialog.Footer>
               <Button

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/GraphScheduleListItem.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/GraphScheduleListItem.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { CalendarDotsIcon, EyeIcon, TrashIcon } from "@phosphor-icons/react";
+import Link from "next/link";
+import { useGraphScheduleListItem } from "./useGraphScheduleListItem";
+
+interface Props {
+  schedule: GraphExecutionJobInfo;
+}
+
+export function GraphScheduleListItem({ schedule }: Props) {
+  const {
+    nextRunLabel,
+    nextRunTitle,
+    recurrenceLabel,
+    agentLabel,
+    agentHref,
+    isDeleteOpen,
+    openDelete,
+    closeDelete,
+    isDeleting,
+    handleDelete,
+    isViewOpen,
+    openView,
+    closeView,
+  } = useGraphScheduleListItem({ schedule });
+
+  return (
+    <div
+      className="flex w-full flex-col gap-3 rounded-large border border-zinc-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
+      data-testid="schedule-row"
+      data-schedule-id={schedule.id}
+      data-schedule-kind="graph"
+    >
+      <Link
+        href={agentHref}
+        className="flex min-w-0 flex-1 items-start gap-3 hover:opacity-80"
+        data-testid="schedule-open-agent"
+      >
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-large border border-slate-50 bg-emerald-50">
+          <CalendarDotsIcon
+            size={18}
+            className="text-emerald-700"
+            weight="bold"
+          />
+        </div>
+        <div className="flex min-w-0 flex-col gap-1">
+          <Text
+            variant="body-medium"
+            className="block w-full truncate text-ellipsis"
+          >
+            {agentLabel}
+          </Text>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+            <Text
+              variant="small"
+              className="!text-zinc-500"
+              title={nextRunTitle}
+            >
+              {nextRunLabel}
+            </Text>
+            <span className="text-zinc-300">•</span>
+            <Text variant="small" className="!text-zinc-500">
+              {recurrenceLabel}
+            </Text>
+            <span className="text-zinc-300">•</span>
+            <span
+              className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs text-emerald-700"
+              data-testid="schedule-kind-badge"
+            >
+              Agent run
+            </span>
+          </div>
+        </div>
+      </Link>
+
+      <div className="flex flex-shrink-0 items-center gap-2">
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={openView}
+          data-testid="schedule-view-button"
+          aria-label="View schedule"
+        >
+          <EyeIcon className="mr-1 h-4 w-4" />
+          View
+        </Button>
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={openDelete}
+          data-testid="schedule-delete-button"
+          aria-label="Delete schedule"
+        >
+          <TrashIcon className="mr-1 h-4 w-4" />
+          Delete
+        </Button>
+      </div>
+
+      <Dialog
+        controlled={{ isOpen: isViewOpen, set: closeView }}
+        styling={{ maxWidth: "40rem" }}
+        title="Scheduled agent run"
+      >
+        <Dialog.Content>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <Text variant="small" className="!text-zinc-500">
+                {nextRunLabel}
+              </Text>
+              <span className="text-zinc-300">•</span>
+              <Text variant="small" className="!text-zinc-500">
+                {recurrenceLabel}
+              </Text>
+              <span className="text-zinc-300">•</span>
+              <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs text-emerald-700">
+                Agent run
+              </span>
+            </div>
+            <Text variant="body-medium">{agentLabel}</Text>
+            <Text variant="small" className="!text-zinc-500">
+              Schedule name: {schedule.name}
+            </Text>
+            <Text variant="small" className="!text-zinc-500">
+              Graph: {schedule.graph_id} (v{schedule.graph_version})
+            </Text>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+
+      <Dialog
+        controlled={{ isOpen: isDeleteOpen, set: closeDelete }}
+        styling={{ maxWidth: "32rem" }}
+        title="Delete scheduled agent run"
+      >
+        <Dialog.Content>
+          <div className="flex flex-col gap-4">
+            <Text variant="large">
+              Delete this scheduled agent run? The agent will stop running on
+              this schedule and you can recreate it from the builder if
+              needed.
+            </Text>
+            <Dialog.Footer>
+              <Button
+                variant="secondary"
+                disabled={isDeleting}
+                onClick={() => closeDelete(false)}
+              >
+                Keep it
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                loading={isDeleting}
+                data-testid="schedule-confirm-delete"
+              >
+                Yes, delete
+              </Button>
+            </Dialog.Footer>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -1,0 +1,99 @@
+import {
+  getGetV1ListExecutionSchedulesForAUserQueryKey,
+  useDeleteV1DeleteExecutionSchedule,
+} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { humanizeCronExpression } from "@/lib/cron-expression-utils";
+import { useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { useState } from "react";
+
+interface Args {
+  schedule: GraphExecutionJobInfo;
+}
+
+export function useGraphScheduleListItem({ schedule }: Args) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isViewOpen, setIsViewOpen] = useState(false);
+
+  const { mutateAsync: deleteSchedule, isPending: isDeleting } =
+    useDeleteV1DeleteExecutionSchedule();
+
+  const nextRunDate = schedule.next_run_time
+    ? new Date(schedule.next_run_time)
+    : null;
+  const nextRunLabel =
+    nextRunDate && !Number.isNaN(nextRunDate.valueOf())
+      ? `Next ${formatDistanceToNow(nextRunDate, { addSuffix: true })}`
+      : "Pending";
+  const nextRunTitle = nextRunDate ? nextRunDate.toString() : undefined;
+
+  const recurrenceLabel = schedule.cron
+    ? safeHumanizeCron(schedule.cron)
+    : "Runs once";
+
+  const agentLabel = schedule.agent_name || schedule.name || "Scheduled agent";
+  const agentHref = `/build?flowID=${schedule.graph_id}&flowVersion=${schedule.graph_version}`;
+
+  function openDelete() {
+    setIsDeleteOpen(true);
+  }
+  function closeDelete(open: boolean) {
+    setIsDeleteOpen(open);
+  }
+  function openView() {
+    setIsViewOpen(true);
+  }
+  function closeView(open: boolean) {
+    setIsViewOpen(open);
+  }
+
+  async function handleDelete() {
+    try {
+      await deleteSchedule({ scheduleId: schedule.id });
+      toast({ title: "Schedule deleted" });
+      setIsDeleteOpen(false);
+      // Refresh BOTH lists since the briefing pill counts both kinds
+      // and the user expects the deleted row to disappear immediately.
+      queryClient.invalidateQueries({
+        queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
+      });
+    } catch (error) {
+      toast({
+        title: "Failed to delete schedule",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An unexpected error occurred.",
+        variant: "destructive",
+      });
+    }
+  }
+
+  return {
+    nextRunLabel,
+    nextRunTitle,
+    recurrenceLabel,
+    agentLabel,
+    agentHref,
+    isDeleteOpen,
+    openDelete,
+    closeDelete,
+    isDeleting,
+    handleDelete,
+    isViewOpen,
+    openView,
+    closeView,
+  };
+}
+
+function safeHumanizeCron(cron: string): string {
+  try {
+    return humanizeCronExpression(cron);
+  } catch {
+    return cron;
+  }
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
@@ -8,13 +8,14 @@ import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
 import { EmptyFollowups } from "./components/EmptyFollowups/EmptyFollowups";
 import { FollowupListItem } from "./components/FollowupListItem/FollowupListItem";
+import { GraphScheduleListItem } from "./components/GraphScheduleListItem/GraphScheduleListItem";
 import { useFollowupsPage } from "./useFollowupsPage";
 
 export default function FollowupsPage() {
-  const { followups, isLoading, error } = useFollowupsPage();
+  const { schedules, isLoading, error } = useFollowupsPage();
 
   useEffect(() => {
-    document.title = "Copilot follow-ups – AutoGPT Platform";
+    document.title = "Scheduled – AutoGPT Platform";
   }, []);
 
   return (
@@ -28,10 +29,12 @@ export default function FollowupsPage() {
         Back to Library
       </Link>
       <header className="flex flex-col gap-2">
-        <Text variant="h2">Copilot follow-ups</Text>
+        <Text variant="h2">Scheduled</Text>
         <Text variant="body" className="!text-zinc-500">
-          Scheduled messages your copilot sessions will send themselves. Open a
-          row to jump into the session, or cancel one you no longer need.
+          Every automated job in one place — follow-up messages your copilot
+          will send itself AND recurring agent runs from the builder. Open a
+          row to jump into the session / agent, or cancel one you no longer
+          need.
         </Text>
       </header>
 
@@ -41,9 +44,9 @@ export default function FollowupsPage() {
             message:
               error instanceof Error
                 ? error.message
-                : "Failed to load follow-ups",
+                : "Failed to load schedules",
           }}
-          context="copilot follow-ups"
+          context="scheduled items"
         />
       ) : isLoading ? (
         <div
@@ -52,17 +55,21 @@ export default function FollowupsPage() {
         >
           <LoadingSpinner />
         </div>
-      ) : followups.length === 0 ? (
+      ) : schedules.length === 0 ? (
         <EmptyFollowups />
       ) : (
         <ul
           className="flex flex-col gap-3"
           data-testid="followups-list"
-          aria-label="Copilot follow-ups"
+          aria-label="Scheduled items"
         >
-          {followups.map((followup) => (
-            <li key={followup.id}>
-              <FollowupListItem followup={followup} />
+          {schedules.map((schedule) => (
+            <li key={`${schedule.kind}:${schedule.item.id}`}>
+              {schedule.kind === "copilot_turn" ? (
+                <FollowupListItem followup={schedule.item} />
+              ) : (
+                <GraphScheduleListItem schedule={schedule.item} />
+              )}
             </li>
           ))}
         </ul>

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/page.tsx
@@ -32,9 +32,8 @@ export default function FollowupsPage() {
         <Text variant="h2">Scheduled</Text>
         <Text variant="body" className="!text-zinc-500">
           Every automated job in one place — follow-up messages your copilot
-          will send itself AND recurring agent runs from the builder. Open a
-          row to jump into the session / agent, or cancel one you no longer
-          need.
+          will send itself AND recurring agent runs from the builder. Open a row
+          to jump into the session / agent, or cancel one you no longer need.
         </Text>
       </header>
 

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/useFollowupsPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/useFollowupsPage.ts
@@ -1,16 +1,58 @@
-import { useListCopilotFollowupSchedules } from "@/app/api/__generated__/endpoints/schedules/schedules";
+import {
+  useGetV1ListExecutionSchedulesForAUser,
+  useListCopilotFollowupSchedules,
+} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { okData } from "@/app/api/helpers";
 
+export type ScheduleItem =
+  | { kind: "copilot_turn"; item: CopilotTurnJobInfo }
+  | { kind: "graph"; item: GraphExecutionJobInfo };
+
+function nextRunMs(item: { next_run_time?: string | null }): number {
+  if (!item.next_run_time) return Number.POSITIVE_INFINITY;
+  const t = new Date(item.next_run_time).valueOf();
+  return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t;
+}
+
 export function useFollowupsPage() {
-  const query = useListCopilotFollowupSchedules({
-    query: {
-      select: (res) => okData(res) ?? [],
-    },
+  // Followups (copilot_turn) — the scheduled-message side of the
+  // feature.  Stored via ``schedule_followup`` MCP tool.
+  const copilotQuery = useListCopilotFollowupSchedules({
+    query: { select: (res) => okData(res) ?? [] },
+  });
+  // Graph schedules — recurring agent runs created via the agent
+  // builder.  Same scheduler, different ``kind`` discriminator.  This
+  // page now unifies both so users see ALL their pending automated
+  // work in one place (briefing pill, this list, single Delete flow).
+  const graphQuery = useGetV1ListExecutionSchedulesForAUser({
+    query: { select: (res) => okData(res) ?? [] },
   });
 
+  const copilotItems: ScheduleItem[] = (copilotQuery.data ?? []).map(
+    (item) => ({ kind: "copilot_turn" as const, item }),
+  );
+  const graphItems: ScheduleItem[] = (graphQuery.data ?? []).map((item) => ({
+    kind: "graph" as const,
+    item,
+  }));
+
+  // Merge + sort by next_run_time ascending so the soonest-firing
+  // schedule lands at the top.  Items with no ``next_run_time`` (e.g.
+  // a one-shot graph schedule that has already fired but hasn't been
+  // cleaned up yet) sink to the bottom.
+  const schedules = [...copilotItems, ...graphItems].sort(
+    (a, b) => nextRunMs(a.item) - nextRunMs(b.item),
+  );
+
   return {
-    followups: query.data ?? [],
-    isLoading: query.isLoading,
-    error: query.error,
+    // Backwards-compat alias — ``followups`` was the only-copilot
+    // collection name before unification.  Existing tests still
+    // reference it.
+    followups: copilotQuery.data ?? [],
+    schedules,
+    isLoading: copilotQuery.isLoading || graphQuery.isLoading,
+    error: copilotQuery.error ?? graphQuery.error,
   };
 }


### PR DESCRIPTION
## Why

Three things were left over after the autopilot consolidation shipped (#13190 + #13195):

1. **Naming drift** — the briefing pill said "Copilot library" even though the product is autopilot.
2. **Per-link hide on 0** — "1 skill · 0 follow-ups" reads as broken UX. Either count being zero should hide just that link.
3. **No kill-switch** — skills + scheduled-followups inject a `<available_skills>` / `<session_context>` block on every turn and gate the four MCP tools. If something regresses we need to disable them per-user without a redeploy.

Plus one piece of unification a sleep-late-Friday user asked for: `/library/followups` should show **both** copilot followups AND recurring agent schedules, since they're the same APScheduler primitive with a `kind` discriminator and the UX of having two separate pages is silly.

## What

### LD kill-switches (default-on)

Two new server-side LaunchDarkly flags, evaluated per-user, default `true`:

- **`copilot-skills`** — gates the four MCP tools (`store_skill` / `read_skill` / `delete_skill` / `list_skills`) and the per-turn `<available_skills>` block. When off, `build_skills_context` returns empty (no list query, no Redis hit) and every tool returns a structured `feature_disabled` error.
- **`copilot-scheduled-followups`** — gates the `schedule_followup` MCP tool and the `pending_followups` line inside `<session_context>`. When off, the tool returns `feature_disabled` and `build_session_context` collapses to the bare `session_id` line WITHOUT calling the scheduler RPC.

Local override pattern unchanged: `FORCE_FLAG_COPILOT_SKILLS=false` / `FORCE_FLAG_COPILOT_SCHEDULED_FOLLOWUPS=false` for dev.

### Briefing pill (`CopilotLibrarySummary`)

- Label: `Copilot library` → **`Autopilot library`**.
- Counts are independent now: shows `N skill(s)` only if N > 0, shows `M scheduled` only if M > 0, drops the `·` separator when only one is shown. Still hides the whole pill when both are 0 (no degenerate state).
- Scheduled count now sums **followups + graph schedules** so it mirrors what `/library/followups` displays.

### Unified Scheduled page (`/library/followups`)

Route name unchanged for backward compat, but the page is now "Scheduled":

- Title `Copilot follow-ups` → **`Scheduled`**.
- `useFollowupsPage` fetches BOTH `listCopilotFollowupSchedules` AND `getV1ListExecutionSchedulesForAUser`, merges into a discriminated `ScheduleItem[]`, sorts by `next_run_time` ascending.
- New `GraphScheduleListItem` component renders graph rows with an emerald "Agent run" badge, agent name, cron label, View dialog showing graph_id + schedule name, and a Delete flow that invalidates the graph-schedules query.
- Existing `FollowupListItem` (copilot_turn) untouched — just rendered as one branch of the polymorphic list.
- Empty-state copy: "No copilot follow-ups" → "Nothing scheduled" + mention both surfaces.

## How (highlights)

- **Skills helper**: `is_skills_feature_enabled(user_id)` returns `True` for anonymous (no user_id) so we don't surprise-break unauthenticated paths; otherwise reads the flag with `default=True`.
- **Followups helper**: `is_followups_feature_enabled(user_id)` same shape, lives in `session_context.py` so the gating function ships with the consumer.
- **Cost half of the kill-switch**: when off, scheduler RPC / list-files / Redis fetches are all skipped — flipping the flag also drops the per-turn cost to zero, not "still calls but ignores result".
- **Frontend merge over backend union**: kept the two existing typed REST endpoints (`/schedules` returns `list[GraphExecutionJobInfo]`, `/schedules/followups` returns `list[CopilotTurnJobInfo]`) and stitched them on the client. A unified `/schedules/all` endpoint with a discriminated union would have been cleaner but required a new model + openapi regen for marginal benefit.

## Test coverage

- **Backend** (102 passed):
  - `build_skills_context_empty_when_flag_disabled` — short-circuit verified
  - `build_skills_context_normal_when_flag_enabled` — happy path still works
  - `store_skill_returns_feature_disabled_when_flag_off` + `list_skills_…` — tool gating
  - `build_session_context_skips_scheduler_when_followups_disabled` — verifies the scheduler RPC is NOT called when off (via `AssertionError(...)` side-effect on the mock)
  - `schedule_followup returns_feature_disabled_when_flag_off` — tool gating + scheduler spy
- **Frontend**: existing skills + followups page suites should still pass post-rename; will run via CI.
- **Live functional /pr-test**: planned on dev preview after the redeploy that pulls this commit.

## Out of scope

- Unifying the MCP tool surface (one `schedule(kind=...)` instead of two tools) — refactor deferred.
- New `/schedules/all` REST endpoint — frontend stitching is enough today.
- Renaming the `/library/followups` route — backward compat with existing deep-links from the briefing pill etc.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Tests added for new behaviors (flag-off paths)
- [x] No new warnings
- [x] Authorization unchanged — endpoints + helpers still scope by `user_id` from auth
- [ ] CI green
- [ ] `/pr-test` on dev-preview validates pill + Scheduled page + flag kill-switch
