### PR TITLE
docs(cache): fix awkward 'in in-memory' repetition in docstring

### DIFF
--- a/autogpt_platform/backend/backend/util/cache.py
+++ b/autogpt_platform/backend/backend/util/cache.py
@@ -279,7 +279,7 @@ def cached(
             return _MISSING
 
         def _set_to_memory(key: tuple, value: Any) -> None:
-            """Set value in in-memory cache with timestamp."""
+            """Set value in the in-memory cache with timestamp."""
             cache_storage[key] = CachedValue(result=value, timestamp=time.time())
 
             # Cleanup if needed


### PR DESCRIPTION
### WHY

The docstring of  read:

```python
"""Set value in in-memory cache with timestamp."""
```

The doubled `in` (preposition `in` + the `in-` prefix of the compound adjective `in-memory`) reads awkwardly as `in in-memory`.

### WHAT

```diff
-"""Set value in in-memory cache with timestamp."""
+"""Set value in the in-memory cache with timestamp."""
```

Docstring only; no code or behavior change.