### PR TITLE
feat(backend): status counts and duration totals in execution cost summary

### DIFF
--- a/autogpt_platform/backend/backend/data/execution_cost_summary.py
+++ b/autogpt_platform/backend/backend/data/execution_cost_summary.py
@@ -29,6 +29,9 @@ class UserDailyCost(BaseModel):
     date: date
     cost_cents: int
     run_count: int
+    success_count: int = 0
+    failed_count: int = 0
+    review_count: int = 0
 
 
 class UserExecutionCostSummary(BaseModel):
@@ -36,6 +39,10 @@ class UserExecutionCostSummary(BaseModel):
     run_count: int
     billable_run_count: int
     failed_cost_cents: int
+    success_run_count: int = 0
+    failed_run_count: int = 0
+    review_run_count: int = 0
+    total_duration_seconds: float = 0
     by_agent: list[UserAgentCostRollup]
     top_runs: list[UserTopRun]
     daily: list[UserDailyCost]
@@ -91,7 +98,15 @@ async def get_user_cost_summary(
             "    AS billable_run_count,"
             "  COALESCE(SUM(CASE WHEN \"executionStatus\" IN ('FAILED', 'TERMINATED')"
             "    THEN (stats->>'cost')::numeric ELSE 0 END), 0)::bigint"
-            "    AS failed_cost_cents"
+            "    AS failed_cost_cents,"
+            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'COMPLETED')::bigint"
+            "    AS success_run_count,"
+            "  COUNT(*) FILTER (WHERE \"executionStatus\" IN ('FAILED', 'TERMINATED'))::bigint"
+            "    AS failed_run_count,"
+            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'REVIEW')::bigint"
+            "    AS review_run_count,"
+            "  COALESCE(SUM((stats->>'duration')::numeric), 0)::float"
+            "    AS total_duration_seconds"
             ' FROM {schema_prefix}"AgentGraphExecution"'
             f" WHERE {base_where}",
             *params,
@@ -129,7 +144,13 @@ async def get_user_cost_summary(
             "SELECT"
             '  ("createdAt" AT TIME ZONE \'UTC\')::date AS "date",'
             "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS cost_cents,"
-            "  COUNT(*)::bigint AS run_count"
+            "  COUNT(*)::bigint AS run_count,"
+            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'COMPLETED')::bigint"
+            "    AS success_count,"
+            "  COUNT(*) FILTER (WHERE \"executionStatus\" IN ('FAILED', 'TERMINATED'))::bigint"
+            "    AS failed_count,"
+            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'REVIEW')::bigint"
+            "    AS review_count"
             ' FROM {schema_prefix}"AgentGraphExecution"'
             f" WHERE {base_where}"
             "  GROUP BY (\"createdAt\" AT TIME ZONE 'UTC')::date"
@@ -144,6 +165,10 @@ async def get_user_cost_summary(
         run_count=int(totals.get("run_count") or 0),
         billable_run_count=int(totals.get("billable_run_count") or 0),
         failed_cost_cents=int(totals.get("failed_cost_cents") or 0),
+        success_run_count=int(totals.get("success_run_count") or 0),
+        failed_run_count=int(totals.get("failed_run_count") or 0),
+        review_run_count=int(totals.get("review_run_count") or 0),
+        total_duration_seconds=float(totals.get("total_duration_seconds") or 0),
         by_agent=[
             UserAgentCostRollup(
                 graph_id=r["graph_id"],
@@ -169,6 +194,9 @@ async def get_user_cost_summary(
                 date=r["date"],
                 cost_cents=int(r.get("cost_cents") or 0),
                 run_count=int(r.get("run_count") or 0),
+                success_count=int(r.get("success_count") or 0),
+                failed_count=int(r.get("failed_count") or 0),
+                review_count=int(r.get("review_count") or 0),
             )
             for r in daily_rows
         ],

--- a/autogpt_platform/backend/backend/data/execution_cost_summary.py
+++ b/autogpt_platform/backend/backend/data/execution_cost_summary.py
@@ -43,6 +43,10 @@ class UserExecutionCostSummary(BaseModel):
     failed_run_count: int = 0
     review_run_count: int = 0
     total_duration_seconds: float = 0
+    # Denominator for "avg run duration": `run_count` also covers QUEUED /
+    # RUNNING rows and rows whose stats never got a `walltime`, which SUM
+    # silently skips — dividing by it biases the average downward.
+    duration_run_count: int = 0
     by_agent: list[UserAgentCostRollup]
     top_runs: list[UserTopRun]
     daily: list[UserDailyCost]
@@ -50,6 +54,14 @@ class UserExecutionCostSummary(BaseModel):
 
 _MAX_BY_AGENT_ROWS = 50
 _MAX_TOP_RUNS = 50
+
+_BASE_WHERE = (
+    '"userId" = $1'
+    ' AND "isDeleted" = false'
+    ' AND "createdAt" >= $2::timestamp'
+    ' AND "createdAt" <= $3::timestamp'
+    " AND COALESCE((stats->>'is_dry_run')::boolean, false) = false"
+)
 
 
 async def get_user_cost_summary(
@@ -80,86 +92,13 @@ async def get_user_cost_summary(
     if until is None:
         until = now
 
-    base_where = (
-        '"userId" = $1'
-        ' AND "isDeleted" = false'
-        ' AND "createdAt" >= $2::timestamp'
-        ' AND "createdAt" <= $3::timestamp'
-        " AND COALESCE((stats->>'is_dry_run')::boolean, false) = false"
-    )
     params = (user_id, since, until)
-
-    totals_rows, by_agent_rows, top_runs_rows, daily_rows = await asyncio.gather(
-        query_raw_with_schema(
-            "SELECT"
-            "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS total_cents,"
-            "  COUNT(*)::bigint AS run_count,"
-            "  COUNT(*) FILTER (WHERE COALESCE((stats->>'cost')::numeric, 0) > 0)::bigint"
-            "    AS billable_run_count,"
-            "  COALESCE(SUM(CASE WHEN \"executionStatus\" IN ('FAILED', 'TERMINATED')"
-            "    THEN (stats->>'cost')::numeric ELSE 0 END), 0)::bigint"
-            "    AS failed_cost_cents,"
-            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'COMPLETED')::bigint"
-            "    AS success_run_count,"
-            "  COUNT(*) FILTER (WHERE \"executionStatus\" IN ('FAILED', 'TERMINATED'))::bigint"
-            "    AS failed_run_count,"
-            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'REVIEW')::bigint"
-            "    AS review_run_count,"
-            "  COALESCE(SUM((stats->>'duration')::numeric), 0)::float"
-            "    AS total_duration_seconds"
-            ' FROM {schema_prefix}"AgentGraphExecution"'
-            f" WHERE {base_where}",
-            *params,
-        ),
-        query_raw_with_schema(
-            "SELECT"
-            '  "agentGraphId" AS graph_id,'
-            "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS cost_cents,"
-            "  COUNT(*)::bigint AS run_count"
-            ' FROM {schema_prefix}"AgentGraphExecution"'
-            f" WHERE {base_where}"
-            '  GROUP BY "agentGraphId"'
-            "  ORDER BY cost_cents DESC"
-            f"  LIMIT {_MAX_BY_AGENT_ROWS}",
-            *params,
-        ),
-        query_raw_with_schema(
-            "SELECT"
-            "  id AS execution_id,"
-            '  "agentGraphId" AS graph_id,'
-            "  COALESCE((stats->>'cost')::numeric, 0)::bigint AS cost_cents,"
-            '  COALESCE("startedAt", "createdAt") AS started_at,'
-            '  "executionStatus" AS status,'
-            "  COALESCE((stats->>'duration')::numeric, 0) AS duration_seconds,"
-            "  COALESCE((stats->>'node_error_count')::int, 0) AS node_error_count"
-            ' FROM {schema_prefix}"AgentGraphExecution"'
-            f" WHERE {base_where}"
-            "  AND COALESCE((stats->>'cost')::numeric, 0) > 0"
-            '  ORDER BY cost_cents DESC, "createdAt" DESC'
-            "  LIMIT $4",
-            *params,
-            top_runs_limit,
-        ),
-        query_raw_with_schema(
-            "SELECT"
-            '  ("createdAt" AT TIME ZONE \'UTC\')::date AS "date",'
-            "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS cost_cents,"
-            "  COUNT(*)::bigint AS run_count,"
-            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'COMPLETED')::bigint"
-            "    AS success_count,"
-            "  COUNT(*) FILTER (WHERE \"executionStatus\" IN ('FAILED', 'TERMINATED'))::bigint"
-            "    AS failed_count,"
-            "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'REVIEW')::bigint"
-            "    AS review_count"
-            ' FROM {schema_prefix}"AgentGraphExecution"'
-            f" WHERE {base_where}"
-            "  GROUP BY (\"createdAt\" AT TIME ZONE 'UTC')::date"
-            '  ORDER BY "date" ASC',
-            *params,
-        ),
+    totals, by_agent, top_runs, daily = await asyncio.gather(
+        _fetch_totals(params),
+        _fetch_by_agent(params),
+        _fetch_top_runs(params, top_runs_limit),
+        _fetch_daily(params),
     )
-
-    totals = totals_rows[0] if totals_rows else {}
     return UserExecutionCostSummary(
         total_cents=int(totals.get("total_cents") or 0),
         run_count=int(totals.get("run_count") or 0),
@@ -169,35 +108,127 @@ async def get_user_cost_summary(
         failed_run_count=int(totals.get("failed_run_count") or 0),
         review_run_count=int(totals.get("review_run_count") or 0),
         total_duration_seconds=float(totals.get("total_duration_seconds") or 0),
-        by_agent=[
-            UserAgentCostRollup(
-                graph_id=r["graph_id"],
-                cost_cents=int(r.get("cost_cents") or 0),
-                run_count=int(r.get("run_count") or 0),
-            )
-            for r in by_agent_rows
-        ],
-        top_runs=[
-            UserTopRun(
-                execution_id=r["execution_id"],
-                graph_id=r["graph_id"],
-                cost_cents=int(r.get("cost_cents") or 0),
-                started_at=r["started_at"],
-                status=AgentExecutionStatus(r["status"]),
-                duration_seconds=float(r.get("duration_seconds") or 0),
-                node_error_count=int(r.get("node_error_count") or 0),
-            )
-            for r in top_runs_rows
-        ],
-        daily=[
-            UserDailyCost(
-                date=r["date"],
-                cost_cents=int(r.get("cost_cents") or 0),
-                run_count=int(r.get("run_count") or 0),
-                success_count=int(r.get("success_count") or 0),
-                failed_count=int(r.get("failed_count") or 0),
-                review_count=int(r.get("review_count") or 0),
-            )
-            for r in daily_rows
-        ],
+        duration_run_count=int(totals.get("duration_run_count") or 0),
+        by_agent=by_agent,
+        top_runs=top_runs,
+        daily=daily,
     )
+
+
+async def _fetch_totals(params: tuple[str, datetime, datetime]) -> dict:
+    rows = await query_raw_with_schema(
+        "SELECT"
+        "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS total_cents,"
+        "  COUNT(*)::bigint AS run_count,"
+        "  COUNT(*) FILTER (WHERE COALESCE((stats->>'cost')::numeric, 0) > 0)::bigint"
+        "    AS billable_run_count,"
+        "  COALESCE(SUM(CASE WHEN \"executionStatus\" IN ('FAILED', 'TERMINATED')"
+        "    THEN (stats->>'cost')::numeric ELSE 0 END), 0)::bigint"
+        "    AS failed_cost_cents,"
+        "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'COMPLETED')::bigint"
+        "    AS success_run_count,"
+        "  COUNT(*) FILTER (WHERE \"executionStatus\" IN ('FAILED', 'TERMINATED'))::bigint"
+        "    AS failed_run_count,"
+        "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'REVIEW')::bigint"
+        "    AS review_run_count,"
+        "  COALESCE(SUM((stats->>'walltime')::numeric), 0)::float"
+        "    AS total_duration_seconds,"
+        "  COUNT(*) FILTER (WHERE (stats->>'walltime') IS NOT NULL)::bigint"
+        "    AS duration_run_count"
+        ' FROM {schema_prefix}"AgentGraphExecution"'
+        f" WHERE {_BASE_WHERE}",
+        *params,
+    )
+    return rows[0] if rows else {}
+
+
+async def _fetch_by_agent(
+    params: tuple[str, datetime, datetime],
+) -> list[UserAgentCostRollup]:
+    rows = await query_raw_with_schema(
+        "SELECT"
+        '  "agentGraphId" AS graph_id,'
+        "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS cost_cents,"
+        "  COUNT(*)::bigint AS run_count"
+        ' FROM {schema_prefix}"AgentGraphExecution"'
+        f" WHERE {_BASE_WHERE}"
+        '  GROUP BY "agentGraphId"'
+        "  ORDER BY cost_cents DESC"
+        f"  LIMIT {_MAX_BY_AGENT_ROWS}",
+        *params,
+    )
+    return [
+        UserAgentCostRollup(
+            graph_id=r["graph_id"],
+            cost_cents=int(r.get("cost_cents") or 0),
+            run_count=int(r.get("run_count") or 0),
+        )
+        for r in rows
+    ]
+
+
+async def _fetch_top_runs(
+    params: tuple[str, datetime, datetime], limit: int
+) -> list[UserTopRun]:
+    rows = await query_raw_with_schema(
+        "SELECT"
+        "  id AS execution_id,"
+        '  "agentGraphId" AS graph_id,'
+        "  COALESCE((stats->>'cost')::numeric, 0)::bigint AS cost_cents,"
+        '  COALESCE("startedAt", "createdAt") AS started_at,'
+        '  "executionStatus" AS status,'
+        "  COALESCE((stats->>'walltime')::numeric, 0) AS duration_seconds,"
+        "  COALESCE((stats->>'node_error_count')::int, 0) AS node_error_count"
+        ' FROM {schema_prefix}"AgentGraphExecution"'
+        f" WHERE {_BASE_WHERE}"
+        "  AND COALESCE((stats->>'cost')::numeric, 0) > 0"
+        '  ORDER BY cost_cents DESC, "createdAt" DESC'
+        "  LIMIT $4",
+        *params,
+        limit,
+    )
+    return [
+        UserTopRun(
+            execution_id=r["execution_id"],
+            graph_id=r["graph_id"],
+            cost_cents=int(r.get("cost_cents") or 0),
+            started_at=r["started_at"],
+            status=AgentExecutionStatus(r["status"]),
+            duration_seconds=float(r.get("duration_seconds") or 0),
+            node_error_count=int(r.get("node_error_count") or 0),
+        )
+        for r in rows
+    ]
+
+
+async def _fetch_daily(
+    params: tuple[str, datetime, datetime],
+) -> list[UserDailyCost]:
+    rows = await query_raw_with_schema(
+        "SELECT"
+        '  ("createdAt" AT TIME ZONE \'UTC\')::date AS "date",'
+        "  COALESCE(SUM((stats->>'cost')::numeric), 0)::bigint AS cost_cents,"
+        "  COUNT(*)::bigint AS run_count,"
+        "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'COMPLETED')::bigint"
+        "    AS success_count,"
+        "  COUNT(*) FILTER (WHERE \"executionStatus\" IN ('FAILED', 'TERMINATED'))::bigint"
+        "    AS failed_count,"
+        "  COUNT(*) FILTER (WHERE \"executionStatus\" = 'REVIEW')::bigint"
+        "    AS review_count"
+        ' FROM {schema_prefix}"AgentGraphExecution"'
+        f" WHERE {_BASE_WHERE}"
+        "  GROUP BY (\"createdAt\" AT TIME ZONE 'UTC')::date"
+        '  ORDER BY "date" ASC',
+        *params,
+    )
+    return [
+        UserDailyCost(
+            date=r["date"],
+            cost_cents=int(r.get("cost_cents") or 0),
+            run_count=int(r.get("run_count") or 0),
+            success_count=int(r.get("success_count") or 0),
+            failed_count=int(r.get("failed_count") or 0),
+            review_count=int(r.get("review_count") or 0),
+        )
+        for r in rows
+    ]

--- a/autogpt_platform/backend/backend/data/execution_cost_summary_test.py
+++ b/autogpt_platform/backend/backend/data/execution_cost_summary_test.py
@@ -53,16 +53,21 @@ async def _create_run(
     status: AgentExecutionStatus,
     cost_cents: int,
     started_at: datetime,
-    duration: float = 1.0,
+    duration: float | None = 1.0,
     node_error_count: int = 0,
     is_dry_run: bool = False,
     created_at: datetime | None = None,
 ) -> None:
-    stats = {
+    # `walltime` is the key the executor actually persists — it comes from
+    # GraphExecutionStats.model_dump() in update_graph_execution_stats().
+    # `duration is None` models an in-flight/never-finalized run whose stats
+    # carry no walltime at all.
+    stats: dict[str, object] = {
         "cost": cost_cents,
-        "duration": duration,
         "node_error_count": node_error_count,
     }
+    if duration is not None:
+        stats["walltime"] = duration
     if is_dry_run:
         stats["is_dry_run"] = True
     await AgentGraphExecution.prisma().create(
@@ -74,7 +79,7 @@ async def _create_run(
             "userId": user_id,
             "createdAt": created_at if created_at is not None else started_at,
             "startedAt": started_at,
-            "endedAt": started_at + timedelta(seconds=duration),
+            "endedAt": started_at + timedelta(seconds=duration or 0),
             "stats": SafeJson(stats),
         }
     )
@@ -109,6 +114,7 @@ async def test_empty_window_returns_zeroed_summary(server: SpinTestServer):
         assert summary.failed_run_count == 0
         assert summary.review_run_count == 0
         assert summary.total_duration_seconds == 0
+        assert summary.duration_run_count == 0
         assert summary.by_agent == []
         assert summary.top_runs == []
         assert summary.daily == []
@@ -193,6 +199,17 @@ async def test_aggregates_by_agent_and_top_runs(server: SpinTestServer):
             cost_cents=0,
             started_at=now - timedelta(minutes=3),
         )
+        # Still running, so its stats carry no walltime yet: it inflates
+        # run_count but must stay out of the duration denominator.
+        await _create_run(
+            run_id=f"e8-{uuid4()}",
+            user_id=user_id,
+            graph_id=graph_a,
+            status=AgentExecutionStatus.RUNNING,
+            cost_cents=0,
+            started_at=now - timedelta(minutes=2),
+            duration=None,
+        )
 
         summary = await get_user_cost_summary(
             user_id=user_id,
@@ -202,21 +219,23 @@ async def test_aggregates_by_agent_and_top_runs(server: SpinTestServer):
         )
 
         assert summary.total_cents == 1570
-        assert summary.run_count == 7
+        assert summary.run_count == 8
         assert summary.billable_run_count == 5
         # 50 FAILED + 20 TERMINATED
         assert summary.failed_cost_cents == 70
-        # 4 COMPLETED vs 1 FAILED + 1 TERMINATED + 1 REVIEW
+        # 4 COMPLETED vs 1 FAILED + 1 TERMINATED + 1 REVIEW + 1 RUNNING
         assert summary.success_run_count == 4
         assert summary.failed_run_count == 2
         assert summary.review_run_count == 1
-        # every run above uses the default 1.0s duration
+        # 7 finished runs at the default 1.0s walltime; the RUNNING run has
+        # none, so it is absent from both the sum and the denominator.
         assert summary.total_duration_seconds == 7.0
+        assert summary.duration_run_count == 7
 
         by_agent = {row.graph_id: row for row in summary.by_agent}
         assert by_agent[graph_a].cost_cents == 500
-        # 2 paid runs + 1 zero-cost run + 1 review run on graph_a
-        assert by_agent[graph_a].run_count == 4
+        # 2 paid + 1 zero-cost + 1 review + 1 running run on graph_a
+        assert by_agent[graph_a].run_count == 5
         assert by_agent[graph_b].cost_cents == 1070
         assert by_agent[graph_b].run_count == 3
         # graph_b leads on total spend so it sorts first
@@ -225,6 +244,8 @@ async def test_aggregates_by_agent_and_top_runs(server: SpinTestServer):
         # Top runs ordered by cost desc; limit honored
         assert summary.top_runs[0].execution_id == big_run_id
         assert summary.top_runs[0].cost_cents == 1000
+        # Projected off the persisted `walltime` key, not a synthetic one
+        assert summary.top_runs[0].duration_seconds == 1.0
         assert len(summary.top_runs) == 3
     finally:
         await _cleanup(user_id, [graph_a, graph_b])

--- a/autogpt_platform/backend/backend/data/execution_cost_summary_test.py
+++ b/autogpt_platform/backend/backend/data/execution_cost_summary_test.py
@@ -105,6 +105,10 @@ async def test_empty_window_returns_zeroed_summary(server: SpinTestServer):
         assert summary.run_count == 0
         assert summary.billable_run_count == 0
         assert summary.failed_cost_cents == 0
+        assert summary.success_run_count == 0
+        assert summary.failed_run_count == 0
+        assert summary.review_run_count == 0
+        assert summary.total_duration_seconds == 0
         assert summary.by_agent == []
         assert summary.top_runs == []
         assert summary.daily == []
@@ -180,6 +184,15 @@ async def test_aggregates_by_agent_and_top_runs(server: SpinTestServer):
             cost_cents=0,
             started_at=now - timedelta(minutes=5),
         )
+        # A run parked on human review counts toward review_run_count only.
+        await _create_run(
+            run_id=f"e7-{uuid4()}",
+            user_id=user_id,
+            graph_id=graph_a,
+            status=AgentExecutionStatus.REVIEW,
+            cost_cents=0,
+            started_at=now - timedelta(minutes=3),
+        )
 
         summary = await get_user_cost_summary(
             user_id=user_id,
@@ -189,15 +202,21 @@ async def test_aggregates_by_agent_and_top_runs(server: SpinTestServer):
         )
 
         assert summary.total_cents == 1570
-        assert summary.run_count == 6
+        assert summary.run_count == 7
         assert summary.billable_run_count == 5
         # 50 FAILED + 20 TERMINATED
         assert summary.failed_cost_cents == 70
+        # 4 COMPLETED vs 1 FAILED + 1 TERMINATED + 1 REVIEW
+        assert summary.success_run_count == 4
+        assert summary.failed_run_count == 2
+        assert summary.review_run_count == 1
+        # every run above uses the default 1.0s duration
+        assert summary.total_duration_seconds == 7.0
 
         by_agent = {row.graph_id: row for row in summary.by_agent}
         assert by_agent[graph_a].cost_cents == 500
-        # 2 paid runs + 1 zero-cost run on graph_a
-        assert by_agent[graph_a].run_count == 3
+        # 2 paid runs + 1 zero-cost run + 1 review run on graph_a
+        assert by_agent[graph_a].run_count == 4
         assert by_agent[graph_b].cost_cents == 1070
         assert by_agent[graph_b].run_count == 3
         # graph_b leads on total spend so it sorts first
@@ -295,6 +314,22 @@ async def test_daily_buckets_group_by_utc_date(server: SpinTestServer):
             cost_cents=400,
             started_at=day2,
         )
+        await _create_run(
+            run_id=f"d2f-{uuid4()}",
+            user_id=user_id,
+            graph_id=graph_id,
+            status=AgentExecutionStatus.FAILED,
+            cost_cents=0,
+            started_at=day2,
+        )
+        await _create_run(
+            run_id=f"d2r-{uuid4()}",
+            user_id=user_id,
+            graph_id=graph_id,
+            status=AgentExecutionStatus.REVIEW,
+            cost_cents=0,
+            started_at=day2,
+        )
 
         summary = await get_user_cost_summary(
             user_id=user_id,
@@ -308,8 +343,14 @@ async def test_daily_buckets_group_by_utc_date(server: SpinTestServer):
         ]
         assert summary.daily[0].cost_cents == 350
         assert summary.daily[0].run_count == 2
+        assert summary.daily[0].success_count == 2
+        assert summary.daily[0].failed_count == 0
+        assert summary.daily[0].review_count == 0
         assert summary.daily[1].cost_cents == 400
-        assert summary.daily[1].run_count == 1
+        assert summary.daily[1].run_count == 3
+        assert summary.daily[1].success_count == 1
+        assert summary.daily[1].failed_count == 1
+        assert summary.daily[1].review_count == 1
     finally:
         await _cleanup(user_id, [graph_id])
 

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -25997,6 +25997,11 @@
             "title": "Total Duration Seconds",
             "default": 0
           },
+          "duration_run_count": {
+            "type": "integer",
+            "title": "Duration Run Count",
+            "default": 0
+          },
           "by_agent": {
             "items": { "$ref": "#/components/schemas/UserAgentCostRollup" },
             "type": "array",

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -25944,7 +25944,22 @@
         "properties": {
           "date": { "type": "string", "format": "date", "title": "Date" },
           "cost_cents": { "type": "integer", "title": "Cost Cents" },
-          "run_count": { "type": "integer", "title": "Run Count" }
+          "run_count": { "type": "integer", "title": "Run Count" },
+          "success_count": {
+            "type": "integer",
+            "title": "Success Count",
+            "default": 0
+          },
+          "failed_count": {
+            "type": "integer",
+            "title": "Failed Count",
+            "default": 0
+          },
+          "review_count": {
+            "type": "integer",
+            "title": "Review Count",
+            "default": 0
+          }
         },
         "type": "object",
         "required": ["date", "cost_cents", "run_count"],
@@ -25961,6 +25976,26 @@
           "failed_cost_cents": {
             "type": "integer",
             "title": "Failed Cost Cents"
+          },
+          "success_run_count": {
+            "type": "integer",
+            "title": "Success Run Count",
+            "default": 0
+          },
+          "failed_run_count": {
+            "type": "integer",
+            "title": "Failed Run Count",
+            "default": 0
+          },
+          "review_run_count": {
+            "type": "integer",
+            "title": "Review Run Count",
+            "default": 0
+          },
+          "total_duration_seconds": {
+            "type": "number",
+            "title": "Total Duration Seconds",
+            "default": 0
           },
           "by_agent": {
             "items": { "$ref": "#/components/schemas/UserAgentCostRollup" },


### PR DESCRIPTION
Part of [SECRT-2523](https://linear.app/autogpt/issue/SECRT-2523) — Home surface v1 (Home & Briefing).

### Why / What / How

**Why:** `get_user_cost_summary()` is the shared aggregation behind the usage/cost views, but it only returns money — total cents, billable runs, failed spend. Any consumer that wants an *activity* chart (runs over time, split by outcome) or an "avg run duration" stat has to issue a second query over the same `AgentGraphExecution` rows. The data is already in the scanned rows; we just weren't projecting it.

**What:** Adds per-status run counts and duration aggregates to the summary — both at the window level (`UserExecutionCostSummary`) and per day (`UserDailyCost`) — so a stacked activity chart can be built from the existing single call.

**How:** Extends the two existing aggregate queries (totals + daily) with `COUNT(*) FILTER (...)` clauses and a `SUM((stats->>'walltime')::numeric)`. No new query, no new round trip, same `WHERE` clause, so the `@@index([userId, isDeleted, createdAt])` hit is unchanged. Rows map into the models with the same `int()` / `float()` + `or 0` guards used for the existing columns.

Purely additive: every new field has a default, so existing consumers and the existing fields' behavior are untouched.

Two things worth calling out, both from review:

- **Duration reads `walltime`, not `duration`.** `update_graph_execution_stats()` persists `GraphExecutionStats.model_dump()`, whose field is `walltime` — nothing writes a `duration` key. The first cut of this PR aggregated `stats->>'duration'`, which would have been `0` for every real run, and the pre-existing `top_runs.duration_seconds` projection had the same bug. Both now read `walltime`, and the test fixture writes the real key so the assertions actually bite.
- **`total_duration_seconds` ships with its own denominator.** `run_count` includes QUEUED/RUNNING rows and rows with no stats, which `SUM` skips — dividing by it biases "avg run duration" downward. `duration_run_count` counts exactly the rows the sum draws from (same idea as `walltime_count` in `backend/data/generate_data.py`).

### Changes 🏗️

- `UserDailyCost`: `success_count`, `failed_count`, `review_count` (default `0`).
- `UserExecutionCostSummary`: `success_run_count`, `failed_run_count`, `review_run_count`, `total_duration_seconds`, `duration_run_count` (default `0`).
- Totals SQL: three `COUNT(*) FILTER` clauses (`COMPLETED`; `FAILED`/`TERMINATED`; `REVIEW`), `COALESCE(SUM((stats->>'walltime')::numeric), 0)::float`, and `COUNT(*) FILTER (WHERE (stats->>'walltime') IS NOT NULL)`.
- Daily SQL: the same three per-status `FILTER` counts, per bucket.
- Top-runs SQL: `duration_seconds` now projects `stats->>'walltime'` (pre-existing bug fix).
- The four aggregate queries moved into `_fetch_totals` / `_fetch_by_agent` / `_fetch_top_runs` / `_fetch_daily`, each owning its SQL and row→model mapping, with the shared predicate hoisted to `_BASE_WHERE`. `get_user_cost_summary` is window validation + `asyncio.gather` + assembly.
- `openapi.json` re-exported — the new response fields are optional with defaults, so no frontend change is required.
- Tests extended in `execution_cost_summary_test.py`: the fixture writes `walltime` (and can omit it entirely), a `REVIEW` run and a stats-less `RUNNING` run added to the mixed-status fixture (counts, duration sum, and duration denominator asserted), `FAILED` + `REVIEW` runs added to the daily-bucket fixture (per-day split asserted), and the empty-window test asserts the new fields are zeroed.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/data/execution_cost_summary_test.py` — 5 passed against real Postgres (mixed statuses produce the right per-status counts, duration sum, and duration denominator; the RUNNING run stays out of both; empty window returns zeros; existing cost/daily/dry-run assertions still hold)
  - [x] `poetry run pytest backend/api/features/v1_test.py -k cost` — 5 passed, the `/api/v1` cost-summary route is unaffected
  - [x] `poetry run format && poetry run lint` clean (ruff, isort, black, pyright)
  - [x] `poetry run export-api-schema` + prettier produces a 5-line diff (the new field only)