### PR TITLE
fix(infra): honor the batch-deploy bot's !deploy past the preview-dispatcher gate

### DIFF
--- a/.github/workflows/platform-dev-deploy-event-dispatcher.yml
+++ b/.github/workflows/platform-dev-deploy-event-dispatcher.yml
@@ -29,12 +29,18 @@ jobs:
             const commentUser = context.payload.comment.user.login;
             const prAuthor = context.payload.issue.user.login;
             const authorAssociation = context.payload.comment.author_association;
-            
+
+            // Trusted bots comment as their app identity, so author_association is
+            // 'NONE' — allowlist them by login. The batch-deploy bot posts !deploy on
+            // its own isolated rollup previews (a rollup PR it authored).
+            const BOT_ALLOWLIST = ['autogpt-batch-bot[bot]'];
+
             // Check permissions
             const hasPermission = (
               authorAssociation === 'OWNER' ||
               authorAssociation === 'MEMBER' ||
-              authorAssociation === 'COLLABORATOR'
+              authorAssociation === 'COLLABORATOR' ||
+              BOT_ALLOWLIST.includes(commentUser)
             );
             
             core.setOutput('comment_body', commentBody);
@@ -239,8 +245,10 @@ jobs:
             // drive-by !deploy comment (ignored by the comment handler's
             // permission gate) would arm auto-redeploy for the next push.
             const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            // Trusted bots comment as 'NONE'; allowlist by login (see comment handler).
+            const BOT_ALLOWLIST = ['autogpt-batch-bot[bot]'];
             comments.forEach((comment, index) => {
-              if (!allowed.includes(comment.author_association)) return;
+              if (!allowed.includes(comment.author_association) && !BOT_ALLOWLIST.includes(comment.user.login)) return;
               if (comment.body.trim() === '!deploy') {
                 lastDeployIndex = index;
               } else if (comment.body.trim() === '!undeploy') {


### PR DESCRIPTION
### Why / What / How

**Why:** batched previews never deploy. `platform-dev-deploy-event-dispatcher.yml` only honors `!deploy`/`!undeploy` from `OWNER`/`MEMBER`/`COLLABORATOR`. The **batch-deploy bot** (`autogpt-batch-bot[bot]`) comments via its GitHub App installation identity, whose `author_association` is **`NONE`**, so its `!deploy` on the rollup PR is rejected — the whole "deploy the batch once" payoff is blocked.

Live proof on the current `orgs` rollup ([#13651](https://github.com/Significant-Gravitas/AutoGPT/pull/13651)): the bot posted `!deploy` ~14×, every one got "❌ Permission denied", no preview ever ran.

**What:** allowlist trusted bot logins by login in **both** permission checks — the comment handler (gate #1) and the auto-redeploy scan (gate #2).

```js
const BOT_ALLOWLIST = ['autogpt-batch-bot[bot]'];
// gate #1:  … || BOT_ALLOWLIST.includes(commentUser)
// gate #2:  if (!allowed.includes(comment.author_association) && !BOT_ALLOWLIST.includes(comment.user.login)) return;
```

**Why it's safe:** the batch-deploy bot only posts `!deploy` on **rollup PRs it authored**, which target isolated per-PR preview envs (namespace `pr-<n>`, own schema) — exactly the "test the combined batch in one preview" behavior the batch bot is designed for. Human `OWNER`/`MEMBER`/`COLLABORATOR` gating is unchanged.

### ⚠️ Deployment note
This dispatcher runs from the **default branch (`master`)**, so — like the batch bot itself — **it only takes effect once it reaches `master`** (via the normal dev→master release), not on merge to `dev`.

### Testing
YAML validated; `comment.user.login` confirmed present (comments come from `listComments`). Full verification is post-merge-to-master: the bot's `!deploy` on a rollup PR should then deploy instead of "Permission denied". Interim stopgap: a member can `!deploy` the rollup manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands who can trigger dev preview deploy/undeploy (trusted bot login only), but scope is narrow and CI-only; wrong allowlist entry could let a bot arm auto-redeploy.
> 
> **Overview**
> **Fixes batched rollup previews never deploying** because `autogpt-batch-bot[bot]` comments as a GitHub App (`author_association` is `NONE`), so its `!deploy` was rejected by the dev preview dispatcher.
> 
> The workflow now **allowlists trusted bot logins** (`autogpt-batch-bot[bot]`) in **both** places that gate deploy authority: the **issue-comment handler** (initial `!deploy` / `!undeploy`) and the **auto-redeploy comment scan** on `synchronize` (so a bot-issued `!deploy` still arms redeploy on push). Human `OWNER` / `MEMBER` / `COLLABORATOR` rules are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c2a7821d5f62ff0969f9d100486f8a78b74482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->