### PR TITLE
docs(platform): org/teams access model — technical reference + user-facing drafts with visualizations

### DIFF
--- a/docs/platform/SUMMARY.md
+++ b/docs/platform/SUMMARY.md
@@ -34,3 +34,18 @@
 
 * [API Introduction](integrating/api-guide.md)
 * [OAuth & SSO](integrating/oauth-guide.md)
+
+## Organizations & Teams
+
+* [Organizations & Teams](organizations/organizations-and-teams.md)
+* [Sharing agents with your team](organizations/sharing-agents.md)
+* [Team credentials](organizations/team-credentials.md)
+* [Shared memory](organizations/shared-memory.md)
+* [Who can see what](organizations/who-can-see-what.md)
+
+## Org Access Model (Reference)
+
+* [Overview & roles](org-access-model.md)
+* [Resources, tenancy & grants](org-access-model-resources.md)
+* [Credentials & memory](org-access-model-credentials-and-memory.md)
+* [Chats & billing](org-access-model-chats-and-billing.md)

--- a/docs/platform/imgs/org-access-model/agent-visibility.svg
+++ b/docs/platform/imgs/org-access-model/agent-visibility.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 520" role="img" aria-label="Animation showing how an agent's visibility changes as it moves from org-home to Team A and is then granted to Team B.">
+  <title>Who can see this agent?</title>
+  <desc>An organization contains an org-home area and two teams. A resource starts as an org-home row visible to every member, moves into Team A so only Team A can see it, then a grant opens execute access to Team B while the rest of the org still cannot see it.</desc>
+
+  <!-- self-contained light panel so it reads on any page theme -->
+  <rect x="10" y="10" width="840" height="500" rx="16" fill="#ffffff" stroke="#e5e7eb" stroke-width="1.5"/>
+  <text x="34" y="46" font-family="ui-sans-serif, system-ui, sans-serif" font-size="21" font-weight="700" fill="#1e293b">Who can see this agent?</text>
+  <text x="34" y="68" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748b">Visibility follows the row's tenancy: org-home &#8594; Team A &#8594; granted to Team B</text>
+
+  <!-- organization boundary -->
+  <rect x="34" y="86" width="792" height="356" rx="14" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="50" y="108" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#475569">Acme Organization</text>
+
+  <!-- org-home band -->
+  <rect x="60" y="118" width="740" height="60" rx="10" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.3" stroke-dasharray="5 4"/>
+  <text x="74" y="142" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12.5" font-weight="600" fill="#475569">Org-home</text>
+  <text x="74" y="160" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11.5" fill="#94a3b8">teamId = NULL &#183; visible to every org member</text>
+
+  <!-- Team A box -->
+  <rect x="60" y="212" width="330" height="210" rx="10" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.3"/>
+  <text x="76" y="236" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#475569">Team A</text>
+  <text x="76" y="254" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11.5" fill="#94a3b8">3 members</text>
+
+  <!-- Team B box -->
+  <rect x="470" y="212" width="330" height="210" rx="10" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.3"/>
+  <text x="486" y="236" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#475569">Team B</text>
+  <text x="486" y="254" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11.5" fill="#94a3b8">3 members</text>
+
+  <!-- Team A members (dots + highlight rings) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <circle cx="130" cy="330" r="12" fill="#cbd5e1"/>
+    <circle cx="185" cy="330" r="12" fill="#cbd5e1"/>
+    <circle cx="240" cy="330" r="12" fill="#cbd5e1"/>
+    <!-- Team A highlight rings: on in org-home phase (via all-ring) AND in team A + grant phases -->
+    <g fill="none" stroke="#4f46e5" stroke-width="3">
+      <circle cx="130" cy="330" r="17"/>
+      <circle cx="185" cy="330" r="17"/>
+      <circle cx="240" cy="330" r="17"/>
+      <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+               keyTimes="0;0.34;0.36;0.95;1" values="0;0;1;1;0"/>
+    </g>
+  </g>
+
+  <!-- Team B members (dots + highlight rings) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <circle cx="540" cy="330" r="12" fill="#cbd5e1"/>
+    <circle cx="595" cy="330" r="12" fill="#cbd5e1"/>
+    <circle cx="650" cy="330" r="12" fill="#cbd5e1"/>
+    <!-- Team B highlight rings: on only in grant phase -->
+    <g fill="none" stroke="#4f46e5" stroke-width="3">
+      <circle cx="540" cy="330" r="17"/>
+      <circle cx="595" cy="330" r="17"/>
+      <circle cx="650" cy="330" r="17"/>
+      <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+               keyTimes="0;0.67;0.69;0.95;1" values="0;0;1;1;0"/>
+    </g>
+  </g>
+
+  <!-- Org-only member (belongs to no team) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <circle cx="430" cy="392" r="12" fill="#cbd5e1"/>
+    <text x="430" y="422" text-anchor="middle" font-size="10.5" fill="#94a3b8">org member, no team</text>
+    <!-- ring on only in org-home phase -->
+    <circle cx="430" cy="392" r="17" fill="none" stroke="#4f46e5" stroke-width="3">
+      <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+               keyTimes="0;0.30;0.34;0.95;1" values="1;1;0;0;1"/>
+    </circle>
+  </g>
+
+  <!-- "all org" highlight rings for the six team members during org-home phase -->
+  <g fill="none" stroke="#4f46e5" stroke-width="3">
+    <circle cx="130" cy="330" r="17"/>
+    <circle cx="185" cy="330" r="17"/>
+    <circle cx="240" cy="330" r="17"/>
+    <circle cx="540" cy="330" r="17"/>
+    <circle cx="595" cy="330" r="17"/>
+    <circle cx="650" cy="330" r="17"/>
+    <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+             keyTimes="0;0.30;0.34;0.95;1" values="1;1;0;0;1"/>
+  </g>
+
+  <!-- grant arrow from Team A to Team B (grant phase only) -->
+  <g opacity="0">
+    <defs>
+      <marker id="arrowhead" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+        <path d="M0,0 L7,3 L0,6 Z" fill="#4f46e5"/>
+      </marker>
+    </defs>
+    <path d="M392,300 C 430,300 430,300 468,300" fill="none" stroke="#4f46e5" stroke-width="2.5"
+          stroke-dasharray="6 4" marker-end="url(#arrowhead)"/>
+    <rect x="393" y="272" width="74" height="22" rx="6" fill="#eef2ff" stroke="#4f46e5" stroke-width="1"/>
+    <text x="430" y="287" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="600" fill="#4338ca">grant: EXECUTE</text>
+    <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+             keyTimes="0;0.67;0.70;0.95;1" values="0;0;1;1;0"/>
+  </g>
+
+  <!-- the moving agent card -->
+  <g>
+    <animateTransform attributeName="transform" type="translate" dur="12s" repeatCount="indefinite"
+                      keyTimes="0;0.30;0.36;0.95;1"
+                      values="0,0; 0,0; -215,148; -215,148; 0,0"/>
+    <rect x="345" y="120" width="190" height="56" rx="11" fill="#eef2ff" stroke="#4f46e5" stroke-width="2"/>
+    <!-- tiny robot glyph -->
+    <rect x="360" y="136" width="24" height="20" rx="4" fill="#4f46e5"/>
+    <circle cx="367" cy="146" r="2.4" fill="#ffffff"/>
+    <circle cx="377" cy="146" r="2.4" fill="#ffffff"/>
+    <line x1="372" y1="130" x2="372" y2="136" stroke="#4f46e5" stroke-width="2"/>
+    <circle cx="372" cy="129" r="2" fill="#4f46e5"/>
+    <text x="396" y="143" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#3730a3">Weekly Report</text>
+    <text x="396" y="160" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" fill="#6366f1">agent graph</text>
+  </g>
+
+  <!-- captions (one visible per phase) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#334155">
+    <text x="34" y="474" opacity="0">
+      Org-home row: every member of Acme can see and run it.
+      <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+               keyTimes="0;0.30;0.34;0.95;1" values="1;1;0;0;1"/>
+    </text>
+    <text x="34" y="474" opacity="0">
+      Moved into Team A: now only Team A members (and the owner) can see it.
+      <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+               keyTimes="0;0.36;0.40;0.66;0.70" values="0;0;1;1;0"/>
+    </text>
+    <text x="34" y="474" opacity="0">
+      Granted to Team B (EXECUTE): Team B can run it too &#8212; the rest of the org still cannot.
+      <animate attributeName="opacity" dur="12s" repeatCount="indefinite"
+               keyTimes="0;0.70;0.74;0.94;0.98" values="0;0;1;1;0"/>
+    </text>
+  </g>
+
+  <text x="826" y="502" text-anchor="end" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#cbd5e1">AutoGPT Platform &#183; org access model</text>
+</svg>

--- a/docs/platform/imgs/org-access-model/memory-recall.svg
+++ b/docs/platform/imgs/org-access-model/memory-recall.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 520" role="img" aria-label="Animation of a team chat recalling memory from three graphs — personal, team, and org — with provenance labels appearing on the shared facts.">
+  <title>Memory recall in a team chat</title>
+  <desc>A chat assembles context by reading from the personal graph, the session's team graph, and the org graph. Facts stream into the context panel; personal facts stay unlabelled while team and org facts arrive tagged with their source. Personal keeps at least half of the budget.</desc>
+
+  <rect x="10" y="10" width="840" height="500" rx="16" fill="#ffffff" stroke="#e5e7eb" stroke-width="1.5"/>
+  <text x="34" y="46" font-family="ui-sans-serif, system-ui, sans-serif" font-size="21" font-weight="700" fill="#1e293b">Memory recall in a team chat</text>
+  <text x="34" y="68" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#64748b">Recall fans out across the tiers the user may read; each shared fact keeps its provenance label</text>
+
+  <!-- ============ SOURCE GRAPHS ============ -->
+  <!-- Personal -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <rect x="40" y="110" width="230" height="76" rx="11" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.4"/>
+    <!-- mini graph glyph -->
+    <circle cx="70" cy="140" r="6" fill="#94a3b8"/>
+    <circle cx="94" cy="128" r="6" fill="#94a3b8"/>
+    <circle cx="92" cy="158" r="6" fill="#94a3b8"/>
+    <line x1="70" y1="140" x2="94" y2="128" stroke="#cbd5e1" stroke-width="2"/>
+    <line x1="70" y1="140" x2="92" y2="158" stroke="#cbd5e1" stroke-width="2"/>
+    <text x="120" y="138" font-size="14" font-weight="700" fill="#334155">Personal memory</text>
+    <text x="120" y="158" font-size="11.5" fill="#94a3b8">user_&lt;id&gt; &#183; private</text>
+    <text x="120" y="174" font-size="11" fill="#94a3b8">facts stay unlabelled</text>
+  </g>
+  <!-- Team -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <rect x="40" y="216" width="230" height="76" rx="11" fill="#ffffff" stroke="#4f46e5" stroke-width="1.6"/>
+    <circle cx="70" cy="246" r="6" fill="#4f46e5"/>
+    <circle cx="94" cy="234" r="6" fill="#4f46e5"/>
+    <circle cx="92" cy="264" r="6" fill="#4f46e5"/>
+    <line x1="70" y1="246" x2="94" y2="234" stroke="#c7d2fe" stroke-width="2"/>
+    <line x1="70" y1="246" x2="92" y2="264" stroke="#c7d2fe" stroke-width="2"/>
+    <text x="120" y="244" font-size="14" font-weight="700" fill="#334155">Team memory</text>
+    <text x="120" y="264" font-size="11.5" fill="#6366f1">team_&lt;id&gt; &#183; session team: Growth</text>
+    <text x="120" y="280" font-size="11" fill="#94a3b8">active members only</text>
+  </g>
+  <!-- Org -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <rect x="40" y="322" width="230" height="76" rx="11" fill="#ffffff" stroke="#4f46e5" stroke-width="1.6"/>
+    <circle cx="70" cy="352" r="6" fill="#4f46e5"/>
+    <circle cx="94" cy="340" r="6" fill="#4f46e5"/>
+    <circle cx="92" cy="370" r="6" fill="#4f46e5"/>
+    <line x1="70" y1="352" x2="94" y2="340" stroke="#c7d2fe" stroke-width="2"/>
+    <line x1="70" y1="352" x2="92" y2="370" stroke="#c7d2fe" stroke-width="2"/>
+    <text x="120" y="350" font-size="14" font-weight="700" fill="#334155">Org memory</text>
+    <text x="120" y="370" font-size="11.5" fill="#6366f1">org_&lt;id&gt; &#183; every member</text>
+    <text x="120" y="386" font-size="11" fill="#94a3b8">shared org knowledge</text>
+  </g>
+
+  <!-- ============ FLOW PATHS (faint guides) ============ -->
+  <g fill="none" stroke="#e2e8f0" stroke-width="1.5">
+    <path d="M270,148 C 400,148 430,262 548,262"/>
+    <path d="M270,254 C 400,254 440,264 548,266"/>
+    <path d="M270,360 C 400,360 430,272 548,270"/>
+  </g>
+
+  <!-- merge label -->
+  <text x="430" y="304" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11.5" font-weight="600" fill="#64748b">budget merge</text>
+  <text x="430" y="320" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10.5" fill="#94a3b8">personal keeps &#8805; &#189;</text>
+
+  <!-- ============ STREAMING PARTICLES ============ -->
+  <!-- Each begins at t=0 sitting on its source box (path start), so no particle
+       ever parks at the origin; different durations desync the flow over time. -->
+  <!-- personal (gray) -->
+  <circle r="4.5" fill="#94a3b8" cx="0" cy="0"><animateMotion dur="2.4s" repeatCount="indefinite" path="M270,148 C 400,148 430,262 548,262"/></circle>
+  <circle r="4.5" fill="#94a3b8" cx="0" cy="0"><animateMotion dur="3.1s" repeatCount="indefinite" path="M270,148 C 400,148 430,262 548,262"/></circle>
+  <!-- team (accent) -->
+  <circle r="4.5" fill="#4f46e5" cx="0" cy="0"><animateMotion dur="2.7s" repeatCount="indefinite" path="M270,254 C 400,254 440,264 548,266"/></circle>
+  <!-- org (accent) -->
+  <circle r="4.5" fill="#4f46e5" cx="0" cy="0"><animateMotion dur="2.9s" repeatCount="indefinite" path="M270,360 C 400,360 430,272 548,270"/></circle>
+
+  <!-- ============ CHAT CONTEXT PANEL ============ -->
+  <rect x="548" y="104" width="278" height="330" rx="12" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="566" y="130" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#475569">Chat context (assembled)</text>
+
+  <!-- chips fade in in render order: personal, personal, team, personal, org -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif">
+    <!-- chip 1 personal -->
+    <g opacity="0">
+      <rect x="564" y="144" width="246" height="34" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.2"/>
+      <text x="576" y="165" font-size="12" fill="#334155">Prefers concise summaries</text>
+      <animate attributeName="opacity" dur="10s" repeatCount="indefinite" keyTimes="0;0.08;0.11;0.93;0.98" values="0;0;1;1;0"/>
+    </g>
+    <!-- chip 2 personal -->
+    <g opacity="0">
+      <rect x="564" y="184" width="246" height="34" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.2"/>
+      <text x="576" y="205" font-size="12" fill="#334155">Works in Pacific time</text>
+      <animate attributeName="opacity" dur="10s" repeatCount="indefinite" keyTimes="0;0.20;0.23;0.93;0.98" values="0;0;1;1;0"/>
+    </g>
+    <!-- chip 3 team -->
+    <g opacity="0">
+      <rect x="564" y="224" width="246" height="48" rx="8" fill="#ffffff" stroke="#4f46e5" stroke-width="1.3"/>
+      <text x="576" y="244" font-size="12" fill="#334155">Q3 goal: 20% activation</text>
+      <rect x="576" y="250" width="150" height="16" rx="8" fill="#eef2ff"/>
+      <text x="584" y="262" font-size="10" font-weight="600" fill="#4338ca">team memory (Growth)</text>
+      <animate attributeName="opacity" dur="10s" repeatCount="indefinite" keyTimes="0;0.34;0.37;0.93;0.98" values="0;0;1;1;0"/>
+    </g>
+    <!-- chip 4 personal -->
+    <g opacity="0">
+      <rect x="564" y="278" width="246" height="34" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.2"/>
+      <text x="576" y="299" font-size="12" fill="#334155">Owns the onboarding project</text>
+      <animate attributeName="opacity" dur="10s" repeatCount="indefinite" keyTimes="0;0.46;0.49;0.93;0.98" values="0;0;1;1;0"/>
+    </g>
+    <!-- chip 5 org -->
+    <g opacity="0">
+      <rect x="564" y="318" width="246" height="48" rx="8" fill="#ffffff" stroke="#4f46e5" stroke-width="1.3"/>
+      <text x="576" y="338" font-size="12" fill="#334155">Brand voice: friendly, direct</text>
+      <rect x="576" y="344" width="104" height="16" rx="8" fill="#eef2ff"/>
+      <text x="584" y="356" font-size="10" font-weight="600" fill="#4338ca">org memory</text>
+      <animate attributeName="opacity" dur="10s" repeatCount="indefinite" keyTimes="0;0.58;0.61;0.93;0.98" values="0;0;1;1;0"/>
+    </g>
+  </g>
+
+  <!-- provenance caption -->
+  <text x="34" y="470" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#334155">Personal facts stay unlabelled; team and org facts carry a provenance label so the model can weigh them.</text>
+  <text x="826" y="502" text-anchor="end" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" fill="#cbd5e1">AutoGPT Platform &#183; org access model</text>
+</svg>

--- a/docs/platform/org-access-model-chats-and-billing.md
+++ b/docs/platform/org-access-model-chats-and-billing.md
@@ -111,8 +111,6 @@ reference flags them at the point of use rather than describing them as live:
 - **Seat enforcement** — `seat_status` rides on `RequestContext`, but seat/
   subscription gating is owned by the paywall workstream and is not enforced
   today.
-- **Grant credential `OWNER` mode** — stored, not yet enforced (see
-  [Grants](org-access-model-resources.md#credential-modes)).
 - **Shared-memory review** — held (`tentative`) team/org memories have no
   promotion path yet (see
   [Write governance](org-access-model-credentials-and-memory.md#write-governance-the-hold-buffer)).

--- a/docs/platform/org-access-model-chats-and-billing.md
+++ b/docs/platform/org-access-model-chats-and-billing.md
@@ -1,0 +1,122 @@
+# Chats & Billing
+
+Part of the [Org Access Model reference](org-access-model.md). Two places where
+"attribution" and "access" pull in different directions: chat sessions are
+**private to their owner** but attributed to an org for billing, and billing is
+pooled at the org but **role-gated**.
+
+## Chat sessions are user-owned
+
+A `ChatSession` carries an owner plus attribution fields:
+
+```
+userId          String              # the owner
+organizationId  String?             # attribution
+teamId          String?             # attribution
+visibility      ResourceVisibility  # default PRIVATE  (PRIVATE | TEAM | ORG)
+```
+
+- **Private by default.** Every session read/write query is scoped by
+  `userId`. There is no query path that lets another org member list or fetch
+  someone else's session — the `organizationId` / `teamId` are recorded for
+  **attribution only** (billing, and "which org was this run charged to"), not
+  to widen visibility. Chats are the one resource class that does **not** follow
+  the org/team visibility union.
+- The `visibility` enum exists on the row for a future team/org-visible chat
+  feature, but the default and the enforced behavior today is `PRIVATE`.
+
+### Membership is re-verified every turn
+
+A session is membership-verified when it is created, but a membership can be
+revoked while a long-lived session is still open. So org/team membership is
+**re-checked on every chat turn** (`verify_session_org_membership`):
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as /stream handler
+    participant V as verify_session_org_membership
+    U->>S: Send chat turn (session has org)
+    S->>V: Re-check org + team membership now
+    alt Org membership revoked
+        V-->>S: raise SessionOrgMembershipRevoked
+        S-->>U: 403 — no longer a member of this org
+    else Team membership stale
+        V-->>S: strip team_id → org-home (None)
+        S-->>U: Turn proceeds in org-home context
+    else Still a member
+        V-->>S: team_id unchanged
+        S-->>U: Turn proceeds
+    end
+```
+
+- **Org membership is a hard gate.** If the user is no longer an `ACTIVE`
+  member of the session's org, the turn is rejected (`403`).
+- **A stale team membership is not fatal.** It is silently stripped to org-home
+  (`team_id = None`), mirroring `get_request_context`'s team fallback — the
+  chat keeps working, just without the team scope.
+- The same re-check runs in the **turn queue**: before a queued turn is
+  promoted, membership is re-verified; on revocation the session is demoted
+  (`queued → idle`) and its cache invalidated rather than dispatched under a
+  revoked org.
+- **Untagged legacy sessions** (`organizationId = NULL`) skip the re-check and
+  fall back to the already-verified request context.
+
+## Billing is pooled and role-gated
+
+Runs in a shared org draw from the **org's credit pool**, and every charge is
+**attributed** so spend can be broken down by team.
+
+### Attribution
+
+`OrgCreditTransaction` records `orgId`, `initiatedByUserId`, and a nullable
+`teamId` on every usage transaction. The charge path
+(`spend_org_credits`, called from the executor's billing) tags each transaction
+with the `team_id` from the running execution's context:
+
+- Execution rows (`AgentGraphExecution`) carry `organizationId` / `teamId`,
+  set at creation.
+- Block-usage and execution-usage charges pull `organization_id` /
+  `team_id` off `ExecutionContext` and pass them through to
+  `spend_org_credits`, which stamps `teamId` on the transaction.
+- **Personal orgs** short-circuit to the user's own wallet, so team attribution
+  only applies to shared (non-personal) orgs.
+
+This is what lets an org see per-team cost breakdowns without any new write
+path — the attribution is already on every transaction.
+
+### Who can touch billing
+
+Billing endpoints are gated by **`OrgAction.MANAGE_BILLING`** — **owner or
+billing manager only** (see the [role matrix](org-access-model.md#org-permission-matrix)):
+
+| Endpoint / capability | Gate |
+| --- | --- |
+| Top-up credits | `MANAGE_BILLING` |
+| Auto-top-up config | `MANAGE_BILLING` |
+| Billing portal / payment methods | `MANAGE_BILLING` |
+| Transactions / refunds / invoices | `MANAGE_BILLING` |
+| Org spend breakdown (`get_org_spend`) | `MANAGE_BILLING` |
+| Team-level spend view | `VIEW_SPEND` (team admin / team billing manager) |
+
+A plain member — even one who can create and run agents that spend org credits
+— cannot see or manage billing. Conversely, a pure billing manager can manage
+finances but cannot create resources or share agents.
+
+## Future directions
+
+A few fields are present in the schema ahead of enforcement. Where honest, this
+reference flags them at the point of use rather than describing them as live:
+
+- **Seat enforcement** — `seat_status` rides on `RequestContext`, but seat/
+  subscription gating is owned by the paywall workstream and is not enforced
+  today.
+- **Grant credential `OWNER` mode** — stored, not yet enforced (see
+  [Grants](org-access-model-resources.md#credential-modes)).
+- **Shared-memory review** — held (`tentative`) team/org memories have no
+  promotion path yet (see
+  [Write governance](org-access-model-credentials-and-memory.md#write-governance-the-hold-buffer)).
+- **Chat visibility** — the `TEAM` / `ORG` values on `ChatSession.visibility`
+  are reserved; chats are `PRIVATE` in practice.
+
+Everything else in this reference describes enforced behavior.

--- a/docs/platform/org-access-model-credentials-and-memory.md
+++ b/docs/platform/org-access-model-credentials-and-memory.md
@@ -1,0 +1,151 @@
+# Credentials & Memory
+
+Part of the [Org Access Model reference](org-access-model.md). Two subsystems
+that resolve *across* the tenancy tiers: integration credentials and copilot
+memory.
+
+## Credential resolution
+
+Scoped credentials live in the `IntegrationCredential` table with an
+`ownerType` of `USER`, `TEAM`, or `ORG`. The scoped store
+(`backend/integrations/scoped_credentials.py`) resolves the credentials visible
+in the current context as the **union** of the three scopes, in this precedence
+order:
+
+```mermaid
+flowchart LR
+    Q[get_scoped_credentials<br/>user, org, team?] --> U[USER<br/>ownerType=USER,<br/>ownerId=user, this org]
+    Q --> T[TEAM<br/>ownerType=TEAM,<br/>ownerId=active team]
+    Q --> O[ORG<br/>ownerType=ORG,<br/>ownerId=org]
+    U --> R[Ordered result:<br/>USER &#8594; TEAM &#8594; ORG]
+    T --> R
+    O --> R
+```
+
+- The **TEAM** slice is included only when a team is active on the context.
+- The **ORG** slice is available to any org member, because `organization_id`
+  comes from a membership-verified `RequestContext`.
+
+This is the newer path. During the dual-read transition, callers try the scoped
+store first and fall back to the legacy `User.integrations` blob.
+
+### Fetching one credential by id
+
+`get_credential_by_id` enforces access **itself** rather than trusting callers,
+because a decrypted read could otherwise exfiltrate another tenant's secret:
+
+| Credential `ownerType` | Who may fetch it |
+| --- | --- |
+| `USER` | Only the creating user. |
+| `TEAM` | Only via the matching active team — or, when the active context is a *different* team, a caller with a verified `ACTIVE` membership of the **owning** team. |
+| `ORG` | Any member of the org. |
+
+### Creating and managing team credentials
+
+- **Creating** a credential takes `owner_type` + `owner_id`. For `TEAM`
+  credentials the store enforces `team_id == owner_id` so the dedicated
+  `teamId` FK is populated — that gives `onDelete: Cascade` cleanup and matches
+  the shape the read path resolves on.
+- **Managing** team credentials is a **team-admin** action. At the team level,
+  `MANAGE_CREDENTIALS` is `team_admin` only, while `USE_CREDENTIALS` is granted
+  to `team_admin` and `team_member`. In other words: members can *use* a team
+  credential in a run, only admins can add or remove them.
+- **Deleting** is scoped tightly:
+  - `delete_team_credential` requires the credential to be `TEAM`-owned by
+    *exactly* that team in that org — a team admin cannot revoke another team's
+    credential by id (no cross-team escalation).
+  - `delete_credential` (user/org creds) allows only the creator, unless
+    `is_org_admin` is set — which callers must derive from a verified context,
+    never from request input.
+
+## Memory tiers
+
+Copilot memory is split across **three FalkorDB graphs**, one substrate per
+group:
+
+| Tier | Group id | Visibility |
+| --- | --- | --- |
+| **Personal** | `user_<id>` | Private to the user. |
+| **Team** | `team_<id>` | `ACTIVE` members of that team. |
+| **Org** | `org_<id>` | Every org member. |
+
+Group ids are derived by `derive_group_id` / `derive_team_group_id` /
+`derive_org_group_id`, which sanitize the id and **raise** if sanitization
+changed it — a tenant id can never collapse into another tenant's namespace.
+
+### Recall fan-out
+
+A chat reads from every tier the user is entitled to, then merges the results
+under a budget. Provenance labels are attached so the model can weigh sources.
+
+![Animation: a team chat streams facts from the personal, team, and org graphs into the assembled context; personal facts stay unlabelled while team and org facts arrive tagged, and personal keeps at least half the budget.](imgs/org-access-model/memory-recall.svg)
+
+Two read paths, both membership-checked at read time (never trusted from the
+session):
+
+- **Warm context** (session-start prefetch, `resolve_warm_targets`): personal
+  **always**; org **only** if the session carries an org and the user is an
+  `ACTIVE` org member; the session's team **only** if the session is team-tagged
+  and the user is an `ACTIVE` member of it.
+- **Explicit search** (`resolve_search_targets`): a `tier` of `all` (default)
+  unions personal + org + **every** `ACTIVE` team the user belongs to;
+  `personal` / `org` / `team` restrict to that tier. Requesting `org` or `team`
+  on a session with no org is a `TierError`.
+
+```mermaid
+flowchart TD
+    C[Chat turn] --> P[Personal graph<br/>always]
+    C --> OG{ACTIVE org member?}
+    OG -- Yes --> ORG[Org graph<br/>label: org memory]
+    OG -- No --> X1[skip]
+    C --> TG{ACTIVE team member?}
+    TG -- Yes --> TEAM["Team graph(s)<br/>label: team memory (name)"]
+    TG -- No --> X2[skip]
+    P --> MRG[merge_tiered]
+    ORG --> MRG
+    TEAM --> MRG
+    MRG --> CTX[Assembled context]
+```
+
+**Budget merge** (`merge_tiered`): personal keeps at least half the total
+(`total // 2`) and absorbs any budget the shared tiers don't use; the remainder
+is filled by round-robin across the shared tiers so each keeps its top hits near
+the front. **Labels**: personal facts stay **unlabelled** (the common case
+reads cleanly); org facts are prefixed `org memory`; team facts
+`team memory (<name>)`. Storage does not resolve cross-tier conflicts —
+provenance labelling hands that judgement to the model.
+
+### Write governance (the hold buffer)
+
+Writing to a **shared** tier is governed. Whether a write lands `active`
+(immediately recallable) or `tentative` (held) depends on the writer's role and
+the org's hold-buffer setting:
+
+| Tier | Who may write | Writer is admin | Writer is member, hold buffer **on** | Hold buffer **off** |
+| --- | --- | --- | --- | --- |
+| **Personal** | the user | `active` | `active` | `active` |
+| **Team** | any `ACTIVE` team member | `active` | `tentative` | `active` |
+| **Org** | any `ACTIVE` org member | `active` | `tentative` | `active` |
+
+- "Admin" means an org admin/owner for the org tier, or a **team** admin
+  (`membership.isAdmin`) for the team tier. An admin's shared write always lands
+  `active`; the admin check short-circuits the hold decision.
+- The **hold buffer** is `Organization.settings["memory"]["holdBuffer"]`,
+  **defaulting to `true`** (and failing safe to `true` on any read error). When
+  on, non-admin shared writes land `tentative`; when off, everyone's permitted
+  writes land `active`.
+- **Personal writes are never held** — they are always `active` and private,
+  and never enter the governance branch at all.
+- Any `ACTIVE` member may *write* to a shared tier — admin status only affects
+  `active` vs `tentative`, not whether the write is permitted.
+
+> **Enforcement status:** the hold buffer *holds* — a `tentative` shared memory
+> is excluded from recall — but there is **no admin review/promotion path
+> implemented yet** for shared tiers. As shipped in the memory-tiers branch, a
+> held team/org memory stays `tentative`; the review queue and the
+> `tentative → active` promotion action are future work. (The personal-tier
+> "dream" ratification pipeline is explicitly scoped out of shared-tier
+> promotion.) Document and build against `tentative` meaning "held, not yet
+> recallable", not "pending a working review UI".
+
+Continue to [Chats & billing](org-access-model-chats-and-billing.md).

--- a/docs/platform/org-access-model-resources.md
+++ b/docs/platform/org-access-model-resources.md
@@ -1,0 +1,195 @@
+# Resources, Tenancy & Grants
+
+Part of the [Org Access Model reference](org-access-model.md). This page covers
+how resources are tenanted, the shared visibility rule every list and fetch
+applies, how agents are shared with a team, and the order of checks a request
+passes through to view or run a graph.
+
+## Resource tenancy: org-home vs team rows
+
+Every tenant-scoped row carries two fields:
+
+- `organizationId` — which org the row belongs to.
+- `teamId` — **nullable**. `NULL` means the row is an **org-home** row (owned
+  by the org, not scoped to a subgroup). A non-null `teamId` scopes the row to
+  that **team**.
+
+So a resource is in exactly one of three states:
+
+| State | `organizationId` | `teamId` | Who it is exposed to |
+| --- | --- | --- | --- |
+| Personal / untagged | (personal org, or NULL pre-backfill) | NULL | The owning user only |
+| Org-home | set | NULL | Every member of the org |
+| Team | set | set | The owner + members of that team |
+
+### Create-time team picking
+
+When a user creates a resource, its `teamId` is chosen with an explicit picker
+that wins over the ambient context (illustrated here with `create_new_graph`):
+
+1. **Body parameter wins** — if the create request carries an explicit
+   `team_id`, it is validated (`_resolve_write_team_id`: it must be one of the
+   user's `ACTIVE` teams in the org) and used. An invalid team is a `400`, not
+   a silent downgrade.
+2. **Otherwise the header context** — `RequestContext.team_id` (from
+   `X-Team-Id`). `None` here means the resource is created as an org-home row.
+3. **On update, inherit** — re-saving a graph without a team (e.g. from the
+   builder, which sends none) inherits the agent's *current* team rather than
+   silently moving a team agent to org-home.
+
+`organizationId` is **always** taken from `RequestContext.org_id` — never from
+request input.
+
+## The visibility union
+
+One predicate, `visibility_filter` (`backend/data/tenancy.py`), defines "what
+can this user see in this org" so every list and fetch surface applies
+identical semantics. It builds a Prisma `OR` clause:
+
+```mermaid
+flowchart TD
+    A[List / fetch request] --> B{org_id on context?}
+    B -- "No (internal caller)" --> P[Personal ownership only:<br/>userId == me]
+    B -- Yes --> U[OR across three clauses]
+    U --> C1[My own rows in this org<br/>userId == me AND<br/>organizationId in this org or NULL]
+    U --> C2[Org-home rows<br/>organizationId == org AND teamId == NULL]
+    U --> C3[Team rows<br/>organizationId == org AND<br/>teamId in my ACTIVE teams]
+    C1 --> R[Visible set]
+    C2 --> R
+    C3 --> R
+```
+
+Notes that matter when you reuse this predicate:
+
+- The **team-id list must be the caller's `ACTIVE` memberships** in *this* org.
+  `get_user_team_ids(user_id, organization_id)` provides exactly that; do not
+  pass a team the user is not an active member of.
+- **Untagged rows stay with their owner.** Rows created before org tagging
+  (`organizationId = NULL`) remain visible to the owning user so nothing
+  disappears mid-migration.
+- With **no org context** the filter degrades to plain `userId == me`,
+  preserving pre-org behavior for internal callers that never resolve a
+  `RequestContext`.
+- This module **does not re-verify membership** — `organization_id` must come
+  from a membership-verified `RequestContext` or `ExecutionContext`.
+
+## Grants (share-with-team)
+
+A **grant** opens access to a specific agent graph for a **team**, without
+moving the graph out of its owner's tenancy. Grants are the mechanism behind
+"share this agent with Team B".
+
+### What a grant is
+
+`AgentGraphGrant` rows carry:
+
+| Field | Meaning |
+| --- | --- |
+| `principalType` | Who the grant is for. **v1 enforces `TEAM` only.** |
+| `principalId` | The team id. |
+| `capability` | `VIEW` or `EXECUTE`. **EXECUTE implies VIEW.** |
+| `agentGraphVersion` | The pinned version. |
+| `followLatest` | If true, the grant tracks the graph's active version instead of a pin. |
+| `credentialMode` | `CONSUMER` or `OWNER` (see below). |
+| `organizationId` | The org the grant lives in. |
+| `createdByUserId` | Who created the grant. |
+
+The schema is **deliberately polymorphic** so `USER` / `PERSONA` principals can
+ship later without a table migration. Until they do, a non-`TEAM` principal is
+a **hard error**, never a silent skip — `resolve_graph_grant` raises
+`GrantPrincipalNotSupportedError` if it ever sees one, so a row that bypassed
+the API can't quietly change access semantics.
+
+### Version pinning vs. follow-latest
+
+- A **pinned** grant (`followLatest = false`) covers only its
+  `agentGraphVersion`. Publishing a new version does not widen the grant.
+- A **follow-latest** grant covers any version, but the resolver additionally
+  requires the version being accessed to be the graph's **active** version
+  (`grant_covers_version` plus an `isActive` / active-version constraint in
+  both the view and execute paths). This prevents a follow-latest grant from
+  reaching a stale or draft version.
+
+### Credential modes
+
+`credentialMode` records whose credentials a granted run should use:
+
+- **`CONSUMER`** (default) — the grantee runs the agent with **their own**
+  resolved credentials.
+- **`OWNER`** — intended to run with the **graph owner's** credentials.
+
+> **Enforcement status:** `credentialMode` is currently **stored but not
+> enforced**. Nothing in the executor or integration layer branches on it — a
+> granted run always resolves the *grantee's* credentials, so an `OWNER`-mode
+> grant behaves exactly like `CONSUMER` today. Treat `OWNER` as a
+> forward-declared field, not a live capability, until owner-credential
+> resolution lands in the executor. (The task premise referenced an in-flight
+> `feat/grant-credential-modes` branch; it is not present on origin and carries
+> no enforcement diff.)
+
+### Who can share and revoke
+
+Sharing and revoking go through routes gated by **`OrgAction.SHARE_RESOURCES`**
+(owner / admin / member) *and* a per-graph check inside `upsert_grant` /
+`revoke_grant`:
+
+- The caller must be the **graph's owner** (`graph.userId == caller`) **or an
+  org admin/owner** (`sharer_is_org_admin`, derived from the context as
+  `is_org_admin or is_org_owner`). Otherwise it is a `NotAuthorizedError`.
+- The target team must be in the same org and **not archived**; the graph must
+  be in the same org.
+- **Re-sharing upserts** — the grant is keyed on
+  `(agentGraphId, principalType, principalId)`, so re-sharing a graph to a team
+  updates the existing row's pin / capability / mode rather than stacking a
+  second grant.
+- **Receiving** a grant is not privileged: any org member can list the grants
+  shared with the teams they are an active member of (`/grants/received`).
+
+## The access-check chain
+
+To decide whether a user may **view** a graph, `get_graph`
+(`backend/data/graph.py`) tries these in order and stops at the first match:
+
+```mermaid
+flowchart TD
+    S[get_graph for user] --> O{Own row or org/team<br/>visibility match?<br/>visibility_filter}
+    O -- Yes --> G[Access granted]
+    O -- No --> M{Approved store<br/>listing version?}
+    M -- Yes --> G
+    M -- No --> L{In the user's<br/>library?}
+    L -- Yes --> G
+    L -- No --> R{VIEW grant to one of<br/>the user's teams?<br/>resolve_graph_grant}
+    R -- "Yes (re-scoped to grant org,<br/>version-constrained)" --> G
+    R -- No --> D[Not accessible]
+```
+
+The **grant fallback is the last resort** — it only runs if ownership,
+visibility, store, and library all miss. When it fires it re-scopes the lookup
+to `grant.organizationId` (so a graph that later changes orgs can't ride an old
+grant) and constrains to the active version for follow-latest grants or the
+exact version for pins.
+
+**Execution** is checked separately by `validate_graph_execution_permissions`,
+which is an **OR** of four independent conditions:
+
+```
+user_owns_graph
+  OR user_has_in_library
+  OR user_has_exec_grant        # EXECUTE grant, same org, version-constrained
+  OR is_graph_published_in_marketplace
+```
+
+An `EXECUTE` grant satisfies the execute path; a `VIEW` grant does not (EXECUTE
+implies VIEW, not the reverse).
+
+## Per-resource access summary
+
+| Resource | Who can read | Who can create / edit | Who can share |
+| --- | --- | --- | --- |
+| **Agent graph (org-home)** | Every org member | Owner; team rules on save | Owner or org admin (`SHARE_RESOURCES`) |
+| **Agent graph (team)** | Owner + that team's members | Owner; `CREATE_AGENTS` / `DELETE_AGENTS` at team level | Owner or org admin |
+| **Agent graph (granted)** | Grantee team via VIEW/EXECUTE grant | Grant does not confer edit | Only the graph owner or org admin |
+| **Execution** | Team members (`VIEW_EXECUTIONS`) + owner | Anyone who can execute the graph | n/a |
+| **Store listing** | Public once approved | `PUBLISH_TO_STORE` (owner/admin/member) | Publishing is the share |
+
+Continue to [Credentials & memory](org-access-model-credentials-and-memory.md).

--- a/docs/platform/org-access-model-resources.md
+++ b/docs/platform/org-access-model-resources.md
@@ -116,16 +116,28 @@ the API can't quietly change access semantics.
 
 - **`CONSUMER`** (default) — the grantee runs the agent with **their own**
   resolved credentials.
-- **`OWNER`** — intended to run with the **graph owner's** credentials.
+- **`OWNER`** — the granted run resolves the graph's credential references
+  against the **graph owner's** credential store. Secrets are injected at
+  execution only; the grantee never sees them (the owner's credential title is
+  redacted from the grantee's execution record).
 
-> **Enforcement status:** `credentialMode` is currently **stored but not
-> enforced**. Nothing in the executor or integration layer branches on it — a
-> granted run always resolves the *grantee's* credentials, so an `OWNER`-mode
-> grant behaves exactly like `CONSUMER` today. Treat `OWNER` as a
-> forward-declared field, not a live capability, until owner-credential
-> resolution lands in the executor. (The task premise referenced an in-flight
-> `feat/grant-credential-modes` branch; it is not present on origin and carries
-> no enforcement diff.)
+`OWNER` mode is enforced with deliberate guardrails:
+
+- **Allowlisted** — only the credential ids the graph itself references
+  (`node.input_default`) resolve against the owner's store; grantee-supplied
+  credential overrides are ignored, so a consumer can never point resolution at
+  arbitrary entries the owner holds.
+- **Fail-closed** — a missing or revoked owner credential fails the run with a
+  clear error naming the graph and credential. It never falls back to the
+  grantee's credentials, which would silently misattribute API usage.
+- **Scope** — inert for owners running their own graphs, for marketplace or
+  library access, and for `CONSUMER` grants. Nested sub-graph executions always
+  run `CONSUMER`; the owner context does not propagate.
+- **Creation** — only the graph's **owner** may create an `OWNER`-mode grant.
+  An org admin sharing another member's graph cannot expose that member's
+  credentials (the API rejects it).
+- **Audit** — an execution-start log records graph, grant, owner, and consumer
+  ids (never secrets) whenever `OWNER` mode engages.
 
 ### Who can share and revoke
 

--- a/docs/platform/org-access-model.md
+++ b/docs/platform/org-access-model.md
@@ -1,0 +1,185 @@
+# Org Access Model — Reference
+
+This is the engineering reference for how the AutoGPT Platform decides **who
+can see and do what** once organizations and teams are in play. It is written
+for people building or reviewing platform code; the language tracks the schema
+and the enforcement functions rather than the product UI.
+
+If you want the plain-language version, start with the user guide:
+[Organizations & Teams](organizations/organizations-and-teams.md).
+
+The reference is split across four pages:
+
+1. **This page** — entities, the role ladder, permission matrices, and how a
+   request's context is resolved.
+2. [Resources, tenancy & grants](org-access-model-resources.md) — org-home vs
+   team rows, the visibility union, sharing agents with a team, and the access
+   check chain.
+3. [Credentials & memory](org-access-model-credentials-and-memory.md) —
+   credential resolution order and the tiered memory model.
+4. [Chats & billing](org-access-model-chats-and-billing.md) — private
+   user-owned sessions, org attribution, and role-gated billing.
+
+> The org/team feature set is landing across a series of branches. Where a
+> capability is stored but not yet enforced, this reference says so explicitly
+> rather than describing the intended end state as if it shipped.
+
+## Entities
+
+```mermaid
+erDiagram
+    User ||--o{ OrgMember : "membership"
+    User ||--o{ TeamMember : "membership"
+    Organization ||--o{ OrgMember : "has members"
+    Organization ||--o{ Team : "contains"
+    Team ||--o{ TeamMember : "has members"
+    Organization ||--o{ AgentGraph : "owns (organizationId)"
+    Team ||--o{ AgentGraph : "scopes (teamId, nullable)"
+    AgentGraph ||--o{ AgentGraphGrant : "shared via"
+    Team ||--o{ AgentGraphGrant : "TEAM principal"
+    Organization ||--o{ IntegrationCredential : "org/user/team scoped"
+    Organization ||--o{ ChatSession : "attributed (billing)"
+```
+
+- **Organization** — the top-level tenant. Every user has at least one: a
+  *personal org* (`isPersonal = true`) bootstrapped at signup, plus any shared
+  orgs they belong to.
+- **Team** — a subgroup inside an org. In the codebase teams are sometimes
+  called *workspaces* (e.g. the `MANAGE_WORKSPACES` / `CREATE_WORKSPACES` org
+  actions and the `is_team_*` flags refer to the same `Team` model). This
+  reference uses **team**.
+- **OrgMember** — a user's membership in an org, carrying `status`
+  (`ACTIVE` / …) and three role booleans: `isOwner`, `isAdmin`,
+  `isBillingManager`.
+- **TeamMember** — a user's membership in a team, carrying `status` and two
+  role booleans: `isAdmin`, `isBillingManager`.
+- **Resources** — agent graphs, executions, chat sessions, credentials, store
+  listings, and API keys carry `organizationId` and (where team-scoped) a
+  nullable `teamId`.
+
+## The role ladder
+
+Roles are booleans, not a single enum, so a member can hold more than one at
+once. At the **org** level the meaningful states form this ladder:
+
+| State | Flags set | What it means |
+| --- | --- | --- |
+| **Member** | *(none)* | An ordinary member of the org. |
+| **Billing manager** | `isBillingManager` | Finance only — *not* a general member. |
+| **Admin** | `isAdmin` | Full operational control; also counts as a member. |
+| **Admin & billing** | `isAdmin` + `isBillingManager` | Admin plus finance. |
+| **Owner** | `isOwner` | Exactly one per org; can do everything, incl. delete. |
+
+Two subtleties that the enforcement code (`permissions.py`) bakes in:
+
+- **Owner and Admin also count as "member"** — anything a member can do, they
+  can do.
+- **A pure Billing manager does _not_ count as a member.** Holding only
+  `isBillingManager` grants the finance-related actions and nothing else — no
+  creating resources, no sharing, no publishing. "Admin & billing" gets member
+  capabilities because of the `isAdmin` half, not the billing half.
+
+### Org permission matrix
+
+Derived from `_ORG_PERMISSIONS` in
+`autogpt_libs/auth/permissions.py`. Columns are the role a user holds on its
+own; **Admin & billing** is simply the union of the Admin and Billing-manager
+columns.
+
+| Org action | Owner | Admin | Billing manager | Member |
+| --- | :---: | :---: | :---: | :---: |
+| `VIEW_ORG` | ✓ | ✓ | ✓ | ✓ |
+| `CREATE_RESOURCES` | ✓ | ✓ | – | ✓ |
+| `SHARE_RESOURCES` | ✓ | ✓ | – | ✓ |
+| `PUBLISH_TO_STORE` | ✓ | ✓ | – | ✓ |
+| `CREATE_WORKSPACES` (teams) | ✓ | ✓ | ✓ | – |
+| `MANAGE_WORKSPACES` (teams) | ✓ | ✓ | – | – |
+| `MANAGE_MEMBERS` | ✓ | ✓ | – | – |
+| `TRANSFER_RESOURCES` | ✓ | ✓ | – | – |
+| `RENAME_ORG` | ✓ | ✓ | – | – |
+| `MANAGE_BILLING` | ✓ | – | ✓ | – |
+| `DELETE_ORG` | ✓ | – | – | – |
+
+### Team permission matrix
+
+Derived from `_TEAM_PERMISSIONS`. Team checks additionally require the request
+to actually carry a team (`team_id is not None`). As at the org level, a Team
+admin also counts as a Team member, and a pure Team billing manager does not.
+
+| Team action | Team admin | Team billing manager | Team member |
+| --- | :---: | :---: | :---: |
+| `CREATE_AGENTS` | ✓ | – | ✓ |
+| `USE_CREDENTIALS` | ✓ | – | ✓ |
+| `VIEW_EXECUTIONS` | ✓ | – | ✓ |
+| `VIEW_SPEND` | ✓ | ✓ | – |
+| `MANAGE_MEMBERS` | ✓ | – | – |
+| `MANAGE_SETTINGS` | ✓ | – | – |
+| `MANAGE_CREDENTIALS` | ✓ | – | – |
+| `DELETE_AGENTS` | ✓ | – | – |
+
+## Request context
+
+Every authenticated request resolves a **`RequestContext`** — a frozen
+dataclass (`autogpt_libs/auth/models.py`) that is the single source of truth
+for the caller's tenancy and roles:
+
+```python
+@dataclass(frozen=True)
+class RequestContext:
+    user_id: str
+    org_id: str
+    team_id: str | None          # None = org-home context
+    is_org_owner: bool
+    is_org_admin: bool
+    is_org_billing_manager: bool
+    is_team_admin: bool
+    is_team_billing_manager: bool
+    seat_status: str             # ACTIVE, INACTIVE, PENDING, NONE
+```
+
+`get_request_context` (`autogpt_libs/auth/dependencies.py`) builds it per
+request:
+
+- **Org selection** — reads the `X-Org-Id` header. With no header it falls back
+  to the caller's **personal org** (the org they own with `isPersonal = true`),
+  self-healing by bootstrapping one if it is somehow missing.
+- **Membership is verified, not trusted** — the selected org must have an
+  `ACTIVE` `OrgMember` row for the user and must not be soft-deleted, or the
+  request is rejected (`403`). The role flags are copied from that row.
+- **Team selection** — reads the `X-Team-Id` header. If present it is validated
+  (an `ACTIVE` `TeamMember` whose team belongs to the selected org). **A bad or
+  stale team header is not fatal**: it is silently dropped to `team_id = None`
+  (org-home context), mirroring how the rest of the system degrades to
+  org-home.
+- **`seat_status`** is carried on the context for the seat/subscription
+  workstream. Seat *enforcement* is deliberately deferred, so today the
+  resolver stamps `ACTIVE` once membership is validated.
+
+Everything downstream — visibility filters, permission checks, credential
+resolution, memory tiers — reads `org_id`, `team_id`, and the role flags off
+this already-verified context. Modules like `tenancy.py` explicitly document
+that they do **not** re-verify membership; they trust the `RequestContext`
+(or an equally trusted `ExecutionContext`) to have done it.
+
+## Who can see this agent?
+
+Resource visibility follows the row's **tenancy** — whether it is an *org-home*
+row (no team) or a *team* row — and grants can extend it to another team without
+moving the row. The animation below walks the three states; the mechanics are
+on the [resources page](org-access-model-resources.md).
+
+![Animation: an agent starts as an org-home row visible to all members, moves into Team A so only Team A sees it, then is granted EXECUTE to Team B while the rest of the org still cannot see it.](imgs/org-access-model/agent-visibility.svg)
+
+## Who can access what — index
+
+| Resource class | Tenancy | Read scope | Write / share control |
+| --- | --- | --- | --- |
+| **Agent graphs** | `organizationId` + nullable `teamId` | Owner, org-home → all members, team row → that team, plus [grants](org-access-model-resources.md#grants-share-with-team) | Owner or org admin shares; creator/team rules to edit |
+| **Executions** | inherit graph's org/team | Team members (`VIEW_EXECUTIONS`) and owner | Runs charge the org pool with team attribution |
+| **Credentials** | `USER` / `TEAM` / `ORG` scope | [Resolution order](org-access-model-credentials-and-memory.md#credential-resolution) USER → TEAM → ORG | Team admins manage team creds; creator/org-admin revoke |
+| **Memory** | personal / team / org graphs | [Tier fan-out](org-access-model-credentials-and-memory.md#memory-tiers) by active membership | Governed writes; admin direct, member held |
+| **Chat sessions** | user-owned, org-attributed | **Private to the owner** | Attribution only; membership re-checked per turn |
+| **Store listings** | org-ownable | Approved listings are public | `PUBLISH_TO_STORE` (owner/admin/member) |
+| **Billing** | org pool | `VIEW_SPEND` / `MANAGE_BILLING` | Owner / billing manager only |
+
+Each row links to the page where its rules are spelled out precisely.

--- a/docs/platform/organizations/organizations-and-teams.md
+++ b/docs/platform/organizations/organizations-and-teams.md
@@ -1,0 +1,65 @@
+# Organizations & Teams
+
+Organizations and teams let a group of people share agents, credentials, and
+billing on the AutoGPT Platform — while keeping personal work private.
+
+## The basics
+
+- **Your personal space.** Everyone starts with a private, personal space. Work
+  you create here is yours alone.
+- **An organization** is a shared space for a company or group. Members can
+  share agents, use shared credentials, and draw from one shared credit
+  balance.
+- **A team** is a smaller group inside an organization — for example
+  *Marketing* or *Engineering*. Teams keep an organization's work organized and
+  let you share things with just the right people.
+
+You can belong to more than one organization, and to more than one team inside
+an organization.
+
+## Org-home vs. team
+
+Inside an organization, something you create is in one of two places:
+
+- **Org-home** — shared with **everyone** in the organization.
+- **A team** — shared with the **members of that team** (and you, the creator).
+
+You choose where a new agent lives when you create it. You can also share a
+team's agent with another team without moving it — see
+[Sharing agents with your team](sharing-agents.md).
+
+## Roles, in plain words
+
+Roles decide what each person can do. In an **organization**:
+
+| Role | What they can do |
+| --- | --- |
+| **Member** | Use the org, create and run agents, share agents with their teams. |
+| **Billing manager** | Manage payment methods and view spend. (This role is finance-only — it does not include the everyday member abilities.) |
+| **Admin** | Everything a member can do, plus manage members and teams. |
+| **Owner** | The person who owns the organization. Can do anything, including deleting it. There is one owner. |
+
+Someone can be both an **Admin and a Billing manager** at once — they get both
+sets of abilities.
+
+Inside a **team**, the roles are:
+
+| Team role | What they can do |
+| --- | --- |
+| **Team member** | Create, use, and run agents in the team; use the team's shared credentials. |
+| **Team billing manager** | See the team's spending. |
+| **Team admin** | Manage the team's members, settings, and shared credentials. |
+
+## Switching context
+
+The org and team switcher (in the navigation bar) sets which space you're
+working in. What you see — agents, credentials, spend — follows the space you
+have selected. If you don't pick an organization, you're in your personal
+space.
+
+## Related
+
+- [Sharing agents with your team](sharing-agents.md)
+- [Team credentials](team-credentials.md)
+- [Shared memory](shared-memory.md)
+- [Who can see what](who-can-see-what.md)

--- a/docs/platform/organizations/organizations-and-teams.md
+++ b/docs/platform/organizations/organizations-and-teams.md
@@ -63,3 +63,5 @@ space.
 - [Team credentials](team-credentials.md)
 - [Shared memory](shared-memory.md)
 - [Who can see what](who-can-see-what.md)
+
+Organization admins can set the organization's logo from **Settings → Organization** — use the **Change** button next to the avatar in the profile section.

--- a/docs/platform/organizations/shared-memory.md
+++ b/docs/platform/organizations/shared-memory.md
@@ -20,20 +20,21 @@ it's off, memories become usable as soon as they're learned.
 Reviewing tentative memories happens in an admin **review queue**: admins see
 what's pending and approve or reject each item.
 
-## Current status
+## Reviewing held memories
 
-The **Shared memory** card ships with the concept and the toggle laid out, but
-the interactive parts are **not yet functional** — they're waiting on backend
-support that hasn't been built:
+The hold buffer is controlled from the org settings API: `PATCH
+/api/orgs/{org_id}` accepts `memory_hold_buffer` (true keeps non-admin shared
+writes in review; false lets them land active immediately), and `GET
+/api/orgs/{org_id}` returns the current value (defaults to true).
 
-- The **Hold new memories for review** toggle is shown **disabled**. There's no
-  way to persist an org memory setting yet (the organization update endpoint
-  doesn't accept a settings value), so the toggle can't be saved.
-- The **review queue** is flagged as unavailable. The endpoints to list
-  tentative memories for an org or team, and to approve or reject them, don't
-  exist yet. The memory-tiers backend shipped **per-user admin tools**
-  (`/api/admin/memory/*`) and deliberately deferred the org-level review flow.
+Org admins have a review queue: `GET /api/orgs/{org_id}/memory/held` lists the
+tentative memories awaiting review across the org tier and all its team tiers,
+each labelled with its tier and originating team. `POST
+/api/orgs/{org_id}/memory/held/{memory_id}/approve` ratifies a held memory into
+active shared memory, and `POST .../reject` retracts it. All three review
+endpoints require org-admin (owner/admin) permission and only ever act on the
+org's own shared tiers — personal memory is never exposed or modified.
 
-When the backend endpoints land, the toggle will become live and the review
-queue will open up. Until then, the card documents the intended behavior and
-marks the blocked pieces so there are no surprises.
+In the org settings **Shared memory** card, the toggle persists through the
+setting above; the review-queue page wiring is the remaining UI step and the
+card says so where it applies.

--- a/docs/platform/organizations/shared-memory.md
+++ b/docs/platform/organizations/shared-memory.md
@@ -1,0 +1,45 @@
+# Shared memory
+
+The AutoGPT copilot can remember useful facts and reuse them in later chats.
+Memory comes in three layers so the right things are remembered at the right
+level.
+
+## The three layers
+
+- **Personal memory** — private to you. Things the copilot learns while helping
+  you, used only in your chats.
+- **Team memory** — shared with a team. Useful facts a team wants the copilot to
+  know (goals, conventions, context) when anyone on the team is working.
+- **Organization memory** — shared with everyone in the organization. Broad,
+  company-wide knowledge.
+
+## How memory is used in a chat
+
+When you're chatting, the copilot pulls from the layers you have access to —
+always your personal memory, plus your organization's and your team's if the
+chat is connected to them. Your personal memory always keeps the largest share
+of the space, and anything drawn from a shared layer is **labeled with where it
+came from** (for example *team memory (Growth)* or *org memory*) so it's clear
+which facts are shared.
+
+You only ever see shared memory from teams you're actually a member of. Leaving
+a team or organization removes your access to its memory.
+
+## Saving to shared memory
+
+- Saving to **personal** memory takes effect right away and stays private.
+- Saving to **team** or **organization** memory may be **held for review**
+  before it's used. When your organization has this review turned on, a save to
+  shared memory from a regular member is set aside instead of being used
+  immediately; saves made by an admin take effect right away.
+
+This lets organizations keep shared memory trustworthy — shared knowledge is
+something the whole team relies on, so it's worth a second look.
+
+> Review is on by default for shared memory. An organization admin can change
+> this in the organization's settings.
+
+## Related
+
+- [Organizations & Teams](organizations-and-teams.md)
+- [Who can see what](who-can-see-what.md)

--- a/docs/platform/organizations/shared-memory.md
+++ b/docs/platform/organizations/shared-memory.md
@@ -35,6 +35,7 @@ active shared memory, and `POST .../reject` retracts it. All three review
 endpoints require org-admin (owner/admin) permission and only ever act on the
 org's own shared tiers — personal memory is never exposed or modified.
 
-In the org settings **Shared memory** card, the toggle persists through the
-setting above; the review-queue page wiring is the remaining UI step and the
-card says so where it applies.
+Both surfaces are live in the org settings UI (General tab → Shared memory):
+admins can flip hold-for-review directly, and the review queue lists each held
+memory with its tier, originating team, and provenance, with per-item approve
+and reject actions.

--- a/docs/platform/organizations/shared-memory.md
+++ b/docs/platform/organizations/shared-memory.md
@@ -1,45 +1,39 @@
 # Shared memory
 
-The AutoGPT copilot can remember useful facts and reuse them in later chats.
-Memory comes in three layers so the right things are remembered at the right
-level.
+Organizations can run agents that build up **shared memory** — facts and context
+your agents learn and reuse across runs. Because shared memory is trusted
+org-wide, admins get a governance surface for it in organization settings.
 
-## The three layers
+## Where to find it
 
-- **Personal memory** — private to you. Things the copilot learns while helping
-  you, used only in your chats.
-- **Team memory** — shared with a team. Useful facts a team wants the copilot to
-  know (goals, conventions, context) when anyone on the team is working.
-- **Organization memory** — shared with everyone in the organization. Broad,
-  company-wide knowledge.
+Open **Settings → Organization → General**. Org admins see a **Shared memory**
+card. (Members without admin rights don't see it, and personal organizations
+don't have it at all.)
 
-## How memory is used in a chat
+## Hold new memories for review
 
-When you're chatting, the copilot pulls from the layers you have access to —
-always your personal memory, plus your organization's and your team's if the
-chat is connected to them. Your personal memory always keeps the largest share
-of the space, and anything drawn from a shared layer is **labeled with where it
-came from** (for example *team memory (Growth)* or *org memory*) so it's clear
-which facts are shared.
+The core control is **Hold new memories for review**. When it's on, new memories
+your agents learn are held as **tentative** until an admin reviews them — so a
+single run can't quietly change what the whole organization treats as true. When
+it's off, memories become usable as soon as they're learned.
 
-You only ever see shared memory from teams you're actually a member of. Leaving
-a team or organization removes your access to its memory.
+Reviewing tentative memories happens in an admin **review queue**: admins see
+what's pending and approve or reject each item.
 
-## Saving to shared memory
+## Current status
 
-- Saving to **personal** memory takes effect right away and stays private.
-- Saving to **team** or **organization** memory may be **held for review**
-  before it's used. When your organization has this review turned on, a save to
-  shared memory from a regular member is set aside instead of being used
-  immediately; saves made by an admin take effect right away.
+The **Shared memory** card ships with the concept and the toggle laid out, but
+the interactive parts are **not yet functional** — they're waiting on backend
+support that hasn't been built:
 
-This lets organizations keep shared memory trustworthy — shared knowledge is
-something the whole team relies on, so it's worth a second look.
+- The **Hold new memories for review** toggle is shown **disabled**. There's no
+  way to persist an org memory setting yet (the organization update endpoint
+  doesn't accept a settings value), so the toggle can't be saved.
+- The **review queue** is flagged as unavailable. The endpoints to list
+  tentative memories for an org or team, and to approve or reject them, don't
+  exist yet. The memory-tiers backend shipped **per-user admin tools**
+  (`/api/admin/memory/*`) and deliberately deferred the org-level review flow.
 
-> Review is on by default for shared memory. An organization admin can change
-> this in the organization's settings.
-
-## Related
-
-- [Organizations & Teams](organizations-and-teams.md)
-- [Who can see what](who-can-see-what.md)
+When the backend endpoints land, the toggle will become live and the review
+queue will open up. Until then, the card documents the intended behavior and
+marks the blocked pieces so there are no surprises.

--- a/docs/platform/organizations/sharing-agents.md
+++ b/docs/platform/organizations/sharing-agents.md
@@ -1,53 +1,77 @@
-# Sharing agents with your team
+# Sharing agents with your teams
 
-You can give a team access to one of your agents without moving it or making a
-copy. This is called **sharing** (a *grant*).
+If you belong to an organization with one or more teams, you can share an agent
+from your library with a whole team instead of sending copies around. The team
+sees the agent, and — depending on how you share it — can run it too.
 
-## Where an agent lives
+Sharing is only available when your organization has teams. If you work solo
+(no teams), you won't see the share option.
 
-When you create an agent inside an organization, you decide where it lives:
+## How to share an agent
 
-- **Org-home** — everyone in the organization can see and run it.
-- **A team** — only that team (and you) can see and run it.
+1. Open your **Library**.
+2. Find the agent you want to share and open its actions menu (the **⋯** button
+   on the agent card, or the same menu on the agent's detail page).
+3. Choose **Share with a team**.
+4. In the dialog, pick:
+   - **Team** — which team to share with.
+   - **Access** — what the team can do (see below).
+   - **Always share latest version** — whether the team follows your edits or
+     stays pinned to today's version (see below).
+   - **Credentials** — whose connected accounts runs use (only shown when you
+     own the agent).
+5. Click **Share**. The team appears in the **Shared with** list at the bottom
+   of the dialog, where you can revoke access at any time.
 
-If an agent is in a team and you want *another* team to use it too, share it.
+To share the same agent with several teams, repeat the steps and pick a
+different team each time.
 
-## What sharing does
+You can share an agent if you own it or if you're an organization admin. If you
+don't have permission, the share is refused and you'll see an error message.
 
-Sharing opens a **specific agent** to a **specific team**. You choose how much
-access they get:
+## Access: view vs. run
 
-- **View** — the team can see the agent.
-- **Run** — the team can run the agent. (Run includes view.)
+- **Can view** — the team can see the agent and its details.
+- **Can run** — the team can run the agent. Running also includes viewing, so
+  "Can run" covers everything "Can view" does.
 
-The agent stays yours — it does not move, and the other team can't edit it just
-because you shared it.
+## Pinned version vs. always-latest
 
-## Version choices
+By default, **Always share latest version is off**, which means the team is
+**pinned to the current version** of the agent. If you keep editing the agent
+afterward, the team keeps using the version you shared — your work in progress
+doesn't reach them until you decide to.
 
-When you share, you can pin the version the team gets:
+Turn **Always share latest version on** to share the **latest** version instead.
+The team then always runs your newest published version, and your edits reach
+them as soon as you make them.
 
-- **Pin to a version** — the team keeps using that exact version even after you
-  publish updates.
-- **Follow the latest** — the team always uses your agent's current published
-  version.
+Pick pinned when you want a stable, known-good version in the team's hands. Pick
+latest when you want the team to always have your most recent changes.
 
-## Who can share and un-share
+## Credentials: whose accounts runs use
 
-- The **agent's owner** can share and un-share it.
-- An **organization admin or owner** can also share or un-share any agent in the
-  organization.
+When you share an agent you own, you choose whose connected accounts (API keys,
+integrations, etc.) a shared run uses:
 
-Re-sharing the same agent with the same team just updates the settings — it
-doesn't create a duplicate.
+- **Run with their credentials** (default) — the team runs the agent with
+  **their own** connected accounts. They'll need the relevant integrations set
+  up on their side.
+- **Run with my credentials** — runs use **your** connected accounts. This is
+  convenient when the team shouldn't need their own keys, but be deliberate:
+  every run the team makes draws on your connected accounts.
 
-## Who receives it
+The credentials choice only appears when you own the agent. If you're sharing as
+an org admin without owning it, runs use the team's own credentials.
 
-Anyone on a team you shared with can see the agents shared to that team. If you
-remove someone from the team, they lose the shared access along with the rest of
-the team's resources.
+## Seeing what's shared with you
 
-## Related
+Agents that other members shared with your teams show up in a **Shared with your
+teams** section at the top of your **Library**. Each entry shows the agent name,
+the team it was shared with, and whether you can view or run it. The section only
+appears when something has actually been shared with one of your teams.
 
-- [Organizations & Teams](organizations-and-teams.md)
-- [Who can see what](who-can-see-what.md)
+## Revoking access
+
+Open the share dialog for an agent again to see the **Shared with** list. Click
+**Revoke** next to any team to remove its access. Revoking is immediate.

--- a/docs/platform/organizations/sharing-agents.md
+++ b/docs/platform/organizations/sharing-agents.md
@@ -1,0 +1,53 @@
+# Sharing agents with your team
+
+You can give a team access to one of your agents without moving it or making a
+copy. This is called **sharing** (a *grant*).
+
+## Where an agent lives
+
+When you create an agent inside an organization, you decide where it lives:
+
+- **Org-home** — everyone in the organization can see and run it.
+- **A team** — only that team (and you) can see and run it.
+
+If an agent is in a team and you want *another* team to use it too, share it.
+
+## What sharing does
+
+Sharing opens a **specific agent** to a **specific team**. You choose how much
+access they get:
+
+- **View** — the team can see the agent.
+- **Run** — the team can run the agent. (Run includes view.)
+
+The agent stays yours — it does not move, and the other team can't edit it just
+because you shared it.
+
+## Version choices
+
+When you share, you can pin the version the team gets:
+
+- **Pin to a version** — the team keeps using that exact version even after you
+  publish updates.
+- **Follow the latest** — the team always uses your agent's current published
+  version.
+
+## Who can share and un-share
+
+- The **agent's owner** can share and un-share it.
+- An **organization admin or owner** can also share or un-share any agent in the
+  organization.
+
+Re-sharing the same agent with the same team just updates the settings — it
+doesn't create a duplicate.
+
+## Who receives it
+
+Anyone on a team you shared with can see the agents shared to that team. If you
+remove someone from the team, they lose the shared access along with the rest of
+the team's resources.
+
+## Related
+
+- [Organizations & Teams](organizations-and-teams.md)
+- [Who can see what](who-can-see-what.md)

--- a/docs/platform/organizations/team-credentials.md
+++ b/docs/platform/organizations/team-credentials.md
@@ -1,0 +1,42 @@
+# Team credentials
+
+Credentials are the connections your agents use to reach other services (for
+example an API key or an authorized account). On the AutoGPT Platform, a
+credential can belong to **you**, to a **team**, or to the whole
+**organization**.
+
+## The three scopes
+
+- **Your credentials** — only you can use them.
+- **Team credentials** — shared with a team, so the team's agents can use a
+  shared connection without everyone bringing their own.
+- **Organization credentials** — available to everyone in the organization.
+
+When you run an agent, the platform offers the credentials available in your
+current space: your own, then your active team's, then the organization's.
+
+## Using vs. managing
+
+There are two different things you can do with a team credential:
+
+- **Use it** — any member of the team can pick a team credential when they set
+  up or run an agent.
+- **Manage it** — only a **team admin** can add a new team credential or remove
+  one.
+
+This keeps day-to-day work easy (members just use the shared connection) while
+keeping control of the connection itself with the team's admins.
+
+## Safety notes
+
+- A team credential can only be managed by admins of **that** team. A team admin
+  can't reach into another team's credentials.
+- Secrets are stored encrypted, and the platform checks your membership before
+  ever handing back a credential — being in the same organization is not enough
+  to read another team's secrets.
+- When a team is deleted, its credentials are removed with it.
+
+## Related
+
+- [Organizations & Teams](organizations-and-teams.md)
+- [Who can see what](who-can-see-what.md)

--- a/docs/platform/organizations/who-can-see-what.md
+++ b/docs/platform/organizations/who-can-see-what.md
@@ -1,0 +1,63 @@
+# Who can see what
+
+A quick reference for how visibility works across an organization. For the exact
+rules the platform enforces, engineers can read the
+[Org Access Model reference](../org-access-model.md).
+
+## Agents
+
+| Where the agent lives | Who can see and run it |
+| --- | --- |
+| **Your personal space** | Only you. |
+| **Org-home** | Everyone in the organization. |
+| **A team** | You and the members of that team. |
+| **Shared with another team** | Also the members of the team you shared it with. |
+
+Sharing lets you give one more team **view** or **run** access without moving
+the agent. See [Sharing agents with your team](sharing-agents.md).
+
+## Credentials
+
+| Credential | Who can use it | Who can manage it |
+| --- | --- | --- |
+| **Yours** | Only you | Only you |
+| **Team** | Members of the team | Team admins |
+| **Organization** | Everyone in the org | Org admins |
+
+## Memory
+
+| Memory layer | Who can read it | Who can save to it |
+| --- | --- | --- |
+| **Personal** | Only you | Only you (used right away) |
+| **Team** | Members of the team | Members of the team (may be held for review) |
+| **Organization** | Everyone in the org | Members of the org (may be held for review) |
+
+See [Shared memory](shared-memory.md).
+
+## Chats
+
+| | Who can see it |
+| --- | --- |
+| **Your chats** | Only you — chats are always private. |
+
+Your chats are counted toward your organization's billing, but no one else in
+the organization can read them.
+
+## Billing
+
+| | Who can access it |
+| --- | --- |
+| **Manage billing** (payment, top-ups, invoices) | Owner and billing managers |
+| **View spend** | Owner, billing managers, and team admins for their team |
+
+## Roles at a glance
+
+| Role | Can create & run agents | Can manage members/teams | Can manage billing |
+| --- | :---: | :---: | :---: |
+| **Member** | ✓ | – | – |
+| **Billing manager** | – | – | ✓ |
+| **Admin** | ✓ | ✓ | – |
+| **Owner** | ✓ | ✓ | ✓ |
+
+See [Organizations & Teams](organizations-and-teams.md) for what each role
+means.


### PR DESCRIPTION
## Why

Nick (2026-07-22): the org/teams interaction model needs to be visualizable — who can access what — technical for the team now, with user-facing docs prepped for agpt.co/docs.

## What

**Technical reference** (new "Org Access Model (Reference)" nav section, 4 pages ≤200 lines each): entities + the role ladder, resource tenancy (org-home vs team rows, visibility union, create-time team picking), grants (pin semantics, capabilities, credential modes — honestly documented as stored-but-not-yet-enforced), credential resolution order, memory tiers with the full governance matrix, chats-are-user-owned, billing gating + attribution. Per-resource "who can access what" tables.

**Visualizations**: 6 mermaid diagrams (entity ER, visibility union, view/execute access chain, credential resolution, memory fan-out, per-turn membership re-verification sequence) + 2 hand-authored **SMIL-animated SVGs** (no JS): agent visibility animating org-home → Team A → granted-to-Team-B, and memory recall assembling provenance-labeled context from the three tiers.

**User-facing drafts** (new "Organizations & Teams" section, plain language): organizations & teams, sharing agents, team credentials, shared memory (incl. held-for-review), who can see what.

Sourced from the actual batch-branch code (grants, scoped credentials, memory tiers, session tenancy), not aspiration; known-deferred items (OWNER enforcement, shared-tier promotion path, seat enforcement) stated as such. All links/anchors validated; SVGs XML-valid; mermaid uses the fence style GitBook already renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jm3mCG9okfdGtAXtFaDF9A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or auth logic modified; main risk is inaccurate or conflicting docs (notably shared-memory review vs. reference “future work”).
> 
> **Overview**
> Adds platform documentation for **organizations and teams**: a new **Organizations & Teams** user section (basics, sharing agents, team credentials, shared memory, visibility tables) and a four-page **Org Access Model (Reference)** tied to enforcement code (`RequestContext`, `visibility_filter`, grants, scoped credentials, memory tiers, chats, billing).
> 
> The reference includes mermaid diagrams (entities, visibility union, access chains, credential resolution, memory fan-out, per-turn chat membership checks) and two SMIL-animated SVGs for agent visibility and tiered memory recall. **`docs/platform/SUMMARY.md`** is updated to link both sections.
> 
> Deferred or partial behavior is called out in the technical pages (e.g. seat enforcement, chat `TEAM`/`ORG` visibility, tentative memory without promotion). The user **Shared memory** page describes a live review queue/API/UI that the reference still marks as not fully implemented—worth aligning in a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9fc432d0c581e8d73a5b9a37c5a3ccfea24bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->