### PR TITLE
perf(backend): compile each JSON schema validator once in validate_with_jsonschema

### DIFF
--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -1,5 +1,7 @@
+import itertools
 import logging
 import re
+from copy import deepcopy
 from typing import Any, Type, TypeVar, overload
 
 import jsonschema
@@ -130,6 +132,68 @@ def loads(
     return parsed
 
 
+_VALIDATOR_CACHE: dict[bytes, Any] = {}
+_VALIDATOR_CACHE_MAX_ENTRIES = 512
+
+
+def _compiled_validator(schema: dict[str, Any]):
+    """Return a validator for `schema`, compiled once per distinct schema.
+
+    `jsonschema.validate()` re-resolves the validator class and re-validates the
+    schema against its meta-schema on every single call; both depend only on the
+    schema, so both are cached here.
+
+    The key is the schema's serialized content, not its identity: a graph's
+    input schema is rebuilt as a fresh dict on every node execution, so identity
+    keying would never hit and would pin every schema object the process has
+    ever seen. Key order is deliberately *not* normalised -- the error strings
+    this function returns embed a repr of the failing sub-schema, so reordering
+    keys would change them.
+
+    A `SchemaError` outcome is cached too, so a malformed schema keeps raising
+    rather than being silently accepted on the second call.
+    """
+    try:
+        key = orjson.dumps(schema)
+    except TypeError:
+        # Not JSON-serializable, so it cannot be keyed; compile without caching.
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator_cls.check_schema(schema)
+        return validator_cls(schema)
+
+    cached = _VALIDATOR_CACHE.get(key)
+    if cached is not None:
+        if isinstance(cached, jsonschema.SchemaError):
+            raise cached
+        return cached
+
+    # Compile against a private copy: a jsonschema validator memoises the
+    # sub-schemas it walks, so a retained one must not alias a dict the caller
+    # still holds and could mutate afterwards. deepcopy also preserves key
+    # order, which the error messages depend on.
+    schema_copy = deepcopy(schema)
+    validator_cls = jsonschema.validators.validator_for(schema_copy)
+    try:
+        validator_cls.check_schema(schema_copy)
+    except jsonschema.SchemaError as e:
+        _remember(key, e)
+        raise
+    validator = validator_cls(schema_copy)
+    _remember(key, validator)
+    return validator
+
+
+def _remember(key: bytes, value: Any) -> None:
+    """Store `value`, evicting the oldest entry when the cache is full.
+
+    The keys are caller-supplied schemas, which on this platform come from
+    user-authored graphs, so the cache has to be bounded.
+    """
+    if len(_VALIDATOR_CACHE) >= _VALIDATOR_CACHE_MAX_ENTRIES:
+        _VALIDATOR_CACHE.pop(next(iter(_VALIDATOR_CACHE)))
+    _VALIDATOR_CACHE[key] = value
+
+
 def validate_with_jsonschema(
     schema: dict[str, Any], data: dict[str, Any]
 ) -> str | None:
@@ -137,11 +201,19 @@ def validate_with_jsonschema(
     Validate the data against the schema.
     Returns the validation error message if the data does not match the schema.
     """
-    try:
-        jsonschema.validate(data, schema)
+    errors = _compiled_validator(schema).iter_errors(data)
+
+    # Valid data is the common case, and it does not need best_match at all.
+    first_error = next(errors, None)
+    if first_error is None:
         return None
-    except jsonschema.ValidationError as e:
-        return str(e)
+
+    # `jsonschema.validate()` raises best_match(iter_errors(...)), which is not
+    # the same error Validator.validate() raises, so match it exactly. chain the
+    # already-consumed first error back in rather than re-running iter_errors.
+    return str(
+        jsonschema.exceptions.best_match(itertools.chain((first_error,), errors))
+    )
 
 
 def sanitize_string(value: str) -> str:

--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -154,8 +154,6 @@ def _compiled_validator(schema: dict[str, Any]):
     this function returns embed a repr of the failing sub-schema, so reordering
     keys would change them.
 
-    A `SchemaError` outcome is cached too, so a malformed schema keeps raising
-    rather than being silently accepted on the second call.
     """
     try:
         key = orjson.dumps(schema)
@@ -168,8 +166,6 @@ def _compiled_validator(schema: dict[str, Any]):
     with _VALIDATOR_CACHE_LOCK:
         cached = _VALIDATOR_CACHE.get(key)
     if cached is not None:
-        if isinstance(cached, jsonschema.SchemaError):
-            raise cached
         return cached
 
     # Compile against a private copy: a jsonschema validator memoises the
@@ -178,20 +174,8 @@ def _compiled_validator(schema: dict[str, Any]):
     # order, which the error messages depend on.
     schema_copy = deepcopy(schema)
     validator_cls = jsonschema.validators.validator_for(schema_copy)
-    try:
-        validator_cls.check_schema(schema_copy)
-    except jsonschema.SchemaError as e:
-        cached = _remember(key, e)
-        if cached is e:
-            raise
-        if isinstance(cached, jsonschema.SchemaError):
-            raise cached
-        return cached
-
-    cached = _remember(key, validator_cls(schema_copy))
-    if isinstance(cached, jsonschema.SchemaError):
-        raise cached
-    return cached
+    validator_cls.check_schema(schema_copy)
+    return _remember(key, validator_cls(schema_copy))
 
 
 def _remember(key: bytes, value: Any) -> Any:

--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from typing import Any, Type, TypeVar, overload
 
 import jsonschema
+import jsonschema.exceptions
+import jsonschema.validators
 import orjson
 from fastapi.encoders import jsonable_encoder as to_dict
 from prisma import Json

--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -1,6 +1,8 @@
 import itertools
 import logging
+import math
 import re
+from collections import OrderedDict
 from copy import deepcopy
 from threading import Lock
 from typing import Any, Type, TypeVar, overload
@@ -135,8 +137,11 @@ def loads(
     return parsed
 
 
-_VALIDATOR_CACHE: dict[bytes, Any] = {}
-_VALIDATOR_CACHE_MAX_ENTRIES = 512
+_VALIDATOR_CACHE: OrderedDict[bytes, Any] = OrderedDict()
+# The 565 built-in Block classes can each contribute a normal and dry-run
+# schema; 2,048 covers that working set while leaving room for user schemas.
+_VALIDATOR_CACHE_MAX_ENTRIES = 2048
+_VALIDATOR_CACHE_MAX_KEY_BYTES = 16 * 1024
 _VALIDATOR_CACHE_LOCK = Lock()
 
 
@@ -155,19 +160,57 @@ def _compiled_validator(schema: dict[str, Any]):
     keys would change them.
 
     """
-    try:
-        key = orjson.dumps(schema)
-    except TypeError:
-        # Not JSON-serializable, so it cannot be keyed; compile without caching.
-        validator_cls = jsonschema.validators.validator_for(schema)
-        validator_cls.check_schema(schema)
-        return validator_cls(schema)
+    key = _schema_cache_key(schema)
+    if key is None:
+        return _new_validator(schema)
 
     with _VALIDATOR_CACHE_LOCK:
         cached = _VALIDATOR_CACHE.get(key)
-    if cached is not None:
-        return cached
+        if cached is not None:
+            _VALIDATOR_CACHE.move_to_end(key)
+            return cached
 
+    return _remember(key, _new_validator(schema))
+
+
+def _schema_cache_key(schema: dict[str, Any]) -> bytes | None:
+    """Return an injective, size-bounded key for safely cacheable schemas."""
+    if not _is_json_native(schema):
+        return None
+    try:
+        key = orjson.dumps(schema)
+    except TypeError:
+        return None
+    if len(key) > _VALIDATOR_CACHE_MAX_KEY_BYTES:
+        return None
+    return key
+
+
+def _is_json_native(value: Any) -> bool:
+    """Check that orjson preserves every value's type and meaning."""
+    pending = [value]
+    while pending:
+        current = pending.pop()
+        current_type = type(current)
+        if current is None or current_type in (str, int, bool):
+            continue
+        if current_type is float:
+            if not math.isfinite(current):
+                return False
+            continue
+        if current_type is list:
+            pending.extend(current)
+            continue
+        if current_type is dict:
+            if any(type(key) is not str for key in current):
+                return False
+            pending.extend(current.values())
+            continue
+        return False
+    return True
+
+
+def _new_validator(schema: dict[str, Any]):
     # Compile against a private copy: a jsonschema validator memoises the
     # sub-schemas it walks, so a retained one must not alias a dict the caller
     # still holds and could mutate afterwards. deepcopy also preserves key
@@ -175,11 +218,11 @@ def _compiled_validator(schema: dict[str, Any]):
     schema_copy = deepcopy(schema)
     validator_cls = jsonschema.validators.validator_for(schema_copy)
     validator_cls.check_schema(schema_copy)
-    return _remember(key, validator_cls(schema_copy))
+    return validator_cls(schema_copy)
 
 
 def _remember(key: bytes, value: Any) -> Any:
-    """Publish and return one value, evicting an oldest entry if needed.
+    """Publish and return one value, evicting the least-recently used entry.
 
     The keys are caller-supplied schemas, which on this platform come from
     user-authored graphs, so the cache has to be bounded.
@@ -187,9 +230,10 @@ def _remember(key: bytes, value: Any) -> Any:
     with _VALIDATOR_CACHE_LOCK:
         cached = _VALIDATOR_CACHE.get(key)
         if cached is not None:
+            _VALIDATOR_CACHE.move_to_end(key)
             return cached
         if len(_VALIDATOR_CACHE) >= _VALIDATOR_CACHE_MAX_ENTRIES:
-            _VALIDATOR_CACHE.pop(next(iter(_VALIDATOR_CACHE)))
+            _VALIDATOR_CACHE.popitem(last=False)
         _VALIDATOR_CACHE[key] = value
         return value
 

--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -4,6 +4,7 @@ import math
 import re
 from collections import OrderedDict
 from copy import deepcopy
+from enum import Enum
 from threading import Lock
 from typing import Any, Type, TypeVar, overload
 
@@ -137,11 +138,14 @@ def loads(
     return parsed
 
 
-_VALIDATOR_CACHE: OrderedDict[bytes, Any] = OrderedDict()
+_SchemaTypeFingerprint = tuple[tuple[int, type[Any]], ...]
+_SchemaCacheKey = tuple[bytes, _SchemaTypeFingerprint]
+
+_VALIDATOR_CACHE: OrderedDict[_SchemaCacheKey, Any] = OrderedDict()
 # The 565 built-in Block classes can each contribute a normal and dry-run
 # schema; 2,048 covers that working set while leaving room for user schemas.
 _VALIDATOR_CACHE_MAX_ENTRIES = 2048
-_VALIDATOR_CACHE_MAX_KEY_BYTES = 16 * 1024
+_VALIDATOR_CACHE_MAX_KEY_BYTES = 32 * 1024
 _VALIDATOR_CACHE_LOCK = Lock()
 
 
@@ -173,41 +177,54 @@ def _compiled_validator(schema: dict[str, Any]):
     return _remember(key, _new_validator(schema))
 
 
-def _schema_cache_key(schema: dict[str, Any]) -> bytes | None:
+def _schema_cache_key(schema: dict[str, Any]) -> _SchemaCacheKey | None:
     """Return an injective, size-bounded key for safely cacheable schemas."""
-    if not _is_json_native(schema):
-        return None
     try:
         key = orjson.dumps(schema)
     except TypeError:
         return None
     if len(key) > _VALIDATOR_CACHE_MAX_KEY_BYTES:
         return None
-    return key
+    type_fingerprint = _schema_type_fingerprint(schema)
+    if type_fingerprint is None:
+        return None
+    return key, type_fingerprint
 
 
-def _is_json_native(value: Any) -> bool:
-    """Check that orjson preserves every value's type and meaning."""
+def _schema_type_fingerprint(value: Any) -> _SchemaTypeFingerprint | None:
+    """Describe string subclasses while rejecting unsafe serialization."""
     pending = [value]
+    seen_containers: set[int] = set()
+    string_subclasses: list[tuple[int, type[Any]]] = []
+    string_position = 0
     while pending:
         current = pending.pop()
         current_type = type(current)
-        if current is None or current_type in (str, int, bool):
+        if current is None or current_type in (int, bool):
+            continue
+        if issubclass(current_type, str):
+            if current_type is not str:
+                if not issubclass(current_type, Enum):
+                    return None
+                string_subclasses.append((string_position, current_type))
+            string_position += 1
             continue
         if current_type is float:
             if not math.isfinite(current):
-                return False
+                return None
             continue
-        if current_type is list:
-            pending.extend(current)
-            continue
+        if current_type not in (list, dict):
+            return None
+        identity = id(current)
+        if identity in seen_containers:
+            return None
+        seen_containers.add(identity)
         if current_type is dict:
-            if any(type(key) is not str for key in current):
-                return False
-            pending.extend(current.values())
-            continue
-        return False
-    return True
+            # orjson.dumps rejects non-exact-string keys before this walk.
+            pending.extend(reversed(tuple(current.values())))
+        else:
+            pending.extend(reversed(current))
+    return tuple(string_subclasses)
 
 
 def _new_validator(schema: dict[str, Any]):
@@ -221,7 +238,7 @@ def _new_validator(schema: dict[str, Any]):
     return validator_cls(schema_copy)
 
 
-def _remember(key: bytes, value: Any) -> Any:
+def _remember(key: _SchemaCacheKey, value: Any) -> Any:
     """Publish and return one value, evicting the least-recently used entry.
 
     The keys are caller-supplied schemas, which on this platform come from

--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import re
 from copy import deepcopy
+from threading import Lock
 from typing import Any, Type, TypeVar, overload
 
 import jsonschema
@@ -136,6 +137,7 @@ def loads(
 
 _VALIDATOR_CACHE: dict[bytes, Any] = {}
 _VALIDATOR_CACHE_MAX_ENTRIES = 512
+_VALIDATOR_CACHE_LOCK = Lock()
 
 
 def _compiled_validator(schema: dict[str, Any]):
@@ -163,7 +165,8 @@ def _compiled_validator(schema: dict[str, Any]):
         validator_cls.check_schema(schema)
         return validator_cls(schema)
 
-    cached = _VALIDATOR_CACHE.get(key)
+    with _VALIDATOR_CACHE_LOCK:
+        cached = _VALIDATOR_CACHE.get(key)
     if cached is not None:
         if isinstance(cached, jsonschema.SchemaError):
             raise cached
@@ -178,22 +181,33 @@ def _compiled_validator(schema: dict[str, Any]):
     try:
         validator_cls.check_schema(schema_copy)
     except jsonschema.SchemaError as e:
-        _remember(key, e)
-        raise
-    validator = validator_cls(schema_copy)
-    _remember(key, validator)
-    return validator
+        cached = _remember(key, e)
+        if cached is e:
+            raise
+        if isinstance(cached, jsonschema.SchemaError):
+            raise cached
+        return cached
+
+    cached = _remember(key, validator_cls(schema_copy))
+    if isinstance(cached, jsonschema.SchemaError):
+        raise cached
+    return cached
 
 
-def _remember(key: bytes, value: Any) -> None:
-    """Store `value`, evicting the oldest entry when the cache is full.
+def _remember(key: bytes, value: Any) -> Any:
+    """Publish and return one value, evicting an oldest entry if needed.
 
     The keys are caller-supplied schemas, which on this platform come from
     user-authored graphs, so the cache has to be bounded.
     """
-    if len(_VALIDATOR_CACHE) >= _VALIDATOR_CACHE_MAX_ENTRIES:
-        _VALIDATOR_CACHE.pop(next(iter(_VALIDATOR_CACHE)))
-    _VALIDATOR_CACHE[key] = value
+    with _VALIDATOR_CACHE_LOCK:
+        cached = _VALIDATOR_CACHE.get(key)
+        if cached is not None:
+            return cached
+        if len(_VALIDATOR_CACHE) >= _VALIDATOR_CACHE_MAX_ENTRIES:
+            _VALIDATOR_CACHE.pop(next(iter(_VALIDATOR_CACHE)))
+        _VALIDATOR_CACHE[key] = value
+        return value
 
 
 def validate_with_jsonschema(

--- a/autogpt_platform/backend/backend/util/test_json.py
+++ b/autogpt_platform/backend/backend/util/test_json.py
@@ -1,4 +1,6 @@
 import datetime
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, cast
 
 import jsonschema
@@ -6,6 +8,7 @@ import pytest
 from prisma import Json
 from pydantic import BaseModel
 
+from backend.util import json as json_util
 from backend.util.json import SafeJson, validate_with_jsonschema
 
 
@@ -834,3 +837,48 @@ class TestValidateWithJsonschema:
         assert validate_with_jsonschema(schema, {"f": "text"}) is not None
         schema["properties"]["f"] = {"type": "string"}
         assert validate_with_jsonschema(schema, {"f": "text"}) is None
+
+    def test_concurrent_compilation_publishes_one_validator(self, monkeypatch):
+        """Concurrent misses may compile in parallel but publish one value."""
+        schema = {"type": "object", "properties": {"f": {"type": "integer"}}}
+        json_util._VALIDATOR_CACHE.clear()
+        original_deepcopy = json_util.deepcopy
+        compile_barrier = threading.Barrier(2)
+
+        def synchronized_deepcopy(value):
+            compile_barrier.wait(timeout=5)
+            return original_deepcopy(value)
+
+        monkeypatch.setattr(json_util, "deepcopy", synchronized_deepcopy)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            validators = list(pool.map(json_util._compiled_validator, (schema, schema)))
+
+        assert validators[0] is validators[1]
+
+    def test_concurrent_eviction_is_atomic(self, monkeypatch):
+        """Two full-cache misses cannot evict the same entry concurrently."""
+        eviction_barrier = threading.Barrier(2)
+
+        class CoordinatedCache(dict[bytes, Any]):
+            def __iter__(self):
+                keys = tuple(super().keys())
+                try:
+                    eviction_barrier.wait(timeout=0.1)
+                except threading.BrokenBarrierError:
+                    pass
+                return iter(keys)
+
+        cache = CoordinatedCache({b"old": object()})
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE_MAX_ENTRIES", 1)
+        values = (object(), object())
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = (
+                pool.submit(json_util._remember, b"new-a", values[0]),
+                pool.submit(json_util._remember, b"new-b", values[1]),
+            )
+            published = tuple(future.result() for future in futures)
+
+        assert published == values
+        assert len(cache) == 1

--- a/autogpt_platform/backend/backend/util/test_json.py
+++ b/autogpt_platform/backend/backend/util/test_json.py
@@ -1,10 +1,12 @@
 import datetime
 from typing import Any, Optional, cast
 
+import jsonschema
+import pytest
 from prisma import Json
 from pydantic import BaseModel
 
-from backend.util.json import SafeJson
+from backend.util.json import SafeJson, validate_with_jsonschema
 
 
 class SamplePydanticModel(BaseModel):
@@ -754,3 +756,81 @@ class TestSafeJson:
         metadata = cast(dict[str, Any], inner["metadata"])
         nested_metadata = metadata["nested_key"]
         assert nested_metadata == "NestedValueDelete"
+
+
+class TestValidateWithJsonschema:
+    """Test cases for validate_with_jsonschema."""
+
+    SCHEMA: dict[str, Any] = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name"],
+    }
+
+    def test_valid_data_returns_none(self):
+        """Valid data produces no error message."""
+        assert (
+            validate_with_jsonschema(self.SCHEMA, {"name": "John", "age": 30}) is None
+        )
+
+    def test_type_mismatch_returns_error_message(self):
+        """A type mismatch produces the underlying jsonschema message."""
+        error = validate_with_jsonschema(self.SCHEMA, {"name": 1})
+        assert error is not None
+        assert "is not of type 'string'" in error
+
+    def test_missing_required_field_returns_error_message(self):
+        """A missing required field produces the underlying jsonschema message."""
+        error = validate_with_jsonschema(self.SCHEMA, {"age": 30})
+        assert error is not None
+        assert "'name' is a required property" in error
+
+    def test_repeated_calls_with_one_schema_stay_correct(self):
+        """The executor validates the same schema against different data on
+        every node execution; repeated calls must not drift."""
+        for i in range(5):
+            assert validate_with_jsonschema(self.SCHEMA, {"name": f"n{i}"}) is None
+            assert validate_with_jsonschema(self.SCHEMA, {"name": i}) is not None
+
+    def test_distinct_schemas_are_not_conflated(self):
+        """Two different schemas must keep producing their own verdicts,
+        including when the first one is revisited."""
+        text_schema = {"type": "object", "properties": {"f": {"type": "string"}}}
+        int_schema = {"type": "object", "properties": {"f": {"type": "integer"}}}
+        assert validate_with_jsonschema(text_schema, {"f": "text"}) is None
+        assert validate_with_jsonschema(int_schema, {"f": "text"}) is not None
+        assert validate_with_jsonschema(text_schema, {"f": "text"}) is None
+
+    def test_equal_but_distinct_schema_objects_agree(self):
+        """A graph's input schema is rebuilt per execution, so the same schema
+        arrives as a fresh object each time."""
+        first = {"type": "object", "properties": {"f": {"type": "integer"}}}
+        second = {"type": "object", "properties": {"f": {"type": "integer"}}}
+        assert validate_with_jsonschema(first, {"f": 1}) is None
+        assert validate_with_jsonschema(second, {"f": 1}) is None
+        assert validate_with_jsonschema(second, {"f": "x"}) is not None
+
+    def test_malformed_schema_raises_on_every_call(self):
+        """`required` with duplicate entries fails the meta-schema check, and
+        agent graphs do carry such schemas. The SchemaError must keep escaping,
+        not just on the first call."""
+        malformed = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a", "a"],
+        }
+        for _ in range(3):
+            with pytest.raises(jsonschema.SchemaError):
+                validate_with_jsonschema(malformed, {"a": "x"})
+
+    def test_schema_mutated_in_place_is_not_stale(self):
+        """Mutating a schema between calls must change the verdict."""
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {"f": {"type": "string"}},
+        }
+        assert validate_with_jsonschema(schema, {"f": "text"}) is None
+        schema["properties"]["f"] = {"type": "integer"}
+        assert validate_with_jsonschema(schema, {"f": "text"}) is not None
+        schema["properties"]["f"] = {"type": "string"}
+        assert validate_with_jsonschema(schema, {"f": "text"}) is None

--- a/autogpt_platform/backend/backend/util/test_json.py
+++ b/autogpt_platform/backend/backend/util/test_json.py
@@ -9,6 +9,9 @@ import pytest
 from prisma import Json
 from pydantic import BaseModel
 
+from backend.blocks.orchestrator import OrchestratorBlock
+from backend.blocks.slack.blocks import SendSlackMessageBlock
+from backend.integrations.providers import ProviderName
 from backend.util import json as json_util
 from backend.util.json import SafeJson, validate_with_jsonschema
 
@@ -873,17 +876,40 @@ class TestValidateWithJsonschema:
 
         assert validators[0] is validators[1]
 
+    def test_cached_validator_is_safe_for_concurrent_use(self, monkeypatch):
+        """Concurrent executions can share the published validator safely."""
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict()
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+        schema = {"type": "object", "properties": {"f": {"type": "integer"}}}
+
+        def validate(index: int) -> bool:
+            value: int | str = index if index % 2 == 0 else str(index)
+            return validate_with_jsonschema(schema, {"f": value}) is None
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            outcomes = list(pool.map(validate, range(200)))
+
+        assert outcomes == [index % 2 == 0 for index in range(200)]
+        assert len(cache) == 1
+
     def test_concurrent_eviction_is_atomic(self, monkeypatch):
         """Two full-cache misses cannot evict the same entry concurrently."""
-        cache: OrderedDict[bytes, Any] = OrderedDict({b"old": object()})
+        old_key: json_util._SchemaCacheKey = (b"old", ())
+        new_keys: tuple[json_util._SchemaCacheKey, ...] = (
+            (b"new-a", ()),
+            (b"new-b", ()),
+        )
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict(
+            {old_key: object()}
+        )
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE_MAX_ENTRIES", 1)
         values = (object(), object())
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             futures = (
-                pool.submit(json_util._remember, b"new-a", values[0]),
-                pool.submit(json_util._remember, b"new-b", values[1]),
+                pool.submit(json_util._remember, new_keys[0], values[0]),
+                pool.submit(json_util._remember, new_keys[1], values[1]),
             )
             published = tuple(future.result() for future in futures)
 
@@ -892,7 +918,7 @@ class TestValidateWithJsonschema:
 
     def test_cache_uses_lru_eviction(self, monkeypatch):
         """A recently reused schema survives the next full-cache insertion."""
-        cache: OrderedDict[bytes, Any] = OrderedDict()
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict()
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE_MAX_ENTRIES", 2)
         schemas = [
@@ -956,7 +982,7 @@ class TestValidateWithJsonschema:
         monkeypatch,
     ):
         """Values that orjson conflates retain jsonschema's exact behavior."""
-        cache: OrderedDict[bytes, Any] = OrderedDict()
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict()
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
 
         assert validate_with_jsonschema(
@@ -970,7 +996,7 @@ class TestValidateWithJsonschema:
 
     def test_nonfinite_key_cannot_hide_malformed_schema(self, monkeypatch):
         """A non-finite key cannot collide with an invalid null constraint."""
-        cache: OrderedDict[bytes, Any] = OrderedDict()
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict()
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
         nonfinite = {
             "type": "object",
@@ -986,13 +1012,72 @@ class TestValidateWithJsonschema:
             validate_with_jsonschema(malformed, {"value": 5})
         assert not cache
 
+    @pytest.mark.parametrize("block_cls", [SendSlackMessageBlock, OrchestratorBlock])
+    def test_real_credentialed_block_schemas_are_cacheable(
+        self, block_cls, monkeypatch
+    ):
+        """Production schemas with ProviderName values should hit the cache."""
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict()
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+        schema = block_cls().input_schema.jsonschema()
+
+        assert json_util._schema_cache_key(schema) is not None
+        first = json_util._compiled_validator(schema)
+        second = json_util._compiled_validator(schema)
+        assert first is second
+        assert len(cache) == 1
+
+    def test_string_subclass_schema_key_stays_injective(self):
+        """A string subclass must not share a key with an exact string."""
+        plain_key = json_util._schema_cache_key({"enum": [ProviderName.SLACK.value]})
+        subclass_key = json_util._schema_cache_key({"enum": [ProviderName.SLACK]})
+
+        assert plain_key is not None
+        assert subclass_key is not None
+        assert subclass_key != plain_key
+
+    def test_unsafe_schema_values_bypass_cache(self):
+        """Only stable JSON primitives and string enums are cacheable."""
+
+        class CustomString(str):
+            pass
+
+        assert json_util._schema_cache_key({"enum": [CustomString("value")]}) is None
+        assert json_util._schema_cache_key(cast(dict[str, Any], {1: "value"})) is None
+        assert json_util._schema_cache_key({"minimum": 1.5}) is not None
+
+    def test_excessively_deep_schema_bypasses_cache(self):
+        """The serializer's recursion bound remains a graceful cache bypass."""
+        schema: dict[str, Any] = {}
+        current = schema
+        for _ in range(300):
+            child: dict[str, Any] = {}
+            current["nested"] = child
+            current = child
+
+        assert json_util._schema_cache_key(schema) is None
+
+    def test_reused_container_bypasses_cache(self):
+        """Repeated identity is rejected so cyclic schemas cannot hang the walk."""
+        shared = {"type": "string"}
+        schema = {"allOf": [shared, shared]}
+
+        assert json_util._schema_cache_key(schema) is None
+
+    def test_cyclic_schema_bypasses_cache(self):
+        """A cyclic schema is rejected without an unbounded admission walk."""
+        schema: dict[str, Any] = {"type": "object"}
+        schema["self"] = schema
+
+        assert json_util._schema_cache_key(schema) is None
+
     def test_oversized_schema_is_not_retained(self, monkeypatch):
         """Caller-controlled schemas above the key budget compile uncached."""
-        cache: OrderedDict[bytes, Any] = OrderedDict()
+        cache: OrderedDict[json_util._SchemaCacheKey, Any] = OrderedDict()
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
         schema = {
             "type": "object",
-            "description": "x" * 20_000,
+            "description": "x" * 40_000,
             "properties": {"value": {"type": "string"}},
         }
 

--- a/autogpt_platform/backend/backend/util/test_json.py
+++ b/autogpt_platform/backend/backend/util/test_json.py
@@ -1,5 +1,6 @@
 import datetime
 import threading
+from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, cast
 
@@ -874,18 +875,7 @@ class TestValidateWithJsonschema:
 
     def test_concurrent_eviction_is_atomic(self, monkeypatch):
         """Two full-cache misses cannot evict the same entry concurrently."""
-        eviction_barrier = threading.Barrier(2)
-
-        class CoordinatedCache(dict[bytes, Any]):
-            def __iter__(self):
-                keys = tuple(super().keys())
-                try:
-                    eviction_barrier.wait(timeout=0.1)
-                except threading.BrokenBarrierError:
-                    pass
-                return iter(keys)
-
-        cache = CoordinatedCache({b"old": object()})
+        cache: OrderedDict[bytes, Any] = OrderedDict({b"old": object()})
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
         monkeypatch.setattr(json_util, "_VALIDATOR_CACHE_MAX_ENTRIES", 1)
         values = (object(), object())
@@ -899,3 +889,164 @@ class TestValidateWithJsonschema:
 
         assert published == values
         assert len(cache) == 1
+
+    def test_cache_uses_lru_eviction(self, monkeypatch):
+        """A recently reused schema survives the next full-cache insertion."""
+        cache: OrderedDict[bytes, Any] = OrderedDict()
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE_MAX_ENTRIES", 2)
+        schemas = [
+            {
+                "type": "object",
+                "properties": {"value": {"type": "integer", "minimum": minimum}},
+            }
+            for minimum in range(3)
+        ]
+
+        for schema in schemas[:2]:
+            assert validate_with_jsonschema(schema, {"value": 2}) is None
+        assert validate_with_jsonschema(schemas[0], {"value": 2}) is None
+        assert validate_with_jsonschema(schemas[2], {"value": 2}) is None
+
+        keys = [json_util._schema_cache_key(schema) for schema in schemas]
+        assert list(cache) == [keys[0], keys[2]]
+
+    @pytest.mark.parametrize(
+        (
+            "first_schema",
+            "first_data",
+            "second_schema",
+            "second_data",
+            "expected_entries",
+        ),
+        [
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number", "maximum": float("inf")}
+                    },
+                },
+                {"value": 5},
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number", "maximum": float("-inf")}
+                    },
+                },
+                {"value": 5},
+                0,
+            ),
+            (
+                {"type": "object", "properties": {"value": {"enum": [(1, 2)]}}},
+                {"value": [1, 2]},
+                {"type": "object", "properties": {"value": {"enum": [[1, 2]]}}},
+                {"value": [1, 2]},
+                1,
+            ),
+        ],
+    )
+    def test_lossy_serializations_bypass_cache(
+        self,
+        first_schema,
+        first_data,
+        second_schema,
+        second_data,
+        expected_entries,
+        monkeypatch,
+    ):
+        """Values that orjson conflates retain jsonschema's exact behavior."""
+        cache: OrderedDict[bytes, Any] = OrderedDict()
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+
+        assert validate_with_jsonschema(
+            first_schema, first_data
+        ) == self._baseline_outcome(first_schema, first_data)
+        assert not cache
+        assert validate_with_jsonschema(
+            second_schema, second_data
+        ) == self._baseline_outcome(second_schema, second_data)
+        assert len(cache) == expected_entries
+
+    def test_nonfinite_key_cannot_hide_malformed_schema(self, monkeypatch):
+        """A non-finite key cannot collide with an invalid null constraint."""
+        cache: OrderedDict[bytes, Any] = OrderedDict()
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+        nonfinite = {
+            "type": "object",
+            "properties": {"value": {"type": "number", "maximum": float("inf")}},
+        }
+        malformed = {
+            "type": "object",
+            "properties": {"value": {"type": "number", "maximum": None}},
+        }
+
+        assert validate_with_jsonschema(nonfinite, {"value": 5}) is None
+        with pytest.raises(jsonschema.SchemaError):
+            validate_with_jsonschema(malformed, {"value": 5})
+        assert not cache
+
+    def test_oversized_schema_is_not_retained(self, monkeypatch):
+        """Caller-controlled schemas above the key budget compile uncached."""
+        cache: OrderedDict[bytes, Any] = OrderedDict()
+        monkeypatch.setattr(json_util, "_VALIDATOR_CACHE", cache)
+        schema = {
+            "type": "object",
+            "description": "x" * 20_000,
+            "properties": {"value": {"type": "string"}},
+        }
+
+        assert validate_with_jsonschema(schema, {"value": "text"}) is None
+        assert validate_with_jsonschema(schema, {"value": "text"}) is None
+        assert not cache
+
+    @pytest.mark.parametrize(
+        ("schema", "data"),
+        [
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+                    },
+                },
+                {"value": []},
+            ),
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {"oneOf": [{"minimum": 5}, {"type": "string"}]}
+                    },
+                },
+                {"value": 3},
+            ),
+            (
+                {
+                    "type": "object",
+                    "properties": {
+                        "nested": {
+                            "type": "object",
+                            "properties": {
+                                "value": {"anyOf": [{"type": "string"}, {"minimum": 5}]}
+                            },
+                        }
+                    },
+                },
+                {"nested": {"value": 3}},
+            ),
+        ],
+    )
+    def test_nested_error_message_matches_jsonschema_exactly(self, schema, data):
+        """best_match keeps byte-for-byte parity for combinator errors."""
+        assert validate_with_jsonschema(schema, data) == self._baseline_outcome(
+            schema, data
+        )
+
+    @staticmethod
+    def _baseline_outcome(schema: dict[str, Any], data: dict[str, Any]) -> str | None:
+        try:
+            jsonschema.validate(data, schema)
+        except jsonschema.ValidationError as error:
+            return str(error)
+        return None

--- a/autogpt_platform/backend/backend/util/test_json.py
+++ b/autogpt_platform/backend/backend/util/test_json.py
@@ -822,9 +822,26 @@ class TestValidateWithJsonschema:
             "properties": {"a": {"type": "string"}},
             "required": ["a", "a"],
         }
+        json_util._VALIDATOR_CACHE.clear()
+        errors: list[jsonschema.SchemaError] = []
         for _ in range(3):
-            with pytest.raises(jsonschema.SchemaError):
+            with pytest.raises(jsonschema.SchemaError) as exc_info:
                 validate_with_jsonschema(malformed, {"a": "x"})
+            errors.append(exc_info.value)
+
+        def traceback_depth(error: BaseException) -> int:
+            depth = 0
+            traceback = error.__traceback__
+            while traceback is not None:
+                depth += 1
+                traceback = traceback.tb_next
+            return depth
+
+        # Re-raising one cached exception grows its retained traceback on every
+        # call. Keep malformed schemas uncached so each failure remains fresh.
+        assert len({id(error) for error in errors}) == len(errors)
+        assert len({traceback_depth(error) for error in errors}) == 1
+        assert not json_util._VALIDATOR_CACHE
 
     def test_schema_mutated_in_place_is_not_stale(self):
         """Mutating a schema between calls must change the verdict."""


### PR DESCRIPTION
### Why / What / How

**Why.** `validate_with_jsonschema` in `backend/util/json.py` calls the
module-level `jsonschema.validate()`. That convenience wrapper does two things on
**every single call** that depend only on the schema: it re-resolves the
validator class, and it runs `cls.check_schema(schema)`, which validates the
schema itself against the full Draft-2020-12 meta-schema. Then it throws the
validator away. This function sees the same handful of schemas over and over.
`BlockSchema.jsonschema()` already caches the schema dict per class, so a busy
executor re-checks the same schemas against the meta-schema thousands of times.

Measured on the **44 unique input schemas across 46 occurrences in the 18 agent JSON files this repository currently ships** in
`autogpt_platform/backend/agents/*.json`, which are the exact objects
`AgentExecutorBlock.Input.get_mismatch_error` passes to this function. Each call
costs **1.46 ms on average**, ranging from 0.40 ms to 2.73 ms. The cost barely
tracks schema size, because the meta-schema check dominates: even the cheapest of
these schemas costs 0.40 ms.

It is on the per-node-execution path four ways:

| call site | frequency |
|---|---|
| `blocks/_base.py:852` / `:861`, `input_schema.validate_data(...)` in `Block.execute` | once per **block execution** |
| `executor/utils.py:372`, `schema.get_mismatch_error(data)` in `validate_exec`, reached from `executor/manager.py:187` | once per **node execution**, before it runs |
| `executor/manager.py:479` | once per **outgoing link traversal** when enqueuing each downstream node |
| `executor/manager.py:526` | once per waiting **incomplete static-link execution** re-checked |

A graph run with N node executions and E link traversals makes roughly `2N + E`
of these calls. `validate_exec` is also a synchronous `def` called from async
executor paths, so the cost lands on executor throughput as well as on
per-execution latency. Two further callers sit outside the executor:
`blocks/agent.py:65` (sub-agent input schemas) and `blocks/mcp/block.py:129`
(MCP tool schemas).

**What.** Compile the validator once per distinct schema and reuse it. Behaviour
does not change, including the awkward parts covered below. **Honest denominator:** the optimization applies to repeated validation of admitted schemas. First-seen, unsafe, and oversized schemas still use the uncached validation path and may pay key inspection and copying overhead. The saving is on every subsequent call with that schema, which is the
normal case here rather than the exception.

**How.** A small `_compiled_validator` helper resolves the validator class, runs
`check_schema` once, and caches the resulting validator. Three details worth
reviewing:

1. **The cache key is the schema's serialized content, not its identity.** A
   graph's input schema is rebuilt as a fresh dict on every execution, so
   identity keying would never hit, and it would pin every schema object the
   process has ever seen alive forever. Key order stays as the caller wrote it,
   because the error strings this function returns embed a `repr` of the failing
   sub-schema, and reordering keys would change them.
2. **Malformed schemas are deliberately not cached.**
   This is not hypothetical. `agent_00fdd42c-…json`'s `output_schema` in this
   repository has duplicate entries in `required` and genuinely fails the
   meta-schema check. `jsonschema.validate()` raises `SchemaError` (not
   `ValidationError`) there, and it escapes this function uncaught. Each call
   runs `check_schema` again and raises a fresh exception, so the cache cannot
   retain a `SchemaError` with a traceback that grows across repeated calls.
3. **The cached validator compiles against a private deep copy.** A `jsonschema`
   validator memoises the sub-schemas it walks, so a retained one must not alias
   a dict the caller still holds and might mutate afterwards.

The cache is a true LRU holding at most 2,048 entries. It admits finite JSON-native schemas plus stable string-backed enums, fingerprints enum types to keep keys injective, rejects repeated container identities, and retains serialized keys no larger than 32 KiB; all 557 currently loadable built-in input schemas fit this bound.

One subtlety that is easy to get wrong: `jsonschema.validate()` raises
`best_match(validator.iter_errors(data))`, whereas `Validator.validate()` raises
the **first** error from `iter_errors`. On a schema with two violated properties
those pick different errors and produce different strings, so this change calls
`best_match` explicitly to keep the returned message identical.

Supplementary autoresearch, as exploratory evidence only: [public dashboard](https://dashboard.weco.ai/share/N7mK0DxJIR-SVWxNqtNux6BJKMmyKA1J). The shipped hardening follows the safe step-5/6 lineage rather than the dashboard's visible best step.

### Changes 🏗️

- `backend/util/json.py`: adds `_compiled_validator`, a bounded content-keyed
  cache of compiled `jsonschema` validators, and routes
  `validate_with_jsonschema` through it instead of the module-level
  `jsonschema.validate()`.
- `backend/util/test_json.py`: adds focused cache coverage; the focused file now passes 58 tests,
  which previously had **no test coverage at all**. They cover valid and invalid
  verdicts, repeated calls with one schema, distinct schemas not being
  conflated, equal-but-distinct schema objects, `SchemaError` still escaping on
  every call, and in-place schema mutation not going stale.

### Results

Same 44 unique current input schemas, 20 iterations per schema, seven alternating CPU-serialized pairs:

| | median ms per call |
| --- | ---: |
| current `dev` | **1.6327** |
| this PR | **0.1578** |

Repeated validation is **10.35x faster** on this fixture. Base and candidate produced the same outcome digest in every pair. This benchmark measures the warmed repeated-validation path; it does not characterize first-seen or uncached schemas.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pytest backend/util/test_json.py -q`: `58 passed` on the repaired head
  - [x] `ruff check backend/util/json.py backend/util/test_json.py`: clean
  - [x] `black --check backend/util/json.py backend/util/test_json.py`: clean
  - [x] `isort --profile black --check-only backend/util/json.py backend/util/test_json.py`: clean
  - [x] Character-for-character comparison of the returned value against the
        unmodified implementation across the 44 unique current input schemas plus
        randomised schemas, including exception type and message where one
        escapes
  - [x] Before/after benchmark on the same fixtures, CPU-serialised