### PR TITLE
fix(frontend): use consistent marble avatar fallback in navbar

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -135,7 +135,7 @@ describe("AccountMenu", () => {
   });
 
   test("renders profile trigger with avatar fallback", () => {
-    render(
+    const { container } = render(
       <AccountMenu
         userName="Ada"
         userEmail="ada@example.com"
@@ -144,7 +144,8 @@ describe("AccountMenu", () => {
     );
 
     expect(screen.getByTestId("profile-popout-menu-trigger")).toBeDefined();
-    expect(screen.getAllByText("A").length).toBeGreaterThan(0);
+    // InitialAvatar uses a marble SVG fallback (not a letter initial).
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
   test("new layout renders the organization switcher header trigger", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
@@ -1,4 +1,7 @@
-import Avatar, { AvatarImage } from "@/components/atoms/Avatar/Avatar";
+import Avatar, {
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/atoms/Avatar/Avatar";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -8,19 +11,10 @@ interface Props {
 }
 
 export function InitialAvatar({ src, name, className }: Props) {
-  const initial = name?.trim().charAt(0).toUpperCase() || "U";
-
   return (
     <Avatar className={cn("h-10 w-10", className)}>
-      <div className="absolute inset-0 z-0 flex items-center justify-center bg-violet-500 text-sm font-semibold text-white">
-        {initial}
-      </div>
-      <AvatarImage
-        src={src}
-        alt=""
-        aria-hidden="true"
-        className="relative z-10"
-      />
+      <AvatarImage src={src} alt={name ? `${name}'s avatar` : "User avatar"} />
+      <AvatarFallback>{name?.trim() || "User"}</AvatarFallback>
     </Avatar>
   );
 }

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
@@ -11,10 +11,17 @@ interface Props {
 }
 
 export function InitialAvatar({ src, name, className }: Props) {
+  const normalizedName = name?.trim();
+
   return (
     <Avatar className={cn("h-10 w-10", className)}>
-      <AvatarImage src={src} alt={name ? `${name}'s avatar` : "User avatar"} />
-      <AvatarFallback>{name?.trim() || "User"}</AvatarFallback>
+      <AvatarImage
+        src={src}
+        alt={normalizedName ? `${normalizedName}'s avatar` : "User avatar"}
+      />
+      <AvatarFallback className={cn("h-10 w-10", className)}>
+        {normalizedName || "User"}
+      </AvatarFallback>
     </Avatar>
   );
 }

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
@@ -3,24 +3,24 @@ import { describe, expect, test } from "vitest";
 import { InitialAvatar } from "../InitialAvatar";
 
 describe("InitialAvatar", () => {
-  test("renders uppercase first character of name", () => {
-    render(<InitialAvatar name="abhimanyu" />);
-    expect(screen.getByText("A")).toBeDefined();
+  test("renders marble gradient fallback when no image is provided", () => {
+    const { container } = render(<InitialAvatar name="abhimanyu" />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test("trims whitespace before extracting initial", () => {
-    render(<InitialAvatar name="   beth" />);
-    expect(screen.getByText("B")).toBeDefined();
+  test("uses trimmed name as fallback seed", () => {
+    const { container } = render(<InitialAvatar name="   beth" />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test("falls back to 'U' when name is missing", () => {
-    render(<InitialAvatar />);
-    expect(screen.getByText("U")).toBeDefined();
+  test("falls back to 'User' when name is missing", () => {
+    const { container } = render(<InitialAvatar />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test("falls back to 'U' when name is an empty string", () => {
-    render(<InitialAvatar name="" />);
-    expect(screen.getByText("U")).toBeDefined();
+  test("falls back to 'User' when name is an empty string", () => {
+    const { container } = render(<InitialAvatar name="" />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
   test("merges className prop into the avatar root", () => {
@@ -31,17 +31,11 @@ describe("InitialAvatar", () => {
     expect(root.className).toContain("size-12");
   });
 
-  test("places image above the initial fallback when src is provided", async () => {
-    const { container } = render(
-      <InitialAvatar name="ada" src="https://example.com/avatar.png" />,
-    );
+  test("shows image when src is provided", async () => {
+    render(<InitialAvatar name="ada" src="https://example.com/avatar.png" />);
 
     await waitFor(() => {
-      expect(container.querySelector("img")).not.toBeNull();
+      expect(screen.getByRole("img", { name: "ada's avatar" })).toBeDefined();
     });
-
-    const image = container.querySelector("img");
-    expect(image?.className).toContain("z-10");
-    expect(screen.getByText("A").className).toContain("z-0");
   });
 });


### PR DESCRIPTION
## Summary
- Replace the navbar account menu's custom letter-on-purple avatar fallback with the shared `AvatarFallback` component (boring-avatars marble gradient)
- Ensures the same user sees a consistent avatar treatment in the navbar and across profile/creator displays

Fixes #13411

## Root cause
`InitialAvatar` in the account menu rendered a hardcoded initial letter on a solid violet background, while the design-system `Avatar` component uses a marble gradient fallback seeded by the user's name everywhere else.

## Test plan
- [x] `pnpm exec vitest run src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx`
- [ ] Manually verify navbar avatar shows marble gradient when no profile image is set
- [ ] Manually verify profile/creator avatars still match navbar fallback style


Made with [Cursor](https://cursor.com)