### PR TITLE
feat(platform): add first-visit tab intro cards for Agents, Marketplace, Build

### DIFF
--- a/autogpt_platform/backend/backend/api/features/onboarding_step_test.py
+++ b/autogpt_platform/backend/backend/api/features/onboarding_step_test.py
@@ -5,6 +5,8 @@ import fastapi.testclient
 import pytest
 
 from backend.api.features.v1 import v1_router
+from backend.data import onboarding as onboarding_module
+from backend.data.model import UserOnboarding
 from backend.data.onboarding import OnboardingStep
 
 app = fastapi.FastAPI()
@@ -107,9 +109,6 @@ def test_complete_step_rejects_rewarded_backend_only_steps(step, mocker):
 async def test_tab_intro_steps_grant_no_reward(step, mocker):
     # The tab intros are client-writable, so "unrewarded" has to be enforced
     # rather than documented: posting one must never reach the credit model.
-    from backend.data import onboarding as onboarding_module
-    from backend.data.model import UserOnboarding
-
     mock_credit_model = mocker.patch.object(
         onboarding_module,
         "get_user_credit_model",
@@ -126,8 +125,6 @@ async def test_tab_intro_steps_grant_no_reward(step, mocker):
 
 
 def test_is_onboarding_completed_true_when_complete_step_present(mocker):
-    from backend.data.model import UserOnboarding
-
     mock_get = mocker.patch(
         "backend.api.features.v1.get_user_onboarding",
         new_callable=AsyncMock,
@@ -143,8 +140,6 @@ def test_is_onboarding_completed_true_when_complete_step_present(mocker):
 
 
 def test_is_onboarding_completed_false_without_complete_step(mocker):
-    from backend.data.model import UserOnboarding
-
     mock_get = mocker.patch(
         "backend.api.features.v1.get_user_onboarding",
         new_callable=AsyncMock,
@@ -160,8 +155,6 @@ def test_is_onboarding_completed_false_without_complete_step(mocker):
 
 
 def test_user_onboarding_response_model_accepts_deprecated_stored_values():
-    from backend.data.model import UserOnboarding
-
     # Deprecated steps stay in OnboardingStep forever: existing rows still
     # contain them and the strict ``list[OnboardingStep]`` response model would
     # 500 reads otherwise. This validates (no ``model_construct``) so it fails
@@ -206,9 +199,6 @@ def test_update_onboarding_rejects_invalid_notified_step(mocker):
 
 @pytest.mark.asyncio
 async def test_update_user_onboarding_merges_notified_as_plain_strings(mocker):
-    from backend.data import onboarding as onboarding_module
-    from backend.data.model import UserOnboarding
-
     mocker.patch.object(
         onboarding_module,
         "get_user_onboarding",

--- a/autogpt_platform/backend/backend/api/features/onboarding_step_test.py
+++ b/autogpt_platform/backend/backend/api/features/onboarding_step_test.py
@@ -47,6 +47,29 @@ def test_complete_step_accepts_renamed_complete_value(mocker):
     assert mock_complete.await_args.args[1] == OnboardingStep.ONBOARDING_COMPLETE
 
 
+@pytest.mark.parametrize(
+    "step",
+    [
+        OnboardingStep.AGENTS_TAB_INTRO,
+        OnboardingStep.MARKETPLACE_TAB_INTRO,
+        OnboardingStep.BUILD_TAB_INTRO,
+    ],
+)
+def test_complete_step_accepts_tab_intros(step, mocker):
+    # Each tab's first-visit card records its own step; without all three on
+    # FrontendOnboardingStep the card would 422 and reappear forever.
+    mock_complete = mocker.patch(
+        "backend.api.features.v1.complete_onboarding_step",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+
+    response = client.post("/onboarding/step", params={"step": step.value})
+
+    assert response.status_code == 200
+    assert mock_complete.await_args.args[1] == step
+
+
 def test_is_onboarding_completed_true_when_complete_step_present(mocker):
     from backend.data.model import UserOnboarding
 

--- a/autogpt_platform/backend/backend/api/features/onboarding_step_test.py
+++ b/autogpt_platform/backend/backend/api/features/onboarding_step_test.py
@@ -70,6 +70,61 @@ def test_complete_step_accepts_tab_intros(step, mocker):
     assert mock_complete.await_args.args[1] == step
 
 
+@pytest.mark.parametrize(
+    "step",
+    [
+        OnboardingStep.MARKETPLACE_ADD_AGENT,
+        OnboardingStep.LIBRARY_RUN_AGENT,
+        OnboardingStep.RUN_AGENTS_100,
+    ],
+)
+def test_complete_step_rejects_rewarded_backend_only_steps(step, mocker):
+    # These are real OnboardingStep values that carry a credit reward and are
+    # deliberately left off FrontendOnboardingStep. The endpoint's Literal is
+    # the only thing standing between an authenticated user and self-awarding
+    # credits, so it gets its own test.
+    mock_complete = mocker.patch(
+        "backend.api.features.v1.complete_onboarding_step",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+
+    response = client.post("/onboarding/step", params={"step": step.value})
+
+    assert response.status_code == 422
+    mock_complete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "step",
+    [
+        OnboardingStep.AGENTS_TAB_INTRO,
+        OnboardingStep.MARKETPLACE_TAB_INTRO,
+        OnboardingStep.BUILD_TAB_INTRO,
+    ],
+)
+async def test_tab_intro_steps_grant_no_reward(step, mocker):
+    # The tab intros are client-writable, so "unrewarded" has to be enforced
+    # rather than documented: posting one must never reach the credit model.
+    from backend.data import onboarding as onboarding_module
+    from backend.data.model import UserOnboarding
+
+    mock_credit_model = mocker.patch.object(
+        onboarding_module,
+        "get_user_credit_model",
+        new_callable=AsyncMock,
+    )
+
+    await onboarding_module._reward_user(
+        "test-user-id",
+        UserOnboarding.model_construct(rewardedFor=[]),
+        step,
+    )
+
+    mock_credit_model.assert_not_awaited()
+
+
 def test_is_onboarding_completed_true_when_complete_step_present(mocker):
     from backend.data.model import UserOnboarding
 

--- a/autogpt_platform/backend/backend/data/onboarding_steps.py
+++ b/autogpt_platform/backend/backend/data/onboarding_steps.py
@@ -58,6 +58,11 @@ class OnboardingStep(StrEnum):
     # Copilot home first-run: the capability-cards modal was completed or
     # skipped. Unrewarded; recorded so it shows only once per user.
     CAPABILITY_CARDS = "CAPABILITY_CARDS"
+    # First-visit intro card for a tab, dismissed via its CTA or otherwise.
+    # Unrewarded; recorded so each tab introduces itself only once per user.
+    AGENTS_TAB_INTRO = "AGENTS_TAB_INTRO"
+    MARKETPLACE_TAB_INTRO = "MARKETPLACE_TAB_INTRO"
+    BUILD_TAB_INTRO = "BUILD_TAB_INTRO"
 
 
 FrontendOnboardingStep = Literal[
@@ -71,4 +76,7 @@ FrontendOnboardingStep = Literal[
     OnboardingStep.ONBOARDING_COMPLETE,
     OnboardingStep.BUILDER_OPEN,
     OnboardingStep.CAPABILITY_CARDS,
+    OnboardingStep.AGENTS_TAB_INTRO,
+    OnboardingStep.MARKETPLACE_TAB_INTRO,
+    OnboardingStep.BUILD_TAB_INTRO,
 ]

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuildTabIntro/BuildTabIntro.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuildTabIntro/BuildTabIntro.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { TabIntroCard } from "@/app/(platform)/components/TabIntroCard/TabIntroCard";
+import { useTabIntroCard } from "@/app/(platform)/components/TabIntroCard/useTabIntroCard";
+import { useTutorialStore } from "@/app/(platform)/build/stores/tutorialStore";
+import { FlowIcon } from "@hugeicons/core-free-icons";
+import { useRouter, useSearchParams } from "next/navigation";
+import { startTutorial } from "../FlowEditor/tutorial";
+
+// First visit to the Build tab. AutoPilot is the primary route on purpose —
+// most users should not start on an empty canvas — with the existing builder
+// tutorial kept as the quiet alternative for people who want the canvas.
+export function BuildTabIntro() {
+  // Deep link into an existing graph: the intro is about starting something,
+  // and its tutorial clears the canvas — neither belongs over someone's saved
+  // agent. Vetoing the visit leaves the step unrecorded, so a later blank
+  // /build still gets the introduction.
+  const isEditingSavedGraph = Boolean(useSearchParams().get("flowID"));
+  const { isOpen, dismiss, takeAction } = useTabIntroCard(
+    "build",
+    !isEditingSavedGraph,
+  );
+  const setIsTutorialRunning = useTutorialStore(
+    (state) => state.setIsTutorialRunning,
+  );
+  const router = useRouter();
+
+  function askAutoPilot() {
+    takeAction("ask_autopilot");
+    router.push("/copilot");
+  }
+
+  function learnToBuild() {
+    takeAction("builder_tutorial");
+    startTutorial();
+    setIsTutorialRunning(true);
+  }
+
+  return (
+    <TabIntroCard
+      isOpen={isOpen}
+      icon={FlowIcon}
+      title="Create your own workflows."
+      body="Wire blocks into an agent that runs exactly how you want — or let AutoPilot build it."
+      cta={{ label: "Ask AutoPilot to build it", onClick: askAutoPilot }}
+      altAction={{ label: "Learn to build it yourself", onClick: learnToBuild }}
+      onDismiss={dismiss}
+    />
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { ReactFlowProvider } from "@xyflow/react";
+import { BuildTabIntro } from "./components/BuildTabIntro/BuildTabIntro";
 import { Flow } from "./components/FlowEditor/Flow/Flow";
 import { MobileWarning } from "./components/MobileWarning/MobileWarning";
 
@@ -10,6 +11,7 @@ export default function BuilderPage() {
         <Flow />
       </ReactFlowProvider>
       <MobileWarning />
+      <BuildTabIntro />
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/TabIntroCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/TabIntroCard.tsx
@@ -7,6 +7,7 @@ import { Text } from "@/components/atoms/Text/Text";
 import type { IconSvgElement } from "@hugeicons/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useRef } from "react";
+import { getFocusableElements } from "./helpers";
 
 interface Action {
   label: string;
@@ -17,7 +18,7 @@ interface Props {
   isOpen: boolean;
   icon: IconSvgElement;
   title: string;
-  /** Capped at 20 words — an icon, a short title, one sentence. */
+  /** One sentence under the title. */
   body: string;
   /** The card's primary way forward, sat next to "Got it". */
   cta: Action;
@@ -41,17 +42,66 @@ export function TabIntroCard({
 }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
 
+  // The listener below is installed once per open, so it would otherwise
+  // capture the `onDismiss` from that render. A ref keeps it on the current
+  // one without tearing the listener down on every parent render.
+  const dismissRef = useRef(onDismiss);
+  useEffect(() => {
+    dismissRef.current = onDismiss;
+  });
+
   // Focus starts inside the card rather than on whatever was behind the
-  // overlay, and Escape is a dismissal like every other way out.
+  // overlay, stays there while the dialog is open (`aria-modal` promises as
+  // much), and goes back where it came from on close. Escape is a dismissal
+  // like every other way out.
   useEffect(() => {
     if (!isOpen) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     dialogRef.current?.focus();
+
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onDismiss();
+      if (event.key === "Escape") {
+        dismissRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const focusable = getFocusableElements(dialog);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (!dialog.contains(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     }
+
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      // Skip a node the close itself removed — refocusing it does nothing but
+      // hand focus back to <body>.
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
   }, [isOpen]);
 
   return (
@@ -92,20 +142,21 @@ export function TabIntroCard({
             </div>
 
             <div className="flex flex-col gap-3 px-7 pb-7 pt-6 text-left">
-              <Text variant="h3" className="!text-[1.25rem] text-zinc-900">
+              <Text variant="lead-semibold" as="h3" className="text-zinc-900">
                 {title}
               </Text>
-              <Text variant="body" className="!text-[0.9375rem] !text-zinc-600">
+              <Text variant="large" className="text-zinc-600">
                 {body}
               </Text>
               {altAction && (
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="small"
                   onClick={altAction.onClick}
-                  className="w-fit text-sm font-medium text-violet-600 underline-offset-4 hover:underline"
+                  className="w-fit self-start px-0 text-violet-600 underline-offset-4 hover:bg-transparent hover:underline"
                 >
                   {altAction.label}
-                </button>
+                </Button>
               )}
 
               <div className="mt-3 flex items-center justify-end gap-3">

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/TabIntroCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/TabIntroCard.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { GlassPixelBackdrop } from "@/components/atoms/GlassPixelBackdrop/GlassPixelBackdrop";
+import { Button } from "@/components/atoms/Button/Button";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import type { IconSvgElement } from "@hugeicons/react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useRef } from "react";
+
+interface Action {
+  label: string;
+  onClick: () => void;
+}
+
+interface Props {
+  isOpen: boolean;
+  icon: IconSvgElement;
+  title: string;
+  /** Capped at 20 words — an icon, a short title, one sentence. */
+  body: string;
+  /** The card's primary way forward, sat next to "Got it". */
+  cta: Action;
+  /** Optional quiet alternative under the copy (Build's DIY route). */
+  altAction?: Action;
+  /** "Got it", Escape, and a click on the backdrop all land here. */
+  onDismiss: () => void;
+}
+
+// One-card, first-visit intro for a tab. Deliberately the same shell as the
+// copilot home's capability cards (OnboardingWelcomeDialog): tinted stage
+// carrying the icon, copy below, one way forward and one way out.
+export function TabIntroCard({
+  isOpen,
+  icon,
+  title,
+  body,
+  cta,
+  altAction,
+  onDismiss,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus starts inside the card rather than on whatever was behind the
+  // overlay, and Escape is a dismissal like every other way out.
+  useEffect(() => {
+    if (!isOpen) return;
+    dialogRef.current?.focus();
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onDismiss();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
+          // Only the backdrop itself dismisses — a click that started on the
+          // card and drifted out (text selection) must not close it.
+          onClick={(event) => {
+            if (event.target === event.currentTarget) onDismiss();
+          }}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-white/30 px-4 backdrop-blur-sm"
+          data-testid="tab-intro-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={title}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 16, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ duration: 0.45, ease: [0, 0, 0.2, 1] }}
+            className="w-full max-w-[26rem] overflow-hidden rounded-3xl bg-white shadow-[0_24px_80px_-24px_rgba(0,0,0,0.3)] outline-none"
+            ref={dialogRef}
+            tabIndex={-1}
+          >
+            {/* Tinted stage: the card's icon floats here. */}
+            <div className="relative h-44 bg-gradient-to-br from-[#e6dbff] via-[#ddccff] to-[#d0b9ff]">
+              <GlassPixelBackdrop />
+              <div className="flex h-full items-center justify-center">
+                <div className="flex h-20 w-20 items-center justify-center rounded-3xl bg-white shadow-lg">
+                  <Icon icon={icon} size={40} className="text-violet-600" />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 px-7 pb-7 pt-6 text-left">
+              <Text variant="h3" className="!text-[1.25rem] text-zinc-900">
+                {title}
+              </Text>
+              <Text variant="body" className="!text-[0.9375rem] !text-zinc-600">
+                {body}
+              </Text>
+              {altAction && (
+                <button
+                  type="button"
+                  onClick={altAction.onClick}
+                  className="w-fit text-sm font-medium text-violet-600 underline-offset-4 hover:underline"
+                >
+                  {altAction.label}
+                </button>
+              )}
+
+              <div className="mt-3 flex items-center justify-end gap-3">
+                <Button variant="secondary" size="small" onClick={onDismiss}>
+                  Got it
+                </Button>
+                <Button variant="primary" size="small" onClick={cta.onClick}>
+                  {cta.label}
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/TabIntroCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/TabIntroCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@/tests/integrations/test-utils";
+import { render, screen, waitFor } from "@/tests/integrations/test-utils";
 import { SparklesIcon } from "@hugeicons/core-free-icons";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,8 +9,8 @@ const onDismiss = vi.fn();
 const onCta = vi.fn();
 const onAlt = vi.fn();
 
-function renderCard(props: { isOpen?: boolean; withAltAction?: boolean } = {}) {
-  return render(
+function card(props: { isOpen?: boolean; withAltAction?: boolean } = {}) {
+  return (
     <TabIntroCard
       isOpen={props.isOpen ?? true}
       icon={SparklesIcon}
@@ -23,8 +23,12 @@ function renderCard(props: { isOpen?: boolean; withAltAction?: boolean } = {}) {
           : undefined
       }
       onDismiss={onDismiss}
-    />,
+    />
   );
+}
+
+function renderCard(props: { isOpen?: boolean; withAltAction?: boolean } = {}) {
+  return render(card(props));
 }
 
 beforeEach(() => {
@@ -105,5 +109,57 @@ describe("TabIntroCard", () => {
 
     expect(onAlt).toHaveBeenCalledTimes(1);
     expect(onDismiss).not.toHaveBeenCalled();
+  });
+});
+
+describe("TabIntroCard — keyboard focus", () => {
+  it("moves focus into the card on open", async () => {
+    renderCard();
+    await screen.findByText("Your mission control.");
+
+    expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(
+      true,
+    );
+  });
+
+  it("keeps Tab and Shift+Tab inside the card", async () => {
+    renderCard({ withAltAction: true });
+    await screen.findByText("Your mission control.");
+
+    const alt = screen.getByRole("button", {
+      name: "Learn to build it yourself",
+    });
+    const gotIt = screen.getByRole("button", { name: "Got it" });
+    const cta = screen.getByRole("button", { name: "See my agents" });
+
+    await userEvent.tab();
+    expect(document.activeElement).toBe(alt);
+    await userEvent.tab();
+    expect(document.activeElement).toBe(gotIt);
+    await userEvent.tab();
+    expect(document.activeElement).toBe(cta);
+
+    // Past the last control the focus wraps back into the card rather than
+    // reaching the page behind an `aria-modal` overlay.
+    await userEvent.tab();
+    expect(document.activeElement).toBe(alt);
+
+    await userEvent.tab({ shift: true });
+    expect(document.activeElement).toBe(cta);
+  });
+
+  it("restores focus to whatever opened it", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const { rerender } = renderCard();
+    await screen.findByText("Your mission control.");
+    expect(document.activeElement).not.toBe(opener);
+
+    rerender(card({ isOpen: false }));
+
+    await waitFor(() => expect(document.activeElement).toBe(opener));
+    opener.remove();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/TabIntroCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/TabIntroCard.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@/tests/integrations/test-utils";
+import { SparklesIcon } from "@hugeicons/core-free-icons";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TabIntroCard } from "../TabIntroCard";
+
+const onDismiss = vi.fn();
+const onCta = vi.fn();
+const onAlt = vi.fn();
+
+function renderCard(props: { isOpen?: boolean; withAltAction?: boolean } = {}) {
+  return render(
+    <TabIntroCard
+      isOpen={props.isOpen ?? true}
+      icon={SparklesIcon}
+      title="Your mission control."
+      body="Everything in one place."
+      cta={{ label: "See my agents", onClick: onCta }}
+      altAction={
+        props.withAltAction
+          ? { label: "Learn to build it yourself", onClick: onAlt }
+          : undefined
+      }
+      onDismiss={onDismiss}
+    />,
+  );
+}
+
+beforeEach(() => {
+  onDismiss.mockClear();
+  onCta.mockClear();
+  onAlt.mockClear();
+});
+
+describe("TabIntroCard", () => {
+  it("renders the copy with one way forward and one way out", async () => {
+    renderCard();
+
+    expect(await screen.findByText("Your mission control.")).toBeDefined();
+    expect(screen.getByText("Everything in one place.")).toBeDefined();
+    expect(screen.getByRole("button", { name: "See my agents" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Got it" })).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: "Learn to build it yourself" }),
+    ).toBeNull();
+  });
+
+  it("renders nothing while closed", () => {
+    renderCard({ isOpen: false });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.queryByText("Your mission control.")).toBeNull();
+  });
+
+  it("dismisses on Got it", async () => {
+    renderCard();
+    await screen.findByText("Your mission control.");
+
+    await userEvent.click(screen.getByRole("button", { name: "Got it" }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onCta).not.toHaveBeenCalled();
+  });
+
+  it("dismisses on Escape", async () => {
+    renderCard();
+    await screen.findByText("Your mission control.");
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses on a click outside the card but not inside it", async () => {
+    renderCard();
+    await screen.findByText("Your mission control.");
+
+    await userEvent.click(screen.getByText("Your mission control."));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByTestId("tab-intro-overlay"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the CTA without also reporting a plain dismissal", async () => {
+    renderCard();
+    await screen.findByText("Your mission control.");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "See my agents" }),
+    );
+
+    expect(onCta).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("offers the quiet alternative when the tab has one", async () => {
+    renderCard({ withAltAction: true });
+    await screen.findByText("Your mission control.");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Learn to build it yourself" }),
+    );
+
+    expect(onAlt).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/tab-intros.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/tab-intros.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const capture = vi.hoisted(() => vi.fn());
+vi.mock("posthog-js", () => ({ default: { capture } }));
+
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+vi.mock("@/services/feature-flags/use-get-flag", () => ({
+  Flag: {
+    ONBOARDING_TAB_INTROS: "onboarding-tab-intros",
+    HIRE_EXPERTS: "hire-experts",
+  },
+  useGetFlag: () => false,
+  useFlagStatus: () => ({ enabled: true, ready: true }),
+}));
+
+const completeStep = vi.hoisted(() => vi.fn());
+vi.mock("@/providers/onboarding/onboarding-provider", () => ({
+  useOnboarding: () => ({ state: { completedSteps: [] }, completeStep }),
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const push = vi.hoisted(() => vi.fn());
+const searchParams = vi.hoisted(() => ({ current: "" }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  useSearchParams: () => new URLSearchParams(searchParams.current),
+  usePathname: () => "/build",
+}));
+
+const startTutorial = vi.hoisted(() => vi.fn());
+vi.mock("@/app/(platform)/build/components/FlowEditor/tutorial", () => ({
+  startTutorial,
+}));
+
+import { AgentsTabIntro } from "@/app/(platform)/library/components/AgentsTabIntro/AgentsTabIntro";
+import { BuildTabIntro } from "@/app/(platform)/build/components/BuildTabIntro/BuildTabIntro";
+import { useTutorialStore } from "@/app/(platform)/build/stores/tutorialStore";
+import { FEATURED_SECTION_ID } from "@/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection";
+import { MarketplaceTabIntro } from "@/app/(platform)/marketplace/components/MarketplaceTabIntro/MarketplaceTabIntro";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  capture.mockReset();
+  completeStep.mockReset();
+  push.mockReset();
+  startTutorial.mockReset();
+  searchParams.current = "";
+  useTutorialStore.getState().setIsTutorialRunning(false);
+});
+
+describe("AgentsTabIntro", () => {
+  it("introduces the tab as mission control and steps aside on the CTA", async () => {
+    render(<AgentsTabIntro />);
+
+    expect(await screen.findByText("Your mission control.")).toBeDefined();
+    expect(
+      screen.getByText(
+        "What's running, what's scheduled, what needs you, and what it costs — all in one place.",
+      ),
+    ).toBeDefined();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "See my agents" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("Your mission control.")).toBeNull(),
+    );
+    expect(completeStep).toHaveBeenCalledWith("AGENTS_TAB_INTRO");
+    expect(capture).toHaveBeenCalledWith("tab_intro_cta_clicked", {
+      tab: "agents",
+      cta: "see_agents",
+    });
+  });
+});
+
+describe("MarketplaceTabIntro", () => {
+  it("scrolls the featured carousel into view on the CTA", async () => {
+    const featured = document.createElement("section");
+    featured.id = FEATURED_SECTION_ID;
+    const scrollIntoView = vi.fn();
+    featured.scrollIntoView = scrollIntoView;
+    document.body.appendChild(featured);
+
+    render(<MarketplaceTabIntro />);
+    expect(await screen.findByText("Agents ready to work.")).toBeDefined();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Browse featured agents" }),
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(completeStep).toHaveBeenCalledWith("MARKETPLACE_TAB_INTRO");
+    featured.remove();
+  });
+
+  it("still closes when nothing is featured right now", async () => {
+    render(<MarketplaceTabIntro />);
+    await screen.findByText("Agents ready to work.");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Browse featured agents" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("Agents ready to work.")).toBeNull(),
+    );
+  });
+});
+
+describe("BuildTabIntro", () => {
+  it("sends the user to AutoPilot from the primary CTA", async () => {
+    render(<BuildTabIntro />);
+    expect(await screen.findByText("Create your own workflows.")).toBeDefined();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Ask AutoPilot to build it" }),
+    );
+
+    expect(push).toHaveBeenCalledWith("/copilot");
+    expect(startTutorial).not.toHaveBeenCalled();
+    expect(completeStep).toHaveBeenCalledWith("BUILD_TAB_INTRO");
+    expect(capture).toHaveBeenCalledWith("tab_intro_cta_clicked", {
+      tab: "build",
+      cta: "ask_autopilot",
+    });
+  });
+
+  it("launches the existing builder tutorial from the quiet alternative", async () => {
+    render(<BuildTabIntro />);
+    await screen.findByText("Create your own workflows.");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Learn to build it yourself" }),
+    );
+
+    expect(startTutorial).toHaveBeenCalledTimes(1);
+    expect(useTutorialStore.getState().isTutorialRunning).toBe(true);
+    expect(push).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith("tab_intro_cta_clicked", {
+      tab: "build",
+      cta: "builder_tutorial",
+    });
+  });
+
+  it("stays out of the way of a saved graph, and keeps the intro for later", () => {
+    searchParams.current = "flowID=graph-1";
+
+    render(<BuildTabIntro />);
+
+    expect(screen.queryByText("Create your own workflows.")).toBeNull();
+    expect(completeStep).not.toHaveBeenCalled();
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/tab-intros.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/tab-intros.test.tsx
@@ -11,7 +11,7 @@ vi.mock("@/lib/auth/hooks/useAuth", () => ({
 
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
   Flag: {
-    ONBOARDING_TAB_INTROS: "onboarding-tab-intros",
+    ONBOARDING_BRAIN_DUMP: "onboarding-brain-dump",
     HIRE_EXPERTS: "hire-experts",
   },
   useGetFlag: () => false,
@@ -40,7 +40,10 @@ vi.mock("@/app/(platform)/build/components/FlowEditor/tutorial", () => ({
 import { AgentsTabIntro } from "@/app/(platform)/library/components/AgentsTabIntro/AgentsTabIntro";
 import { BuildTabIntro } from "@/app/(platform)/build/components/BuildTabIntro/BuildTabIntro";
 import { useTutorialStore } from "@/app/(platform)/build/stores/tutorialStore";
-import { FEATURED_SECTION_ID } from "@/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection";
+import {
+  AGENTS_SECTION_ID,
+  FEATURED_SECTION_ID,
+} from "@/app/(platform)/marketplace/components/MarketplaceTabIntro/helpers";
 import { MarketplaceTabIntro } from "@/app/(platform)/marketplace/components/MarketplaceTabIntro/MarketplaceTabIntro";
 
 beforeEach(() => {
@@ -96,10 +99,35 @@ describe("MarketplaceTabIntro", () => {
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
     expect(completeStep).toHaveBeenCalledWith("MARKETPLACE_TAB_INTRO");
+    expect(capture).toHaveBeenCalledWith("tab_intro_cta_clicked", {
+      tab: "marketplace",
+      cta: "browse_featured",
+    });
     featured.remove();
   });
 
-  it("still closes when nothing is featured right now", async () => {
+  it("falls back to the full listing when nothing is featured right now", async () => {
+    const listing = document.createElement("div");
+    listing.id = AGENTS_SECTION_ID;
+    const scrollIntoView = vi.fn();
+    listing.scrollIntoView = scrollIntoView;
+    document.body.appendChild(listing);
+
+    render(<MarketplaceTabIntro />);
+    await screen.findByText("Agents ready to work.");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Browse featured agents" }),
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.queryByText("Agents ready to work.")).toBeNull(),
+    );
+    listing.remove();
+  });
+
+  it("still closes when there is nothing to scroll to at all", async () => {
     render(<MarketplaceTabIntro />);
     await screen.findByText("Agents ready to work.");
 

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/useTabIntroCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/useTabIntroCard.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/lib/auth/hooks/useAuth", () => ({
 const flags = vi.hoisted(() => ({ current: {} as Record<string, boolean> }));
 const flagsReady = vi.hoisted(() => ({ current: true }));
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
-  Flag: { ONBOARDING_TAB_INTROS: "onboarding-tab-intros" },
+  Flag: { ONBOARDING_BRAIN_DUMP: "onboarding-brain-dump" },
   useFlagStatus: (flag: string) => ({
     enabled: flags.current[flag] ?? false,
     ready: flagsReady.current,
@@ -46,7 +46,7 @@ beforeEach(() => {
   window.localStorage.clear();
   capture.mockReset();
   authUser.current = { id: "user-1" };
-  flags.current = { "onboarding-tab-intros": true };
+  flags.current = { "onboarding-brain-dump": true };
   flagsReady.current = true;
   onboarding.current = { state: { completedSteps: [] }, completeStep: vi.fn() };
 });
@@ -61,6 +61,10 @@ describe("useTabIntroCard — when it opens", () => {
         tab: "agents",
       }),
     );
+    // Exactly once: a re-render must not re-report the same impression.
+    expect(
+      capture.mock.calls.filter(([event]) => event === "tab_intro_shown"),
+    ).toHaveLength(1);
   });
 
   it("stays closed while the flag is off", () => {
@@ -104,6 +108,39 @@ describe("useTabIntroCard — when it opens", () => {
     window.localStorage.setItem(SEEN_KEY, "someone-else");
 
     expect(renderGate().result.current.isOpen).toBe(true);
+  });
+
+  it("stays closed until auth has said who the user is", () => {
+    authUser.current = null;
+
+    expect(renderGate().result.current.isOpen).toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("never opens for a returning user whose id arrives after mount", () => {
+    window.localStorage.setItem(SEEN_KEY, "user-1");
+    authUser.current = null;
+
+    const { result, rerender } = renderGate();
+    expect(result.current.isOpen).toBe(false);
+
+    authUser.current = { id: "user-1" };
+    rerender();
+
+    expect(result.current.isOpen).toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("opens once a first-time user's id arrives after mount", () => {
+    authUser.current = null;
+
+    const { result, rerender } = renderGate();
+    expect(result.current.isOpen).toBe(false);
+
+    authUser.current = { id: "user-1" };
+    rerender();
+
+    expect(result.current.isOpen).toBe(true);
   });
 
   it("burns nothing when the tab vetoes this particular visit", () => {
@@ -151,6 +188,20 @@ describe("useTabIntroCard — dismissal", () => {
       "tab_intro_dismissed",
       expect.anything(),
     );
+  });
+
+  it("gives a second account signing in on the same tab its own intro", () => {
+    const { result, rerender } = renderGate();
+
+    result.current.dismiss();
+    rerender();
+    expect(result.current.isOpen).toBe(false);
+
+    // No remount — just a different account behind the same mounted hook.
+    authUser.current = { id: "user-2" };
+    rerender();
+
+    expect(result.current.isOpen).toBe(true);
   });
 
   it("still closes when localStorage is unavailable", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/useTabIntroCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/__tests__/useTabIntroCard.test.tsx
@@ -1,0 +1,173 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const capture = vi.hoisted(() => vi.fn());
+vi.mock("posthog-js", () => ({ default: { capture } }));
+
+const authUser = vi.hoisted(() => ({
+  current: { id: "user-1" } as { id: string } | null,
+}));
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => ({ user: authUser.current }),
+}));
+
+const flags = vi.hoisted(() => ({ current: {} as Record<string, boolean> }));
+const flagsReady = vi.hoisted(() => ({ current: true }));
+vi.mock("@/services/feature-flags/use-get-flag", () => ({
+  Flag: { ONBOARDING_TAB_INTROS: "onboarding-tab-intros" },
+  useFlagStatus: (flag: string) => ({
+    enabled: flags.current[flag] ?? false,
+    ready: flagsReady.current,
+  }),
+}));
+
+const onboarding = vi.hoisted(() => ({
+  current: {
+    state: null as { completedSteps: string[] } | null,
+    completeStep: vi.fn(),
+  },
+}));
+vi.mock("@/providers/onboarding/onboarding-provider", () => ({
+  useOnboarding: () => onboarding.current,
+}));
+
+import { useTabIntroCard } from "../useTabIntroCard";
+
+const SEEN_KEY = "autogpt:tab-intro-seen:agents";
+
+function renderGate(
+  tab: "agents" | "marketplace" | "build" = "agents",
+  canShow = true,
+) {
+  return renderHook(() => useTabIntroCard(tab, canShow));
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  capture.mockReset();
+  authUser.current = { id: "user-1" };
+  flags.current = { "onboarding-tab-intros": true };
+  flagsReady.current = true;
+  onboarding.current = { state: { completedSteps: [] }, completeStep: vi.fn() };
+});
+
+describe("useTabIntroCard — when it opens", () => {
+  it("opens on a first visit and reports the card as shown", async () => {
+    const { result } = renderGate();
+
+    expect(result.current.isOpen).toBe(true);
+    await waitFor(() =>
+      expect(capture).toHaveBeenCalledWith("tab_intro_shown", {
+        tab: "agents",
+      }),
+    );
+  });
+
+  it("stays closed while the flag is off", () => {
+    flags.current = {};
+
+    expect(renderGate().result.current.isOpen).toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it("stays closed until LaunchDarkly has answered", () => {
+    flagsReady.current = false;
+
+    expect(renderGate().result.current.isOpen).toBe(false);
+  });
+
+  it("stays closed until the onboarding record has loaded", () => {
+    onboarding.current.state = null;
+
+    expect(renderGate().result.current.isOpen).toBe(false);
+  });
+
+  it("stays closed when the step was already recorded on another device", () => {
+    onboarding.current.state = { completedSteps: ["AGENTS_TAB_INTRO"] };
+
+    expect(renderGate().result.current.isOpen).toBe(false);
+  });
+
+  it("only consults its own tab's step", () => {
+    onboarding.current.state = { completedSteps: ["AGENTS_TAB_INTRO"] };
+
+    expect(renderGate("marketplace").result.current.isOpen).toBe(true);
+  });
+
+  it("stays closed when this browser already saw it for this user", () => {
+    window.localStorage.setItem(SEEN_KEY, "user-1");
+
+    expect(renderGate().result.current.isOpen).toBe(false);
+  });
+
+  it("opens for a different account on the same browser", () => {
+    window.localStorage.setItem(SEEN_KEY, "someone-else");
+
+    expect(renderGate().result.current.isOpen).toBe(true);
+  });
+
+  it("burns nothing when the tab vetoes this particular visit", () => {
+    const { result } = renderGate("agents", false);
+
+    expect(result.current.isOpen).toBe(false);
+    expect(capture).not.toHaveBeenCalled();
+    expect(onboarding.current.completeStep).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(SEEN_KEY)).toBeNull();
+  });
+});
+
+describe("useTabIntroCard — dismissal", () => {
+  it("records the step, caches it locally, and never reopens", async () => {
+    const { result, rerender } = renderGate();
+
+    result.current.dismiss();
+    rerender();
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onboarding.current.completeStep).toHaveBeenCalledWith(
+      "AGENTS_TAB_INTRO",
+    );
+    expect(window.localStorage.getItem(SEEN_KEY)).toBe("user-1");
+    expect(capture).toHaveBeenCalledWith("tab_intro_dismissed", {
+      tab: "agents",
+    });
+  });
+
+  it("tags a CTA dismissal with the action that was taken", () => {
+    const { result, rerender } = renderGate("build");
+
+    result.current.takeAction("ask_autopilot");
+    rerender();
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onboarding.current.completeStep).toHaveBeenCalledWith(
+      "BUILD_TAB_INTRO",
+    );
+    expect(capture).toHaveBeenCalledWith("tab_intro_cta_clicked", {
+      tab: "build",
+      cta: "ask_autopilot",
+    });
+    expect(capture).not.toHaveBeenCalledWith(
+      "tab_intro_dismissed",
+      expect.anything(),
+    );
+  });
+
+  it("still closes when localStorage is unavailable", () => {
+    const setItem = vi
+      .spyOn(window.localStorage, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+    const { result, rerender } = renderGate();
+
+    result.current.dismiss();
+    rerender();
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onboarding.current.completeStep).toHaveBeenCalledWith(
+      "AGENTS_TAB_INTRO",
+    );
+    setItem.mockRestore();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/helpers.ts
@@ -2,6 +2,15 @@ import { PostV1CompleteOnboardingStepStep } from "@/app/api/__generated__/models
 
 export type TabIntroTab = "agents" | "marketplace" | "build";
 
+// Every call to action a tab intro can offer. A union rather than a bare
+// string so a typo lands as a type error instead of a silent extra branch in
+// the funnel.
+export type TabIntroCta =
+  | "see_agents"
+  | "browse_featured"
+  | "ask_autopilot"
+  | "builder_tutorial";
+
 // One onboarding step per tab. The backend record is the source of truth —
 // it is what stops the card reappearing on a new browser or device.
 export const TAB_INTRO_STEPS: Record<
@@ -42,4 +51,20 @@ export function setTabIntroSeen(
     // Storage can be unavailable (private mode, quota). The server step
     // still records the dismissal, so this is only a latency shortcut.
   }
+}
+
+// Everything inside the card that can hold focus, in tab order. Used to keep
+// Tab inside an `aria-modal` dialog rather than letting it reach the page
+// behind the overlay.
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export function getFocusableElements(root: HTMLElement) {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
 }

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/helpers.ts
@@ -1,0 +1,45 @@
+import { PostV1CompleteOnboardingStepStep } from "@/app/api/__generated__/models/postV1CompleteOnboardingStepStep";
+
+export type TabIntroTab = "agents" | "marketplace" | "build";
+
+// One onboarding step per tab. The backend record is the source of truth —
+// it is what stops the card reappearing on a new browser or device.
+export const TAB_INTRO_STEPS: Record<
+  TabIntroTab,
+  PostV1CompleteOnboardingStepStep
+> = {
+  agents: PostV1CompleteOnboardingStepStep.AGENTS_TAB_INTRO,
+  marketplace: PostV1CompleteOnboardingStepStep.MARKETPLACE_TAB_INTRO,
+  build: PostV1CompleteOnboardingStepStep.BUILD_TAB_INTRO,
+};
+
+// Local cache of the step above, so the card disappears the instant it is
+// dismissed rather than waiting on the round trip — and stays gone if that
+// round trip failed. The stored value is the user id, not a boolean: another
+// account signing in on the same browser must still get its own intro.
+const SEEN_KEY_PREFIX = "autogpt:tab-intro-seen:";
+
+export function peekTabIntroSeen(
+  tab: TabIntroTab,
+  userId: string | null | undefined,
+) {
+  if (typeof window === "undefined" || !userId) return false;
+  try {
+    return window.localStorage.getItem(SEEN_KEY_PREFIX + tab) === userId;
+  } catch {
+    return false;
+  }
+}
+
+export function setTabIntroSeen(
+  tab: TabIntroTab,
+  userId: string | null | undefined,
+) {
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    window.localStorage.setItem(SEEN_KEY_PREFIX + tab, userId);
+  } catch {
+    // Storage can be unavailable (private mode, quota). The server step
+    // still records the dismissal, so this is only a latency shortcut.
+  }
+}

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/useTabIntroCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/useTabIntroCard.ts
@@ -9,6 +9,7 @@ import {
   peekTabIntroSeen,
   setTabIntroSeen,
   TAB_INTRO_STEPS,
+  type TabIntroCta,
   type TabIntroTab,
 } from "./helpers";
 
@@ -22,34 +23,39 @@ export function useTabIntroCard(tab: TabIntroTab, canShow = true) {
   const { user } = useAuth();
   const userId = user?.id ?? null;
   const { state, completeStep } = useOnboarding();
-  const { enabled, ready } = useFlagStatus(Flag.ONBOARDING_TAB_INTROS);
+  // Same gate as the rest of the new onboarding: the tab intros are part of
+  // that rollout, so they ship and roll back with it rather than on a flag
+  // of their own.
+  const { enabled, ready } = useFlagStatus(Flag.ONBOARDING_BRAIN_DUMP);
   const step = TAB_INTRO_STEPS[tab];
 
-  const [isFinished, setIsFinished] = useState(() =>
-    peekTabIntroSeen(tab, userId),
-  );
+  // Who closed the card in this mounted session, rather than a boolean: a
+  // second account signing in behind the same mounted hook gets its own intro.
+  const [dismissedFor, setDismissedFor] = useState<string | null>(null);
 
-  useEffect(() => {
-    // The user record can arrive after mount — re-check once it does.
-    if (peekTabIntroSeen(tab, userId)) setIsFinished(true);
-  }, [tab, userId]);
-
-  // `state` is null until the provider has fetched the onboarding record.
-  // Waiting for it is what keeps the card from flashing in front of a user
-  // who already dismissed it on another device.
+  // `state` is null until the provider has fetched the onboarding record, and
+  // `userId` is null until auth resolves. Waiting for both is what keeps the
+  // card from flashing in front of a user who already dismissed it — on
+  // another device, or on this one before we knew who they were.
+  //
+  // The cache read is derived here rather than latched into state so it can
+  // never lag a render behind the user id, and it sits last so the disabled
+  // case never touches localStorage at all.
   const isOpen =
     canShow &&
     ready &&
     Boolean(enabled) &&
-    !isFinished &&
+    userId !== null &&
+    dismissedFor !== userId &&
     state !== null &&
-    !state.completedSteps.includes(step);
+    !state.completedSteps.includes(step) &&
+    !peekTabIntroSeen(tab, userId);
 
   useEffect(() => {
     if (isOpen) trackTabIntro("tab_intro_shown", { tab });
   }, [isOpen, tab]);
 
-  function finish(cta?: string) {
+  function finish(cta?: TabIntroCta) {
     if (cta) {
       trackTabIntro("tab_intro_cta_clicked", { tab, cta });
     } else {
@@ -57,7 +63,7 @@ export function useTabIntroCard(tab: TabIntroTab, canShow = true) {
     }
     setTabIntroSeen(tab, userId);
     completeStep(step);
-    setIsFinished(true);
+    setDismissedFor(userId);
   }
 
   return {
@@ -66,6 +72,6 @@ export function useTabIntroCard(tab: TabIntroTab, canShow = true) {
     dismiss: () => finish(),
     // Any of the card's calls to action, named so the funnel can tell a
     // Build "ask AutoPilot" apart from a Build "learn it yourself".
-    takeAction: (cta: string) => finish(cta),
+    takeAction: (cta: TabIntroCta) => finish(cta),
   };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/useTabIntroCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/components/TabIntroCard/useTabIntroCard.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useAuth } from "@/lib/auth/hooks/useAuth";
+import { useOnboarding } from "@/providers/onboarding/onboarding-provider";
+import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
+import { trackTabIntro } from "@/services/onboarding/tab-intro-analytics";
+import { useEffect, useState } from "react";
+import {
+  peekTabIntroSeen,
+  setTabIntroSeen,
+  TAB_INTRO_STEPS,
+  type TabIntroTab,
+} from "./helpers";
+
+// First-visit gate for a tab's intro card. Opens once per user per tab and
+// never again: the onboarding step decides across devices, localStorage
+// covers the window before that write lands.
+//
+// `canShow` lets a tab veto this particular visit without burning the intro —
+// the step stays unrecorded, so the next qualifying visit still gets it.
+export function useTabIntroCard(tab: TabIntroTab, canShow = true) {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const { state, completeStep } = useOnboarding();
+  const { enabled, ready } = useFlagStatus(Flag.ONBOARDING_TAB_INTROS);
+  const step = TAB_INTRO_STEPS[tab];
+
+  const [isFinished, setIsFinished] = useState(() =>
+    peekTabIntroSeen(tab, userId),
+  );
+
+  useEffect(() => {
+    // The user record can arrive after mount — re-check once it does.
+    if (peekTabIntroSeen(tab, userId)) setIsFinished(true);
+  }, [tab, userId]);
+
+  // `state` is null until the provider has fetched the onboarding record.
+  // Waiting for it is what keeps the card from flashing in front of a user
+  // who already dismissed it on another device.
+  const isOpen =
+    canShow &&
+    ready &&
+    Boolean(enabled) &&
+    !isFinished &&
+    state !== null &&
+    !state.completedSteps.includes(step);
+
+  useEffect(() => {
+    if (isOpen) trackTabIntro("tab_intro_shown", { tab });
+  }, [isOpen, tab]);
+
+  function finish(cta?: string) {
+    if (cta) {
+      trackTabIntro("tab_intro_cta_clicked", { tab, cta });
+    } else {
+      trackTabIntro("tab_intro_dismissed", { tab });
+    }
+    setTabIntroSeen(tab, userId);
+    completeStep(step);
+    setIsFinished(true);
+  }
+
+  return {
+    isOpen,
+    // "Got it", Escape, or a click on the backdrop.
+    dismiss: () => finish(),
+    // Any of the card's calls to action, named so the funnel can tell a
+    // Build "ask AutoPilot" apart from a Build "learn it yourself".
+    takeAction: (cta: string) => finish(cta),
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/components/AgentsTabIntro/AgentsTabIntro.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/components/AgentsTabIntro/AgentsTabIntro.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { TabIntroCard } from "@/app/(platform)/components/TabIntroCard/TabIntroCard";
+import { useTabIntroCard } from "@/app/(platform)/components/TabIntroCard/useTabIntroCard";
+import { GridViewIcon } from "@hugeicons/core-free-icons";
+
+// First visit to the Agents tab. The fleet is already rendered behind the
+// card, so "See my agents" only has to get out of the way.
+export function AgentsTabIntro() {
+  const { isOpen, dismiss, takeAction } = useTabIntroCard("agents");
+
+  return (
+    <TabIntroCard
+      isOpen={isOpen}
+      icon={GridViewIcon}
+      title="Your mission control."
+      body="What's running, what's scheduled, what needs you, and what it costs — all in one place."
+      cta={{ label: "See my agents", onClick: () => takeAction("see_agents") }}
+      onDismiss={dismiss}
+    />
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/library/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/library/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { AgentsTabIntro } from "./components/AgentsTabIntro/AgentsTabIntro";
 import { LibraryActionHeader } from "./components/LibraryActionHeader/LibraryActionHeader";
 import { LibraryAgentList } from "./components/LibraryAgentList/LibraryAgentList";
 import { useLibraryListPage } from "./components/useLibraryListPage";
@@ -61,6 +62,7 @@ export default function LibraryPage() {
           briefingAgents={isAgentBriefingEnabled ? agents : undefined}
         />
       </main>
+      <AgentsTabIntro />
     </FavoriteAnimationProvider>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { FeaturedAgentCard } from "../FeaturedAgentCard/FeaturedAgentCard";
 import { SparklesIcon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import { FEATURED_SECTION_ID } from "../MarketplaceTabIntro/helpers";
 
 const FEATURED_COLORS = [
   "bg-violet-50 border-violet-100/70",
@@ -23,10 +24,7 @@ interface FeaturedSectionProps {
   featuredAgents: StoreAgent[];
 }
 
-// Scroll target for the Marketplace tab intro's "Browse featured agents".
-export const FEATURED_SECTION_ID = "marketplace-featured-agents";
-
-export const FeaturedSection = ({ featuredAgents }: FeaturedSectionProps) => {
+export function FeaturedSection({ featuredAgents }: FeaturedSectionProps) {
   return (
     <section
       id={FEATURED_SECTION_ID}
@@ -75,4 +73,4 @@ export const FeaturedSection = ({ featuredAgents }: FeaturedSectionProps) => {
       </Carousel>
     </section>
   );
-};
+}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/FeaturedSection/FeaturedSection.tsx
@@ -23,9 +23,15 @@ interface FeaturedSectionProps {
   featuredAgents: StoreAgent[];
 }
 
+// Scroll target for the Marketplace tab intro's "Browse featured agents".
+export const FEATURED_SECTION_ID = "marketplace-featured-agents";
+
 export const FeaturedSection = ({ featuredAgents }: FeaturedSectionProps) => {
   return (
-    <section className="mb-8 w-full border-b border-zinc-200/70 pb-6">
+    <section
+      id={FEATURED_SECTION_ID}
+      className="mb-8 w-full border-b border-zinc-200/70 pb-6"
+    >
       <Carousel
         opts={{
           align: "start",

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/MainMarketplacePage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/MainMarketplacePage.tsx
@@ -9,6 +9,7 @@ import { FeaturedSection } from "../FeaturedSection/FeaturedSection";
 import { ExpertsSection } from "../ExpertsSection/ExpertsSection";
 import { HeroSection } from "../HeroSection/HeroSection";
 import { MainMarketplacePageLoading } from "../MainMarketplacePageLoading";
+import { MarketplaceTabIntro } from "../MarketplaceTabIntro/MarketplaceTabIntro";
 import { useMainMarketplacePage } from "./useMainMarketplacePage";
 
 export const MainMarkeplacePage = () => {
@@ -73,6 +74,7 @@ export const MainMarkeplacePage = () => {
           buttonText="Become a Creator"
         />
       </main>
+      <MarketplaceTabIntro />
     </div>
   );
 };

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/MainMarketplacePage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/MainMarketplacePage.tsx
@@ -10,6 +10,7 @@ import { ExpertsSection } from "../ExpertsSection/ExpertsSection";
 import { HeroSection } from "../HeroSection/HeroSection";
 import { MainMarketplacePageLoading } from "../MainMarketplacePageLoading";
 import { MarketplaceTabIntro } from "../MarketplaceTabIntro/MarketplaceTabIntro";
+import { AGENTS_SECTION_ID } from "../MarketplaceTabIntro/helpers";
 import { useMainMarketplacePage } from "./useMainMarketplacePage";
 
 export const MainMarkeplacePage = () => {
@@ -46,7 +47,7 @@ export const MainMarkeplacePage = () => {
         <HeroSection />
         {isHireExpertsEnabled ? <ExpertsSection /> : null}
         {topAgents && (
-          <div className="mb-20">
+          <div className="mb-20" id={AGENTS_SECTION_ID}>
             <AgentsSection
               sectionTitle="All AI Workflows"
               titleIcon={<AICatalogIcon size={30} />}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MarketplaceTabIntro/MarketplaceTabIntro.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MarketplaceTabIntro/MarketplaceTabIntro.tsx
@@ -3,19 +3,21 @@
 import { TabIntroCard } from "@/app/(platform)/components/TabIntroCard/TabIntroCard";
 import { useTabIntroCard } from "@/app/(platform)/components/TabIntroCard/useTabIntroCard";
 import { Store01Icon } from "@hugeicons/core-free-icons";
-import { FEATURED_SECTION_ID } from "../FeaturedSection/FeaturedSection";
+import { AGENTS_SECTION_ID, FEATURED_SECTION_ID } from "./helpers";
 
 // First visit to the Marketplace tab. The CTA lands the user on the
-// hand-picked carousel rather than the top of a long page; if there is
-// nothing featured right now it just gets out of the way.
+// hand-picked carousel rather than the top of a long page, falling back to the
+// full listing on the days nothing is featured — the card promises movement,
+// so it has to produce some.
 export function MarketplaceTabIntro() {
   const { isOpen, dismiss, takeAction } = useTabIntroCard("marketplace");
 
   function browseFeatured() {
     takeAction("browse_featured");
-    document
-      .getElementById(FEATURED_SECTION_ID)
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    const target =
+      document.getElementById(FEATURED_SECTION_ID) ??
+      document.getElementById(AGENTS_SECTION_ID);
+    target?.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 
   return (

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MarketplaceTabIntro/MarketplaceTabIntro.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MarketplaceTabIntro/MarketplaceTabIntro.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { TabIntroCard } from "@/app/(platform)/components/TabIntroCard/TabIntroCard";
+import { useTabIntroCard } from "@/app/(platform)/components/TabIntroCard/useTabIntroCard";
+import { Store01Icon } from "@hugeicons/core-free-icons";
+import { FEATURED_SECTION_ID } from "../FeaturedSection/FeaturedSection";
+
+// First visit to the Marketplace tab. The CTA lands the user on the
+// hand-picked carousel rather than the top of a long page; if there is
+// nothing featured right now it just gets out of the way.
+export function MarketplaceTabIntro() {
+  const { isOpen, dismiss, takeAction } = useTabIntroCard("marketplace");
+
+  function browseFeatured() {
+    takeAction("browse_featured");
+    document
+      .getElementById(FEATURED_SECTION_ID)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  return (
+    <TabIntroCard
+      isOpen={isOpen}
+      icon={Store01Icon}
+      title="Agents ready to work."
+      body="Hundreds built by the community. Install one in a single click and run it today."
+      cta={{ label: "Browse featured agents", onClick: browseFeatured }}
+      onDismiss={dismiss}
+    />
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MarketplaceTabIntro/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MarketplaceTabIntro/helpers.ts
@@ -1,0 +1,6 @@
+// Scroll targets for the Marketplace tab intro's "Browse featured agents".
+// The hand-picked carousel is the preferred landing spot, but it is only
+// rendered when something is actually featured — so the CTA falls back to the
+// full listing rather than closing the card and moving nothing.
+export const FEATURED_SECTION_ID = "marketplace-featured-agents";
+export const AGENTS_SECTION_ID = "marketplace-all-agents";

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -9340,7 +9340,10 @@
                 "CONGRATS",
                 "ONBOARDING_COMPLETE",
                 "BUILDER_OPEN",
-                "CAPABILITY_CARDS"
+                "CAPABILITY_CARDS",
+                "AGENTS_TAB_INTRO",
+                "MARKETPLACE_TAB_INTRO",
+                "BUILD_TAB_INTRO"
               ],
               "type": "string",
               "title": "Step"
@@ -20264,7 +20267,10 @@
           "RUN_AGENTS_100",
           "BUILDER_OPEN",
           "BUILDER_RUN_AGENT",
-          "CAPABILITY_CARDS"
+          "CAPABILITY_CARDS",
+          "AGENTS_TAB_INTRO",
+          "MARKETPLACE_TAB_INTRO",
+          "BUILD_TAB_INTRO"
         ],
         "title": "OnboardingStep",
         "description": "Application-level onboarding step identifiers."

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/types.ts
@@ -898,7 +898,11 @@ export type OnboardingStep =
   | "BUILDER_OPEN"
   | "BUILDER_RUN_AGENT"
   // Copilot home first-run: capability-cards modal completed or skipped
-  | "CAPABILITY_CARDS";
+  | "CAPABILITY_CARDS"
+  // First-visit intro card for a tab, dismissed however the user chose
+  | "AGENTS_TAB_INTRO"
+  | "MARKETPLACE_TAB_INTRO"
+  | "BUILD_TAB_INTRO";
 
 export interface UserOnboarding {
   // Plain string[] so legacy step names from existing rows pass through.

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -26,10 +26,6 @@ export enum Flag {
   // Mirror of the backend ``Flag`` enum — the endpoints 404 when off, so
   // both sides must agree. Off renders the pillbox flow untouched.
   ONBOARDING_BRAIN_DUMP = "onboarding-brain-dump",
-  // First-visit intro card on the Agents / Marketplace / Build tabs. Kept
-  // separate from ONBOARDING_BRAIN_DUMP so the tab intros can roll out on
-  // their own — nothing about them depends on a dump having happened.
-  ONBOARDING_TAB_INTROS = "onboarding-tab-intros",
   // Graphiti memory + dream-system gates. Mirror of the backend
   // ``Flag`` enum in ``backend/util/feature_flag.py``. Frontend reads
   // them when memory/dream-related UI surfaces ship (P6+ on the
@@ -74,9 +70,6 @@ const defaultFlags = {
   // brain dump for everyone — which is what the backend 404s are meant to
   // prevent. Use NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP locally.
   [Flag.ONBOARDING_BRAIN_DUMP]: false,
-  // Off by default for the same reason as the dump: with no LaunchDarkly key
-  // a `true` here would pop a modal on every tab for every existing user.
-  [Flag.ONBOARDING_TAB_INTROS]: false,
   [Flag.GRAPHITI_MEMORY]: false,
   [Flag.GRAPHITI_COMMUNITIES_ENABLED]: false,
   [Flag.DREAM_PASS_ENABLED]: false,
@@ -140,8 +133,6 @@ function readEnvOverride(flag: Flag): string | undefined {
       return process.env.NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS;
     case Flag.ONBOARDING_BRAIN_DUMP:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP;
-    case Flag.ONBOARDING_TAB_INTROS:
-      return process.env.NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_TAB_INTROS;
     case Flag.GRAPHITI_MEMORY:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_GRAPHITI_MEMORY;
     case Flag.GRAPHITI_COMMUNITIES_ENABLED:

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -26,6 +26,10 @@ export enum Flag {
   // Mirror of the backend ``Flag`` enum — the endpoints 404 when off, so
   // both sides must agree. Off renders the pillbox flow untouched.
   ONBOARDING_BRAIN_DUMP = "onboarding-brain-dump",
+  // First-visit intro card on the Agents / Marketplace / Build tabs. Kept
+  // separate from ONBOARDING_BRAIN_DUMP so the tab intros can roll out on
+  // their own — nothing about them depends on a dump having happened.
+  ONBOARDING_TAB_INTROS = "onboarding-tab-intros",
   // Graphiti memory + dream-system gates. Mirror of the backend
   // ``Flag`` enum in ``backend/util/feature_flag.py``. Frontend reads
   // them when memory/dream-related UI surfaces ship (P6+ on the
@@ -70,6 +74,9 @@ const defaultFlags = {
   // brain dump for everyone — which is what the backend 404s are meant to
   // prevent. Use NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP locally.
   [Flag.ONBOARDING_BRAIN_DUMP]: false,
+  // Off by default for the same reason as the dump: with no LaunchDarkly key
+  // a `true` here would pop a modal on every tab for every existing user.
+  [Flag.ONBOARDING_TAB_INTROS]: false,
   [Flag.GRAPHITI_MEMORY]: false,
   [Flag.GRAPHITI_COMMUNITIES_ENABLED]: false,
   [Flag.DREAM_PASS_ENABLED]: false,
@@ -133,6 +140,8 @@ function readEnvOverride(flag: Flag): string | undefined {
       return process.env.NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS;
     case Flag.ONBOARDING_BRAIN_DUMP:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP;
+    case Flag.ONBOARDING_TAB_INTROS:
+      return process.env.NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_TAB_INTROS;
     case Flag.GRAPHITI_MEMORY:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_GRAPHITI_MEMORY;
     case Flag.GRAPHITI_COMMUNITIES_ENABLED:

--- a/autogpt_platform/frontend/src/services/onboarding/__tests__/tab-intro-analytics.test.ts
+++ b/autogpt_platform/frontend/src/services/onboarding/__tests__/tab-intro-analytics.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const capture = vi.hoisted(() => vi.fn());
+vi.mock("posthog-js", () => ({ default: { capture } }));
+
+import { trackTabIntro } from "../tab-intro-analytics";
+
+beforeEach(() => {
+  capture.mockReset();
+});
+
+describe("trackTabIntro", () => {
+  it("reports the event with its tab", () => {
+    trackTabIntro("tab_intro_cta_clicked", {
+      tab: "build",
+      cta: "ask_autopilot",
+    });
+
+    expect(capture).toHaveBeenCalledWith("tab_intro_cta_clicked", {
+      tab: "build",
+      cta: "ask_autopilot",
+    });
+  });
+
+  it("swallows a blocked analytics host rather than breaking a first visit", () => {
+    capture.mockImplementation(() => {
+      throw new Error("blocked by client");
+    });
+
+    expect(() =>
+      trackTabIntro("tab_intro_shown", { tab: "agents" }),
+    ).not.toThrow();
+  });
+});

--- a/autogpt_platform/frontend/src/services/onboarding/tab-intro-analytics.ts
+++ b/autogpt_platform/frontend/src/services/onboarding/tab-intro-analytics.ts
@@ -2,10 +2,13 @@
 // Every event carries the tab it belongs to, so one funnel answers both
 // "which tabs get discovered" and "does the card's CTA earn its place".
 //
-// Separate from brain-dump-analytics because the tab intros ship on their
-// own flag and outlive the dump funnel — a shared event union would tie
-// two unrelated rollouts together.
+// Separate from brain-dump-analytics because the tab intros outlive the dump
+// funnel — a shared event union would tie two unrelated questions together.
 
+import type {
+  TabIntroCta,
+  TabIntroTab,
+} from "@/app/(platform)/components/TabIntroCard/helpers";
 import posthog from "posthog-js";
 
 type TabIntroEvent =
@@ -17,7 +20,7 @@ type TabIntroEvent =
 
 export function trackTabIntro(
   event: TabIntroEvent,
-  properties: { tab: string; cta?: string },
+  properties: { tab: TabIntroTab; cta?: TabIntroCta },
 ) {
   try {
     posthog.capture(event, properties);

--- a/autogpt_platform/frontend/src/services/onboarding/tab-intro-analytics.ts
+++ b/autogpt_platform/frontend/src/services/onboarding/tab-intro-analytics.ts
@@ -1,0 +1,27 @@
+// Tab-intro funnel (PRD section 4: "Tab cards: shown, CTA vs dismiss").
+// Every event carries the tab it belongs to, so one funnel answers both
+// "which tabs get discovered" and "does the card's CTA earn its place".
+//
+// Separate from brain-dump-analytics because the tab intros ship on their
+// own flag and outlive the dump funnel — a shared event union would tie
+// two unrelated rollouts together.
+
+import posthog from "posthog-js";
+
+type TabIntroEvent =
+  | "tab_intro_shown"
+  // The card's primary CTA was used, as opposed to any of the ways out
+  // ("Got it", Escape, the backdrop) that all land on `tab_intro_dismissed`.
+  | "tab_intro_cta_clicked"
+  | "tab_intro_dismissed";
+
+export function trackTabIntro(
+  event: TabIntroEvent,
+  properties: { tab: string; cta?: string },
+) {
+  try {
+    posthog.capture(event, properties);
+  } catch {
+    // A blocked analytics host must never break a first visit.
+  }
+}


### PR DESCRIPTION
### Why / What / How

**Why:** The Agents, Marketplace and Build tabs give a new user no orientation — you land on a fleet view, a long storefront, or an empty canvas with no idea what the tab is for or what to do first. **What:** Each of those three tabs now shows a single first-visit intro card: an icon, a short title, one sentence, one way forward and one way out. **How:** A shared `TabIntroCard` shell plus a thin per-tab wrapper, gated behind the existing `onboarding-brain-dump` LaunchDarkly flag (off by default). Dismissal is recorded as a per-tab onboarding step so the backend record is the source of truth across devices, with a user-scoped `localStorage` cache covering the window before that write lands.

### Changes 🏗️

- **New shared component** `(platform)/components/TabIntroCard` — card shell, the `useTabIntroCard` first-visit gate, and `helpers.ts` holding the step map, the CTA union and the `localStorage` cache. The card dismisses on "Got it", Escape, and a backdrop click. It moves focus into itself on open, contains `Tab`/`Shift+Tab` while open, and restores focus to the opener on close.
- **Three per-tab wrappers**: `AgentsTabIntro` (Library), `MarketplaceTabIntro` (CTA scrolls the featured carousel into view, falling back to the full listing when nothing is featured), `BuildTabIntro` (AutoPilot as the primary route, the existing builder tutorial as a quiet alternative).
- **Build vetoes the card** when deep-linked into a saved graph (`?flowID=`) — the intro is about starting something and its tutorial clears the canvas. Vetoing leaves the step unrecorded, so a later blank `/build` still gets the introduction.
- **The gate is derived, not latched.** `isOpen` waits on the flag, the resolved user id, the onboarding record and the local cache, all evaluated during render. Nothing is copied into state, so the card cannot flash open for a returning user in the frame before their id resolves. Dismissal is tracked per user id, so a second account signing in behind the same mounted hook still gets its own intro. The cache read sits last in the expression, so a user with the flag off never touches `localStorage`.
- **Backend**: three new `OnboardingStep` values (`AGENTS_TAB_INTRO`, `MARKETPLACE_TAB_INTRO`, `BUILD_TAB_INTRO`) added to the enum and to `FrontendOnboardingStep` so `POST /onboarding/step` accepts them instead of 422-ing. They are unrewarded, and there is a test asserting the credit model is never reached for them.
- **Flag**: the tab intros ride the existing `Flag.ONBOARDING_BRAIN_DUMP` rather than one of their own, so they ship and roll back with the rest of the new onboarding. No new flag key.
- **Analytics**: `tab_intro_shown` / `tab_intro_cta_clicked` / `tab_intro_dismissed`, each carrying its tab, so one funnel shows both which tabs get discovered and whether the CTA earns its place. The tab and CTA properties are typed unions, not strings.
- Scroll targets for the Marketplace CTA (`FEATURED_SECTION_ID`, `AGENTS_SECTION_ID`) live in `MarketplaceTabIntro/helpers.ts` so `FeaturedSection` and `MainMarketplacePage` can carry the ids without the intro importing its own parent page.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `TabIntroCard` renders its copy, CTA and "Got it"; renders nothing while closed
  - [x] Dismisses on "Got it", on Escape, and on a backdrop click — but *not* on a click inside the card that drifts out (text selection)
  - [x] The CTA fires its own action without also reporting a plain dismissal
  - [x] Focus lands inside the card on open, `Tab`/`Shift+Tab` wrap inside it rather than reaching the page behind, and focus returns to the opener on close
  - [x] Gate stays closed while the flag is off, before LaunchDarkly answers, before auth resolves the user, and before the onboarding record loads
  - [x] Gate stays closed when the step was already recorded on another device, and only consults its own tab's step
  - [x] A returning user whose id arrives after mount never opens the card (and never reports it shown); a first-time user does, exactly once
  - [x] A second account signing in without a remount gets its own intro
  - [x] Dismissal records the step, caches locally, never reopens — and still closes when `localStorage` throws
  - [x] Agents CTA steps aside; Marketplace CTA scrolls the carousel, falls back to the listing when nothing is featured, and still closes when neither exists; Build CTA routes to `/copilot` and the alternative launches the builder tutorial
  - [x] Build stays out of the way of `?flowID=` and leaves the step unrecorded for later
  - [x] A blocked analytics host does not break a first visit
  - [x] Backend: `POST /onboarding/step` accepts all three new steps, still 422s on rewarded backend-only steps, and grants no credits for the tab intros (parametrised)
  - [x] No regressions in the touched areas — full library, marketplace, build, shared-component and services suites green (832 tests)
  - [ ] Manual pass in the browser with the flag forced on, across all three tabs

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes. The feature is read through the existing `onboarding-brain-dump` LaunchDarkly wiring and defaults to `false`, so an environment with no flag key behaves exactly as before.
