### PR TITLE
fix(frontend): skip expired session screen when logged out

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/error/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/error/__tests__/page.test.tsx
@@ -1,0 +1,56 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ErrorPage from "../page";
+
+let searchMessage: string | null = null;
+let supabaseState = {
+  isUserLoading: false,
+  isLoggedIn: false,
+};
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    get: (key: string) => (key === "message" ? searchMessage : null),
+  }),
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock("@/lib/supabase/hooks/useSupabase", () => ({
+  useSupabase: () => supabaseState,
+}));
+
+describe("ErrorPage", () => {
+  afterEach(() => {
+    searchMessage = null;
+    supabaseState = {
+      isUserLoading: false,
+      isLoggedIn: false,
+    };
+    replaceMock.mockClear();
+  });
+
+  it("redirects logged-out users away from the session expired screen", async () => {
+    searchMessage = "session-expired";
+
+    render(<ErrorPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("keeps the session expired screen for authenticated users", () => {
+    searchMessage = "session-expired";
+    supabaseState = {
+      isUserLoading: false,
+      isLoggedIn: true,
+    };
+
+    render(<ErrorPage />);
+
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/error/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/error/__tests__/page.test.tsx
@@ -42,14 +42,18 @@ describe("ErrorPage", () => {
     });
   });
 
-  it("keeps the session expired screen for authenticated users", () => {
+  it("keeps the session expired screen for authenticated users", async () => {
     searchMessage = "session-expired";
     supabaseState = {
       isUserLoading: false,
       isLoggedIn: true,
     };
 
-    render(<ErrorPage />);
+    const { container } = render(<ErrorPage />);
+
+    await waitFor(() => {
+      expect(container.querySelector(".min-h-screen")).not.toBeNull();
+    });
 
     expect(replaceMock).not.toHaveBeenCalled();
   });

--- a/autogpt_platform/frontend/src/app/(platform)/error/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/error/page.tsx
@@ -1,14 +1,25 @@
 "use client";
 
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { useSupabase } from "@/lib/supabase/hooks/useSupabase";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
 import { getErrorDetails } from "./helpers";
 
 function ErrorPageContent() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const { isLoggedIn, isUserLoading } = useSupabase();
   const errorMessage = searchParams.get("message");
   const errorDetails = getErrorDetails(errorMessage);
+  const shouldRedirectLoggedOutSessionExpired =
+    errorMessage === "session-expired" && !isUserLoading && !isLoggedIn;
+
+  useEffect(() => {
+    if (shouldRedirectLoggedOutSessionExpired) {
+      router.replace("/login");
+    }
+  }, [router, shouldRedirectLoggedOutSessionExpired]);
 
   function handleRetry() {
     // Auth-related errors should redirect to login
@@ -30,9 +41,13 @@ function ErrorPageContent() {
     }
   }
 
+  if (shouldRedirectLoggedOutSessionExpired) {
+    return null;
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
-      <div className="relative w-full max-w-xl lg:bottom-[4rem]">
+      <div className="relative w-full max-w-xl">
         <ErrorCard
           responseError={errorDetails.responseError}
           context={errorDetails.context}
@@ -48,7 +63,7 @@ export default function ErrorPage() {
     <Suspense
       fallback={
         <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
-          <div className="relative w-full max-w-xl lg:-top-[4rem]">
+          <div className="relative w-full max-w-xl">
             <ErrorCard
               responseError={{ message: "Loading..." }}
               context="application"


### PR DESCRIPTION
## Summary
- redirect logged-out users from `/error?message=session-expired` to `/login` instead of showing the expired-session error screen
- keep the expired-session screen for authenticated users whose session state has actually expired
- remove the large-screen vertical offset from the error page card so its action area is not pushed toward the viewport edge

Fixes #13305.

## Tests
- `npx -p node@22 -p pnpm@10.20.0 pnpm exec vitest run 'src/app/(platform)/error/__tests__/page.test.tsx'`
- `npx -p node@22 -p pnpm@10.20.0 pnpm exec eslint 'src/app/(platform)/error/page.tsx' 'src/app/(platform)/error/__tests__/page.test.tsx'`
- `npx -p node@22 -p pnpm@10.20.0 pnpm exec prettier --check 'src/app/(platform)/error/page.tsx' 'src/app/(platform)/error/__tests__/page.test.tsx'`
- `git diff --check`