### PR TITLE
Fix/9326 improve add-block placement without viewport jump

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/AllBlocksContent/AllBlocksContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/AllBlocksContent/AllBlocksContent.tsx
@@ -6,7 +6,6 @@ import { beautifyString } from "@/lib/utils";
 import { useAllBlockContent } from "./useAllBlockContent";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { blockMenuContainerStyle } from "../style";
-import { useNodeStore } from "../../../../stores/nodeStore";
 
 export const AllBlocksContent = () => {
   const {
@@ -18,8 +17,6 @@ export const AllBlocksContent = () => {
     isLoadingMore,
     isErrorOnLoadingMore,
   } = useAllBlockContent();
-
-  const addBlock = useNodeStore((state) => state.addBlock);
 
   if (isLoading) {
     return (
@@ -74,7 +71,6 @@ export const AllBlocksContent = () => {
                   key={`${category.name}-${block.id}`}
                   title={block.name as string}
                   description={block.name as string}
-                  onClick={() => addBlock(block)}
                   blockData={block}
                 />
               ))}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/Block.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/Block.tsx
@@ -1,14 +1,14 @@
 import { Button } from "@/components/__legacy__/ui/button";
 import { Skeleton } from "@/components/__legacy__/ui/skeleton";
 import { beautifyString, cn } from "@/lib/utils";
-import React, { ButtonHTMLAttributes, useCallback, useState } from "react";
+import React, { ButtonHTMLAttributes, useState } from "react";
 import { highlightText } from "./helpers";
 import { PlusIcon } from "@phosphor-icons/react";
 import { BlockInfo } from "@/app/api/__generated__/models/blockInfo";
 import { useControlPanelStore } from "../../../stores/controlPanelStore";
 import { blockDragPreviewStyle } from "./style";
-import { useReactFlow } from "@xyflow/react";
 import { useNodeStore } from "../../../stores/nodeStore";
+import { useAddBlockToBuilder } from "./hooks/useAddBlockToBuilder";
 import { BlockUIType, SpecialBlockID } from "@/lib/autogpt-server-api";
 import {
   MCPToolDialog,
@@ -37,76 +37,52 @@ export const Block: BlockComponent = ({
   const setBlockMenuOpen = useControlPanelStore(
     (state) => state.setBlockMenuOpen,
   );
-  const { setViewport } = useReactFlow();
-  const { addBlock } = useNodeStore();
+  const { addBlockWithPlacement } = useAddBlockToBuilder();
   const [mcpDialogOpen, setMcpDialogOpen] = useState(false);
 
   const isMCPBlock = blockData.uiType === BlockUIType.MCP_TOOL;
 
-  const addBlockAndCenter = useCallback(
-    (block: BlockInfo, hardcodedValues?: Record<string, any>) => {
-      const customNode = addBlock(block, hardcodedValues);
-      setTimeout(() => {
-        setViewport(
-          {
-            x: -customNode.position.x * 0.8 + window.innerWidth / 2,
-            y: -customNode.position.y * 0.8 + (window.innerHeight - 400) / 2,
-            zoom: 0.8,
-          },
-          { duration: 500 },
-        );
-      }, 50);
-      return customNode;
-    },
-    [addBlock, setViewport],
-  );
-
   const updateNodeData = useNodeStore((state) => state.updateNodeData);
 
-  const handleMCPToolConfirm = useCallback(
-    (result: MCPToolDialogResult) => {
-      // Derive a display label: prefer server name, fall back to URL hostname.
-      let serverLabel = result.serverName;
-      if (!serverLabel) {
-        try {
-          serverLabel = new URL(result.serverUrl).hostname;
-        } catch {
-          serverLabel = "MCP";
-        }
+  function handleMCPToolConfirm(result: MCPToolDialogResult) {
+    let serverLabel = result.serverName;
+    if (!serverLabel) {
+      try {
+        serverLabel = new URL(result.serverUrl).hostname;
+      } catch {
+        serverLabel = "MCP";
       }
+    }
 
-      const customNode = addBlockAndCenter(blockData, {
-        server_url: result.serverUrl,
-        server_name: serverLabel,
-        selected_tool: result.selectedTool,
-        tool_input_schema: result.toolInputSchema,
-        available_tools: result.availableTools,
-        credentials: result.credentials ?? undefined,
+    const customNode = addBlockWithPlacement(blockData, {
+      server_url: result.serverUrl,
+      server_name: serverLabel,
+      selected_tool: result.selectedTool,
+      tool_input_schema: result.toolInputSchema,
+      available_tools: result.availableTools,
+      credentials: result.credentials ?? undefined,
+    });
+    if (customNode) {
+      const displayName = result.selectedTool
+        ? `${serverLabel}: ${beautifyString(result.selectedTool)}`
+        : undefined;
+      updateNodeData(customNode.id, {
+        metadata: {
+          ...customNode.data.metadata,
+          credentials_optional: true,
+          ...(displayName && { customized_name: displayName }),
+        },
       });
-      if (customNode) {
-        const title = result.selectedTool
-          ? `${serverLabel}: ${beautifyString(result.selectedTool)}`
-          : undefined;
-        updateNodeData(customNode.id, {
-          metadata: {
-            ...customNode.data.metadata,
-            credentials_optional: true,
-            ...(title && { customized_name: title }),
-          },
-        });
-      }
-      setMcpDialogOpen(false);
-    },
-    [addBlockAndCenter, blockData, updateNodeData],
-  );
+    }
+    setMcpDialogOpen(false);
+  }
 
-  const handleClick = () => {
+  function handleClick() {
     if (isMCPBlock) {
       setMcpDialogOpen(true);
       return;
     }
-    const customNode = addBlockAndCenter(blockData);
-    // Set customized_name for agent blocks so the agent's name persists
+    const customNode = addBlockWithPlacement(blockData);
     if (customNode && blockData.id === SpecialBlockID.AGENT) {
       updateNodeData(customNode.id, {
         metadata: {
@@ -115,16 +91,15 @@ export const Block: BlockComponent = ({
         },
       });
     }
-  };
+  }
 
-  const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
+  function handleDragStart(e: React.DragEvent<HTMLButtonElement>) {
     if (isMCPBlock) return;
     e.dataTransfer.effectAllowed = "copy";
     e.dataTransfer.setData("application/reactflow", JSON.stringify(blockData));
 
     setBlockMenuOpen(false);
 
-    // preview when user drags it
     const dragPreview = document.createElement("div");
     dragPreview.style.cssText = blockDragPreviewStyle;
     dragPreview.textContent = beautifyString(title || "").replace(
@@ -136,9 +111,8 @@ export const Block: BlockComponent = ({
     e.dataTransfer.setDragImage(dragPreview, 0, 0);
 
     setTimeout(() => document.body.removeChild(dragPreview), 0);
-  };
+  }
 
-  // Generate a data-id from the block id (e.g., "AgentInputBlock" -> "block-card-AgentInputBlock")
   const blockDataId = blockData.id
     ? `block-card-${blockData.id.replace(/[^a-zA-Z0-9]/g, "")}`
     : undefined;

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/IntergrationBlock.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/IntergrationBlock.tsx
@@ -6,8 +6,7 @@ import React, { ButtonHTMLAttributes } from "react";
 import { highlightText } from "./helpers";
 import { Button } from "@/components/atoms/Button/Button";
 import { useControlPanelStore } from "../../../stores/controlPanelStore";
-import { useReactFlow } from "@xyflow/react";
-import { useNodeStore } from "../../../stores/nodeStore";
+import { useAddBlockToBuilder } from "./hooks/useAddBlockToBuilder";
 import { BlockInfo } from "@/app/api/__generated__/models/blockInfo";
 import { blockDragPreviewStyle } from "./style";
 
@@ -35,30 +34,18 @@ export const IntegrationBlock: IntegrationBlockComponent = ({
   const setBlockMenuOpen = useControlPanelStore(
     (state) => state.setBlockMenuOpen,
   );
-  const { setViewport } = useReactFlow();
-  const { addBlock } = useNodeStore();
+  const { addBlockWithPlacement } = useAddBlockToBuilder();
 
-  const handleClick = () => {
-    const customNode = addBlock(blockData);
-    setTimeout(() => {
-      setViewport(
-        {
-          x: -customNode.position.x * 0.8 + window.innerWidth / 2,
-          y: -customNode.position.y * 0.8 + (window.innerHeight - 400) / 2,
-          zoom: 0.8,
-        },
-        { duration: 500 },
-      );
-    }, 50);
-  };
+  function handleClick() {
+    addBlockWithPlacement(blockData);
+  }
 
-  const handleDragStart = (e: React.DragEvent<HTMLButtonElement>) => {
+  function handleDragStart(e: React.DragEvent<HTMLButtonElement>) {
     e.dataTransfer.effectAllowed = "copy";
     e.dataTransfer.setData("application/reactflow", JSON.stringify(blockData));
 
     setBlockMenuOpen(false);
 
-    // preview when user drags it
     const dragPreview = document.createElement("div");
     dragPreview.style.cssText = blockDragPreviewStyle;
     dragPreview.textContent = beautifyString(title || "").replace(
@@ -70,7 +57,7 @@ export const IntegrationBlock: IntegrationBlockComponent = ({
     e.dataTransfer.setDragImage(dragPreview, 0, 0);
 
     setTimeout(() => document.body.removeChild(dragPreview), 0);
-  };
+  }
 
   return (
     <Button

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/__tests__/useAddBlockToBuilder.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/__tests__/useAddBlockToBuilder.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const mockGetViewport = vi.fn(() => ({ x: 0, y: 0, zoom: 1 }));
+
+vi.mock("@xyflow/react", () => ({
+  useReactFlow: () => ({ getViewport: mockGetViewport }),
+  useStore: (selector: (state: { width: number; height: number }) => number) =>
+    selector({ width: 1000, height: 800 }),
+}));
+
+const mockAddBlock = vi.fn((_block, _hv, position) => ({
+  id: "node-1",
+  position,
+  data: { metadata: {} },
+}));
+
+const nodeState = {
+  addBlock: mockAddBlock,
+  nodes: [] as Array<{
+    position: { x: number; y: number };
+    width?: number;
+    measured?: { width: number; height: number };
+    data: { uiType: string };
+  }>,
+};
+
+vi.mock("@/app/(platform)/build/stores/nodeStore", () => ({
+  useNodeStore: (selector: (state: typeof nodeState) => unknown) =>
+    selector(nodeState),
+}));
+
+import { useAddBlockToBuilder } from "../useAddBlockToBuilder";
+import { BlockUIType } from "@/app/(platform)/build/components/types";
+
+function makeBlock(uiType = BlockUIType.STANDARD) {
+  return {
+    id: "test-block",
+    name: "Test Block",
+    description: "",
+    inputSchema: {},
+    outputSchema: {},
+    uiType,
+  } as Parameters<
+    ReturnType<typeof useAddBlockToBuilder>["addBlockWithPlacement"]
+  >[0];
+}
+
+describe("useAddBlockToBuilder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nodeState.nodes = [];
+  });
+
+  it("places a block on an empty canvas", () => {
+    const { result } = renderHook(() => useAddBlockToBuilder());
+
+    result.current.addBlockWithPlacement(makeBlock());
+
+    expect(mockAddBlock).toHaveBeenCalledOnce();
+    const position = mockAddBlock.mock.calls[0][2];
+    expect(position).toEqual({ x: 70, y: 70 });
+  });
+
+  it("avoids overlapping existing nodes", () => {
+    nodeState.nodes = [
+      {
+        position: { x: 70, y: 70 },
+        measured: { width: 400, height: 400 },
+        data: { uiType: BlockUIType.STANDARD },
+      },
+    ];
+
+    const { result } = renderHook(() => useAddBlockToBuilder());
+    result.current.addBlockWithPlacement(makeBlock());
+
+    const position = mockAddBlock.mock.calls[0][2];
+    expect(position.x).not.toBe(70);
+  });
+
+  it("uses smaller dimensions for note blocks", () => {
+    const { result } = renderHook(() => useAddBlockToBuilder());
+
+    result.current.addBlockWithPlacement(makeBlock(BlockUIType.NOTE));
+
+    expect(mockAddBlock).toHaveBeenCalledOnce();
+  });
+
+  it("passes hardcoded values through to addBlock", () => {
+    const { result } = renderHook(() => useAddBlockToBuilder());
+    const hardcoded = { key: "value" };
+
+    result.current.addBlockWithPlacement(makeBlock(), hardcoded);
+
+    expect(mockAddBlock).toHaveBeenCalledWith(
+      expect.anything(),
+      hardcoded,
+      expect.any(Object),
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddAgentToBuilder.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddAgentToBuilder.ts
@@ -1,15 +1,12 @@
-import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
-import { useShallow } from "zustand/react/shallow";
-import { useReactFlow } from "@xyflow/react";
 import { convertLibraryAgentIntoCustomNode } from "../helpers";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { getV2GetLibraryAgent } from "@/app/api/__generated__/endpoints/library/library";
+import { useAddBlockToBuilder } from "./useAddBlockToBuilder";
 
-export const useAddAgentToBuilder = () => {
-  const addBlock = useNodeStore(useShallow((state) => state.addBlock));
-  const { setViewport } = useReactFlow();
+export function useAddAgentToBuilder() {
+  const { addBlockWithPlacement } = useAddBlockToBuilder();
 
-  const addAgentToBuilder = (libraryAgent: LibraryAgent) => {
+  function addAgentToBuilder(libraryAgent: LibraryAgent) {
     const { input_schema, output_schema } = libraryAgent;
 
     const { block, hardcodedValues } = convertLibraryAgentIntoCustomNode(
@@ -18,23 +15,10 @@ export const useAddAgentToBuilder = () => {
       output_schema,
     );
 
-    const customNode = addBlock(block, hardcodedValues);
+    return addBlockWithPlacement(block, hardcodedValues);
+  }
 
-    setTimeout(() => {
-      setViewport(
-        {
-          x: -customNode.position.x * 0.8 + window.innerWidth / 2,
-          y: -customNode.position.y * 0.8 + (window.innerHeight - 400) / 2,
-          zoom: 0.8,
-        },
-        { duration: 500 },
-      );
-    }, 50);
-
-    return customNode;
-  };
-
-  const addLibraryAgentToBuilder = async (agent: LibraryAgent) => {
+  async function addLibraryAgentToBuilder(agent: LibraryAgent) {
     const response = await getV2GetLibraryAgent(agent.id);
 
     if (!response.data) {
@@ -43,10 +27,10 @@ export const useAddAgentToBuilder = () => {
 
     const libraryAgent = response.data as LibraryAgent;
     return addAgentToBuilder(libraryAgent);
-  };
+  }
 
   return {
     addAgentToBuilder,
     addLibraryAgentToBuilder,
   };
-};
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddBlockToBuilder.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewBlockMenu/hooks/useAddBlockToBuilder.ts
@@ -1,0 +1,58 @@
+import { BlockInfo } from "@/app/api/__generated__/models/blockInfo";
+import { useReactFlow, useStore } from "@xyflow/react";
+import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
+import { BlockUIType } from "@/app/(platform)/build/components/types";
+import {
+  findFreePosition,
+  getFlowViewportBounds,
+  getNodeDimensions,
+} from "@/app/(platform)/build/components/placementHelpers";
+import { CustomNode } from "@/app/(platform)/build/components/FlowEditor/nodes/CustomNode/CustomNode";
+
+const NOTE_SIZE = 300;
+const BLOCK_SIZE = 400;
+const DEFAULT_MEASURED_WIDTH = 500;
+const PLACEMENT_MARGIN = 30;
+
+export function useAddBlockToBuilder() {
+  const addBlock = useNodeStore((state) => state.addBlock);
+  const nodes = useNodeStore((state) => state.nodes);
+  const { getViewport } = useReactFlow();
+  const flowWidth = useStore((s) => s.width);
+  const flowHeight = useStore((s) => s.height);
+
+  function addBlockWithPlacement(
+    block: BlockInfo,
+    hardcodedValues?: Record<string, unknown>,
+  ): CustomNode {
+    const viewportBounds = getFlowViewportBounds(
+      getViewport(),
+      flowWidth,
+      flowHeight,
+    );
+
+    const isNote = block.uiType === BlockUIType.NOTE;
+    const width = isNote ? NOTE_SIZE : BLOCK_SIZE;
+    const height = isNote ? NOTE_SIZE : BLOCK_SIZE;
+
+    const existingNodes = nodes.map((n) => ({
+      position: n.position,
+      measured: getNodeDimensions(
+        n,
+        n.data.uiType === BlockUIType.NOTE ? NOTE_SIZE : DEFAULT_MEASURED_WIDTH,
+      ),
+    }));
+
+    const position = findFreePosition(
+      existingNodes,
+      width,
+      PLACEMENT_MARGIN,
+      viewportBounds,
+      height,
+    );
+
+    return addBlock(block, hardcodedValues, position);
+  }
+
+  return { addBlockWithPlacement };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/__tests__/placementHelpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/__tests__/placementHelpers.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  findFreePosition,
+  getFlowViewportBounds,
+  getNodeDimensions,
+  type ExistingNodeForPlacement,
+} from "../placementHelpers";
+
+const viewport = getFlowViewportBounds({ x: 0, y: 0, zoom: 1 }, 1000, 800, 0);
+
+function node(
+  x: number,
+  y: number,
+  width = 500,
+  height = 400,
+): ExistingNodeForPlacement {
+  return {
+    position: { x, y },
+    measured: { width, height },
+  };
+}
+
+describe("getFlowViewportBounds", () => {
+  it("maps screen corners to flow coordinates", () => {
+    expect(
+      getFlowViewportBounds({ x: -100, y: -50, zoom: 0.5 }, 1200, 900, 0),
+    ).toEqual({
+      minX: 200,
+      minY: 100,
+      maxX: 2600,
+      maxY: 1900,
+    });
+  });
+});
+
+describe("findFreePosition", () => {
+  it("returns default origin when there are no nodes", () => {
+    expect(findFreePosition([])).toEqual({ x: 100, y: 100 });
+  });
+
+  it("places the first block inside the viewport when bounds are provided", () => {
+    expect(findFreePosition([], 400, 30, viewport)).toEqual({ x: 30, y: 30 });
+  });
+
+  it("places a block to the right of the most recent node when space is available", () => {
+    expect(findFreePosition([node(100, 100)], 400, 30)).toEqual({
+      x: 630,
+      y: 100,
+    });
+  });
+
+  it("prefers a visible grid slot over an off-screen adjacent slot", () => {
+    const crowdedCanvas = [node(5000, 5000)];
+
+    const position = findFreePosition(crowdedCanvas, 400, 30, viewport);
+
+    expect(position.x).toBeGreaterThanOrEqual(viewport.minX);
+    expect(position.y).toBeGreaterThanOrEqual(viewport.minY);
+    expect(position.x + 400).toBeLessThanOrEqual(viewport.maxX);
+    expect(position.y + 400).toBeLessThanOrEqual(viewport.maxY);
+  });
+
+  it("does not jump far to the right when the viewport is full", () => {
+    const gridNodes: ExistingNodeForPlacement[] = [];
+    for (let row = 0; row < 3; row++) {
+      for (let col = 0; col < 3; col++) {
+        gridNodes.push(node(col * 430, row * 430, 400, 400));
+      }
+    }
+
+    const position = findFreePosition(gridNodes, 400, 30, viewport);
+
+    expect(position).toEqual({ x: 30, y: 1260 });
+  });
+
+  it("uses adjacent placement without viewport bounds when canvas is not crowded", () => {
+    expect(findFreePosition([node(200, 150)], 400, 30)).toEqual({
+      x: 730,
+      y: 150,
+    });
+  });
+
+  it("uses default dimensions for nodes without measured property", () => {
+    const unmeasuredNode: ExistingNodeForPlacement = {
+      position: { x: 0, y: 0 },
+    };
+    const position = findFreePosition([unmeasuredNode], 400, 30);
+
+    expect(position).toEqual({ x: 530, y: 0 });
+  });
+
+  it("picks an adjacent candidate visible in the viewport", () => {
+    const nodes = [node(0, 0, 400, 400)];
+    const smallViewport = getFlowViewportBounds(
+      { x: 0, y: 0, zoom: 1 },
+      900,
+      900,
+      0,
+    );
+    const position = findFreePosition(nodes, 400, 30, smallViewport, 400);
+
+    expect(position.x + 400).toBeLessThanOrEqual(smallViewport.maxX);
+    expect(position.y + 400).toBeLessThanOrEqual(smallViewport.maxY);
+  });
+
+  it("falls back to last-node position when no viewport and all adjacent spots blocked", () => {
+    const tightCluster = [
+      node(0, 0, 400, 400),
+      node(430, 0, 400, 400),
+      node(-430, 0, 400, 400),
+      node(0, 430, 400, 400),
+    ];
+
+    const position = findFreePosition(tightCluster, 400, 30, undefined, 400);
+
+    expect(position.x).toBeGreaterThanOrEqual(0);
+  });
+
+  it("finds adjacent gap when grid scan misses it due to alignment", () => {
+    const smallNode = node(0, 0, 100, 100);
+    const narrowViewport = getFlowViewportBounds(
+      { x: 0, y: 0, zoom: 1 },
+      350,
+      350,
+      0,
+    );
+    const position = findFreePosition(
+      [smallNode],
+      200,
+      30,
+      narrowViewport,
+      200,
+    );
+
+    expect(position).toEqual({ x: 130, y: 0 });
+  });
+});
+
+describe("getNodeDimensions", () => {
+  it("returns measured dimensions when available", () => {
+    const dims = getNodeDimensions({ measured: { width: 300, height: 200 } });
+    expect(dims).toEqual({ width: 300, height: 200 });
+  });
+
+  it("prefers node.width over measured width", () => {
+    const dims = getNodeDimensions({
+      width: 600,
+      measured: { width: 300, height: 200 },
+    });
+    expect(dims.width).toBe(600);
+  });
+
+  it("falls back to default dimensions for unmeasured nodes", () => {
+    const dims = getNodeDimensions({});
+    expect(dims).toEqual({ width: 500, height: 400 });
+  });
+
+  it("uses custom fallback width when provided", () => {
+    const dims = getNodeDimensions({}, 300);
+    expect(dims.width).toBe(300);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/helper.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/helper.ts
@@ -8,7 +8,6 @@ import { NodeModel } from "@/app/api/__generated__/models/nodeModel";
 import { NodeModelMetadata } from "@/app/api/__generated__/models/nodeModelMetadata";
 import { Link } from "@/app/api/__generated__/models/link";
 import { CustomEdge } from "./FlowEditor/edges/CustomEdge";
-import { XYPosition } from "@xyflow/react";
 
 export const convertBlockInfoIntoCustomNodeData = (
   block: BlockInfo,
@@ -123,106 +122,4 @@ export const isCostFilterMatch = (
     : costFilter === inputValues;
 };
 
-// ----- Position related helpers -----
-
-export interface NodeDimensions {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
-
-function rectanglesOverlap(
-  rect1: NodeDimensions,
-  rect2: NodeDimensions,
-): boolean {
-  const x1 = rect1.x,
-    y1 = rect1.y,
-    w1 = rect1.width,
-    h1 = rect1.height;
-  const x2 = rect2.x,
-    y2 = rect2.y,
-    w2 = rect2.width,
-    h2 = rect2.height;
-
-  return !(x1 + w1 <= x2 || x1 >= x2 + w2 || y1 + h1 <= y2 || y1 >= y2 + h2);
-}
-
-export function findFreePosition(
-  existingNodes: Array<{
-    position: XYPosition;
-    measured?: { width: number; height: number };
-  }>,
-  newNodeWidth: number = 500,
-  margin: number = 60,
-): XYPosition {
-  if (existingNodes.length === 0) {
-    return { x: 100, y: 100 }; // Default starting position
-  }
-
-  // Start from the most recently added node
-  for (let i = existingNodes.length - 1; i >= 0; i--) {
-    const lastNode = existingNodes[i];
-    const lastNodeWidth = lastNode.measured?.width ?? 500;
-    const lastNodeHeight = lastNode.measured?.height ?? 400;
-
-    // Try right
-    const candidate = {
-      x: lastNode.position.x + lastNodeWidth + margin,
-      y: lastNode.position.y,
-      width: newNodeWidth,
-      height: 400, // Estimated height
-    };
-
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-
-    // Try left
-    candidate.x = lastNode.position.x - newNodeWidth - margin;
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-
-    // Try below
-    candidate.x = lastNode.position.x;
-    candidate.y = lastNode.position.y + lastNodeHeight + margin;
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-  }
-
-  // Fallback: place it far to the right
-  const lastNode = existingNodes[existingNodes.length - 1];
-  return {
-    x: lastNode.position.x + 600,
-    y: lastNode.position.y,
-  };
-}
+export { findFreePosition, type NodeDimensions } from "./placementHelpers";

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/helper.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/helper.ts
@@ -122,4 +122,11 @@ export const isCostFilterMatch = (
     : costFilter === inputValues;
 };
 
-export { findFreePosition, type NodeDimensions } from "./placementHelpers";
+export {
+  findFreePosition,
+  getFlowViewportBounds,
+  getNodeDimensions,
+  type ExistingNodeForPlacement,
+  type FlowViewportBounds,
+  type NodeDimensions,
+} from "./placementHelpers";

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/placementHelpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/placementHelpers.ts
@@ -1,0 +1,91 @@
+import { XYPosition } from "@xyflow/react";
+
+export interface NodeDimensions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+function rectanglesOverlap(a: NodeDimensions, b: NodeDimensions): boolean {
+  return !(
+    a.x + a.width <= b.x ||
+    a.x >= b.x + b.width ||
+    a.y + a.height <= b.y ||
+    a.y >= b.y + b.height
+  );
+}
+
+export function findFreePosition(
+  existingNodes: Array<{
+    position: XYPosition;
+    measured?: { width: number; height: number };
+  }>,
+  newNodeWidth: number = 500,
+  margin: number = 60,
+): XYPosition {
+  if (existingNodes.length === 0) {
+    return { x: 100, y: 100 };
+  }
+
+  for (let i = existingNodes.length - 1; i >= 0; i--) {
+    const lastNode = existingNodes[i];
+    const lastNodeWidth = lastNode.measured?.width ?? 500;
+    const lastNodeHeight = lastNode.measured?.height ?? 400;
+
+    const candidate = {
+      x: lastNode.position.x + lastNodeWidth + margin,
+      y: lastNode.position.y,
+      width: newNodeWidth,
+      height: 400,
+    };
+
+    if (
+      !existingNodes.some((n) =>
+        rectanglesOverlap(candidate, {
+          x: n.position.x,
+          y: n.position.y,
+          width: n.measured?.width ?? 500,
+          height: n.measured?.height ?? 400,
+        }),
+      )
+    ) {
+      return { x: candidate.x, y: candidate.y };
+    }
+
+    candidate.x = lastNode.position.x - newNodeWidth - margin;
+    if (
+      !existingNodes.some((n) =>
+        rectanglesOverlap(candidate, {
+          x: n.position.x,
+          y: n.position.y,
+          width: n.measured?.width ?? 500,
+          height: n.measured?.height ?? 400,
+        }),
+      )
+    ) {
+      return { x: candidate.x, y: candidate.y };
+    }
+
+    candidate.x = lastNode.position.x;
+    candidate.y = lastNode.position.y + lastNodeHeight + margin;
+    if (
+      !existingNodes.some((n) =>
+        rectanglesOverlap(candidate, {
+          x: n.position.x,
+          y: n.position.y,
+          width: n.measured?.width ?? 500,
+          height: n.measured?.height ?? 400,
+        }),
+      )
+    ) {
+      return { x: candidate.x, y: candidate.y };
+    }
+  }
+
+  const lastNode = existingNodes[existingNodes.length - 1];
+  return {
+    x: lastNode.position.x + 600,
+    y: lastNode.position.y,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/placementHelpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/placementHelpers.ts
@@ -7,6 +7,21 @@ export interface NodeDimensions {
   height: number;
 }
 
+export type FlowViewportBounds = {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+};
+
+export type ExistingNodeForPlacement = {
+  position: XYPosition;
+  measured?: { width: number; height: number };
+};
+
+const DEFAULT_NODE_WIDTH = 500;
+const DEFAULT_NODE_HEIGHT = 400;
+
 function rectanglesOverlap(a: NodeDimensions, b: NodeDimensions): boolean {
   return !(
     a.x + a.width <= b.x ||
@@ -16,76 +31,181 @@ function rectanglesOverlap(a: NodeDimensions, b: NodeDimensions): boolean {
   );
 }
 
+function nodeToRect(node: ExistingNodeForPlacement): NodeDimensions {
+  return {
+    x: node.position.x,
+    y: node.position.y,
+    width: node.measured?.width ?? DEFAULT_NODE_WIDTH,
+    height: node.measured?.height ?? DEFAULT_NODE_HEIGHT,
+  };
+}
+
+function overlapsAnyNode(
+  candidate: NodeDimensions,
+  nodes: ExistingNodeForPlacement[],
+): boolean {
+  return nodes.some((n) => rectanglesOverlap(candidate, nodeToRect(n)));
+}
+
+function fitsInViewport(
+  rect: NodeDimensions,
+  bounds: FlowViewportBounds,
+): boolean {
+  return (
+    rect.x >= bounds.minX &&
+    rect.y >= bounds.minY &&
+    rect.x + rect.width <= bounds.maxX &&
+    rect.y + rect.height <= bounds.maxY
+  );
+}
+
+export function getFlowViewportBounds(
+  viewport: { x: number; y: number; zoom: number },
+  screenWidth: number,
+  screenHeight: number,
+  padding = 40,
+): FlowViewportBounds {
+  const { x, y, zoom } = viewport;
+  return {
+    minX: (-x + padding) / zoom,
+    minY: (-y + padding) / zoom,
+    maxX: (screenWidth - x - padding) / zoom,
+    maxY: (screenHeight - y - padding) / zoom,
+  };
+}
+
+function scanViewportGrid(
+  nodes: ExistingNodeForPlacement[],
+  width: number,
+  height: number,
+  margin: number,
+  bounds: FlowViewportBounds,
+): XYPosition | null {
+  const stepX = width + margin;
+  const stepY = height + margin;
+
+  for (let y = bounds.minY; y + height <= bounds.maxY; y += stepY) {
+    for (let x = bounds.minX; x + width <= bounds.maxX; x += stepX) {
+      const candidate: NodeDimensions = { x, y, width, height };
+      if (!overlapsAnyNode(candidate, nodes)) {
+        return { x, y };
+      }
+    }
+  }
+
+  return null;
+}
+
+function getAdjacentPositions(
+  nodes: ExistingNodeForPlacement[],
+  width: number,
+  height: number,
+  margin: number,
+): XYPosition[] {
+  const positions: XYPosition[] = [];
+
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const rect = nodeToRect(nodes[i]);
+
+    const candidates: XYPosition[] = [
+      { x: rect.x + rect.width + margin, y: rect.y },
+      { x: rect.x - width - margin, y: rect.y },
+      { x: rect.x, y: rect.y + rect.height + margin },
+    ];
+
+    for (const pos of candidates) {
+      if (!overlapsAnyNode({ ...pos, width, height }, nodes)) {
+        positions.push(pos);
+      }
+    }
+  }
+
+  return positions;
+}
+
+export function getNodeDimensions(
+  node: {
+    width?: number;
+    height?: number;
+    measured?: { width?: number; height?: number };
+  },
+  fallbackWidth = DEFAULT_NODE_WIDTH,
+): { width: number; height: number } {
+  return {
+    width: node.width ?? node.measured?.width ?? fallbackWidth,
+    height: node.height ?? node.measured?.height ?? DEFAULT_NODE_HEIGHT,
+  };
+}
+
 export function findFreePosition(
-  existingNodes: Array<{
-    position: XYPosition;
-    measured?: { width: number; height: number };
-  }>,
-  newNodeWidth: number = 500,
+  existingNodes: ExistingNodeForPlacement[],
+  newNodeWidth: number = DEFAULT_NODE_WIDTH,
   margin: number = 60,
+  viewportBounds?: FlowViewportBounds,
+  newNodeHeight: number = DEFAULT_NODE_HEIGHT,
 ): XYPosition {
   if (existingNodes.length === 0) {
+    if (viewportBounds) {
+      return {
+        x: viewportBounds.minX + margin,
+        y: viewportBounds.minY + margin,
+      };
+    }
     return { x: 100, y: 100 };
   }
 
-  for (let i = existingNodes.length - 1; i >= 0; i--) {
-    const lastNode = existingNodes[i];
-    const lastNodeWidth = lastNode.measured?.width ?? 500;
-    const lastNodeHeight = lastNode.measured?.height ?? 400;
-
-    const candidate = {
-      x: lastNode.position.x + lastNodeWidth + margin,
-      y: lastNode.position.y,
-      width: newNodeWidth,
-      height: 400,
-    };
-
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-
-    candidate.x = lastNode.position.x - newNodeWidth - margin;
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
-
-    candidate.x = lastNode.position.x;
-    candidate.y = lastNode.position.y + lastNodeHeight + margin;
-    if (
-      !existingNodes.some((n) =>
-        rectanglesOverlap(candidate, {
-          x: n.position.x,
-          y: n.position.y,
-          width: n.measured?.width ?? 500,
-          height: n.measured?.height ?? 400,
-        }),
-      )
-    ) {
-      return { x: candidate.x, y: candidate.y };
-    }
+  // First try: find an open slot in the visible viewport grid
+  if (viewportBounds) {
+    const gridSlot = scanViewportGrid(
+      existingNodes,
+      newNodeWidth,
+      newNodeHeight,
+      margin,
+      viewportBounds,
+    );
+    if (gridSlot) return gridSlot;
   }
 
-  const lastNode = existingNodes[existingNodes.length - 1];
+  // Second try: adjacent to existing nodes (right, left, below)
+  const adjacent = getAdjacentPositions(
+    existingNodes,
+    newNodeWidth,
+    newNodeHeight,
+    margin,
+  );
+
+  if (viewportBounds && adjacent.length > 0) {
+    const visibleAdj = adjacent.find((pos) =>
+      fitsInViewport(
+        { ...pos, width: newNodeWidth, height: newNodeHeight },
+        viewportBounds,
+      ),
+    );
+    if (visibleAdj) return visibleAdj;
+  } else if (adjacent.length > 0) {
+    return adjacent[0];
+  }
+
+  // Last resort: scan below the viewport
+  if (viewportBounds) {
+    const x = viewportBounds.minX + margin;
+    let y = viewportBounds.maxY + margin;
+
+    while (
+      overlapsAnyNode(
+        { x, y, width: newNodeWidth, height: newNodeHeight },
+        existingNodes,
+      )
+    ) {
+      y += newNodeHeight + margin;
+    }
+
+    return { x, y };
+  }
+
+  const lastRect = nodeToRect(existingNodes[existingNodes.length - 1]);
   return {
-    x: lastNode.position.x + 600,
-    y: lastNode.position.y,
+    x: lastRect.x + lastRect.width + margin,
+    y: lastRect.y,
   };
 }


### PR DESCRIPTION
### Why / What / How

Why: When clicking to add a block from the block menu, the canvas forces a zoom + pan animation to center the new node (issue #9326). This is disorienting — the user loses their place on the canvas and has to navigate back.

What: Replace the forced setViewport (pan/zoom) behavior with a viewport-aware placement algorithm that finds a free spot within the user's current view. The camera stays put.

How: The change is split into two commits for reviewability:

Commit 1 (Refactor): Extract existing placement helpers (NodeDimensions, rectanglesOverlap, findFreePosition) from the monolithic helper.ts into a dedicated placementHelpers.ts module. Re-exports maintain backward compatibility. Zero behavior changes.

Commit 2 (Feature): Enhance the placement algorithm with viewport awareness, create a useAddBlockToBuilder hook to centralise click-to-add behavior, and remove forced setViewport calls from all components.

Before / After: Placement Flow
BEFORE: Forced pan/zoom on every add

```mermaid
flowchart TD
    A[User clicks 'Add Block' in menu] --> B[Block/IntegrationBlock/useAddAgentToBuilder]
    B --> C["addBlock(blockData) — places node at next free position using findFreePosition in helper.ts"]
    C --> D["setTimeout 50ms"]
    D --> E["setViewport() — forces zoom=0.8, pans camera to center on new node"]
    E --> F["❌ User loses current viewport position — disorienting jump"]

    style E fill:#f88,stroke:#c00,color:#000
    style F fill:#fcc,stroke:#c00,color:#000
```

Old placement logic (findFreePosition in helper.ts):

Tries right/left/below relative to existing nodes
No concept of viewport — places wherever there's space in the graph
After placement, always force-pans the camera to the new node

AFTER: Viewport-aware placement, no camera jump

```mermaid
flowchart TD
    A[User clicks 'Add Block' in menu] --> B[Block/IntegrationBlock/useAddAgentToBuilder]
    B --> C["useAddBlockToBuilder hook"]
    C --> D["getFlowViewportBounds() — compute visible area in flow coordinates"]
    D --> E{"findFreePosition(nodes, width, margin, viewportBounds)"}

    E --> F["Strategy 1: Grid scan within viewport — find open slot inside visible area"]
    F --> G{Found?}
    G -->|Yes| H["✅ Place node in viewport — camera stays put"]
    G -->|No| I["Strategy 2: Adjacent to existing nodes — try right/left/below, prefer in-viewport"]
    I --> J{Found in viewport?}
    J -->|Yes| H
    J -->|No| K["Strategy 3: Below viewport — place below visible area, scan downward"]
    K --> H

    style H fill:#8f8,stroke:#0a0,color:#000
```

New placement logic (findFreePosition in placementHelpers.ts):

Grid scan the visible viewport for an open slot (most common case)
Adjacent fallback: try right/left/below existing nodes, preferring positions within viewport
Below-viewport fallback: place below the visible area if viewport is full
Camera never moves — the node appears where the user is already looking

Architecture: Before vs After
Before
```mermaid
graph LR
    subgraph "3 components, duplicated logic"
        BL["Block.tsx<br/>addBlock + setViewport"]
        IB["IntegrationBlock.tsx<br/>addBlock + setViewport"]
        UA["useAddAgentToBuilder.ts<br/>addBlock + setViewport"]
    end
    BL --> H["helper.ts<br/>(findFreePosition + 200 lines of unrelated utils)"]
    IB --> H
    UA --> H
```

Each component independently called addBlock() then setTimeout → setViewport(). The placement logic was buried in a 228-line utility file alongside unrelated block/edge converters.

After
```mermaid
graph LR
    subgraph "3 components, shared hook"
        BL["Block.tsx"]
        IB["IntegrationBlock.tsx"]
        UA["useAddAgentToBuilder.ts"]
    end
    BL --> HOOK["useAddBlockToBuilder<br/>(centralised add + place)"]
    IB --> HOOK
    UA --> HOOK
    HOOK --> PH["placementHelpers.ts<br/>(viewport-aware placement)"]
```
One hook (useAddBlockToBuilder) centralises the add-block-and-place logic. Placement helpers live in a focused, testable module.

### Changes 🏗️

| Commit | File | Change |
|--------|------|--------|
| Refactor | `placementHelpers.ts` | **New file** – extracted `NodeDimensions`, `rectanglesOverlap`, and `findFreePosition` from `helper.ts`. |
| Refactor | `helper.ts` | Removed placement logic; now re-exports from `placementHelpers.ts`. |
| Feature | `placementHelpers.ts` | Added viewport-aware placement (`FlowViewportBounds`, `getFlowViewportBounds`, `getNodeDimensions`, grid scan, adjacent-node fallback). |
| Feature | `useAddBlockToBuilder.ts` | **New hook** – reads viewport bounds, computes placement via `findFreePosition`, and passes the position to `addBlock`. |
| Feature | `Block.tsx` | Replaced `useCallback + setViewport` with `useAddBlockToBuilder`. |
| Feature | `IntegrationBlock.tsx` | Replaced `setViewport` with `useAddBlockToBuilder`. |
| Feature | `useAddAgentToBuilder.ts` | Replaced `setViewport` with `useAddBlockToBuilder`. |
| Feature | `AllBlocksContent.tsx` | Removed unused `addBlock` import (click handling now lives in `Block`). |
| Feature | `placementHelpers.test.ts` | **New** – 162 lines of unit tests for placement helpers. |
| Feature | `useAddBlockToBuilder.test.ts` | **New** – 101 lines of unit tests for the hook. |

### Checklist 📋

#### For code changes:


- [ ✓]  I have clearly listed my changes in the PR description
- [ ✓]  I have made a test plan
- [ ✓]  I have tested my changes according to the test plan:
- [ ✓]  Unit tests pass for placementHelpers.ts (grid scan, adjacent fallback, collision detection)
- [ ✓]  Unit tests pass for useAddBlockToBuilder hook
- [ ✓]  Manually verified: adding a block from the menu places it in the visible viewport
- [ ✓]  Manually verified: adding multiple blocks fills viewport then falls back to adjacent placement
- [ ✓]  Manually verified: drag-and-drop still works unchanged
- [ ✓]  Manually verified: MCP tool dialog flow still works
- [ ✓]  Manually verified: agent blocks retain customized_name


#### For configuration changes:

- [ ✓] `.env.default`  is updated or already compatible with my changes (no config changes needed)
- [ ✓] `docker-compose.yml` is updated or already compatible with my changes (no config changes needed)


[Screencast from 2026-06-30 12-09-51.webm](https://github.com/user-attachments/assets/43a79b29-25bd-48ed-aee3-e01c77e79751)
