### PR TITLE
ci(platform): validate and publish single-container images

### DIFF
--- a/.github/scripts/platform-single-container-smoke.sh
+++ b/.github/scripts/platform-single-container-smoke.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+: "${SMOKE_IMAGE:?SMOKE_IMAGE is required}"
+: "${SMOKE_PLATFORM:?SMOKE_PLATFORM is required}"
+
+readonly PUBLIC_URL=http://localhost:3300
+readonly TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-2700}"
+readonly SAFE_PLATFORM="${SMOKE_PLATFORM//\//-}"
+readonly RUN_TOKEN="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-${SAFE_PLATFORM}-${RANDOM}"
+readonly RUN_CONTAINER_NAME="autogpt-single-smoke-${RUN_TOKEN}"
+readonly COMPOSE_PROJECT_NAME="autogpt-single-smoke-${RUN_TOKEN,,}"
+readonly COMPOSE_FILE="autogpt_platform/docker-compose.single-container.yml"
+readonly COMPOSE_ENV_FILE="autogpt_platform/single-container/.env.example"
+readonly COMPOSE_IMAGE_REPOSITORY="autogpt-platform-single-container-smoke"
+readonly COMPOSE_IMAGE_TAG="${RUN_TOKEN,,}"
+readonly COMPOSE_IMAGE="${COMPOSE_IMAGE_REPOSITORY}:${COMPOSE_IMAGE_TAG}"
+HEADERS_FILE="$(mktemp)"
+readonly HEADERS_FILE
+
+CONTAINER_NAME="${RUN_CONTAINER_NAME}"
+DATA_VOLUME=
+COMPOSE_STARTED=false
+
+compose() {
+  env \
+    AUTOGPT_COMPOSE_ENV_LOADED=true \
+    AUTOGPT_IMAGE="${COMPOSE_IMAGE_REPOSITORY}" \
+    AUTOGPT_TAG="${COMPOSE_IMAGE_TAG}" \
+    AUTOGPT_PUBLIC_URL="${PUBLIC_URL}" \
+    AUTOGPT_BIND_ADDRESS=127.0.0.1 \
+    AUTOGPT_PORT=3300 \
+    AUTOGPT_DATA_VOLUME="${DATA_VOLUME}" \
+    docker compose \
+      --project-name "${COMPOSE_PROJECT_NAME}" \
+      --env-file "${COMPOSE_ENV_FILE}" \
+      --file "${COMPOSE_FILE}" \
+      "$@"
+}
+
+diagnostics() {
+  if [[ "${COMPOSE_STARTED}" == true ]]; then
+    compose ps --all || true
+    compose logs --timestamps --tail 2000 || true
+  fi
+  if docker container inspect "${CONTAINER_NAME}" >/dev/null 2>&1; then
+    docker inspect --format '{{json .State}}' "${CONTAINER_NAME}" || true
+    docker logs --timestamps --tail 2000 "${CONTAINER_NAME}" || true
+  fi
+}
+
+cleanup() {
+  local result=$?
+  trap - EXIT INT TERM
+  if ((result != 0)); then
+    diagnostics
+  fi
+  if [[ "${COMPOSE_STARTED}" == true ]]; then
+    compose down --timeout 360 --remove-orphans >/dev/null 2>&1 || true
+  fi
+  if docker container inspect "${CONTAINER_NAME}" >/dev/null 2>&1; then
+    docker stop --timeout 360 "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+    docker rm --force --volumes "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${DATA_VOLUME}" ]] && docker volume inspect "${DATA_VOLUME}" >/dev/null 2>&1; then
+    docker volume rm "${DATA_VOLUME}" >/dev/null 2>&1 || true
+  fi
+  docker image rm "${COMPOSE_IMAGE}" >/dev/null 2>&1 || true
+  rm -f "${HEADERS_FILE}"
+  exit "${result}"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+[[ "${TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || {
+  echo "SMOKE_TIMEOUT_SECONDS must be an integer" >&2
+  exit 2
+}
+
+wait_for_healthy() {
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  local state
+  local health
+  local exit_code
+  while ((SECONDS < deadline)); do
+    read -r state health exit_code < <(
+      docker inspect \
+        --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}} {{.State.ExitCode}}' \
+        "${CONTAINER_NAME}"
+    )
+    case "${state}:${health}" in
+      running:healthy)
+        return 0
+        ;;
+      exited:* | dead:* | removing:* | *:unhealthy)
+        echo "container failed while waiting for health: state=${state} health=${health} exit=${exit_code}" >&2
+        return 1
+        ;;
+    esac
+    sleep 10
+  done
+  echo "container did not become healthy within ${TIMEOUT_SECONDS}s" >&2
+  return 1
+}
+
+wait_for_automatic_restart() {
+  local minimum_restart_count="$1"
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+  local state
+  local health
+  local restart_count
+  while ((SECONDS < deadline)); do
+    read -r state health restart_count < <(
+      docker inspect \
+        --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}} {{.RestartCount}}' \
+        "${CONTAINER_NAME}"
+    )
+    if [[ "${state}:${health}" == running:healthy ]] &&
+      ((restart_count >= minimum_restart_count)); then
+      return 0
+    fi
+    case "${state}" in
+      dead | removing)
+        echo "container failed while waiting for automatic restart: state=${state}" >&2
+        return 1
+        ;;
+    esac
+    sleep 10
+  done
+  echo "container did not automatically restart and become healthy" >&2
+  return 1
+}
+
+runtime_config_hash() {
+  docker exec "${CONTAINER_NAME}" sha256sum /data/config/runtime.env | awk '{print $1}'
+}
+
+discover_data_volume() {
+  local mount_record
+  local mount_type
+  mount_record="$(
+    docker inspect \
+      --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Type}} {{.Name}}{{println}}{{end}}{{end}}' \
+      "${CONTAINER_NAME}"
+  )"
+  read -r mount_type DATA_VOLUME <<<"${mount_record}"
+  [[ "${mount_type}" == volume && "${DATA_VOLUME}" =~ ^[A-Za-z0-9_.-]+$ ]] || {
+    echo "image did not create one Docker volume at /data" >&2
+    return 1
+  }
+}
+
+preseed_hostile_backend_config() {
+  docker run --rm \
+    --platform "${SMOKE_PLATFORM}" \
+    --volume "${DATA_VOLUME}:/data" \
+    --entrypoint /app/autogpt_platform/backend/.venv/bin/python \
+    "${SMOKE_IMAGE}" -c '
+import json
+import os
+from pathlib import Path
+
+path = Path("/data/config/backend.json")
+path.write_text(json.dumps({
+    "pyro_host": "0.0.0.0",
+    "websocket_server_host": "0.0.0.0",
+    "websocket_server_port": 18001,
+    "execution_manager_port": 18002,
+    "execution_scheduler_port": 18003,
+    "database_api_port": 18005,
+    "agent_api_host": "0.0.0.0",
+    "agent_api_port": 18006,
+    "notification_service_port": 18007,
+    "copilot_executor_port": 18008,
+    "platform_linking_service_port": 18009,
+    "copilot_chat_bridge_port": 18010,
+    "batch_executor_port": 18011,
+}) + "\n", encoding="utf-8")
+os.chown(path, 10001, 10001)
+os.chmod(path, 0o600)
+' >/dev/null
+}
+
+assert_pinned_topology_environment() {
+  local pid
+  local process_env
+  pid="$(
+    docker exec "${CONTAINER_NAME}" \
+      supervisorctl -c /opt/autogpt/single-container/supervisor/supervisord.conf pid rest
+  )"
+  [[ "${pid}" =~ ^[0-9]+$ ]]
+  # Docker Desktop can deny cross-UID /proc reads even to container root.
+  # Read the service environment as the same unprivileged UID instead.
+  process_env="$(
+    docker exec --user autogpt "${CONTAINER_NAME}" \
+      /bin/bash -Eeuo pipefail -c 'tr "\0" "\n" <"/proc/${1}/environ"' \
+      bash "${pid}"
+  )"
+  for expected in \
+    PYRO_HOST=127.0.0.1 \
+    WEBSOCKET_SERVER_HOST=127.0.0.1 WEBSOCKET_SERVER_PORT=8001 \
+    EXECUTION_MANAGER_PORT=8002 EXECUTION_SCHEDULER_PORT=8003 \
+    DATABASE_API_PORT=8005 AGENT_API_HOST=127.0.0.1 AGENT_API_PORT=8006 \
+    NOTIFICATION_SERVICE_PORT=8007 COPILOT_EXECUTOR_PORT=8008 \
+    PLATFORM_LINKING_SERVICE_PORT=8009 COPILOT_CHAT_BRIDGE_PORT=8010 \
+    BATCH_EXECUTOR_PORT=8011; do
+    grep -Fxq "${expected}" <<<"${process_env}"
+  done
+}
+
+assert_request_tokens_absent_from_logs() {
+  local sentinel=AUTOGPT_LOG_SENTINEL_6f2b3cb87e9a
+  local websocket_key=dGhlIHNhbXBsZSBub25jZQ== # pragma: allowlist secret # gitleaks:allow
+  local websocket_status
+
+  curl --fail --silent --show-error --max-time 30 \
+    "${PUBLIC_URL}/_agpt/health?token=${sentinel}" >/dev/null
+  curl --silent --show-error --max-time 30 \
+    "${PUBLIC_URL}/link/${sentinel}?token=${sentinel}" >/dev/null
+  websocket_status="$(
+    curl --silent --show-error --max-time 30 --http1.1 \
+      --output /dev/null --write-out '%{http_code}' \
+      --header 'Connection: Upgrade' \
+      --header 'Upgrade: websocket' \
+      --header 'Sec-WebSocket-Version: 13' \
+      --header "Sec-WebSocket-Key: ${websocket_key}" \
+      --header "Origin: ${PUBLIC_URL}" \
+      "${PUBLIC_URL}/_agpt/ws?token=${sentinel}"
+  )"
+  [[ "${websocket_status}" == 403 ]] || {
+    echo "invalid-token WebSocket handshake returned ${websocket_status}, expected 403" >&2
+    return 1
+  }
+  sleep 2
+  # Do not use grep -q here: with pipefail an early grep exit can SIGPIPE
+  # `docker logs` and accidentally turn a positive match into a false result.
+  if docker logs "${CONTAINER_NAME}" 2>&1 | grep -F "${sentinel}" >/dev/null; then
+    echo "request token sentinel leaked into container logs" >&2
+    return 1
+  fi
+}
+
+assert_internal_tooling_is_private() {
+  local path
+  local status
+  for path in \
+    /_agpt/docs /_agpt/redoc /_agpt/openapi.json /_agpt/metrics \
+    /_agpt/external-api/docs /_agpt/external-api/redoc \
+    /_agpt/external-api/openapi.json /_agpt/external-api/metrics; do
+    status="$(
+      curl --silent --show-error --max-time 30 \
+        --output /dev/null --write-out '%{http_code}' "${PUBLIC_URL}${path}"
+    )"
+    [[ "${status}" == 404 ]] || {
+      echo "internal tooling path ${path} returned ${status}, expected 404" >&2
+      return 1
+    }
+  done
+}
+
+assert_runtime_config_mode() {
+  local mode
+  mode="$(docker exec "${CONTAINER_NAME}" stat -c '%a' /data/config/runtime.env)"
+  [[ "${mode}" == 600 ]] || {
+    echo "runtime config mode is ${mode}, expected 600" >&2
+    return 1
+  }
+}
+
+assert_redirect() {
+  local request_url="$1"
+  shift
+  local status
+  local location
+  status="$(
+    curl --silent --show-error --max-time 30 \
+      --dump-header "${HEADERS_FILE}" --output /dev/null \
+      --write-out '%{http_code}' "$@" "${request_url}"
+  )"
+  location="$(
+    tr -d '\r' <"${HEADERS_FILE}" |
+      awk 'tolower($1) == "location:" {sub(/^[^:]+:[[:space:]]*/, ""); print; exit}'
+  )"
+  [[ "${status}" == 307 ]] || {
+    echo "protected route returned ${status}, expected 307" >&2
+    return 1
+  }
+  [[ "${location}" == "${PUBLIC_URL}/login?next=%2Fcopilot" ]] || {
+    echo "unexpected protected-route Location: ${location}" >&2
+    return 1
+  }
+}
+
+assert_prefixed_backend_redirect() {
+  local status
+  local location
+  status="$(
+    curl --silent --show-error --max-time 30 \
+      --request POST --dump-header "${HEADERS_FILE}" --output /dev/null \
+      --write-out '%{http_code}' "${PUBLIC_URL}/_agpt/api/email"
+  )"
+  location="$(
+    tr -d '\r' <"${HEADERS_FILE}" |
+      awk 'tolower($1) == "location:" {sub(/^[^:]+:[[:space:]]*/, ""); print; exit}'
+  )"
+  [[ "${status}" == 307 ]] || {
+    echo "backend slash redirect returned ${status}, expected 307" >&2
+    return 1
+  }
+  [[ "${location}" == "${PUBLIC_URL}/_agpt/api/email/" ]] || {
+    echo "backend slash redirect lost its public prefix: ${location}" >&2
+    return 1
+  }
+}
+
+# Phase one deliberately supplies no environment, port, volume, entrypoint, or
+# command override. This is the CI proof for literal `docker run IMAGE`.
+docker run --detach \
+  --platform "${SMOKE_PLATFORM}" \
+  --name "${CONTAINER_NAME}" \
+  "${SMOKE_IMAGE}" >/dev/null
+discover_data_volume
+wait_for_healthy
+
+first_hash="$(runtime_config_hash)"
+[[ "${first_hash}" =~ ^[0-9a-f]{64}$ ]] || {
+  echo "runtime config checksum is invalid" >&2
+  exit 1
+}
+assert_runtime_config_mode
+
+docker stop --timeout 360 "${CONTAINER_NAME}" >/dev/null
+[[ "$(docker inspect --format '{{.State.ExitCode}}' "${CONTAINER_NAME}")" == 0 ]] || {
+  echo "container did not exit cleanly after docker stop" >&2
+  exit 1
+}
+docker rm "${CONTAINER_NAME}" >/dev/null
+
+# A persistent user config must not be able to move internal listeners or bind
+# them publicly. Environment-pinned topology has higher Pydantic precedence.
+preseed_hostile_backend_config
+
+# Phase two proves explicit public-origin configuration, container replacement,
+# and reuse of the exact state volume discovered above.
+docker run --detach \
+  --platform "${SMOKE_PLATFORM}" \
+  --name "${CONTAINER_NAME}" \
+  --restart unless-stopped \
+  --publish 127.0.0.1:3300:3000 \
+  --env "AUTOGPT_PUBLIC_URL=${PUBLIC_URL}" \
+  --volume "${DATA_VOLUME}:/data" \
+  "${SMOKE_IMAGE}" >/dev/null
+wait_for_healthy
+
+[[ "$(runtime_config_hash)" == "${first_hash}" ]] || {
+  echo "runtime config changed across container replacement" >&2
+  exit 1
+}
+assert_runtime_config_mode
+assert_pinned_topology_environment
+curl --fail --silent --show-error "${PUBLIC_URL}/healthz" >/dev/null
+assert_redirect "${PUBLIC_URL}/copilot" --resolve localhost:3300:127.0.0.1
+assert_redirect http://127.0.0.1:3300/copilot \
+  --header 'Host: attacker.invalid' \
+  --header 'X-Forwarded-Proto: https'
+assert_prefixed_backend_redirect
+assert_internal_tooling_is_private
+assert_request_tokens_absent_from_logs
+
+restart_count="$(docker inspect --format '{{.RestartCount}}' "${CONTAINER_NAME}")"
+docker exec "${CONTAINER_NAME}" \
+  supervisorctl \
+  -c /opt/autogpt/single-container/supervisor/supervisord.conf \
+  stop nginx >/dev/null
+wait_for_automatic_restart "$((restart_count + 1))"
+[[ "$(runtime_config_hash)" == "${first_hash}" ]] || {
+  echo "runtime config changed across automatic Docker restart" >&2
+  exit 1
+}
+assert_runtime_config_mode
+assert_redirect "${PUBLIC_URL}/copilot" --resolve localhost:3300:127.0.0.1
+
+docker stop --timeout 360 "${CONTAINER_NAME}" >/dev/null
+[[ "$(docker inspect --format '{{.State.ExitCode}}' "${CONTAINER_NAME}")" == 0 ]] || {
+  echo "container did not exit cleanly before the Compose phase" >&2
+  exit 1
+}
+docker rm "${CONTAINER_NAME}" >/dev/null
+
+# Phase three launches the documented one-service Compose distribution against
+# the same persistent state and locally built image.
+docker image tag "${SMOKE_IMAGE}" "${COMPOSE_IMAGE}"
+COMPOSE_STARTED=true
+compose up --detach --no-build
+CONTAINER_NAME="$(compose ps --quiet autogpt)"
+[[ -n "${CONTAINER_NAME}" ]] || {
+  echo "Compose did not create the autogpt service container" >&2
+  exit 1
+}
+wait_for_healthy
+[[ "$(runtime_config_hash)" == "${first_hash}" ]] || {
+  echo "runtime config changed during the Compose lifecycle" >&2
+  exit 1
+}
+assert_runtime_config_mode
+assert_redirect "${PUBLIC_URL}/copilot" --resolve localhost:3300:127.0.0.1
+
+echo "single-container smoke test passed for ${SMOKE_PLATFORM}"

--- a/.github/workflows/platform-single-container-docker.yml
+++ b/.github/workflows/platform-single-container-docker.yml
@@ -1,0 +1,547 @@
+name: AutoGPT Platform - Single-container image
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - ".dockerignore"
+      - ".github/scripts/platform-single-container-smoke.sh"
+      - ".github/workflows/platform-single-container-docker.yml"
+      - "autogpt_platform/**"
+      - "docs/**"
+  pull_request:
+    branches: [dev]
+    paths:
+      - ".dockerignore"
+      - ".github/scripts/platform-single-container-smoke.sh"
+      - ".github/workflows/platform-single-container-docker.yml"
+      - "autogpt_platform/**"
+      - "docs/**"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish an experimental Docker Hub image"
+        required: true
+        type: boolean
+        default: false
+      tag:
+        description: "Unique Docker tag; publishing requires an experimental-* tag"
+        required: false
+        type: string
+      confirmation:
+        description: "Type PUBLISH EXPERIMENTAL to authorize a push"
+        required: false
+        type: string
+      falkordb_sspl_approval:
+        description: "After legal review, type FALKORDB SSPL DISTRIBUTION APPROVED"
+        required: false
+        type: string
+      whole_image_distribution_approval:
+        description: "After full SBOM/notice review, type WHOLE IMAGE DISTRIBUTION APPROVED"
+        required: false
+        type: string
+      whole_image_review_reference:
+        description: "Ticket or approval reference for the full-image license and notice review"
+        required: false
+        type: string
+      legal_review_reference:
+        description: "Ticket or approval reference for the FalkorDB SSPL distribution review"
+        required: false
+        type: string
+      security_review_reference:
+        description: "Ticket or approval reference for the image vulnerability and secret review"
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-scan:
+    name: Build, smoke, and scan (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            suffix: amd64
+          - platform: linux/arm64
+            suffix: arm64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          version: v0.36.0
+          driver-opts: |
+            image=docker.io/moby/buildkit:v0.32.0@sha256:1f8167fcb0eca5b7126353d35299386945cbb8949cc516c592a49f80cfce4fa2
+
+      - name: Build image without publishing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: autogpt_platform/backend/Dockerfile
+          target: single-container
+          platforms: ${{ matrix.platform }}
+          load: true
+          push: false
+          tags: autogpt-platform-single-container:ci-${{ matrix.suffix }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=LicenseRef-PolyForm-Shield-1.0.0 AND SSPL-1.0
+          cache-from: type=gha,scope=platform-single-container-${{ matrix.suffix }}
+          cache-to: type=gha,scope=platform-single-container-${{ matrix.suffix }},mode=max
+
+      - name: Smoke-test the complete image
+        shell: bash
+        env:
+          SMOKE_IMAGE: autogpt-platform-single-container:ci-${{ matrix.suffix }}
+          SMOKE_PLATFORM: ${{ matrix.platform }}
+        run: bash .github/scripts/platform-single-container-smoke.sh
+
+      - name: Scan for fixable critical vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: autogpt-platform-single-container:ci-${{ matrix.suffix }}
+          format: table
+          ignore-unfixed: true
+          severity: CRITICAL
+          exit-code: "1"
+          timeout: 30m
+
+      - name: Report all high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: autogpt-platform-single-container:ci-${{ matrix.suffix }}
+          format: table
+          ignore-unfixed: false
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+          timeout: 30m
+
+      - name: Scan image filesystem for embedded secrets
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: autogpt-platform-single-container:ci-${{ matrix.suffix }}
+          scanners: secret
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          timeout: 30m
+
+  publication-gate:
+    name: Validate experimental publication request
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate branch, tag, and explicit approvals
+        shell: bash
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          FALKORDB_SSPL_APPROVAL: ${{ inputs.falkordb_sspl_approval }}
+          WHOLE_IMAGE_DISTRIBUTION_APPROVAL: ${{ inputs.whole_image_distribution_approval }}
+          WHOLE_IMAGE_REVIEW_REFERENCE: ${{ inputs.whole_image_review_reference }}
+          LEGAL_REVIEW_REFERENCE: ${{ inputs.legal_review_reference }}
+          SECURITY_REVIEW_REFERENCE: ${{ inputs.security_review_reference }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/dev" ]]; then
+            echo "experimental images may only be published from the dev branch" >&2
+            exit 1
+          fi
+          if [[ "$CONFIRMATION" != "PUBLISH EXPERIMENTAL" ]]; then
+            echo "confirmation must be exactly: PUBLISH EXPERIMENTAL" >&2
+            exit 1
+          fi
+          if [[ "$FALKORDB_SSPL_APPROVAL" != "FALKORDB SSPL DISTRIBUTION APPROVED" ]]; then
+            echo "FalkorDB SSPL distribution approval must be explicitly acknowledged" >&2
+            exit 1
+          fi
+          if [[ "$WHOLE_IMAGE_DISTRIBUTION_APPROVAL" != "WHOLE IMAGE DISTRIBUTION APPROVED" ]]; then
+            echo "whole-image SBOM, license, and notice approval must be explicitly acknowledged" >&2
+            exit 1
+          fi
+          if [[ -z "${LEGAL_REVIEW_REFERENCE//[[:space:]]/}" ]]; then
+            echo "a legal review ticket or approval reference is required" >&2
+            exit 1
+          fi
+          if (( ${#LEGAL_REVIEW_REFERENCE} > 200 )) || [[ "$LEGAL_REVIEW_REFERENCE" == *$'\n'* || "$LEGAL_REVIEW_REFERENCE" == *$'\r'* ]]; then
+            echo "legal review reference must be a single line of no more than 200 characters" >&2
+            exit 1
+          fi
+          legal_reference_pattern='^[A-Za-z0-9][A-Za-z0-9._:/# -]*$'
+          if [[ ! "$LEGAL_REVIEW_REFERENCE" =~ $legal_reference_pattern ]]; then
+            echo "legal review reference contains unsupported characters" >&2
+            exit 1
+          fi
+          if [[ -z "${SECURITY_REVIEW_REFERENCE//[[:space:]]/}" ]]; then
+            echo "a security review ticket or approval reference is required" >&2
+            exit 1
+          fi
+          if (( ${#SECURITY_REVIEW_REFERENCE} > 200 )) || [[ "$SECURITY_REVIEW_REFERENCE" == *$'\n'* || "$SECURITY_REVIEW_REFERENCE" == *$'\r'* ]]; then
+            echo "security review reference must be a single line of no more than 200 characters" >&2
+            exit 1
+          fi
+          if [[ ! "$SECURITY_REVIEW_REFERENCE" =~ $legal_reference_pattern ]]; then
+            echo "security review reference contains unsupported characters" >&2
+            exit 1
+          fi
+          if [[ -z "${WHOLE_IMAGE_REVIEW_REFERENCE//[[:space:]]/}" ]]; then
+            echo "a whole-image license and notice review reference is required" >&2
+            exit 1
+          fi
+          if (( ${#WHOLE_IMAGE_REVIEW_REFERENCE} > 200 )) || [[ "$WHOLE_IMAGE_REVIEW_REFERENCE" == *$'\n'* || "$WHOLE_IMAGE_REVIEW_REFERENCE" == *$'\r'* ]]; then
+            echo "whole-image review reference must be a single line of no more than 200 characters" >&2
+            exit 1
+          fi
+          if [[ ! "$WHOLE_IMAGE_REVIEW_REFERENCE" =~ $legal_reference_pattern ]]; then
+            echo "whole-image review reference contains unsupported characters" >&2
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_TAG" =~ ^experimental-[a-z0-9]([a-z0-9._-]*[a-z0-9])?$ ]]; then
+            echo "tag must use lowercase Docker tag characters and begin with experimental-" >&2
+            exit 1
+          fi
+          if (( ${#REQUESTED_TAG} > 128 )); then
+            echo "tag must be no more than 128 characters" >&2
+            exit 1
+          fi
+          if [[ "$REQUESTED_TAG" == *-latest ]]; then
+            echo "latest-style tags are not permitted" >&2
+            exit 1
+          fi
+
+  publish-platform-digests:
+    name: Build, push, smoke, and scan (${{ matrix.platform }})
+    if: ${{ needs.publication-gate.result == 'success' && needs.build-and-scan.result == 'success' }}
+    needs: [publication-gate, build-and-scan]
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    environment: dockerhub-experimental
+    env:
+      DEPLOY_IMAGE: ${{ secrets.DOCKER_USER }}/autogpt-platform
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            suffix: amd64
+          - platform: linux/arm64
+            suffix: arm64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          version: v0.36.0
+          driver-opts: |
+            image=docker.io/moby/buildkit:v0.32.0@sha256:1f8167fcb0eca5b7126353d35299386945cbb8949cc516c592a49f80cfce4fa2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Validate image coordinates and require an absent tag
+        shell: bash
+        env:
+          IMAGE: ${{ env.DEPLOY_IMAGE }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$IMAGE" =~ ^[a-z0-9]+([._-][a-z0-9]+)*/[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+            echo "DOCKER_USER does not produce a valid lowercase Docker Hub image name" >&2
+            exit 1
+          fi
+          set +e
+          inspect_output="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" 2>&1)"
+          inspect_status=$?
+          set -e
+          if ((inspect_status == 0)); then
+            echo "refusing to overwrite existing tag ${IMAGE}:${TAG}" >&2
+            exit 1
+          fi
+          if ! grep -Eq '(manifest unknown|: not found)$' <<<"$inspect_output"; then
+            echo "could not prove that ${IMAGE}:${TAG} is absent; failing closed" >&2
+            printf '%s\n' "$inspect_output" >&2
+            exit 1
+          fi
+
+      - name: Build and push canonical platform digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: autogpt_platform/backend/Dockerfile
+          target: single-container
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            IMAGE_VERSION=${{ inputs.tag }}
+            VCS_REF=${{ github.sha }}
+          outputs: type=image,name=${{ env.DEPLOY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.title=AutoGPT Platform single-container image
+            org.opencontainers.image.description=Experimental all-in-one AutoGPT Platform distribution
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=LicenseRef-PolyForm-Shield-1.0.0 AND SSPL-1.0
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha,scope=platform-single-container-${{ matrix.suffix }}
+          cache-to: type=gha,scope=platform-single-container-${{ matrix.suffix }},mode=max
+
+      - name: Pull the exact pushed platform digest
+        shell: bash
+        env:
+          SMOKE_IMAGE: ${{ env.DEPLOY_IMAGE }}@${{ steps.build.outputs.digest }}
+          SMOKE_PLATFORM: ${{ matrix.platform }}
+        run: docker pull --platform "${SMOKE_PLATFORM}" "${SMOKE_IMAGE}"
+
+      - name: Smoke-test the exact pushed platform digest
+        shell: bash
+        env:
+          SMOKE_IMAGE: ${{ env.DEPLOY_IMAGE }}@${{ steps.build.outputs.digest }}
+          SMOKE_PLATFORM: ${{ matrix.platform }}
+        run: bash .github/scripts/platform-single-container-smoke.sh
+
+      - name: Scan the exact pushed digest
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: ${{ matrix.platform }}
+        with:
+          image-ref: ${{ env.DEPLOY_IMAGE }}@${{ steps.build.outputs.digest }}
+          format: table
+          ignore-unfixed: true
+          severity: CRITICAL
+          exit-code: "1"
+          timeout: 30m
+
+      - name: Report high and critical findings for the exact pushed digest
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: ${{ matrix.platform }}
+        with:
+          image-ref: ${{ env.DEPLOY_IMAGE }}@${{ steps.build.outputs.digest }}
+          format: table
+          ignore-unfixed: false
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+          timeout: 30m
+
+      - name: Scan the exact pushed digest for embedded secrets
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_PLATFORM: ${{ matrix.platform }}
+        with:
+          image-ref: ${{ env.DEPLOY_IMAGE }}@${{ steps.build.outputs.digest }}
+          scanners: secret
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          timeout: 30m
+
+      - name: Export scanned digest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST_DIR: ${{ runner.temp }}/platform-single-container-digests
+          PLATFORM_SUFFIX: ${{ matrix.suffix }}
+        run: |
+          set -euo pipefail
+          digest_hex="${DIGEST#sha256:}"
+          if [[ ! "$digest_hex" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "build did not return a valid sha256 digest" >&2
+            exit 1
+          fi
+          mkdir -p "$DIGEST_DIR"
+          touch "${DIGEST_DIR}/${PLATFORM_SUFFIX}-${digest_hex}"
+
+      - name: Upload scanned digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: platform-single-container-digest-${{ matrix.suffix }}
+          path: ${{ runner.temp }}/platform-single-container-digests/*
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish-experimental-manifest:
+    name: Publish experimental manifest
+    if: ${{ needs.publish-platform-digests.result == 'success' }}
+    needs: publish-platform-digests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: dockerhub-experimental
+    env:
+      DEPLOY_IMAGE: ${{ secrets.DOCKER_USER }}/autogpt-platform
+    steps:
+      - name: Download scanned digests
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          pattern: platform-single-container-digest-*
+          path: ${{ runner.temp }}/platform-single-container-digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          version: v0.36.0
+          driver-opts: |
+            image=docker.io/moby/buildkit:v0.32.0@sha256:1f8167fcb0eca5b7126353d35299386945cbb8949cc516c592a49f80cfce4fa2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create manifest from the scanned digests
+        id: manifest
+        shell: bash
+        env:
+          IMAGE: ${{ env.DEPLOY_IMAGE }}
+          TAG: ${{ inputs.tag }}
+          DIGEST_DIR: ${{ runner.temp }}/platform-single-container-digests
+          MANIFEST_METADATA: ${{ runner.temp }}/platform-single-container-manifest.json
+          SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}
+          REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$IMAGE" =~ ^[a-z0-9]+([._-][a-z0-9]+)*/[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+            echo "DOCKER_USER does not produce a valid lowercase Docker Hub image name" >&2
+            exit 1
+          fi
+          if [[ ! "$TAG" =~ ^experimental-[a-z0-9]([a-z0-9._-]*[a-z0-9])?$ ]] || (( ${#TAG} > 128 )); then
+            echo "invalid experimental tag" >&2
+            exit 1
+          fi
+          set +e
+          inspect_output="$(docker buildx imagetools inspect "${IMAGE}:${TAG}" 2>&1)"
+          inspect_status=$?
+          set -e
+          if ((inspect_status == 0)); then
+            echo "refusing to overwrite existing tag ${IMAGE}:${TAG}" >&2
+            exit 1
+          fi
+          if ! grep -Eq '(manifest unknown|: not found)$' <<<"$inspect_output"; then
+            echo "could not prove that ${IMAGE}:${TAG} is absent; failing closed" >&2
+            printf '%s\n' "$inspect_output" >&2
+            exit 1
+          fi
+
+          mapfile -t digest_files < <(find "$DIGEST_DIR" -maxdepth 1 -type f -print | sort)
+          if (( ${#digest_files[@]} != 2 )); then
+            echo "expected exactly two scanned platform digests" >&2
+            exit 1
+          fi
+
+          declare -A seen_platforms=()
+          image_refs=()
+          for digest_file in "${digest_files[@]}"; do
+            descriptor="$(basename "$digest_file")"
+            if [[ ! "$descriptor" =~ ^(amd64|arm64)-([0-9a-f]{64})$ ]]; then
+              echo "invalid digest artifact name" >&2
+              exit 1
+            fi
+            expected_arch="${BASH_REMATCH[1]}"
+            digest_hex="${BASH_REMATCH[2]}"
+            if [[ -n "${seen_platforms[$expected_arch]:-}" ]]; then
+              echo "duplicate digest artifact for linux/${expected_arch}" >&2
+              exit 1
+            fi
+            seen_platforms[$expected_arch]=1
+            image_ref="${IMAGE}@sha256:${digest_hex}"
+            actual_platforms="$(
+              docker buildx imagetools inspect --raw "$image_ref" |
+                jq -r '.manifests[]?.platform | select(.os == "linux" and (.architecture == "amd64" or .architecture == "arm64")) | "\(.os)/\(.architecture)"' |
+                sort -u
+            )"
+            if [[ "$actual_platforms" != "linux/${expected_arch}" ]]; then
+              echo "${image_ref} does not contain exactly linux/${expected_arch}" >&2
+              exit 1
+            fi
+            image_refs+=("$image_ref")
+          done
+          if [[ -z "${seen_platforms[amd64]:-}" || -z "${seen_platforms[arm64]:-}" ]]; then
+            echo "both linux/amd64 and linux/arm64 digest artifacts are required" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.title=AutoGPT Platform single-container image" \
+            --annotation "index:org.opencontainers.image.description=Experimental all-in-one AutoGPT Platform distribution" \
+            --annotation "index:org.opencontainers.image.source=${SOURCE_URL}" \
+            --annotation "index:org.opencontainers.image.revision=${REVISION}" \
+            --annotation "index:org.opencontainers.image.licenses=LicenseRef-PolyForm-Shield-1.0.0 AND SSPL-1.0" \
+            --metadata-file "$MANIFEST_METADATA" \
+            --tag "${IMAGE}:${TAG}" \
+            "${image_refs[@]}"
+          manifest_digest="$(jq -er '."containerimage.descriptor".digest' "$MANIFEST_METADATA")"
+          if [[ ! "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "published tag did not resolve to a valid manifest digest" >&2
+            exit 1
+          fi
+          published_platforms="$(
+            docker buildx imagetools inspect --raw "${IMAGE}:${TAG}" |
+              jq -r '.manifests[]?.platform | select(.os == "linux" and (.architecture == "amd64" or .architecture == "arm64")) | "\(.os)/\(.architecture)"' |
+              sort -u
+          )"
+          if [[ "$published_platforms" != $'linux/amd64\nlinux/arm64' ]]; then
+            echo "published manifest does not contain exactly linux/amd64 and linux/arm64" >&2
+            exit 1
+          fi
+          echo "digest=$manifest_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Record published digest
+        shell: bash
+        env:
+          IMAGE: ${{ env.DEPLOY_IMAGE }}
+          TAG: ${{ inputs.tag }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+          LEGAL_REVIEW_REFERENCE: ${{ inputs.legal_review_reference }}
+          SECURITY_REVIEW_REFERENCE: ${{ inputs.security_review_reference }}
+          WHOLE_IMAGE_REVIEW_REFERENCE: ${{ inputs.whole_image_review_reference }}
+        run: |
+          {
+            echo "## Experimental image published"
+            echo
+            echo "\`${IMAGE}:${TAG}\`"
+            echo
+            echo "Digest: \`${DIGEST}\`"
+            echo
+            echo "Legal review reference: \`${LEGAL_REVIEW_REFERENCE}\`"
+            echo
+            echo "Whole-image review reference: \`${WHOLE_IMAGE_REVIEW_REFERENCE}\`"
+            echo
+            echo "Security review reference: \`${SECURITY_REVIEW_REFERENCE}\`"
+            echo
+            echo "Both platform digests passed the critical-vulnerability scan before this manifest was created."
+            echo
+            echo "The image includes BuildKit SBOM and provenance attestations. No latest tag was created."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Why / What / How

**Why**

A public all-in-one image needs architecture-specific boot testing and guarded publication controls; a successful Docker build alone is not enough.

**What**

- Builds and smoke-tests exact `linux/amd64` and `linux/arm64` images.
- Exercises startup, health, persistence, restart recovery, and secret handling.
- Adds vulnerability, embedded-secret, SBOM, provenance, and digest checks.
- Provides protected manual Docker Hub publication using immutable experimental tags.

**How**

Architecture jobs validate exact local image digests before a gated publication job assembles the manifest. The workflow intentionally does not create `latest`.

### Stack

Part **5 of 6**. Base: `feat/single-container-04-image`. It depends on the appliance layer and is documented by part 6. It supersedes the CI/publication portion of draft #13754.

### Changes 🏗️

- `.github/scripts/platform-single-container-smoke.sh`.
- `.github/workflows/platform-single-container-docker.yml`.
- Exactly 2 files in this layer.

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] Signed commit passed the repository pre-commit suite under Node 24
- [x] Smoke harness was exercised against the original exact image validation
- [ ] Let PR CI execute the architecture matrix
- [ ] Obtain project-owner/legal approval before public publication

#### For configuration changes:

- [x] Publication requires a protected `dockerhub-experimental` environment and credentials
- [x] No image is published by opening or merging this PR


### Stack navigation

Bottom → top:

1. [#13755 — backend supervision](https://github.com/Significant-Gravitas/AutoGPT/pull/13755)
2. [#13757 — frontend routing](https://github.com/Significant-Gravitas/AutoGPT/pull/13757)
3. [#13756 — runtime options](https://github.com/Significant-Gravitas/AutoGPT/pull/13756)
4. [#13758 — single-container image](https://github.com/Significant-Gravitas/AutoGPT/pull/13758)
5. [#13759 — validation and publication CI](https://github.com/Significant-Gravitas/AutoGPT/pull/13759)
6. [#13760 — operations documentation](https://github.com/Significant-Gravitas/AutoGPT/pull/13760)

The base refs already form GitHub's required linear chain. The native Stack association is pending GitHub's repository-by-repository public-preview rollout; the Stack API currently returns its documented not-enabled response for this repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release plumbing and public image distribution with secret scanning and strict publication gates; runtime app code is untouched but mistaken publish configuration could expose credentials or ship a bad image.
> 
> **Overview**
> Adds **CI for the all-in-one platform image**: a new workflow builds `single-container` on **linux/amd64** and **linux/arm64**, runs an end-to-end smoke harness, and fails on fixable **critical** Trivy findings and high/critical embedded secrets (with informational high/critical vuln reporting).
> 
> The smoke script exercises **bare `docker run`**, then a configured run with **persistent `/data`**, hostile `backend.json` (listener pinning), **auth redirects**, hidden docs/metrics, **token non-leakage in logs**, **supervisor/nginx restart recovery**, and the documented **single-container Compose** file—all while asserting stable `runtime.env` checksum and mode `600`.
> 
> **Manual publication** is opt-in via `workflow_dispatch`: typed confirmations, legal/security/SBOM references, `experimental-*` tags only from `dev`, protected `dockerhub-experimental` environment, push-by-digest per arch with SBOM/provenance, re-smoke/re-scan on the exact digest, then a multi-arch manifest (no `latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595658891e9aa62529eff26c6804dbba36ce57b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->