### PR TITLE
fix(backend): expert attribution on HITL resume, resume guardrail, thread race

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
@@ -489,6 +489,39 @@ async def test_enforce_budget_pauses_blocks_and_resumes(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_resume_without_pause_is_noop_and_keeps_counter(
+    server: SpinTestServer, test_user
+):
+    """Resume on a not-paused expert must be an idempotent success that
+    leaves the weekly spend counter alone — otherwise repeated Resume calls
+    keep the counter near zero and defeat the guardrail."""
+    template = await _seed_template(name="Nia", preload_listings=[])
+    hired = await experts_db.hire_expert(test_user.id, template.id, None)
+
+    with patch.object(scheduling, "reset_weekly_spend", new=AsyncMock()) as reset_spend:
+        assert await scheduling.resume_expert_schedules(test_user.id, hired.expert.id)
+    reset_spend.assert_not_awaited()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_resume_archived_expert_returns_false(server: SpinTestServer, test_user):
+    """Archive's reversal is re-hiring, not Resume: resuming an archived
+    expert must fail (404 at the route) instead of clearing her pause state
+    and forgiving spend while her schedules stay deleted."""
+    template = await _seed_template(name="Ola", preload_listings=[])
+    sched = AsyncMock()
+    with patch.object(scheduling, "get_scheduler_client", return_value=sched):
+        hired = await experts_db.hire_expert(test_user.id, template.id, None)
+        await experts_db.archive_expert(test_user.id, hired.expert.id)
+
+    with patch.object(scheduling, "reset_weekly_spend", new=AsyncMock()) as reset_spend:
+        assert not await scheduling.resume_expert_schedules(
+            test_user.id, hired.expert.id
+        )
+    reset_spend.assert_not_awaited()
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_seed_roster_round_trip(server: SpinTestServer):
     first_ids = await seed.seed_roster()
     assert len(first_ids) == 3

--- a/autogpt_platform/backend/backend/api/features/experts/scheduling.py
+++ b/autogpt_platform/backend/backend/api/features/experts/scheduling.py
@@ -260,13 +260,32 @@ async def resume_expert_schedules(user_id: str, expert_id: str) -> bool:
     would re-pause her and Resume would be a no-op until the ISO week rolls
     over. Resuming is the user explicitly accepting more spend this week —
     the durable billing ledger is untouched, only the guardrail's counter
-    restarts."""
+    restarts.
+
+    The forgiveness only fires when a pause was actually reversed: resume
+    on a not-paused expert is an idempotent success that leaves the counter
+    alone, so repeated calls can't hold the guardrail at zero. Archived
+    experts return False (re-hiring is archive's reversal, not Resume)."""
     updated = await prisma.models.Expert.prisma().update_many(
-        where={"id": expert_id, "ownerUserId": user_id, "isTemplate": False},
+        where={
+            "id": expert_id,
+            "ownerUserId": user_id,
+            "isTemplate": False,
+            "isArchived": False,
+            "schedulesPausedAt": {"not": None},
+        },
         data={"schedulesPausedAt": None},
     )
     if updated == 0:
-        return False
+        expert = await prisma.models.Expert.prisma().find_first(
+            where={
+                "id": expert_id,
+                "ownerUserId": user_id,
+                "isTemplate": False,
+                "isArchived": False,
+            }
+        )
+        return expert is not None
     await reset_weekly_spend(expert_id)
     await prisma.models.ExpertPauseEvent.prisma().update_many(
         where={"expertId": expert_id, "clearedAt": None},

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -1061,17 +1061,23 @@ async def append_expert_run_message(
     if existing is not None:
         return None
 
-    session = await PrismaChatSession.prisma().find_first(
-        where={"userId": user_id, "expertId": expert_id},
-        order={"updatedAt": "desc"},
-    )
-    if session is not None:
-        session_id = session.id
-    else:
-        created = await create_chat_session(
-            session_id=str(uuid.uuid4()), user_id=user_id, expert_id=expert_id
+    # Find-or-create serializes on an expert-scoped lock: the per-session
+    # lock below can't cover this window (the session may not exist yet),
+    # and without it two concurrent first posts each create a session and
+    # fork the expert's thread. Degraded mode (Redis down) falls back to
+    # best-effort, same as the sequence lock.
+    async with _get_session_lock(f"expert-thread:{user_id}:{expert_id}"):
+        session = await PrismaChatSession.prisma().find_first(
+            where={"userId": user_id, "expertId": expert_id},
+            order={"updatedAt": "desc"},
         )
-        session_id = created.session_id
+        if session is not None:
+            session_id = session.id
+        else:
+            created = await create_chat_session(
+                session_id=str(uuid.uuid4()), user_id=user_id, expert_id=expert_id
+            )
+            session_id = created.session_id
 
     # Same Redis NX lock as turn_queue.append_and_save_message: the
     # sequence read + insert must not interleave with a concurrent turn

--- a/autogpt_platform/backend/backend/copilot/db_test.py
+++ b/autogpt_platform/backend/backend/copilot/db_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, AsyncIterator
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1113,3 +1114,61 @@ async def test_append_expert_run_message_creates_session_when_none_exists() -> N
     assert result == "sess-new"
     assert created.call_args.kwargs["expert_id"] == "e1"
     assert add_message.call_args.kwargs["session_id"] == "sess-new"
+
+
+@pytest.mark.asyncio
+async def test_append_expert_run_message_find_or_create_under_expert_lock() -> None:
+    """The session find-or-create must serialize on an expert-scoped lock,
+    not just the (not-yet-existing) session id — otherwise two concurrent
+    first posts each create a session and fork the expert's thread."""
+    from backend.copilot import db as copilot_db
+    from backend.copilot.db import append_expert_run_message
+
+    order: list[str] = []
+
+    @asynccontextmanager
+    async def fake_lock(key: str) -> AsyncIterator[bool]:
+        order.append(f"lock:{key}")
+        yield True
+        order.append(f"unlock:{key}")
+
+    async def record_find_first(**kwargs: Any) -> None:
+        order.append("find")
+        return None
+
+    created_info = AsyncMock()
+    created_info.session_id = "sess-new"
+
+    async def record_create(**kwargs: Any) -> Any:
+        order.append("create")
+        return created_info
+
+    find_unique = AsyncMock(return_value=None)
+    with (
+        patch.object(
+            PrismaChatMessage, "prisma", return_value=AsyncMock(find_unique=find_unique)
+        ),
+        patch.object(
+            PrismaChatSession,
+            "prisma",
+            return_value=AsyncMock(find_first=AsyncMock(side_effect=record_find_first)),
+        ),
+        patch.object(copilot_db, "_get_session_lock", new=fake_lock),
+        patch("backend.copilot.db.add_chat_message", new=AsyncMock()),
+        patch(
+            "backend.copilot.db.create_chat_session",
+            new=AsyncMock(side_effect=record_create),
+        ),
+        patch("backend.copilot.db.get_next_sequence", new=AsyncMock(return_value=0)),
+    ):
+        result = await append_expert_run_message(
+            user_id="u1", expert_id="e1", content="done", message_id="m1"
+        )
+
+    assert result == "sess-new"
+    assert order[:4] == [
+        "lock:expert-thread:u1:e1",
+        "find",
+        "create",
+        "unlock:expert-thread:u1:e1",
+    ]

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1401,16 +1401,19 @@ async def add_graph_execution(
             # persisted row on resume/requeue.
             expert_id=expert_id or graph_exec.expert_id,
         )
-    elif execution_context.organization_id is None and graph_exec.organization_id:
+    else:
         # A caller-supplied context (e.g. review-resume, admin-requeue) may
-        # be built before org/team are known. Backfill from the persisted
-        # row so billing and sub-graph runs aren't tenant-blind on resume.
-        execution_context = execution_context.model_copy(
-            update={
-                "organization_id": graph_exec.organization_id,
-                "team_id": graph_exec.team_id,
-            }
-        )
+        # be built before org/team/expert attribution is known. Backfill
+        # from the persisted row so billing, sub-graph runs, and expert
+        # thread posts aren't attribution-blind on resume.
+        backfill: dict[str, str | None] = {}
+        if execution_context.organization_id is None and graph_exec.organization_id:
+            backfill["organization_id"] = graph_exec.organization_id
+            backfill["team_id"] = graph_exec.team_id
+        if execution_context.expert_id is None and graph_exec.expert_id:
+            backfill["expert_id"] = graph_exec.expert_id
+        if backfill:
+            execution_context = execution_context.model_copy(update=backfill)
 
     try:
         graph_exec_entry = graph_exec.to_graph_execution_entry(

--- a/autogpt_platform/backend/backend/executor/utils_test.py
+++ b/autogpt_platform/backend/backend/executor/utils_test.py
@@ -609,6 +609,7 @@ async def test_add_graph_execution_born_tenanted_via_rpc_when_prisma_disconnecte
     mock_graph_exec = mocker.MagicMock(spec=GraphExecutionWithNodes)
     mock_graph_exec.organization_id = "org-rpc"
     mock_graph_exec.team_id = "team-rpc"
+    mock_graph_exec.expert_id = None
     mock_graph_exec.id = "exec-id-rpc"
     mock_graph_exec.node_executions = []
     mock_graph_exec.status = ExecutionStatus.QUEUED
@@ -973,6 +974,67 @@ async def test_add_graph_execution_resume_backfills_org_from_row(mocker: MockerF
     assert captured_kwargs["execution_context"].team_id == "team-row"
     # The "CREATE path only" invariant: resume never consults the resolver.
     mock_get_default_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_graph_execution_resume_backfills_expert_from_row(
+    mocker: MockerFixture,
+):
+    """On resume, a caller-supplied ExecutionContext built without expert_id
+    (e.g. the review-resume path) must recover it from the persisted row —
+    otherwise weekly spend metering and the expert thread post silently stop
+    after a human-in-the-loop resume. Row deliberately has no org so the
+    org-backfill condition alone can't mask a missing expert backfill."""
+    from backend.data.execution import ExecutionContext, GraphExecutionWithNodes
+    from backend.executor.utils import add_graph_execution
+
+    mock_graph_exec = mocker.MagicMock(spec=GraphExecutionWithNodes)
+    mock_graph_exec.id = "exec-resume-2"
+    mock_graph_exec.node_executions = []
+    mock_graph_exec.status = ExecutionStatus.QUEUED
+    mock_graph_exec.graph_version = 1
+    mock_graph_exec.nodes_input_masks = {}
+    mock_graph_exec.organization_id = None
+    mock_graph_exec.team_id = None
+    mock_graph_exec.expert_id = "expert-row"
+
+    captured_kwargs: dict = {}
+
+    def capture_to_entry(**kwargs):
+        captured_kwargs.update(kwargs)
+        return mocker.MagicMock()
+
+    mock_graph_exec.to_graph_execution_entry.side_effect = capture_to_entry
+
+    mock_edb = mocker.patch("backend.executor.utils.execution_db")
+    mock_prisma = mocker.patch("backend.executor.utils.prisma")
+    mock_get_queue = mocker.patch("backend.executor.utils.get_async_execution_queue")
+    mock_get_event_bus = mocker.patch(
+        "backend.executor.utils.get_async_execution_event_bus"
+    )
+    mock_prisma.is_connected.return_value = True
+    mock_edb.get_graph_execution = mocker.AsyncMock(return_value=mock_graph_exec)
+    mock_edb.update_graph_execution_stats = mocker.AsyncMock(
+        return_value=mock_graph_exec
+    )
+    mock_edb.update_node_execution_status_batch = mocker.AsyncMock()
+    mock_get_queue.return_value = mocker.AsyncMock()
+    mock_get_event_bus.return_value = mocker.MagicMock(publish=mocker.AsyncMock())
+    mocker.patch(
+        "backend.executor.utils._enforce_expert_run_budget", new=mocker.AsyncMock()
+    )
+
+    resume_ctx = ExecutionContext(user_id="test-user-id", workspace_id="ws-1")
+    assert resume_ctx.expert_id is None
+
+    await add_graph_execution(
+        graph_id="test-graph-id",
+        user_id="test-user-id",
+        graph_exec_id="exec-resume-2",
+        execution_context=resume_ctx,
+    )
+
+    assert captured_kwargs["execution_context"].expert_id == "expert-row"
 
 
 @pytest.mark.asyncio
@@ -1997,6 +2059,7 @@ def _mock_add_graph_execution_create_path(
     mock_graph_exec = mocker.MagicMock(spec=GraphExecutionWithNodes)
     mock_graph_exec.organization_id = org_id
     mock_graph_exec.team_id = team_id
+    mock_graph_exec.expert_id = None
     mock_graph_exec.id = "exec-id"
     mock_graph_exec.node_executions = []
     mock_graph_exec.status = ExecutionStatus.QUEUED


### PR DESCRIPTION
### Why / What / How

**Why:** A post-merge deep review of #13772 (expert scheduling) surfaced three real defects: expert-attributed runs that go through human-in-the-loop review lose their attribution on resume (weekly spend stops metering and the completion post never lands in the expert's thread), the `schedules/resume` endpoint resets the weekly-spend counter even when the expert isn't paused (repeated calls hold the guardrail at zero), and the expert-thread find-or-create can race two concurrent first posts into two forked sessions.

**What:** Fixes all three, plus repairs 6 `utils_test` failures the merged PR left on dev (graph-exec mocks missing the new `expert_id` field).

**How:**
- `executor/utils.py`: the caller-supplied-context backfill branch now recovers `expert_id` from the persisted row alongside org/team, so review-resume/admin-requeue keep attribution.
- `experts/scheduling.py`: `resume_expert_schedules` only forgives the weekly counter when a pause was actually reversed (`schedulesPausedAt: {not: None}` + `isArchived: False` guards); resume on a not-paused expert is an idempotent no-op that leaves the counter alone, archived experts return False → 404 (re-hiring is archive's reversal).
- `copilot/db.py`: `append_expert_run_message` serializes session find-or-create on an expert-scoped Redis lock (`expert-thread:{user_id}:{expert_id}`) — the per-session lock can't cover that window because the session may not exist yet; degraded mode stays best-effort like the sequence lock.

### Changes 🏗️

- `backend/executor/utils.py` — resume backfill covers `expert_id`, not just org/team
- `backend/api/features/experts/scheduling.py` — pause-reversal-gated spend forgiveness; archived-expert guard
- `backend/copilot/db.py` — expert-scoped lock around thread find-or-create
- Tests (written first, RED→GREEN): expert backfill on resume, resume-without-pause keeps counter, resume-archived returns False, find-or-create-under-lock ordering; `utils_test` mock helpers stamp `expert_id=None` (fixes 6 pre-existing dev failures)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pytest backend/executor/utils_test.py backend/copilot/db_test.py backend/executor/expert_posts_test.py backend/executor/scheduler_unit_test.py` — 132 passed (37 utils incl. 6 previously failing on dev)
  - [x] DB-backed `pytest backend/api/features/experts/experts_db_test.py` — 20 passed (incl. 2 new resume tests + existing budget pause/resume regression)
  - [x] `poetry run format` (black/isort/ruff/pyright) clean

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
