### PR TITLE
fix(dx): batch bot — push rollup objects instead of refs-API update, fix add-then-list race (dev)

### DIFF
--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -150,9 +150,12 @@ function buildRollup(list) {
 // --- rollup PR (sticky status + deploy + merge target) -------------------
 
 function findRollupPR() {
-  const owner = REPO.split("/")[0];
+  // Plain branch name only: `gh pr list --head` does NOT understand the
+  // owner-qualified `owner:branch` form (that's a `pr create` convention) —
+  // it silently matches nothing, which made every rebuild after the first
+  // try to create a duplicate rollup PR and die on "already exists".
   const rows = ghJSON([
-    "pr", "list", "--repo", REPO, "--head", `${owner}:${ROLLUP}`, "--base", BASE, "--state", "open",
+    "pr", "list", "--repo", REPO, "--head", ROLLUP, "--base", BASE, "--state", "open",
     "--json", "number,url",
   ]);
   return rows[0] || null;

--- a/.github/batch-bot/batch.mjs
+++ b/.github/batch-bot/batch.mjs
@@ -137,19 +137,13 @@ function buildRollup(list) {
     );
   }
 
-  // Force-update the ephemeral, bot-owned rollup branch via the refs API. This is
-  // a non-ff update of a throwaway branch nobody builds on — protect it in branch
-  // settings so only the bot can push to it (see README).
-  const sha = git(["rev-parse", "HEAD"]);
-  const ref = `refs/heads/${ROLLUP}`;
-  // Exact-match existence check via the singular `git/ref/…`; the plural
-  // `git/refs/…` prefix-matches and can false-positive on a sibling branch.
-  const exists = tryGh(["api", `repos/${REPO}/git/ref/heads/${ROLLUP}`]).ok;
-  if (exists) {
-    gh(["api", "-X", "PATCH", `repos/${REPO}/git/${ref}`, "-f", `sha=${sha}`, "-F", "force=true"]);
-  } else {
-    gh(["api", "-X", "POST", `repos/${REPO}/git/refs`, "-f", `ref=${ref}`, "-f", `sha=${sha}`]);
-  }
+  // Force-push the ephemeral, bot-owned rollup branch. The refs API cannot be
+  // used here: the merge commits exist only in this runner's clone, and the
+  // API refuses to point a ref at objects the server has never received
+  // (422 "Object does not exist"). The push uploads the objects and creates
+  // or force-moves the branch in one step, authenticated as the bot via the
+  // checkout token — keep batch/rollup protected to bot-only pushes (README).
+  git(["push", "--force", "origin", `HEAD:refs/heads/${ROLLUP}`]);
   return { merged, ejected };
 }
 
@@ -231,8 +225,19 @@ function assertBatchable(pr) {
   return p;
 }
 
-function rebuildAndReport(actionNote) {
-  const { merged, ejected } = buildRollup(members());
+function rebuildAndReport(actionNote, ensureNumber = null) {
+  // GitHub's label index lags behind `pr edit --add-label`, so the very first
+  // /batch on a PR can list an empty batch and build nothing. When the caller
+  // just labeled a PR, fetch it directly and union it into the member list.
+  let list = members();
+  if (ensureNumber && !list.some((p) => p.number === ensureNumber)) {
+    const row = ghJSON([
+      "pr", "view", String(ensureNumber), "--repo", REPO,
+      "--json", "number,title,headRefName,headRefOid,url,labels,reviewDecision,mergeable,isDraft",
+    ]);
+    if (!row.labels.some((l) => l.name === NEVER)) list.push(row);
+  }
+  const { merged, ejected } = buildRollup(list);
   const pr = upsertRollupPR(merged, ejected);
   if (pr) deployRollup(pr); // (re)deploy the combined preview to reflect the new batch
   if (prNumber) {
@@ -252,7 +257,7 @@ function cmdBatch() {
   if (!prNumber) throw new Error("no PR number");
   assertBatchable(prNumber);
   gh(["pr", "edit", String(prNumber), "--repo", REPO, "--add-label", LABEL]);
-  rebuildAndReport(`Added #${prNumber} to the batch.`);
+  rebuildAndReport(`Added #${prNumber} to the batch.`, prNumber);
 }
 
 function cmdBatchRemove() {


### PR DESCRIPTION
### Why / What / How

Forward-port of #13534 to `dev` (the bot executes master's copy — see that PR for the full analysis of the two live failures: refs-API 422 on unpushed objects, and the label-index race making the first /batch build nothing). Same two fixes applied to dev's copy of `batch.mjs`, preserving dev's #13521 hardening (exact-match ref check becomes moot — the whole refs-API block is replaced by the force-push).

### Changes 🏗️
- `.github/batch-bot/batch.mjs`: force-push rollup branch; union just-added PR into the rebuild

### Checklist 📋
#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `node --check` clean; same edits as #13534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core batch/rollup publishing and membership logic used in CI; misconfiguration could break previews or duplicate rollup PRs, but scope is limited to the bot script with documented GitHub API behavior.
> 
> **Overview**
> Fixes two production failures in the batch bot’s rollup flow by changing how the ephemeral `batch/rollup` branch is published and how members are collected right after `/batch`.
> 
> **Rollup branch update:** After assembling merges locally, the bot now **force-pushes** `HEAD` to `refs/heads/batch/rollup` instead of using the GitHub git refs API. Merge objects only exist in the Actions runner clone, so pointing a ref at them via API returned **422 “Object does not exist”**; push uploads objects and moves the branch in one step.
> 
> **Rollup PR lookup:** `gh pr list --head` now uses the **plain branch name** (`batch/rollup`), not `owner:branch`. The qualified form is ignored by `pr list`, so later rebuilds failed to find the existing rollup PR and tried to create duplicates.
> 
> **First `/batch` race:** `rebuildAndReport` accepts an optional PR number; when `/batch` just added a label, that PR is **fetched with `pr view` and unioned** into the member list if the label index hasn’t caught up yet—avoiding an empty first rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe127081457e8d9750dcd78d96636670df9a8ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->