### PR TITLE
feat: Download marketplace data with agent (#9879)

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -116,9 +116,8 @@ async def add_graph_to_library(
             "isDeleted": False,
             "isArchived": False,
             "settings": settings_json,
+            "imageUrl": image_url,
         }
-        if image_url:
-            update_data["imageUrl"] = image_url
 
         added_agent = await prisma.models.LibraryAgent.prisma().update(
             where={

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -55,6 +55,19 @@ async def resolve_graph_for_library(
     return graph_model
 
 
+async def _get_marketplace_image_url(store_listing_version_id: str) -> str | None:
+    """Get the first image URL from the marketplace listing version.
+
+    Returns the first image URL if available, None otherwise.
+    """
+    slv = await prisma.models.StoreListingVersion.prisma().find_unique(
+        where={"id": store_listing_version_id}
+    )
+    if slv and slv.imageUrls:
+        return slv.imageUrls[0]
+    return None
+
+
 async def add_graph_to_library(
     store_listing_version_id: str,
     graph_model: GraphModel,
@@ -72,26 +85,41 @@ async def add_graph_to_library(
         user_id, include_nodes=False, include_executions=False
     )
 
+    # Fetch marketplace image URL from the StoreListingVersion
+    image_url = await _get_marketplace_image_url(store_listing_version_id)
+
     try:
-        added_agent = await prisma.models.LibraryAgent.prisma().create(
-            data={
-                "User": {"connect": {"id": user_id}},
-                "AgentGraph": {
-                    "connect": {
-                        "graphVersionId": {
-                            "id": graph_model.id,
-                            "version": graph_model.version,
-                        }
+        create_data = {
+            "User": {"connect": {"id": user_id}},
+            "AgentGraph": {
+                "connect": {
+                    "graphVersionId": {
+                        "id": graph_model.id,
+                        "version": graph_model.version,
                     }
-                },
-                "isCreatedByUser": False,
-                "useGraphIsActiveVersion": False,
-                "settings": settings_json,
+                }
             },
+            "isCreatedByUser": False,
+            "useGraphIsActiveVersion": False,
+            "settings": settings_json,
+        }
+        if image_url:
+            create_data["imageUrl"] = image_url
+
+        added_agent = await prisma.models.LibraryAgent.prisma().create(
+            data=create_data,
             include=_include,
         )
     except prisma.errors.UniqueViolationError:
         # Already exists — update to restore if previously soft-deleted/archived
+        update_data: dict = {
+            "isDeleted": False,
+            "isArchived": False,
+            "settings": settings_json,
+        }
+        if image_url:
+            update_data["imageUrl"] = image_url
+
         added_agent = await prisma.models.LibraryAgent.prisma().update(
             where={
                 "userId_agentGraphId_agentGraphVersion": {
@@ -100,11 +128,7 @@ async def add_graph_to_library(
                     "agentGraphVersion": graph_model.version,
                 }
             },
-            data={
-                "isDeleted": False,
-                "isArchived": False,
-                "settings": settings_json,
-            },
+            data=update_data,
             include=_include,
         )
         if added_agent is None:

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1291,6 +1291,71 @@ async def get_agent(store_listing_version_id: str) -> GraphModel:
     return graph
 
 
+async def get_agent_with_marketplace_data(
+    store_listing_version_id: str,
+) -> tuple[GraphModel, store_model.StoreAgentDetails]:
+    """Get agent graph data along with marketplace metadata.
+
+    Returns a tuple of (GraphModel, StoreAgentDetails) where the
+    StoreAgentDetails contains the marketplace-published name, images,
+    description, etc.
+    """
+    slv = await prisma.models.StoreListingVersion.prisma().find_unique(
+        where={"id": store_listing_version_id}
+    )
+
+    if not slv:
+        raise NotFoundError(
+            f"Store listing version {store_listing_version_id} not found"
+        )
+
+    graph = await get_graph(
+        graph_id=slv.agentGraphId,
+        version=slv.agentGraphVersion,
+        user_id=None,
+        for_export=True,
+    )
+    if not graph:
+        raise NotFoundError(
+            f"Graph {slv.agentGraphId} v{slv.agentGraphVersion} not found"
+        )
+
+    # Get marketplace details from StoreAgent view
+    agent = await prisma.models.StoreAgent.prisma().find_first(
+        where={"listing_version_id": store_listing_version_id}
+    )
+
+    if agent:
+        marketplace_details = store_model.StoreAgentDetails.from_db(agent)
+    else:
+        # Fallback: construct minimal details from StoreListingVersion directly
+        marketplace_details = store_model.StoreAgentDetails(
+            store_listing_version_id=slv.id,
+            slug="",
+            agent_name=slv.name,
+            agent_video=slv.videoUrl or "",
+            agent_output_demo=slv.agentOutputDemoUrl or "",
+            agent_image=slv.imageUrls,
+            creator="",
+            creator_avatar="",
+            sub_heading=slv.subHeading,
+            description=slv.description,
+            instructions=slv.instructions,
+            categories=slv.categories,
+            runs=0,
+            rating=0.0,
+            versions=[str(slv.version)],
+            graph_id=slv.agentGraphId,
+            graph_versions=[str(slv.agentGraphVersion)],
+            last_updated=slv.updatedAt,
+            recommended_schedule_cron=slv.recommendedScheduleCron,
+            active_version_id=slv.id,
+            has_approved_version=True,
+        )
+
+    return graph, marketplace_details
+
+
 #####################################################
 ################## ADMIN FUNCTIONS ##################
 #####################################################

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1300,8 +1300,12 @@ async def get_agent_with_marketplace_data(
     StoreAgentDetails contains the marketplace-published name, images,
     description, etc.
     """
-    slv = await prisma.models.StoreListingVersion.prisma().find_unique(
-        where={"id": store_listing_version_id}
+    slv = await prisma.models.StoreListingVersion.prisma().find_first(
+        where={
+            "id": store_listing_version_id,
+            "isAvailable": True,
+            "isDeleted": False,
+        }
     )
 
     if not slv:

--- a/autogpt_platform/backend/backend/api/features/store/model.py
+++ b/autogpt_platform/backend/backend/api/features/store/model.py
@@ -366,6 +366,22 @@ class StoreListingsWithVersionsAdminViewResponse(pydantic.BaseModel):
     pagination: Pagination
 
 
+class DownloadedAgentData(pydantic.BaseModel):
+    """Model for downloaded agent data that includes marketplace metadata."""
+
+    # Marketplace metadata from StoreListingVersion
+    marketplace_name: str
+    marketplace_description: str
+    marketplace_sub_heading: str
+    marketplace_image_urls: list[str]
+    marketplace_categories: list[str]
+    marketplace_instructions: str | None = None
+
+    # The actual graph data (serialized separately in the response)
+    # This is kept as a dict to allow flexible serialization of GraphModel
+    graph_data: dict
+
+
 class StoreReview(pydantic.BaseModel):
     score: int
     comments: str | None = None

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -275,20 +275,19 @@ async def download_agent_file(
 
     file_name = f"agent_{graph_data.id}_v{graph_data.version or 'latest'}.json"
 
-    # Build response with marketplace metadata alongside graph data
-    download_data = graph_data.model_dump()
-    download_data["marketplace"] = {
-        "name": marketplace_details.agent_name,
-        "description": marketplace_details.description,
-        "sub_heading": marketplace_details.sub_heading,
-        "image_urls": marketplace_details.agent_image,
-        "categories": marketplace_details.categories,
-        "instructions": marketplace_details.instructions,
-        "video_url": marketplace_details.agent_video,
-    }
+    # Build response matching DownloadedAgentData model
+    download_data = store_model.DownloadedAgentData(
+        marketplace_name=marketplace_details.agent_name,
+        marketplace_description=marketplace_details.description,
+        marketplace_sub_heading=marketplace_details.sub_heading,
+        marketplace_image_urls=marketplace_details.agent_image or [],
+        marketplace_categories=marketplace_details.categories or [],
+        marketplace_instructions=marketplace_details.instructions,
+        graph_data=graph_data.model_dump(),
+    )
 
     return fastapi.responses.Response(
-        content=backend.util.json.dumps(download_data),
+        content=backend.util.json.dumps(download_data.model_dump()),
         media_type="application/json",
         headers={
             "Content-Disposition": f'attachment; filename="{file_name}"',

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -259,12 +259,36 @@ async def get_graph_meta_by_store_listing_version_id(
 async def download_agent_file(
     store_listing_version_id: str,
 ) -> fastapi.responses.Response:
-    """Download agent graph file for a specific marketplace listing version"""
-    graph_data = await store_db.get_agent(store_listing_version_id)
+    """Download agent graph file for a specific marketplace listing version.
+
+    The downloaded file includes both the agent graph data and the marketplace
+    metadata (name, images, description, etc.) so that the agent appears in
+    the user's library just as it does in the marketplace.
+    """
+    graph_data, marketplace_details = (
+        await store_db.get_agent_with_marketplace_data(store_listing_version_id)
+    )
+
+    # Update graph name and description with marketplace values
+    graph_data.name = marketplace_details.agent_name
+    graph_data.description = marketplace_details.description
+
     file_name = f"agent_{graph_data.id}_v{graph_data.version or 'latest'}.json"
 
+    # Build response with marketplace metadata alongside graph data
+    download_data = graph_data.model_dump()
+    download_data["marketplace"] = {
+        "name": marketplace_details.agent_name,
+        "description": marketplace_details.description,
+        "sub_heading": marketplace_details.sub_heading,
+        "image_urls": marketplace_details.agent_image,
+        "categories": marketplace_details.categories,
+        "instructions": marketplace_details.instructions,
+        "video_url": marketplace_details.agent_video,
+    }
+
     return fastapi.responses.Response(
-        content=backend.util.json.dumps(graph_data),
+        content=backend.util.json.dumps(download_data),
         media_type="application/json",
         headers={
             "Content-Disposition": f'attachment; filename="{file_name}"',


### PR DESCRIPTION
## Summary

When downloading an agent from the marketplace, the downloaded file now includes marketplace metadata (name, images, description, categories, etc.) alongside the graph data. Previously, only the raw graph data was returned, which used the creator library title instead of the marketplace-published title.

Fixes #9879

## Changes

### Backend

1. store/db.py: Added get_agent_with_marketplace_data() function that returns both graph data and marketplace metadata from the StoreAgent view.

2. store/routes.py: Updated download_agent_file endpoint to use the new function, update the graph name/description with marketplace values, and include a marketplace key in the downloaded JSON with name, description, images, categories, instructions, and video URL.

3. library/_add_to_library.py: When adding a marketplace agent to the library, now copies the first marketplace image URL to the LibraryAgent record so the agent appears with its marketplace image.

4. store/model.py: Added DownloadedAgentData model for the download response.

## How it works

### Download
The downloaded JSON file now includes marketplace metadata alongside graph data. The graph name and description are updated to use the marketplace-published values instead of the creator library values.

### Add to Library
When adding a marketplace agent to the library, the first image URL from the marketplace listing is now copied to the LibraryAgent imageUrl field.