### PR TITLE
dx(infra): add cross-platform Orca worktree hooks

### DIFF
--- a/.orca/hooks.mjs
+++ b/.orca/hooks.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Orca worktree hooks for AutoGPT, invoked from orca.yaml as
+// `node .orca/hooks.mjs <setup|archive>`. Node is the entry point (rather than
+// a shell script) because Orca runs hooks under /bin/bash on macOS/Linux but
+// cmd.exe on Windows, and `node` resolves identically in both.
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const mode = process.argv[2];
+const worktree = process.env.ORCA_WORKTREE_PATH ?? process.cwd();
+const root = process.env.ORCA_ROOT_PATH;
+
+function run(cmd, cwd) {
+  console.log(`$ ${cmd}  (in ${cwd})`);
+  const r = spawnSync(cmd, { shell: true, stdio: "inherit", cwd });
+  if (r.status !== 0) {
+    console.error(`command failed with status ${r.status}: ${cmd}`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+function git(args, cwd) {
+  return spawnSync("git", args, { encoding: "utf8", cwd });
+}
+
+function setup() {
+  if (!root) {
+    console.error("ORCA_ROOT_PATH not set; skipping setup");
+    return;
+  }
+
+  // Symlink gitignored .env files from the primary checkout so edits propagate
+  // to every worktree (tracked files like .env.default come with the checkout
+  // and must not be linked — that would dirty git status with a typechange).
+  const envDirs = [
+    "",
+    "autogpt_platform",
+    "autogpt_platform/backend",
+    "autogpt_platform/frontend",
+    "autogpt_platform/db/docker",
+  ];
+  for (const dir of envDirs) {
+    const srcDir = join(root, dir);
+    if (!existsSync(srcDir)) continue;
+    for (const name of readdirSync(srcDir)) {
+      if (!name.startsWith(".env")) continue;
+      const src = join(srcDir, name);
+      if (!lstatSync(src).isFile()) continue;
+      if (git(["-C", root, "check-ignore", "-q", src]).status !== 0) continue;
+      const destDir = join(worktree, dir);
+      mkdirSync(destDir, { recursive: true });
+      const dest = join(destDir, name);
+      rmSync(dest, { force: true });
+      try {
+        symlinkSync(src, dest);
+      } catch {
+        copyFileSync(src, dest); // Windows without Developer Mode: no symlinks
+      }
+    }
+  }
+
+  for (const dir of [".vscode", ".auth", "autogpt_platform/frontend/.auth"]) {
+    const src = join(root, dir);
+    if (existsSync(src)) {
+      cpSync(src, join(worktree, dir), { recursive: true });
+    }
+  }
+
+  // .claude local config, excluding nested agent worktree checkouts
+  const claudeSrc = join(root, ".claude");
+  if (existsSync(claudeSrc)) {
+    const skip = resolve(claudeSrc, "worktrees");
+    cpSync(claudeSrc, join(worktree, ".claude"), {
+      recursive: true,
+      filter: (s) => resolve(s) !== skip,
+    });
+  }
+
+  // Dependency install (was branchlet postCreateCmd, plus generate:api so the
+  // frontend typecheck pre-commit hook works in fresh worktrees).
+  if (!process.env.ORCA_HOOKS_SKIP_INSTALL) {
+    run("poetry install", join(worktree, "autogpt_platform/autogpt_libs"));
+    run("poetry install", join(worktree, "autogpt_platform/backend"));
+    run("poetry run prisma generate", join(worktree, "autogpt_platform/backend"));
+    run("pnpm install", join(worktree, "autogpt_platform/frontend"));
+    run("pnpm generate:api", join(worktree, "autogpt_platform/frontend"));
+  }
+}
+
+// Archive hooks are killed after 120s, so this only dumps text — no installs.
+function archive() {
+  const status = git(["status", "--porcelain"], worktree);
+  if (status.status !== 0) {
+    console.log("not a git worktree, nothing to back up");
+    return;
+  }
+  if (!status.stdout.trim()) {
+    console.log("worktree clean, nothing to back up");
+    return;
+  }
+
+  const outDir = join(dirname(root ?? worktree), "worktree-archive-backups");
+  mkdirSync(outDir, { recursive: true });
+  const name = process.env.ORCA_WORKSPACE_NAME || basename(worktree);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const outPath = join(outDir, `${name.replace(/[^\w.-]+/g, "_")}-${stamp}.patch`);
+
+  const parts = [
+    git(["diff"], worktree).stdout ?? "",
+    git(["diff", "--cached"], worktree).stdout ?? "",
+  ];
+  const untracked = (git(["ls-files", "--others", "--exclude-standard"], worktree)
+    .stdout ?? "")
+    .split("\n")
+    .filter(Boolean);
+  for (const f of untracked) {
+    let content;
+    try {
+      content = readFileSync(join(worktree, f), "utf8");
+    } catch (err) {
+      content = `<< unreadable: ${err.message} >>\n`;
+    }
+    parts.push(`=== UNTRACKED: ${f} ===\n${content}`);
+  }
+
+  writeFileSync(outPath, parts.filter(Boolean).join("\n"));
+  console.log(`uncommitted work backed up to ${outPath}`);
+}
+
+if (mode === "setup") {
+  setup();
+} else if (mode === "archive") {
+  archive();
+} else {
+  console.error("usage: node .orca/hooks.mjs <setup|archive>");
+  process.exit(2);
+}

--- a/.orca/hooks.mjs
+++ b/.orca/hooks.mjs
@@ -7,6 +7,7 @@ import {
   copyFileSync,
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -21,6 +22,14 @@ import { spawnSync } from "node:child_process";
 const mode = process.argv[2];
 const worktree = process.env.ORCA_WORKTREE_PATH ?? process.cwd();
 const root = process.env.ORCA_ROOT_PATH;
+
+const ENV_DIRS = [
+  "",
+  "autogpt_platform",
+  "autogpt_platform/backend",
+  "autogpt_platform/frontend",
+  "autogpt_platform/db/docker",
+];
 
 function run(cmd, cwd) {
   console.log(`$ ${cmd}  (in ${cwd})`);
@@ -55,14 +64,7 @@ function setup() {
   // Symlink gitignored .env files from the primary checkout so edits propagate
   // to every worktree (tracked files like .env.default come with the checkout
   // and must not be linked — that would dirty git status with a typechange).
-  const envDirs = [
-    "",
-    "autogpt_platform",
-    "autogpt_platform/backend",
-    "autogpt_platform/frontend",
-    "autogpt_platform/db/docker",
-  ];
-  for (const dir of envDirs) {
+  for (const dir of ENV_DIRS) {
     const srcDir = join(root, dir);
     if (!existsSync(srcDir)) continue;
     for (const name of readdirSync(srcDir)) {
@@ -116,6 +118,40 @@ function setup() {
   }
 }
 
+// Git-ignored .env files are invisible to git status/diff, so a worktree can
+// look "clean" while carrying local env edits (e.g. the Windows copy fallback,
+// or a deliberately divergent config). Collect any non-symlink ignored .env*
+// whose content differs from the root checkout's copy so archive() backs it up.
+function collectDivergentEnvFiles() {
+  if (!root) return [];
+  const out = [];
+  for (const dir of ENV_DIRS) {
+    const wtDir = join(worktree, dir);
+    if (!existsSync(wtDir)) continue;
+    for (const name of readdirSync(wtDir)) {
+      if (!name.startsWith(".env")) continue;
+      const f = join(wtDir, name);
+      let st;
+      try {
+        st = lstatSync(f);
+      } catch {
+        continue;
+      }
+      if (!st.isFile()) continue; // symlinks already live in the root checkout
+      const rel = dir ? `${dir}/${name}` : name;
+      if (git(["check-ignore", "-q", rel], worktree).status !== 0) continue; // tracked files are covered by git diff
+      let same = false;
+      try {
+        same = readFileSync(f, "utf8") === readFileSync(join(root, dir, name), "utf8");
+      } catch {
+        // missing/unreadable in root -> treat as divergent
+      }
+      if (!same) out.push({ rel, path: f });
+    }
+  }
+  return out;
+}
+
 // Archive hooks are killed after 120s, so this only dumps text — no installs.
 function archive() {
   const status = git(["status", "--porcelain"], worktree);
@@ -127,7 +163,8 @@ function archive() {
     console.log("not a git worktree, nothing to back up");
     return;
   }
-  if (!status.stdout.trim()) {
+  const divergentEnvs = collectDivergentEnvFiles();
+  if (!status.stdout.trim() && divergentEnvs.length === 0) {
     console.log("worktree clean, nothing to back up");
     return;
   }
@@ -156,6 +193,11 @@ function archive() {
       content = `<< unreadable: ${err.message} >>\n`;
     }
     parts.push(`=== UNTRACKED: ${f} ===\n${content}`);
+  }
+  for (const e of divergentEnvs) {
+    parts.push(
+      `=== IGNORED-LOCAL: ${e.rel} (differs from root checkout) ===\n${readFileSync(e.path, "utf8")}`,
+    );
   }
 
   writeFileSync(outPath, parts.filter(Boolean).join("\n"));

--- a/.orca/hooks.mjs
+++ b/.orca/hooks.mjs
@@ -109,7 +109,9 @@ function listIgnoredEnvFiles(base) {
   // 0 = at least one path ignored, 1 = none ignored, anything else = git error
   if (r.status !== 0 && r.status !== 1) {
     console.error(
-      `git check-ignore failed in ${base}: ${r.error?.message ?? r.stderr}`,
+      `warning: could not determine which .env files are ignored in ${base} ` +
+        `(${r.error?.message ?? r.stderr}); env files will not be linked, and ` +
+        `local-only env edits will not be backed up`,
     );
     return [];
   }
@@ -237,10 +239,21 @@ function copyInto(destRoot, rel, srcPath) {
 }
 
 function restoreDoc({ outDir, branch, head, patches, untracked, envs }) {
-  const apply = patches
-    .map((p) => `git apply --binary <archive>/${p}`)
-    .concat(untracked ? ["cp -R <archive>/untracked/. ."] : [])
-    .join("\n");
+  const steps = [
+    ...patches.map((p) => `git apply --binary <archive>/${p}`),
+    ...(untracked ? ["cp -R <archive>/untracked/. ."] : []),
+    // Not an unconditional copy: these are local, git-ignored env files and
+    // blindly restoring them can clobber a working config.
+    ...(envs
+      ? [
+          "# review these first, then copy back the ones you want:",
+          "#   cp -R <archive>/ignored-env/. .",
+        ]
+      : []),
+  ];
+  const apply = steps.length
+    ? steps.join("\n")
+    : "# nothing could be captured — check the archive hook output for errors";
   return `# Worktree archive: ${basename(outDir)}
 
 Written by \`.orca/hooks.mjs archive\` just before Orca deleted the worktree

--- a/.orca/hooks.mjs
+++ b/.orca/hooks.mjs
@@ -72,6 +72,24 @@ function gitStrict(args, cwd) {
   return r.stdout ?? "";
 }
 
+// Same, but returning raw stdout bytes. Patch output must never be decoded:
+// git base85-encodes only the blobs it classifies as *binary* (i.e. containing
+// a NUL byte), so a tracked text file that is merely not valid UTF-8 — latin-1
+// fixtures, legacy .po/.csv data — travels through `git diff --binary` as raw
+// bytes. Decoding those to a JS string turns them into U+FFFD, the patch stops
+// matching the blob it came from, and `git apply` rejects the developer's only
+// surviving copy of the change.
+function gitStrictRaw(args, cwd) {
+  const r = spawnSync("git", args, { cwd, maxBuffer: 1024 ** 3 });
+  if (r.error || r.status !== 0) {
+    console.error(
+      `git ${args.join(" ")} failed: ${r.error?.message ?? r.stderr}`,
+    );
+    process.exit(1);
+  }
+  return r.stdout ?? Buffer.alloc(0);
+}
+
 // Best-effort permission tightening: chmod is a no-op on Windows/ACL volumes.
 function restrictPerms(target, perms) {
   try {
@@ -328,8 +346,8 @@ function archive() {
     ["staged.patch", ["diff", "--cached", "--binary"]],
     ["unstaged.patch", ["diff", "--binary"]],
   ]) {
-    const body = gitStrict(args, worktree);
-    if (!body.trim()) continue;
+    const body = gitStrictRaw(args, worktree);
+    if (body.length === 0) continue; // git prints nothing for an empty diff
     const p = join(outDir, file);
     writeFileSync(p, body, { mode: 0o600 });
     restrictPerms(p, 0o600);

--- a/.orca/hooks.mjs
+++ b/.orca/hooks.mjs
@@ -4,6 +4,7 @@
 // a shell script) because Orca runs hooks under /bin/bash on macOS/Linux but
 // cmd.exe on Windows, and `node` resolves identically in both.
 import {
+  chmodSync,
   copyFileSync,
   cpSync,
   existsSync,
@@ -23,6 +24,9 @@ const mode = process.argv[2];
 const worktree = process.env.ORCA_WORKTREE_PATH ?? process.cwd();
 const root = process.env.ORCA_ROOT_PATH;
 
+// Every directory that carries .env* files. When a new service with its own
+// .env joins the monorepo, add its directory here — otherwise its env is
+// silently not linked into worktrees and not captured by archive().
 const ENV_DIRS = [
   "",
   "autogpt_platform",
@@ -32,6 +36,12 @@ const ENV_DIRS = [
 ];
 
 function run(cmd, cwd) {
+  if (cwd && !existsSync(cwd)) {
+    // Older branches predate some of these directories; a missing one means
+    // there is nothing to install, not a failure worth aborting setup over.
+    console.log(`skipping (no such directory: ${cwd}): ${cmd}`);
+    return;
+  }
   console.log(`$ ${cmd}  (in ${cwd})`);
   const r = spawnSync(cmd, { shell: true, stdio: "inherit", cwd });
   if (r.status !== 0) {
@@ -40,54 +50,116 @@ function run(cmd, cwd) {
   }
 }
 
-function git(args, cwd) {
+function git(args, cwd, input) {
   // maxBuffer: worktrees can carry very large uncommitted diffs; the 1MB
   // spawnSync default would silently truncate exactly what archive() backs up
-  return spawnSync("git", args, { encoding: "utf8", cwd, maxBuffer: 1024 ** 3 });
+  return spawnSync("git", args, {
+    encoding: "utf8",
+    cwd,
+    input,
+    maxBuffer: 1024 ** 3,
+  });
 }
 
 function gitStrict(args, cwd) {
   const r = git(args, cwd);
   if (r.error || r.status !== 0) {
-    console.error(`git ${args.join(" ")} failed: ${r.error?.message ?? r.stderr}`);
+    console.error(
+      `git ${args.join(" ")} failed: ${r.error?.message ?? r.stderr}`,
+    );
     process.exit(1);
   }
   return r.stdout ?? "";
 }
 
+// Best-effort permission tightening: chmod is a no-op on Windows/ACL volumes.
+function restrictPerms(target, perms) {
+  try {
+    chmodSync(target, perms);
+  } catch {
+    // no better fallback than the platform default
+  }
+}
+
+// The git-ignored .env* files under `base`, across every ENV_DIRS entry. One
+// batched `git check-ignore --stdin` rather than a fork per file. check-ignore
+// consults the index, so tracked files (.env.default) are never reported —
+// that is what keeps them out of both the symlink pass and the archive.
+function listIgnoredEnvFiles(base) {
+  const candidates = [];
+  for (const dir of ENV_DIRS) {
+    const dirPath = join(base, dir);
+    if (!existsSync(dirPath)) continue;
+    for (const name of readdirSync(dirPath)) {
+      if (!name.startsWith(".env")) continue;
+      candidates.push({
+        dir,
+        name,
+        rel: dir ? `${dir}/${name}` : name,
+        path: join(dirPath, name),
+      });
+    }
+  }
+  if (candidates.length === 0) return [];
+  const r = git(
+    ["check-ignore", "--stdin"],
+    base,
+    `${candidates.map((c) => c.rel).join("\n")}\n`,
+  );
+  // 0 = at least one path ignored, 1 = none ignored, anything else = git error
+  if (r.status !== 0 && r.status !== 1) {
+    console.error(
+      `git check-ignore failed in ${base}: ${r.error?.message ?? r.stderr}`,
+    );
+    return [];
+  }
+  const ignored = new Set((r.stdout ?? "").split("\n").filter(Boolean));
+  return candidates.filter((c) => ignored.has(c.rel));
+}
+
 function setup() {
   if (!root) {
-    console.error("ORCA_ROOT_PATH not set; skipping setup");
+    console.error(
+      "!!! ORCA_ROOT_PATH not set: .env files were NOT linked and dependencies\n" +
+        "!!! were NOT installed. This worktree is NOT ready to use. Re-run\n" +
+        "!!! `ORCA_ROOT_PATH=<primary checkout> node .orca/hooks.mjs setup`.",
+    );
     return;
   }
 
   // Symlink gitignored .env files from the primary checkout so edits propagate
   // to every worktree (tracked files like .env.default come with the checkout
   // and must not be linked — that would dirty git status with a typechange).
-  for (const dir of ENV_DIRS) {
-    const srcDir = join(root, dir);
-    if (!existsSync(srcDir)) continue;
-    for (const name of readdirSync(srcDir)) {
-      if (!name.startsWith(".env")) continue;
-      const src = join(srcDir, name);
-      let srcStat;
-      try {
-        srcStat = statSync(src); // follows links: root's .env may itself be a symlink
-      } catch {
-        continue; // broken symlink
-      }
-      if (!srcStat.isFile()) continue;
-      if (git(["-C", root, "check-ignore", "-q", src]).status !== 0) continue;
-      const destDir = join(worktree, dir);
-      mkdirSync(destDir, { recursive: true });
-      const dest = join(destDir, name);
-      rmSync(dest, { force: true });
-      try {
-        symlinkSync(src, dest);
-      } catch {
-        copyFileSync(src, dest); // Windows without Developer Mode: no symlinks
-      }
+  let linked = 0;
+  for (const env of listIgnoredEnvFiles(root)) {
+    let srcStat;
+    try {
+      srcStat = statSync(env.path); // follows links: root's .env may itself be a symlink
+    } catch {
+      continue; // broken symlink
     }
+    if (!srcStat.isFile()) continue;
+    const destDir = join(worktree, env.dir);
+    mkdirSync(destDir, { recursive: true });
+    const dest = join(destDir, env.name);
+    rmSync(dest, { force: true });
+    try {
+      symlinkSync(env.path, dest);
+      linked++;
+    } catch {
+      copyFileSync(env.path, dest); // Windows without Developer Mode: no symlinks
+      console.warn(
+        `warning: could not symlink ${env.rel}, copied it instead. Edits to ` +
+          `the copy do NOT reach the primary checkout and are overwritten the ` +
+          `next time setup runs (archive() backs up a diverged copy first).`,
+      );
+    }
+  }
+  if (linked > 0) {
+    console.log(
+      `linked ${linked} .env file(s) from ${root} — these are shared, so ` +
+        `editing env in this worktree changes it for every worktree`,
+    );
   }
 
   for (const dir of [".vscode", ".auth", "autogpt_platform/frontend/.auth"]) {
@@ -107,14 +179,17 @@ function setup() {
     });
   }
 
-  // Dependency install (was branchlet postCreateCmd, plus generate:api so the
-  // frontend typecheck pre-commit hook works in fresh worktrees).
+  // Dependency install. generate:api is included so the frontend typecheck
+  // pre-commit hook passes in a fresh worktree.
   if (!process.env.ORCA_HOOKS_SKIP_INSTALL) {
-    run("poetry install", join(worktree, "autogpt_platform/autogpt_libs"));
-    run("poetry install", join(worktree, "autogpt_platform/backend"));
-    run("poetry run prisma generate", join(worktree, "autogpt_platform/backend"));
-    run("pnpm install", join(worktree, "autogpt_platform/frontend"));
-    run("pnpm generate:api", join(worktree, "autogpt_platform/frontend"));
+    const platform = join(worktree, "autogpt_platform");
+    const backend = join(platform, "backend");
+    const frontend = join(platform, "frontend");
+    run("poetry install", join(platform, "autogpt_libs"));
+    run("poetry install", backend);
+    run("poetry run prisma generate", backend);
+    run("pnpm install", frontend);
+    run("pnpm generate:api", frontend);
   }
 }
 
@@ -125,34 +200,81 @@ function setup() {
 function collectDivergentEnvFiles() {
   if (!root) return [];
   const out = [];
-  for (const dir of ENV_DIRS) {
-    const wtDir = join(worktree, dir);
-    if (!existsSync(wtDir)) continue;
-    for (const name of readdirSync(wtDir)) {
-      if (!name.startsWith(".env")) continue;
-      const f = join(wtDir, name);
-      let st;
-      try {
-        st = lstatSync(f);
-      } catch {
-        continue;
-      }
-      if (!st.isFile()) continue; // symlinks already live in the root checkout
-      const rel = dir ? `${dir}/${name}` : name;
-      if (git(["check-ignore", "-q", rel], worktree).status !== 0) continue; // tracked files are covered by git diff
-      let same = false;
-      try {
-        same = readFileSync(f, "utf8") === readFileSync(join(root, dir, name), "utf8");
-      } catch {
-        // missing/unreadable in root -> treat as divergent
-      }
-      if (!same) out.push({ rel, path: f });
+  for (const env of listIgnoredEnvFiles(worktree)) {
+    let st;
+    try {
+      st = lstatSync(env.path);
+    } catch {
+      continue;
     }
+    if (!st.isFile()) continue; // symlinks already live in the root checkout
+    let same = false;
+    try {
+      // byte comparison, not utf8: a lossy decode must never make a diverged
+      // file look identical to the root copy
+      same = readFileSync(env.path).equals(readFileSync(join(root, env.rel)));
+    } catch {
+      // missing/unreadable in root -> treat as divergent
+    }
+    if (!same) out.push(env);
   }
   return out;
 }
 
-// Archive hooks are killed after 120s, so this only dumps text — no installs.
+// Copy one file into the archive, preserving its exact bytes. Never throws:
+// one unreadable file must not cost the developer the rest of the backup.
+function copyInto(destRoot, rel, srcPath) {
+  const dest = join(destRoot, rel);
+  try {
+    mkdirSync(dirname(dest), { recursive: true, mode: 0o700 });
+    copyFileSync(srcPath, dest);
+    restrictPerms(dest, 0o600);
+    return true;
+  } catch (err) {
+    console.error(`could not back up ${rel}: ${err.message}`);
+    return false;
+  }
+}
+
+function restoreDoc({ outDir, branch, head, patches, untracked, envs }) {
+  const apply = patches
+    .map((p) => `git apply --binary <archive>/${p}`)
+    .concat(untracked ? ["cp -R <archive>/untracked/. ."] : [])
+    .join("\n");
+  return `# Worktree archive: ${basename(outDir)}
+
+Written by \`.orca/hooks.mjs archive\` just before Orca deleted the worktree
+\`${worktree}\` (branch \`${branch}\`, at commit \`${head}\`).
+
+> **This archive can contain secrets.** Diverged \`.env\` files and any untracked
+> credential material are stored verbatim. It is created owner-only (0700 dirs,
+> 0600 files) and is **never cleaned up automatically** — delete it yourself once
+> you have recovered what you need.
+
+## Contents
+
+${patches.map((p) => `- \`${p}\` — tracked-file changes (\`git diff --binary\`).`).join("\n")}
+${untracked ? `- \`untracked/\` — byte-for-byte copies of ${untracked} untracked file(s).\n` : ""}${envs ? `- \`ignored-env/\` — ${envs} git-ignored \`.env*\` file(s) whose contents had diverged from the primary checkout.\n` : ""}
+## Restoring
+
+From a checkout at \`${head}\`:
+
+\`\`\`sh
+${apply}
+\`\`\`
+
+Apply \`staged.patch\` before \`unstaged.patch\`: the first is HEAD→index, the
+second is index→working tree. \`--binary\` is required — the patches embed the
+contents of modified binary files.${
+    envs
+      ? "\n\nFiles under `ignored-env/` are not tracked by git; review them before copying\nthem back over the primary checkout's env."
+      : ""
+  }
+`;
+}
+
+// Archive hooks are killed after 120s, so this only writes/copies bytes — no
+// installs, no compression.
 function archive() {
   const status = git(["status", "--porcelain"], worktree);
   if (status.error) {
@@ -169,39 +291,81 @@ function archive() {
     return;
   }
 
-  const outDir = join(dirname(root ?? worktree), "worktree-archive-backups");
-  mkdirSync(outDir, { recursive: true });
-  const name = process.env.ORCA_WORKSPACE_NAME || basename(worktree);
+  const name = (process.env.ORCA_WORKSPACE_NAME || basename(worktree)).replace(
+    /[^\w.-]+/g,
+    "_",
+  );
   const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-  const outPath = join(outDir, `${name.replace(/[^\w.-]+/g, "_")}-${stamp}.patch`);
+  const backupsDir = join(
+    dirname(root ?? worktree),
+    "worktree-archive-backups",
+  );
+  const outDir = join(backupsDir, `${name}-${stamp}`);
+  mkdirSync(outDir, { recursive: true });
+  // The archive holds .env values and whatever secrets happened to be sitting
+  // untracked in the worktree, so keep the whole tree owner-only.
+  restrictPerms(backupsDir, 0o700);
+  restrictPerms(outDir, 0o700);
 
-  const parts = [
-    gitStrict(["diff"], worktree),
-    gitStrict(["diff", "--cached"], worktree),
-  ];
+  // --binary: without it git emits only "Binary files ... differ" and the new
+  // bytes of a modified tracked binary are lost. Staged and unstaged changes go
+  // to separate files so each one is genuinely applyable with `git apply`.
+  const patches = [];
+  for (const [file, args] of [
+    ["staged.patch", ["diff", "--cached", "--binary"]],
+    ["unstaged.patch", ["diff", "--binary"]],
+  ]) {
+    const body = gitStrict(args, worktree);
+    if (!body.trim()) continue;
+    const p = join(outDir, file);
+    writeFileSync(p, body, { mode: 0o600 });
+    restrictPerms(p, 0o600);
+    patches.push(file);
+  }
+
+  // Untracked and diverged env files are copied byte-for-byte rather than
+  // inlined as decoded text: a utf8 decode silently corrupts PNGs, sqlite DBs
+  // and archives, and copyFileSync never buffers the file in the JS heap, so a
+  // large untracked file cannot OOM the hook.
   const untracked = gitStrict(
     ["ls-files", "--others", "--exclude-standard"],
     worktree,
   )
     .split("\n")
     .filter(Boolean);
-  for (const f of untracked) {
-    let content;
-    try {
-      content = readFileSync(join(worktree, f), "utf8");
-    } catch (err) {
-      content = `<< unreadable: ${err.message} >>\n`;
+  let untrackedCount = 0;
+  for (const rel of untracked) {
+    if (copyInto(join(outDir, "untracked"), rel, join(worktree, rel))) {
+      untrackedCount++;
     }
-    parts.push(`=== UNTRACKED: ${f} ===\n${content}`);
   }
+  let envCount = 0;
   for (const e of divergentEnvs) {
-    parts.push(
-      `=== IGNORED-LOCAL: ${e.rel} (differs from root checkout) ===\n${readFileSync(e.path, "utf8")}`,
-    );
+    if (copyInto(join(outDir, "ignored-env"), e.rel, e.path)) envCount++;
   }
 
-  writeFileSync(outPath, parts.filter(Boolean).join("\n"));
-  console.log(`uncommitted work backed up to ${outPath}`);
+  const doc = join(outDir, "RESTORE.md");
+  writeFileSync(
+    doc,
+    restoreDoc({
+      outDir,
+      branch: git(
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        worktree,
+      ).stdout?.trim(),
+      head: git(["rev-parse", "HEAD"], worktree).stdout?.trim(),
+      patches,
+      untracked: untrackedCount,
+      envs: envCount,
+    }),
+    { mode: 0o600 },
+  );
+  restrictPerms(doc, 0o600);
+  console.log(
+    `uncommitted work backed up to ${outDir} (${patches.length} patch file(s), ` +
+      `${untrackedCount} untracked file(s), ${envCount} diverged env file(s)) — ` +
+      `see RESTORE.md`,
+  );
 }
 
 if (mode === "setup") {

--- a/.orca/hooks.mjs
+++ b/.orca/hooks.mjs
@@ -7,11 +7,11 @@ import {
   copyFileSync,
   cpSync,
   existsSync,
-  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -32,7 +32,18 @@ function run(cmd, cwd) {
 }
 
 function git(args, cwd) {
-  return spawnSync("git", args, { encoding: "utf8", cwd });
+  // maxBuffer: worktrees can carry very large uncommitted diffs; the 1MB
+  // spawnSync default would silently truncate exactly what archive() backs up
+  return spawnSync("git", args, { encoding: "utf8", cwd, maxBuffer: 1024 ** 3 });
+}
+
+function gitStrict(args, cwd) {
+  const r = git(args, cwd);
+  if (r.error || r.status !== 0) {
+    console.error(`git ${args.join(" ")} failed: ${r.error?.message ?? r.stderr}`);
+    process.exit(1);
+  }
+  return r.stdout ?? "";
 }
 
 function setup() {
@@ -57,7 +68,13 @@ function setup() {
     for (const name of readdirSync(srcDir)) {
       if (!name.startsWith(".env")) continue;
       const src = join(srcDir, name);
-      if (!lstatSync(src).isFile()) continue;
+      let srcStat;
+      try {
+        srcStat = statSync(src); // follows links: root's .env may itself be a symlink
+      } catch {
+        continue; // broken symlink
+      }
+      if (!srcStat.isFile()) continue;
       if (git(["-C", root, "check-ignore", "-q", src]).status !== 0) continue;
       const destDir = join(worktree, dir);
       mkdirSync(destDir, { recursive: true });
@@ -102,6 +119,10 @@ function setup() {
 // Archive hooks are killed after 120s, so this only dumps text — no installs.
 function archive() {
   const status = git(["status", "--porcelain"], worktree);
+  if (status.error) {
+    console.error(`git unavailable: ${status.error.message}`);
+    process.exit(1);
+  }
   if (status.status !== 0) {
     console.log("not a git worktree, nothing to back up");
     return;
@@ -118,11 +139,13 @@ function archive() {
   const outPath = join(outDir, `${name.replace(/[^\w.-]+/g, "_")}-${stamp}.patch`);
 
   const parts = [
-    git(["diff"], worktree).stdout ?? "",
-    git(["diff", "--cached"], worktree).stdout ?? "",
+    gitStrict(["diff"], worktree),
+    gitStrict(["diff", "--cached"], worktree),
   ];
-  const untracked = (git(["ls-files", "--others", "--exclude-standard"], worktree)
-    .stdout ?? "")
+  const untracked = gitStrict(
+    ["ls-files", "--others", "--exclude-standard"],
+    worktree,
+  )
     .split("\n")
     .filter(Boolean);
   for (const f of untracked) {

--- a/.orca/hooks.test.mjs
+++ b/.orca/hooks.test.mjs
@@ -264,6 +264,12 @@ test("archive backs up a git-clean worktree carrying a diverged ignored .env", (
   );
   // An identical (non-diverged) copy is not worth archiving.
   assert.ok(!existsSync(join(out, "ignored-env", "autogpt_platform")));
+  // This archive has no patches and no untracked files, so the restore block
+  // would be empty if ignored-env were left out of it.
+  assert.match(
+    readFileSync(join(out, "RESTORE.md"), "utf8"),
+    /cp -R <archive>\/ignored-env\/\. \./,
+  );
 });
 
 test(

--- a/.orca/hooks.test.mjs
+++ b/.orca/hooks.test.mjs
@@ -198,6 +198,37 @@ test("archive round-trips staged, unstaged and binary tracked changes", (t) => {
   );
 });
 
+test("archive round-trips a tracked text file that is not valid UTF-8", (t) => {
+  const { base, root, wt, env } = makeFixture(t);
+  runHook("setup", env);
+
+  // git only base85-encodes blobs it classifies as *binary*, and it classifies
+  // by looking for a NUL byte. LATIN1 has none, so git calls it text and emits
+  // its bytes into `git diff --binary` verbatim — no base85 armour. If the hook
+  // decodes that patch as utf8, 0xe9/0xef become U+FFFD, the patch no longer
+  // matches the blob it came from, and `git apply` rejects it: the developer's
+  // only copy of this file's changes is gone.
+  const LATIN1 = Buffer.from("caf\xe9 na\xefve\n", "latin1");
+  const LATIN1_EDIT = Buffer.from("caf\xe9 na\xefve edited\n", "latin1");
+  writeFileSync(join(wt, "latin1.txt"), LATIN1);
+  git(["add", "latin1.txt"], wt);
+  git(["commit", "-qm", "add latin1"], wt);
+  writeFileSync(join(wt, "latin1.txt"), LATIN1_EDIT);
+
+  const r = runHook("archive", env);
+  assert.equal(r.status, 0, r.stderr);
+  const out = latestArchive(base);
+  assert.ok(existsSync(join(out, "unstaged.patch")));
+
+  const replay = join(base, "replay");
+  git(["worktree", "add", "-q", "--detach", replay, "feature"], root);
+  git(["apply", "--binary", join(out, "unstaged.patch")], replay);
+  assert.ok(
+    readFileSync(join(replay, "latin1.txt")).equals(LATIN1_EDIT),
+    "non-UTF-8 tracked text must survive the archive/restore round trip",
+  );
+});
+
 test("archive preserves untracked binary files byte-for-byte", (t) => {
   const { base, wt, env } = makeFixture(t);
   runHook("setup", env);

--- a/.orca/hooks.test.mjs
+++ b/.orca/hooks.test.mjs
@@ -1,0 +1,340 @@
+// Tests for the Orca worktree hooks. Self-contained: node:test + node:assert
+// only, no repo test harness, no network, no package installs.
+//
+//   node --test .orca/hooks.test.mjs
+//
+// archive() is the data-loss path — it runs immediately before Orca deletes a
+// worktree for good — so the assertions here are about faithfulness: every byte
+// the developer had must come back out of the archive.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOKS = join(dirname(fileURLToPath(import.meta.url)), "hooks.mjs");
+const POSIX = process.platform !== "win32";
+// Bytes that do not survive a utf8 round-trip: a lone 0xff, a NUL, a truncated
+// UTF-8 sequence. Anything that inlines file contents as decoded text mangles
+// these into U+FFFD and the "backup" becomes unrestorable.
+const BINARY = Buffer.from([0x00, 0xff, 0xfe, 0x89, 0x50, 0x4e, 0x47, 0x0d]);
+
+function git(args, cwd, opts = {}) {
+  const r = spawnSync("git", args, { encoding: "utf8", cwd, ...opts });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr ?? r.error}`);
+  }
+  return r.stdout ?? "";
+}
+
+function runHook(mode, env) {
+  return spawnSync(process.execPath, [HOOKS, mode], {
+    encoding: "utf8",
+    env: { ...process.env, ORCA_HOOKS_SKIP_INSTALL: "1", ...env },
+  });
+}
+
+/**
+ * base/
+ *   root/            primary checkout (committed .env.default, ignored .env)
+ *   wt/              git worktree of root — the "child" worktree Orca manages
+ *   worktree-archive-backups/   where archive() writes
+ */
+function makeFixture(t, { platformDirs = true } = {}) {
+  const base = mkdtempSync(join(tmpdir(), "orca-hooks-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+  const root = join(base, "root");
+  mkdirSync(root);
+  git(["init", "-q", "-b", "main"], root);
+  git(["config", "user.email", "hooks@test"], root);
+  git(["config", "user.name", "hooks test"], root);
+  git(["config", "commit.gpgsign", "false"], root);
+
+  writeFileSync(join(root, ".gitignore"), ".env*\n!.env.default\n");
+  writeFileSync(join(root, ".env.default"), "TRACKED=default\n");
+  writeFileSync(join(root, ".env"), "ROOT_SECRET=from-root\n");
+  writeFileSync(join(root, "tracked.txt"), "original\n");
+  writeFileSync(join(root, "tracked.bin"), BINARY);
+  if (platformDirs) {
+    const backend = join(root, "autogpt_platform", "backend");
+    mkdirSync(backend, { recursive: true });
+    writeFileSync(join(backend, ".env"), "BACKEND_SECRET=from-root\n");
+    writeFileSync(join(backend, "keep.txt"), "backend\n");
+  }
+  git(["add", "-A"], root);
+  git(["commit", "-qm", "init"], root);
+
+  const wt = join(base, "wt");
+  git(["worktree", "add", "-q", "-b", "feature", wt], root);
+  return {
+    base,
+    root,
+    wt,
+    env: { ORCA_ROOT_PATH: root, ORCA_WORKTREE_PATH: wt },
+  };
+}
+
+function latestArchive(base) {
+  const dir = join(base, "worktree-archive-backups");
+  if (!existsSync(dir)) return null;
+  const entries = readdirSync(dir).sort();
+  return entries.length ? join(dir, entries[entries.length - 1]) : null;
+}
+
+test("setup symlinks ignored .env files and leaves tracked files alone", (t) => {
+  const { root, wt, env } = makeFixture(t);
+  const r = runHook("setup", env);
+  assert.equal(r.status, 0, r.stderr);
+
+  assert.ok(lstatSync(join(wt, ".env")).isSymbolicLink());
+  assert.equal(
+    readFileSync(join(wt, ".env"), "utf8"),
+    "ROOT_SECRET=from-root\n",
+  );
+  assert.ok(
+    lstatSync(join(wt, "autogpt_platform/backend/.env")).isSymbolicLink(),
+    "nested ENV_DIRS entries are linked too",
+  );
+
+  // .env.default is tracked, so check-ignore must not report it: linking it
+  // would show up as a typechange in git status.
+  assert.ok(!lstatSync(join(root, ".env.default")).isSymbolicLink());
+  assert.ok(!lstatSync(join(wt, ".env.default")).isSymbolicLink());
+  assert.equal(git(["status", "--porcelain"], wt), "");
+});
+
+test("setup copies .claude but skips the nested worktrees checkout", (t) => {
+  const { root, wt, env } = makeFixture(t);
+  mkdirSync(join(root, ".claude", "worktrees", "nested"), { recursive: true });
+  writeFileSync(join(root, ".claude", "settings.json"), "{}\n");
+  writeFileSync(join(root, ".claude", "worktrees", "nested", "huge"), "x");
+
+  assert.equal(runHook("setup", env).status, 0);
+  assert.ok(existsSync(join(wt, ".claude", "settings.json")));
+  assert.ok(!existsSync(join(wt, ".claude", "worktrees")));
+});
+
+test("setup skips install steps whose directory does not exist", (t) => {
+  // No autogpt_platform at all, and installs NOT skipped: every run() must
+  // no-op instead of exiting non-zero on spawn ENOENT.
+  const { env } = makeFixture(t, { platformDirs: false });
+  const r = runHook("setup", { ...env, ORCA_HOOKS_SKIP_INSTALL: "" });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /skipping \(no such directory/);
+  assert.doesNotMatch(r.stdout, /\$ poetry install/);
+});
+
+test("setup fails loudly when ORCA_ROOT_PATH is missing", (t) => {
+  const { wt } = makeFixture(t);
+  const r = runHook("setup", {
+    ORCA_WORKTREE_PATH: wt,
+    ORCA_ROOT_PATH: undefined,
+  });
+  assert.match(r.stderr, /ORCA_ROOT_PATH not set/);
+  assert.match(r.stderr, /NOT ready to use/);
+});
+
+test("archive writes nothing for a clean worktree", (t) => {
+  const { base, wt, env } = makeFixture(t);
+  runHook("setup", env);
+  const r = runHook("archive", env);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /worktree clean/);
+  assert.equal(latestArchive(base), null);
+  assert.equal(git(["status", "--porcelain"], wt), "");
+});
+
+test("archive round-trips staged, unstaged and binary tracked changes", (t) => {
+  const { base, root, wt, env } = makeFixture(t);
+  runHook("setup", env);
+
+  // staged change
+  writeFileSync(join(wt, "tracked.txt"), "staged edit\n");
+  git(["add", "tracked.txt"], wt);
+  // unstaged change on top of it
+  writeFileSync(join(wt, "tracked.txt"), "staged edit\nthen unstaged\n");
+  // modified tracked binary — plain `git diff` would only say "Binary files differ"
+  const newBinary = Buffer.from([0xff, 0x00, 0x01, 0x02, 0x80, 0xfe]);
+  writeFileSync(join(wt, "tracked.bin"), newBinary);
+
+  const r = runHook("archive", env);
+  assert.equal(r.status, 0, r.stderr);
+  const out = latestArchive(base);
+  assert.ok(out, "archive directory created");
+  assert.ok(existsSync(join(out, "staged.patch")));
+  assert.ok(existsSync(join(out, "unstaged.patch")));
+  assert.match(
+    readFileSync(join(out, "unstaged.patch"), "utf8"),
+    /GIT binary patch/,
+    "binary contents are embedded, not just a 'differ' marker",
+  );
+
+  // Replay the documented restore procedure into a pristine checkout.
+  const replay = join(base, "replay");
+  git(["worktree", "add", "-q", "--detach", replay, "feature"], root);
+  git(["apply", "--binary", join(out, "staged.patch")], replay);
+  git(["apply", "--binary", join(out, "unstaged.patch")], replay);
+  assert.equal(
+    readFileSync(join(replay, "tracked.txt"), "utf8"),
+    "staged edit\nthen unstaged\n",
+  );
+  assert.ok(
+    readFileSync(join(replay, "tracked.bin")).equals(newBinary),
+    "tracked binary bytes survive the archive/restore round trip",
+  );
+});
+
+test("archive preserves untracked binary files byte-for-byte", (t) => {
+  const { base, wt, env } = makeFixture(t);
+  runHook("setup", env);
+  mkdirSync(join(wt, "nested", "deep"), { recursive: true });
+  writeFileSync(join(wt, "nested", "deep", "image.png"), BINARY);
+  writeFileSync(join(wt, "notes.txt"), "scratch\n");
+
+  assert.equal(runHook("archive", env).status, 0);
+  const out = latestArchive(base);
+  assert.ok(
+    readFileSync(join(out, "untracked", "nested", "deep", "image.png")).equals(
+      BINARY,
+    ),
+    "untracked binary must not be utf8-decoded into the backup",
+  );
+  assert.equal(
+    readFileSync(join(out, "untracked", "notes.txt"), "utf8"),
+    "scratch\n",
+  );
+});
+
+test(
+  "archive keeps going when an untracked file cannot be read",
+  { skip: !POSIX },
+  (t) => {
+    const { base, wt, env } = makeFixture(t);
+    runHook("setup", env);
+    symlinkSync(join(wt, "does-not-exist"), join(wt, "dangling"));
+    writeFileSync(join(wt, "survivor.txt"), "keep me\n");
+
+    const r = runHook("archive", env);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stderr, /could not back up dangling/);
+    const out = latestArchive(base);
+    assert.equal(
+      readFileSync(join(out, "untracked", "survivor.txt"), "utf8"),
+      "keep me\n",
+      "one unreadable file must not cost the rest of the backup",
+    );
+  },
+);
+
+test("archive backs up a git-clean worktree carrying a diverged ignored .env", (t) => {
+  const { base, wt, env } = makeFixture(t);
+  runHook("setup", env);
+
+  // Exactly the state the Windows copy fallback produces: a real file, not a
+  // symlink, ignored by git, with content the root checkout does not have.
+  rmSync(join(wt, ".env"));
+  writeFileSync(join(wt, ".env"), "ROOT_SECRET=edited-locally\n");
+  assert.equal(
+    git(["status", "--porcelain"], wt),
+    "",
+    "git still sees it clean",
+  );
+
+  const r = runHook("archive", env);
+  assert.equal(r.status, 0, r.stderr);
+  const out = latestArchive(base);
+  assert.ok(out, "a clean-but-diverged worktree still produces an archive");
+  assert.equal(
+    readFileSync(join(out, "ignored-env", ".env"), "utf8"),
+    "ROOT_SECRET=edited-locally\n",
+  );
+  // An identical (non-diverged) copy is not worth archiving.
+  assert.ok(!existsSync(join(out, "ignored-env", "autogpt_platform")));
+});
+
+test(
+  "archive restricts the backup tree to the owner",
+  { skip: !POSIX },
+  (t) => {
+    const { base, wt, env } = makeFixture(t);
+    runHook("setup", env);
+    writeFileSync(join(wt, "tracked.txt"), "TOKEN=hunter2\n");
+    writeFileSync(join(wt, "untracked.txt"), "SECRET=hunter2\n");
+    rmSync(join(wt, ".env"));
+    writeFileSync(join(wt, ".env"), "ROOT_SECRET=diverged\n");
+
+    assert.equal(runHook("archive", env).status, 0);
+    const out = latestArchive(base);
+    const perms = (p) => statSync(p).mode & 0o777;
+    assert.equal(perms(join(base, "worktree-archive-backups")), 0o700);
+    assert.equal(perms(out), 0o700);
+    assert.equal(perms(join(out, "unstaged.patch")), 0o600);
+    assert.equal(perms(join(out, "untracked", "untracked.txt")), 0o600);
+    assert.equal(perms(join(out, "ignored-env", ".env")), 0o600);
+    assert.equal(perms(join(out, "RESTORE.md")), 0o600);
+  },
+);
+
+test("archive documents how to restore what it wrote", (t) => {
+  const { base, wt, env } = makeFixture(t);
+  runHook("setup", env);
+  writeFileSync(join(wt, "tracked.txt"), "changed\n");
+  writeFileSync(join(wt, "extra.txt"), "new\n");
+
+  assert.equal(runHook("archive", env).status, 0);
+  const doc = readFileSync(join(latestArchive(base), "RESTORE.md"), "utf8");
+  assert.match(doc, /git apply --binary <archive>\/unstaged\.patch/);
+  assert.match(doc, /cp -R <archive>\/untracked\/\. \./);
+  assert.match(doc, /can contain secrets/);
+  assert.match(doc, new RegExp(git(["rev-parse", "HEAD"], wt).trim()));
+});
+
+test("archive is a no-op outside a git worktree", (t) => {
+  const { base } = makeFixture(t);
+  const plain = join(base, "plain");
+  mkdirSync(plain);
+  const r = runHook("archive", {
+    ORCA_WORKTREE_PATH: plain,
+    ORCA_ROOT_PATH: undefined,
+  });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /not a git worktree/);
+});
+
+// chmod 000 is not honoured for root, so this only proves the degrade path for
+// an ordinary user.
+test(
+  "archive degrades gracefully on an unreadable diverged env",
+  { skip: !POSIX || process.getuid?.() === 0 },
+  (t) => {
+    const { base, wt, env } = makeFixture(t);
+    runHook("setup", env);
+    rmSync(join(wt, ".env"));
+    writeFileSync(join(wt, ".env"), "ROOT_SECRET=diverged\n");
+    writeFileSync(join(wt, "untracked.txt"), "keep me\n");
+    chmodSync(join(wt, ".env"), 0o000);
+
+    const r = runHook("archive", env);
+    assert.equal(r.status, 0, r.stderr);
+    const out = latestArchive(base);
+    assert.ok(out, "the rest of the backup is still written");
+    assert.equal(
+      readFileSync(join(out, "untracked", "untracked.txt"), "utf8"),
+      "keep me\n",
+    );
+  },
+);

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,3 @@
+scripts:
+  setup: node .orca/hooks.mjs setup
+  archive: node .orca/hooks.mjs archive


### PR DESCRIPTION
### Why / What / How

**Why:** We manage this repo as a fleet of git worktrees, now via the Orca worktree manager (previously branchlet). Orca reads repo-owned worktree hooks from `orca.yaml` at the repo root — without it, every fresh worktree needs manual `.env` wiring and dependency installs, and deleting a worktree silently discards any uncommitted work. The old branchlet config (`.branchlet.json`) is already tracked in-repo; this gives the Orca equivalent the same treatment.

**What:** Adds `orca.yaml` (setup/archive hook entry points) and `.orca/hooks.mjs` (the hook implementation).

**How:** Orca executes hook scripts under `/bin/bash` on macOS/Linux but `cmd.exe` on Windows, so `orca.yaml` contains only `node .orca/hooks.mjs setup|archive` — a command that parses identically in both shells — and the logic lives in Node (already guaranteed present since setup requires pnpm). Setup symlinks git-ignored `.env` files from the primary checkout so edits propagate to all worktrees (falls back to copying on Windows without Developer Mode, where symlinks are disallowed), copies `.vscode`/`.auth`/`.claude` local config (excluding nested agent worktrees), then runs the standard installs including `pnpm generate:api` so the frontend typecheck pre-commit hook passes in fresh worktrees. Archive salvages uncommitted work into a timestamped directory outside the worktree before Orca deletes it: `git diff --binary` split into separately applyable `staged.patch`/`unstaged.patch`, byte-for-byte copies of untracked files and of git-ignored `.env*` that has diverged from the primary checkout, and a `RESTORE.md` recording the base commit and the restore commands. The tree is owner-only (0700/0600) because it can hold secrets. Hooks are killed after 120s, so archive only writes and copies bytes — no installs, no compression.

### Changes 🏗️

- New `orca.yaml`: declares Orca `scripts.setup` / `scripts.archive`, each a one-line cross-platform `node .orca/hooks.mjs <mode>` invocation
- New `.orca/hooks.mjs`:
  - `setup`: symlink git-ignored `.env*` from the primary checkout (copy fallback on Windows), copy `.vscode`/`.auth`/`frontend/.auth`/`.claude` (minus `.claude/worktrees`), then `poetry install` (libs + backend), `prisma generate`, `pnpm install`, `pnpm generate:api`; `ORCA_HOOKS_SKIP_INSTALL=1` skips the install phase
  - `archive`: if the worktree is dirty **or** carries a content-divergent git-ignored `.env*` (invisible to `git status`), write `../worktree-archive-backups/<name>-<timestamp>/` containing `staged.patch` + `unstaged.patch` (`git diff --binary`, so modified tracked binaries survive), `untracked/` and `ignored-env/` byte-for-byte copies (no UTF-8 decode, so PNGs/sqlite DBs stay intact and a huge file cannot OOM the hook), and `RESTORE.md`. Created 0700/0600 — it can contain `.env` secrets and is never auto-cleaned
- New `.orca/hooks.test.mjs`: 13 `node:test` tests over temp git fixtures (`node --test .orca/hooks.test.mjs`), no deps and no repo harness. Covers the archive round trip through a real `git apply --binary` into a fresh checkout, untracked-binary fidelity, the clean-worktree-with-diverged-env branch, archive permissions, and the degrade-do-not-abort paths
- Only git-ignored env files are linked — tracked files like `.env.default` are excluded so worktrees don't show typechange noise in `git status`
- No-op for anyone not using Orca: nothing in the platform reads these files

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `node --check .orca/hooks.mjs` passes
  - [x] `orca.yaml` parses with only Orca-recognized top-level keys
  - [x] Setup against a fixture repo pair: git-ignored `.env` symlinked to the primary checkout; tracked `.env.default` correctly NOT linked; `.vscode` and `.claude` copied; `.claude/worktrees` excluded
  - [x] `node --test .orca/hooks.test.mjs` — 13/13 pass, including replaying the emitted patches with `git apply --binary` into a pristine checkout and asserting the restored bytes (text and binary) match the originals
  - [x] Archive against a dirty fixture worktree: staged/unstaged/binary changes, untracked files and a diverged ignored `.env` all recovered; clean worktree no-ops without writing anything
  - [ ] Windows path not exercised (no Windows machine available): `cmd.exe` compatibility rests on the single-line `node` invocation; symlink-permission fallback to copy is code-reviewed only

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZtHBEUNMruL3b4XXcnqVB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional DX tooling only; no runtime app, auth, or deployment paths change, and behavior is gated on Orca hook invocation.
> 
> **Overview**
> Introduces **Orca worktree automation** via root `orca.yaml` pointing at `node .orca/hooks.mjs setup|archive` so hooks run the same on Unix shells and Windows `cmd.exe`.
> 
> **Setup** links git-ignored `.env*` from the primary checkout (`ORCA_ROOT_PATH`) into known monorepo env paths (copy fallback when symlinks fail), copies local `.vscode`/`.auth`/`.claude` (skipping `.claude/worktrees`), and runs Poetry/Prisma/pnpm installs including `pnpm generate:api` unless `ORCA_HOOKS_SKIP_INSTALL=1`.
> 
> **Archive** runs before worktree removal: if the tree is dirty or has diverged ignored `.env` files, it writes `worktree-archive-backups/<name>-<timestamp>/` with raw-byte `staged.patch`/`unstaged.patch` (`git diff --binary`), `untracked/` and `ignored-env/` copies, owner-only permissions, and `RESTORE.md` with restore steps.
> 
> Adds **`.orca/hooks.test.mjs`** (13 `node:test` cases) covering env symlink behavior, patch/binary round-trips, diverged-env backup, permissions, and partial-failure handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af81f98da3bea0f5136d8de82a471745624b363e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

