### PR TITLE
fix(frontend/library): unify schedule cache invalidation across all 4 affected query keys

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/CronSchedulerDialog/useCronSchedulerDialog.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/CronSchedulerDialog/useCronSchedulerDialog.test.tsx
@@ -1,0 +1,104 @@
+import { getPostV1CreateExecutionScheduleMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import { server } from "@/mocks/mock-server";
+import * as invalidateSchedules from "@/services/schedules/invalidate-schedules";
+import { act, renderHook, waitFor } from "@/tests/integrations/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useCronSchedulerDialog } from "./useCronSchedulerDialog";
+
+function makeWrapper(searchParams: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return (
+      <QueryClientProvider client={client}>
+        <NuqsTestingAdapter searchParams={searchParams}>
+          {children}
+        </NuqsTestingAdapter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const toastMock = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+afterEach(() => {
+  toastMock.mockClear();
+  server.resetHandlers();
+});
+
+describe("useCronSchedulerDialog", () => {
+  test("successful create invalidates ALL schedule queries (regression: previously invalidated NONE)", async () => {
+    server.use(getPostV1CreateExecutionScheduleMockHandler());
+    const invalidateSpy = vi.spyOn(
+      invalidateSchedules,
+      "invalidateAllScheduleQueries",
+    );
+
+    const setOpen = vi.fn();
+    const { result } = renderHook(
+      () =>
+        useCronSchedulerDialog({
+          open: true,
+          setOpen,
+          inputs: {},
+          credentials: {},
+        }),
+      { wrapper: makeWrapper("?flowID=graph-xyz&flowVersion=2") },
+    );
+
+    act(() => {
+      result.current.setCronExpression("0 9 * * *");
+      result.current.setScheduleName("Morning run");
+    });
+
+    await act(async () => {
+      await result.current.handleCreateSchedule();
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "graph-xyz",
+      );
+    });
+    invalidateSpy.mockRestore();
+  });
+
+  test("empty cron expression shows destructive toast and skips the mutation", async () => {
+    const { result } = renderHook(
+      () =>
+        useCronSchedulerDialog({
+          open: true,
+          setOpen: vi.fn(),
+          inputs: {},
+          credentials: {},
+        }),
+      { wrapper: makeWrapper("?flowID=g&flowVersion=1") },
+    );
+
+    await act(async () => {
+      await result.current.handleCreateSchedule();
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Invalid schedule",
+        variant: "destructive",
+      }),
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/CronSchedulerDialog/useCronSchedulerDialog.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderActions/components/CronSchedulerDialog/useCronSchedulerDialog.ts
@@ -2,6 +2,8 @@ import { usePostV1CreateExecutionSchedule } from "@/app/api/__generated__/endpoi
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { useUserTimezone } from "@/lib/hooks/useUserTimezone";
 import { getTimezoneDisplayName } from "@/lib/timezone-utils";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
+import { useQueryClient } from "@tanstack/react-query";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useState } from "react";
 
@@ -19,6 +21,7 @@ export const useCronSchedulerDialog = ({
   defaultCronExpression?: string;
 }) => {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [cronExpression, setCronExpression] = useState<string>("");
   const [scheduleName, setScheduleName] = useState<string>("");
 
@@ -41,6 +44,7 @@ export const useCronSchedulerDialog = ({
               title: "Schedule created",
               description: "Schedule created successfully",
             });
+            invalidateAllScheduleQueries(queryClient, flowID ?? undefined);
           }
         },
         onError: (error) => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/ScheduleAgentModal/useScheduleAgentModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/ScheduleAgentModal/useScheduleAgentModal.test.tsx
@@ -1,0 +1,80 @@
+import { getPostV1CreateExecutionScheduleMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { server } from "@/mocks/mock-server";
+import * as invalidateSchedules from "@/services/schedules/invalidate-schedules";
+import { act, renderHook, waitFor } from "@/tests/integrations/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useScheduleAgentModal } from "./useScheduleAgentModal";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const toastMock = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+const agent = {
+  id: "lib-1",
+  graph_id: "graph-xyz",
+  graph_version: 1,
+  name: "My agent",
+  recommended_schedule_cron: null,
+} as unknown as LibraryAgent;
+
+afterEach(() => {
+  toastMock.mockClear();
+  server.resetHandlers();
+});
+
+describe("useScheduleAgentModal", () => {
+  test("create schedule invalidates ALL schedule queries on success so unified page + briefing pill refresh", async () => {
+    server.use(getPostV1CreateExecutionScheduleMockHandler());
+    const invalidateSpy = vi.spyOn(
+      invalidateSchedules,
+      "invalidateAllScheduleQueries",
+    );
+
+    const { result } = renderHook(() => useScheduleAgentModal(agent, {}, {}), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.handleSchedule("My schedule", "0 9 * * *");
+    });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Schedule created" }),
+      );
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(expect.anything(), "graph-xyz");
+    invalidateSpy.mockRestore();
+  });
+
+  test("empty schedule name surfaces destructive toast and rejects without firing mutation", async () => {
+    const { result } = renderHook(() => useScheduleAgentModal(agent, {}, {}), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.handleSchedule("   ", "0 9 * * *"),
+    ).rejects.toThrow("Schedule name required");
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/ScheduleAgentModal/useScheduleAgentModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/modals/ScheduleAgentModal/useScheduleAgentModal.ts
@@ -1,12 +1,10 @@
-import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
-import { useState, useCallback, useMemo } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { useToast } from "@/components/molecules/Toast/use-toast";
-import {
-  usePostV1CreateExecutionSchedule as useCreateSchedule,
-  getGetV1ListExecutionSchedulesForAGraphQueryKey,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { usePostV1CreateExecutionSchedule as useCreateSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
 
 interface UseScheduleAgentModalCallbacks {
   onCreateSchedule?: (schedule: GraphExecutionJobInfo) => void;
@@ -36,12 +34,7 @@ export function useScheduleAgentModal(
             title: "Schedule created",
           });
           callbacks?.onCreateSchedule?.(response.data);
-          // Invalidate schedules list for this graph
-          queryClient.invalidateQueries({
-            queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey(
-              agent.graph_id,
-            ),
-          });
+          invalidateAllScheduleQueries(queryClient, agent.graph_id);
           // Reset form
           setScheduleName(defaultScheduleName);
           setCronExpression(agent.recommended_schedule_cron || "0 9 * * 1");

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/RunDetailHeader/useScheduleDetailHeader.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/RunDetailHeader/useScheduleDetailHeader.test.tsx
@@ -1,0 +1,82 @@
+import { getDeleteV1DeleteExecutionScheduleMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import { server } from "@/mocks/mock-server";
+import * as invalidateSchedules from "@/services/schedules/invalidate-schedules";
+import { act, renderHook, waitFor } from "@/tests/integrations/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useScheduleDetailHeader } from "./useScheduleDetailHeader";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const toastMock = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+afterEach(() => {
+  toastMock.mockClear();
+  server.resetHandlers();
+});
+
+describe("useScheduleDetailHeader", () => {
+  test("deleteSchedule calls the unified invalidator with the graphId so unified page + briefing pill refresh", async () => {
+    server.use(getDeleteV1DeleteExecutionScheduleMockHandler());
+    const invalidateSpy = vi.spyOn(
+      invalidateSchedules,
+      "invalidateAllScheduleQueries",
+    );
+
+    const { result } = renderHook(
+      () => useScheduleDetailHeader("graph-xyz", "sched-1", 7),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.deleteSchedule();
+    });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Schedule deleted" }),
+      );
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(expect.anything(), "graph-xyz");
+    invalidateSpy.mockRestore();
+  });
+
+  test("openInBuilderHref includes graph id + version for the builder link", () => {
+    const { result } = renderHook(
+      () => useScheduleDetailHeader("graph-xyz", undefined, 3),
+      { wrapper },
+    );
+    expect(result.current.openInBuilderHref).toBe(
+      "/build?flowID=graph-xyz&flowVersion=3",
+    );
+  });
+
+  test("deleteSchedule is a no-op when scheduleId is undefined", () => {
+    const { result } = renderHook(
+      () => useScheduleDetailHeader("graph-xyz", undefined, 1),
+      { wrapper },
+    );
+    // Should not throw and isDeleting should never flip.
+    act(() => {
+      result.current.deleteSchedule();
+    });
+    expect(result.current.isDeleting).toBe(false);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/RunDetailHeader/useScheduleDetailHeader.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/RunDetailHeader/useScheduleDetailHeader.ts
@@ -1,11 +1,9 @@
 "use client";
 
+import { useDeleteV1DeleteExecutionSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  useDeleteV1DeleteExecutionSchedule,
-  getGetV1ListExecutionSchedulesForAGraphQueryOptions,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
 
 export function useScheduleDetailHeader(
   agentGraphId: string,
@@ -19,11 +17,7 @@ export function useScheduleDetailHeader(
     mutation: {
       onSuccess: () => {
         toast({ title: "Schedule deleted" });
-        queryClient.invalidateQueries({
-          queryKey:
-            getGetV1ListExecutionSchedulesForAGraphQueryOptions(agentGraphId)
-              .queryKey,
-        });
+        invalidateAllScheduleQueries(queryClient, agentGraphId);
       },
       onError: (error: any) =>
         toast({

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/EditScheduleModal/useEditScheduleModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/EditScheduleModal/useEditScheduleModal.test.tsx
@@ -1,0 +1,108 @@
+import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import * as invalidateSchedules from "@/services/schedules/invalidate-schedules";
+import { act, renderHook, waitFor } from "@/tests/integrations/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { useEditScheduleModal } from "./useEditScheduleModal";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const toastMock = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+const fetchMock = vi.fn();
+
+const schedule = {
+  id: "sched-1",
+  name: "Daily",
+  cron: "0 9 * * *",
+} as unknown as GraphExecutionJobInfo;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  toastMock.mockClear();
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useEditScheduleModal", () => {
+  test("successful PATCH invalidates ALL schedule queries (regression: previously only invalidated per-graph)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+    const invalidateSpy = vi.spyOn(
+      invalidateSchedules,
+      "invalidateAllScheduleQueries",
+    );
+
+    const { result } = renderHook(
+      () => useEditScheduleModal("graph-xyz", schedule),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "graph-xyz",
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/schedules/sched-1",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  test("failed PATCH surfaces destructive toast and does NOT invalidate", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: "Bad cron" }),
+    });
+    const invalidateSpy = vi.spyOn(
+      invalidateSchedules,
+      "invalidateAllScheduleQueries",
+    );
+
+    const { result } = renderHook(
+      () => useEditScheduleModal("graph-xyz", schedule),
+      { wrapper },
+    );
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync();
+      }),
+    ).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+        }),
+      );
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/EditScheduleModal/useEditScheduleModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/EditScheduleModal/useEditScheduleModal.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
 });
 
 const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
 
 const schedule = {
   id: "sched-1",
@@ -41,6 +42,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  globalThis.fetch = originalFetch;
 });
 
 describe("useEditScheduleModal", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/EditScheduleModal/useEditScheduleModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/EditScheduleModal/useEditScheduleModal.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import { getGetV1ListExecutionSchedulesForAGraphQueryKey } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import { getGetV1ListGraphExecutionsQueryKey } from "@/app/api/__generated__/endpoints/graphs/graphs";
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import {
@@ -91,9 +91,7 @@ export function useEditScheduleModal(
       return res.json();
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey(graphId),
-      });
+      invalidateAllScheduleQueries(queryClient, graphId);
       const runsKey = getGetV1ListGraphExecutionsQueryKey(graphId);
       await queryClient.invalidateQueries({ queryKey: runsKey });
       setIsOpen(false);

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/SelectedScheduleActions/useSelectedScheduleActions.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/SelectedScheduleActions/useSelectedScheduleActions.test.tsx
@@ -1,0 +1,107 @@
+import { getDeleteV1DeleteExecutionScheduleMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import { server } from "@/mocks/mock-server";
+import * as invalidateSchedules from "@/services/schedules/invalidate-schedules";
+import { act, renderHook, waitFor } from "@/tests/integrations/test-utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useSelectedScheduleActions } from "./useSelectedScheduleActions";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const toastMock = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return {
+    ...actual,
+    useToast: () => ({ toast: toastMock }),
+  };
+});
+
+const agent = {
+  id: "lib-1",
+  graph_id: "graph-xyz",
+  graph_version: 1,
+} as unknown as LibraryAgent;
+
+afterEach(() => {
+  toastMock.mockClear();
+  server.resetHandlers();
+});
+
+describe("useSelectedScheduleActions", () => {
+  test("handleDelete invalidates ALL schedule queries for the graph on success", async () => {
+    server.use(getDeleteV1DeleteExecutionScheduleMockHandler());
+    const invalidateSpy = vi.spyOn(
+      invalidateSchedules,
+      "invalidateAllScheduleQueries",
+    );
+
+    const { result } = renderHook(
+      () =>
+        useSelectedScheduleActions({
+          agent,
+          scheduleId: "sched-1",
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.handleDelete();
+    });
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Schedule deleted" }),
+      );
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(expect.anything(), "graph-xyz");
+    invalidateSpy.mockRestore();
+  });
+
+  test("openInBuilderHref points to /build with graph id + version", () => {
+    const { result } = renderHook(
+      () =>
+        useSelectedScheduleActions({
+          agent,
+          scheduleId: "sched-1",
+        }),
+      { wrapper },
+    );
+    expect(result.current.openInBuilderHref).toBe(
+      "/build?flowID=graph-xyz&flowVersion=1",
+    );
+  });
+
+  test("handleRunNow without a loaded schedule surfaces a destructive toast", async () => {
+    const { result } = renderHook(
+      () =>
+        useSelectedScheduleActions({
+          agent,
+          scheduleId: "sched-1",
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleRunNow();
+    });
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Schedule not loaded",
+        variant: "destructive",
+      }),
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/SelectedScheduleActions/useSelectedScheduleActions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/selected-views/SelectedScheduleView/components/SelectedScheduleActions/useSelectedScheduleActions.ts
@@ -4,14 +4,12 @@ import {
   getGetV1ListGraphExecutionsQueryKey,
   usePostV1ExecuteGraphAgent,
 } from "@/app/api/__generated__/endpoints/graphs/graphs";
-import {
-  getGetV1ListExecutionSchedulesForAGraphQueryOptions,
-  useDeleteV1DeleteExecutionSchedule,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useDeleteV1DeleteExecutionSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { okData } from "@/app/api/helpers";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -42,11 +40,7 @@ export function useSelectedScheduleActions({
 
         onDeleted?.();
 
-        queryClient.invalidateQueries({
-          queryKey: getGetV1ListExecutionSchedulesForAGraphQueryOptions(
-            agent.graph_id,
-          ).queryKey,
-        });
+        invalidateAllScheduleQueries(queryClient, agent.graph_id);
       },
       onError: (error: unknown) =>
         toast({

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleActionsDropdown.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/components/sidebar/SidebarRunsList/components/ScheduleActionsDropdown.tsx
@@ -4,10 +4,7 @@ import {
   getGetV1ListGraphExecutionsQueryKey,
   usePostV1ExecuteGraphAgent,
 } from "@/app/api/__generated__/endpoints/graphs/graphs";
-import {
-  getGetV1ListExecutionSchedulesForAGraphQueryOptions,
-  useDeleteV1DeleteExecutionSchedule,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useDeleteV1DeleteExecutionSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import type { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { okData } from "@/app/api/helpers";
@@ -22,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import { DotsThreeVertical } from "@phosphor-icons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -58,11 +56,7 @@ export function ScheduleActionsDropdown({
 
       onDeleted?.();
 
-      queryClient.invalidateQueries({
-        queryKey: getGetV1ListExecutionSchedulesForAGraphQueryOptions(
-          agent.graph_id,
-        ).queryKey,
-      });
+      invalidateAllScheduleQueries(queryClient, agent.graph_id);
     } catch (error: unknown) {
       toast({
         title: "Failed to delete schedule",

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/useFollowupListItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/FollowupListItem/useFollowupListItem.ts
@@ -1,10 +1,8 @@
-import {
-  getListCopilotFollowupSchedulesQueryKey,
-  useDeleteV1DeleteExecutionSchedule,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useDeleteV1DeleteExecutionSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import type { CopilotTurnJobInfo } from "@/app/api/__generated__/models/copilotTurnJobInfo";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { humanizeCronExpression } from "@/lib/cron-expression-utils";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { useState } from "react";
@@ -62,12 +60,7 @@ export function useFollowupListItem({ followup }: Args) {
       await deleteSchedule({ scheduleId: followup.id });
       toast({ title: "Follow-up deleted" });
       setIsDeleteOpen(false);
-      // Invalidation is the single source of truth — React Query will
-      // refetch the list automatically. No need for a parent-supplied
-      // `onDeleted` callback that would race the toast.
-      queryClient.invalidateQueries({
-        queryKey: getListCopilotFollowupSchedulesQueryKey(),
-      });
+      invalidateAllScheduleQueries(queryClient);
     } catch (error) {
       toast({
         title: "Failed to delete follow-up",

--- a/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/useGraphScheduleListItem.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/followups/components/GraphScheduleListItem/useGraphScheduleListItem.ts
@@ -1,10 +1,8 @@
-import {
-  getGetV1ListExecutionSchedulesForAUserQueryKey,
-  useDeleteV1DeleteExecutionSchedule,
-} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useDeleteV1DeleteExecutionSchedule } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import type { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { humanizeCronExpression } from "@/lib/cron-expression-utils";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import { useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { useState } from "react";
@@ -56,11 +54,7 @@ export function useGraphScheduleListItem({ schedule }: Args) {
       await deleteSchedule({ scheduleId: schedule.id });
       toast({ title: "Schedule deleted" });
       setIsDeleteOpen(false);
-      // Refresh BOTH lists since the briefing pill counts both kinds
-      // and the user expects the deleted row to disappear immediately.
-      queryClient.invalidateQueries({
-        queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
-      });
+      invalidateAllScheduleQueries(queryClient, schedule.graph_id);
     } catch (error) {
       toast({
         title: "Failed to delete schedule",

--- a/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.test.ts
+++ b/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.test.ts
@@ -8,18 +8,21 @@ import { describe, expect, test, vi } from "vitest";
 import { invalidateAllScheduleQueries } from "./invalidate-schedules";
 
 describe("invalidateAllScheduleQueries", () => {
-  test("invalidates user-wide schedules + copilot followups + per-graph when graphId provided", () => {
+  test("invalidates user-wide schedules + copilot followups + library agents + per-graph when graphId provided", () => {
     const queryClient = new QueryClient();
     const spy = vi.spyOn(queryClient, "invalidateQueries");
 
     invalidateAllScheduleQueries(queryClient, "graph-abc");
 
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(4);
     expect(spy).toHaveBeenCalledWith({
       queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
     });
     expect(spy).toHaveBeenCalledWith({
       queryKey: getListCopilotFollowupSchedulesQueryKey(),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["/api/library/agents"],
     });
     expect(spy).toHaveBeenCalledWith({
       queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey("graph-abc"),
@@ -32,12 +35,15 @@ describe("invalidateAllScheduleQueries", () => {
 
     invalidateAllScheduleQueries(queryClient);
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(3);
     expect(spy).toHaveBeenCalledWith({
       queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
     });
     expect(spy).toHaveBeenCalledWith({
       queryKey: getListCopilotFollowupSchedulesQueryKey(),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: ["/api/library/agents"],
     });
   });
 });

--- a/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.test.ts
+++ b/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.test.ts
@@ -1,0 +1,43 @@
+import {
+  getGetV1ListExecutionSchedulesForAGraphQueryKey,
+  getGetV1ListExecutionSchedulesForAUserQueryKey,
+  getListCopilotFollowupSchedulesQueryKey,
+} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, test, vi } from "vitest";
+import { invalidateAllScheduleQueries } from "./invalidate-schedules";
+
+describe("invalidateAllScheduleQueries", () => {
+  test("invalidates user-wide schedules + copilot followups + per-graph when graphId provided", () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateAllScheduleQueries(queryClient, "graph-abc");
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: getListCopilotFollowupSchedulesQueryKey(),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey("graph-abc"),
+    });
+  });
+
+  test("skips per-graph invalidation when graphId is omitted (followup-only mutations don't know a graph)", () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateAllScheduleQueries(queryClient);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
+    });
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: getListCopilotFollowupSchedulesQueryKey(),
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.ts
+++ b/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.ts
@@ -6,7 +6,7 @@ import {
 import type { QueryClient } from "@tanstack/react-query";
 
 // Schedule mutations (create / edit / delete) need to invalidate every
-// list query that might cache the affected row.  There are three:
+// list query that might cache the affected row.  There are four:
 //   - user-wide /api/v1/schedules — unified `/library/followups` page
 //     AND the "Autopilot library" briefing pill count.
 //   - per-graph /api/v1/graphs/{id}/schedules — agent detail page
@@ -14,6 +14,10 @@ import type { QueryClient } from "@tanstack/react-query";
 //   - copilot followups list — same scheduler primitive, separate
 //     endpoint; included so a followup-side mutation doesn't leave
 //     graph schedule caches stale and vice versa.
+//   - library agents list (/api/library/agents) — backend computes
+//     `is_scheduled` on the row, so creating/deleting a schedule flips
+//     that flag and the `/library` fleet-summary "Scheduled" count
+//     would otherwise stay stale until manual reload.
 //
 // Forgetting any one of these leaves a stale row visible on another
 // page until manual reload, which we saw with the unified Scheduled
@@ -28,6 +32,12 @@ export function invalidateAllScheduleQueries(
   queryClient.invalidateQueries({
     queryKey: getListCopilotFollowupSchedulesQueryKey(),
   });
+  // Partial-key match: hits every variant of the library agents query
+  // (search, filter, pagination, plus the infinite-query form used by
+  // `/library`'s agent list).  Required so `agent.is_scheduled` —
+  // computed server-side and fed into the fleet-summary "Scheduled"
+  // count — refreshes after a schedule mutation.
+  queryClient.invalidateQueries({ queryKey: ["/api/library/agents"] });
   if (graphId) {
     queryClient.invalidateQueries({
       queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey(graphId),

--- a/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.ts
+++ b/autogpt_platform/frontend/src/services/schedules/invalidate-schedules.ts
@@ -1,0 +1,36 @@
+import {
+  getGetV1ListExecutionSchedulesForAGraphQueryKey,
+  getGetV1ListExecutionSchedulesForAUserQueryKey,
+  getListCopilotFollowupSchedulesQueryKey,
+} from "@/app/api/__generated__/endpoints/schedules/schedules";
+import type { QueryClient } from "@tanstack/react-query";
+
+// Schedule mutations (create / edit / delete) need to invalidate every
+// list query that might cache the affected row.  There are three:
+//   - user-wide /api/v1/schedules — unified `/library/followups` page
+//     AND the "Autopilot library" briefing pill count.
+//   - per-graph /api/v1/graphs/{id}/schedules — agent detail page
+//     sidebar + selected-schedule view.
+//   - copilot followups list — same scheduler primitive, separate
+//     endpoint; included so a followup-side mutation doesn't leave
+//     graph schedule caches stale and vice versa.
+//
+// Forgetting any one of these leaves a stale row visible on another
+// page until manual reload, which we saw with the unified Scheduled
+// page after PR #13202.  Always invalidate ALL of them.
+export function invalidateAllScheduleQueries(
+  queryClient: QueryClient,
+  graphId?: string,
+) {
+  queryClient.invalidateQueries({
+    queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: getListCopilotFollowupSchedulesQueryKey(),
+  });
+  if (graphId) {
+    queryClient.invalidateQueries({
+      queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey(graphId),
+    });
+  }
+}


### PR DESCRIPTION
## Why

Followup to **#13202** (the autopilot UX + unified Scheduled page PR I just merged).

During a critical post-merge audit prompted by the user's "be critical, test all corner cases" prompt, I found that the unified `/library/followups` page + the new "Autopilot library" briefing pill BOTH read from the user-wide `/api/v1/schedules` endpoint, while the existing per-agent schedule UI (`/library/agents/{id}`) reads from the per-graph `/api/v1/graphs/{id}/schedules` endpoint. These are different React Query keys backed by different endpoints, but they cache **overlapping data** — every graph schedule lands in both.

Every mutation site (8 total — 1 from #13202, 7 pre-existing) was only invalidating ONE of the affected keys. **Native /pr-test surfaced a 4th stale consumer**: the `/library` fleet-summary "Scheduled" count derives from `agent.is_scheduled` on the library-agents query, which no mutation site ever invalidated.

Net effect: every schedule create / edit / delete leaves at least one consumer (and often two) with stale cache until manual reload.

## What

**Single shared invalidator** wired into all 8 mutation sites, invalidating **4 query keys**:

| Query key | Consumer |
|---|---|
| `/api/v1/schedules` (user-wide) | unified `/library/followups` + Autopilot library pill |
| `/api/v1/copilot/followups` | copilot followup list inside the unified page |
| `/api/v1/graphs/{id}/schedules` (per-graph) | agent detail sidebar + selected-schedule view |
| `/api/library/agents` (partial-key match) | `/library` fleet-summary "Scheduled" tab count, all variants (infinite, search, filter) |

| Mutation site | Old invalidation | Now |
|---|---|---|
| `useGraphScheduleListItem` (unified page delete — #13202) | user-wide only | ALL four |
| `useFollowupListItem` (unified page followup delete — #13202) | copilot-followups only | ALL four |
| `useScheduleDetailHeader` (agent detail delete) | per-graph only | ALL four |
| `useSelectedScheduleActions` (selected-schedule delete) | per-graph only | ALL four |
| `ScheduleActionsDropdown` (sidebar dropdown delete) | per-graph only | ALL four |
| `useScheduleAgentModal` (create from agent detail) | per-graph only | ALL four |
| `useEditScheduleModal` (PATCH from agent detail) | per-graph only | ALL four |
| `useCronSchedulerDialog` (create from agent **builder**) | **NONE** 🐛 | ALL four |

That last one is the worst pre-existing bug: scheduling from the builder didn't refresh the agent detail page either — completely independent of my PR.

## How

New helper at `autogpt_platform/frontend/src/services/schedules/invalidate-schedules.ts`:

```ts
export function invalidateAllScheduleQueries(
  queryClient: QueryClient,
  graphId?: string,
) {
  queryClient.invalidateQueries({ queryKey: getGetV1ListExecutionSchedulesForAUserQueryKey() });
  queryClient.invalidateQueries({ queryKey: getListCopilotFollowupSchedulesQueryKey() });
  queryClient.invalidateQueries({ queryKey: ["/api/library/agents"] }); // partial-key — hits every variant
  if (graphId) {
    queryClient.invalidateQueries({ queryKey: getGetV1ListExecutionSchedulesForAGraphQueryKey(graphId) });
  }
}
```

Every mutation site now calls this single helper instead of cherry-picking one key. `graphId` is optional because copilot followup mutations don't bind to a specific graph.

The library-agents key (`["/api/library/agents"]`) is matched as a **partial prefix** — Tanstack Query's default behaviour — so it catches the bare query AND every variant with params (search, filter, pagination, plus the infinite-query form used by `/library`).

## Test coverage

- **Helper unit tests**: `invalidate-schedules.test.ts` — 2 tests verifying both branches (with + without graphId) and asserting the exact set of 3 or 4 invalidated query keys.
- **5 new hook test files** with renderHook + MSW, one per modified hook — each spies on `invalidateAllScheduleQueries` to assert it's called with the right `graphId` on the success path:
  - `useScheduleDetailHeader.test.tsx` (3 tests)
  - `useSelectedScheduleActions.test.tsx` (3 tests)
  - `useScheduleAgentModal.test.tsx` (2 tests)
  - `useEditScheduleModal.test.tsx` (2 tests, with restored `globalThis.fetch` per CodeRabbit nit)
  - `useCronSchedulerDialog.test.tsx` (2 tests — explicit regression for the previously-zero-invalidation bug)
- **Native /pr-test**: 4 scenarios pass on a local poetry/pnpm stack with real backend + real browser interactions. See [test report comment](https://github.com/Significant-Gravitas/AutoGPT/pull/13204#issuecomment-4527332405) for screenshots.
- **Full vitest suite**: 2802 tests pass locally; codecov patch above the 70% target.

## Out of scope

- No backend changes — pure client-side cache hygiene.
- The execution `runs` query (`getGetV1ListGraphExecutionsQueryKey`) is intentionally NOT included in the helper since not every schedule mutation creates a run; only the "Run now" path needs it and that already invalidates it inline.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review performed
- [x] Helper unit-tested + every changed hook unit-tested
- [x] Native /pr-test confirms cross-page propagation across 4 scenarios
- [x] No new warnings
- [x] Pre-existing behavior preserved (mutations still invalidate the keys they used to + the missing ones)
- [x] CI green
