### PR TITLE
fix: resolve missing edges and hollow handle states for dynamic outputs

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/__tests__/edgeStore.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/__tests__/edgeStore.test.ts
@@ -399,6 +399,28 @@ describe("edgeStore", () => {
         false,
       );
     });
+
+    it("returns true when a nested child of the source handle is connected", () => {
+      useEdgeStore.setState({
+        edges: [
+          makeEdge({
+            id: "e1",
+            source: "node-a",
+            sourceHandle: "response_#_has_new_reviews",
+          }),
+        ],
+      });
+
+      expect(
+        useEdgeStore.getState().isOutputConnected("node-a", "response"),
+      ).toBe(true);
+      expect(
+        useEdgeStore.getState().isOutputConnected("node-a", "response_#_has_new_reviews"),
+      ).toBe(true);
+      expect(
+        useEdgeStore.getState().isOutputConnected("node-a", "response_#_other"),
+      ).toBe(false);
+    });
   });
 
   describe("getBackendLinks", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx
@@ -12,7 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/Tooltip/BaseTooltip";
 import { useEdgeStore } from "@/app/(platform)/build/stores/edgeStore";
-import { getTypeDisplayInfo } from "./helpers";
+import { getTypeDisplayInfo, augmentOutputSchemaWithEdges } from "./helpers";
 import { BlockUIType } from "../../types";
 import { cn } from "@/lib/utils";
 import { useBrokenOutputs } from "./useBrokenOutputs";
@@ -27,7 +27,8 @@ export const OutputHandler = ({
   uiType: BlockUIType;
 }) => {
   const { isOutputConnected } = useEdgeStore();
-  const properties = outputSchema?.properties || {};
+  const edges = useEdgeStore((state) => state.edges);
+  const properties = augmentOutputSchemaWithEdges(outputSchema, nodeId, edges);
   const [isOutputVisible, setIsOutputVisible] = useState(true);
   const brokenOutputs = useBrokenOutputs(nodeId);
   const [expandedObjects, setExpandedObjects] = useState<

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/__tests__/helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { augmentOutputSchemaWithEdges } from "../helpers";
+
+describe("augmentOutputSchemaWithEdges", () => {
+  it("returns empty properties when outputSchema has no properties", () => {
+    const outputSchema = {};
+    const edges: any[] = [];
+    const result = augmentOutputSchemaWithEdges(outputSchema, "node-a", edges);
+    expect(result).toEqual({});
+  });
+
+  it("does not modify schema when there are no matching outgoing edges", () => {
+    const outputSchema = {
+      properties: {
+        response: { type: "object" },
+      },
+    };
+    const edges = [
+      { source: "node-b", sourceHandle: "response_#_key" }, // different node
+      { source: "node-a", sourceHandle: "other" }, // non-nested handle
+    ];
+    const result = augmentOutputSchemaWithEdges(outputSchema, "node-a", edges);
+    expect(result).toEqual({
+      response: { type: "object" },
+    });
+  });
+
+  it("dynamically injects nested properties for matching outgoing edges", () => {
+    const outputSchema = {
+      properties: {
+        response: { type: "object" },
+      },
+    };
+    const edges = [
+      { source: "node-a", sourceHandle: "response_#_has_new_reviews" },
+      { source: "node-a", sourceHandle: "response_#_reviews_#_author" },
+    ];
+    const result = augmentOutputSchemaWithEdges(outputSchema, "node-a", edges);
+    expect(result).toEqual({
+      response: {
+        type: "object",
+        properties: {
+          has_new_reviews: { title: "has_new_reviews" },
+          reviews: {
+            type: "object",
+            title: "reviews",
+            properties: {
+              author: { title: "author" },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/helpers.ts
@@ -222,3 +222,44 @@ export function getEdgeColorFromOutputType(
 
   return defaultColor;
 }
+
+export function augmentOutputSchemaWithEdges(
+  outputSchema: RJSFSchema | undefined,
+  nodeId: string,
+  edges: any[],
+): Record<string, RJSFSchema> {
+  const properties = JSON.parse(JSON.stringify(outputSchema?.properties || {}));
+
+  // Filter for outgoing edges from this node that have a source handle
+  const outgoingEdges = edges.filter(
+    (e) => e.source === nodeId && e.sourceHandle,
+  );
+
+  outgoingEdges.forEach((edge) => {
+    const handleId = edge.sourceHandle!;
+    const segments = handleId.split("_#_");
+    if (segments.length <= 1) return; // Only process dynamic nested properties
+
+    let current = properties;
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      const isLast = i === segments.length - 1;
+
+      if (!current[segment]) {
+        current[segment] = isLast
+          ? { title: segment } // Default to any type (displays as 'any')
+          : { type: "object", title: segment, properties: {} };
+      } else {
+        if (!isLast) {
+          current[segment].properties = current[segment].properties || {};
+        }
+      }
+
+      if (!isLast) {
+        current = current[segment].properties;
+      }
+    }
+  });
+
+  return properties;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/stores/edgeStore.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/stores/edgeStore.ts
@@ -118,7 +118,12 @@ export const useEdgeStore = create<EdgeStore>((set, get) => ({
   },
 
   isOutputConnected: (nodeId, handle) =>
-    get().edges.some((e) => e.source === nodeId && e.sourceHandle === handle),
+    get().edges.some(
+      (e) =>
+        e.source === nodeId &&
+        (e.sourceHandle === handle ||
+          (e.sourceHandle && e.sourceHandle.startsWith(handle + "_#_"))),
+    ),
 
   getBackendLinks: () => get().edges.map(customEdgeToLink),
 


### PR DESCRIPTION
### Why / What / How

<!-- Why: Why does this PR exist? What problem does it solve, or what's broken/missing without it? -->
**Why**: 
An agent created by AutoPilot renders with missing edges, input handles that show "connected" with no edge attached, and edges that appear to land on handles drawn as unconnected. This is a builder-rendering bug caused by dynamic dict outputs (e.g. `response_#_has_new_reviews`) not having handles dynamically materialized in the DOM like inputs do, and connection-check string matches failing because the edges carry the nested separator.

<!-- What: What does this PR change? Summarize the changes at a high level. -->
**What**: 
Materializes phantom handles for dynamic outputs based on outgoing edges, and updates output connection status checking to support prefix matches.

<!-- How: How does it work? Describe the approach, key implementation details, or architecture decisions. -->
**How**: 
1. Added `augmentOutputSchemaWithEdges` to nodes helper which parses outgoing edges and recursively inserts sub-keys into the schema properties in memory.
2. `OutputHandler` uses this augmented properties schema to render and mount the nested sub-handles in the DOM.
3. Updated `isOutputConnected` in `edgeStore` to check for prefix matches using the `_#_` separator.

### Changes 🏗️

<!-- List the key changes. Keep it higher level than the diff but specific enough to highlight what's new/modified. -->
- Added `augmentOutputSchemaWithEdges` in `autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/helpers.ts`
- Updated `OutputHandler` in `autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/OutputHandler.tsx` to use the augmented schema.
- Updated `isOutputConnected` in `autogpt_platform/frontend/src/app/(platform)/build/stores/edgeStore.ts`
- Added Vitest unit test suites in `helpers.test.ts` and `edgeStore.test.ts`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Tested store connection state logic with Vitest unit tests (all 38 passed).
  - [x] Tested schema properties parser with Vitest unit tests (all 3 passed).