### PR TITLE
fix(frontend): redirect missing library agents

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
@@ -37,6 +37,7 @@ const mockRouter = vi.hoisted(() => ({
   replace: vi.fn(),
   refresh: vi.fn(),
 }));
+const mockUseRouter = vi.hoisted(() => vi.fn());
 const mockRouterReplace = mockRouter.replace;
 
 vi.mock("next/navigation", async (importOriginal) => {
@@ -44,7 +45,7 @@ vi.mock("next/navigation", async (importOriginal) => {
   return {
     ...actual,
     useParams: () => ({ id: PARENT_ID }),
-    useRouter: () => mockRouter,
+    useRouter: () => mockUseRouter(),
     usePathname: () => `/library/agents/${PARENT_ID}`,
     useSearchParams: () => new URLSearchParams(),
   };
@@ -171,6 +172,7 @@ function singlePresetListHandler(
 describe("Library agent view — trigger agents", () => {
   beforeEach(() => {
     server.resetHandlers();
+    mockUseRouter.mockReturnValue(mockRouter);
     mockRouterReplace.mockReset();
     mockToast.mockClear();
     mockUseGetFlag.mockReturnValue(true);
@@ -178,6 +180,7 @@ describe("Library agent view — trigger agents", () => {
 
   test("redirects to the library when the requested agent does not exist", async () => {
     mockUseGetFlag.mockReturnValue(false);
+    mockUseRouter.mockImplementation(() => ({ ...mockRouter }));
     server.use(
       http.get("/api/proxy/api/library/agents/:libraryAgentId", () =>
         HttpResponse.json(
@@ -195,6 +198,8 @@ describe("Library agent view — trigger agents", () => {
     expect(
       mockRouterReplace.mock.calls.filter(([href]) => href === "/library"),
     ).toHaveLength(1);
+    expect(screen.queryByText("Something went wrong")).toBeNull();
+    expect(screen.queryByText("Agent not found in library")).toBeNull();
   });
 
   test("hides Triggers tab when there are no trigger agents and no webhook triggers", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/__tests__/trigger-agents.test.tsx
@@ -32,17 +32,19 @@ const PARENT_ID = "parent-agent-id";
 const PARENT_GRAPH_ID = "parent-graph-id";
 const TRIGGER_ID = "trigger-agent-id";
 const TRIGGER_GRAPH_ID = "trigger-graph-id";
+const mockRouter = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  refresh: vi.fn(),
+}));
+const mockRouterReplace = mockRouter.replace;
 
 vi.mock("next/navigation", async (importOriginal) => {
   const actual = await importOriginal<typeof import("next/navigation")>();
   return {
     ...actual,
     useParams: () => ({ id: PARENT_ID }),
-    useRouter: () => ({
-      push: vi.fn(),
-      replace: vi.fn(),
-      refresh: vi.fn(),
-    }),
+    useRouter: () => mockRouter,
     usePathname: () => `/library/agents/${PARENT_ID}`,
     useSearchParams: () => new URLSearchParams(),
   };
@@ -169,8 +171,30 @@ function singlePresetListHandler(
 describe("Library agent view — trigger agents", () => {
   beforeEach(() => {
     server.resetHandlers();
+    mockRouterReplace.mockReset();
     mockToast.mockClear();
     mockUseGetFlag.mockReturnValue(true);
+  });
+
+  test("redirects to the library when the requested agent does not exist", async () => {
+    mockUseGetFlag.mockReturnValue(false);
+    server.use(
+      http.get("/api/proxy/api/library/agents/:libraryAgentId", () =>
+        HttpResponse.json(
+          { detail: "Agent not found in library" },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    renderWithInitialParams(<NewAgentLibraryView />);
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith("/library");
+    });
+    expect(
+      mockRouterReplace.mock.calls.filter(([href]) => href === "/library"),
+    ).toHaveLength(1);
   });
 
   test("hides Triggers tab when there are no trigger agents and no webhook triggers", async () => {
@@ -905,6 +929,7 @@ describe("Library agent view — trigger agents", () => {
     // On the Templates tab the shared preset query's error must still
     // surface — the tab guard only suppresses it elsewhere.
     await screen.findByText(/when retrieving agent/i);
+    expect(mockRouterReplace).not.toHaveBeenCalledWith("/library");
   });
 
   test("when generic-trigger-agents flag is off, hides 'Trigger Agents' subsection and skips the trigger-agents fetch", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/useNewAgentLibraryView.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/useNewAgentLibraryView.ts
@@ -9,11 +9,12 @@ import { GraphExecutionMeta } from "@/app/api/__generated__/models/graphExecutio
 import { LibraryAgentPreset } from "@/app/api/__generated__/models/libraryAgentPreset";
 import { okData } from "@/app/api/helpers";
 import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   deriveSelectedTriggerKind,
+  getErrorStatus,
   parseActiveItemParam,
   retryUnlessClientError,
   SelectedTriggerKind,
@@ -36,6 +37,7 @@ function parseTab(
 
 export function useNewAgentLibraryView() {
   const { id } = useParams();
+  const router = useRouter();
   const agentId = id as string;
 
   // TODO(#12740 / autogpt-pr-reviewer): when agent.is_hidden is true,
@@ -46,8 +48,17 @@ export function useNewAgentLibraryView() {
   const {
     data: agent,
     isSuccess,
-    error,
-  } = useGetV2GetLibraryAgent(agentId, { query: { select: okData } });
+    error: agentError,
+  } = useGetV2GetLibraryAgent(agentId, {
+    query: { select: okData, retry: retryUnlessClientError },
+  });
+  const agentNotFound = getErrorStatus(agentError) === 404;
+
+  useEffect(() => {
+    if (agentNotFound) {
+      router.replace("/library");
+    }
+  }, [agentNotFound, router]);
 
   const { enabled: triggerAgentsEnabled, ready: triggerAgentsFlagReady } =
     useFlagStatus(Flag.GENERIC_TRIGGER_AGENTS);
@@ -293,7 +304,7 @@ export function useNewAgentLibraryView() {
     ready: isSuccess,
     activeTemplate,
     isTemplateLoading,
-    error: error || templateError,
+    error: agentNotFound ? null : agentError || templateError,
     hasAnyItems,
     showSidebarLayout,
     activeItemId,

--- a/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/useNewAgentLibraryView.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/library/agents/[id]/components/NewAgentLibraryView/useNewAgentLibraryView.ts
@@ -11,7 +11,7 @@ import { okData } from "@/app/api/helpers";
 import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
 import { useParams, useRouter } from "next/navigation";
 import { parseAsString, useQueryStates } from "nuqs";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   deriveSelectedTriggerKind,
   getErrorStatus,
@@ -39,6 +39,7 @@ export function useNewAgentLibraryView() {
   const { id } = useParams();
   const router = useRouter();
   const agentId = id as string;
+  const redirectedAgentIDRef = useRef<string | null>(null);
 
   // TODO(#12740 / autogpt-pr-reviewer): when agent.is_hidden is true,
   // surface a banner that this is a trigger agent and link to its parent.
@@ -55,10 +56,15 @@ export function useNewAgentLibraryView() {
   const agentNotFound = getErrorStatus(agentError) === 404;
 
   useEffect(() => {
-    if (agentNotFound) {
-      router.replace("/library");
+    if (!agentNotFound) {
+      redirectedAgentIDRef.current = null;
+      return;
     }
-  }, [agentNotFound, router]);
+    if (redirectedAgentIDRef.current === agentId) return;
+
+    redirectedAgentIDRef.current = agentId;
+    router.replace("/library");
+  }, [agentId, agentNotFound, router]);
 
   const { enabled: triggerAgentsEnabled, ready: triggerAgentsFlagReady } =
     useFlagStatus(Flag.GENERIC_TRIGGER_AGENTS);


### PR DESCRIPTION
### Why / What / How

Fixes #9268.

**Why:** Opening a library agent URL for an agent that no longer exists leaves
the user on an error card instead of returning them to a usable page.

**What:** Redirect missing library agents to `/library`, while preserving the
existing page-level error handling for other failures.

**How:** Detect a 404 from the primary library-agent query in
`useNewAgentLibraryView`, replace the current route with `/library`, and suppress
the transient error card during that redirect. Client errors also stop retrying
immediately; transient failures retain the existing retry behavior.

### Changes 🏗️

- Redirect the agent detail view to `/library` when its primary agent request
  returns 404.
- Keep preset/template 404s on their existing inline or page-level error paths.
- Add integration coverage for both the redirect and the template regression
  case.
- No configuration changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Missing primary agent redirects to `/library` exactly once
  - [x] Missing template does not redirect away from the agent page
  - [x] `pnpm format`
  - [x] `pnpm lint`
  - [x] `pnpm types`
  - [x] `pnpm test:unit` (405 files; 4,238 passed, 2 skipped)

#### For configuration changes:

- [x] `.env.default` is already compatible with my changes
- [x] `docker-compose.yml` is already compatible with my changes
- [x] No configuration changes are required
