### PR TITLE
fix(copilot): hide internal agent-JSON handoff files from Files tab

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/agent_json_input.py
+++ b/autogpt_platform/backend/backend/copilot/tools/agent_json_input.py
@@ -243,7 +243,10 @@ async def write_agent_json_to_workspace(
             content=json.dumps(agent_json, indent=2).encode("utf-8"),
             filename=write_to,
             overwrite=True,
-            metadata={"origin": "agent-created"},
+            # `internal: True` marks this as a tool-to-tool handoff file (the
+            # agent JSON is never re-emitted inline), not a user-facing
+            # artifact — the CoPilot Files tab hides files with this flag.
+            metadata={"origin": "agent-created", "internal": True},
         )
     except Exception as e:
         logger.warning(f"Failed to write agent JSON to {write_to!r}: {e}")

--- a/autogpt_platform/backend/backend/copilot/tools/fix_agent_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/fix_agent_test.py
@@ -263,6 +263,8 @@ async def test_write_to_returns_file_ref_and_diff(tool, session):
     assert written["filename"] == "agent.json"
     assert written["overwrite"] is True
     assert b'\n  "nodes"' in written["content"]  # pretty-printed
+    # Tool-to-tool handoff file — must stay hidden from the CoPilot Files tab.
+    assert written["metadata"]["internal"] is True
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/helpers.ts
@@ -11,6 +11,13 @@ export function isUploadedFile(item: WorkspaceFileItem): boolean {
   return item.origin === "uploaded";
 }
 
+// Files written purely as tool-to-tool handoffs (e.g. the agent JSON a
+// create_agent/edit_agent call writes to pass to itself) — internal and
+// technical, not something the user created or asked to see.
+export function isInternalFile(item: WorkspaceFileItem): boolean {
+  return (item.metadata as Record<string, unknown> | undefined)?.internal === true;
+}
+
 export function fileItemToArtifactRef(item: WorkspaceFileItem): ArtifactRef {
   return {
     id: item.id,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/helpers.ts
@@ -15,7 +15,8 @@ export function isUploadedFile(item: WorkspaceFileItem): boolean {
 // create_agent/edit_agent call writes to pass to itself) — internal and
 // technical, not something the user created or asked to see.
 export function isInternalFile(item: WorkspaceFileItem): boolean {
-  return (item.metadata as Record<string, unknown> | undefined)?.internal === true;
+  const metadata = item.metadata as Record<string, unknown> | undefined;
+  return metadata?.internal === true;
 }
 
 export function fileItemToArtifactRef(item: WorkspaceFileItem): ArtifactRef {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/useSessionFiles.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/useSessionFiles.ts
@@ -5,7 +5,7 @@ import type { ListFilesResponse } from "@/app/api/__generated__/models/listFiles
 import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
 import { useCopilotStreamStore } from "../../../../copilotStreamStore";
 import { getMessageArtifacts } from "../../../ChatMessagesContainer/helpers";
-import { isUploadedFile } from "./helpers";
+import { isInternalFile, isUploadedFile } from "./helpers";
 
 export interface SessionFile {
   item: WorkspaceFileItem;
@@ -36,10 +36,12 @@ export function useSessionFiles(sessionId: string | null) {
     }
   }
 
-  const files: SessionFile[] = (query.data?.files ?? []).map((item) => ({
-    item,
-    messageID: fileIdToMessageId.get(item.id) ?? null,
-  }));
+  const files: SessionFile[] = (query.data?.files ?? [])
+    .filter((item) => !isInternalFile(item))
+    .map((item) => ({
+      item,
+      messageID: fileIdToMessageId.get(item.id) ?? null,
+    }));
 
   const uploaded = files.filter((f) => isUploadedFile(f.item));
   const generated = files.filter((f) => !isUploadedFile(f.item));


### PR DESCRIPTION
## Problem

When CoPilot creates/edits/fixes an agent, the agent JSON graph is written to a workspace file purely as a tool-to-tool handoff (so the LLM passes a file ref instead of re-emitting the JSON inline — see `write_agent_json_to_workspace`). That handoff file was showing up in the chat's Files tab next to real uploads and generated outputs, which is noisy and overly technical for most users (raised by @Ubbe, flagged by @Nick Tindle).

## Fix

- Tag these handoff writes with `metadata={"internal": true}` in `agent_json_input.py` (shared by create_agent/edit_agent/fix_agent/find_library_agent).
- Filter files carrying that flag out in `useSessionFiles` on the frontend, before they're split into the Files tab's Uploaded/Generated sections.
- Left the generic `write_workspace_file` tool (used for real user-facing outputs like reports/docs) untouched — it still shows up as before.

## Test plan
- Added an assertion in `fix_agent_test.py` that the handoff write carries `metadata["internal"] is True`.
- Manually reviewed all callers of `write_agent_json_to_workspace` (create_agent, edit_agent, fix_agent, find_library_agent) — all go through the shared helper, so one change covers every case.
