### PR TITLE
feat(frontend): use GPT Transcribe for voice input

### DIFF
--- a/autogpt_platform/frontend/.env.default
+++ b/autogpt_platform/frontend/.env.default
@@ -81,3 +81,4 @@ NEXT_PUBLIC_VAPID_PUBLIC_KEY=BBg49iVTWthVbRYphwmZNvZyiSJDqtSO4nmLxDzLKe3Oo9jbtu0
 
 # OpenAI (for voice transcription)
 OPENAI_API_KEY=
+TRANSCRIPTION_MODEL=gpt-transcribe

--- a/autogpt_platform/frontend/src/app/api/transcribe/__tests__/route.test.ts
+++ b/autogpt_platform/frontend/src/app/api/transcribe/__tests__/route.test.ts
@@ -81,7 +81,7 @@ describe("transcribe route", () => {
     );
   });
 
-  it("uses the OpenAI API key for the default transcription endpoint", async () => {
+  it("uses GPT Transcribe and the OpenAI API key by default", async () => {
     process.env.OPENAI_API_KEY = "openai-token";
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ text: "ok" }), {
@@ -103,6 +103,8 @@ describe("transcribe route", () => {
     expect((fetchInit.headers as Headers).get("Authorization")).toBe(
       "Bearer openai-token",
     );
+    const upstreamBody = fetchInit.body as FormData;
+    expect(upstreamBody.get("model")).toBe("gpt-transcribe");
   });
 
   it("does not send the OpenAI API key to a custom transcription endpoint", async () => {

--- a/autogpt_platform/frontend/src/app/api/transcribe/route.ts
+++ b/autogpt_platform/frontend/src/app/api/transcribe/route.ts
@@ -2,8 +2,8 @@ import { getServerAuthToken } from "@/lib/auth/server/getServerAuthToken";
 import { NextRequest, NextResponse } from "next/server";
 
 const DEFAULT_TRANSCRIPTION_API_BASE_URL = "https://api.openai.com/v1";
-const DEFAULT_TRANSCRIPTION_MODEL = "whisper-1";
-const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB - Whisper's limit
+const DEFAULT_TRANSCRIPTION_MODEL = "gpt-transcribe";
+const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB - Transcriptions API limit
 
 function getTranscriptionApiBaseUrl(): string {
   return (
@@ -76,9 +76,9 @@ export async function POST(request: NextRequest) {
     }
 
     const ext = getExtensionFromMimeType(audioFile.type);
-    const whisperFormData = new FormData();
-    whisperFormData.append("file", audioFile, `recording.${ext}`);
-    whisperFormData.append("model", getTranscriptionModel());
+    const transcriptionFormData = new FormData();
+    transcriptionFormData.append("file", audioFile, `recording.${ext}`);
+    transcriptionFormData.append("model", getTranscriptionModel());
     const headers = new Headers();
     if (apiKey) {
       headers.set("Authorization", `Bearer ${apiKey}`);
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
     const response = await fetch(getTranscriptionApiUrl(), {
       method: "POST",
       headers,
-      body: whisperFormData,
+      body: transcriptionFormData,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
### Why / What / How

AutoPilot voice input currently defaults to OpenAI's legacy `whisper-1` transcription model. This PR moves the default to the current GPT Transcribe model, `gpt-transcribe`, while preserving the existing OpenAI-hosted Transcriptions API flow and self-hosted/OpenAI-compatible overrides.

The route continues to send the recorded audio as multipart form data to `/audio/transcriptions`, authenticate with the existing server-side key logic, and return only the transcription text to the client. Deployments that set `TRANSCRIPTION_MODEL` explicitly remain supported.

### Changes 🏗️

- Change AutoPilot's default voice transcription model from `whisper-1` to `gpt-transcribe`
- Add `TRANSCRIPTION_MODEL=gpt-transcribe` to the frontend default environment configuration
- Rename the request form-data variable and file-size comment to be provider-neutral
- Add a regression assertion for the default model sent to the upstream Transcriptions API
- No new secrets, services, ports, dependencies, endpoint changes, or migrations

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm exec vitest run src/app/api/transcribe/__tests__/route.test.ts` (6/6)
  - [x] `pnpm lint`
  - [x] `pnpm types`
  - [x] Frontend `integration_test` / `pnpm test:unit` on Ubuntu CI
  - [x] Platform full-stack end-to-end tests on Ubuntu CI
  - [x] CodeQL, Snyk, Codecov project/patch, Vercel, CLA, and repository policy checks

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes (the frontend service already loads `frontend/.env.default`)
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)