### PR TITLE
fix(backend): offer saved cards in subscription checkout

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -2590,6 +2590,13 @@ async def create_subscription_checkout(
         automatic_tax={"enabled": True},
         billing_address_collection="auto",
         customer_update={"address": "auto"},
+        # Cards attached by a previous subscription-mode Checkout carry
+        # allow_redisplay=limited; without "limited" in the filters Stripe
+        # hides them and returning subscribers must re-enter card details.
+        saved_payment_method_options={
+            "payment_method_save": "enabled",
+            "allow_redisplay_filters": ["always", "limited"],
+        },
         metadata=datafast,
     )
     if not session.url:

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -904,6 +904,49 @@ async def test_create_subscription_checkout_returns_url():
 
 
 @pytest.mark.asyncio
+async def test_create_subscription_checkout_offers_saved_payment_methods():
+    """Returning subscribers must see their saved cards in Checkout.
+
+    Cards attached by a previous subscription-mode Checkout get
+    ``allow_redisplay=limited``, so the filters must include ``limited`` —
+    the default (``always`` only) would hide every card saved this way and
+    force the user to re-enter card details.
+    """
+    mock_session = MagicMock()
+    mock_session.url = "https://checkout.stripe.com/pay/cs_test_abc123"
+    with (
+        patch(
+            "backend.data.credit.get_subscription_price_id",
+            new_callable=AsyncMock,
+            return_value="price_pro_monthly",
+        ),
+        patch(
+            "backend.data.credit.get_stripe_customer_id",
+            new_callable=AsyncMock,
+            return_value="cus_123",
+        ),
+        patch(
+            "backend.data.credit._expire_open_subscription_sessions",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.data.credit.stripe.checkout.Session.create",
+            return_value=mock_session,
+        ) as mock_create,
+    ):
+        await create_subscription_checkout(
+            user_id="user-1",
+            tier=SubscriptionTier.PRO,
+            success_url="https://app.example.com/success",
+            cancel_url="https://app.example.com/cancel",
+        )
+    assert mock_create.call_args.kwargs["saved_payment_method_options"] == {
+        "payment_method_save": "enabled",
+        "allow_redisplay_filters": ["always", "limited"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_subscription_checkout_no_price_raises():
     with patch(
         "backend.data.credit.get_subscription_price_id",


### PR DESCRIPTION
### Why / What / How

**Why:** When an existing customer goes through the subscription Checkout (upgrade, or re-subscribe after a cancellation), Stripe asks them to type their card details again even though they have saved cards on their Stripe customer. The top-up Checkout already surfaces saved cards; the subscription Checkout does not.

This surfaced in dev on 2026-07-30: a user whose sandbox subscription was auto-canceled by Stripe's 90-day test-data retention policy re-subscribed via Checkout and had to re-enter a card that was still attached to their customer (4 saved cards, all `allow_redisplay: limited`).

**What:** Pass `saved_payment_method_options` in `create_subscription_checkout` so hosted Checkout offers the customer's saved payment methods, and lets them save the new card with explicit consent.

**How:** Cards attached by a previous subscription-mode Checkout get `allow_redisplay: limited` (saved for renewals, no explicit redisplay consent). Stripe's default redisplay filter is `["always"]`, which hides every such card — so the filters must include `limited` for this change to have any effect. `payment_method_save: "enabled"` additionally shows the save-consent checkbox, which marks newly saved cards `always` going forward. Both parameters verified accepted by the Stripe API in subscription mode against the sandbox.

### Changes 🏗️

- `backend/data/credit.py`: `create_subscription_checkout` now passes `saved_payment_method_options={"payment_method_save": "enabled", "allow_redisplay_filters": ["always", "limited"]}` to `stripe.checkout.Session.create`.
- `backend/data/credit_subscription_test.py`: new test `test_create_subscription_checkout_offers_saved_payment_methods` asserting the parameter is passed (TDD: written first as xfail, then fix applied).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New unit test fails without the fix (XFAIL) and passes with it
  - [x] Existing `credit_subscription_test.py` checkout tests pass
  - [x] Verified `saved_payment_method_options` with both params is accepted by Stripe in `mode="subscription"` (sandbox checkout session created + expired)

#### For configuration changes:
- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

Note for `data/*.py` check: no new user-ID handling — the function already resolves the Stripe customer from the authenticated `user_id`; this change only adds a Checkout Session parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D7xcv6SmutzB5PGH7cGsS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Stripe Checkout Session parameter change in billing; no auth or ledger logic changes, covered by a new unit test.
> 
> **Overview**
> **Subscription Checkout now surfaces saved cards** for returning customers (upgrade or re-subscribe), matching the behavior users already get on credit top-up Checkout.
> 
> `create_subscription_checkout` passes **`saved_payment_method_options`** to Stripe: **`payment_method_save: "enabled"`** (save-consent checkbox) and **`allow_redisplay_filters: ["always", "limited"]`**. Cards from prior subscription Checkout are tagged **`allow_redisplay=limited`**, so including **`limited`** is required—Stripe’s default **`always`-only** filter would hide them and force re-entering card details.
> 
> A unit test asserts **`stripe.checkout.Session.create`** receives these kwargs when building subscription checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63d2bfef262722da58f126312e94f9eae4eff650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->