### PR TITLE
fix(library): carry marketplace image onto downloaded agents (#9879)

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
@@ -229,6 +229,7 @@ async def test_resolve_graph_admin_uses_get_graph_as_admin() -> None:
 
     mock_slv = MagicMock()
     mock_slv.AgentGraph = MagicMock(id=GRAPH_ID, version=GRAPH_VERSION)
+    mock_slv.imageUrls = []
     mock_graph_model = MagicMock(name="GraphModel")
 
     with (
@@ -249,9 +250,11 @@ async def test_resolve_graph_admin_uses_get_graph_as_admin() -> None:
     ):
         mock_prisma.return_value.find_unique = AsyncMock(return_value=mock_slv)
 
-        result = await resolve_graph_for_library(SLV_ID, ADMIN_USER_ID, admin=True)
+        graph_model, _ = await resolve_graph_for_library(
+            SLV_ID, ADMIN_USER_ID, admin=True
+        )
 
-    assert result is mock_graph_model
+    assert graph_model is mock_graph_model
     mock_admin.assert_awaited_once_with(
         graph_id=GRAPH_ID, version=GRAPH_VERSION, user_id=ADMIN_USER_ID
     )
@@ -266,6 +269,7 @@ async def test_resolve_graph_regular_uses_get_graph() -> None:
 
     mock_slv = MagicMock()
     mock_slv.AgentGraph = MagicMock(id=GRAPH_ID, version=GRAPH_VERSION)
+    mock_slv.imageUrls = []
     mock_graph_model = MagicMock(name="GraphModel")
 
     with (
@@ -286,9 +290,11 @@ async def test_resolve_graph_regular_uses_get_graph() -> None:
     ):
         mock_prisma.return_value.find_unique = AsyncMock(return_value=mock_slv)
 
-        result = await resolve_graph_for_library(SLV_ID, "regular-user-id", admin=False)
+        graph_model, _ = await resolve_graph_for_library(
+            SLV_ID, "regular-user-id", admin=False
+        )
 
-    assert result is mock_graph_model
+    assert graph_model is mock_graph_model
     mock_regular.assert_awaited_once_with(
         graph_id=GRAPH_ID, version=GRAPH_VERSION, user_id="regular-user-id"
     )

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -27,11 +27,14 @@ async def resolve_graph_for_library(
     user_id: str,
     *,
     admin: bool,
-) -> GraphModel:
+) -> tuple[GraphModel, str | None]:
     """Look up a StoreListingVersion and resolve its graph.
 
     When ``admin=True``, uses ``get_graph_as_admin`` to bypass the marketplace
     APPROVED-only check.  Otherwise uses the regular ``get_graph``.
+
+    Also returns the listing's marketplace image (issue #9879), extracted
+    from this same lookup rather than a second query.
     """
     slv = await prisma.models.StoreListingVersion.prisma().find_unique(
         where={"id": store_listing_version_id}, include={"AgentGraph": True}
@@ -53,30 +56,21 @@ async def resolve_graph_for_library(
 
     if not graph_model:
         raise NotFoundError(f"Graph #{ag.id} v{ag.version} not found or accessible")
-    return graph_model
+    return graph_model, _extract_marketplace_image_url(slv)
 
 
-async def _fetch_marketplace_image_url(
-    store_listing_version_id: str,
+def _extract_marketplace_image_url(
+    slv: prisma.models.StoreListingVersion,
 ) -> str | None:
-    """Return the first marketplace image for a store listing version, if any.
-
-    The marketplace stores its artwork on ``StoreListingVersion.imageUrls``.
-    Downloading an agent should carry that image over to the user's library
-    entry (issue #9879); returns ``None`` when the listing has no images.
-    """
-    slv = await prisma.models.StoreListingVersion.prisma().find_unique(
-        where={"id": store_listing_version_id}
-    )
-    if slv and slv.imageUrls:
-        return slv.imageUrls[0]
-    return None
+    """Return the first marketplace image on an already-fetched listing, if any."""
+    return slv.imageUrls[0] if slv.imageUrls else None
 
 
 async def add_graph_to_library(
-    store_listing_version_id: str,
     graph_model: GraphModel,
     user_id: str,
+    *,
+    marketplace_image_url: str | None = None,
 ) -> library_model.LibraryAgent:
     """Check existing / restore soft-deleted / create new LibraryAgent.
 
@@ -88,13 +82,6 @@ async def add_graph_to_library(
     settings_json = SafeJson(GraphSettings.from_graph(graph_model).model_dump())
     _include = library_agent_include(
         user_id, include_nodes=False, include_executions=False
-    )
-
-    # Carry the marketplace image over to the library so the downloaded agent
-    # shows the same artwork it had on the marketplace, rather than no image.
-    # See issue #9879.
-    marketplace_image_url = await _fetch_marketplace_image_url(
-        store_listing_version_id
     )
 
     try:
@@ -146,7 +133,6 @@ async def add_graph_to_library(
 
     logger.debug(
         f"Added graph #{graph_model.id} v{graph_model.version} "
-        f"for store listing version #{store_listing_version_id} "
         f"to library for user #{user_id}"
     )
     schedule_info = await _fetch_schedule_info(user_id, graph_id=graph_model.id)

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -9,6 +9,7 @@ import logging
 
 import prisma.errors
 import prisma.models
+import prisma.types
 
 import backend.api.features.library.model as library_model
 import backend.data.graph as graph_db
@@ -55,6 +56,23 @@ async def resolve_graph_for_library(
     return graph_model
 
 
+async def _fetch_marketplace_image_url(
+    store_listing_version_id: str,
+) -> str | None:
+    """Return the first marketplace image for a store listing version, if any.
+
+    The marketplace stores its artwork on ``StoreListingVersion.imageUrls``.
+    Downloading an agent should carry that image over to the user's library
+    entry (issue #9879); returns ``None`` when the listing has no images.
+    """
+    slv = await prisma.models.StoreListingVersion.prisma().find_unique(
+        where={"id": store_listing_version_id}
+    )
+    if slv and slv.imageUrls:
+        return slv.imageUrls[0]
+    return None
+
+
 async def add_graph_to_library(
     store_listing_version_id: str,
     graph_model: GraphModel,
@@ -72,6 +90,13 @@ async def add_graph_to_library(
         user_id, include_nodes=False, include_executions=False
     )
 
+    # Carry the marketplace image over to the library so the downloaded agent
+    # shows the same artwork it had on the marketplace, rather than no image.
+    # See issue #9879.
+    marketplace_image_url = await _fetch_marketplace_image_url(
+        store_listing_version_id
+    )
+
     try:
         added_agent = await prisma.models.LibraryAgent.prisma().create(
             data={
@@ -87,11 +112,21 @@ async def add_graph_to_library(
                 "isCreatedByUser": False,
                 "useGraphIsActiveVersion": False,
                 "settings": settings_json,
+                "imageUrl": marketplace_image_url,
             },
             include=_include,
         )
     except prisma.errors.UniqueViolationError:
         # Already exists — update to restore if previously soft-deleted/archived
+        restore_data: prisma.types.LibraryAgentUpdateInput = {
+            "isDeleted": False,
+            "isArchived": False,
+            "settings": settings_json,
+        }
+        # Only set the image when the marketplace has one, so we never blank out
+        # an image the user might already have on an existing library entry.
+        if marketplace_image_url:
+            restore_data["imageUrl"] = marketplace_image_url
         added_agent = await prisma.models.LibraryAgent.prisma().update(
             where={
                 "userId_agentGraphId_agentGraphVersion": {
@@ -100,11 +135,7 @@ async def add_graph_to_library(
                     "agentGraphVersion": graph_model.version,
                 }
             },
-            data={
-                "isDeleted": False,
-                "isArchived": False,
-                "settings": settings_json,
-            },
+            data=restore_data,
             include=_include,
         )
         if added_agent is None:

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
@@ -25,6 +25,10 @@ async def test_add_graph_to_library_create_new_agent() -> None:
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
         ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_marketplace_image_url",
+            new=AsyncMock(return_value=None),
+        ),
     ):
         mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
 
@@ -62,6 +66,10 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
         ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_marketplace_image_url",
+            new=AsyncMock(return_value=None),
+        ),
     ):
         mock_prisma.return_value.create = AsyncMock(
             side_effect=prisma.errors.UniqueViolationError(
@@ -86,3 +94,59 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
     update_data = update_call.kwargs["data"]
     assert update_data["isDeleted"] is False
     assert update_data["isArchived"] is False
+
+
+@pytest.mark.asyncio
+async def test_add_graph_to_library_carries_marketplace_image() -> None:
+    """The marketplace image is copied onto the new library agent (issue #9879)."""
+    graph_model = MagicMock(id="graph-id", version=2, nodes=[])
+    created_agent = MagicMock(name="CreatedLibraryAgent")
+    converted_agent = MagicMock(name="ConvertedLibraryAgent")
+
+    with (
+        patch(
+            "backend.api.features.library._add_to_library.prisma.models.LibraryAgent.prisma"
+        ) as mock_prisma,
+        patch(
+            "backend.api.features.library._add_to_library.library_model.LibraryAgent.from_db",
+            return_value=converted_agent,
+        ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_schedule_info",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_marketplace_image_url",
+            new=AsyncMock(return_value="https://cdn.example.com/agent.png"),
+        ),
+    ):
+        mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
+
+        await add_graph_to_library("slv-id", graph_model, "user-id")
+
+    create_data = mock_prisma.return_value.create.call_args.kwargs["data"]
+    assert create_data["imageUrl"] == "https://cdn.example.com/agent.png"
+
+
+@pytest.mark.asyncio
+async def test_fetch_marketplace_image_url_returns_first_image() -> None:
+    """_fetch_marketplace_image_url returns the first listing image, or None."""
+    from ._add_to_library import _fetch_marketplace_image_url
+
+    listing = MagicMock(imageUrls=["https://cdn.example.com/a.png", "b.png"])
+    with patch(
+        "backend.api.features.library._add_to_library.prisma.models.StoreListingVersion.prisma"
+    ) as mock_slv:
+        mock_slv.return_value.find_unique = AsyncMock(return_value=listing)
+        assert (
+            await _fetch_marketplace_image_url("slv-id")
+            == "https://cdn.example.com/a.png"
+        )
+
+        mock_slv.return_value.find_unique = AsyncMock(
+            return_value=MagicMock(imageUrls=[])
+        )
+        assert await _fetch_marketplace_image_url("slv-id") is None
+
+        mock_slv.return_value.find_unique = AsyncMock(return_value=None)
+        assert await _fetch_marketplace_image_url("slv-id") is None

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import prisma.errors
 import pytest
 
-from ._add_to_library import add_graph_to_library
+from ._add_to_library import _extract_marketplace_image_url, add_graph_to_library
 
 
 @pytest.mark.asyncio
@@ -25,14 +25,10 @@ async def test_add_graph_to_library_create_new_agent() -> None:
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
         ),
-        patch(
-            "backend.api.features.library._add_to_library._fetch_marketplace_image_url",
-            new=AsyncMock(return_value=None),
-        ),
     ):
         mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
 
-        result = await add_graph_to_library("slv-id", graph_model, "user-id")
+        result = await add_graph_to_library(graph_model, "user-id")
 
     assert result is converted_agent
     mock_from_db.assert_called_once_with(created_agent, schedule_info={})
@@ -45,6 +41,7 @@ async def test_add_graph_to_library_create_new_agent() -> None:
     }
     assert create_data["isCreatedByUser"] is False
     assert create_data["useGraphIsActiveVersion"] is False
+    assert create_data["imageUrl"] is None
 
 
 @pytest.mark.asyncio
@@ -66,10 +63,6 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
         ),
-        patch(
-            "backend.api.features.library._add_to_library._fetch_marketplace_image_url",
-            new=AsyncMock(return_value=None),
-        ),
     ):
         mock_prisma.return_value.create = AsyncMock(
             side_effect=prisma.errors.UniqueViolationError(
@@ -78,7 +71,7 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
         )
         mock_prisma.return_value.update = AsyncMock(return_value=updated_agent)
 
-        result = await add_graph_to_library("slv-id", graph_model, "user-id")
+        result = await add_graph_to_library(graph_model, "user-id")
 
     assert result is converted_agent
     mock_from_db.assert_called_once_with(updated_agent, schedule_info={})
@@ -94,6 +87,7 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
     update_data = update_call.kwargs["data"]
     assert update_data["isDeleted"] is False
     assert update_data["isArchived"] is False
+    assert "imageUrl" not in update_data
 
 
 @pytest.mark.asyncio
@@ -115,38 +109,59 @@ async def test_add_graph_to_library_carries_marketplace_image() -> None:
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
         ),
-        patch(
-            "backend.api.features.library._add_to_library._fetch_marketplace_image_url",
-            new=AsyncMock(return_value="https://cdn.example.com/agent.png"),
-        ),
     ):
         mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
 
-        await add_graph_to_library("slv-id", graph_model, "user-id")
+        await add_graph_to_library(
+            graph_model,
+            "user-id",
+            marketplace_image_url="https://cdn.example.com/agent.png",
+        )
 
     create_data = mock_prisma.return_value.create.call_args.kwargs["data"]
     assert create_data["imageUrl"] == "https://cdn.example.com/agent.png"
 
 
 @pytest.mark.asyncio
-async def test_fetch_marketplace_image_url_returns_first_image() -> None:
-    """_fetch_marketplace_image_url returns the first listing image, or None."""
-    from ._add_to_library import _fetch_marketplace_image_url
+async def test_add_graph_to_library_restore_keeps_existing_image_when_none_found() -> (
+    None
+):
+    """Restoring a soft-deleted entry must not blank an existing image when the
+    listing has none (issue #9879 restore-path guard)."""
+    graph_model = MagicMock(id="graph-id", version=2, nodes=[])
+    updated_agent = MagicMock(name="UpdatedLibraryAgent")
+    converted_agent = MagicMock(name="ConvertedLibraryAgent")
 
+    with (
+        patch(
+            "backend.api.features.library._add_to_library.prisma.models.LibraryAgent.prisma"
+        ) as mock_prisma,
+        patch(
+            "backend.api.features.library._add_to_library.library_model.LibraryAgent.from_db",
+            return_value=converted_agent,
+        ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_schedule_info",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        mock_prisma.return_value.create = AsyncMock(
+            side_effect=prisma.errors.UniqueViolationError(
+                MagicMock(), message="unique constraint"
+            )
+        )
+        mock_prisma.return_value.update = AsyncMock(return_value=updated_agent)
+
+        await add_graph_to_library(graph_model, "user-id", marketplace_image_url=None)
+
+    update_data = mock_prisma.return_value.update.call_args.kwargs["data"]
+    assert "imageUrl" not in update_data
+
+
+def test_extract_marketplace_image_url_returns_first_image() -> None:
+    """_extract_marketplace_image_url reads the first image off an
+    already-fetched listing, or None — no extra DB query."""
     listing = MagicMock(imageUrls=["https://cdn.example.com/a.png", "b.png"])
-    with patch(
-        "backend.api.features.library._add_to_library.prisma.models.StoreListingVersion.prisma"
-    ) as mock_slv:
-        mock_slv.return_value.find_unique = AsyncMock(return_value=listing)
-        assert (
-            await _fetch_marketplace_image_url("slv-id")
-            == "https://cdn.example.com/a.png"
-        )
+    assert _extract_marketplace_image_url(listing) == "https://cdn.example.com/a.png"
 
-        mock_slv.return_value.find_unique = AsyncMock(
-            return_value=MagicMock(imageUrls=[])
-        )
-        assert await _fetch_marketplace_image_url("slv-id") is None
-
-        mock_slv.return_value.find_unique = AsyncMock(return_value=None)
-        assert await _fetch_marketplace_image_url("slv-id") is None
+    assert _extract_marketplace_image_url(MagicMock(imageUrls=[])) is None

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -1085,10 +1085,12 @@ async def add_store_agent_to_library(
         f"Adding agent from store listing version #{store_listing_version_id} "
         f"to library for user #{user_id}"
     )
-    graph_model = await resolve_graph_for_library(
+    graph_model, marketplace_image_url = await resolve_graph_for_library(
         store_listing_version_id, user_id, admin=False
     )
-    return await add_graph_to_library(store_listing_version_id, graph_model, user_id)
+    return await add_graph_to_library(
+        graph_model, user_id, marketplace_image_url=marketplace_image_url
+    )
 
 
 async def add_store_agent_to_library_as_admin(
@@ -1102,10 +1104,12 @@ async def add_store_agent_to_library_as_admin(
         f"ADMIN adding agent from store listing version "
         f"#{store_listing_version_id} to library for user #{user_id}"
     )
-    graph_model = await resolve_graph_for_library(
+    graph_model, marketplace_image_url = await resolve_graph_for_library(
         store_listing_version_id, user_id, admin=True
     )
-    return await add_graph_to_library(store_listing_version_id, graph_model, user_id)
+    return await add_graph_to_library(
+        graph_model, user_id, marketplace_image_url=marketplace_image_url
+    )
 
 
 ##############################################


### PR DESCRIPTION
### Why / What / How

**Why:** When a user downloads an agent from the marketplace into their library, the new `LibraryAgent` is created from the graph only — its `imageUrl` is never populated, so the library entry shows no artwork even though the marketplace listing has one. This is the "missing images" half of #9879.

**What:** `add_graph_to_library()` now carries the marketplace listing's image onto the `LibraryAgent`, on both the create path and the soft-delete-restore path (guarded so restoring never blanks out an image the user already has).

**How:** `resolve_graph_for_library()` already fetches the `StoreListingVersion` to resolve the graph. It now also extracts `imageUrls[0]` from that same lookup (via `_extract_marketplace_image_url`) and returns it alongside the `GraphModel`, so `add_graph_to_library()` receives the image directly instead of re-querying for it.

### Changes 🏗️

- `_add_to_library.py`: `resolve_graph_for_library()` now returns `(GraphModel, marketplace_image_url)`; `add_graph_to_library()` takes `marketplace_image_url` and sets it on create/restore.
- `db.py`: both callers (`add_store_agent_to_library`, `add_store_agent_to_library_as_admin`) updated to unpack and pass through the image URL.
- Tests updated/added in `_add_to_library_test.py`; admin-path tests in `store_admin_routes_test.py` updated for the new return type.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit tests for create-path image carry-over, restore-path guard (no blanking), and the image-extraction helper — all mock-based, no live DB required
  - [x] Confirmed via CI that `db_test.py::test_add_agent_to_library` (which asserts `StoreListingVersion.find_unique` is called exactly once) still passes — an earlier version of this PR queried it twice and broke this test
  - [ ] Not run: full local `pytest` suite end-to-end (no local Postgres/Prisma available in my environment) — relying on CI

Progresses #9879 (image half only). The title half is a separate, larger change needing a `LibraryAgent` schema migration — intentionally out of scope here, documented as follow-up in [my contribution write-up](https://github.com/Kidus5168/open-source-contribution).
