### PR TITLE
fix(backend): stamp expert_id on schedules created from expert chat

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/_test_data.py
+++ b/autogpt_platform/backend/backend/copilot/tools/_test_data.py
@@ -42,7 +42,13 @@ async def _ensure_db_connected() -> None:
         await db_module.connect()
 
 
-def make_session(user_id: str, *, guide_read: bool = True, library_check: bool = True):
+def make_session(
+    user_id: str,
+    *,
+    guide_read: bool = True,
+    library_check: bool = True,
+    expert_id: str | None = None,
+):
     """Build a fake ChatSession for tool tests.
 
     ``guide_read=True`` (default) pre-populates the session with a
@@ -74,6 +80,7 @@ def make_session(user_id: str, *, guide_read: bool = True, library_check: bool =
         updated_at=datetime.now(UTC),
         successful_agent_runs={},
         successful_agent_schedules={},
+        expert_id=expert_id,
     )
     if library_check:
         session.announce_inflight_tool_call(

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent.py
@@ -1132,6 +1132,10 @@ class RunAgentTool(BaseTool):
         # sees the credential setup card instead of a generic error.
         # Session-anchored tenancy, mirroring ``_run_agent``: fire-time
         # executions of this schedule attribute to the chat session's org.
+        # Likewise for expert attribution: a schedule created in an
+        # expert-scoped chat belongs to that expert, so it surfaces on her
+        # Team card / expert page, counts toward her weekly credit budget,
+        # and is cleaned up when she is archived.
         org_id, team_id = session.organization_id, session.team_id
         if org_id is None:
             from backend.api.features.orgs.db import get_user_default_team
@@ -1150,6 +1154,7 @@ class RunAgentTool(BaseTool):
                 user_timezone=user_timezone,
                 organization_id=org_id,
                 team_id=team_id,
+                expert_id=session.expert_id,
             )
         except GraphValidationError as e:
             return self._handle_graph_validation_race(

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 
 from backend.data.execution import ExecutionStatus
+from backend.executor.scheduler import GraphExecutionJobInfo
 from backend.executor.utils import is_credential_validation_error_message
 from backend.util.exceptions import GraphValidationError
 
@@ -683,6 +684,105 @@ async def test_run_agent_schedule_credential_race_returns_setup_card(
     # credentials — the important thing is that the card renders instead of
     # a generic error or Builder redirect).
     assert "missing_credentials" in result_data["setup_info"]["user_readiness"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_run_agent_schedule_in_expert_session_stamps_expert_id(
+    setup_test_data,
+):
+    """A schedule created from an expert-scoped chat session must carry the
+    session's expert_id, otherwise it never shows on the Team card / expert
+    page and archive-time cleanup misses it."""
+    user = setup_test_data["user"]
+    store_submission = setup_test_data["store_submission"]
+
+    tool = RunAgentTool()
+    agent_marketplace_id = f"{user.email.split('@')[0]}/{store_submission.slug}"
+    expert_id = str(uuid.uuid4())
+    session = make_session(user_id=user.id, expert_id=expert_id)
+
+    fake_scheduler = AsyncMock()
+    fake_scheduler.add_execution_schedule.return_value = GraphExecutionJobInfo(
+        id=str(uuid.uuid4()),
+        name="My Schedule",
+        next_run_time="",
+        timezone="UTC",
+        user_id=user.id,
+        graph_id=str(uuid.uuid4()),
+        graph_version=1,
+        cron="0 9 * * *",
+        input_data={},
+        expert_id=expert_id,
+    )
+
+    with patch(
+        "backend.copilot.tools.run_agent.get_scheduler_client",
+        return_value=fake_scheduler,
+    ):
+        response = await tool.execute(
+            user_id=user.id,
+            session_id=str(uuid.uuid4()),
+            tool_call_id=str(uuid.uuid4()),
+            username_agent_slug=agent_marketplace_id,
+            inputs={"test_input": "value"},
+            schedule_name="My Schedule",
+            cron="0 9 * * *",
+            dry_run=False,
+            session=session,
+        )
+
+    assert response is not None
+    assert fake_scheduler.add_execution_schedule.await_count == 1
+    schedule_kwargs = fake_scheduler.add_execution_schedule.await_args.kwargs
+    assert schedule_kwargs["expert_id"] == expert_id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_run_agent_schedule_in_plain_session_has_no_expert_id(
+    setup_test_data,
+):
+    """A schedule created from a plain Autopilot session (no expert) must not
+    be expert-attributed — expert_id stays None."""
+    user = setup_test_data["user"]
+    store_submission = setup_test_data["store_submission"]
+
+    tool = RunAgentTool()
+    agent_marketplace_id = f"{user.email.split('@')[0]}/{store_submission.slug}"
+    session = make_session(user_id=user.id)
+
+    fake_scheduler = AsyncMock()
+    fake_scheduler.add_execution_schedule.return_value = GraphExecutionJobInfo(
+        id=str(uuid.uuid4()),
+        name="My Schedule",
+        next_run_time="",
+        timezone="UTC",
+        user_id=user.id,
+        graph_id=str(uuid.uuid4()),
+        graph_version=1,
+        cron="0 9 * * *",
+        input_data={},
+    )
+
+    with patch(
+        "backend.copilot.tools.run_agent.get_scheduler_client",
+        return_value=fake_scheduler,
+    ):
+        response = await tool.execute(
+            user_id=user.id,
+            session_id=str(uuid.uuid4()),
+            tool_call_id=str(uuid.uuid4()),
+            username_agent_slug=agent_marketplace_id,
+            inputs={"test_input": "value"},
+            schedule_name="My Schedule",
+            cron="0 9 * * *",
+            dry_run=False,
+            session=session,
+        )
+
+    assert response is not None
+    assert fake_scheduler.add_execution_schedule.await_count == 1
+    schedule_kwargs = fake_scheduler.add_execution_schedule.await_args.kwargs
+    assert schedule_kwargs["expert_id"] is None
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1175,9 +1175,10 @@ class GraphExecutionJobArgs(BaseModel):
     organization_id: str = ""
     team_id: str | None = None
     # Expert attribution: set when the schedule belongs to a hired expert
-    # (install-time schedule or manual schedule of an expert-installed
-    # workflow). Stamped onto every execution this schedule fires. Optional
-    # for backward compat with rows persisted before expert attribution.
+    # (install-time schedule, manual schedule of an expert-installed
+    # workflow, or a schedule created from the expert's chat). Stamped onto
+    # every execution this schedule fires. Optional for backward compat
+    # with rows persisted before expert attribution.
     expert_id: str | None = None
 
 


### PR DESCRIPTION
### Why / What / How

**Why:** Since #13787 / #13772, an agent scheduled from an expert's chat (e.g. asking Maria to create and schedule an agent) claims success and shows up in the chat `list_schedules` tool, but never appears on the Team card, the `/team/[expertId]` page, or the chat schedules drawer — the card keeps saying "No schedules yet".

**What:** Stamp the chat session's `expert_id` on schedules created through the copilot `run_agent` tool, so expert-chat-created schedules are attributed like install-time and REST-created ones.

**How:** All expert schedule surfaces filter on `schedule.expert_id` (`getExpertSchedules` in `team/helpers.ts`, with a fallback join on `ExpertWorkflow.schedule_id`). The install-time path (`experts/scheduling.py`) and the REST endpoint (`POST /graphs/{id}/schedules`) both pass `expert_id` to `add_execution_schedule`, but the chat tool's `_schedule_agent` did not — even though the `ChatSession` already carries the expert it is scoped to. The chat `list_schedules` tool lists all user schedules unfiltered, which is why the expert could "see" the schedule while every expert surface could not. Passing `session.expert_id` follows the same session-anchored pattern already used for org/team tenancy in the same call. Attribution also means these schedules now count toward the expert's weekly credit guardrail and get deleted by `detach_expert_triggers` on archive — previously they escaped both. Plain Autopilot sessions have `expert_id = None`, so nothing changes for them.

### Changes 🏗️

- `copilot/tools/run_agent.py`: `_schedule_agent` passes `expert_id=session.expert_id` to `add_execution_schedule`.
- `executor/scheduler.py`: `GraphExecutionJobArgs.expert_id` comment now mentions the chat-created source.
- `copilot/tools/_test_data.py`: `make_session` accepts an optional `expert_id`.
- `copilot/tools/run_agent_test.py`: regression tests — expert-scoped session stamps `expert_id` on the scheduler call; plain session leaves it `None`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `poetry run pytest backend/copilot/tools/run_agent_test.py -k expert` (not run locally; please verify via CI)
  - [ ] Manual: in an expert chat, ask the expert to schedule an agent → schedule appears on the Team card, `/team/[expertId]`, and the chat schedules drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
