### PR TITLE
ci(platform): register single-container dispatch workflow

### DIFF
--- a/.github/workflows/platform-single-container-docker.yml
+++ b/.github/workflows/platform-single-container-docker.yml
@@ -1,0 +1,20 @@
+name: AutoGPT Platform - Single-container image
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the current dev commit to Docker Hub
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  default-branch-frame:
+    if: ${{ github.sha == '' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - run: ":"

--- a/.github/workflows/platform-single-container-docker.yml
+++ b/.github/workflows/platform-single-container-docker.yml
@@ -1,10 +1,11 @@
+# Registration-only on master; selecting dev loads the publishing workflow from dev.
 name: AutoGPT Platform - Single-container image
 
 on:
   workflow_dispatch:
     inputs:
       publish:
-        description: Publish the current dev commit to Docker Hub
+        description: Publish the current dev commit to Docker Hub (select dev as the ref)
         required: true
         type: boolean
         default: false
@@ -13,7 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  default-branch-frame:
+  registration-placeholder:
+    # workflow_dispatch always supplies a SHA, so this never allocates a runner.
     if: ${{ github.sha == '' }}
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
### Why / What / How

GitHub only exposes a manually dispatched workflow when the workflow file exists on the repository's default branch. The real single-container publisher is being developed on `dev`, so this PR registers the same workflow path and input on `master` without adding publishing behavior there.

The frame's only job is skipped before runner allocation for every valid dispatch: `workflow_dispatch` always supplies a commit SHA, while the job requires that SHA to be empty. Selecting `dev` as the dispatch ref uses the full workflow definition from `dev`.

### Changes 🏗️

- Register `.github/workflows/platform-single-container-docker.yml` on the default branch.
- Define the `publish` boolean input used by the `dev` workflow.
- Keep the default-branch frame inert: no checkout, actions, Docker operations, environments, secrets, or publishing permissions.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `actionlint .github/workflows/platform-single-container-docker.yml`
  - [x] `git diff --check`
  - [x] Pre-commit hooks
  - [x] Static audit confirms the workflow cannot allocate a runner, consume secrets, or publish

#### For configuration changes:

- [x] `.env.default` is already compatible; no environment variables change
- [x] `docker-compose.yml` is already compatible; no Compose behavior changes
- [x] Configuration changes are listed under **Changes**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only registration stub with a job condition that prevents runners or publishing on the default branch; no application or secret usage.
> 
> **Overview**
> GitHub only shows manually dispatched workflows when the workflow file exists on the **default branch**. This PR adds `.github/workflows/platform-single-container-docker.yml` on `master` as a **registration frame** only.
> 
> The workflow exposes the same **`publish`** boolean input as the real publisher on `dev`. When someone dispatches it and selects **`dev`** as the ref, GitHub runs the full definition from that branch.
> 
> On **default branch** runs, the sole job is gated with `if: ${{ github.sha == '' }}`, which is never true for `workflow_dispatch`, so **no runner is allocated** and there is no checkout, Docker, secrets, or publish behavior—only `contents: read`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011c3627c2ce1b7bfed29a19580a56525853bf30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->