### PR TITLE
fix(backend): born-tenanted executions/library/notifications — stop the startup-migration tenancy sweep leak

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -147,22 +147,11 @@ async def add_graph_to_library(
                 "name": marketplace["name"],
                 "description": marketplace["description"],
                 "imageUrl": marketplace["imageUrl"],
-                # Re-adding under a different active org re-tags the row — and
-                # resets the team alongside it, since a stale team from the
-                # previous org would point across tenants. Untagged callers
-                # (bootstrap failure → organization_id None) leave both as-is.
-                **(
-                    {
-                        "organizationId": organization_id,
-                        "Team": (
-                            {"connect": {"id": team_id}}
-                            if team_id
-                            else {"disconnect": True}
-                        ),
-                    }
-                    if organization_id
-                    else {}
-                ),
+                # Deliberately leave organizationId/Team untouched on re-add:
+                # an existing bookmark already carries its tenancy (stamped at
+                # create, or backfilled by the boot sweep). Only the create
+                # branch born-tenants; re-tagging here risked disconnecting an
+                # existing team when a default team couldn't be resolved.
             },
             include=_include,
         )

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -13,6 +13,7 @@ import prisma.models
 import backend.api.features.library.model as library_model
 import backend.data.graph as graph_db
 from backend.api.features.library.db import _fetch_schedule_info
+from backend.api.features.orgs.db import resolve_default_tenancy
 from backend.data.graph import GraphModel, GraphSettings
 from backend.data.includes import library_agent_include
 from backend.util.exceptions import NotFoundError
@@ -102,8 +103,6 @@ async def add_graph_to_library(
     # resolve_default_tenancy is best-effort — an unresolvable org or a raised
     # lookup yields (None, None) and the row is left untagged; never block a
     # library add on tenancy resolution.
-    from backend.api.features.orgs.db import resolve_default_tenancy
-
     organization_id, team_id = await resolve_default_tenancy(user_id)
 
     try:

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -96,6 +96,15 @@ async def add_graph_to_library(
     )
     marketplace = _marketplace_metadata(store_listing_version)
 
+    # Born-tenanted: mirror create_library_agent — a library entry is the
+    # adding user's bookmark, so tag it with their default org/team instead of
+    # leaving it untenanted for the startup migration sweep to backfill.
+    # get_user_default_team returns (None, None) if bootstrap failed; in that
+    # case leave the row untagged (never block a library add on tenancy).
+    from backend.api.features.orgs.db import get_user_default_team
+
+    organization_id, team_id = await get_user_default_team(user_id)
+
     try:
         added_agent = await prisma.models.LibraryAgent.prisma().create(
             data={
@@ -114,6 +123,8 @@ async def add_graph_to_library(
                 "name": marketplace["name"],
                 "description": marketplace["description"],
                 "imageUrl": marketplace["imageUrl"],
+                **({"organizationId": organization_id} if organization_id else {}),
+                **({"Team": {"connect": {"id": team_id}}} if team_id else {}),
             },
             include=_include,
         )
@@ -135,6 +146,22 @@ async def add_graph_to_library(
                 "name": marketplace["name"],
                 "description": marketplace["description"],
                 "imageUrl": marketplace["imageUrl"],
+                # Re-adding under a different active org re-tags the row — and
+                # resets the team alongside it, since a stale team from the
+                # previous org would point across tenants. Untagged callers
+                # (bootstrap failure → organization_id None) leave both as-is.
+                **(
+                    {
+                        "organizationId": organization_id,
+                        "Team": (
+                            {"connect": {"id": team_id}}
+                            if team_id
+                            else {"disconnect": True}
+                        ),
+                    }
+                    if organization_id
+                    else {}
+                ),
             },
             include=_include,
         )

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -99,11 +99,12 @@ async def add_graph_to_library(
     # Born-tenanted: mirror create_library_agent — a library entry is the
     # adding user's bookmark, so tag it with their default org/team instead of
     # leaving it untenanted for the startup migration sweep to backfill.
-    # get_user_default_team returns (None, None) if bootstrap failed; in that
-    # case leave the row untagged (never block a library add on tenancy).
-    from backend.api.features.orgs.db import get_user_default_team
+    # resolve_default_tenancy is best-effort — an unresolvable org or a raised
+    # lookup yields (None, None) and the row is left untagged; never block a
+    # library add on tenancy resolution.
+    from backend.api.features.orgs.db import resolve_default_tenancy
 
-    organization_id, team_id = await get_user_default_team(user_id)
+    organization_id, team_id = await resolve_default_tenancy(user_id)
 
     try:
         added_agent = await prisma.models.LibraryAgent.prisma().create(

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -97,9 +97,8 @@ async def add_graph_to_library(
     )
     marketplace = _marketplace_metadata(store_listing_version)
 
-    # Born-tenanted: mirror create_library_agent — a library entry is the
-    # adding user's bookmark, so tag it with their default org/team instead of
-    # leaving it untenanted for the startup migration sweep to backfill.
+    # A library entry is the adding user's bookmark, so tag it with their
+    # default org/team at creation (mirrors create_library_agent).
     # resolve_default_tenancy is best-effort — an unresolvable org or a raised
     # lookup yields (None, None) and the row is left untagged; never block a
     # library add on tenancy resolution.
@@ -147,10 +146,9 @@ async def add_graph_to_library(
                 "description": marketplace["description"],
                 "imageUrl": marketplace["imageUrl"],
                 # Deliberately leave organizationId/Team untouched on re-add:
-                # an existing bookmark already carries its tenancy (stamped at
-                # create, or backfilled by the boot sweep). Only the create
-                # branch born-tenants; re-tagging here risked disconnecting an
-                # existing team when a default team couldn't be resolved.
+                # an existing bookmark already carries its tenancy. Only the
+                # create branch tenants; re-tagging here risked disconnecting
+                # an existing team when a default team couldn't be resolved.
             },
             include=_include,
         )

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
@@ -108,6 +108,43 @@ async def test_add_graph_to_library_no_default_team_stays_untenanted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_add_graph_to_library_default_team_lookup_failure_stays_untenanted() -> (
+    None
+):
+    """The default-team lookup is best-effort: if it RAISES, the library add
+    still succeeds (untagged) rather than aborting the bookmark."""
+    graph_model = MagicMock(id="graph-id", version=2, nodes=[])
+    created_agent = MagicMock(name="CreatedLibraryAgent")
+    converted_agent = MagicMock(name="ConvertedLibraryAgent")
+
+    with (
+        patch(
+            "backend.api.features.library._add_to_library.prisma.models.LibraryAgent.prisma"
+        ) as mock_prisma,
+        patch(
+            "backend.api.features.library._add_to_library.library_model.LibraryAgent.from_db",
+            return_value=converted_agent,
+        ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_schedule_info",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "backend.api.features.orgs.db.get_user_default_team",
+            new=AsyncMock(side_effect=RuntimeError("bootstrap unavailable")),
+        ),
+    ):
+        mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
+
+        result = await add_graph_to_library(graph_model, "user-id", _make_slv())
+
+    assert result is converted_agent
+    create_data = mock_prisma.return_value.create.call_args.kwargs["data"]
+    assert "organizationId" not in create_data
+    assert "Team" not in create_data
+
+
+@pytest.mark.asyncio
 async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
     """UniqueViolationError on create falls back to update."""
     graph_model = MagicMock(id="graph-id", version=2, nodes=[])

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
@@ -195,9 +195,11 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
     assert update_data["name"] == "Marketplace Title"
     assert update_data["description"] == "Marketplace description"
     assert update_data["imageUrl"] == "https://cdn.example.com/agent.png"
-    # Re-adding re-tags the restored row with the adder's default org/team
-    assert update_data["organizationId"] == "org-lib"
-    assert update_data["Team"] == {"connect": {"id": "team-lib"}}
+    # Re-add must NOT touch tenancy — the existing row keeps its org/team
+    # (only the create branch born-tenants). Prevents disconnecting an
+    # existing team when no default team resolves.
+    assert "organizationId" not in update_data
+    assert "Team" not in update_data
 
 
 def test_marketplace_metadata_returns_first_image() -> None:

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library_test.py
@@ -25,7 +25,8 @@ def _make_slv(
 
 @pytest.mark.asyncio
 async def test_add_graph_to_library_create_new_agent() -> None:
-    """When no matching LibraryAgent exists, create inserts a new one."""
+    """When no matching LibraryAgent exists, create inserts a new one — born
+    tenanted with the adding user's default org/team."""
     graph_model = MagicMock(id="graph-id", version=2, nodes=[])
     created_agent = MagicMock(name="CreatedLibraryAgent")
     converted_agent = MagicMock(name="ConvertedLibraryAgent")
@@ -41,6 +42,10 @@ async def test_add_graph_to_library_create_new_agent() -> None:
         patch(
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "backend.api.features.orgs.db.get_user_default_team",
+            new=AsyncMock(return_value=("org-lib", "team-lib")),
         ),
     ):
         mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
@@ -62,6 +67,44 @@ async def test_add_graph_to_library_create_new_agent() -> None:
     assert create_data["name"] == "Marketplace Title"
     assert create_data["description"] == "Marketplace description"
     assert create_data["imageUrl"] == "https://cdn.example.com/agent.png"
+    # Born tenanted: stamped with the user's default org/team
+    assert create_data["organizationId"] == "org-lib"
+    assert create_data["Team"] == {"connect": {"id": "team-lib"}}
+
+
+@pytest.mark.asyncio
+async def test_add_graph_to_library_no_default_team_stays_untenanted() -> None:
+    """Bootstrap failure → get_user_default_team returns (None, None) → the
+    library add still succeeds and leaves the row untagged (no crash)."""
+    graph_model = MagicMock(id="graph-id", version=2, nodes=[])
+    created_agent = MagicMock(name="CreatedLibraryAgent")
+    converted_agent = MagicMock(name="ConvertedLibraryAgent")
+
+    with (
+        patch(
+            "backend.api.features.library._add_to_library.prisma.models.LibraryAgent.prisma"
+        ) as mock_prisma,
+        patch(
+            "backend.api.features.library._add_to_library.library_model.LibraryAgent.from_db",
+            return_value=converted_agent,
+        ),
+        patch(
+            "backend.api.features.library._add_to_library._fetch_schedule_info",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "backend.api.features.orgs.db.get_user_default_team",
+            new=AsyncMock(return_value=(None, None)),
+        ),
+    ):
+        mock_prisma.return_value.create = AsyncMock(return_value=created_agent)
+
+        result = await add_graph_to_library(graph_model, "user-id", _make_slv())
+
+    assert result is converted_agent
+    create_data = mock_prisma.return_value.create.call_args.kwargs["data"]
+    assert "organizationId" not in create_data
+    assert "Team" not in create_data
 
 
 @pytest.mark.asyncio
@@ -82,6 +125,10 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
         patch(
             "backend.api.features.library._add_to_library._fetch_schedule_info",
             new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "backend.api.features.orgs.db.get_user_default_team",
+            new=AsyncMock(return_value=("org-lib", "team-lib")),
         ),
     ):
         mock_prisma.return_value.create = AsyncMock(
@@ -111,6 +158,9 @@ async def test_add_graph_to_library_unique_violation_updates_existing() -> None:
     assert update_data["name"] == "Marketplace Title"
     assert update_data["description"] == "Marketplace description"
     assert update_data["imageUrl"] == "https://cdn.example.com/agent.png"
+    # Re-adding re-tags the restored row with the adder's default org/team
+    assert update_data["organizationId"] == "org-lib"
+    assert update_data["Team"] == {"connect": {"id": "team-lib"}}
 
 
 def test_marketplace_metadata_returns_first_image() -> None:

--- a/autogpt_platform/backend/backend/api/features/orgs/db.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/db.py
@@ -174,20 +174,20 @@ async def get_user_default_team(
 
 
 async def resolve_default_tenancy(user_id: str) -> tuple[str | None, str | None]:
-    """Best-effort default org/team for born-tenanting newly created rows.
+    """Best-effort default org/team for tenanting newly created rows.
 
     Wraps ``get_user_default_team`` so tenancy resolution can never abort the
     operation that needs it (an execution, a library add, a notification): a
     raised lookup — or an unresolvable org — yields ``(None, None)`` and the
-    row is left for the startup migration sweep to backfill. Callers stamp the
-    returned pair only when non-null.
+    row is created untenanted. Callers stamp the returned pair only when
+    non-null.
     """
     try:
         return await get_user_default_team(user_id)
     except Exception:
         logger.warning(
             f"Default org/team lookup failed for user {user_id}; "
-            "leaving the row untenanted for the boot sweep to backfill",
+            "creating the row untenanted",
             exc_info=True,
         )
         return None, None

--- a/autogpt_platform/backend/backend/api/features/orgs/db.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/db.py
@@ -173,6 +173,26 @@ async def get_user_default_team(
     return org_id, ws_id
 
 
+async def resolve_default_tenancy(user_id: str) -> tuple[str | None, str | None]:
+    """Best-effort default org/team for born-tenanting newly created rows.
+
+    Wraps ``get_user_default_team`` so tenancy resolution can never abort the
+    operation that needs it (an execution, a library add, a notification): a
+    raised lookup — or an unresolvable org — yields ``(None, None)`` and the
+    row is left for the startup migration sweep to backfill. Callers stamp the
+    returned pair only when non-null.
+    """
+    try:
+        return await get_user_default_team(user_id)
+    except Exception:
+        logger.warning(
+            f"Default org/team lookup failed for user {user_id}; "
+            "leaving the row untenanted for the boot sweep to backfill",
+            exc_info=True,
+        )
+        return None, None
+
+
 async def _create_personal_org_for_user(
     user_id: str,
     slug_base: str,

--- a/autogpt_platform/backend/backend/api/features/orgs/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/routes_test.py
@@ -2941,3 +2941,32 @@ class TestCanonicalPersonalOrgOrdering:
 
         order = prisma.orgmember.find_first.call_args.kwargs["order"]
         assert order == {"createdAt": "asc"}
+
+
+class TestResolveDefaultTenancy:
+    """resolve_default_tenancy is the single best-effort wrapper the
+    born-tenanted create paths (executions, library, notifications) share."""
+
+    @pytest.mark.asyncio
+    async def test_passes_through_resolved_org_team(self, mocker):
+        from backend.api.features.orgs import db as orgs_db
+
+        mocker.patch.object(
+            orgs_db,
+            "get_user_default_team",
+            new=AsyncMock(return_value=("org-x", "team-x")),
+        )
+
+        assert await orgs_db.resolve_default_tenancy("u1") == ("org-x", "team-x")
+
+    @pytest.mark.asyncio
+    async def test_lookup_exception_yields_none_none(self, mocker):
+        from backend.api.features.orgs import db as orgs_db
+
+        mocker.patch.object(
+            orgs_db,
+            "get_user_default_team",
+            new=AsyncMock(side_effect=RuntimeError("bootstrap unavailable")),
+        )
+
+        assert await orgs_db.resolve_default_tenancy("u1") == (None, None)

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -31,7 +31,7 @@ from backend.api.features.library.triggers import (
     setup_triggered_preset,
     update_triggered_preset,
 )
-from backend.api.features.orgs.db import get_user_default_team
+from backend.api.features.orgs.db import get_user_default_team, resolve_default_tenancy
 from backend.api.features.search.embeddings import (
     cleanup_orphaned_embeddings,
     get_embedding_stats,
@@ -441,6 +441,7 @@ class DatabaseManager(AppService):
     # ============ Platform Linking ============ #
     # ============ Orgs ============ #
     get_user_default_team = _(get_user_default_team)
+    resolve_default_tenancy = _(resolve_default_tenancy)
 
     find_server_link_owner = _(platform_linking_db.find_server_link_owner)
     find_user_link_owner = _(platform_linking_db.find_user_link_owner)
@@ -732,6 +733,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     # ============ Platform Linking ============ #
     find_server_link_owner = d.find_server_link_owner
     get_user_default_team = d.get_user_default_team
+    resolve_default_tenancy = d.resolve_default_tenancy
     find_user_link_owner = d.find_user_link_owner
     resolve_server_link = d.resolve_server_link
     resolve_user_link = d.resolve_user_link

--- a/autogpt_platform/backend/backend/data/notifications.py
+++ b/autogpt_platform/backend/backend/data/notifications.py
@@ -466,14 +466,15 @@ async def create_or_add_to_user_notification_batch(
 
         # Born-tenanted: stamp the batch with the user's default org/team so it
         # doesn't land in the untenanted pool the startup migration sweep
-        # backfills on every boot. Callers may pass an explicit tenancy;
-        # otherwise resolve the user's default. get_user_default_team returns
-        # (None, None) on bootstrap failure — leave the batch untenanted rather
-        # than crash a notification.
-        if organization_id is None:
-            from backend.api.features.orgs.db import get_user_default_team
+        # backfills on every boot. Resolve a default only when the caller
+        # supplied NEITHER field (never overwrite an explicit team_id).
+        # resolve_default_tenancy is best-effort — an unresolvable org or a
+        # raised lookup both leave the batch untenanted rather than crash a
+        # notification.
+        if organization_id is None and team_id is None:
+            from backend.api.features.orgs.db import resolve_default_tenancy
 
-            organization_id, team_id = await get_user_default_team(user_id)
+            organization_id, team_id = await resolve_default_tenancy(user_id)
 
         # Prisma's upsert is find→INSERT/UPDATE under the hood, not a true
         # SQL ON CONFLICT, so two concurrent calls on a missing row can both

--- a/autogpt_platform/backend/backend/data/notifications.py
+++ b/autogpt_platform/backend/backend/data/notifications.py
@@ -464,13 +464,11 @@ async def create_or_add_to_user_notification_batch(
 
         json_data: Json = SafeJson(notification_data.data.model_dump())
 
-        # Born-tenanted: stamp the batch with the user's default org/team so it
-        # doesn't land in the untenanted pool the startup migration sweep
-        # backfills on every boot. Resolve a default only when the caller
-        # supplied NEITHER field (never overwrite an explicit team_id).
-        # resolve_default_tenancy is best-effort — an unresolvable org or a
-        # raised lookup both leave the batch untenanted rather than crash a
-        # notification.
+        # Stamp the batch with the user's default org/team at creation.
+        # Resolve a default only when the caller supplied NEITHER field (never
+        # overwrite an explicit team_id). resolve_default_tenancy is
+        # best-effort — an unresolvable org or a raised lookup both leave the
+        # batch untenanted rather than crash a notification.
         if organization_id is None and team_id is None:
             from backend.api.features.orgs.db import resolve_default_tenancy
 

--- a/autogpt_platform/backend/backend/data/notifications.py
+++ b/autogpt_platform/backend/backend/data/notifications.py
@@ -455,12 +455,25 @@ async def create_or_add_to_user_notification_batch(
     user_id: str,
     notification_type: NotificationType,
     notification_data: NotificationEventModel,
+    organization_id: Optional[str] = None,
+    team_id: Optional[str] = None,
 ) -> UserNotificationBatchDTO:
     try:
         if not notification_data.data:
             raise ValueError("Notification data must be provided")
 
         json_data: Json = SafeJson(notification_data.data.model_dump())
+
+        # Born-tenanted: stamp the batch with the user's default org/team so it
+        # doesn't land in the untenanted pool the startup migration sweep
+        # backfills on every boot. Callers may pass an explicit tenancy;
+        # otherwise resolve the user's default. get_user_default_team returns
+        # (None, None) on bootstrap failure — leave the batch untenanted rather
+        # than crash a notification.
+        if organization_id is None:
+            from backend.api.features.orgs.db import get_user_default_team
+
+            organization_id, team_id = await get_user_default_team(user_id)
 
         # Prisma's upsert is find→INSERT/UPDATE under the hood, not a true
         # SQL ON CONFLICT, so two concurrent calls on a missing row can both
@@ -483,6 +496,12 @@ async def create_or_add_to_user_notification_batch(
                         "create": UserNotificationBatchCreateInput(
                             userId=user_id,
                             type=notification_type,
+                            **(
+                                {"organizationId": organization_id}
+                                if organization_id
+                                else {}
+                            ),
+                            **({"teamId": team_id} if team_id else {}),
                             Notifications={
                                 "create": [
                                     NotificationEventCreateInput(

--- a/autogpt_platform/backend/backend/data/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/notifications_test.py
@@ -468,8 +468,8 @@ async def test_get_all_batches_does_not_eager_load_events(server: SpinTestServer
 @pytest.mark.asyncio
 async def test_create_batch_born_tenanted_stamps_default_team(mocker):
     """The create branch of the upsert stamps the batch with the user's default
-    org/team so a new batch isn't left in the untenanted pool that the startup
-    migration sweep backfills on every boot. Mocked at the Prisma boundary."""
+    org/team at creation; the update branch must not, so re-batching never
+    overwrites an existing batch's tenant. Mocked at the Prisma boundary."""
     mock_upsert = AsyncMock(return_value=object())
     mocker.patch(
         "backend.data.notifications.UserNotificationBatch.prisma"
@@ -495,6 +495,11 @@ async def test_create_batch_born_tenanted_stamps_default_team(mocker):
     create_input = mock_upsert.call_args.kwargs["data"]["create"]
     assert create_input["organizationId"] == "org-notif"
     assert create_input["teamId"] == "team-notif"
+    # Re-batch (update) must leave tenancy alone — an existing batch keeps its
+    # tenant; only the create branch tenants.
+    update_input = mock_upsert.call_args.kwargs["data"]["update"]
+    assert "organizationId" not in update_input
+    assert "teamId" not in update_input
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/notifications_test.py
@@ -462,3 +462,71 @@ async def test_get_all_batches_does_not_eager_load_events(server: SpinTestServer
         assert mine[0].notifications == []
     finally:
         await _cleanup_test_user(user_id)
+
+
+@pytest.mark.asyncio
+async def test_create_batch_born_tenanted_stamps_default_team(mocker):
+    """The create branch of the upsert stamps the batch with the user's default
+    org/team so a new batch isn't left in the untenanted pool that the startup
+    migration sweep backfills on every boot. Mocked at the Prisma boundary."""
+    from unittest.mock import AsyncMock
+
+    mock_upsert = AsyncMock(return_value=object())
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatch.prisma"
+    ).return_value.upsert = mock_upsert
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatchDTO.from_db",
+        return_value="dto-sentinel",
+    )
+    mock_get_default_team = mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=AsyncMock(return_value=("org-notif", "team-notif")),
+    )
+
+    user_id = "notif-tenancy-user"
+    result = await create_or_add_to_user_notification_batch(
+        user_id=user_id,
+        notification_type=NotificationType.AGENT_RUN,
+        notification_data=_make_agent_run_event(user_id),
+    )
+
+    assert result == "dto-sentinel"
+    mock_get_default_team.assert_awaited_once_with(user_id)
+    create_input = mock_upsert.call_args.kwargs["data"]["create"]
+    assert create_input["organizationId"] == "org-notif"
+    assert create_input["teamId"] == "team-notif"
+
+
+@pytest.mark.asyncio
+async def test_create_batch_explicit_tenancy_not_overridden(mocker):
+    """An explicit org/team passed by a caller is used as-is; the default-team
+    resolver is not consulted."""
+    from unittest.mock import AsyncMock
+
+    mock_upsert = AsyncMock(return_value=object())
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatch.prisma"
+    ).return_value.upsert = mock_upsert
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatchDTO.from_db",
+        return_value="dto-sentinel",
+    )
+    mock_get_default_team = mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=AsyncMock(return_value=("fallback-org", "fallback-team")),
+    )
+
+    user_id = "notif-explicit-user"
+    await create_or_add_to_user_notification_batch(
+        user_id=user_id,
+        notification_type=NotificationType.AGENT_RUN,
+        notification_data=_make_agent_run_event(user_id),
+        organization_id="explicit-org",
+        team_id="explicit-team",
+    )
+
+    mock_get_default_team.assert_not_called()
+    create_input = mock_upsert.call_args.kwargs["data"]["create"]
+    assert create_input["organizationId"] == "explicit-org"
+    assert create_input["teamId"] == "explicit-team"

--- a/autogpt_platform/backend/backend/data/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/notifications_test.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -469,8 +470,6 @@ async def test_create_batch_born_tenanted_stamps_default_team(mocker):
     """The create branch of the upsert stamps the batch with the user's default
     org/team so a new batch isn't left in the untenanted pool that the startup
     migration sweep backfills on every boot. Mocked at the Prisma boundary."""
-    from unittest.mock import AsyncMock
-
     mock_upsert = AsyncMock(return_value=object())
     mocker.patch(
         "backend.data.notifications.UserNotificationBatch.prisma"
@@ -502,8 +501,6 @@ async def test_create_batch_born_tenanted_stamps_default_team(mocker):
 async def test_create_batch_explicit_tenancy_not_overridden(mocker):
     """An explicit org/team passed by a caller is used as-is; the default-team
     resolver is not consulted."""
-    from unittest.mock import AsyncMock
-
     mock_upsert = AsyncMock(return_value=object())
     mocker.patch(
         "backend.data.notifications.UserNotificationBatch.prisma"
@@ -536,8 +533,6 @@ async def test_create_batch_explicit_tenancy_not_overridden(mocker):
 async def test_create_batch_default_team_lookup_failure_stays_untenanted(mocker):
     """The default-team lookup is best-effort: if it RAISES, the batch is still
     created (untenanted) rather than crashing the notification."""
-    from unittest.mock import AsyncMock
-
     mock_upsert = AsyncMock(return_value=object())
     mocker.patch(
         "backend.data.notifications.UserNotificationBatch.prisma"
@@ -569,8 +564,6 @@ async def test_create_batch_explicit_team_id_preserved_when_org_absent(mocker):
     """An explicit team_id with no org must NOT be clobbered by the default-
     team lookup — the guard only fires when BOTH fields are unset (mirrors the
     executor-path guard)."""
-    from unittest.mock import AsyncMock
-
     mock_upsert = AsyncMock(return_value=object())
     mocker.patch(
         "backend.data.notifications.UserNotificationBatch.prisma"

--- a/autogpt_platform/backend/backend/data/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/notifications_test.py
@@ -530,3 +530,35 @@ async def test_create_batch_explicit_tenancy_not_overridden(mocker):
     create_input = mock_upsert.call_args.kwargs["data"]["create"]
     assert create_input["organizationId"] == "explicit-org"
     assert create_input["teamId"] == "explicit-team"
+
+
+@pytest.mark.asyncio
+async def test_create_batch_default_team_lookup_failure_stays_untenanted(mocker):
+    """The default-team lookup is best-effort: if it RAISES, the batch is still
+    created (untenanted) rather than crashing the notification."""
+    from unittest.mock import AsyncMock
+
+    mock_upsert = AsyncMock(return_value=object())
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatch.prisma"
+    ).return_value.upsert = mock_upsert
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatchDTO.from_db",
+        return_value="dto-sentinel",
+    )
+    mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=AsyncMock(side_effect=RuntimeError("bootstrap unavailable")),
+    )
+
+    user_id = "notif-lookup-fail-user"
+    result = await create_or_add_to_user_notification_batch(
+        user_id=user_id,
+        notification_type=NotificationType.AGENT_RUN,
+        notification_data=_make_agent_run_event(user_id),
+    )
+
+    assert result == "dto-sentinel"
+    create_input = mock_upsert.call_args.kwargs["data"]["create"]
+    assert create_input.get("organizationId") is None
+    assert create_input.get("teamId") is None

--- a/autogpt_platform/backend/backend/data/notifications_test.py
+++ b/autogpt_platform/backend/backend/data/notifications_test.py
@@ -562,3 +562,37 @@ async def test_create_batch_default_team_lookup_failure_stays_untenanted(mocker)
     create_input = mock_upsert.call_args.kwargs["data"]["create"]
     assert create_input.get("organizationId") is None
     assert create_input.get("teamId") is None
+
+
+@pytest.mark.asyncio
+async def test_create_batch_explicit_team_id_preserved_when_org_absent(mocker):
+    """An explicit team_id with no org must NOT be clobbered by the default-
+    team lookup — the guard only fires when BOTH fields are unset (mirrors the
+    executor-path guard)."""
+    from unittest.mock import AsyncMock
+
+    mock_upsert = AsyncMock(return_value=object())
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatch.prisma"
+    ).return_value.upsert = mock_upsert
+    mocker.patch(
+        "backend.data.notifications.UserNotificationBatchDTO.from_db",
+        return_value="dto-sentinel",
+    )
+    mock_get_default_team = mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=AsyncMock(return_value=("fallback-org", "fallback-team")),
+    )
+
+    user_id = "notif-team-only-user"
+    await create_or_add_to_user_notification_batch(
+        user_id=user_id,
+        notification_type=NotificationType.AGENT_RUN,
+        notification_data=_make_agent_run_event(user_id),
+        team_id="explicit-team",
+    )
+
+    mock_get_default_team.assert_not_called()
+    create_input = mock_upsert.call_args.kwargs["data"]["create"]
+    assert create_input["teamId"] == "explicit-team"
+    assert create_input.get("organizationId") is None

--- a/autogpt_platform/backend/backend/executor/conftest.py
+++ b/autogpt_platform/backend/backend/executor/conftest.py
@@ -27,3 +27,23 @@ def _bypass_paywall(mocker):
         "backend.executor.utils.is_user_paywalled",
         new=mocker.AsyncMock(return_value=False),
     )
+
+
+@pytest.fixture(autouse=True)
+def _default_team_untenanted(mocker):
+    """Default the born-tenanted fallback to a no-op for executor tests.
+
+    ``add_graph_execution`` now resolves the user's default org/team via
+    ``get_user_default_team`` when no organization_id is passed on the create
+    path. Executor tests use synthetic user_ids with no personal org, so let
+    the resolver return ``(None, None)`` by default — the row stays untenanted,
+    matching the pre-fallback behavior every existing test asserts. Tests that
+    exercise the fallback override this patch with an explicit org/team.
+
+    Patched at the source module because ``add_graph_execution`` does a
+    call-time ``from backend.api.features.orgs.db import get_user_default_team``.
+    """
+    mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=mocker.AsyncMock(return_value=(None, None)),
+    )

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1297,19 +1297,17 @@ async def add_graph_execution(
         # the execution_context backfill below), so we must not re-resolve and
         # risk re-tenanting an existing row under a different org.
         #
-        # If bootstrap hasn't provisioned the user's personal org yet,
-        # get_user_default_team returns (None, None); leave the row untenanted
-        # and let the boot sweep catch it — never crash a run over tenancy.
-        if not organization_id:
-            from backend.api.features.orgs.db import get_user_default_team
+        # Only resolve a default when NEITHER field was supplied — never
+        # overwrite an explicitly-passed team_id. resolve_default_tenancy is
+        # best-effort: an unresolvable org or a raised lookup yields
+        # (None, None) and the row is left for the boot sweep to backfill —
+        # never crash a run over tenancy.
+        if not organization_id and not team_id:
+            from backend.api.features.orgs.db import resolve_default_tenancy
 
-            default_org_id, default_team_id = await get_user_default_team(user_id)
+            default_org_id, default_team_id = await resolve_default_tenancy(user_id)
             if default_org_id:
                 organization_id, team_id = default_org_id, default_team_id
-                logger.info(
-                    "born-tenanted fallback: resolved default org/team "
-                    f"for user {user_id}"
-                )
 
         graph_exec = await edb.create_graph_execution(
             user_id=user_id,

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1305,7 +1305,17 @@ async def add_graph_execution(
         if not organization_id and not team_id:
             from backend.api.features.orgs.db import resolve_default_tenancy
 
-            default_org_id, default_team_id = await resolve_default_tenancy(user_id)
+            # add_graph_execution runs in both the API server (direct prisma)
+            # and the scheduler/executor (no prisma — DB access via the RPC
+            # client). Dispatch the resolver the same way every other DB dep in
+            # this function does, or the fallback silently no-ops in the very
+            # process that runs the leaky scheduled executions.
+            resolve = (
+                resolve_default_tenancy
+                if prisma.is_connected()
+                else get_database_manager_async_client().resolve_default_tenancy
+            )
+            default_org_id, default_team_id = await resolve(user_id)
             if default_org_id:
                 organization_id, team_id = default_org_id, default_team_id
 

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1282,34 +1282,30 @@ async def add_graph_execution(
             dry_run=dry_run,
         )
 
-        # Born-tenanted fallback: a NEW execution must carry org/team so it
-        # doesn't leak into the untenanted pool that the startup org-migration
-        # sweep has to backfill on every boot. Legacy schedules (empty
-        # organizationId → falsy), sub-graphs inheriting an untenanted parent
-        # (organization_id here comes from the parent's ExecutionContext, see
-        # AgentExecutorBlock), and any caller that omits tenancy all arrive
-        # with a falsy organization_id. Resolve the user's default org/team up
-        # front so the value handed to create_graph_execution is already
-        # non-null and the ExecutionContext built below inherits it.
+        # Tenant a NEW execution at creation: several callers arrive with a
+        # falsy organization_id — legacy schedules (empty organizationId),
+        # sub-graphs inheriting an untenanted parent's ExecutionContext (see
+        # AgentExecutorBlock), or any caller that omits tenancy. Resolve the
+        # user's default org/team so create_graph_execution gets a non-null
+        # value and the ExecutionContext built below inherits it.
         #
-        # CREATE path only — resume/requeue never reaches here; it backfills
-        # org/team from the persisted row (the graph_exec_id branch above and
-        # the execution_context backfill below), so we must not re-resolve and
-        # risk re-tenanting an existing row under a different org.
+        # CREATE path only — resume/requeue backfills org/team from the
+        # persisted row (the graph_exec_id branch above and the
+        # execution_context backfill below), so re-resolving here would risk
+        # re-tenanting an existing row under a different org.
         #
-        # Only resolve a default when NEITHER field was supplied — never
-        # overwrite an explicitly-passed team_id. resolve_default_tenancy is
-        # best-effort: an unresolvable org or a raised lookup yields
-        # (None, None) and the row is left for the boot sweep to backfill —
-        # never crash a run over tenancy.
+        # Only resolve when NEITHER field was supplied — never overwrite an
+        # explicit team_id. resolve_default_tenancy is best-effort: an
+        # unresolvable org or a raised lookup yields (None, None) and the row
+        # is created untenanted rather than crashing the run.
         if not organization_id and not team_id:
             from backend.api.features.orgs.db import resolve_default_tenancy
 
             # add_graph_execution runs in both the API server (direct prisma)
             # and the scheduler/executor (no prisma — DB access via the RPC
             # client). Dispatch the resolver the same way every other DB dep in
-            # this function does, or the fallback silently no-ops in the very
-            # process that runs the leaky scheduled executions.
+            # this function does, or it silently no-ops in the scheduler
+            # process — exactly where scheduled executions are created.
             resolve = (
                 resolve_default_tenancy
                 if prisma.is_connected()

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1282,6 +1282,35 @@ async def add_graph_execution(
             dry_run=dry_run,
         )
 
+        # Born-tenanted fallback: a NEW execution must carry org/team so it
+        # doesn't leak into the untenanted pool that the startup org-migration
+        # sweep has to backfill on every boot. Legacy schedules (empty
+        # organizationId → falsy), sub-graphs inheriting an untenanted parent
+        # (organization_id here comes from the parent's ExecutionContext, see
+        # AgentExecutorBlock), and any caller that omits tenancy all arrive
+        # with a falsy organization_id. Resolve the user's default org/team up
+        # front so the value handed to create_graph_execution is already
+        # non-null and the ExecutionContext built below inherits it.
+        #
+        # CREATE path only — resume/requeue never reaches here; it backfills
+        # org/team from the persisted row (the graph_exec_id branch above and
+        # the execution_context backfill below), so we must not re-resolve and
+        # risk re-tenanting an existing row under a different org.
+        #
+        # If bootstrap hasn't provisioned the user's personal org yet,
+        # get_user_default_team returns (None, None); leave the row untenanted
+        # and let the boot sweep catch it — never crash a run over tenancy.
+        if not organization_id:
+            from backend.api.features.orgs.db import get_user_default_team
+
+            default_org_id, default_team_id = await get_user_default_team(user_id)
+            if default_org_id:
+                organization_id, team_id = default_org_id, default_team_id
+                logger.info(
+                    "born-tenanted fallback: resolved default org/team "
+                    f"for user {user_id}"
+                )
+
         graph_exec = await edb.create_graph_execution(
             user_id=user_id,
             graph_id=graph_id,

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -569,6 +569,7 @@ async def test_add_graph_execution_via_rpc_returns_typed_user(
         return_value=mock_workspace
     )
     mock_db_client.increment_onboarding_runs = mocker.AsyncMock()
+    mock_db_client.resolve_default_tenancy = mocker.AsyncMock(return_value=(None, None))
 
     mocker.patch(
         "backend.executor.utils.get_database_manager_async_client",
@@ -588,6 +589,85 @@ async def test_add_graph_execution_via_rpc_returns_typed_user(
         user_id=user_id,
     )
     assert result == mock_graph_exec
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_born_tenanted_via_rpc_when_prisma_disconnected(
+    mocker: MockerFixture,
+):
+    """In the scheduler/executor process (no direct prisma), the born-tenanted
+    fallback must resolve tenancy through the DB-manager RPC client — NOT the
+    direct prisma client, which would fail there and silently no-op, leaving
+    scheduled executions (the primary leak source) untenanted."""
+    mock_graph = mocker.MagicMock()
+    mock_graph.version = 1
+
+    mock_graph_exec = mocker.MagicMock(spec=GraphExecutionWithNodes)
+    mock_graph_exec.organization_id = "org-rpc"
+    mock_graph_exec.team_id = "team-rpc"
+    mock_graph_exec.id = "exec-id-rpc"
+    mock_graph_exec.node_executions = []
+    mock_graph_exec.status = ExecutionStatus.QUEUED
+    mock_graph_exec.graph_version = 1
+    mock_graph_exec.to_graph_execution_entry.return_value = mocker.MagicMock()
+
+    mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input",
+        return_value=(mock_graph, [], {}, set()),
+    )
+    mocker.patch("backend.executor.utils.prisma").is_connected.return_value = False
+
+    mock_user = User(
+        id="sched-user",
+        email="sched@example.com",
+        name=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        stripe_customer_id=None,
+        top_up_config=None,
+        timezone="UTC",
+    )
+    mock_db_client = mocker.MagicMock()
+    mock_db_client.get_user_by_id = mocker.AsyncMock(return_value=mock_user)
+    mock_db_client.get_graph_settings = mocker.AsyncMock(
+        return_value=mocker.MagicMock(
+            human_in_the_loop_safe_mode=False, sensitive_action_safe_mode=False
+        )
+    )
+    mock_db_client.create_graph_execution = mocker.AsyncMock(
+        return_value=mock_graph_exec
+    )
+    mock_db_client.update_graph_execution_stats = mocker.AsyncMock(
+        return_value=mock_graph_exec
+    )
+    mock_db_client.update_node_execution_status_batch = mocker.AsyncMock()
+    mock_db_client.get_or_create_workspace = mocker.AsyncMock(
+        return_value=mocker.MagicMock(id="ws-id")
+    )
+    mock_db_client.increment_onboarding_runs = mocker.AsyncMock()
+    # The RPC resolver (runs in the DB-manager process, which HAS prisma).
+    mock_rpc_resolve = mocker.AsyncMock(return_value=("org-rpc", "team-rpc"))
+    mock_db_client.resolve_default_tenancy = mock_rpc_resolve
+
+    mocker.patch(
+        "backend.executor.utils.get_database_manager_async_client",
+        return_value=mock_db_client,
+    )
+    mocker.patch(
+        "backend.executor.utils.get_async_execution_queue",
+        return_value=mocker.AsyncMock(),
+    )
+    mocker.patch(
+        "backend.executor.utils.get_async_execution_event_bus",
+        return_value=mocker.MagicMock(publish=mocker.AsyncMock()),
+    )
+
+    await add_graph_execution(graph_id="g", user_id="sched-user")
+
+    mock_rpc_resolve.assert_awaited_once_with("sched-user")
+    create_kwargs = mock_db_client.create_graph_execution.call_args.kwargs
+    assert create_kwargs["organization_id"] == "org-rpc"
+    assert create_kwargs["team_id"] == "team-rpc"
 
 
 # ============================================================================

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -945,6 +945,13 @@ async def test_add_graph_execution_resume_backfills_org_from_row(mocker: MockerF
     mock_get_queue.return_value = mocker.AsyncMock()
     mock_get_event_bus.return_value = mocker.MagicMock(publish=mocker.AsyncMock())
 
+    # Resume must backfill tenancy from the row, never re-resolve a default —
+    # re-resolving could re-tenant an existing row under a different org.
+    mock_get_default_team = mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=mocker.AsyncMock(return_value=(None, None)),
+    )
+
     # Caller-supplied context with NO org/team (the bug condition).
     resume_ctx = ExecutionContext(user_id="test-user-id", workspace_id="ws-1")
     assert resume_ctx.organization_id is None
@@ -958,6 +965,8 @@ async def test_add_graph_execution_resume_backfills_org_from_row(mocker: MockerF
 
     assert captured_kwargs["execution_context"].organization_id == "org-row"
     assert captured_kwargs["execution_context"].team_id == "team-row"
+    # The "CREATE path only" invariant: resume never consults the resolver.
+    mock_get_default_team.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1956,9 +1965,8 @@ async def test_add_graph_execution_bypass_paywall_skips_check(
 
 
 # ============================================================================
-# Born-tenanted fallback: a NEW execution created without an explicit org must
-# be stamped with the user's default org/team so it never lands in the
-# untenanted pool that the startup org-migration sweep backfills every boot.
+# Born-tenanted fallback: a NEW execution created without an explicit org is
+# tenanted at creation with the user's default org/team.
 # ============================================================================
 
 
@@ -2040,8 +2048,8 @@ def _mock_add_graph_execution_create_path(
 async def test_add_graph_execution_born_tenanted_resolves_default_team(
     mocker: MockerFixture,
 ):
-    """CREATE path with no org → the row is born tenanted with the user's
-    default org/team (closes the startup-sweep leak)."""
+    """CREATE path with no org → the row is tenanted at creation with the
+    user's default org/team."""
     mock_edb, mock_get_default_team = _mock_add_graph_execution_create_path(
         mocker, org_id="org-x", team_id="team-x"
     )
@@ -2059,7 +2067,7 @@ async def test_add_graph_execution_no_default_team_stays_untenanted(
     mocker: MockerFixture,
 ):
     """CREATE path when bootstrap hasn't provisioned an org → (None, None)
-    resolves, no crash, row stays untenanted for the boot sweep to backfill."""
+    resolves, no crash, row stays untenanted."""
     mock_edb, _ = _mock_add_graph_execution_create_path(
         mocker, org_id=None, team_id=None
     )

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -2016,6 +2016,51 @@ async def test_add_graph_execution_explicit_org_not_overridden(
 
 
 @pytest.mark.asyncio
+async def test_add_graph_execution_explicit_team_id_preserved_when_org_absent(
+    mocker: MockerFixture,
+):
+    """An explicit team_id with no org must NOT be clobbered by the default-
+    team lookup — the fallback only fires when BOTH fields are unset."""
+    mock_edb, mock_get_default_team = _mock_add_graph_execution_create_path(
+        mocker, org_id="fallback-org", team_id="fallback-team"
+    )
+
+    await add_graph_execution(
+        graph_id="g",
+        user_id="user-1",
+        organization_id=None,
+        team_id="explicit-team",
+    )
+
+    mock_get_default_team.assert_not_called()
+    create_kwargs = mock_edb.create_graph_execution.call_args.kwargs
+    assert create_kwargs["team_id"] == "explicit-team"
+    assert create_kwargs["organization_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_default_team_lookup_failure_stays_untenanted(
+    mocker: MockerFixture,
+):
+    """The default-team lookup is best-effort: if it RAISES, the run is still
+    created (untenanted) rather than aborted."""
+    mock_edb, _ = _mock_add_graph_execution_create_path(
+        mocker, org_id=None, team_id=None
+    )
+    mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=mocker.AsyncMock(side_effect=RuntimeError("bootstrap unavailable")),
+    )
+
+    result = await add_graph_execution(graph_id="g", user_id="user-1")
+
+    assert result is not None
+    create_kwargs = mock_edb.create_graph_execution.call_args.kwargs
+    assert create_kwargs["organization_id"] is None
+    assert create_kwargs["team_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_add_graph_execution_subgraph_untenanted_parent_triggers_fallback(
     mocker: MockerFixture,
 ):

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -1873,3 +1873,181 @@ async def test_add_graph_execution_bypass_paywall_skips_check(
         )
 
     paywall_mock.assert_not_called()
+
+
+# ============================================================================
+# Born-tenanted fallback: a NEW execution created without an explicit org must
+# be stamped with the user's default org/team so it never lands in the
+# untenanted pool that the startup org-migration sweep backfills every boot.
+# ============================================================================
+
+
+def _mock_add_graph_execution_create_path(
+    mocker: MockerFixture,
+    *,
+    org_id: object = None,
+    team_id: object = None,
+):
+    """Wire up the mocks ``add_graph_execution`` needs on the CREATE path.
+
+    Returns ``(mock_edb, mock_get_default_team)``. ``get_user_default_team`` is
+    patched at its source module (``backend.api.features.orgs.db``) because
+    ``add_graph_execution`` does a call-time local import of it; it resolves to
+    ``(org_id, team_id)``.
+    """
+    from backend.data.execution import GraphExecutionWithNodes
+
+    mock_graph = mocker.MagicMock()
+    mock_graph.version = 1
+
+    mock_graph_exec = mocker.MagicMock(spec=GraphExecutionWithNodes)
+    mock_graph_exec.organization_id = org_id
+    mock_graph_exec.team_id = team_id
+    mock_graph_exec.id = "exec-id"
+    mock_graph_exec.node_executions = []
+    mock_graph_exec.status = ExecutionStatus.QUEUED
+    mock_graph_exec.graph_version = 1
+    mock_graph_exec.to_graph_execution_entry.return_value = mocker.MagicMock()
+
+    mock_validate = mocker.patch(
+        "backend.executor.utils.validate_and_construct_node_execution_input"
+    )
+    mock_validate.return_value = (mock_graph, [("node1", {"input1": "v"})], {}, set())
+
+    mock_edb = mocker.patch("backend.executor.utils.execution_db")
+    mock_edb.create_graph_execution = mocker.AsyncMock(return_value=mock_graph_exec)
+    mock_edb.update_graph_execution_stats = mocker.AsyncMock(
+        return_value=mock_graph_exec
+    )
+    mock_edb.update_node_execution_status_batch = mocker.AsyncMock()
+
+    mocker.patch("backend.executor.utils.prisma").is_connected.return_value = True
+
+    mock_user = mocker.MagicMock()
+    mock_user.timezone = "UTC"
+    mock_udb = mocker.patch("backend.executor.utils.user_db")
+    mock_udb.get_user_by_id = mocker.AsyncMock(return_value=mock_user)
+
+    mock_settings = mocker.MagicMock()
+    mock_settings.human_in_the_loop_safe_mode = True
+    mock_settings.sensitive_action_safe_mode = False
+    mock_gdb = mocker.patch("backend.executor.utils.graph_db")
+    mock_gdb.get_graph_settings = mocker.AsyncMock(return_value=mock_settings)
+
+    mock_workspace = mocker.MagicMock()
+    mock_workspace.id = "ws-id"
+    mock_wdb = mocker.patch("backend.executor.utils.workspace_db")
+    mock_wdb.get_or_create_workspace = mocker.AsyncMock(return_value=mock_workspace)
+
+    mocker.patch("backend.executor.utils.get_async_execution_queue").return_value = (
+        mocker.AsyncMock()
+    )
+    mock_event_bus = mocker.MagicMock()
+    mock_event_bus.publish = mocker.AsyncMock()
+    mocker.patch(
+        "backend.executor.utils.get_async_execution_event_bus"
+    ).return_value = mock_event_bus
+
+    # Overrides the autouse (None, None) default from executor/conftest.py.
+    mock_get_default_team = mocker.patch(
+        "backend.api.features.orgs.db.get_user_default_team",
+        new=mocker.AsyncMock(return_value=(org_id, team_id)),
+    )
+    return mock_edb, mock_get_default_team
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_born_tenanted_resolves_default_team(
+    mocker: MockerFixture,
+):
+    """CREATE path with no org → the row is born tenanted with the user's
+    default org/team (closes the startup-sweep leak)."""
+    mock_edb, mock_get_default_team = _mock_add_graph_execution_create_path(
+        mocker, org_id="org-x", team_id="team-x"
+    )
+
+    await add_graph_execution(graph_id="g", user_id="user-1")
+
+    mock_get_default_team.assert_awaited_once_with("user-1")
+    create_kwargs = mock_edb.create_graph_execution.call_args.kwargs
+    assert create_kwargs["organization_id"] == "org-x"
+    assert create_kwargs["team_id"] == "team-x"
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_no_default_team_stays_untenanted(
+    mocker: MockerFixture,
+):
+    """CREATE path when bootstrap hasn't provisioned an org → (None, None)
+    resolves, no crash, row stays untenanted for the boot sweep to backfill."""
+    mock_edb, _ = _mock_add_graph_execution_create_path(
+        mocker, org_id=None, team_id=None
+    )
+
+    result = await add_graph_execution(graph_id="g", user_id="user-1")
+
+    assert result is not None
+    create_kwargs = mock_edb.create_graph_execution.call_args.kwargs
+    assert create_kwargs["organization_id"] is None
+    assert create_kwargs["team_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_explicit_org_not_overridden(
+    mocker: MockerFixture,
+):
+    """CREATE path with an explicit org → the fallback does NOT fire; the
+    caller's org/team are passed through untouched."""
+    mock_edb, mock_get_default_team = _mock_add_graph_execution_create_path(
+        mocker, org_id="fallback-org", team_id="fallback-team"
+    )
+
+    await add_graph_execution(
+        graph_id="g",
+        user_id="user-1",
+        organization_id="explicit-org",
+        team_id="explicit-team",
+    )
+
+    mock_get_default_team.assert_not_called()
+    create_kwargs = mock_edb.create_graph_execution.call_args.kwargs
+    assert create_kwargs["organization_id"] == "explicit-org"
+    assert create_kwargs["team_id"] == "explicit-team"
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_subgraph_untenanted_parent_triggers_fallback(
+    mocker: MockerFixture,
+):
+    """A sub-graph inheriting an untenanted parent arrives with
+    organization_id=None (AgentExecutorBlock passes
+    execution_context.organization_id) → the fallback fires and the child row
+    is born tenanted."""
+    from backend.data.execution import ExecutionContext
+
+    mock_edb, mock_get_default_team = _mock_add_graph_execution_create_path(
+        mocker, org_id="org-sub", team_id="team-sub"
+    )
+    parent_ctx = ExecutionContext(
+        user_id="user-1",
+        graph_id="g",
+        graph_exec_id="child",
+        graph_version=1,
+        parent_execution_id="parent-123",
+        organization_id=None,
+        team_id=None,
+    )
+
+    await add_graph_execution(
+        graph_id="g",
+        user_id="user-1",
+        execution_context=parent_ctx,
+        organization_id=None,
+        team_id=None,
+    )
+
+    mock_get_default_team.assert_awaited_once_with("user-1")
+    create_kwargs = mock_edb.create_graph_execution.call_args.kwargs
+    assert create_kwargs["organization_id"] == "org-sub"
+    assert create_kwargs["team_id"] == "team-sub"
+    assert create_kwargs["parent_graph_exec_id"] == "parent-123"


### PR DESCRIPTION
## Why

New rows for **executions**, **library agents**, and **notification batches** are created *untenanted* (no `organizationId`/`teamId`) whenever the caller doesn't supply one. Every boot, the startup org-migration sweep has to find and backfill that untenanted pool — on dev that's ~**4852 executions swept on every startup**. It's a slow, repeated no-op-shaped write, and the pool never stops refilling because the create paths keep leaking new untenanted rows.

The leaks trace to three create sites:
- **Executions** — `create_graph_execution` only stamps org/team when a non-null value is passed (`**({"organizationId": org} if org else {})`). Its sole funnel, `add_graph_execution`, doesn't resolve a default. Untenanted rows come from: legacy schedules (`GraphExecutionJobArgs.organization_id = ""` → falsy → dropped), sub-graphs inheriting an untenanted parent, and any path that omits tenancy.
- **LibraryAgent** — `add_graph_to_library` does a direct `LibraryAgent.prisma().create(...)` with no org/team (unlike `create_library_agent`, which already resolves a default team).
- **UserNotificationBatch** — `create_or_add_to_user_notification_batch` never set org/team.

## What

Resolve the user's default org/team **at each create funnel** so the rows are *born tenanted*, using the same `get_user_default_team` self-healing resolver the webhook/copilot/external-API paths already use.

- **`resolve_default_tenancy` (api/features/orgs/db.py)** — new best-effort wrapper over `get_user_default_team`: any raised lookup yields `(None, None)` plus a warning log, so tenancy resolution can never abort the operation that needed it. Also exported on `DatabaseManager` / `DatabaseManagerAsyncClient` so processes without a direct Prisma connection can resolve over RPC.
- **`add_graph_execution` (executor/utils.py)** — on the **create path only**, when *neither* `organization_id` nor `team_id` is set (a falsy check, so the legacy `""` from `GraphExecutionJobArgs` counts as unset), resolve the default org/team and pass the result down to `create_graph_execution`. The resolver is dispatched the same way every other DB dep in that function is — direct when `prisma.is_connected()`, else via `get_database_manager_async_client()` — because the scheduler/executor processes have no Prisma connection and that is exactly where scheduled runs are created. This covers the sub-graph path (`AgentExecutorBlock` passes `execution_context.organization_id`; when the parent is untenanted that's `None`, so the fallback fires) and legacy schedules. The resolved value also flows into the runtime `ExecutionContext` built just below, so billing and nested runs are tenant-aware.
- **`add_graph_to_library` (library/_add_to_library.py)** — resolve the default team and stamp `organizationId` + `Team.connect` on the **create branch only**. The `UniqueViolationError` update branch deliberately leaves tenancy untouched: an existing bookmark already carries its tenancy, and re-tagging there risked disconnecting an existing team when no default resolves.
- **`create_or_add_to_user_notification_batch` (data/notifications.py)** — add optional `organization_id`/`team_id` params (default `None`); when both are unset, resolve internally and stamp the **create** branch of the upsert only. `UserNotificationBatch` has no `Team` relation in the schema, so `teamId` is stamped as a scalar (unlike `LibraryAgent`, which declares `Team` and therefore uses `connect`). The single caller is unchanged (resolves internally).

`create_graph_execution`'s `if org else {}` is intentionally left alone — the value is resolved **upstream** so what's passed in is already non-null.

**Guard rails**
- **Resume/requeue is untouched.** The fallback lives strictly in the create branch. Resume/requeue already backfills org/team from the persisted row (the `graph_exec_id` branch and the `execution_context` backfill at utils.py). Re-resolving there would risk re-tenanting an existing row under a different org — so we don't.
- **Never crash a run over tenancy.** If bootstrap hasn't provisioned the user's personal org yet, `resolve_default_tenancy` returns `(None, None)`; we leave the row untenanted and let the boot sweep catch it (unchanged fallback behavior).
- **Explicit tenancy is never overwritten.** The fallback only fires when *both* fields are unset, so a caller-supplied `team_id` without an org survives untouched.
- The **credit path (`org_credit.py`) is deliberately not touched** — that's a separate decision.

This makes the startup org-migration sweep a **fast no-op** in steady state (nothing new to backfill), while the sweep stays in place as a safety net — to be retired to a one-off Job later per SECRT-2476.

## How (tested)

Scenario-named tests, mocked at the Prisma/RPC boundary per existing patterns:

**executor/utils_test.py**
- `test_add_graph_execution_born_tenanted_resolves_default_team` — no org → row created with the user's default org/team.
- `test_add_graph_execution_born_tenanted_via_rpc_when_prisma_disconnected` — no Prisma connection → resolution goes through the DB-manager RPC client (the scheduler/executor case).
- `test_add_graph_execution_no_default_team_stays_untenanted` — `(None, None)` → no crash, row stays untenanted.
- `test_add_graph_execution_default_team_lookup_failure_stays_untenanted` — resolver raises → run still created, untenanted.
- `test_add_graph_execution_explicit_org_not_overridden` — explicit org → fallback does **not** fire.
- `test_add_graph_execution_explicit_team_id_preserved_when_org_absent` — explicit team, no org → fallback does **not** fire, team survives.
- `test_add_graph_execution_subgraph_untenanted_parent_triggers_fallback` — sub-graph with untenanted parent → fallback fires, child born tenanted.
- Resume/requeue asserts the resolver is never called, so existing rows are never re-tagged.
- Existing `test_add_graph_execution_is_repeatable` stays green (new autouse fixture defaults the resolver to `(None, None)`).

**library/_add_to_library_test.py**
- create → stamped with default org/team (asserts the exact `organizationId` + `Team.connect` create input); `(None, None)` → untagged, no crash; resolver raises → untagged, no crash; UniqueViolation update → tenancy left untouched.

**data/notifications_test.py**
- create branch stamps default org/team; explicit tenancy not overridden; explicit team without org preserved; resolver failure leaves the batch untenanted.

**orgs/routes_test.py**
- `resolve_default_tenancy` passes through the resolved pair and converts a raised lookup into `(None, None)`.

Checks: `isort --profile black` + `black` on touched files; `pyright` touched files → **0 errors, 0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBwmh7CkHiF8vKLBf2GWTU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution creation and tenancy stamping across API and scheduler paths; guards limit changes to create paths and best-effort failure handling reduces blast radius.
> 
> **Overview**
> Stops new **executions**, **library bookmarks**, and **notification batches** from being created without `organizationId`/`teamId`, which was refilling the pool the startup org-migration sweep has to backfill.
> 
> Adds **`resolve_default_tenancy`** in orgs `db` — a best-effort wrapper around `get_user_default_team` that returns `(None, None)` on failure so creates never abort — and exposes it on the DB manager RPC for scheduler/executor processes without direct Prisma.
> 
> **`add_graph_execution`** (create path only): when neither org nor team is set, resolves defaults and passes them into `create_graph_execution`; uses direct Prisma in the API server and **`resolve_default_tenancy` via RPC** when Prisma is disconnected. Resume/requeue paths are unchanged so existing rows are not re-tagged.
> 
> **`add_graph_to_library`**: stamps org/team on **new** `LibraryAgent` creates only; UniqueViolation restore updates leave tenancy alone.
> 
> **`create_or_add_to_user_notification_batch`**: optional `organization_id`/`team_id`; if both unset, resolves defaults and stamps the upsert **create** branch only (not update).
> 
> Tests and an executor **autouse** fixture default tenancy resolution to `(None, None)` so existing tests stay stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75a6bda60c3c05abaef6da7df05cd29e5c3e271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
