### PR TITLE
fix(frontend): let sidebar inset shrink so copilot panels stay in the viewport

### DIFF
--- a/autogpt_platform/frontend/src/components/ui/sidebar.tsx
+++ b/autogpt_platform/frontend/src/components/ui/sidebar.tsx
@@ -339,7 +339,11 @@ const SidebarInset = React.forwardRef<
     <main
       ref={ref}
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-white dark:bg-neutral-950",
+        // min-w-0 lets the inset shrink to the space next to the sidebar;
+        // without it, min-width:auto sizes it to its content and fixed-width
+        // panels (e.g. the copilot artifact panel) push the page past the
+        // viewport instead of shrinking.
+        "relative flex w-full min-w-0 flex-1 flex-col bg-white dark:bg-neutral-950",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className,
       )}


### PR DESCRIPTION
### Why / What / How

**Why:** On `/copilot` in the new layout, opening the Files drawer and previewing a file (artifact panel) pushes the page wider than the viewport — a horizontal page scrollbar appears and the panel's right-edge header buttons (download / all files / close) end up off-screen.

**Root cause:** `SidebarInset` is a `flex-1` item in the sidebar layout row but has no `min-w-0`. Its default `min-width: auto` resolves to its content's intrinsic min width. The copilot right-side panels are `shrink-0` with fixed widths (context panel 432px default, artifact panel 640px default and freely resizable/persisted), and the chat column's intrinsic min is ~480px, so on typical laptop widths the inset's min-content exceeds the space next to the 292px sidebar. Instead of shrinking, the inset grows the page past the viewport.

The width clamp added in #13630 can't catch this: it clamps the artifact panel to `parent.offsetWidth - PANEL_RESERVED_WIDTH`, but the parent row has already grown along with the inset, so the measurement reports enough room and the clamp never engages.

**What/How:** Add `min-w-0` to `SidebarInset`'s base classes so the flex layout can shrink it to the space the sidebar leaves. With the inset held to the available width, the existing #13630 clamp measures the real row width and correctly sizes the artifact panel, keeping its close button in view. `TourCopilot` already works around the same issue locally with `overflow-hidden` on its inset; this fixes it at the source for all `SidebarInset` usages.

### Changes 🏗️

- `components/ui/sidebar.tsx`: add `min-w-0` to `SidebarInset` base classes (one-line CSS fix + comment).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` pass
  - [ ] On `/copilot` (new layout) with a chat that produced a document artifact: open the file preview, resize the panel wide, verify no horizontal page scrollbar and the panel close button stays visible
  - [ ] Verify chat + Files drawer (context panel) still lay out correctly at 1280px and 1024px widths

No integration test added: the bug is flex-layout behavior (`min-width: auto` intrinsic sizing) which jsdom does not implement, so it can only be verified in a real browser.

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)
