### PR TITLE
fix(platform): drop running balance from user transaction history

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -904,10 +904,11 @@ class UserCredit(UserCreditBase):
         logger.warning(
             f"Adding extra info for dispute from {user_id} for ${amount / 100}"
         )
-        # Retrieve recent transaction history to support our evidence.
-        # This provides a concise timeline that shows service usage and proper credit application.
-        transaction_history = await self.get_transaction_history(
-            user_id, transaction_count_limit=None
+        # Retrieve recent transaction rows directly from prisma to preserve
+        # per-row runningBalance in the dispute evidence narrative.
+        dispute_transactions = await CreditTransaction.prisma().find_many(
+            where={"userId": user_id, "isActive": True},
+            order={"createdAt": "desc"},
         )
         user = await get_user_by_id(user_id)
 
@@ -920,17 +921,19 @@ class UserCredit(UserCreditBase):
             "were applied to the user’s account. Our records confirm that the funds were utilized for the intended services. "
             "Below is a summary of recent transaction activity:\n"
         )
-        for tx in transaction_history.transactions:
-            if tx.transaction_key == transaction.transactionKey:
+        for t in dispute_transactions:
+            if t.transactionKey == transaction.transactionKey:
                 additional_comment = (
                     " [This top-up transaction is the subject of the dispute]."
                 )
             else:
                 additional_comment = ""
 
+            tx_time = t.createdAt.replace(tzinfo=timezone.utc)
+            running_balance = t.runningBalance or 0
             evidence_text += (
-                f"- {tx.description}: Amount ${tx.amount / 100:.2f} on {tx.transaction_time.isoformat()}"
-                f"{additional_comment}\n"
+                f"- {t.type} Transaction: Amount ${t.amount / 100:.2f} on {tx_time.isoformat()}, "
+                f"resulting balance ${running_balance / 100:.2f}{additional_comment}\n"
             )
         evidence_text += (
             "\nThis evidence demonstrates that the transaction was authorized and that the charged amount was used to render the service as agreed."
@@ -1220,7 +1223,6 @@ class UserCredit(UserCreditBase):
             take=transaction_count_limit,
         )
 
-        # doesn't fill current_balance, reason, user_email, admin_email, or extra_data
         grouped_transactions: dict[str, CreditTransactionItem] = defaultdict(
             lambda: CreditTransactionItem(user_id=user_id)
         )

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -27,6 +27,7 @@ from backend.data.db import query_raw_with_schema
 from backend.data.includes import MAX_CREDIT_REFUND_REQUESTS_FETCH
 from backend.data.model import (
     AutoTopUpConfig,
+    CreditTransactionItem,
     RefundRequest,
     TopUpType,
     TransactionHistory,
@@ -928,8 +929,8 @@ class UserCredit(UserCreditBase):
                 additional_comment = ""
 
             evidence_text += (
-                f"- {tx.description}: Amount ${tx.amount / 100:.2f} on {tx.transaction_time.isoformat()}, "
-                f"resulting balance ${tx.running_balance / 100:.2f} {additional_comment}\n"
+                f"- {tx.description}: Amount ${tx.amount / 100:.2f} on {tx.transaction_time.isoformat()}"
+                f"{additional_comment}\n"
             )
         evidence_text += (
             "\nThis evidence demonstrates that the transaction was authorized and that the charged amount was used to render the service as agreed."
@@ -1220,8 +1221,8 @@ class UserCredit(UserCreditBase):
         )
 
         # doesn't fill current_balance, reason, user_email, admin_email, or extra_data
-        grouped_transactions: dict[str, UserTransaction] = defaultdict(
-            lambda: UserTransaction(user_id=user_id)
+        grouped_transactions: dict[str, CreditTransactionItem] = defaultdict(
+            lambda: CreditTransactionItem(user_id=user_id)
         )
         tx_time = None
         for t in transactions:
@@ -1251,7 +1252,6 @@ class UserCredit(UserCreditBase):
 
             if tx_time > gt.transaction_time:
                 gt.transaction_time = tx_time
-                gt.running_balance = t.runningBalance or 0
 
         return TransactionHistory(
             transactions=list(grouped_transactions.values()),

--- a/autogpt_platform/backend/backend/data/credit_refund_test.py
+++ b/autogpt_platform/backend/backend/data/credit_refund_test.py
@@ -220,11 +220,13 @@ async def test_handle_dispute_with_sufficient_balance(
 async def test_handle_dispute_with_insufficient_balance(
     mock_get_user, mock_stripe_modify, mock_settings, server: SpinTestServer
 ):
-    """Test handling dispute when user has insufficient balance (evidence gets added)."""
-    topup_tx = await setup_test_user_with_topup()
+    """Test handling dispute when user has insufficient balance (evidence gets added).
 
-    # Save original method for restoration before any try blocks
-    original_get_history = credit_system.get_transaction_history
+    handle_dispute reads CreditTransaction rows directly via prisma, so the
+    evidence-building path is exercised against the real DB state created by
+    setup_test_user_with_topup — this is an integration test by design.
+    """
+    topup_tx = await setup_test_user_with_topup()
 
     try:
         # Mock settings to have a high tolerance threshold so dispute isn't closed
@@ -234,13 +236,6 @@ async def test_handle_dispute_with_insufficient_balance(
         mock_user = MagicMock()
         mock_user.email = f"{REFUND_TEST_USER_ID}@example.com"
         mock_get_user.return_value = mock_user
-
-        # Mock the transaction history method to return an async result
-        from unittest.mock import AsyncMock
-
-        mock_history = MagicMock()
-        mock_history.transactions = []
-        credit_system.get_transaction_history = AsyncMock(return_value=mock_history)
 
         # Create a mock dispute object for full amount (user has 1000, disputing 1000)
         dispute = MagicMock(spec=stripe.Dispute)
@@ -270,7 +265,6 @@ async def test_handle_dispute_with_insufficient_balance(
         assert user_balance.balance == 1000, "Balance should remain unchanged"
 
     finally:
-        credit_system.get_transaction_history = original_get_history
         await cleanup_test_user()
 
 

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -815,8 +815,26 @@ class UserTransaction(BaseModel):
     extra_data: str | None = None
 
 
+class CreditTransactionItem(BaseModel):
+    transaction_key: str = ""
+    transaction_time: datetime = datetime.min.replace(tzinfo=timezone.utc)
+    transaction_type: CreditTransactionType = CreditTransactionType.USAGE
+    amount: int = 0
+    current_balance: int = 0
+    description: str | None = None
+    usage_graph_id: str | None = None
+    usage_execution_id: str | None = None
+    usage_node_count: int = 0
+    usage_start_time: datetime = datetime.max.replace(tzinfo=timezone.utc)
+    user_id: str
+    user_email: str | None = None
+    reason: str | None = None
+    admin_email: str | None = None
+    extra_data: str | None = None
+
+
 class TransactionHistory(BaseModel):
-    transactions: list[UserTransaction]
+    transactions: list[CreditTransactionItem]
     next_transaction_time: datetime | None
 
 

--- a/autogpt_platform/backend/backend/data/model.py
+++ b/autogpt_platform/backend/backend/data/model.py
@@ -820,17 +820,12 @@ class CreditTransactionItem(BaseModel):
     transaction_time: datetime = datetime.min.replace(tzinfo=timezone.utc)
     transaction_type: CreditTransactionType = CreditTransactionType.USAGE
     amount: int = 0
-    current_balance: int = 0
     description: str | None = None
     usage_graph_id: str | None = None
     usage_execution_id: str | None = None
     usage_node_count: int = 0
     usage_start_time: datetime = datetime.max.replace(tzinfo=timezone.utc)
     user_id: str
-    user_email: str | None = None
-    reason: str | None = None
-    admin_email: str | None = None
-    extra_data: str | None = None
 
 
 class TransactionHistory(BaseModel):

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/AdminUserGrantHistory.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/AdminUserGrantHistory.tsx
@@ -130,7 +130,10 @@ export async function AdminUserGrantHistory({
                     {transaction.admin_email}
                   </TableCell>
                   <TableCell className="font-medium text-green-600">
-                    ${(transaction.running_balance + -transaction.amount) / 100}
+                    $
+                    {((transaction.running_balance ?? 0) +
+                      -transaction.amount) /
+                      100}
                   </TableCell>
                   <TableCell>
                     {formatAmount(
@@ -139,7 +142,7 @@ export async function AdminUserGrantHistory({
                     )}
                   </TableCell>
                   <TableCell className="font-medium text-green-600">
-                    ${transaction.running_balance / 100}
+                    ${(transaction.running_balance ?? 0) / 100}
                   </TableCell>
                   {/* <TableCell className="font-medium text-green-600">
                     ${transaction.current_balance / 100}

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/AdminUserGrantHistory.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/AdminUserGrantHistory.tsx
@@ -110,70 +110,73 @@ export async function AdminUserGrantHistory({
                 </TableCell>
               </TableRow>
             ) : (
-              history.map((transaction) => (
-                <TableRow
-                  key={`${transaction.user_id}-${transaction.transaction_time}`}
-                  className="hover:bg-gray-50"
-                >
-                  <TableCell className="font-medium">
-                    {transaction.user_email}
-                  </TableCell>
+              history.map((transaction) => {
+                const runningBalance = transaction.running_balance;
+                const hasRunningBalance = runningBalance != null;
+                return (
+                  <TableRow
+                    key={`${transaction.user_id}-${transaction.transaction_time}`}
+                    className="hover:bg-gray-50"
+                  >
+                    <TableCell className="font-medium">
+                      {transaction.user_email}
+                    </TableCell>
 
-                  <TableCell>
-                    {formatType(transaction.transaction_type)}
-                  </TableCell>
-                  <TableCell className="text-gray-600">
-                    {formatDate(transaction.transaction_time)}
-                  </TableCell>
-                  <TableCell>{transaction.reason}</TableCell>
-                  <TableCell className="text-gray-600">
-                    {transaction.admin_email}
-                  </TableCell>
-                  <TableCell className="font-medium text-green-600">
-                    $
-                    {((transaction.running_balance ?? 0) +
-                      -transaction.amount) /
-                      100}
-                  </TableCell>
-                  <TableCell>
-                    {formatAmount(
-                      transaction.amount,
-                      transaction.transaction_type,
-                    )}
-                  </TableCell>
-                  <TableCell className="font-medium text-green-600">
-                    ${(transaction.running_balance ?? 0) / 100}
-                  </TableCell>
-                  {/* <TableCell className="font-medium text-green-600">
-                    ${transaction.current_balance / 100}
-                  </TableCell> */}
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-2">
-                      <RateLimitModal
-                        userId={transaction.user_id}
-                        userEmail={transaction.user_email ?? ""}
-                      />
-                      <AdminAddMoneyButton
-                        userId={transaction.user_id}
-                        userEmail={transaction.user_email ?? ""}
-                        currentBalance={transaction.current_balance}
-                        defaultAmount={
-                          transaction.transaction_type ===
-                          CreditTransactionType.USAGE
-                            ? -transaction.amount
-                            : undefined
-                        }
-                        defaultComments={
-                          transaction.transaction_type ===
-                          CreditTransactionType.USAGE
-                            ? "Refund for usage"
-                            : undefined
-                        }
-                      />
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))
+                    <TableCell>
+                      {formatType(transaction.transaction_type)}
+                    </TableCell>
+                    <TableCell className="text-gray-600">
+                      {formatDate(transaction.transaction_time)}
+                    </TableCell>
+                    <TableCell>{transaction.reason}</TableCell>
+                    <TableCell className="text-gray-600">
+                      {transaction.admin_email}
+                    </TableCell>
+                    <TableCell className="font-medium text-green-600">
+                      {hasRunningBalance
+                        ? `$${(runningBalance - transaction.amount) / 100}`
+                        : "N/A"}
+                    </TableCell>
+                    <TableCell>
+                      {formatAmount(
+                        transaction.amount,
+                        transaction.transaction_type,
+                      )}
+                    </TableCell>
+                    <TableCell className="font-medium text-green-600">
+                      {hasRunningBalance ? `$${runningBalance / 100}` : "N/A"}
+                    </TableCell>
+                    {/* <TableCell className="font-medium text-green-600">
+                      ${transaction.current_balance / 100}
+                    </TableCell> */}
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <RateLimitModal
+                          userId={transaction.user_id}
+                          userEmail={transaction.user_email ?? ""}
+                        />
+                        <AdminAddMoneyButton
+                          userId={transaction.user_id}
+                          userEmail={transaction.user_email ?? ""}
+                          currentBalance={transaction.current_balance}
+                          defaultAmount={
+                            transaction.transaction_type ===
+                            CreditTransactionType.USAGE
+                              ? -transaction.amount
+                              : undefined
+                          }
+                          defaultComments={
+                            transaction.transaction_type ===
+                            CreditTransactionType.USAGE
+                              ? "Refund for usage"
+                              : undefined
+                          }
+                        />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
             )}
           </TableBody>
         </Table>

--- a/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/AdminUserGrantHistory.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/admin/spending/components/AdminUserGrantHistory.tsx
@@ -110,73 +110,70 @@ export async function AdminUserGrantHistory({
                 </TableCell>
               </TableRow>
             ) : (
-              history.map((transaction) => {
-                const runningBalance = transaction.running_balance;
-                const hasRunningBalance = runningBalance != null;
-                return (
-                  <TableRow
-                    key={`${transaction.user_id}-${transaction.transaction_time}`}
-                    className="hover:bg-gray-50"
-                  >
-                    <TableCell className="font-medium">
-                      {transaction.user_email}
-                    </TableCell>
+              history.map((transaction) => (
+                <TableRow
+                  key={`${transaction.user_id}-${transaction.transaction_time}`}
+                  className="hover:bg-gray-50"
+                >
+                  <TableCell className="font-medium">
+                    {transaction.user_email}
+                  </TableCell>
 
-                    <TableCell>
-                      {formatType(transaction.transaction_type)}
-                    </TableCell>
-                    <TableCell className="text-gray-600">
-                      {formatDate(transaction.transaction_time)}
-                    </TableCell>
-                    <TableCell>{transaction.reason}</TableCell>
-                    <TableCell className="text-gray-600">
-                      {transaction.admin_email}
-                    </TableCell>
-                    <TableCell className="font-medium text-green-600">
-                      {hasRunningBalance
-                        ? `$${(runningBalance - transaction.amount) / 100}`
-                        : "N/A"}
-                    </TableCell>
-                    <TableCell>
-                      {formatAmount(
-                        transaction.amount,
-                        transaction.transaction_type,
-                      )}
-                    </TableCell>
-                    <TableCell className="font-medium text-green-600">
-                      {hasRunningBalance ? `$${runningBalance / 100}` : "N/A"}
-                    </TableCell>
-                    {/* <TableCell className="font-medium text-green-600">
-                      ${transaction.current_balance / 100}
-                    </TableCell> */}
-                    <TableCell className="text-right">
-                      <div className="flex items-center justify-end gap-2">
-                        <RateLimitModal
-                          userId={transaction.user_id}
-                          userEmail={transaction.user_email ?? ""}
-                        />
-                        <AdminAddMoneyButton
-                          userId={transaction.user_id}
-                          userEmail={transaction.user_email ?? ""}
-                          currentBalance={transaction.current_balance}
-                          defaultAmount={
-                            transaction.transaction_type ===
-                            CreditTransactionType.USAGE
-                              ? -transaction.amount
-                              : undefined
-                          }
-                          defaultComments={
-                            transaction.transaction_type ===
-                            CreditTransactionType.USAGE
-                              ? "Refund for usage"
-                              : undefined
-                          }
-                        />
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                );
-              })
+                  <TableCell>
+                    {formatType(transaction.transaction_type)}
+                  </TableCell>
+                  <TableCell className="text-gray-600">
+                    {formatDate(transaction.transaction_time)}
+                  </TableCell>
+                  <TableCell>{transaction.reason}</TableCell>
+                  <TableCell className="text-gray-600">
+                    {transaction.admin_email}
+                  </TableCell>
+                  <TableCell className="font-medium text-green-600">
+                    $
+                    {((transaction.running_balance ?? 0) +
+                      -transaction.amount) /
+                      100}
+                  </TableCell>
+                  <TableCell>
+                    {formatAmount(
+                      transaction.amount,
+                      transaction.transaction_type,
+                    )}
+                  </TableCell>
+                  <TableCell className="font-medium text-green-600">
+                    ${(transaction.running_balance ?? 0) / 100}
+                  </TableCell>
+                  {/* <TableCell className="font-medium text-green-600">
+                    ${transaction.current_balance / 100}
+                  </TableCell> */}
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <RateLimitModal
+                        userId={transaction.user_id}
+                        userEmail={transaction.user_email ?? ""}
+                      />
+                      <AdminAddMoneyButton
+                        userId={transaction.user_id}
+                        userEmail={transaction.user_email ?? ""}
+                        currentBalance={transaction.current_balance}
+                        defaultAmount={
+                          transaction.transaction_type ===
+                          CreditTransactionType.USAGE
+                            ? -transaction.amount
+                            : undefined
+                        }
+                        defaultComments={
+                          transaction.transaction_type ===
+                          CreditTransactionType.USAGE
+                            ? "Refund for usage"
+                            : undefined
+                        }
+                      />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
             )}
           </TableBody>
         </Table>

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/page.tsx
@@ -309,10 +309,6 @@ export default function CreditsPage() {
 
           {/* Transaction History */}
           <h3 className="text-lg font-medium">Transaction History</h3>
-          <p className="text-neutral-600">
-            Running balance might not be ordered accurately when concurrent
-            executions are happening.
-          </p>
           {transactionHistory.transactions.length === 0 && (
             <p className="text-neutral-600">No transactions found.</p>
           )}
@@ -326,7 +322,6 @@ export default function CreditsPage() {
                 <TableHead>Date</TableHead>
                 <TableHead>Description</TableHead>
                 <TableHead>Amount</TableHead>
-                <TableHead>Balance</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -352,9 +347,6 @@ export default function CreditsPage() {
                     }
                   >
                     <b>{formatCredits(transaction.amount)}</b>
-                  </TableCell>
-                  <TableCell>
-                    {formatCredits(transaction.running_balance)}
                   </TableCell>
                 </TableRow>
               ))}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -1074,6 +1074,7 @@ describe("TransactionHistoryCard", () => {
     expect(screen.getByText("Agent run")).toBeDefined();
     expect(screen.getByText("+$50.00")).toBeDefined();
     expect(screen.getByText("-$2.50")).toBeDefined();
+    expect(screen.queryByText(/^Balance$/)).toBeNull();
   });
 
   it("renders ErrorCard with a Retry button on a 500", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -1005,7 +1005,6 @@ describe("UsageCard", () => {
             transaction_type: "USAGE",
             amount: -150,
             description: "Agent run",
-            running_balance: 850,
           },
         ],
         next_transaction_time: null,
@@ -1056,7 +1055,6 @@ describe("TransactionHistoryCard", () => {
             transaction_type: "TOP_UP",
             amount: 5000,
             description: "Top up",
-            running_balance: 5000,
           },
           {
             transaction_key: "TXN-B",
@@ -1064,7 +1062,6 @@ describe("TransactionHistoryCard", () => {
             transaction_type: "USAGE",
             amount: -250,
             description: "Agent run",
-            running_balance: 4750,
           },
         ],
         next_transaction_time: null,

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/TransactionHistoryCard/TransactionHistoryCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/TransactionHistoryCard/TransactionHistoryCard.tsx
@@ -64,9 +64,6 @@ export function TransactionHistoryCard({ index = 0 }: Props) {
                   <Th className="hidden sm:table-cell">Date</Th>
                   <Th>Description</Th>
                   <Th align="right">Amount</Th>
-                  <Th align="right" className="hidden sm:table-cell">
-                    Balance
-                  </Th>
                 </tr>
               </thead>
               <motion.tbody
@@ -112,15 +109,6 @@ export function TransactionHistoryCard({ index = 0 }: Props) {
                         }
                       >
                         {transaction.amount}
-                      </Text>
-                    </td>
-                    <td className="hidden px-2 py-4 text-right sm:table-cell sm:px-4">
-                      <Text
-                        variant="body-medium"
-                        as="span"
-                        className="tabular-nums text-textBlack"
-                      >
-                        {transaction.balance}
                       </Text>
                     </td>
                   </motion.tr>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/TransactionHistoryCard/useTransactionHistoryCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/TransactionHistoryCard/useTransactionHistoryCard.ts
@@ -10,7 +10,6 @@ export interface TransactionRow {
   date: string;
   description: string;
   amount: string;
-  balance: string;
   kind: "credit" | "debit";
 }
 
@@ -42,7 +41,6 @@ export function useTransactionHistoryCard() {
           : "—",
         description: tx.description ?? tx.transaction_type ?? "Transaction",
         amount: `${amountCents > 0 ? "+" : ""}${formatCents(amountCents)}`,
-        balance: formatCents(tx.running_balance ?? 0),
         kind: amountCents >= 0 ? "credit" : "debit",
       };
     },

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -12067,6 +12067,74 @@
         "required": ["id", "provider", "type", "title", "scopes", "username"],
         "title": "CredentialsMetaResponse"
       },
+      "CreditTransactionItem": {
+        "properties": {
+          "transaction_key": {
+            "type": "string",
+            "title": "Transaction Key",
+            "default": ""
+          },
+          "transaction_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Transaction Time",
+            "default": "0001-01-01T00:00:00Z"
+          },
+          "transaction_type": {
+            "$ref": "#/components/schemas/CreditTransactionType",
+            "default": "USAGE"
+          },
+          "amount": { "type": "integer", "title": "Amount", "default": 0 },
+          "current_balance": {
+            "type": "integer",
+            "title": "Current Balance",
+            "default": 0
+          },
+          "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Description"
+          },
+          "usage_graph_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Usage Graph Id"
+          },
+          "usage_execution_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Usage Execution Id"
+          },
+          "usage_node_count": {
+            "type": "integer",
+            "title": "Usage Node Count",
+            "default": 0
+          },
+          "usage_start_time": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Usage Start Time",
+            "default": "9999-12-31T23:59:59.999999Z"
+          },
+          "user_id": { "type": "string", "title": "User Id" },
+          "user_email": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "User Email"
+          },
+          "reason": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Reason"
+          },
+          "admin_email": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Admin Email"
+          },
+          "extra_data": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Extra Data"
+          }
+        },
+        "type": "object",
+        "required": ["user_id"],
+        "title": "CreditTransactionItem"
+      },
       "CreditTransactionType": {
         "type": "string",
         "enum": [
@@ -18867,7 +18935,7 @@
       "TransactionHistory": {
         "properties": {
           "transactions": {
-            "items": { "$ref": "#/components/schemas/UserTransaction" },
+            "items": { "$ref": "#/components/schemas/CreditTransactionItem" },
             "type": "array",
             "title": "Transactions"
           },

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -12085,11 +12085,6 @@
             "default": "USAGE"
           },
           "amount": { "type": "integer", "title": "Amount", "default": 0 },
-          "current_balance": {
-            "type": "integer",
-            "title": "Current Balance",
-            "default": 0
-          },
           "description": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description"
@@ -12113,23 +12108,7 @@
             "title": "Usage Start Time",
             "default": "9999-12-31T23:59:59.999999Z"
           },
-          "user_id": { "type": "string", "title": "User Id" },
-          "user_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "User Email"
-          },
-          "reason": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Reason"
-          },
-          "admin_email": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Admin Email"
-          },
-          "extra_data": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "Extra Data"
-          }
+          "user_id": { "type": "string", "title": "User Id" }
         },
         "type": "object",
         "required": ["user_id"],

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -831,7 +831,7 @@ export interface CreditTransaction {
   transaction_time: Date;
   transaction_type: CreditTransactionType;
   amount: number;
-  running_balance: number;
+  running_balance?: number;
   current_balance: number;
   description: string;
   usage_graph_id: GraphID;


### PR DESCRIPTION
### Why / What / How

**Why:** The running balance shown on the user billing page (`/settings/billing`) was unreliable — it didn't reflect the correct balance under concurrent executions, which led to confusion and bug reports. The legacy `/profile/credits` page even shipped a disclaimer (_"Running balance might not be ordered accurately when concurrent executions are happening"_) acknowledging the issue. Rather than try to make the per-row running balance trustworthy under concurrency, the simpler call is to stop showing it on the user-facing pages — the current balance is already displayed via the BalanceCard and is accurate.

**What:** Remove the running balance column from the user-facing transaction history (both the new `/settings/billing` page and the legacy `/profile/credits` page) and from the user-facing API response. Admin pages are untouched and still display running balance.

**How:** Introduced a slimmer Pydantic response model `CreditTransactionItem` for the user-facing endpoint `/api/v1/credits/transactions`. The admin endpoints (`/admin/users_history`, `/admin/transactions/export`) keep returning `UserTransaction` with `running_balance` intact. The DB column `CreditTransaction.runningBalance` is unchanged — it remains the atomic balance source-of-truth used by the credit-update SQL.

### Changes 🏗️

**Backend (user-facing only):**
- `backend/data/model.py` — added `CreditTransactionItem` (mirrors `UserTransaction` minus `running_balance`); `TransactionHistory.transactions` now uses it.
- `backend/data/credit.py` — `get_transaction_history` builds `CreditTransactionItem`s and no longer reads `runningBalance`. Stripe dispute evidence text no longer prints the per-row resulting balance.

**Backend (admin — untouched):**
- `UserTransaction` model still has `running_balance`.
- `admin_get_user_history` and `admin_export_user_history` still populate `running_balance`.
- Admin tests, snapshots, and routes unchanged.

**Frontend:**
- `openapi.json` — added `CreditTransactionItem` schema; `TransactionHistory.transactions` references it.
- `TransactionHistoryCard` (new billing page) — Balance column removed.
- Legacy `/profile/credits/page.tsx` — Balance column + ordering disclaimer removed.
- Billing-card tests — running balance dropped from user-facing mocks.
- Admin spending page (`AdminUserGrantHistory`), CSV export (`helpers.ts`), and admin tests untouched — admins still see Starting / Amount / Ending Balance and the `running_balance_usd` CSV column.

**Not changed:**
- `CreditTransaction.runningBalance` DB column (still used as the atomic balance snapshot during credit updates).
- Admin endpoints, models, frontend, or tests.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] User-facing `/settings/billing` transaction history renders without the Balance column
  - [ ] Legacy `/profile/credits` transaction history renders without the Balance column and without the ordering disclaimer
  - [ ] Admin `/admin/spending` still shows Starting Balance, Amount, and Ending Balance columns unchanged
  - [ ] Admin CSV export still includes the `running_balance_usd` column
  - [ ] Topping up credits and running an agent still updates the displayed current balance correctly (atomicity intact via the unchanged `runningBalance` DB column)
