### PR TITLE
fix(frontend): use consistent marble avatar fallback across navbar and marketplace

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/AgentInfo/AgentInfo.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/AgentInfo/AgentInfo.tsx
@@ -164,7 +164,7 @@ export const AgentInfo = ({
               {creatorAvatar && (
                 <AvatarImage src={creatorAvatar} alt={`${creator} avatar`} />
               )}
-              <AvatarFallback size={28}>{creator.charAt(0)}</AvatarFallback>
+              <AvatarFallback size={28}>{creator}</AvatarFallback>
             </Avatar>
             <Text variant="body" className="text-md">
               by

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx
@@ -9,6 +9,7 @@ import { backgroundColor } from "./helper";
 
 interface Props {
   creatorName: string;
+  creatorUsername?: string;
   creatorImage: string | null;
   bio: string;
   agentsUploaded: number;
@@ -18,6 +19,7 @@ interface Props {
 
 export function CreatorCard({
   creatorName,
+  creatorUsername,
   creatorImage,
   bio,
   agentsUploaded,
@@ -36,7 +38,9 @@ export function CreatorCard({
         {creatorImage && (
           <AvatarImage src={creatorImage} alt={`${creatorName} avatar`} />
         )}
-        <AvatarFallback size={56}>{creatorName}</AvatarFallback>
+        <AvatarFallback size={56}>
+          {creatorUsername || creatorName}
+        </AvatarFallback>
       </Avatar>
 
       <div className="mt-3 flex w-full flex-1 flex-col">

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorCard/CreatorCard.tsx
@@ -36,7 +36,7 @@ export function CreatorCard({
         {creatorImage && (
           <AvatarImage src={creatorImage} alt={`${creatorName} avatar`} />
         )}
-        <AvatarFallback size={56}>{creatorName.charAt(0)}</AvatarFallback>
+        <AvatarFallback size={56}>{creatorName}</AvatarFallback>
       </Avatar>
 
       <div className="mt-3 flex w-full flex-1 flex-col">

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorInfoCard/CreatorInfoCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/CreatorInfoCard/CreatorInfoCard.tsx
@@ -41,7 +41,7 @@ export const CreatorInfoCard = ({
             size={130}
             className="h-[100px] w-[100px] sm:h-[130px] sm:w-[130px]"
           >
-            {username.charAt(0)}
+            {username}
           </AvatarFallback>
         </Avatar>
         <div className="flex w-full flex-col items-start justify-start gap-1.5">

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedAgentCard/FeaturedAgentCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedAgentCard/FeaturedAgentCard.tsx
@@ -109,9 +109,7 @@ export function FeaturedAgentCard({ agent, backgroundColor }: Props) {
                   alt={`${agent.creator} creator avatar`}
                 />
               )}
-              <AvatarFallback size={20}>
-                {agent.creator.charAt(0)}
-              </AvatarFallback>
+              <AvatarFallback size={20}>{agent.creator}</AvatarFallback>
             </Avatar>
             <span className="truncate text-[13px] text-zinc-500">
               by {agent.creator}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedCreators/FeaturedCreators.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedCreators/FeaturedCreators.tsx
@@ -34,6 +34,7 @@ export const FeaturedCreators = ({
             <CreatorCard
               key={index}
               creatorName={creator.name || creator.username}
+              creatorUsername={creator.username}
               creatorImage={creator.avatar_url}
               bio={creator.description}
               agentsUploaded={creator.num_agents}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/StoreCard/StoreCard.tsx
@@ -96,7 +96,7 @@ export function StoreCard({
                   alt={`${creatorName} creator avatar`}
                 />
               )}
-              <AvatarFallback size={20}>{creatorName.charAt(0)}</AvatarFallback>
+              <AvatarFallback size={20}>{creatorName}</AvatarFallback>
             </Avatar>
             <span className="truncate text-[13px] text-zinc-500">
               by {creatorName}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/components/MainCreatorPage/MainCreatorPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/components/MainCreatorPage/MainCreatorPage.tsx
@@ -85,9 +85,7 @@ export function MainCreatorPage({ params }: Props) {
                         alt={`${creator.name} avatar`}
                       />
                     )}
-                    <AvatarFallback size={96}>
-                      {creator.name.charAt(0)}
-                    </AvatarFallback>
+                    <AvatarFallback size={96}>{creator.name}</AvatarFallback>
                   </Avatar>
 
                   {/* Name */}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/components/MainCreatorPage/MainCreatorPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/creator/[creator]/components/MainCreatorPage/MainCreatorPage.tsx
@@ -85,7 +85,9 @@ export function MainCreatorPage({ params }: Props) {
                         alt={`${creator.name} avatar`}
                       />
                     )}
-                    <AvatarFallback size={96}>{creator.name}</AvatarFallback>
+                    <AvatarFallback size={96}>
+                      {creator.username}
+                    </AvatarFallback>
                   </Avatar>
 
                   {/* Name */}

--- a/autogpt_platform/frontend/src/components/atoms/Avatar/Avatar.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Avatar/Avatar.tsx
@@ -126,7 +126,7 @@ export function AvatarImage({
       // eslint-disable-next-line @next/next/no-img-element
       <img
         src={normalizedSrc}
-        alt={alt || "Avatar image"}
+        alt={alt ?? "Avatar image"}
         className={cn("h-full w-full object-cover", className)}
         width={computedWidth}
         height={computedHeight}
@@ -147,8 +147,9 @@ export function AvatarImage({
 
   return (
     <Image
+      {...rest}
       src={normalizedSrc}
-      alt={alt || "Avatar image"}
+      alt={alt ?? "Avatar image"}
       className={cn("h-full w-full object-cover", className)}
       width={fill ? undefined : computedWidth}
       height={fill ? undefined : computedHeight}
@@ -176,12 +177,18 @@ export function AvatarFallback({
   const show = !isLoaded || !hasImage;
   if (!show) return null;
   const computedSize = _size || getAvatarSizeFromClassName(className) || 40;
+  // Trim the seed so call sites with padded names render the same gradient
   const name =
-    typeof children === "string" && children.trim() ? children : "User";
+    typeof children === "string" && children.trim() ? children.trim() : "User";
   return (
     <span
+      // decorative gradient — hide from AT so the marble's unnamed role="img"
+      // svg doesn't surface as an axe violation
+      aria-hidden="true"
       className={cn(
-        "flex h-full w-full items-center justify-center rounded-full bg-transparent text-lg text-neutral-600",
+        // absolute so the fallback overlays (not flows beside) the image while it loads;
+        // svg stretched to fill so the marble always matches the avatar size
+        "absolute inset-0 flex items-center justify-center rounded-full bg-transparent text-lg text-neutral-600 [&>svg]:h-full [&>svg]:w-full",
         className,
       )}
       {...props}

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/SidebarUserActions/SidebarUserActions.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/SidebarUserActions/SidebarUserActions.tsx
@@ -43,6 +43,7 @@ export function SidebarUserActions() {
   const accountMenu = (
     <AccountMenu
       userName={profile?.name || profile?.username}
+      userHandle={profile?.username}
       userEmail={user?.email}
       avatarSrc={profile?.avatar_url ?? ""}
       menuItemGroups={dynamicMenuItems}

--- a/autogpt_platform/frontend/src/components/layout/Navbar/Navbar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/Navbar.tsx
@@ -119,6 +119,7 @@ export function Navbar() {
                 {profile && <Wallet key={profile.username} />}
                 <AccountMenu
                   userName={profile?.name || profile?.username}
+                  userHandle={profile?.username}
                   userEmail={user?.email}
                   avatarSrc={profile?.avatar_url ?? ""}
                   menuItemGroups={dynamicMenuItems}

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenu.tsx
@@ -14,6 +14,7 @@ import { getAccountMenuIcon } from "./helpers";
 
 interface Props {
   userName?: string;
+  userHandle?: string;
   userEmail?: string;
   avatarSrc?: string;
   hideNavBarUsername?: boolean;
@@ -29,6 +30,7 @@ interface Props {
 
 export function AccountMenu({
   userName,
+  userHandle,
   userEmail,
   avatarSrc,
   menuItemGroups,
@@ -43,6 +45,7 @@ export function AccountMenu({
     return (
       <AccountMenuNewLayout
         userName={userName}
+        userHandle={userHandle}
         userEmail={userEmail}
         avatarSrc={avatarSrc}
         menuItemGroups={menuItemGroups}
@@ -64,7 +67,12 @@ export function AccountMenu({
           aria-haspopup="true"
           data-testid="profile-popout-menu-trigger"
         >
-          <InitialAvatar src={avatarSrc} name={userName} className="h-8 w-8" />
+          <InitialAvatar
+            src={avatarSrc}
+            name={userName}
+            username={userHandle}
+            className="h-8 w-8"
+          />
         </button>
       </PopoverTrigger>
 
@@ -76,7 +84,11 @@ export function AccountMenu({
         data-testid="account-menu-popover"
       >
         <div className="flex items-center gap-3 px-4 py-3">
-          <InitialAvatar src={avatarSrc} name={userName} />
+          <InitialAvatar
+            src={avatarSrc}
+            name={userName}
+            username={userHandle}
+          />
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             {isLoading || !userName || !userEmail ? (
               <>

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenuNewLayout.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/AccountMenuNewLayout.tsx
@@ -14,6 +14,7 @@ import { getAccountMenuIcon } from "./helpers";
 
 interface Props {
   userName?: string;
+  userHandle?: string;
   userEmail?: string;
   avatarSrc?: string;
   menuItemGroups: MenuItemGroup[];
@@ -24,6 +25,7 @@ interface Props {
 
 export function AccountMenuNewLayout({
   userName,
+  userHandle,
   userEmail,
   avatarSrc,
   menuItemGroups,
@@ -44,7 +46,12 @@ export function AccountMenuNewLayout({
           aria-haspopup="true"
           data-testid="profile-popout-menu-trigger"
         >
-          <InitialAvatar src={avatarSrc} name={userName} className="h-8 w-8" />
+          <InitialAvatar
+            src={avatarSrc}
+            name={userName}
+            username={userHandle}
+            className="h-8 w-8"
+          />
         </button>
       </PopoverTrigger>
 
@@ -59,6 +66,7 @@ export function AccountMenuNewLayout({
         <div className="px-2">
           <AccountMenuHeader
             userName={userName}
+            userHandle={userHandle}
             userEmail={userEmail}
             avatarSrc={avatarSrc}
             isLoading={isLoading}

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -5,7 +5,7 @@ import { AccountMenu } from "../AccountMenu";
 import { InitialAvatar } from "../components/InitialAvatar";
 import { MenuItemGroup } from "../../../helpers";
 
-function getFallbackSvg(root: HTMLElement) {
+function getFallbackSVG(root: HTMLElement) {
   const svg = root.querySelector("svg");
   return svg?.innerHTML.replace(/:r[0-9a-z]+:/g, "id") ?? null;
 }
@@ -152,9 +152,9 @@ describe("AccountMenu", () => {
     const reference = render(<InitialAvatar name="ada" />);
 
     const trigger = screen.getByTestId("profile-popout-menu-trigger");
-    expect(getFallbackSvg(trigger)).not.toBeNull();
+    expect(getFallbackSVG(trigger)).not.toBeNull();
     // The marble gradient must be seeded by the user's handle, not a constant.
-    expect(getFallbackSvg(trigger)).toBe(getFallbackSvg(reference.container));
+    expect(getFallbackSVG(trigger)).toBe(getFallbackSVG(reference.container));
   });
 
   test("new layout renders the organization switcher header trigger", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -135,7 +135,7 @@ describe("AccountMenu", () => {
   });
 
   test("renders profile trigger with avatar fallback", () => {
-    render(
+    const { container } = render(
       <AccountMenu
         userName="Ada"
         userEmail="ada@example.com"
@@ -144,7 +144,8 @@ describe("AccountMenu", () => {
     );
 
     expect(screen.getByTestId("profile-popout-menu-trigger")).toBeDefined();
-    expect(screen.getAllByText("A").length).toBeGreaterThan(0);
+    // InitialAvatar uses a marble SVG fallback (not a letter initial).
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
   test("new layout renders the organization switcher header trigger", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/__tests__/AccountMenu.test.tsx
@@ -2,7 +2,13 @@ import { IconType } from "@/components/__legacy__/ui/icons";
 import { render, screen } from "@/tests/integrations/test-utils";
 import { describe, expect, test, vi } from "vitest";
 import { AccountMenu } from "../AccountMenu";
+import { InitialAvatar } from "../components/InitialAvatar";
 import { MenuItemGroup } from "../../../helpers";
+
+function getFallbackSvg(root: HTMLElement) {
+  const svg = root.querySelector("svg");
+  return svg?.innerHTML.replace(/:r[0-9a-z]+:/g, "id") ?? null;
+}
 
 vi.mock("next/link", () => ({
   __esModule: true,
@@ -134,18 +140,21 @@ describe("AccountMenu", () => {
     expect(helpLink?.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  test("renders profile trigger with avatar fallback", () => {
-    const { container } = render(
+  test("renders profile trigger with avatar fallback seeded by the user", () => {
+    render(
       <AccountMenu
         userName="Ada"
+        userHandle="ada"
         userEmail="ada@example.com"
         menuItemGroups={baseGroups}
       />,
     );
+    const reference = render(<InitialAvatar name="ada" />);
 
-    expect(screen.getByTestId("profile-popout-menu-trigger")).toBeDefined();
-    // InitialAvatar uses a marble SVG fallback (not a letter initial).
-    expect(container.querySelector("svg")).not.toBeNull();
+    const trigger = screen.getByTestId("profile-popout-menu-trigger");
+    expect(getFallbackSvg(trigger)).not.toBeNull();
+    // The marble gradient must be seeded by the user's handle, not a constant.
+    expect(getFallbackSvg(trigger)).toBe(getFallbackSvg(reference.container));
   });
 
   test("new layout renders the organization switcher header trigger", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/AccountMenuHeader.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/AccountMenuHeader.tsx
@@ -14,6 +14,7 @@ import { Icon } from "@/components/atoms/Icon/Icon";
 
 interface Props {
   userName?: string;
+  userHandle?: string;
   userEmail?: string;
   avatarSrc?: string;
   isLoading?: boolean;
@@ -21,6 +22,7 @@ interface Props {
 
 export function AccountMenuHeader({
   userName,
+  userHandle,
   userEmail,
   avatarSrc,
   isLoading = false,
@@ -37,7 +39,12 @@ export function AccountMenuHeader({
           aria-haspopup="true"
           data-testid="account-menu-org-trigger"
         >
-          <InitialAvatar src={avatarSrc} name={userName} className="h-8 w-8" />
+          <InitialAvatar
+            src={avatarSrc}
+            name={userName}
+            username={userHandle}
+            className="h-8 w-8"
+          />
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
             {isLoading || !userName || !userEmail ? (
               <>

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
@@ -1,4 +1,7 @@
-import Avatar, { AvatarImage } from "@/components/atoms/Avatar/Avatar";
+import Avatar, {
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/atoms/Avatar/Avatar";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -8,19 +11,10 @@ interface Props {
 }
 
 export function InitialAvatar({ src, name, className }: Props) {
-  const initial = name?.trim().charAt(0).toUpperCase() || "U";
-
   return (
     <Avatar className={cn("h-10 w-10", className)}>
-      <div className="absolute inset-0 z-0 flex items-center justify-center bg-violet-500 text-sm font-semibold text-white">
-        {initial}
-      </div>
-      <AvatarImage
-        src={src}
-        alt=""
-        aria-hidden="true"
-        className="relative z-10"
-      />
+      <AvatarImage src={src} alt={name ? `${name}'s avatar` : "User avatar"} />
+      <AvatarFallback>{name?.trim() || "User"}</AvatarFallback>
     </Avatar>
   );
 }

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
@@ -11,10 +11,17 @@ interface Props {
 }
 
 export function InitialAvatar({ src, name, className }: Props) {
+  const normalizedName = name?.trim();
+
   return (
     <Avatar className={cn("h-10 w-10", className)}>
-      <AvatarImage src={src} alt={name ? `${name}'s avatar` : "User avatar"} />
-      <AvatarFallback>{name?.trim() || "User"}</AvatarFallback>
+      <AvatarImage
+        src={src}
+        alt={normalizedName ? `${normalizedName}'s avatar` : "User avatar"}
+      />
+      <AvatarFallback className={cn("h-10 w-10", className)}>
+        {normalizedName || "User"}
+      </AvatarFallback>
     </Avatar>
   );
 }

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/InitialAvatar.tsx
@@ -7,21 +7,15 @@ import { cn } from "@/lib/utils";
 interface Props {
   src?: string;
   name?: string;
+  username?: string;
   className?: string;
 }
 
-export function InitialAvatar({ src, name, className }: Props) {
-  const normalizedName = name?.trim();
-
+export function InitialAvatar({ src, name, username, className }: Props) {
   return (
     <Avatar className={cn("h-10 w-10", className)}>
-      <AvatarImage
-        src={src}
-        alt={normalizedName ? `${normalizedName}'s avatar` : "User avatar"}
-      />
-      <AvatarFallback className={cn("h-10 w-10", className)}>
-        {normalizedName || "User"}
-      </AvatarFallback>
+      <AvatarImage src={src} alt="" aria-hidden="true" />
+      <AvatarFallback aria-hidden="true">{username || name}</AvatarFallback>
     </Avatar>
   );
 }

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
@@ -3,24 +3,24 @@ import { describe, expect, test } from "vitest";
 import { InitialAvatar } from "../InitialAvatar";
 
 describe("InitialAvatar", () => {
-  test("renders uppercase first character of name", () => {
-    render(<InitialAvatar name="abhimanyu" />);
-    expect(screen.getByText("A")).toBeDefined();
+  test("renders marble gradient fallback when no image is provided", () => {
+    const { container } = render(<InitialAvatar name="abhimanyu" />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test("trims whitespace before extracting initial", () => {
-    render(<InitialAvatar name="   beth" />);
-    expect(screen.getByText("B")).toBeDefined();
+  test("uses trimmed name as fallback seed", () => {
+    const { container } = render(<InitialAvatar name="   beth" />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test("falls back to 'U' when name is missing", () => {
-    render(<InitialAvatar />);
-    expect(screen.getByText("U")).toBeDefined();
+  test("falls back to 'User' when name is missing", () => {
+    const { container } = render(<InitialAvatar />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  test("falls back to 'U' when name is an empty string", () => {
-    render(<InitialAvatar name="" />);
-    expect(screen.getByText("U")).toBeDefined();
+  test("falls back to 'User' when name is an empty string", () => {
+    const { container } = render(<InitialAvatar name="" />);
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 
   test("merges className prop into the avatar root", () => {
@@ -31,17 +31,11 @@ describe("InitialAvatar", () => {
     expect(root.className).toContain("size-12");
   });
 
-  test("places image above the initial fallback when src is provided", async () => {
-    const { container } = render(
-      <InitialAvatar name="ada" src="https://example.com/avatar.png" />,
-    );
+  test("shows image when src is provided", async () => {
+    render(<InitialAvatar name="ada" src="https://example.com/avatar.png" />);
 
     await waitFor(() => {
-      expect(container.querySelector("img")).not.toBeNull();
+      expect(screen.getByRole("img", { name: "ada's avatar" })).toBeDefined();
     });
-
-    const image = container.querySelector("img");
-    expect(image?.className).toContain("z-10");
-    expect(screen.getByText("A").className).toContain("z-0");
   });
 });

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
@@ -47,6 +47,21 @@ describe("InitialAvatar", () => {
     );
   });
 
+  test("prefers username over display name as the gradient seed", () => {
+    const withUsername = render(
+      <InitialAvatar name="Ada Lovelace" username="ada" />,
+    );
+    const usernameOnly = render(<InitialAvatar name="ada" />);
+    const nameOnly = render(<InitialAvatar name="Ada Lovelace" />);
+
+    expect(getFallbackSvg(withUsername.container)).toBe(
+      getFallbackSvg(usernameOnly.container),
+    );
+    expect(getFallbackSvg(withUsername.container)).not.toBe(
+      getFallbackSvg(nameOnly.container),
+    );
+  });
+
   test("merges className prop into the avatar root", () => {
     const { container } = render(
       <InitialAvatar name="ada" className="size-12" />,
@@ -55,11 +70,16 @@ describe("InitialAvatar", () => {
     expect(root.className).toContain("size-12");
   });
 
-  test("shows image when src is provided", async () => {
-    render(<InitialAvatar name="ada" src="https://example.com/avatar.png" />);
+  test("shows a decorative image when src is provided", async () => {
+    const { container } = render(
+      <InitialAvatar name="ada" src="https://example.com/avatar.png" />,
+    );
 
     await waitFor(() => {
-      expect(screen.getByRole("img", { name: "ada's avatar" })).toBeDefined();
+      const image = container.querySelector("img");
+      expect(image).not.toBeNull();
+      expect(image?.getAttribute("aria-hidden")).toBe("true");
     });
+    expect(screen.queryByRole("img")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
@@ -2,25 +2,49 @@ import { render, screen, waitFor } from "@/tests/integrations/test-utils";
 import { describe, expect, test } from "vitest";
 import { InitialAvatar } from "../InitialAvatar";
 
+function getFallbackSvg(container: HTMLElement) {
+  const svg = container.querySelector("svg");
+  return svg?.innerHTML.replace(/:r[0-9a-z]+:/g, "id") ?? null;
+}
+
 describe("InitialAvatar", () => {
   test("renders marble gradient fallback when no image is provided", () => {
     const { container } = render(<InitialAvatar name="abhimanyu" />);
-    expect(container.querySelector("svg")).not.toBeNull();
+    expect(getFallbackSvg(container)).not.toBeNull();
   });
 
-  test("uses trimmed name as fallback seed", () => {
-    const { container } = render(<InitialAvatar name="   beth" />);
-    expect(container.querySelector("svg")).not.toBeNull();
+  test("seeds the gradient deterministically by name", () => {
+    const first = render(<InitialAvatar name="ada" />);
+    const second = render(<InitialAvatar name="ada" />);
+    const other = render(<InitialAvatar name="beth" />);
+
+    expect(getFallbackSvg(first.container)).toBe(
+      getFallbackSvg(second.container),
+    );
+    expect(getFallbackSvg(first.container)).not.toBe(
+      getFallbackSvg(other.container),
+    );
   });
 
-  test("falls back to 'User' when name is missing", () => {
-    const { container } = render(<InitialAvatar />);
-    expect(container.querySelector("svg")).not.toBeNull();
+  test("trims the name before seeding the gradient", () => {
+    const padded = render(<InitialAvatar name="   beth" />);
+    const plain = render(<InitialAvatar name="beth" />);
+    expect(getFallbackSvg(padded.container)).toBe(
+      getFallbackSvg(plain.container),
+    );
   });
 
-  test("falls back to 'User' when name is an empty string", () => {
-    const { container } = render(<InitialAvatar name="" />);
-    expect(container.querySelector("svg")).not.toBeNull();
+  test("falls back to the 'User' seed when name is missing or empty", () => {
+    const missing = render(<InitialAvatar />);
+    const empty = render(<InitialAvatar name="" />);
+    const user = render(<InitialAvatar name="User" />);
+
+    expect(getFallbackSvg(missing.container)).toBe(
+      getFallbackSvg(user.container),
+    );
+    expect(getFallbackSvg(empty.container)).toBe(
+      getFallbackSvg(user.container),
+    );
   });
 
   test("merges className prop into the avatar root", () => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/AccountMenu/components/__tests__/InitialAvatar.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@/tests/integrations/test-utils";
 import { describe, expect, test } from "vitest";
 import { InitialAvatar } from "../InitialAvatar";
 
-function getFallbackSvg(container: HTMLElement) {
+function getFallbackSVG(container: HTMLElement) {
   const svg = container.querySelector("svg");
   return svg?.innerHTML.replace(/:r[0-9a-z]+:/g, "id") ?? null;
 }
@@ -10,7 +10,7 @@ function getFallbackSvg(container: HTMLElement) {
 describe("InitialAvatar", () => {
   test("renders marble gradient fallback when no image is provided", () => {
     const { container } = render(<InitialAvatar name="abhimanyu" />);
-    expect(getFallbackSvg(container)).not.toBeNull();
+    expect(getFallbackSVG(container)).not.toBeNull();
   });
 
   test("seeds the gradient deterministically by name", () => {
@@ -18,19 +18,19 @@ describe("InitialAvatar", () => {
     const second = render(<InitialAvatar name="ada" />);
     const other = render(<InitialAvatar name="beth" />);
 
-    expect(getFallbackSvg(first.container)).toBe(
-      getFallbackSvg(second.container),
+    expect(getFallbackSVG(first.container)).toBe(
+      getFallbackSVG(second.container),
     );
-    expect(getFallbackSvg(first.container)).not.toBe(
-      getFallbackSvg(other.container),
+    expect(getFallbackSVG(first.container)).not.toBe(
+      getFallbackSVG(other.container),
     );
   });
 
   test("trims the name before seeding the gradient", () => {
     const padded = render(<InitialAvatar name="   beth" />);
     const plain = render(<InitialAvatar name="beth" />);
-    expect(getFallbackSvg(padded.container)).toBe(
-      getFallbackSvg(plain.container),
+    expect(getFallbackSVG(padded.container)).toBe(
+      getFallbackSVG(plain.container),
     );
   });
 
@@ -39,11 +39,11 @@ describe("InitialAvatar", () => {
     const empty = render(<InitialAvatar name="" />);
     const user = render(<InitialAvatar name="User" />);
 
-    expect(getFallbackSvg(missing.container)).toBe(
-      getFallbackSvg(user.container),
+    expect(getFallbackSVG(missing.container)).toBe(
+      getFallbackSVG(user.container),
     );
-    expect(getFallbackSvg(empty.container)).toBe(
-      getFallbackSvg(user.container),
+    expect(getFallbackSVG(empty.container)).toBe(
+      getFallbackSVG(user.container),
     );
   });
 
@@ -54,11 +54,11 @@ describe("InitialAvatar", () => {
     const usernameOnly = render(<InitialAvatar name="ada" />);
     const nameOnly = render(<InitialAvatar name="Ada Lovelace" />);
 
-    expect(getFallbackSvg(withUsername.container)).toBe(
-      getFallbackSvg(usernameOnly.container),
+    expect(getFallbackSVG(withUsername.container)).toBe(
+      getFallbackSVG(usernameOnly.container),
     );
-    expect(getFallbackSvg(withUsername.container)).not.toBe(
-      getFallbackSvg(nameOnly.container),
+    expect(getFallbackSVG(withUsername.container)).not.toBe(
+      getFallbackSVG(nameOnly.container),
     );
   });
 

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/MobileNavbar/MobileNavBar.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/MobileNavbar/MobileNavBar.tsx
@@ -82,9 +82,7 @@ export function MobileNavBar({
                       src={avatarSrc}
                       alt={userName || "Unknown User"}
                     />
-                    <AvatarFallback>
-                      {userName?.charAt(0) || "U"}
-                    </AvatarFallback>
+                    <AvatarFallback>{userName}</AvatarFallback>
                   </Avatar>
                   <div className="relative h-14 w-full">
                     <div className="absolute left-0 top-0 text-lg font-semibold leading-7 text-[#474747]">


### PR DESCRIPTION
### Why 🤔

User avatar fallbacks were inconsistent across the app: the navbar account menu rendered a hardcoded initial letter on a solid violet background, while profile/creator displays use the design-system `Avatar` with a `boring-avatars` marble-gradient fallback. The same user saw two different avatar treatments depending on where they looked.

On top of the treatment mismatch, the gradient *seed* was also inconsistent between surfaces that already used the marble fallback: most marketplace call sites seeded with `name.charAt(0)` while others used the full name, so the same creator got different gradients on different cards ("Alice" and "Alan" also collided on the same "A" gradient).

Fixes #13411 (OPEN-3178)

Supersedes #13426 by @Chessing234 — their commits are cherry-picked into this PR with authorship preserved (the original PR was closed after a review-turnaround delay on our side; CLA was signed). Thank you Taksh! 🙏

### What / How 🏗️

**Cherry-picked from #13426 (credit: @Chessing234):**

- Replace the navbar `InitialAvatar` letter-on-purple fallback with the shared `AvatarFallback` (marble gradient seeded by user name), including sizing and name normalization
- Update `AccountMenu` test accordingly

**Added on top:**

- Normalize all person-avatar gradient seeds to the **full display name** instead of `charAt(0)`, so the same person gets the same gradient everywhere: `CreatorCard`, `MainCreatorPage`, `CreatorInfoCard`, `StoreCard`, `FeaturedAgentCard`, `AgentInfo`, `MobileNavBar` (org avatars intentionally left as-is — they are a separate entity type and already self-consistent)
- Strengthen `InitialAvatar` tests: instead of only asserting "an SVG rendered", they now verify the gradient is deterministically seeded by name, trims whitespace before seeding, and that a missing/empty name uses the same seed as the `"User"` default

Known follow-up (out of scope): the mobile navbar receives `profile?.username` while the desktop account menu receives `profile?.name || profile?.username`, so their seeds can still differ for users with a display name; aligning that changes the visible text in the mobile menu, so it is left for a separate decision. The settings profile page uses a deliberate upload-placeholder treatment (`UserIcon` on zinc), which is unrelated to identity fallbacks.

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm exec vitest run src/components/layout/Navbar/components/AccountMenu` (50 tests pass, incl. new deterministic-seed tests)
  - [x] `pnpm format` / `pnpm lint` / `pnpm types` clean
  - [x] `pnpm test:unit` full suite passes

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
