### PR TITLE
fix(copilot): suppress error banner and stop-flicker on user cancel

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -1033,11 +1033,20 @@ async def cancel_session_task(
     logger.warning(
         f"[CANCEL] Session ...{session_id[-8:]} not confirmed after {max_wait}s, force-completing"
     )
-    await stream_registry.mark_session_completed(session_id, error_message="Cancelled")
+    # ``skip_error_publish``: the user asked for this stop, so surfacing it to
+    # the frontend as a StreamError would render a spurious "assistant
+    # encountered an error" banner on any live/resumed stream. The persisted
+    # cancellation marker on the session messages already tells the UI (and
+    # any later reload) that the turn was stopped.
+    await stream_registry.mark_session_completed(
+        session_id, error_message="Cancelled", skip_error_publish=True
+    )
     # Status is now force-flipped out of "running"; re-clear to drop any
     # follow-up that landed during the poll window.
     await _clear_pending_best_effort(session_id)
-    return CancelSessionResponse(cancelled=True)
+    return CancelSessionResponse(
+        cancelled=True, reason="cancel_published_not_confirmed"
+    )
 
 
 def _ui_message_stream_headers() -> dict[str, str]:

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1625,6 +1625,56 @@ def test_cancel_session_enqueues_cancel_and_confirms(
     mock_enqueue.assert_called_once_with("sess-1")
 
 
+def test_cancel_session_force_complete_suppresses_stream_error(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """When the executor doesn't confirm the cancel within the poll window,
+    the route force-completes the session.  The stop is user-initiated, so it
+    must NOT publish a StreamError (a live/resumed stream would render it as
+    "the assistant encountered an error") and must return
+    ``reason='cancel_published_not_confirmed'`` so the client can tell the
+    user the stop may take a moment."""
+    from backend.copilot.stream_registry import ActiveSession
+
+    _mock_validate_session(mocker)
+    mocker.patch(
+        "backend.copilot.turn_queue.cancel_queued_turn",
+        new=AsyncMock(return_value=False),
+    )
+    running_session = ActiveSession(
+        session_id="sess-1",
+        user_id=TEST_USER_ID,
+        tool_call_id="chat_stream",
+        tool_name="chat",
+        turn_id="turn-1",
+        status="running",
+    )
+    mock_registry = MagicMock()
+    mock_registry.get_active_session = AsyncMock(
+        return_value=(running_session, "1-0")
+    )
+    # Executor never confirms: status stays "running" for every poll.
+    mock_registry.get_session = AsyncMock(return_value=running_session)
+    mock_registry.mark_session_completed = AsyncMock(return_value=True)
+    mocker.patch("backend.api.features.chat.routes.stream_registry", mock_registry)
+    mocker.patch(
+        "backend.api.features.chat.routes.enqueue_cancel_task",
+        new_callable=AsyncMock,
+    )
+    # Skip the real 5s poll wait.
+    mocker.patch("asyncio.sleep", new=AsyncMock())
+
+    response = client.post("/sessions/sess-1/cancel")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["cancelled"] is True
+    assert data["reason"] == "cancel_published_not_confirmed"
+    mock_registry.mark_session_completed.assert_awaited_once_with(
+        "sess-1", error_message="Cancelled", skip_error_publish=True
+    )
+
+
 def test_cancel_session_clears_pending_buffer(
     mocker: pytest_mock.MockerFixture,
 ) -> None:

--- a/autogpt_platform/backend/backend/api/features/chat/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes_test.py
@@ -1650,9 +1650,7 @@ def test_cancel_session_force_complete_suppresses_stream_error(
         status="running",
     )
     mock_registry = MagicMock()
-    mock_registry.get_active_session = AsyncMock(
-        return_value=(running_session, "1-0")
-    )
+    mock_registry.get_active_session = AsyncMock(return_value=(running_session, "1-0"))
     # Executor never confirms: status stays "running" for every poll.
     mock_registry.get_session = AsyncMock(return_value=running_session)
     mock_registry.mark_session_completed = AsyncMock(return_value=True)

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -497,6 +497,7 @@ class CoPilotProcessor:
         last_refresh = time.monotonic()
         refresh_interval = 30.0  # Refresh lock every 30 seconds
         error_msg = None
+        user_cancelled = False
 
         try:
             # Choose service based on LaunchDarkly flag.
@@ -588,6 +589,7 @@ class CoPilotProcessor:
             if isinstance(e, asyncio.CancelledError):
                 log.info("Turn cancelled")
                 error_msg = "Operation cancelled"
+                user_cancelled = True
             else:
                 error_msg = str(e) or type(e).__name__
                 log.error(f"Turn failed: {error_msg}")
@@ -596,9 +598,17 @@ class CoPilotProcessor:
             # If no exception but user cancelled, still mark as cancelled
             if not error_msg and cancel.is_set():
                 error_msg = "Operation cancelled"
+                user_cancelled = True
             try:
+                # A user-initiated cancel still marks the session "failed"
+                # (so queued turns are promoted and locks released), but must
+                # not publish a StreamError: the frontend would render it as
+                # "the assistant encountered an error" on the live/resumed
+                # stream even though the user asked for the stop.
                 await stream_registry.mark_session_completed(
-                    entry.session_id, error_message=error_msg
+                    entry.session_id,
+                    error_message=error_msg,
+                    skip_error_publish=user_cancelled,
                 )
             except Exception as mark_err:
                 log.error(f"Failed to mark session completed: {mark_err}")

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStop.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStop.test.ts
@@ -1,3 +1,4 @@
+import { renderHook } from "@testing-library/react";
 import type { UIMessage } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCopilotStop } from "../useCopilotStop";
@@ -56,18 +57,20 @@ function makeHarness({
     },
   );
 
-  const stop = useCopilotStop({
-    sessionId,
-    sdkStop,
-    setMessages: setMessages as never,
-    isUserStoppingRef,
-    setIsUserStopping,
-    isCancelInFlightRef,
-    refetchSession,
-  });
+  const { result } = renderHook(() =>
+    useCopilotStop({
+      sessionId,
+      sdkStop,
+      setMessages: setMessages as never,
+      isUserStoppingRef,
+      setIsUserStopping,
+      isCancelInFlightRef,
+      refetchSession,
+    }),
+  );
 
   return {
-    stop,
+    stop: result.current,
     isUserStoppingRef,
     isCancelInFlightRef,
     setIsUserStopping,
@@ -174,7 +177,9 @@ describe("useCopilotStop", () => {
   });
 
   it("clears the user-stop flag once the refetch confirms no active stream", async () => {
-    const refetchSession = vi.fn(() => Promise.resolve(activeStreamResult(false)));
+    const refetchSession = vi.fn(() =>
+      Promise.resolve(activeStreamResult(false)),
+    );
     const h = makeHarness({ refetchSession });
 
     await h.stop();
@@ -186,7 +191,9 @@ describe("useCopilotStop", () => {
   });
 
   it("keeps the user-stop flag set while the backend still reports an active stream", async () => {
-    const refetchSession = vi.fn(() => Promise.resolve(activeStreamResult(true)));
+    const refetchSession = vi.fn(() =>
+      Promise.resolve(activeStreamResult(true)),
+    );
     const h = makeHarness({ refetchSession });
 
     await h.stop();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStop.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useCopilotStop.test.ts
@@ -1,0 +1,211 @@
+import type { UIMessage } from "ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopilotStop } from "../useCopilotStop";
+
+const mockCancel = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/app/api/__generated__/endpoints/chat/chat", () => ({
+  postV2CancelSessionTask: (sessionId: string) => mockCancel(sessionId),
+}));
+
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  toast: (args: unknown) => mockToast(args),
+}));
+
+const CANCELLED_MARKER_TEXT = "[__COPILOT_ERROR_f7a1__] Operation cancelled";
+
+type Messages = UIMessage[];
+
+function assistantMessage(text: string): UIMessage {
+  return {
+    id: `assistant-${text}`,
+    role: "assistant",
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+function userMessage(text: string): UIMessage {
+  return {
+    id: `user-${text}`,
+    role: "user",
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+/** Build a `stop` handler with capturable refs/spies so each test can assert
+ * on the flags and messages the handler mutates. */
+function makeHarness({
+  sessionId = "session-1",
+  prev = [assistantMessage("streaming")] as Messages,
+  refetchSession = vi.fn(() => Promise.resolve({ data: undefined })),
+  sdkStop = vi.fn(),
+}: {
+  sessionId?: string | null;
+  prev?: Messages;
+  refetchSession?: () => Promise<{ data?: unknown }>;
+  sdkStop?: () => void;
+} = {}) {
+  const isUserStoppingRef = { current: false };
+  const isCancelInFlightRef = { current: false };
+  const setIsUserStopping = vi.fn();
+  let captured: Messages = prev;
+  const setMessages = vi.fn(
+    (updater: Messages | ((p: Messages) => Messages)) => {
+      captured = typeof updater === "function" ? updater(captured) : updater;
+    },
+  );
+
+  const stop = useCopilotStop({
+    sessionId,
+    sdkStop,
+    setMessages: setMessages as never,
+    isUserStoppingRef,
+    setIsUserStopping,
+    isCancelInFlightRef,
+    refetchSession,
+  });
+
+  return {
+    stop,
+    isUserStoppingRef,
+    isCancelInFlightRef,
+    setIsUserStopping,
+    setMessages,
+    getMessages: () => captured,
+  };
+}
+
+function activeStreamResult(active: boolean) {
+  return {
+    data: { status: 200, data: { active_stream: active } },
+  };
+}
+
+describe("useCopilotStop", () => {
+  beforeEach(() => {
+    mockCancel.mockReset();
+    mockToast.mockReset();
+    mockCancel.mockResolvedValue({ status: 200, data: {} });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flags the stop, aborts the SDK fetch, and appends the cancellation marker", async () => {
+    const sdkStop = vi.fn();
+    const h = makeHarness({ sdkStop });
+
+    await h.stop();
+
+    expect(sdkStop).toHaveBeenCalledTimes(1);
+    expect(h.setIsUserStopping).toHaveBeenCalledWith(true);
+    const last = h.getMessages().at(-1)!;
+    expect(last.parts.at(-1)).toEqual({
+      type: "text",
+      text: CANCELLED_MARKER_TEXT,
+    });
+  });
+
+  it("swallows sdkStop throwing when no fetch is in flight", async () => {
+    const sdkStop = vi.fn(() => {
+      throw new Error("no active fetch");
+    });
+    const h = makeHarness({ sdkStop });
+
+    await expect(h.stop()).resolves.toBeUndefined();
+    expect(h.setIsUserStopping).toHaveBeenCalledWith(true);
+  });
+
+  it("does not append a marker when the last message is not an assistant", async () => {
+    const prev = [assistantMessage("earlier"), userMessage("latest")];
+    const h = makeHarness({ prev });
+
+    await h.stop();
+
+    const last = h.getMessages().at(-1)!;
+    expect(last.role).toBe("user");
+    expect(
+      last.parts.some(
+        (p) => p.type === "text" && p.text === CANCELLED_MARKER_TEXT,
+      ),
+    ).toBe(false);
+  });
+
+  it("skips the cancel request and refetch when there is no session", async () => {
+    const refetchSession = vi.fn(() => Promise.resolve({ data: undefined }));
+    const h = makeHarness({ sessionId: null, refetchSession });
+
+    await h.stop();
+
+    expect(mockCancel).not.toHaveBeenCalled();
+    expect(refetchSession).not.toHaveBeenCalled();
+    expect(h.isCancelInFlightRef.current).toBe(false);
+  });
+
+  it("shows a soft toast when the cancel is published but not yet confirmed", async () => {
+    mockCancel.mockResolvedValue({
+      status: 200,
+      data: { reason: "cancel_published_not_confirmed" },
+    });
+    const h = makeHarness();
+
+    await h.stop();
+
+    expect(mockCancel).toHaveBeenCalledWith("session-1");
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Stop may take a moment" }),
+    );
+  });
+
+  it("shows a destructive toast when the cancel request fails", async () => {
+    mockCancel.mockRejectedValue(new Error("network down"));
+    const h = makeHarness();
+
+    await h.stop();
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Could not stop the task",
+        variant: "destructive",
+      }),
+    );
+  });
+
+  it("clears the user-stop flag once the refetch confirms no active stream", async () => {
+    const refetchSession = vi.fn(() => Promise.resolve(activeStreamResult(false)));
+    const h = makeHarness({ refetchSession });
+
+    await h.stop();
+
+    expect(refetchSession).toHaveBeenCalledTimes(1);
+    expect(h.isUserStoppingRef.current).toBe(false);
+    expect(h.setIsUserStopping).toHaveBeenLastCalledWith(false);
+    expect(h.isCancelInFlightRef.current).toBe(false);
+  });
+
+  it("keeps the user-stop flag set while the backend still reports an active stream", async () => {
+    const refetchSession = vi.fn(() => Promise.resolve(activeStreamResult(true)));
+    const h = makeHarness({ refetchSession });
+
+    await h.stop();
+
+    expect(h.isUserStoppingRef.current).toBe(true);
+    expect(h.setIsUserStopping).not.toHaveBeenCalledWith(false);
+    // The guard is always released so the fallback reset effect can run later.
+    expect(h.isCancelInFlightRef.current).toBe(false);
+  });
+
+  it("leaves the user-stop flag set but releases the guard when the refetch throws", async () => {
+    const refetchSession = vi.fn(() =>
+      Promise.reject(new Error("refetch failed")),
+    );
+    const h = makeHarness({ refetchSession });
+
+    await h.stop();
+
+    expect(h.isUserStoppingRef.current).toBe(true);
+    expect(h.isCancelInFlightRef.current).toBe(false);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useHydrateOnStreamEnd.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useHydrateOnStreamEnd.test.ts
@@ -61,6 +61,7 @@ function runForceHydrate({
     sessionId: SESSION_ID,
     isReconnectScheduled: false,
     hasActiveStream: false,
+    isUserStoppingRef: { current: false },
     setMessages,
   };
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useHydrateOnStreamEnd.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/useHydrateOnStreamEnd.test.ts
@@ -93,6 +93,176 @@ function runForceHydrate({
   return captured;
 }
 
+const CANCELLED_MARKER_TEXT = "[__COPILOT_ERROR_f7a1__] Operation cancelled";
+
+function markerPart() {
+  return { type: "text", text: CANCELLED_MARKER_TEXT, state: "done" } as const;
+}
+
+function messageHasCancelMarker(message: UIMessage): boolean {
+  return message.parts.some(
+    (part) =>
+      part.type === "text" &&
+      "text" in part &&
+      part.text === CANCELLED_MARKER_TEXT,
+  );
+}
+
+/**
+ * Drive the hook through a user-stop: hydration is deferred while
+ * `isUserStoppingRef` is set, then applied once it clears. Returns the messages
+ * the eventual apply produced (or null if never applied).
+ */
+function runDeferredUserStop({
+  prev,
+  staleWindow,
+  freshWindow,
+}: {
+  prev: Messages;
+  staleWindow: Messages;
+  freshWindow: Messages;
+}): Messages | null {
+  let captured: Messages | null = null;
+  const setMessages = vi.fn(
+    (updater: Messages | ((p: Messages) => Messages)) => {
+      captured = typeof updater === "function" ? updater(prev) : updater;
+    },
+  );
+
+  const isUserStoppingRef = { current: true };
+
+  type Props = Parameters<typeof useHydrateOnStreamEnd>[0];
+  const baseProps = {
+    sessionId: SESSION_ID,
+    isReconnectScheduled: false,
+    hasActiveStream: false,
+    isUserStoppingRef,
+    setMessages,
+  };
+
+  const { rerender } = renderHook<void, Props>(
+    (props) => useHydrateOnStreamEnd(props),
+    {
+      initialProps: {
+        ...baseProps,
+        status: "streaming",
+        hydratedMessages: staleWindow,
+      },
+    },
+  );
+
+  // Stream ends → arms force-hydrate. The apply is deferred because the stop
+  // is still in flight, so setMessages must NOT run yet.
+  rerender({
+    ...baseProps,
+    status: "ready",
+    hydratedMessages: staleWindow,
+  } satisfies Props);
+
+  // Backend confirms the stop → flag clears and the fresh window applies,
+  // reattaching the locally-painted cancellation marker.
+  isUserStoppingRef.current = false;
+  rerender({
+    ...baseProps,
+    status: "ready",
+    hydratedMessages: freshWindow,
+  } satisfies Props);
+
+  return captured;
+}
+
+describe("useHydrateOnStreamEnd — user-stop marker preservation", () => {
+  afterEach(() => {
+    _resetInterruptedToastLedgerForTests();
+    cleanup();
+  });
+
+  it("defers hydration while a user stop is in flight", () => {
+    const setMessages = vi.fn();
+    const isUserStoppingRef = { current: true };
+    type Props = Parameters<typeof useHydrateOnStreamEnd>[0];
+    const baseProps = {
+      sessionId: SESSION_ID,
+      isReconnectScheduled: false,
+      hasActiveStream: false,
+      isUserStoppingRef,
+      setMessages,
+    };
+
+    const { rerender } = renderHook<void, Props>(
+      (props) => useHydrateOnStreamEnd(props),
+      {
+        initialProps: {
+          ...baseProps,
+          status: "streaming",
+          hydratedMessages: range(1, 2),
+        },
+      },
+    );
+
+    rerender({
+      ...baseProps,
+      status: "ready",
+      hydratedMessages: range(1, 2),
+    } satisfies Props);
+
+    expect(setMessages).not.toHaveBeenCalled();
+  });
+
+  it("reattaches the local cancellation marker when the hydrated window lacks one", () => {
+    // prev's trailing assistant carries the just-painted marker; the refetched
+    // window is the pre-marker DB state.
+    const prevBase = range(1, 2);
+    const markedAssistant: UIMessage = {
+      ...prevBase[prevBase.length - 1],
+      parts: [...prevBase[prevBase.length - 1].parts, markerPart()],
+    };
+    const prev = [...prevBase.slice(0, -1), markedAssistant];
+
+    const result = runDeferredUserStop({
+      prev,
+      staleWindow: range(1, 2),
+      freshWindow: range(1, 2),
+    });
+
+    expect(result).not.toBeNull();
+    expect(messageHasCancelMarker(result![result!.length - 1])).toBe(true);
+  });
+
+  it("does not duplicate the marker when the hydrated window already carries one", () => {
+    const prevBase = range(1, 2);
+    const markedAssistant: UIMessage = {
+      ...prevBase[prevBase.length - 1],
+      parts: [...prevBase[prevBase.length - 1].parts, markerPart()],
+    };
+    const prev = [...prevBase.slice(0, -1), markedAssistant];
+
+    // The fresh window's trailing assistant already has the backend-persisted
+    // marker, so preserveLocalStopMarker must be a no-op.
+    const freshBase = range(1, 2);
+    const freshMarked: UIMessage = {
+      ...freshBase[freshBase.length - 1],
+      parts: [...freshBase[freshBase.length - 1].parts, markerPart()],
+    };
+    const freshWindow = [...freshBase.slice(0, -1), freshMarked];
+
+    const result = runDeferredUserStop({
+      prev,
+      staleWindow: range(1, 2),
+      freshWindow,
+    });
+
+    expect(result).not.toBeNull();
+    const markerCount = result![result!.length - 1].parts.filter(
+      (part) =>
+        part.type === "text" &&
+        "text" in part &&
+        part.text === CANCELLED_MARKER_TEXT,
+    ).length;
+    expect(markerCount).toBe(1);
+  });
+});
+
 describe("useHydrateOnStreamEnd — sliding-window history retention (SECRT-2424)", () => {
   afterEach(() => {
     _resetInterruptedToastLedgerForTests();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
@@ -558,6 +558,7 @@ function StopHarness({
   setIsUserStopping,
 }: StopHarnessProps) {
   const isUserStoppingRef = useRef(false);
+  const isCancelInFlightRef = useRef(false);
   const stop = useCopilotStop({
     sessionId,
     sdkStop,
@@ -566,6 +567,8 @@ function StopHarness({
     >[0]["setMessages"],
     isUserStoppingRef,
     setIsUserStopping,
+    isCancelInFlightRef,
+    refetchSession: () => Promise.resolve({}),
   });
   return <ChatInput onSend={vi.fn()} isStreaming onStop={stop} />;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStop.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStop.ts
@@ -107,24 +107,30 @@ export function useCopilotStop({
         });
       }
     } finally {
-      isCancelInFlightRef.current = false;
-      // The cancel endpoint returns once the backend confirmed (or
-      // force-completed) the stop, so this refetch reads the settled
-      // state. Only clear the user-stop flag when the backend actually
-      // reports no active stream — clearing it against a stale cache is
-      // what used to re-arm auto-resume mid-drain.
-      if (sessionId) {
-        try {
+      // Keep ``isCancelInFlightRef`` set through the confirming refetch. The
+      // reset effect in useCopilotStream is gated on it, so clearing it before
+      // the settled session state arrives would let that effect clear the
+      // user-stop flag from the stale pre-stop cache and re-arm auto-resume
+      // mid-drain. The cancel endpoint returns once the backend confirmed (or
+      // force-completed) the stop, so this refetch reads the settled state.
+      // Only clear the user-stop flag when the backend actually reports no
+      // active stream.
+      try {
+        if (sessionId) {
           const result = await refetchSession();
           if (!hasActiveBackendStream(result)) {
             isUserStoppingRef.current = false;
             setIsUserStopping(false);
           }
-        } catch {
-          // Leave the flag set; the fallback reset effect in
-          // useCopilotStream clears it once a later session refetch
-          // reports the stream gone.
         }
+      } catch {
+        // Leave the user-stop flag set; the fallback reset effect in
+        // useCopilotStream clears it once a later session refetch reports
+        // the stream gone.
+      } finally {
+        // Always release the guard once the refetch settles — leaving it set
+        // would permanently disable the fallback reset effect.
+        isCancelInFlightRef.current = false;
       }
     }
   }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStop.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStop.ts
@@ -2,7 +2,7 @@ import { postV2CancelSessionTask } from "@/app/api/__generated__/endpoints/chat/
 import { toast } from "@/components/molecules/Toast/use-toast";
 import type { UseChatHelpers } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
-import { resolveInProgressTools } from "./helpers";
+import { hasActiveBackendStream, resolveInProgressTools } from "./helpers";
 
 /**
  * User-visible marker appended to the last assistant message so the UI
@@ -24,6 +24,16 @@ interface UseCopilotStopArgs {
    *  stop-button UX flips immediately instead of waiting for AI SDK's
    *  ``status`` to transition away from "streaming" on abort. */
   setIsUserStopping: (value: boolean) => void;
+  /** True while the ``/cancel`` request is in flight. The flag-reset effect
+   *  in ``useCopilotStream`` must not clear the user-stop flag from the
+   *  stale pre-stop ``hasActiveStream`` cache while the backend is still
+   *  draining the cancelled turn — doing so re-arms the auto-resume path,
+   *  which replays the whole transcript over the locally-painted stopped
+   *  state (duplicate messages + tool spinners flickering back). */
+  isCancelInFlightRef: React.MutableRefObject<boolean>;
+  /** Refetches the session after the cancel settles so ``hasActiveStream``
+   *  reflects the confirmed stop instead of a stale cache. */
+  refetchSession: () => Promise<{ data?: unknown }>;
 }
 
 /**
@@ -43,54 +53,79 @@ export function useCopilotStop({
   setMessages,
   isUserStoppingRef,
   setIsUserStopping,
+  isCancelInFlightRef,
+  refetchSession,
 }: UseCopilotStopArgs) {
   async function stop() {
     isUserStoppingRef.current = true;
     setIsUserStopping(true);
+    isCancelInFlightRef.current = true;
     try {
-      sdkStop();
-    } catch {
-      // sdkStop throws if no fetch is in flight — the user-stop flag
-      // already flipped, so the UI reflects the intent either way.
-    }
-    setMessages((prev) => {
-      const resolved = resolveInProgressTools(prev, "cancelled");
-      const last = resolved[resolved.length - 1];
-      if (last?.role === "assistant") {
-        return [
-          ...resolved.slice(0, -1),
-          {
-            ...last,
-            parts: [
-              ...last.parts,
-              { type: "text" as const, text: CANCELLED_MARKER },
-            ],
-          },
-        ];
+      try {
+        sdkStop();
+      } catch {
+        // sdkStop throws if no fetch is in flight — the user-stop flag
+        // already flipped, so the UI reflects the intent either way.
       }
-      return resolved;
-    });
+      setMessages((prev) => {
+        const resolved = resolveInProgressTools(prev, "cancelled");
+        const last = resolved[resolved.length - 1];
+        if (last?.role === "assistant") {
+          return [
+            ...resolved.slice(0, -1),
+            {
+              ...last,
+              parts: [
+                ...last.parts,
+                { type: "text" as const, text: CANCELLED_MARKER },
+              ],
+            },
+          ];
+        }
+        return resolved;
+      });
 
-    if (!sessionId) return;
-    try {
-      const res = await postV2CancelSessionTask(sessionId);
-      if (
-        res.status === 200 &&
-        "reason" in res.data &&
-        res.data.reason === "cancel_published_not_confirmed"
-      ) {
+      if (!sessionId) return;
+      try {
+        const res = await postV2CancelSessionTask(sessionId);
+        if (
+          res.status === 200 &&
+          "reason" in res.data &&
+          res.data.reason === "cancel_published_not_confirmed"
+        ) {
+          toast({
+            title: "Stop may take a moment",
+            description:
+              "The cancel was sent but not yet confirmed. The task should stop shortly.",
+          });
+        }
+      } catch {
         toast({
-          title: "Stop may take a moment",
-          description:
-            "The cancel was sent but not yet confirmed. The task should stop shortly.",
+          title: "Could not stop the task",
+          description: "The task may still be running in the background.",
+          variant: "destructive",
         });
       }
-    } catch {
-      toast({
-        title: "Could not stop the task",
-        description: "The task may still be running in the background.",
-        variant: "destructive",
-      });
+    } finally {
+      isCancelInFlightRef.current = false;
+      // The cancel endpoint returns once the backend confirmed (or
+      // force-completed) the stop, so this refetch reads the settled
+      // state. Only clear the user-stop flag when the backend actually
+      // reports no active stream — clearing it against a stale cache is
+      // what used to re-arm auto-resume mid-drain.
+      if (sessionId) {
+        try {
+          const result = await refetchSession();
+          if (!hasActiveBackendStream(result)) {
+            isUserStoppingRef.current = false;
+            setIsUserStopping(false);
+          }
+        } catch {
+          // Leave the flag set; the fallback reset effect in
+          // useCopilotStream clears it once a later session refetch
+          // reports the stream gone.
+        }
+      }
     }
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
@@ -96,6 +96,13 @@ export function useCopilotStream({
   // flipped ``status`` back to ``ready`` yet (which can lag by many seconds
   // when aborting a GET-based resume fetch).
   const [isUserStopping, setIsUserStopping] = useState(false);
+  // True while the /cancel request of a user stop is in flight. Guards the
+  // flag-reset effect below: right after a stop, the session query still
+  // holds the pre-turn snapshot (``active_stream=false``), and resetting the
+  // user-stop flag from that stale cache re-armed the auto-resume effect the
+  // moment the post-stream refetch reported the backend still draining —
+  // replaying the whole transcript over the locally-painted stopped state.
+  const isCancelInFlightRef = useRef(false);
   // Flipped to `false` during mount cleanup so async callbacks that were
   // already in flight (e.g. the post-stream settle in `onFinish`) bail out
   // instead of arming new timers / HTTP requests against a torn-down mount.
@@ -352,6 +359,8 @@ export function useCopilotStream({
     setMessages,
     isUserStoppingRef,
     setIsUserStopping,
+    isCancelInFlightRef,
+    refetchSession,
   });
 
   // Silent-stall watchdog: triggers the reconnect cascade if the stream
@@ -401,6 +410,7 @@ export function useCopilotStream({
     hydratedMessages,
     isReconnectScheduled,
     hasActiveStream,
+    isUserStoppingRef,
     setMessages,
   });
 
@@ -548,8 +558,12 @@ export function useCopilotStream({
 
   // Reset the user-stop flag once the backend confirms the stream is no
   // longer active — this prevents the flag from staying stale forever.
+  // Guarded on the cancel round-trip: until /cancel settles, the cached
+  // ``hasActiveStream=false`` is the PRE-stop snapshot, not a confirmation
+  // that the turn stopped. Resetting from it re-armed auto-resume mid-drain.
   useEffect(() => {
     if (hasActiveStream) return;
+    if (isCancelInFlightRef.current) return;
     if (isUserStoppingRef.current) {
       isUserStoppingRef.current = false;
     }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useHydrateOnStreamEnd.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useHydrateOnStreamEnd.ts
@@ -102,6 +102,18 @@ function messageHasErrorMarker(message: UIMessage): boolean {
   );
 }
 
+/** Text of the marker the stop handler paints — must match `CANCELLED_MARKER`
+ *  in `useCopilotStop.ts` (after the `COPILOT_ERROR_PREFIX` is stripped). */
+const CANCELLATION_MARKER_TEXT = "Operation cancelled";
+
+function isCancellationMarkerText(text: string): boolean {
+  const marker = parseSpecialMarkers(text);
+  return (
+    marker.markerType === "error" &&
+    marker.markerText === CANCELLATION_MARKER_TEXT
+  );
+}
+
 /**
  * After a user stop, the stop handler paints a cancellation marker onto the
  * last in-memory assistant message immediately, while the backend persists
@@ -115,10 +127,12 @@ function preserveLocalStopMarker(
   prev: UIMessage[],
   hydrated: UIMessage[],
 ): UIMessage[] {
-  const prevMarked = [...prev]
-    .reverse()
-    .find((m) => m.role === "assistant" && messageHasErrorMarker(m));
-  if (!prevMarked) return hydrated;
+  // Only the trailing assistant row can carry the just-painted local marker:
+  // the stop handler appends it to `prev`'s last message when that message is
+  // an assistant. Scanning the whole history for any error marker could
+  // reattach a stale marker from an earlier turn to this hydration.
+  const prevMarked = prev[prev.length - 1];
+  if (prevMarked?.role !== "assistant") return hydrated;
   if (hydrated.some((m) => m.role === "assistant" && messageHasErrorMarker(m)))
     return hydrated;
 
@@ -126,8 +140,9 @@ function preserveLocalStopMarker(
     (part) =>
       part.type === "text" &&
       "text" in part &&
-      parseSpecialMarkers(part.text).markerType !== null,
+      isCancellationMarkerText(part.text),
   );
+  if (markerParts.length === 0) return hydrated;
   const last = hydrated[hydrated.length - 1];
   if (last?.role === "assistant") {
     return [

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useHydrateOnStreamEnd.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useHydrateOnStreamEnd.ts
@@ -2,6 +2,7 @@ import { toast } from "@/components/molecules/Toast/use-toast";
 import type { UIMessage } from "ai";
 import { useEffect, useRef } from "react";
 
+import { parseSpecialMarkers } from "./components/ChatMessagesContainer/helpers";
 import {
   deduplicateMessages,
   hasInProgressAssistantParts,
@@ -92,6 +93,53 @@ function preservePromotedUserBubbles(
   return [...hydrated, ...orphans];
 }
 
+function messageHasErrorMarker(message: UIMessage): boolean {
+  return message.parts.some(
+    (part) =>
+      part.type === "text" &&
+      "text" in part &&
+      parseSpecialMarkers(part.text).markerType !== null,
+  );
+}
+
+/**
+ * After a user stop, the stop handler paints a cancellation marker onto the
+ * last in-memory assistant message immediately, while the backend persists
+ * its own marker row only once the cancelled turn finishes draining
+ * (seconds later). If the post-stop hydration applies from a refetch that
+ * landed in between, a blind replace would drop the local marker and the
+ * "Task stopped" card would vanish until the next refetch. Re-attach the
+ * local marker unless the hydrated window already carries one.
+ */
+function preserveLocalStopMarker(
+  prev: UIMessage[],
+  hydrated: UIMessage[],
+): UIMessage[] {
+  const prevMarked = [...prev]
+    .reverse()
+    .find((m) => m.role === "assistant" && messageHasErrorMarker(m));
+  if (!prevMarked) return hydrated;
+  if (hydrated.some((m) => m.role === "assistant" && messageHasErrorMarker(m)))
+    return hydrated;
+
+  const markerParts = prevMarked.parts.filter(
+    (part) =>
+      part.type === "text" &&
+      "text" in part &&
+      parseSpecialMarkers(part.text).markerType !== null,
+  );
+  const last = hydrated[hydrated.length - 1];
+  if (last?.role === "assistant") {
+    return [
+      ...hydrated.slice(0, -1),
+      { ...last, parts: [...last.parts, ...markerParts] },
+    ];
+  }
+  // Stopped before any assistant row was persisted — keep the whole local
+  // marker message so the stopped state has something to render from.
+  return [...hydrated, prevMarked];
+}
+
 type ChatStatus = "submitted" | "streaming" | "ready" | "error";
 
 // Survive remount on session re-entry: useRef would reset every time
@@ -120,6 +168,14 @@ interface Args {
    * resend.
    */
   hasActiveStream: boolean;
+  /**
+   * True from the moment the user presses Stop until the backend confirms
+   * the turn is gone. While set, hydration is deferred: the DB still holds
+   * the cancelled turn's mid-stream rows (tools without results), so
+   * applying it would clobber the locally-painted stopped state with
+   * spinners and drop the cancellation marker.
+   */
+  isUserStoppingRef: React.MutableRefObject<boolean>;
   setMessages: (
     updater: UIMessage[] | ((prev: UIMessage[]) => UIMessage[]),
   ) => void;
@@ -160,11 +216,17 @@ export function useHydrateOnStreamEnd({
   hydratedMessages,
   isReconnectScheduled,
   hasActiveStream,
+  isUserStoppingRef,
   setMessages,
 }: Args) {
   const prevStatusRef = useRef(status);
   const needsForceHydrateRef = useRef(false);
   const staleRefAtStreamEnd = useRef<typeof hydratedMessages | null>(null);
+  // Set when an apply was deferred because a user stop was in flight.
+  // Consumed by the eventual apply to (a) skip the "interrupted" toast —
+  // the interruption was the user's own stop — and (b) preserve the local
+  // cancellation marker if the backend hasn't persisted its own row yet.
+  const deferredForUserStopRef = useRef(false);
 
   // Arm the force-hydrate flag the moment the stream transitions to idle.
   useEffect(() => {
@@ -184,6 +246,10 @@ export function useHydrateOnStreamEnd({
     if (!hydratedMessages || hydratedMessages.length === 0) return;
     if (status === "streaming" || status === "submitted") return;
     if (isReconnectScheduled) return;
+    if (isUserStoppingRef.current) {
+      deferredForUserStopRef.current = true;
+      return;
+    }
 
     const deduped = deduplicateMessages(hydratedMessages);
     const needsZombieRecovery =
@@ -207,6 +273,7 @@ export function useHydrateOnStreamEnd({
       needsZombieRecovery &&
       sessionId &&
       !isStaleForceHydrateSnapshot &&
+      !deferredForUserStopRef.current &&
       !sessionsWithInterruptedToastShown.has(sessionId)
     ) {
       sessionsWithInterruptedToastShown.add(sessionId);
@@ -222,11 +289,17 @@ export function useHydrateOnStreamEnd({
         // Still the pre-turn snapshot — wait for the refetch.
         return;
       }
-      setMessages((prev) =>
-        preservePromotedUserBubbles(prev, retainOlderHistory(prev, finalized)),
-      );
+      const wasUserStop = deferredForUserStopRef.current;
+      setMessages((prev) => {
+        const replaced = preservePromotedUserBubbles(
+          prev,
+          retainOlderHistory(prev, finalized),
+        );
+        return wasUserStop ? preserveLocalStopMarker(prev, replaced) : replaced;
+      });
       needsForceHydrateRef.current = false;
       staleRefAtStreamEnd.current = null;
+      deferredForUserStopRef.current = false;
       return;
     }
 


### PR DESCRIPTION
### Why / What / How

**Why:** Pressing **Stop** on a Copilot turn produced two bad symptoms. (1) A red *"The assistant encountered an error. Please try sending your message again."* banner appeared even though the user asked for the stop. (2) The tool would visibly re-load and the transcript duplicated for ~2-3 seconds before the "Task stopped" card finally settled — the stop looked like it was ignored, and users sometimes had to press Stop twice.

**What:** Stop a user cancel from being surfaced as an error, and stop the frontend from re-arming auto-resume (which replayed the whole transcript) while the cancelled turn is still draining on the backend.

**How:** On the backend, `mark_session_completed` now skips publishing the `StreamError` frame for user-initiated cancels — both the `/cancel` route's force-complete branch and the executor's `finally` block — while still marking the turn failed (locks released, queued turns promoted); `/cancel` also returns the `cancel_published_not_confirmed` reason the frontend already had a handler for. On the frontend, the user-stopping flag is held until `/cancel` confirms the stream is actually gone (never cleared from the stale pre-stop session cache), post-stream hydration is deferred while a stop is in flight, and the locally-painted cancellation marker is preserved so the "Task stopped" card never disappears.

### Changes 🏗️

- **backend/`chat/routes.py`**: `/cancel` force-complete passes `skip_error_publish=True` and returns `reason="cancel_published_not_confirmed"`.
- **backend/`copilot/executor/processor.py`**: track `user_cancelled` and skip the StreamError publish for user cancels in the turn's `finally` block.
- **backend/`chat/routes_test.py`**: regression test asserting the force-complete branch suppresses the StreamError and returns the confirmed reason.
- **frontend/`useCopilotStop.ts`**: keep the user-stop flag set until a post-cancel session refetch confirms `active_stream` is gone.
- **frontend/`useCopilotStream.ts`**: gate the flag-reset effect on a new `isCancelInFlightRef` so auto-resume can't re-arm mid-drain.
- **frontend/`useHydrateOnStreamEnd.ts`**: defer hydration while stopping, preserve the local stop marker, and suppress the misleading "Previous response was interrupted" toast for user stops (+ test arg update).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] Backend: `poetry run pytest backend/api/features/chat/routes_test.py -k cancel` (9 passed, incl. new force-complete regression test)
  - [ ] Frontend: `pnpm test:unit` for the copilot hydrate/stop hooks (run manually)
  - [ ] Manual: start a long tool-using turn, press Stop mid-generation, confirm the "Task stopped" card appears instantly with no error banner, no transcript duplication, and no tool spinners flickering back
