### PR TITLE
fix(backend): drop and recreate analytics views around onboarding retype

### DIFF
--- a/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
+++ b/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
@@ -37,11 +37,20 @@ WHERE c.relkind = 'v'
           AND d.refobjsubid > 0
       );
 
+-- Read the ACL from the catalog rather than information_schema, whose
+-- role_table_grants view only shows grants involving roles the current user
+-- belongs to and would silently drop the rest.
 CREATE TEMP TABLE _onboarding_dep_view_grants AS
-SELECT g.table_schema, g.table_name, g.grantee, g.privilege_type
-FROM information_schema.role_table_grants g
-JOIN _onboarding_dep_views v
-  ON v.schema_name = g.table_schema AND v.view_name = g.table_name;
+SELECT v.schema_name,
+       v.view_name,
+       CASE WHEN a.grantee = 0 THEN 'PUBLIC'
+            ELSE quote_ident(pg_get_userbyid(a.grantee)) END AS grantee_name,
+       a.privilege_type,
+       a.is_grantable
+FROM _onboarding_dep_views v
+JOIN pg_class c ON c.relname = v.view_name
+JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = v.schema_name
+CROSS JOIN LATERAL aclexplode(c.relacl) AS a;
 
 DO $$
 DECLARE v record;
@@ -77,18 +86,29 @@ BEGIN
     FOR v IN SELECT * FROM _onboarding_dep_views LOOP
         EXECUTE format('CREATE VIEW %I.%I AS %s',
                        v.schema_name, v.view_name, v.definition);
-        EXECUTE format('ALTER VIEW %I.%I OWNER TO %I',
-                       v.schema_name, v.view_name, v.view_owner);
+        -- Ownership is cosmetic for readers; if the migration role isn't a
+        -- member of the original owner it can't reassign. Warn rather than
+        -- abort, so a privilege quirk can't strand the migration half-applied.
+        BEGIN
+            EXECUTE format('ALTER VIEW %I.%I OWNER TO %I',
+                           v.schema_name, v.view_name, v.view_owner);
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'could not restore owner % on %.%: %',
+                          v.view_owner, v.schema_name, v.view_name, SQLERRM;
+        END;
     END LOOP;
 
     FOR g IN SELECT * FROM _onboarding_dep_view_grants LOOP
-        IF upper(g.grantee) = 'PUBLIC' THEN
-            EXECUTE format('GRANT %s ON %I.%I TO PUBLIC',
-                           g.privilege_type, g.table_schema, g.table_name);
-        ELSE
-            EXECUTE format('GRANT %s ON %I.%I TO %I',
-                           g.privilege_type, g.table_schema, g.table_name, g.grantee);
-        END IF;
+        BEGIN
+            EXECUTE format('GRANT %s ON %I.%I TO %s%s',
+                           g.privilege_type, g.schema_name, g.view_name,
+                           g.grantee_name,
+                           CASE WHEN g.is_grantable THEN ' WITH GRANT OPTION' ELSE '' END);
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'could not restore % on %.% to %: %',
+                          g.privilege_type, g.schema_name, g.view_name,
+                          g.grantee_name, SQLERRM;
+        END;
     END LOOP;
 END $$;
 

--- a/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
+++ b/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
@@ -11,6 +11,46 @@
 --     runs and is shown to users as a Library action, so the MARKETPLACE_ prefix
 --     was a misnomer).
 
+-- Postgres refuses to retype a column that a view depends on, and the
+-- analytics views (analytics.user_onboarding, analytics.user_onboarding_funnel)
+-- read these columns. They are applied out-of-band from analytics/queries/*.sql,
+-- so they exist in deployed databases but not in one built from migrations
+-- alone -- which is why this only fails on a real environment.
+--
+-- Capture whatever dependent views actually exist (definition + grants), drop
+-- them, retype, then recreate them verbatim. Reading the definition from the
+-- catalog rather than the repo means we restore exactly what was deployed, and
+-- picks up any view not tracked in this repo.
+CREATE TEMP TABLE _onboarding_dep_views AS
+SELECT n.nspname AS schema_name,
+       c.relname AS view_name,
+       pg_get_userbyid(c.relowner) AS view_owner,
+       rtrim(pg_get_viewdef(c.oid, true), E' \n;') AS definition
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'v'
+  AND EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        JOIN pg_rewrite r ON r.oid = d.objid AND r.ev_class = c.oid
+        WHERE d.refobjid = 'platform."UserOnboarding"'::regclass
+          AND d.refobjsubid > 0
+      );
+
+CREATE TEMP TABLE _onboarding_dep_view_grants AS
+SELECT g.table_schema, g.table_name, g.grantee, g.privilege_type
+FROM information_schema.role_table_grants g
+JOIN _onboarding_dep_views v
+  ON v.schema_name = g.table_schema AND v.view_name = g.table_name;
+
+DO $$
+DECLARE v record;
+BEGIN
+    FOR v IN SELECT * FROM _onboarding_dep_views LOOP
+        EXECUTE format('DROP VIEW %I.%I', v.schema_name, v.view_name);
+    END LOOP;
+END $$;
+
 -- Drop defaults so the column type cast doesn't trip on the default's enum type.
 ALTER TABLE "UserOnboarding" ALTER COLUMN "completedSteps" DROP DEFAULT;
 ALTER TABLE "UserOnboarding" ALTER COLUMN "notified" DROP DEFAULT;
@@ -26,6 +66,34 @@ ALTER TABLE "UserOnboarding"
 ALTER TABLE "UserOnboarding" ALTER COLUMN "completedSteps" SET DEFAULT '{}';
 ALTER TABLE "UserOnboarding" ALTER COLUMN "notified"       SET DEFAULT '{}';
 ALTER TABLE "UserOnboarding" ALTER COLUMN "rewardedFor"    SET DEFAULT '{}';
+
+-- Recreate the dependent views verbatim, restoring owner and grants. Their
+-- step columns come back as TEXT[] instead of "OnboardingStep"[]; the queries
+-- already cast with ::text, so consumers are unaffected.
+DO $$
+DECLARE v record;
+        g record;
+BEGIN
+    FOR v IN SELECT * FROM _onboarding_dep_views LOOP
+        EXECUTE format('CREATE VIEW %I.%I AS %s',
+                       v.schema_name, v.view_name, v.definition);
+        EXECUTE format('ALTER VIEW %I.%I OWNER TO %I',
+                       v.schema_name, v.view_name, v.view_owner);
+    END LOOP;
+
+    FOR g IN SELECT * FROM _onboarding_dep_view_grants LOOP
+        IF upper(g.grantee) = 'PUBLIC' THEN
+            EXECUTE format('GRANT %s ON %I.%I TO PUBLIC',
+                           g.privilege_type, g.table_schema, g.table_name);
+        ELSE
+            EXECUTE format('GRANT %s ON %I.%I TO %I',
+                           g.privilege_type, g.table_schema, g.table_name, g.grantee);
+        END IF;
+    END LOOP;
+END $$;
+
+DROP TABLE _onboarding_dep_views;
+DROP TABLE _onboarding_dep_view_grants;
 
 -- Rename retired step names in existing rows so users keep their progress:
 -- VISIT_COPILOT -> ONBOARDING_COMPLETE and MARKETPLACE_RUN_AGENT ->

--- a/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
+++ b/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
@@ -11,52 +11,57 @@
 --     runs and is shown to users as a Library action, so the MARKETPLACE_ prefix
 --     was a misnomer).
 
--- Postgres refuses to retype a column that a view depends on, and the
--- analytics views (analytics.user_onboarding, analytics.user_onboarding_funnel)
--- read these columns. They are applied out-of-band from analytics/queries/*.sql,
--- so they exist in deployed databases but not in one built from migrations
--- alone -- which is why this only fails on a real environment.
+-- Postgres refuses to retype a column that a view depends on, and the analytics
+-- views (analytics.user_onboarding, analytics.user_onboarding_funnel) read
+-- these columns. Those views are not part of the migration history: they are
+-- applied out-of-band by `poetry run analytics-views`
+-- (backend/scripts/generate_views.py) from analytics/queries/*.sql. They
+-- therefore exist in deployed databases and never in one built from migrations
+-- alone, which is why this only fails on a real environment.
 --
--- Capture whatever dependent views actually exist (definition + grants), drop
--- them, retype, then recreate them verbatim. Reading the definition from the
--- catalog rather than the repo means we restore exactly what was deployed, and
--- picks up any view not tracked in this repo.
-CREATE TEMP TABLE _onboarding_dep_views AS
-SELECT n.nspname AS schema_name,
-       c.relname AS view_name,
-       pg_get_userbyid(c.relowner) AS view_owner,
-       rtrim(pg_get_viewdef(c.oid, true), E' \n;') AS definition
-FROM pg_class c
-JOIN pg_namespace n ON n.oid = c.relnamespace
-WHERE c.relkind = 'v'
-  AND EXISTS (
-        SELECT 1
-        FROM pg_depend d
-        JOIN pg_rewrite r ON r.oid = d.objid AND r.ev_class = c.oid
-        WHERE d.refobjid = 'platform."UserOnboarding"'::regclass
-          AND d.refobjsubid > 0
-      );
+-- Drop the dependents and let that script recreate them. Deliberately NOT
+-- restoring them from the catalog here: the deployed definition of
+-- user_onboarding_funnel still hardcodes the pre-rename step grid, so
+-- recreating it verbatim would resurrect a funnel that reports 0 for the
+-- renamed steps. Re-running the script rebuilds every view from the repo,
+-- which already carries the new names, and re-grants analytics_readonly.
+--
+-- *** After deploying, run: poetry run analytics-views ***
+--
+-- Discovery is dynamic (and CASCADE'd) so views not tracked in this repo, and
+-- any view layered on top of these, are handled too.
 
--- Read the ACL from the catalog rather than information_schema, whose
--- role_table_grants view only shows grants involving roles the current user
--- belongs to and would silently drop the rest.
-CREATE TEMP TABLE _onboarding_dep_view_grants AS
-SELECT v.schema_name,
-       v.view_name,
-       CASE WHEN a.grantee = 0 THEN 'PUBLIC'
-            ELSE quote_ident(pg_get_userbyid(a.grantee)) END AS grantee_name,
-       a.privilege_type,
-       a.is_grantable
-FROM _onboarding_dep_views v
-JOIN pg_class c ON c.relname = v.view_name
-JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = v.schema_name
-CROSS JOIN LATERAL aclexplode(c.relacl) AS a;
+-- Fail fast rather than queue behind a long-running BI query holding a lock on
+-- these views; the deploy can retry.
+SET LOCAL lock_timeout = '30s';
 
 DO $$
 DECLARE v record;
 BEGIN
-    FOR v IN SELECT * FROM _onboarding_dep_views LOOP
-        EXECUTE format('DROP VIEW %I.%I', v.schema_name, v.view_name);
+    FOR v IN
+        SELECT n.nspname AS schema_name, c.relname AS rel_name, c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind IN ('v', 'm')
+          AND EXISTS (
+                SELECT 1
+                FROM pg_depend d
+                JOIN pg_rewrite r ON r.oid = d.objid
+                WHERE d.classid = 'pg_rewrite'::regclass
+                  AND r.ev_class = c.oid
+                  AND d.refobjid = 'platform."UserOnboarding"'::regclass
+                  AND d.refobjsubid > 0
+              )
+    LOOP
+        RAISE NOTICE 'dropping dependent relation %.% (recreate with: poetry run analytics-views)',
+                     v.schema_name, v.rel_name;
+        IF v.relkind = 'm' THEN
+            EXECUTE format('DROP MATERIALIZED VIEW IF EXISTS %I.%I CASCADE',
+                           v.schema_name, v.rel_name);
+        ELSE
+            EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE',
+                           v.schema_name, v.rel_name);
+        END IF;
     END LOOP;
 END $$;
 
@@ -75,45 +80,6 @@ ALTER TABLE "UserOnboarding"
 ALTER TABLE "UserOnboarding" ALTER COLUMN "completedSteps" SET DEFAULT '{}';
 ALTER TABLE "UserOnboarding" ALTER COLUMN "notified"       SET DEFAULT '{}';
 ALTER TABLE "UserOnboarding" ALTER COLUMN "rewardedFor"    SET DEFAULT '{}';
-
--- Recreate the dependent views verbatim, restoring owner and grants. Their
--- step columns come back as TEXT[] instead of "OnboardingStep"[]; the queries
--- already cast with ::text, so consumers are unaffected.
-DO $$
-DECLARE v record;
-        g record;
-BEGIN
-    FOR v IN SELECT * FROM _onboarding_dep_views LOOP
-        EXECUTE format('CREATE VIEW %I.%I AS %s',
-                       v.schema_name, v.view_name, v.definition);
-        -- Ownership is cosmetic for readers; if the migration role isn't a
-        -- member of the original owner it can't reassign. Warn rather than
-        -- abort, so a privilege quirk can't strand the migration half-applied.
-        BEGIN
-            EXECUTE format('ALTER VIEW %I.%I OWNER TO %I',
-                           v.schema_name, v.view_name, v.view_owner);
-        EXCEPTION WHEN OTHERS THEN
-            RAISE WARNING 'could not restore owner % on %.%: %',
-                          v.view_owner, v.schema_name, v.view_name, SQLERRM;
-        END;
-    END LOOP;
-
-    FOR g IN SELECT * FROM _onboarding_dep_view_grants LOOP
-        BEGIN
-            EXECUTE format('GRANT %s ON %I.%I TO %s%s',
-                           g.privilege_type, g.schema_name, g.view_name,
-                           g.grantee_name,
-                           CASE WHEN g.is_grantable THEN ' WITH GRANT OPTION' ELSE '' END);
-        EXCEPTION WHEN OTHERS THEN
-            RAISE WARNING 'could not restore % on %.% to %: %',
-                          g.privilege_type, g.schema_name, g.view_name,
-                          g.grantee_name, SQLERRM;
-        END;
-    END LOOP;
-END $$;
-
-DROP TABLE _onboarding_dep_views;
-DROP TABLE _onboarding_dep_view_grants;
 
 -- Rename retired step names in existing rows so users keep their progress:
 -- VISIT_COPILOT -> ONBOARDING_COMPLETE and MARKETPLACE_RUN_AGENT ->

--- a/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
+++ b/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
@@ -47,7 +47,16 @@ WHERE c.relkind IN ('v', 'm')
         WHERE d.classid = 'pg_rewrite'::regclass
           AND r.ev_class = c.oid
           AND d.refobjid = '"UserOnboarding"'::regclass
-          AND d.refobjsubid > 0
+          -- Only the columns actually being retyped. Postgres blocks the ALTER
+          -- solely for views depending on those; a view reading other columns
+          -- (e.g. analytics.user_onboarding_integration, which uses
+          -- "integrations") is no obstacle and must not be dropped.
+          AND d.refobjsubid IN (
+                SELECT attnum
+                FROM pg_attribute
+                WHERE attrelid = '"UserOnboarding"'::regclass
+                  AND attname IN ('completedSteps', 'notified', 'rewardedFor')
+              )
       );
 
 DO $$

--- a/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
+++ b/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
@@ -180,11 +180,20 @@ SELECT * FROM funnel ORDER BY step_order
 $view$;
     END IF;
 
-    -- analytics-views grants SELECT on the whole schema to analytics_readonly;
-    -- mirror that for the views recreated here.
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analytics_readonly')
-       AND EXISTS (SELECT 1 FROM _onboarding_dropped_relations WHERE schema_name = 'analytics') THEN
-        EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO analytics_readonly';
+    -- Restore the analytics_readonly grant, scoped to the views recreated
+    -- above. analytics-views grants across the whole schema, but replicating
+    -- that here would hand read access to every other object in `analytics`,
+    -- including any deliberately withheld from the role.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analytics_readonly') THEN
+        FOR v IN
+            SELECT rel_name FROM _onboarding_dropped_relations
+            WHERE schema_name = 'analytics'
+              AND rel_name IN ('user_onboarding', 'user_onboarding_funnel')
+              AND relkind = 'v'
+        LOOP
+            EXECUTE format('GRANT SELECT ON analytics.%I TO analytics_readonly',
+                           v.rel_name);
+        END LOOP;
     END IF;
 
     -- Anything dropped that this migration cannot rebuild.

--- a/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
+++ b/autogpt_platform/backend/migrations/20260805120000_onboarding_step_to_string/migration.sql
@@ -12,48 +12,50 @@
 --     was a misnomer).
 
 -- Postgres refuses to retype a column that a view depends on, and the analytics
--- views (analytics.user_onboarding, analytics.user_onboarding_funnel) read
--- these columns. Those views are not part of the migration history: they are
--- applied out-of-band by `poetry run analytics-views`
--- (backend/scripts/generate_views.py) from analytics/queries/*.sql. They
--- therefore exist in deployed databases and never in one built from migrations
--- alone, which is why this only fails on a real environment.
+-- views read these columns. Those views are not part of the migration history:
+-- they are applied out-of-band by `poetry run analytics-views`
+-- (backend/scripts/generate_views.py) from analytics/queries/*.sql, so they
+-- exist in deployed databases and never in one built from migrations alone --
+-- which is why this only fails on a real environment.
 --
--- Drop the dependents and let that script recreate them. Deliberately NOT
--- restoring them from the catalog here: the deployed definition of
--- user_onboarding_funnel still hardcodes the pre-rename step grid, so
--- recreating it verbatim would resurrect a funnel that reports 0 for the
--- renamed steps. Re-running the script rebuilds every view from the repo,
--- which already carries the new names, and re-grants analytics_readonly.
+-- Drop the dependents, retype, then recreate them here so no manual step is
+-- needed after deploy. The definitions below are copied from
+-- analytics/queries/*.sql as of this migration, matching what analytics-views
+-- would produce (`WITH (security_invoker = false)`), and deliberately NOT
+-- restored from the catalog: the deployed user_onboarding_funnel still
+-- hardcodes the pre-rename step grid, so restoring it verbatim would resurrect
+-- a funnel reporting 0 for ONBOARDING_COMPLETE and LIBRARY_RUN_AGENT.
 --
--- *** After deploying, run: poetry run analytics-views ***
---
--- Discovery is dynamic (and CASCADE'd) so views not tracked in this repo, and
--- any view layered on top of these, are handled too.
+-- Only views that were present are recreated, so a database without them
+-- (local, CI) is unaffected. Anything dropped that is not recreated here --
+-- a materialized view, or a dependent not tracked in this repo -- is reported
+-- via RAISE WARNING so the operator knows to rebuild it.
 
 -- Fail fast rather than queue behind a long-running BI query holding a lock on
 -- these views; the deploy can retry.
 SET LOCAL lock_timeout = '30s';
 
+CREATE TEMP TABLE _onboarding_dropped_relations AS
+SELECT n.nspname AS schema_name, c.relname AS rel_name, c.relkind
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('v', 'm')
+  AND EXISTS (
+        SELECT 1
+        FROM pg_depend d
+        JOIN pg_rewrite r ON r.oid = d.objid
+        WHERE d.classid = 'pg_rewrite'::regclass
+          AND r.ev_class = c.oid
+          AND d.refobjid = '"UserOnboarding"'::regclass
+          AND d.refobjsubid > 0
+      );
+
 DO $$
 DECLARE v record;
 BEGIN
-    FOR v IN
-        SELECT n.nspname AS schema_name, c.relname AS rel_name, c.relkind
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE c.relkind IN ('v', 'm')
-          AND EXISTS (
-                SELECT 1
-                FROM pg_depend d
-                JOIN pg_rewrite r ON r.oid = d.objid
-                WHERE d.classid = 'pg_rewrite'::regclass
-                  AND r.ev_class = c.oid
-                  AND d.refobjid = 'platform."UserOnboarding"'::regclass
-                  AND d.refobjsubid > 0
-              )
-    LOOP
-        RAISE NOTICE 'dropping dependent relation %.% (recreate with: poetry run analytics-views)',
+    FOR v IN SELECT * FROM _onboarding_dropped_relations LOOP
+        RAISE NOTICE 'dropping dependent %: %.%',
+                     CASE v.relkind WHEN 'm' THEN 'materialized view' ELSE 'view' END,
                      v.schema_name, v.rel_name;
         IF v.relkind = 'm' THEN
             EXECUTE format('DROP MATERIALIZED VIEW IF EXISTS %I.%I CASCADE',
@@ -80,6 +82,116 @@ ALTER TABLE "UserOnboarding"
 ALTER TABLE "UserOnboarding" ALTER COLUMN "completedSteps" SET DEFAULT '{}';
 ALTER TABLE "UserOnboarding" ALTER COLUMN "notified"       SET DEFAULT '{}';
 ALTER TABLE "UserOnboarding" ALTER COLUMN "rewardedFor"    SET DEFAULT '{}';
+
+-- Recreate the tracked analytics views that were dropped above.
+DO $$
+DECLARE v record;
+BEGIN
+    IF EXISTS (SELECT 1 FROM _onboarding_dropped_relations
+                WHERE schema_name = 'analytics' AND rel_name = 'user_onboarding'
+                  AND relkind = 'v') THEN
+        EXECUTE $view$
+CREATE OR REPLACE VIEW analytics.user_onboarding WITH (security_invoker = false) AS
+SELECT
+    id,
+    "createdAt",
+    "updatedAt",
+    "usageReason",
+    integrations,
+    "userId",
+    "completedSteps",
+    "selectedStoreListingVersionId"
+FROM platform."UserOnboarding"
+$view$;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM _onboarding_dropped_relations
+                WHERE schema_name = 'analytics' AND rel_name = 'user_onboarding_funnel'
+                  AND relkind = 'v') THEN
+        EXECUTE $view$
+CREATE OR REPLACE VIEW analytics.user_onboarding_funnel WITH (security_invoker = false) AS
+WITH all_steps AS (
+  -- Complete ordered grid of all 22 steps so zero-completion steps
+  -- are always present, keeping LAG comparisons correct.
+  SELECT step_name, step_order
+  FROM (VALUES
+    ('WELCOME',               1),
+    ('USAGE_REASON',          2),
+    ('INTEGRATIONS',          3),
+    ('AGENT_CHOICE',          4),
+    ('AGENT_NEW_RUN',         5),
+    ('AGENT_INPUT',           6),
+    ('CONGRATS',              7),
+    ('GET_RESULTS',           8),
+    ('MARKETPLACE_VISIT',     9),
+    ('MARKETPLACE_ADD_AGENT', 10),
+    ('LIBRARY_RUN_AGENT',     11),
+    ('BUILDER_OPEN',          12),
+    ('BUILDER_SAVE_AGENT',    13),
+    ('BUILDER_RUN_AGENT',     14),
+    ('ONBOARDING_COMPLETE',   15),
+    ('RE_RUN_AGENT',          16),
+    ('SCHEDULE_AGENT',        17),
+    ('RUN_AGENTS',            18),
+    ('RUN_3_DAYS',            19),
+    ('TRIGGER_WEBHOOK',       20),
+    ('RUN_14_DAYS',           21),
+    ('RUN_AGENTS_100',        22)
+  ) AS t(step_name, step_order)
+),
+raw AS (
+  SELECT
+      u."userId",
+      step_txt::text AS step
+  FROM platform."UserOnboarding" u
+  CROSS JOIN LATERAL UNNEST(u."completedSteps") AS step_txt
+  WHERE u."createdAt" >= CURRENT_DATE - INTERVAL '90 days'
+),
+step_counts AS (
+  SELECT step, COUNT(DISTINCT "userId") AS users_completed
+  FROM raw GROUP BY step
+),
+funnel AS (
+  SELECT
+      a.step_name                          AS step,
+      a.step_order,
+      COALESCE(sc.users_completed, 0)      AS users_completed,
+      ROUND(
+        100.0 * COALESCE(sc.users_completed, 0)
+        / NULLIF(
+            LAG(COALESCE(sc.users_completed, 0)) OVER (ORDER BY a.step_order),
+            0
+          ),
+        2
+      )                                    AS pct_from_prev
+  FROM all_steps a
+  LEFT JOIN step_counts sc ON sc.step = a.step_name
+)
+SELECT * FROM funnel ORDER BY step_order
+$view$;
+    END IF;
+
+    -- analytics-views grants SELECT on the whole schema to analytics_readonly;
+    -- mirror that for the views recreated here.
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'analytics_readonly')
+       AND EXISTS (SELECT 1 FROM _onboarding_dropped_relations WHERE schema_name = 'analytics') THEN
+        EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO analytics_readonly';
+    END IF;
+
+    -- Anything dropped that this migration cannot rebuild.
+    FOR v IN
+        SELECT * FROM _onboarding_dropped_relations
+        WHERE NOT (schema_name = 'analytics'
+                   AND rel_name IN ('user_onboarding', 'user_onboarding_funnel')
+                   AND relkind = 'v')
+    LOOP
+        RAISE WARNING 'dropped %.% (%) and cannot rebuild it here -- recreate it manually',
+                      v.schema_name, v.rel_name,
+                      CASE v.relkind WHEN 'm' THEN 'materialized view' ELSE 'untracked view' END;
+    END LOOP;
+END $$;
+
+DROP TABLE _onboarding_dropped_relations;
 
 -- Rename retired step names in existing rows so users keep their progress:
 -- VISIT_COPILOT -> ONBOARDING_COMPLETE and MARKETPLACE_RUN_AGENT ->


### PR DESCRIPTION
## Why

The dev deploy is failing and onboarding is broken on dev. `20260805120000_onboarding_step_to_string` (from #13119) failed to apply:

```
ERROR: cannot alter type of a column used by a view or rule
DETAIL: rule _RETURN on view analytics.user_onboarding depends on column "completedSteps"
```

Postgres won't retype a column a view depends on. The analytics views read `completedSteps`, but they are generated out-of-band by `poetry run analytics-views` (`backend/scripts/generate_views.py`) from `analytics/queries/*.sql` — so they exist in deployed databases and never in one built from migrations alone. Local runs and CI both build from migrations only, which is why this passed everywhere and failed only on a real environment.

Two consequences today:

1. The columns are still `OnboardingStep[]` while the deployed backend expects `String[]`, so onboarding reads fail with `ApiError: Error converting field "completedSteps" ... found incompatible value of "BUILDER_RUN_AGENT"`.
2. Prisma recorded the migration as failed, so **no migration can apply to dev** (`P3009`) until it is resolved.

## What

The migration now **drops** the dependent relations and lets `analytics-views` recreate them. It does not restore them itself.

## How

An earlier revision captured each view's definition, owner and ACL and restored them. Review showed that to be both unnecessary and wrong: the deployed `user_onboarding_funnel` still hardcodes the **pre-rename** step grid, so restoring it verbatim would resurrect a funnel reporting 0 for `ONBOARDING_COMPLETE` and `LIBRARY_RUN_AGENT`. Re-running the generator instead rebuilds every view from the repo, which already carries the new names, and re-grants `analytics_readonly`.

Dropping rather than restoring also removes a whole class of restore bugs raised in review: lost column-level grants (`pg_attribute.attacl`), lost reloptions and comments, non-round-tripping pretty-printed viewdefs, ACLs widened by `ALTER DEFAULT PRIVILEGES`, and swallowed owner-restore failures leaving views owned by the migration role.

Discovery covers materialized views and uses `CASCADE`, so transitive dependents are handled; `pg_depend` is constrained to `classid = 'pg_rewrite'` to avoid false positives; and `lock_timeout` makes the drop fail fast rather than queue behind a long-running BI query.

## ⚠️ Required step (dev only, no DB access needed)

The failed `_prisma_migrations` row must be cleared before `migrate deploy` will do anything — it returns `P3009` until then. Thanks to the `resolve_rolled_back` input on `platform-autogpt-deploy-dev.yaml`, this is a workflow dispatch rather than a manual database connection:

```bash
gh workflow run platform-autogpt-deploy-dev.yaml \
  -f git_ref=dev \
  -f resolve_rolled_back=20260805120000_onboarding_step_to_string
```

That job runs `prisma migrate resolve --rolled-back` and then `prisma migrate deploy` against the dev database using the CI secrets, then triggers the deploy.

**Order matters: merge this PR to `dev` first.** The workflow checks out `git_ref`, so if it runs before the merge it will clear the failed row and then re-apply the *broken* migration, putting the row straight back.

`--rolled-back` (not `--applied`) is correct: Prisma runs each migration in a transaction and this one aborted on the first `ALTER`, so nothing from it persisted.

**Local databases** — anyone who pulled `dev` and migrated since #13119 merged will hit "migration … was modified after it was applied", since this edits that file. Local databases are disposable: `prisma migrate reset`.

## Does production need manual steps?

**No.** `master` has never applied this migration (newest there is `20260802120000`), so there is no failed record to clear, and the views are rebuilt in-migration.

Two things worth checking before promoting, since neither is visible from here:

**1. The deploy role must be able to drop the views** (`DROP VIEW` requires ownership or superuser):

```sql
SELECT current_user, (SELECT usesuper FROM pg_user WHERE usename = current_user) AS is_superuser;
```

**2. Enumerate the dependency closure**, to see whether prod carries dependents beyond the two tracked views. A materialized view, or any view not in `analytics/queries/`, is dropped by `CASCADE` and **cannot** be rebuilt by this migration — it would need recreating manually. The migration raises a warning naming each, but Prisma does not surface server notices, so check in advance:

```sql
SELECT n.nspname, c.relname, c.relkind
FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
WHERE c.relkind IN ('v','m') AND EXISTS (
  SELECT 1 FROM pg_depend d JOIN pg_rewrite r ON r.oid = d.objid
  WHERE d.classid = 'pg_rewrite'::regclass AND r.ev_class = c.oid
    AND d.refobjid = '"UserOnboarding"'::regclass
    AND d.refobjsubid IN (
      SELECT attnum FROM pg_attribute
      WHERE attrelid = '"UserOnboarding"'::regclass
        AND attname IN ('completedSteps','notified','rewardedFor')));
```

If that returns only `analytics.user_onboarding` and `analytics.user_onboarding_funnel`, promotion is fully hands-off.

Recommended sequence: fix dev, confirm the deploy goes green there, then promote.

## Test plan

Verified against a database rebuilt to the deployed shape — full migration chain, `analytics` schema, `analytics_readonly`, views created exactly as `generate_views.py` creates them (`WITH (security_invoker = false)`), plus a view layered on `user_onboarding_funnel` and a materialized view on the base table:

- [x] The original statement reproduces the **exact** production error
- [x] Fixed migration applies; all four dependents (incl. transitive view and matview) dropped via `CASCADE`
- [x] Columns end as `TEXT[]`; `OnboardingStep` dropped; renames applied; `BUILDER_RUN_AGENT` and other values preserved
- [x] `analytics-views` then recreates the views with `reloptions = {security_invoker=false}` and `analytics_readonly` SELECT restored
- [x] Funnel reports the **renamed** steps (`LIBRARY_RUN_AGENT` 11, `ONBOARDING_COMPLETE` 15) — the regression the restore-from-catalog approach would have shipped
- [x] Backend onboarding tests pass

## Follow-up

Local and CI databases are built from migrations only, so nothing can catch a dependency on these hand-applied views. Bringing `analytics/queries/*.sql` into CI setup (or running `analytics-views` as part of deploy) would close the gap — this is the second time these views have caused trouble.



