### PR TITLE
fix(blocks/firecrawl): yield declared json_data output for JSON scrape format

### DIFF
--- a/autogpt_platform/backend/backend/blocks/firecrawl/crawl.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/crawl.py
@@ -114,4 +114,4 @@ class FirecrawlCrawlBlock(Block):
                 elif f == ScrapeFormat.CHANGE_TRACKING:
                     yield "change_tracking", data.change_tracking
                 elif f == ScrapeFormat.JSON:
-                    yield "json", data.json
+                    yield "json_data", data.json

--- a/autogpt_platform/backend/backend/blocks/firecrawl/scrape.py
+++ b/autogpt_platform/backend/backend/blocks/firecrawl/scrape.py
@@ -105,4 +105,4 @@ class FirecrawlScrapeBlock(Block):
             elif f == ScrapeFormat.CHANGE_TRACKING:
                 yield "change_tracking", scrape_result.change_tracking
             elif f == ScrapeFormat.JSON:
-                yield "json", scrape_result.json
+                yield "json_data", scrape_result.json


### PR DESCRIPTION
### Background

The Firecrawl `Scrape` and `Crawl` blocks declare a `json_data` output, but the `ScrapeFormat.JSON` branch yields the **undeclared** name `"json"`:

```python
elif f == ScrapeFormat.JSON:
    yield "json", scrape_result.json   # "json" is not a declared output ("json_data" is)
```

Every other format branch yields its declared output name (`markdown`, `html`, `raw_html`, `links`, `screenshot`, `screenshot_full_page`, `change_tracking`). Because `"json"` isn't a declared output, `Block._execute` → `output_schema.validate_field("json", ...)` → `get_field_schema` raises `ValueError: Invalid property name json` (`backend/blocks/_base.py`). So selecting the JSON format **crashes both blocks** on a normal, first-class enum option (`ScrapeFormat.JSON`).

### Changes

Yield the declared `json_data` output name in the `ScrapeFormat.JSON` branch of both `firecrawl/scrape.py` and `firecrawl/crawl.py`. The data access (`scrape_result.json` / `data.json`) is already correct — only the output key was wrong.

### Testing

Verified by inspection: the `Output` schemas declare `json_data` (not `json`); all sibling format branches yield their declared names; and `get_field_schema` raises `ValueError` for any undeclared output name. Minimal one-line fix in each block, no behaviour change for other formats. (These two blocks currently ship without `test_input`/`test_output` fixtures, which is why the JSON path wasn't exercised by `test_available_blocks` — happy to add fixtures in a follow-up if preferred.)
