### PR TITLE
fix(backend): exclude soft-deleted orgs from org migration backfill JOINs

### DIFF
--- a/autogpt_platform/backend/backend/data/org_migration.py
+++ b/autogpt_platform/backend/backend/data/org_migration.py
@@ -336,7 +336,7 @@ async def create_orgs_for_existing_users(
         WHERE NOT EXISTS (
             SELECT 1 FROM "OrgMember" om
             JOIN "Organization" o ON o."id" = om."orgId"
-            WHERE om."userId" = u."id" AND om."isOwner" = true AND o."isPersonal" = true
+            WHERE om."userId" = u."id" AND om."isOwner" = true AND o."isPersonal" = true AND o."deletedAt" IS NULL
         )
         """,
     )
@@ -534,7 +534,7 @@ async def migrate_org_balances() -> int:
         SELECT o."id", ub."balance", ub."updatedAt"
         FROM "UserBalance" ub
         JOIN "OrgMember" om ON om."userId" = ub."userId" AND om."isOwner" = true
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         WHERE NOT EXISTS (
             SELECT 1 FROM "OrgBalance" ob WHERE ob."orgId" = o."id"
         )
@@ -563,7 +563,7 @@ async def migrate_credit_transactions() -> int:
             ct."amount", ct."type", ct."runningBalance", ct."isActive", ct."metadata"
         FROM "CreditTransaction" ct
         JOIN "OrgMember" om ON om."userId" = ct."userId" AND om."isOwner" = true
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         WHERE NOT EXISTS (
             SELECT 1 FROM "OrgCreditTransaction" oct
             WHERE oct."transactionKey" = ct."transactionKey" AND oct."orgId" = o."id"
@@ -643,7 +643,7 @@ async def assign_resources_to_teams(
         UPDATE "AgentGraph" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -656,7 +656,7 @@ async def assign_resources_to_teams(
         UPDATE "AgentGraphExecution" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true
           AND t."id" IN (
@@ -665,7 +665,7 @@ async def assign_resources_to_teams(
               JOIN "OrgMember" om2
                 ON om2."userId" = t2."userId" AND om2."isOwner" = true
               JOIN "Organization" o2
-                ON o2."id" = om2."orgId" AND o2."isPersonal" = true
+                ON o2."id" = om2."orgId" AND o2."isPersonal" = true AND o2."deletedAt" IS NULL
               JOIN "Team" w2
                 ON w2."orgId" = o2."id" AND w2."isDefault" = true
               WHERE t2."organizationId" IS NULL
@@ -681,7 +681,7 @@ async def assign_resources_to_teams(
         UPDATE "ChatSession" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true
           AND t."id" IN (
@@ -690,7 +690,7 @@ async def assign_resources_to_teams(
               JOIN "OrgMember" om2
                 ON om2."userId" = t2."userId" AND om2."isOwner" = true
               JOIN "Organization" o2
-                ON o2."id" = om2."orgId" AND o2."isPersonal" = true
+                ON o2."id" = om2."orgId" AND o2."isPersonal" = true AND o2."deletedAt" IS NULL
               JOIN "Team" w2
                 ON w2."orgId" = o2."id" AND w2."isDefault" = true
               WHERE t2."organizationId" IS NULL
@@ -705,7 +705,7 @@ async def assign_resources_to_teams(
         UPDATE "AgentPreset" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -717,7 +717,7 @@ async def assign_resources_to_teams(
         UPDATE "LibraryAgent" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -729,7 +729,7 @@ async def assign_resources_to_teams(
         UPDATE "LibraryFolder" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -741,7 +741,7 @@ async def assign_resources_to_teams(
         UPDATE "IntegrationWebhook" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -753,7 +753,7 @@ async def assign_resources_to_teams(
         UPDATE "APIKey" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -765,7 +765,7 @@ async def assign_resources_to_teams(
         UPDATE "UserNotificationBatch" t
         SET "organizationId" = o."id", "teamId" = w."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         JOIN "Team" w ON w."orgId" = o."id" AND w."isDefault" = true
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
@@ -779,7 +779,7 @@ async def assign_resources_to_teams(
         UPDATE "BuilderSearchHistory" t
         SET "organizationId" = o."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
         renew_lock=renew_lock,
@@ -790,7 +790,7 @@ async def assign_resources_to_teams(
         UPDATE "PendingHumanReview" t
         SET "organizationId" = o."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         WHERE t."userId" = om."userId" AND om."isOwner" = true AND t."organizationId" IS NULL
         """,
         renew_lock=renew_lock,
@@ -803,7 +803,7 @@ async def assign_resources_to_teams(
         FROM "StoreListingVersion" v
         JOIN "StoreListing" sl ON sl."id" = v."storeListingId"
         JOIN "OrgMember" om ON om."userId" = sl."owningUserId" AND om."isOwner" = true
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         WHERE slv."id" = v."id" AND slv."organizationId" IS NULL
         """,
         renew_lock=renew_lock,
@@ -826,7 +826,7 @@ async def migrate_store_listings() -> int:
         UPDATE "StoreListing" sl
         SET "owningOrgId" = o."id"
         FROM "OrgMember" om
-        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true
+        JOIN "Organization" o ON o."id" = om."orgId" AND o."isPersonal" = true AND o."deletedAt" IS NULL
         WHERE sl."owningUserId" = om."userId"
           AND om."isOwner" = true
           AND sl."owningOrgId" IS NULL

--- a/autogpt_platform/backend/backend/data/org_migration_test.py
+++ b/autogpt_platform/backend/backend/data/org_migration_test.py
@@ -1265,3 +1265,47 @@ class TestCredentialMigration:
 
         assert created == 0
         mock_prisma.integrationcredential.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Soft-deleted org exclusion (dev incident follow-up: dead duplicate orgs must
+# never re-enter the money-copy or tenancy JOINs, or deleted-org cleanup gets
+# resurrected on the next startup)
+# ---------------------------------------------------------------------------
+
+
+class TestSoftDeletedOrgsExcludedFromMigrationSQL:
+    @pytest.mark.asyncio
+    async def test_balance_copy_sql_excludes_soft_deleted_orgs(self, mock_prisma):
+        await migrate_org_balances()
+
+        sql = mock_prisma.execute_raw.call_args[0][0]
+        assert 'o."deletedAt" IS NULL' in sql
+
+    @pytest.mark.asyncio
+    async def test_ledger_copy_sql_excludes_soft_deleted_orgs(self, mock_prisma):
+        await migrate_credit_transactions()
+
+        sql = mock_prisma.execute_raw.call_args[0][0]
+        assert 'o."deletedAt" IS NULL' in sql
+
+    @pytest.mark.asyncio
+    async def test_tenancy_assignment_sql_excludes_soft_deleted_orgs(self, mock_prisma):
+        await assign_resources_to_teams()
+
+        for call in mock_prisma.execute_raw.call_args_list:
+            sql = call[0][0]
+            assert 'o."deletedAt" IS NULL' in sql, sql
+
+    def test_every_personal_org_join_in_module_excludes_soft_deleted(self):
+        """Tripwire: any raw-SQL JOIN on personal orgs added to this module
+        must carry the soft-delete guard on the same line."""
+        import inspect
+
+        import backend.data.org_migration as org_migration
+
+        for lineno, line in enumerate(
+            inspect.getsource(org_migration).splitlines(), start=1
+        ):
+            if '"isPersonal" = true' in line:
+                assert '"deletedAt" IS NULL' in line, f"line {lineno}: {line.strip()}"


### PR DESCRIPTION
## Why

The org-migration backfill's raw-SQL JOINs match personal orgs with `o."isPersonal" = true` but never filter `deletedAt`. Soft-deleted personal orgs (the dev dedupe's 84 losers, or any org a future flow soft-deletes) therefore re-enter every startup backfill:

- `migrate_org_balances` / `migrate_credit_transactions` resurrect a soft-deleted org's balance and re-copy its entire ledger from the legacy tables — undoing any cleanup and re-creating double-counted money with zero alerts.
- The tenancy-assign JOINs can match both a live and a dead org for the same owner, stamping unassigned rows nondeterministically.
- The backfill snapshot's `NOT EXISTS` counts a soft-deleted org as "has a personal org", so a user whose only org is soft-deleted is skipped by the backfill forever.

Prod is not currently affected (zero soft-deleted personal orgs), but the first feature that soft-deletes a personal org while leaving membership rows intact steps on this. It also blocks the dev remediation: deleting the dead orgs' duplicated ledgers is futile while every deploy re-inserts them.

## What

- Add `AND o."deletedAt" IS NULL` (and `o2.` for the batched subqueries) to all 18 raw-SQL personal-org JOINs in `backend/data/org_migration.py`: backfill snapshot, balance copy, ledger copy, all tenancy-assign helpers, store-listing assignment, and alias creation.
- Regression tests: SQL emitted by `migrate_org_balances` / `migrate_credit_transactions` / `assign_resources_to_teams` must carry the guard, plus a source-scan tripwire failing any future `"isPersonal" = true` JOIN line in the module that lacks it.

## How

Mechanical predicate addition — no behavior change for live orgs; soft-deleted orgs simply stop matching. Full `org_migration_test.py` suite passes (64/64).

## Changes

- `backend/data/org_migration.py`: 18 JOIN predicates gain the soft-delete guard
- `backend/data/org_migration_test.py`: 4 new regression tests

## Checklist

- [x] Tests added/updated (`org_migration_test.py`, 64/64 passing)
- [x] No user-ID check changes (`data/*` change is SQL-predicate-only; all queries remain scoped by the same ownership JOINs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches idempotent startup SQL that copies balances and credit transactions and assigns tenancy; live org behavior is unchanged, but incorrect predicates could skip users or mis-assign resources.
> 
> **Overview**
> Startup org backfill raw SQL that joins personal organizations now requires **`o."deletedAt" IS NULL`** (and **`o2."deletedAt" IS NULL`** in batched subqueries) everywhere it previously matched only `isPersonal = true`.
> 
> That guard is applied across personal-org discovery, **balance and credit ledger copy**, **tenancy assignment** for tenant-bound tables, and **store listing** org assignment so soft-deleted duplicate personal orgs are not treated as live targets on every deploy.
> 
> **Regression coverage** in `org_migration_test.py` asserts the emitted SQL for balance/ledger/tenancy paths includes the predicate, plus a source-scan tripwire so new `"isPersonal" = true` JOIN lines in the module must include the same guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3f444e29228ee00de1b89e1f5eceed18ef4367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->