### PR TITLE
feat(copilot): upgrade default model to Claude Sonnet 5

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -161,6 +161,7 @@ class LlmModel(str, Enum, metaclass=LlmModelMeta):
     CLAUDE_4_6_OPUS = "claude-opus-4-6"
     CLAUDE_4_7_OPUS = "claude-opus-4-7"
     CLAUDE_4_6_SONNET = "claude-sonnet-4-6"
+    CLAUDE_SONNET_5 = "claude-sonnet-5"
     # AI/ML API models
     AIML_API_LLAMA3_3_70B = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     # Groq models
@@ -338,6 +339,9 @@ MODEL_METADATA = {
     LlmModel.CLAUDE_4_6_SONNET: ModelMetadata(
         "anthropic", 200000, 64000, "Claude Sonnet 4.6", "Anthropic", "Anthropic", 3
     ),  # claude-sonnet-4-6
+    LlmModel.CLAUDE_SONNET_5: ModelMetadata(
+        "anthropic", 260000, 64000, "Claude Sonnet 5", "Anthropic", "Anthropic", 3
+    ),  # claude-sonnet-5 (260k = 200k * 1.3 tokenizer inflation)
     LlmModel.CLAUDE_4_5_OPUS: ModelMetadata(
         "anthropic", 200000, 64000, "Claude Opus 4.5", "Anthropic", "Anthropic", 3
     ),  # claude-opus-4-5-20251101

--- a/autogpt_platform/backend/backend/blocks/stagehand/blocks.py
+++ b/autogpt_platform/backend/backend/blocks/stagehand/blocks.py
@@ -40,6 +40,7 @@ class StagehandRecommendedLlmModel(str, Enum):
     # Anthropic
     CLAUDE_4_5_SONNET = "claude-sonnet-4-5-20250929"  # Keep for backwards compat
     CLAUDE_4_6_SONNET = "claude-sonnet-4-6"
+    CLAUDE_SONNET_5 = "claude-sonnet-5"
 
     @property
     def provider_name(self) -> str:
@@ -93,7 +94,7 @@ class StagehandObserveBlock(Block):
         model: StagehandRecommendedLlmModel = SchemaField(
             title="LLM Model",
             description="LLM to use for Stagehand (provider is inferred)",
-            default=StagehandRecommendedLlmModel.CLAUDE_4_6_SONNET,
+            default=StagehandRecommendedLlmModel.CLAUDE_SONNET_5,
             advanced=False,
         )
         model_credentials: AICredentials = AICredentialsField()
@@ -176,7 +177,7 @@ class StagehandActBlock(Block):
         model: StagehandRecommendedLlmModel = SchemaField(
             title="LLM Model",
             description="LLM to use for Stagehand (provider is inferred)",
-            default=StagehandRecommendedLlmModel.CLAUDE_4_6_SONNET,
+            default=StagehandRecommendedLlmModel.CLAUDE_SONNET_5,
             advanced=False,
         )
         model_credentials: AICredentials = AICredentialsField()
@@ -272,7 +273,7 @@ class StagehandExtractBlock(Block):
         model: StagehandRecommendedLlmModel = SchemaField(
             title="LLM Model",
             description="LLM to use for Stagehand (provider is inferred)",
-            default=StagehandRecommendedLlmModel.CLAUDE_4_6_SONNET,
+            default=StagehandRecommendedLlmModel.CLAUDE_SONNET_5,
             advanced=False,
         )
         model_credentials: AICredentials = AICredentialsField()

--- a/autogpt_platform/backend/backend/copilot/anthropic_rates.json
+++ b/autogpt_platform/backend/backend/copilot/anthropic_rates.json
@@ -652,5 +652,28 @@
       "supports_xhigh_reasoning_effort": true,
       "tool_use_system_prompt_tokens": 346
     }
+  },
+  "claude-sonnet-5": {
+    "cache_creation_input_token_cost": 2.5e-06,
+    "cache_read_input_token_cost": 2e-07,
+    "input_cost_per_token": 2e-06,
+    "litellm_provider": "anthropic",
+    "max_input_tokens": 260000,
+    "max_output_tokens": 64000,
+    "max_tokens": 64000,
+    "mode": "chat",
+    "output_cost_per_token": 1e-05,
+    "supports_assistant_prefill": true,
+    "supports_computer_use": true,
+    "supports_function_calling": true,
+    "supports_max_reasoning_effort": true,
+    "supports_minimal_reasoning_effort": true,
+    "supports_pdf_input": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "tool_use_system_prompt_tokens": 346
   }
 }

--- a/autogpt_platform/backend/backend/copilot/baseline/reasoning.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/reasoning.py
@@ -227,6 +227,7 @@ def reasoning_extra_body(model: str, max_thinking_tokens: int) -> dict[str, Any]
 # ``"claude" in model``.
 _THINKING_CAPABLE_PREFIXES: tuple[str, ...] = (
     "claude-opus-4",  # 4.0 / 4.1 / 4.5 / 4.7
+    "claude-sonnet-5",  # 5.x — adaptive thinking API
     "claude-sonnet-4",  # 4.0 / 4.5 / 4.6
     "claude-haiku-4",  # 4.5
     "claude-3-7",  # 3.7 sonnet — only 3.x with thinking
@@ -240,6 +241,20 @@ def _is_thinking_capable_claude(model: str) -> bool:
             lowered = lowered[len(prefix) :]
             break
     return lowered.startswith(_THINKING_CAPABLE_PREFIXES)
+
+
+# Sonnet 5+ uses the adaptive thinking API — budget_tokens removed (400s).
+# Pass {type: "adaptive"} to enable; {type: "disabled"} to suppress.
+_ADAPTIVE_THINKING_PREFIXES: tuple[str, ...] = ("claude-sonnet-5",)
+
+
+def _is_adaptive_thinking_claude(model: str) -> bool:
+    lowered = model.lower()
+    for prefix in ("anthropic/", "anthropic."):
+        if lowered.startswith(prefix):
+            lowered = lowered[len(prefix) :]
+            break
+    return lowered.startswith(_ADAPTIVE_THINKING_PREFIXES)
 
 
 def anthropic_thinking_extra_body(
@@ -258,9 +273,14 @@ def anthropic_thinking_extra_body(
     that isn't in the thinking-capable allowlist (older Claude 3 / 3.5
     variants 400 on the ``thinking`` field).
     """
-    if not _is_reasoning_route(model) or max_thinking_tokens <= 0:
+    if not _is_reasoning_route(model) or not _is_thinking_capable_claude(model):
         return None
-    if not _is_thinking_capable_claude(model):
+    # Sonnet 5+ uses adaptive thinking — budget_tokens param removed (returns HTTP 400).
+    if _is_adaptive_thinking_claude(model):
+        thinking_type = "adaptive" if max_thinking_tokens > 0 else "disabled"
+        return {"thinking": {"type": thinking_type}}
+    # Older thinking-capable models (Claude 4.x, 3.7) use the enabled+budget_tokens API.
+    if max_thinking_tokens <= 0:
         return None
     return {
         "thinking": {

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -829,10 +829,12 @@ async def _baseline_llm_caller(
         # Direct: Anthropic requires max_tokens > budget_tokens explicitly; OR injects a default.
         max_tokens_arg: int | Any = openai_omit
         if not is_openrouter_transport and "thinking" in extra_body:
-            model_max = get_max_output_tokens(state.model)
-            budget = min(config.claude_agent_max_thinking_tokens, model_max - 1)
-            extra_body["thinking"]["budget_tokens"] = budget
-            max_tokens_arg = min(budget + 4096, model_max)
+            # Sonnet 5+ uses adaptive thinking — budget_tokens param removed (returns HTTP 400).
+            if extra_body["thinking"].get("type") not in ("adaptive", "disabled"):
+                model_max = get_max_output_tokens(state.model)
+                budget = min(config.claude_agent_max_thinking_tokens, model_max - 1)
+                extra_body["thinking"]["budget_tokens"] = budget
+                max_tokens_arg = min(budget + 4096, model_max)
         # Route through the shared providers helper so future provider
         # work (streaming flex tier, new SDK upgrades) propagates here
         # without a parallel migration. The pre-built ``client`` is


### PR DESCRIPTION
## Summary

Upgrades AutoPilot default model `claude-sonnet-4-6` → `claude-sonnet-5` and handles Sonnet 5 breaking API changes.

> **⚠️ Depends on #13579** (already merged) — `config.py` fast/thinking defaults are set there.

## Changes

### `blocks/llm.py`
- Add `LlmModel.CLAUDE_SONNET_5` with **260k** input tokens (200k × 1.3 tokenizer inflation, keeps effective context ~100k)

### `copilot/anthropic_rates.json`
- Add `claude-sonnet-5` pricing entry ($2/$10 per MTok intro, same 260k cap)

### `blocks/stagehand/blocks.py`
- Add `CLAUDE_SONNET_5` to `StagehandRecommendedLlmModel`, set as default

### `copilot/baseline/reasoning.py`
- Add `claude-sonnet-5` to `_THINKING_CAPABLE_PREFIXES`
- Add `_ADAPTIVE_THINKING_PREFIXES` + `_is_adaptive_thinking_claude()` helper
- Update `anthropic_thinking_extra_body()`: Sonnet 5 uses `{type: adaptive}`/`{type: disabled}` — `budget_tokens` removed (HTTP 400)

### `copilot/baseline/service.py`
- Guard `budget_tokens` injection: skip for adaptive-thinking models

## Cost

- Intro pricing $2/$10 per MTok until Aug 31 2026, then $3/$15 (same as 4.6)
- 260k cap (not 1M) avoids ~25x cost explosion on long sessions
- Adaptive thinking suppressed on fast route via `{type: disabled}`
- Plan: test in dev, monitor costs, promote to prod only when confident

## LaunchDarkly

Needs LD flag `copilot-model-routing` → `fast.standard`/`thinking.standard` = `anthropic/claude-sonnet-5` flipped for dev/internal cohort.