### PR TITLE
ci(backend): stop merge queue ejecting healthy PRs on the 20m test timeout

### DIFF
--- a/.github/workflows/platform-backend-ci.yml
+++ b/.github/workflows/platform-backend-ci.yml
@@ -169,7 +169,14 @@ jobs:
   test:
     permissions:
       contents: read
-    timeout-minutes: 20
+    # The suite is ~10.6k tests run serially (no pytest-xdist): the pytest step
+    # alone measures p50 ~13min / max ~18min, on top of 2-7min of container,
+    # checkout and dependency setup. A 20min cap sat *below* the job's real p95,
+    # so healthy runs were killed mid-suite and reported as `cancelled`. On
+    # merge_group that is fatal: `Check PR Status` treats a non-success check as
+    # a failure and GitHub ejects the PR from the merge queue. This is a guard
+    # against a hung job, not a performance budget - keep it well above p99.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -248,7 +255,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Full ref history is needed so the "Install Poetry" step below can
+          # read poetry.lock off the base branch. `filter: blob:none` keeps
+          # every ref reachable while skipping the blob download for all of
+          # them, then lazily fetches the one blob that step actually reads.
+          # Without it this checkout has been measured at 429s vs 27s for a
+          # sibling matrix leg in the same run - enough variance on its own to
+          # blow the job budget.
           fetch-depth: 0
+          filter: blob:none
           submodules: true
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
### Why / What / How

**Why.** Roughly half of all `dev` merge-queue enqueues were ejecting PRs whose own checks were fully green, and the time-to-ejection clustered hard around 17-22 minutes. Observed live on 2026-08-04/05:

| PR | enqueued | ejected | elapsed | PR's own checks | actual cause |
|---|---|---|---|---|---|
| #13434 | 02:55 | 03:12 | ~17 min | all green | real test failures (credit suite) |
| #13434 | 04:07 (2nd) | 04:29 | ~22 min | all green | **20m job timeout** |
| #13743 | 18:33 | 18:54 | ~21 min | all green | **20m job timeout** |
| #13575 | 19:05 | 19:26 | ~21 min | all green | **20m job timeout** |

(A fifth ejection, #13764 at 03:21→03:42, was also the 20m timeout.)

**What.** The `test` job in `platform-backend-ci.yml` had `timeout-minutes: 20`, which sits *below* the job's real p95 runtime. GitHub reports a `timeout-minutes` kill as conclusion **`cancelled`**, not `failure` — which is why this was invisible when reading the merge-queue runs. `.github/workflows/scripts/check_actions_status.py` treats any conclusion outside `success`/`skipped`/`neutral` as a failure, so a timed-out `test` leg makes **`Check PR Status`** fail, and GitHub ejects the PR from the merge queue.

**How.** Raise the cap so it guards against a genuinely hung job instead of acting as a performance budget, and remove the single largest source of setup variance from the job.

### Root-cause evidence

The three ~21-22 min ejections are all the same mechanism. GitHub's own annotation on the cancelled job (`check-runs/92414409798/annotations`):

> `failure | The job has exceeded the maximum execution time of 20m0s`

Every timed-out leg died at **1217-1222s** — exactly the 20m0s cap:

| run | merge group | leg | job total | pytest step |
|---|---|---|---|---|
| 31037832829 | pr-13575 | `test (3.12)` | 1222s | 674s (killed) |
| 31035323338 | pr-13743 | `test (3.12)` | 1219s | killed |
| 30974258262 | pr-13434 | `test (3.12)` | 1217s | 1049s (killed) |
| 30972001003 | pr-13764 | `test (3.11)` | 1218s | 1054s (killed) |

These were healthy runs killed mid-suite, not hangs — the pytest step was still actively emitting `PASSED` lines when the runner pulled the plug.

Sibling matrix legs in the *same* runs passed comfortably, which is what makes this look like a "flake":

- run 31037832829: `test (3.11)` 956s ✅, `test (3.13)` 975s ✅, `test (3.12)` **1222s ❌**
- run 30972001003: `test (3.12)` 949s ✅, `test (3.13)` 898s ✅, `test (3.11)` **1218s ❌**

Two independent variance sources push a leg over the line:

1. **The suite's own runtime.** ~10.6k tests run **serially** — `pytest-xdist` is not a dependency, and the pytest invocation has no `-n`. Measured across 126 `test` legs: pytest step p50 **787s**, max **1093s**. Two of the four kills had entirely normal setup and were killed purely because pytest itself was still running at 1049s/1054s.
2. **Checkout.** The `test` job is the only job using `fetch-depth: 0` (it needs base-branch refs for the poetry.lock version comparison in "Install Poetry"). On run 31037832829 that checkout took **429s** on the leg that died, versus **27s** and **49s** on the two legs that passed — same commit, same run.

Measured `test`-leg duration distribution (126 legs):

| event | n | p50 | p90 | max | killed at 20m |
|---|---|---|---|---|---|
| `pull_request` | 78 | 922s | 978s | 1218s | 2 (2.6%) |
| `merge_group` | 27 | 950s | 1056s | 1222s | 2 (7.4%) |
| `push` | 21 | 928s | 954s | 976s | 0 |

`merge_group` carries the heaviest tail. It is also the most damaging place to fail: `merge_group` has no `paths:` filter (GitHub doesn't support one), so **every** merge group runs the full backend suite even for PRs that cannot touch the backend — #13434 only changed `platform-backend-ci.yml` and `TESTING.md`.

### Before / after

The meaningful rate for a `timeout-minutes` change is the share of legs the cap kills, not a test pass rate:

| | legs exceeding the cap | per-leg | per enqueue (3-leg matrix) |
|---|---|---|---|
| **Before** (`20m`) | 4 / 126 | 3.2% | ~9.2%; on `merge_group` legs alone 7.4% → **~20.6%** |
| **After** (`35m`) | **0 / 126** | 0% | 0% |

No leg in the sample has ever come within 14 minutes of the new cap. The longest *completed* leg observed is 1218s (20.3m); the killed legs were truncated, but extrapolating from their pytest progress they would have landed at roughly 21-25m — still comfortably inside 35m, which retains hang detection while leaving ~40% headroom over the worst realistic run.

### Not fixed here (separate issue)

The **#13434 02:55 ejection was a genuinely different failure mode** and is *not* addressed by this PR. `test (3.11)` (job 92194348225) failed with 12 failures + 7 errors, all in the credit suite:

- First failure: `credit_concurrency_test.py::test_concurrent_spends_insufficient_balance` — `Expected 5 failures, got 4`. One of 10 concurrent `spend_credits` coroutines raised something that was neither a success nor `InsufficientBalanceError`.
- Then `test_race_condition_exact_balance` — `ValueError: User not found with ID: exact-balance-…` for a user that had just been created successfully.
- Then everything cascaded: ~8 minutes of `25P02 current transaction is aborted, commands ignored until end of transaction block` across `credit_concurrency_test.py`, `credit_integration_test.py`, `credit_metadata_test.py` and `credit_refund_test.py`.

I deliberately have **not** shipped a speculative fix for this. My initial hypothesis (a leaked interactive transaction in the spend path) was **disproven**: `credit.py` opens no Prisma interactive transaction anywhere — `_add_transaction` runs a single autocommit `query_raw` CTE with `SELECT … FOR UPDATE`, so it structurally cannot leave a connection in an aborted state. The real poisoning vector is still open, and reproducing it needs the full stack (Postgres + 3-shard Redis cluster + RabbitMQ + ClamAV + FalkorDB), which I could not stand up in this environment. Fixing it on a guess risks introducing a *new* merge-queue failure mode, which is exactly the problem this PR exists to remove.

### Changes 🏗️

- `.github/workflows/platform-backend-ci.yml`, `test` job:
  - `timeout-minutes: 20` → **`35`**, with a comment recording the measured runtime distribution so it doesn't get tightened back into the failure zone.
  - Added **`filter: blob:none`** to the `fetch-depth: 0` checkout. This is a blobless partial clone: every ref stays reachable (so the base-branch `poetry.lock` lookup in "Install Poetry" is unchanged) while the blobs for all other branches are never downloaded. If the lazy fetch ever fails, the existing `; true` fallback already degrades to the HEAD poetry version, so the worst case is benign.

No configuration, service, port, secret or env changes. Behaviour of the tests themselves is unchanged.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `python3 -c "yaml.safe_load(...)"` parses the workflow; `jobs.test.timeout-minutes == 35` and the checkout `with:` block resolves to `{fetch-depth: 0, filter: blob:none, submodules: true}`
  - [x] `actionlint` on the changed workflow reports **5** shellcheck findings — byte-identical to the count on `dev`, so no new lint issues are introduced (all 5 are pre-existing, on lines this PR does not touch)
  - [x] Confirmed `test` is the only job referencing `BASE_REF`, so `fetch-depth: 0` is load-bearing there and nowhere else — it is preserved, only made blobless
  - [x] All `pre-commit` hooks pass on the commit
  - [ ] End-to-end confirmation that a `merge_group` run completes inside 35m and that the blobless checkout still resolves `git show "origin/$BASE_BRANCH":./poetry.lock` — this can only be observed on CI, and this PR's own `merge_group` run is the test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only timing and checkout tuning; no application code, secrets, or test behavior changes.
> 
> **Overview**
> Raises the backend CI **`test`** job cap from **20m to 35m** and documents why: serial ~10.6k-test runs often exceed 20m, GitHub marks timeouts as **`cancelled`**, and merge-queue **`Check PR Status`** treats that as failure—ejecting otherwise green PRs.
> 
> Adds **`filter: blob:none`** on the existing **`fetch-depth: 0`** checkout so base-branch **`poetry.lock`** resolution for Install Poetry stays the same while avoiding full blob downloads that sometimes stretched checkout to hundreds of seconds on one matrix leg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2814a3a7b61aa3b49b59e1dbeeb01178e0533405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

### CI verification (this PR's own run 31045429279)

All three legs green, and both changes behave as intended:

| leg | result | job total | headroom to 35m | checkout | pytest |
|---|---|---|---|---|---|
| `test (3.11)` | ✅ success | 935s (15.6m) | 19.4m | **9s** | 795s |
| `test (3.12)` | ✅ success | 751s (12.5m) | 22.5m | **9s** | 624s |
| `test (3.13)` | ✅ success | 925s (15.4m) | 19.6m | **14s** | 773s |

**Checkout: 9s / 9s / 14s**, against **27s / 49s / 429s** on the pre-change baseline (run 31037832829) — the 429s outlier that blew the budget is gone.

The one real risk in the checkout change was whether a blobless clone could still resolve the base branch's `poetry.lock`. Confirmed from the `Install Poetry` step log:

```
Found Poetry version 2.2.1 in backend/poetry.lock
Found Poetry version 2.2.1 in backend/poetry.lock on dev
Using Poetry version 2.2.1
```

The lazy blob fetch resolves correctly and the base-branch comparison is unchanged.
