### PR TITLE
fix(backend/copilot): handle budget-exceeded turn kill gracefully

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -20,8 +20,8 @@ from backend.copilot.active_turns import (
     get_inflight_turn_limit,
     inflight_turn_limit_message,
 )
-from backend.copilot.builder_context import resolve_session_permissions
 from backend.copilot.budget import MIN_VIABLE_TASK_BUDGET_USD
+from backend.copilot.builder_context import resolve_session_permissions
 from backend.copilot.config import ChatConfig, CopilotLlmModel, CopilotMode
 from backend.copilot.db import get_chat_messages_paginated
 from backend.copilot.executor.utils import enqueue_cancel_task, schedule_chat_turn

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -52,6 +52,7 @@ from backend.copilot.rate_limit import (
     enforce_payment_paywall,
     get_daily_reset_count,
     get_global_rate_limits,
+    get_remaining_usd_budget,
     get_usage_status,
     increment_daily_reset_count,
     release_reset_lock,
@@ -1107,6 +1108,28 @@ async def stream_chat_post(
                 daily_cost_limit=daily_limit,
                 weekly_cost_limit=weekly_limit,
             )
+
+            # Budget-viability gate: even when the user hasn't hit their
+            # daily/weekly cap yet, a tiny remaining budget (< $1) means
+            # the turn is doomed before it starts (median task cost ~$5).
+            # Block early and surface the rate-limit / credit-reset UI
+            # instead of dispatching a turn that will die mid-stream.
+            _MIN_VIABLE_TASK_BUDGET_USD = 1.0
+            remaining = await get_remaining_usd_budget(
+                user_id=user_id,
+                daily_cost_limit=daily_limit,
+                weekly_cost_limit=weekly_limit,
+                floor_usd=0.0,  # faithful signal, no floor
+            )
+            if 0 <= remaining < _MIN_VIABLE_TASK_BUDGET_USD:
+                raise HTTPException(
+                    status_code=429,
+                    detail=(
+                        "Your remaining budget is too low for a viable task. "
+                        "Please wait for your usage to reset, or upgrade "
+                        "your plan."
+                    ),
+                )
         except RateLimitExceeded as e:
             raise HTTPException(status_code=429, detail=str(e)) from e
         except RateLimitUnavailable as e:

--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -21,6 +21,7 @@ from backend.copilot.active_turns import (
     inflight_turn_limit_message,
 )
 from backend.copilot.builder_context import resolve_session_permissions
+from backend.copilot.budget import MIN_VIABLE_TASK_BUDGET_USD
 from backend.copilot.config import ChatConfig, CopilotLlmModel, CopilotMode
 from backend.copilot.db import get_chat_messages_paginated
 from backend.copilot.executor.utils import enqueue_cancel_task, schedule_chat_turn
@@ -1114,14 +1115,13 @@ async def stream_chat_post(
             # the turn is doomed before it starts (median task cost ~$5).
             # Block early and surface the rate-limit / credit-reset UI
             # instead of dispatching a turn that will die mid-stream.
-            _MIN_VIABLE_TASK_BUDGET_USD = 1.0
             remaining = await get_remaining_usd_budget(
                 user_id=user_id,
                 daily_cost_limit=daily_limit,
                 weekly_cost_limit=weekly_limit,
                 floor_usd=0.0,  # faithful signal, no floor
             )
-            if 0 <= remaining < _MIN_VIABLE_TASK_BUDGET_USD:
+            if 0 <= remaining < MIN_VIABLE_TASK_BUDGET_USD:
                 raise HTTPException(
                     status_code=429,
                     detail=(

--- a/autogpt_platform/backend/backend/copilot/budget.py
+++ b/autogpt_platform/backend/backend/copilot/budget.py
@@ -1,0 +1,6 @@
+"""Shared CoPilot budget thresholds."""
+
+# Minimum viable per-query budget (USD). A turn dispatched with less than this
+# is almost certainly doomed: the median task cost is ~$5.37 (p50), and even a
+# lightweight follow-up needs about $1 of headroom.
+MIN_VIABLE_TASK_BUDGET_USD = 1.0

--- a/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/interrupted_partial_test.py
@@ -340,3 +340,6 @@ class TestRetryableStreamErrorCodes:
     def test_unknown_codes_are_not_retryable(self):
         assert "sdk_error" not in _RETRYABLE_STREAM_ERROR_CODES
         assert "all_attempts_exhausted" not in _RETRYABLE_STREAM_ERROR_CODES
+
+    def test_budget_below_viable_is_retryable(self):
+        assert "budget_below_viable" in _RETRYABLE_STREAM_ERROR_CODES

--- a/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/response_adapter.py
@@ -603,12 +603,14 @@ class SDKResponseAdapter:
                 # SDK signalled the per-turn USD budget was exhausted.
                 # Surface a specific message instead of the generic empty-
                 # completion overlay (which would shadow the real reason).
+                # This error is retryable — a follow-up may succeed if the
+                # per-query cap tripped (daily/weekly cap requires a reset).
                 responses.append(
                     StreamError(
                         errorText=(
                             "The turn ended because it exceeded the budget. "
-                            "Try a smaller scope, or wait for the next "
-                            "billing window."
+                            "Send a follow-up to continue, or try a smaller "
+                            "scope."
                         ),
                         code="max_budget_exhausted",
                     )

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -209,6 +209,7 @@ _CIRCUIT_BREAKER_ERROR_MSG = (
 _IDLE_TIMEOUT_SECONDS = 30 * 60
 _HUNG_TOOL_CAP_SECONDS = 2 * 60 * 60
 
+
 async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     """Pick the per-query ``max_budget_usd`` for this user *now*.
 
@@ -1009,7 +1010,12 @@ def _idle_timeout_threshold(adapter: SDKResponseAdapter) -> int:
 # ``_append_error_marker`` directly already pass ``retryable=True``; this set
 # covers the codes that flow through the adapter -> ``_dispatch_response``.
 _RETRYABLE_STREAM_ERROR_CODES: frozenset[str] = frozenset(
-    {"transient_api_error", "empty_completion", "max_budget_exhausted", "budget_below_viable"}
+    {
+        "transient_api_error",
+        "empty_completion",
+        "max_budget_exhausted",
+        "budget_below_viable",
+    }
 )
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -119,6 +119,7 @@ from ..builder_context import (
     build_builder_context_turn_prefix,
     build_builder_system_prompt_suffix,
 )
+from ..budget import MIN_VIABLE_TASK_BUDGET_USD
 from ..service import (
     _build_system_prompt,
     _is_langfuse_configured,
@@ -208,16 +209,6 @@ _CIRCUIT_BREAKER_ERROR_MSG = (
 _IDLE_TIMEOUT_SECONDS = 30 * 60
 _HUNG_TOOL_CAP_SECONDS = 2 * 60 * 60
 
-# Minimum viable per-query budget (USD).  A turn dispatched with less than
-# this is almost certainly doomed — the median task cost is ~$5.37 (p50)
-# and even a lightweight follow-up needs ~$1 of headroom.  When the
-# user's *actual* remaining daily/weekly budget is below this threshold
-# we short-circuit with a rate-limit error instead of dispatching a turn
-# that will be hard-killed mid-stream by the CLI's ``max_budget_usd``
-# enforcement, producing a confusing "budget exceeded" ErrorCard.
-_MIN_VIABLE_BUDGET_USD = 1.0
-
-
 async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     """Pick the per-query ``max_budget_usd`` for this user *now*.
 
@@ -229,7 +220,7 @@ async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     internal turn run without auth).
 
     Returns ``0.0`` when the user's *actual* remaining budget is positive
-    but below ``_MIN_VIABLE_BUDGET_USD`` — the turn would be doomed (the
+    but below ``MIN_VIABLE_TASK_BUDGET_USD`` — the turn would be doomed (the
     CLI would hard-kill it mid-stream).  Callers must check for ``0.0``
     and short-circuit with a rate-limit error instead of dispatching.
     """
@@ -259,7 +250,7 @@ async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     # If the user's actual remaining budget is below the viable threshold
     # the turn is doomed — it will be hard-killed mid-stream.  Signal this
     # to the caller so it can surface a rate-limit error instead.
-    if 0 < remaining < _MIN_VIABLE_BUDGET_USD:
+    if 0 < remaining < MIN_VIABLE_TASK_BUDGET_USD:
         return 0.0
     return min(static_cap, remaining)
 
@@ -4139,7 +4130,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         # can short-circuit with a rate-limit error when the user's
         # remaining daily/weekly budget is too low for a viable turn.
         # ``_resolve_dynamic_max_budget_usd`` returns 0.0 when the actual
-        # remaining is positive but below ``_MIN_VIABLE_BUDGET_USD`` —
+        # remaining is positive but below ``MIN_VIABLE_TASK_BUDGET_USD`` —
         # dispatching in that case would produce a doomed turn that the
         # CLI hard-kills mid-stream.
         resolved_budget = await _resolve_dynamic_max_budget_usd(user_id)
@@ -4148,7 +4139,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 "%s Remaining budget below viable threshold ($%.2f); "
                 "rejecting turn with rate-limit error",
                 log_prefix,
-                _MIN_VIABLE_BUDGET_USD,
+                MIN_VIABLE_TASK_BUDGET_USD,
             )
             _append_error_marker(
                 session,

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -214,6 +214,15 @@ _HUNG_TOOL_CAP_SECONDS = 2 * 60 * 60
 # wrap up gracefully instead of hitting an immediate hard stop.
 _MAX_BUDGET_USD_FLOOR = 0.5
 
+# Minimum viable per-query budget (USD).  A turn dispatched with less than
+# this is almost certainly doomed — the median task cost is ~$5.37 (p50)
+# and even a lightweight follow-up needs ~$1 of headroom.  When the
+# user's *actual* remaining daily/weekly budget is below this threshold
+# we short-circuit with a rate-limit error instead of dispatching a turn
+# that will be hard-killed mid-stream by the CLI's ``max_budget_usd``
+# enforcement, producing a confusing "budget exceeded" ErrorCard.
+_MIN_VIABLE_BUDGET_USD = 1.0
+
 
 async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     """Pick the per-query ``max_budget_usd`` for this user *now*.
@@ -1007,7 +1016,7 @@ def _idle_timeout_threshold(adapter: SDKResponseAdapter) -> int:
 # ``_append_error_marker`` directly already pass ``retryable=True``; this set
 # covers the codes that flow through the adapter -> ``_dispatch_response``.
 _RETRYABLE_STREAM_ERROR_CODES: frozenset[str] = frozenset(
-    {"transient_api_error", "empty_completion"}
+    {"transient_api_error", "empty_completion", "max_budget_exhausted"}
 )
 
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -235,6 +235,11 @@ async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     internal turn run without auth).  Floored at ``_MAX_BUDGET_USD_FLOOR``
     so a near-capped user still gets enough headroom to surface the
     "wrap up" reminder rather than failing to dispatch.
+
+    Returns ``0.0`` when the user's *actual* remaining budget is positive
+    but below ``_MIN_VIABLE_BUDGET_USD`` — the turn would be doomed (the
+    CLI would hard-kill it mid-stream).  Callers must check for ``0.0``
+    and short-circuit with a rate-limit error instead of dispatching.
     """
     static_cap = config.claude_agent_max_budget_usd
     if not user_id:
@@ -259,6 +264,11 @@ async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     )
     if remaining < 0 or remaining == float("inf"):
         return static_cap
+    # If the user's actual remaining budget is below the viable threshold
+    # the turn is doomed — it will be hard-killed mid-stream.  Signal this
+    # to the caller so it can surface a rate-limit error instead.
+    if 0 < remaining < _MIN_VIABLE_BUDGET_USD:
+        return 0.0
     return max(_MAX_BUDGET_USD_FLOOR, min(static_cap, remaining))
 
 
@@ -1016,7 +1026,7 @@ def _idle_timeout_threshold(adapter: SDKResponseAdapter) -> int:
 # ``_append_error_marker`` directly already pass ``retryable=True``; this set
 # covers the codes that flow through the adapter -> ``_dispatch_response``.
 _RETRYABLE_STREAM_ERROR_CODES: frozenset[str] = frozenset(
-    {"transient_api_error", "empty_completion", "max_budget_exhausted"}
+    {"transient_api_error", "empty_completion", "max_budget_exhausted", "budget_below_viable"}
 )
 
 
@@ -4132,6 +4142,38 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             cross_user_cache=config.claude_agent_cross_user_prompt_cache,
         )
 
+        # --- Pre-dispatch budget viability gate ---
+        # Resolve the per-query budget *before* building SDK options so we
+        # can short-circuit with a rate-limit error when the user's
+        # remaining daily/weekly budget is too low for a viable turn.
+        # ``_resolve_dynamic_max_budget_usd`` returns 0.0 when the actual
+        # remaining is positive but below ``_MIN_VIABLE_BUDGET_USD`` —
+        # dispatching in that case would produce a doomed turn that the
+        # CLI hard-kills mid-stream.
+        resolved_budget = await _resolve_dynamic_max_budget_usd(user_id)
+        if resolved_budget == 0.0:
+            logger.info(
+                "%s Remaining budget below viable threshold ($%.2f); "
+                "rejecting turn with rate-limit error",
+                log_prefix,
+                _MIN_VIABLE_BUDGET_USD,
+            )
+            _append_error_marker(
+                session,
+                "Your remaining budget is too low to start a new turn. "
+                "Please wait for your budget to reset, or upgrade your plan.",
+                retryable=True,
+            )
+            yield StreamError(
+                errorText=(
+                    "Your remaining budget is too low to start a new turn. "
+                    "Please wait for your budget to reset, or upgrade your plan."
+                ),
+                code="budget_below_viable",
+            )
+            yield StreamFinish()
+            return
+
         sdk_options = ClaudeAgentOptions(
             system_prompt=system_prompt_value,
             mcp_servers={"copilot": mcp_server},
@@ -4153,7 +4195,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             # the user's *actual* remaining daily/weekly USD cap so the
             # CLI's "wrap up gracefully" reminder fires when they're close
             # to the real limit, not the static $10 default.
-            max_budget_usd=await _resolve_dynamic_max_budget_usd(user_id),
+            max_budget_usd=resolved_budget,
             # thinking: specify extended thinking mode. Thinking tokens are
             # billed at output rate ($75/M for Opus) and account for ~54%
             # of total cost.  The CLI silently ignores this field for

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -208,12 +208,6 @@ _CIRCUIT_BREAKER_ERROR_MSG = (
 _IDLE_TIMEOUT_SECONDS = 30 * 60
 _HUNG_TOOL_CAP_SECONDS = 2 * 60 * 60
 
-# Floor on the per-query SDK budget — too small and the CLI refuses to
-# start a turn at all.  Caller (``_resolve_dynamic_max_budget_usd``) clamps
-# to this so a user near (but not yet at) their cap still gets a chance to
-# wrap up gracefully instead of hitting an immediate hard stop.
-_MAX_BUDGET_USD_FLOOR = 0.5
-
 # Minimum viable per-query budget (USD).  A turn dispatched with less than
 # this is almost certainly doomed — the median task cost is ~$5.37 (p50)
 # and even a lightweight follow-up needs ~$1 of headroom.  When the
@@ -232,9 +226,7 @@ async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
       * the user's remaining daily/weekly USD cap (from Redis)
 
     Falls back to the static cap when no ``user_id`` is available (e.g. an
-    internal turn run without auth).  Floored at ``_MAX_BUDGET_USD_FLOOR``
-    so a near-capped user still gets enough headroom to surface the
-    "wrap up" reminder rather than failing to dispatch.
+    internal turn run without auth).
 
     Returns ``0.0`` when the user's *actual* remaining budget is positive
     but below ``_MIN_VIABLE_BUDGET_USD`` — the turn would be doomed (the
@@ -269,7 +261,7 @@ async def _resolve_dynamic_max_budget_usd(user_id: str | None) -> float:
     # to the caller so it can surface a rate-limit error instead.
     if 0 < remaining < _MIN_VIABLE_BUDGET_USD:
         return 0.0
-    return max(_MAX_BUDGET_USD_FLOOR, min(static_cap, remaining))
+    return min(static_cap, remaining)
 
 
 @dataclass

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -1873,10 +1873,10 @@ class TestResolveDynamicMaxBudgetUsd:
         assert result == 2.5
 
     @pytest.mark.asyncio
-    async def test_clamps_to_floor_when_remaining_is_below(self):
-        # A near-capped user still gets enough headroom to dispatch the
-        # turn (and surface the wrap-up reminder) instead of being
-        # blocked at the SDK level.
+    async def test_returns_zero_when_remaining_below_viable(self):
+        # When the user's actual remaining budget is below the viable
+        # threshold the turn would be doomed — return 0.0 so the caller
+        # can short-circuit with a rate-limit error.
         with (
             patch(
                 "backend.copilot.sdk.service.get_global_rate_limits",
@@ -1885,6 +1885,28 @@ class TestResolveDynamicMaxBudgetUsd:
             patch(
                 "backend.copilot.sdk.service.get_remaining_usd_budget",
                 new=AsyncMock(return_value=0.05),
+            ),
+            patch(
+                "backend.copilot.sdk.service.config.claude_agent_max_budget_usd",
+                10.0,
+            ),
+        ):
+            result = await _resolve_dynamic_max_budget_usd("u-1")
+        assert result == 0.0
+
+    @pytest.mark.asyncio
+    async def test_clamps_to_floor_when_remaining_is_at_viable(self):
+        # When remaining is at or above the viable threshold, the floor
+        # still applies so a near-capped user gets enough headroom to
+        # dispatch the turn (and surface the wrap-up reminder).
+        with (
+            patch(
+                "backend.copilot.sdk.service.get_global_rate_limits",
+                new=AsyncMock(return_value=(10_000_000, 0, "FREE")),
+            ),
+            patch(
+                "backend.copilot.sdk.service.get_remaining_usd_budget",
+                new=AsyncMock(return_value=1.0),
             ),
             patch(
                 "backend.copilot.sdk.service.config.claude_agent_max_budget_usd",

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -16,7 +16,6 @@ from backend.copilot.permissions import CopilotPermissions, all_known_tool_names
 from .service import (
     _HUNG_TOOL_CAP_SECONDS,
     _IDLE_TIMEOUT_SECONDS,
-    _MAX_BUDGET_USD_FLOOR,
     _THINKING_ONLY_REPROMPT,
     _build_system_prompt_value,
     _hidden_short_names_for_permissions,
@@ -1914,7 +1913,10 @@ class TestResolveDynamicMaxBudgetUsd:
             ),
         ):
             result = await _resolve_dynamic_max_budget_usd("u-1")
-        assert result == _MAX_BUDGET_USD_FLOOR
+        # remaining=1.0 is >= _MIN_VIABLE_BUDGET_USD (1.0), so the viable
+        # gate does NOT fire.  The resolver returns min(static_cap, remaining)
+        # = min(10.0, 1.0) = 1.0.
+        assert result == 1.0
 
     @pytest.mark.asyncio
     async def test_static_cap_wins_when_smaller_than_remaining(self):

--- a/autogpt_platform/backend/backend/copilot/sdk/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service_test.py
@@ -1894,10 +1894,9 @@ class TestResolveDynamicMaxBudgetUsd:
         assert result == 0.0
 
     @pytest.mark.asyncio
-    async def test_clamps_to_floor_when_remaining_is_at_viable(self):
-        # When remaining is at or above the viable threshold, the floor
-        # still applies so a near-capped user gets enough headroom to
-        # dispatch the turn (and surface the wrap-up reminder).
+    async def test_uses_remaining_when_at_viable_threshold(self):
+        # When remaining is at or above the viable threshold, the resolver
+        # uses the smaller of the static cap and actual remaining budget.
         with (
             patch(
                 "backend.copilot.sdk.service.get_global_rate_limits",
@@ -1913,9 +1912,8 @@ class TestResolveDynamicMaxBudgetUsd:
             ),
         ):
             result = await _resolve_dynamic_max_budget_usd("u-1")
-        # remaining=1.0 is >= _MIN_VIABLE_BUDGET_USD (1.0), so the viable
-        # gate does NOT fire.  The resolver returns min(static_cap, remaining)
-        # = min(10.0, 1.0) = 1.0.
+        # remaining=1.0 is at the viable threshold, so the viable gate does
+        # not fire. The resolver returns min(static_cap, remaining) = 1.0.
         assert result == 1.0
 
     @pytest.mark.asyncio

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/MessagePartRenderer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/MessagePartRenderer.tsx
@@ -171,7 +171,7 @@ export function MessagePartRenderer({
           <ErrorCard
             key={key}
             responseError={{ message: markerText }}
-            context="execution"
+            context="your request"
             onRetry={markerType === "retryable_error" ? onRetry : undefined}
           />
         );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/copilotStreamErrorHandlers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/copilotStreamErrorHandlers.ts
@@ -61,6 +61,11 @@ const TOAST_BY_BACKEND_CODE: Record<
     fallbackDescription:
       "The assistant couldn't complete this turn. Press Try Again to retry.",
   },
+  max_budget_exhausted: {
+    title: "Budget exceeded",
+    fallbackDescription:
+      "The turn ended because it exceeded the budget. Send a follow-up to continue, or try a smaller scope.",
+  },
 };
 
 /** Fallback toast shown for any `[code:X]` we don't have specific copy for. */

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/copilotStreamErrorHandlers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/copilotStreamErrorHandlers.ts
@@ -66,6 +66,11 @@ const TOAST_BY_BACKEND_CODE: Record<
     fallbackDescription:
       "The turn ended because it exceeded the budget. Send a follow-up to continue, or try a smaller scope.",
   },
+  budget_below_viable: {
+    title: "Budget too low",
+    fallbackDescription:
+      "Your remaining budget is too low to start a new turn. Please wait for your budget to reset, or upgrade your plan.",
+  },
 };
 
 /** Fallback toast shown for any `[code:X]` we don't have specific copy for. */


### PR DESCRIPTION
Fixes #13398

## Summary

Budget-exceeded turns were dying mid-stream with a non-retryable ErrorCard and misleading copy. This PR fixes all 4 root causes identified in the issue.

## Changes

### 1. Pre-turn budget-viability gate (routes.py)
- After check_rate_limit passes, check if remaining budget < $1 (below viable-task threshold)
- Block dispatch early with 429 instead of starting a doomed turn that dies mid-stream
- Uses get_remaining_usd_budget(floor_usd=0.0) for faithful signal (no floor applied)

### 2. Make max_budget_exhausted retryable (service.py)
- Added to _RETRYABLE_STREAM_ERROR_CODES so the ErrorCard renders with a retry button
- Users can now retry instead of being stuck with a terminal error

### 3. Improve error message (response_adapter.py)
- Old: "Try a smaller scope, or wait for the next billing window." (misleading - per-query cap allows immediate follow-up)
- New: "Send a follow-up to continue, or try a smaller scope." (actionable for both per-query and daily/weekly caps)

### 4. Fix ErrorCard context (MessagePartRenderer.tsx)
- Changed context="execution" to context="your request"
- Fixes nonsensical "We had the following error when retrieving execution" phrasing

### 5. Add specific toast for max_budget_exhausted (copilotStreamErrorHandlers.ts)
- Previously fell through to generic "AutoPilot ran into a problem" toast
- Now shows "Budget exceeded" with the specific error message