### PR TITLE
fix(frontend): localize recent chat date groups

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/__tests__/helpers.test.ts
@@ -36,7 +36,9 @@ describe("getDateGroupLabel", () => {
   });
 
   it("formats older same-year dates with the browser locale date order", () => {
-    const date = new Date("2026-06-20T08:00:00");
+    const date = new Date(NOW);
+    date.setDate(date.getDate() - 10);
+    date.setHours(8, 0, 0, 0);
     const label = getDateGroupLabel(date.toISOString());
     expect(label).toBe(
       new Intl.DateTimeFormat(undefined, {
@@ -47,7 +49,9 @@ describe("getDateGroupLabel", () => {
   });
 
   it("includes the year for dates in a previous year using locale order", () => {
-    const date = new Date("2024-12-01T08:00:00");
+    const date = new Date(NOW);
+    date.setFullYear(date.getFullYear() - 2);
+    date.setHours(8, 0, 0, 0);
     const label = getDateGroupLabel(date.toISOString());
     expect(label).toBe(
       new Intl.DateTimeFormat(undefined, {

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/__tests__/helpers.test.ts
@@ -35,28 +35,27 @@ describe("getDateGroupLabel", () => {
     expect(getDateGroupLabel(isoDaysAgo(1))).toBe("Yesterday");
   });
 
-  it("labels an older same-year date with an ordinal day and month", () => {
-    // 2026-06-20 -> "20th June"
-    const label = getDateGroupLabel("2026-06-20T08:00:00");
-    expect(label).toBe("20th June");
+  it("formats older same-year dates with the browser locale date order", () => {
+    const date = new Date("2026-06-20T08:00:00");
+    const label = getDateGroupLabel(date.toISOString());
+    expect(label).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        month: "long",
+        day: "numeric",
+      }).format(date),
+    );
   });
 
-  it("includes the year for dates in a previous year", () => {
-    const label = getDateGroupLabel("2024-12-01T08:00:00");
-    expect(label).toBe("1st December 2024");
-  });
-
-  it("uses 'st', 'nd', 'rd', 'th' ordinal suffixes correctly", () => {
-    expect(getDateGroupLabel("2026-06-01T08:00:00")).toBe("1st June");
-    expect(getDateGroupLabel("2026-06-02T08:00:00")).toBe("2nd June");
-    expect(getDateGroupLabel("2026-06-03T08:00:00")).toBe("3rd June");
-    expect(getDateGroupLabel("2026-06-04T08:00:00")).toBe("4th June");
-  });
-
-  it("uses 'th' for the 11th–13th teen exceptions", () => {
-    expect(getDateGroupLabel("2026-06-11T08:00:00")).toBe("11th June");
-    expect(getDateGroupLabel("2026-06-12T08:00:00")).toBe("12th June");
-    expect(getDateGroupLabel("2026-06-13T08:00:00")).toBe("13th June");
+  it("includes the year for dates in a previous year using locale order", () => {
+    const date = new Date("2024-12-01T08:00:00");
+    const label = getDateGroupLabel(date.toISOString());
+    expect(label).toBe(
+      new Intl.DateTimeFormat(undefined, {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      }).format(date),
+    );
   });
 });
 

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/helpers.ts
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/helpers.ts
@@ -12,27 +12,12 @@ function diffInDays(iso: string): number {
   return Math.round((startOfDay(new Date()) - startOfDay(date)) / dayMs);
 }
 
-function ordinalSuffix(day: number): string {
-  if (day >= 11 && day <= 13) return "th";
-  switch (day % 10) {
-    case 1:
-      return "st";
-    case 2:
-      return "nd";
-    case 3:
-      return "rd";
-    default:
-      return "th";
-  }
-}
-
-// e.g. "26th June" (current year) or "26th June 2024" (older).
 function formatDayLabel(date: Date): string {
-  const day = date.getDate();
-  const month = date.toLocaleDateString(undefined, { month: "long" });
-  const label = `${day}${ordinalSuffix(day)} ${month}`;
   const sameYear = date.getFullYear() === new Date().getFullYear();
-  return sameYear ? label : `${label} ${date.getFullYear()}`;
+  const options: Intl.DateTimeFormatOptions = sameYear
+    ? { month: "long", day: "numeric" }
+    : { month: "long", day: "numeric", year: "numeric" };
+  return new Intl.DateTimeFormat(undefined, options).format(date);
 }
 
 export function getDateGroupLabel(iso: string): string {


### PR DESCRIPTION
## Summary
- Use a single browser locale formatter for recent chat date group labels.
- Remove the hand-built English ordinal suffix path that mixed with localized month names.
- Update helper coverage so same-year and prior-year labels follow `Intl.DateTimeFormat` output.

Fixes #13519

## Testing
- `node_modules\.bin\vitest.cmd run src/components/layout/AppSidebar/components/RecentChats/__tests__/helpers.test.ts --reporter=verbose`
- `node_modules\.bin\prettier.cmd --check src/components/layout/AppSidebar/components/RecentChats/helpers.ts src/components/layout/AppSidebar/components/RecentChats/__tests__/helpers.test.ts`

## Notes
- Full `tsc --noEmit --pretty false` is blocked in this checkout because generated API modules under `src/app/api/__generated__` are absent.
