### PR TITLE
feat(blocks): add sort list block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/sort_list.py
+++ b/autogpt_platform/backend/backend/blocks/sort_list.py
@@ -35,7 +35,10 @@ class SortListBlock(Block):
 
         sorted_list: List[Any] = SchemaField(description="The sorted list.")
         length: int = SchemaField(description="The number of items in the sorted list.")
-        error: str = SchemaField(description="Error message if sorting failed.")
+        error: str = SchemaField(
+            default="",
+            description="Error message if sorting failed.",
+        )
 
     def __init__(self):
         """Initialize the block metadata and built-in test cases."""

--- a/autogpt_platform/backend/backend/blocks/sort_list.py
+++ b/autogpt_platform/backend/backend/blocks/sort_list.py
@@ -1,0 +1,97 @@
+from typing import Any, List
+
+from backend.blocks._base import (
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+)
+from backend.data.model import SchemaField
+
+
+class SortListBlock(Block):
+    class Input(BlockSchemaInput):
+        list: List[Any] = SchemaField(
+            description="The list to sort.",
+            placeholder="e.g., [3, 1, 2]",
+        )
+        key: str | None = SchemaField(
+            default=None,
+            description="Dictionary key to sort by. Leave empty to sort list items directly.",
+            advanced=True,
+        )
+        reverse: bool = SchemaField(
+            default=False,
+            description="Whether to sort in descending order.",
+        )
+
+    class Output(BlockSchemaOutput):
+        sorted_list: List[Any] = SchemaField(description="The sorted list.")
+        length: int = SchemaField(description="The number of items in the sorted list.")
+        error: str = SchemaField(description="Error message if sorting failed.")
+
+    def __init__(self):
+        super().__init__(
+            id="d294805e-3b2f-48c8-81ca-eaf13c582ef1",
+            description="Sorts a list directly or by a key on dictionary items.",
+            categories={BlockCategory.BASIC},
+            input_schema=SortListBlock.Input,
+            output_schema=SortListBlock.Output,
+            test_input=[
+                {"list": [3, 1, 2]},
+                {"list": [3, 1, 2], "reverse": True},
+                {
+                    "list": [
+                        {"name": "b", "score": 2},
+                        {"name": "a", "score": 1},
+                    ],
+                    "key": "score",
+                },
+            ],
+            test_output=[
+                ("sorted_list", [1, 2, 3]),
+                ("length", 3),
+                ("sorted_list", [3, 2, 1]),
+                ("length", 3),
+                (
+                    "sorted_list",
+                    [
+                        {"name": "a", "score": 1},
+                        {"name": "b", "score": 2},
+                    ],
+                ),
+                ("length", 2),
+            ],
+        )
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        try:
+            sorted_list = _sort_items(
+                input_data.list, input_data.key, input_data.reverse
+            )
+        except ValueError as e:
+            yield "error", str(e)
+            return
+        except TypeError as e:
+            yield "error", f"Failed to sort list: {e}"
+            return
+
+        yield "sorted_list", sorted_list
+        yield "length", len(sorted_list)
+
+
+def _sort_items(items: List[Any], key: str | None, reverse: bool) -> List[Any]:
+    copied_items = items.copy()
+    if key is None:
+        return sorted(copied_items, reverse=reverse)
+
+    for index, item in enumerate(copied_items):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"Item at index {index} must be a dictionary when sorting by key."
+            )
+        if key not in item:
+            raise ValueError(f"Item at index {index} is missing key '{key}'.")
+
+    return sorted(copied_items, key=lambda item: item[key], reverse=reverse)

--- a/autogpt_platform/backend/backend/blocks/sort_list.py
+++ b/autogpt_platform/backend/backend/blocks/sort_list.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, Callable, List
 
 from backend.blocks._base import (
     Block,
@@ -74,16 +74,7 @@ class SortListBlock(Block):
 
     async def run(self, input_data: Input, **kwargs) -> BlockOutput:
         """Yield sorted list outputs or a sorting error message."""
-        try:
-            sorted_list = _sort_items(
-                input_data.list, input_data.key, input_data.reverse
-            )
-        except ValueError as e:
-            yield "error", str(e)
-            return
-        except TypeError as e:
-            yield "error", f"Failed to sort list: {e}"
-            return
+        sorted_list = _sort_items(input_data.list, input_data.key, input_data.reverse)
 
         yield "sorted_list", sorted_list
         yield "length", len(sorted_list)
@@ -93,7 +84,7 @@ def _sort_items(items: List[Any], key: str | None, reverse: bool) -> List[Any]:
     """Return a sorted copy of items."""
     copied_items = items.copy()
     if not key:
-        return sorted(copied_items, reverse=reverse)
+        return _sorted_items(copied_items, reverse=reverse)
 
     for index, item in enumerate(copied_items):
         if not isinstance(item, dict):
@@ -103,4 +94,16 @@ def _sort_items(items: List[Any], key: str | None, reverse: bool) -> List[Any]:
         if key not in item:
             raise ValueError(f"Item at index {index} is missing key '{key}'.")
 
-    return sorted(copied_items, key=lambda item: item[key], reverse=reverse)
+    return _sorted_items(copied_items, key=lambda item: item[key], reverse=reverse)
+
+
+def _sorted_items(
+    items: List[Any],
+    reverse: bool,
+    key: Callable[[Any], Any] | None = None,
+) -> List[Any]:
+    """Sort items and convert comparison failures into ValueError."""
+    try:
+        return sorted(items, key=key, reverse=reverse)
+    except TypeError as e:
+        raise ValueError(f"Failed to sort list: {e}") from e

--- a/autogpt_platform/backend/backend/blocks/sort_list.py
+++ b/autogpt_platform/backend/backend/blocks/sort_list.py
@@ -11,7 +11,11 @@ from backend.data.model import SchemaField
 
 
 class SortListBlock(Block):
+    """Sort a list directly or by a dictionary item key."""
+
     class Input(BlockSchemaInput):
+        """Input schema for list sorting."""
+
         list: List[Any] = SchemaField(
             description="The list to sort.",
             placeholder="e.g., [3, 1, 2]",
@@ -27,11 +31,14 @@ class SortListBlock(Block):
         )
 
     class Output(BlockSchemaOutput):
+        """Output schema for list sorting."""
+
         sorted_list: List[Any] = SchemaField(description="The sorted list.")
         length: int = SchemaField(description="The number of items in the sorted list.")
         error: str = SchemaField(description="Error message if sorting failed.")
 
     def __init__(self):
+        """Initialize the block metadata and built-in test cases."""
         super().__init__(
             id="d294805e-3b2f-48c8-81ca-eaf13c582ef1",
             description="Sorts a list directly or by a key on dictionary items.",
@@ -66,6 +73,7 @@ class SortListBlock(Block):
         )
 
     async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        """Yield sorted list outputs or a sorting error message."""
         try:
             sorted_list = _sort_items(
                 input_data.list, input_data.key, input_data.reverse
@@ -82,8 +90,9 @@ class SortListBlock(Block):
 
 
 def _sort_items(items: List[Any], key: str | None, reverse: bool) -> List[Any]:
+    """Return a sorted copy of items."""
     copied_items = items.copy()
-    if key is None:
+    if not key:
         return sorted(copied_items, reverse=reverse)
 
     for index, item in enumerate(copied_items):

--- a/autogpt_platform/backend/test/blocks/test_sort_list.py
+++ b/autogpt_platform/backend/test/blocks/test_sort_list.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+from backend.blocks.sort_list import SortListBlock
+
+
+async def _collect_outputs(input_data: dict[str, Any]) -> list[tuple[str, Any]]:
+    block = SortListBlock()
+    model = SortListBlock.Input(**input_data)
+    return [(name, value) async for name, value in block.run(model)]
+
+
+async def test_builtin_block_cases():
+    block = SortListBlock()
+    assert isinstance(block.test_input, list)
+    assert isinstance(block.test_output, list)
+    outputs: list[tuple[str, Any]] = []
+
+    for input_data in block.test_input:
+        outputs.extend(await _collect_outputs(input_data))
+
+    assert outputs == block.test_output
+
+
+async def test_sorts_numbers_naturally():
+    outputs = await _collect_outputs({"list": [3, 1, 2]})
+
+    assert outputs == [("sorted_list", [1, 2, 3]), ("length", 3)]
+
+
+async def test_sorts_in_reverse_order():
+    outputs = await _collect_outputs({"list": [3, 1, 2], "reverse": True})
+
+    assert outputs == [("sorted_list", [3, 2, 1]), ("length", 3)]
+
+
+async def test_sorts_dictionaries_by_key():
+    outputs = await _collect_outputs(
+        {
+            "list": [
+                {"name": "b", "score": 2},
+                {"name": "a", "score": 1},
+            ],
+            "key": "score",
+        }
+    )
+
+    assert outputs == [
+        (
+            "sorted_list",
+            [
+                {"name": "a", "score": 1},
+                {"name": "b", "score": 2},
+            ],
+        ),
+        ("length", 2),
+    ]
+
+
+async def test_does_not_mutate_original_list():
+    original = [{"name": "b", "score": 2}, {"name": "a", "score": 1}]
+
+    await _collect_outputs({"list": original, "key": "score"})
+
+    assert original == [{"name": "b", "score": 2}, {"name": "a", "score": 1}]
+
+
+async def test_returns_error_for_mixed_unsortable_values():
+    outputs = await _collect_outputs({"list": [1, "two"]})
+
+    assert outputs[0][0] == "error"
+    assert "sort" in outputs[0][1].lower()
+
+
+async def test_returns_error_when_key_sort_item_is_not_dictionary():
+    outputs = await _collect_outputs({"list": [{"score": 1}, 2], "key": "score"})
+
+    assert outputs[0][0] == "error"
+    assert "dictionary" in outputs[0][1].lower()
+
+
+async def test_returns_error_when_key_is_missing():
+    outputs = await _collect_outputs(
+        {"list": [{"score": 1}, {"name": "a"}], "key": "score"}
+    )
+
+    assert outputs[0][0] == "error"
+    assert "score" in outputs[0][1]

--- a/autogpt_platform/backend/test/blocks/test_sort_list.py
+++ b/autogpt_platform/backend/test/blocks/test_sort_list.py
@@ -1,24 +1,19 @@
 from typing import Any
 
+import pytest
+
 from backend.blocks.sort_list import SortListBlock
+from backend.util.exceptions import BlockExecutionError
+from backend.util.test import execute_block_test
 
 
 async def _collect_outputs(input_data: dict[str, Any]) -> list[tuple[str, Any]]:
     block = SortListBlock()
-    model = SortListBlock.Input(**input_data)
-    return [(name, value) async for name, value in block.run(model)]
+    return [(name, value) async for name, value in block.execute(input_data)]
 
 
 async def test_builtin_block_cases():
-    block = SortListBlock()
-    assert isinstance(block.test_input, list)
-    assert isinstance(block.test_output, list)
-    outputs: list[tuple[str, Any]] = []
-
-    for input_data in block.test_input:
-        outputs.extend(await _collect_outputs(input_data))
-
-    assert outputs == block.test_output
+    await execute_block_test(SortListBlock())
 
 
 async def test_sorts_numbers_naturally():
@@ -31,6 +26,12 @@ async def test_sorts_in_reverse_order():
     outputs = await _collect_outputs({"list": [3, 1, 2], "reverse": True})
 
     assert outputs == [("sorted_list", [3, 2, 1]), ("length", 3)]
+
+
+async def test_empty_key_sorts_items_directly():
+    outputs = await _collect_outputs({"list": [3, 1, 2], "key": ""})
+
+    assert outputs == [("sorted_list", [1, 2, 3]), ("length", 3)]
 
 
 async def test_sorts_dictionaries_by_key():
@@ -65,23 +66,15 @@ async def test_does_not_mutate_original_list():
 
 
 async def test_returns_error_for_mixed_unsortable_values():
-    outputs = await _collect_outputs({"list": [1, "two"]})
-
-    assert outputs[0][0] == "error"
-    assert "sort" in outputs[0][1].lower()
+    with pytest.raises(BlockExecutionError, match="sort"):
+        await _collect_outputs({"list": [1, "two"]})
 
 
 async def test_returns_error_when_key_sort_item_is_not_dictionary():
-    outputs = await _collect_outputs({"list": [{"score": 1}, 2], "key": "score"})
-
-    assert outputs[0][0] == "error"
-    assert "dictionary" in outputs[0][1].lower()
+    with pytest.raises(BlockExecutionError, match="dictionary"):
+        await _collect_outputs({"list": [{"score": 1}, 2], "key": "score"})
 
 
 async def test_returns_error_when_key_is_missing():
-    outputs = await _collect_outputs(
-        {"list": [{"score": 1}, {"name": "a"}], "key": "score"}
-    )
-
-    assert outputs[0][0] == "error"
-    assert "score" in outputs[0][1]
+    with pytest.raises(BlockExecutionError, match="score"):
+        await _collect_outputs({"list": [{"score": 1}, {"name": "a"}], "key": "score"})

--- a/autogpt_platform/backend/test/blocks/test_sort_list.py
+++ b/autogpt_platform/backend/test/blocks/test_sort_list.py
@@ -3,17 +3,31 @@ from typing import Any
 import pytest
 
 from backend.blocks.sort_list import SortListBlock
+from backend.data.execution import ExecutionContext
 from backend.util.exceptions import BlockExecutionError
 from backend.util.test import execute_block_test
 
 
 async def _collect_outputs(input_data: dict[str, Any]) -> list[tuple[str, Any]]:
     block = SortListBlock()
-    return [(name, value) async for name, value in block.execute(input_data)]
+    return [
+        (name, value)
+        async for name, value in block.execute(
+            input_data,
+            execution_context=ExecutionContext(),
+        )
+    ]
 
 
 async def test_builtin_block_cases():
     await execute_block_test(SortListBlock())
+
+
+def test_error_output_keeps_default_value():
+    error_field = SortListBlock.Output.model_fields["error"]
+
+    assert not error_field.is_required()
+    assert error_field.default == ""
 
 
 async def test_sorts_numbers_naturally():

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -85,6 +85,7 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [Slant3D Get Orders](block-integrations/slant3d/order.md#slant3d-get-orders) | Get all orders for the account |
 | [Slant3D Slicer](block-integrations/slant3d/slicing.md#slant3d-slicer) | Slice a 3D model file and get pricing information |
 | [Slant3D Tracking](block-integrations/slant3d/order.md#slant3d-tracking) | Track order status and shipping |
+| [Sort List](block-integrations/basic.md#sort-list) | Sorts a list directly or by a key on dictionary items |
 | [Store Value](block-integrations/basic.md#store-value) | A basic block that stores and forwards a value throughout workflows, allowing it to be reused without changes across multiple blocks |
 | [Universal Type Converter](block-integrations/basic.md#universal-type-converter) | This block is used to convert a value to a universal type |
 | [XML Parser](block-integrations/basic.md#xml-parser) | Parses XML using gravitasml to tokenize and coverts it to dict |

--- a/docs/integrations/block-integrations/basic.md
+++ b/docs/integrations/block-integrations/basic.md
@@ -1493,6 +1493,44 @@ The search is performed against the Mem0 memory store and returns memories ranke
 
 ---
 
+## Sort List
+
+### What it is
+Sorts a list directly or by a key on dictionary items.
+
+### How it works
+<!-- MANUAL: how_it_works -->
+Sort List creates a sorted copy of the input list. Without a key, it sorts list
+items directly using Python's built-in ordering. With a key, each item must be a
+dictionary and the block sorts by that dictionary value. If the values cannot be
+compared, the block returns an error output instead of failing the workflow.
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| list | The list to sort. | List[Any] | Yes |
+| key | Dictionary key to sort by. Leave empty to sort list items directly. | str | No |
+| reverse | Whether to sort in descending order. | bool | No |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| error | Error message if sorting failed. | str |
+| sorted_list | The sorted list. | List[Any] |
+| length | The number of items in the sorted list. | int |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+Use Sort List after collecting records from another block, such as ordering
+tasks by priority, products by price, or search results by score before passing
+them to later workflow steps.
+<!-- END MANUAL -->
+
+---
+
 ## Store Value
 
 ### What it is


### PR DESCRIPTION
Fixes #11110

## Summary
- Add `SortListBlock` for sorting lists directly or by dictionary key
- Return `sorted_list`, `length`, or `error` without mutating input
- Cover natural sorting, reverse sorting, key sorting, mutation safety, and error cases

## Test Plan
- `uvx --from poetry==2.2.1 poetry run lint`
- `uvx --from poetry==2.2.1 poetry run pytest test/blocks/test_sort_list.py -xvs`
- `uvx --from poetry==2.2.1 poetry run python - <<'PY' ... execute_block_test(SortListBlock()) ... PY`