### PR TITLE
feat(frontend/copilot): composer + menu opens the connect-service dialog

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ComposerPlusMenu.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ComposerPlusMenu.tsx
@@ -91,11 +91,11 @@ export function ComposerPlusMenu({
           <DropdownMenuItem
             onSelect={() => {
               onClearGuidedPrompt?.();
-              openModal("integrations");
+              openModal("connect");
             }}
           >
             <Icon icon={PlugSocketIcon} className="mr-2 h-4 w-4" />
-            Integrations
+            Connect service
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => openModal("skills")}>
             <Icon icon={BookOpen01Icon} className="mr-2 h-4 w-4" />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ComposerPlusMenu.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ComposerPlusMenu.test.tsx
@@ -33,7 +33,7 @@ describe("ComposerPlusMenu", () => {
     const items = await screen.findAllByRole("menuitem");
     expect(items.map((item) => item.textContent)).toEqual([
       "Attach file",
-      "Integrations",
+      "Connect service",
       "Skills",
       "Scheduled",
     ]);
@@ -53,7 +53,7 @@ describe("ComposerPlusMenu", () => {
     expect(screen.getByTestId("modal-probe").textContent).toBe("skills");
   });
 
-  it("selecting Scheduled and Integrations open their modals", async () => {
+  it("selecting Scheduled and Connect service open their modals", async () => {
     render(
       <>
         <ComposerPlusMenu onFilesSelected={vi.fn()} />
@@ -68,9 +68,9 @@ describe("ComposerPlusMenu", () => {
 
     openMenu();
     fireEvent.click(
-      await screen.findByRole("menuitem", { name: /integrations/i }),
+      await screen.findByRole("menuitem", { name: /connect service/i }),
     );
-    expect(screen.getByTestId("modal-probe").textContent).toBe("integrations");
+    expect(screen.getByTestId("modal-probe").textContent).toBe("connect");
   });
 
   it("adds a flat workspace option after Attach file when its flag is enabled", async () => {
@@ -88,7 +88,7 @@ describe("ComposerPlusMenu", () => {
     expect(items.map((item) => item.textContent)).toEqual([
       "Attach file",
       "Use File from Workspace",
-      "Integrations",
+      "Connect service",
       "Skills",
       "Scheduled",
     ]);
@@ -99,7 +99,7 @@ describe("ComposerPlusMenu", () => {
     expect(onUseWorkspaceFile).toHaveBeenCalledTimes(1);
   });
 
-  it("clears the guided prompt for Attach file and Integrations but not Skills or Scheduled", async () => {
+  it("clears the guided prompt for Attach file and Connect service but not Skills or Scheduled", async () => {
     const onClearGuidedPrompt = vi.fn();
     render(
       <ComposerPlusMenu
@@ -116,7 +116,7 @@ describe("ComposerPlusMenu", () => {
 
     openMenu();
     fireEvent.click(
-      await screen.findByRole("menuitem", { name: /integrations/i }),
+      await screen.findByRole("menuitem", { name: /connect service/i }),
     );
     expect(onClearGuidedPrompt).toHaveBeenCalledTimes(2);
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/CopilotModals.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/CopilotModals.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ConnectServiceDialog } from "@/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/ConnectServiceDialog";
 import { IntegrationsPanel } from "@/components/contextual/IntegrationsPanel/IntegrationsPanel";
 import { SchedulesPanel } from "@/components/contextual/SchedulesPanel/SchedulesPanel";
 import { SkillsPanel } from "@/components/contextual/SkillsPanel/SkillsPanel";
@@ -57,6 +58,11 @@ export function CopilotModals() {
           <IntegrationsPanel withHeading={false} />
         </Dialog.Content>
       </Dialog>
+
+      <ConnectServiceDialog
+        open={modal === "connect"}
+        onOpenChange={handleOpenChange}
+      />
     </>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/__tests__/CopilotModals.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/__tests__/CopilotModals.test.tsx
@@ -1,11 +1,20 @@
-import { getGetV1ListCredentialsMockHandler } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
+import {
+  getGetV1ListCredentialsMockHandler,
+  getGetV1ListProvidersMockHandler,
+} from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
 import {
   getGetV1ListExecutionSchedulesForAUserMockHandler,
   getListCopilotFollowupSchedulesMockHandler,
 } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
 import { getListCopilotSkillsMockHandler } from "@/app/api/__generated__/endpoints/skills/skills.msw";
 import { server } from "@/mocks/mock-server";
-import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@/tests/integrations/test-utils";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { useCopilotUIStore } from "../../../store";
 import { useCopilotModal } from "../../../useCopilotModal";
@@ -13,14 +22,29 @@ import { CopilotModals } from "../CopilotModals";
 
 function Harness() {
   const { openModal } = useCopilotModal();
+
+  function openSkills() {
+    openModal("skills");
+  }
+
+  function openScheduled() {
+    openModal("scheduled");
+  }
+
+  function openIntegrations() {
+    openModal("integrations");
+  }
+
+  function openConnect() {
+    openModal("connect");
+  }
+
   return (
     <>
-      <button onClick={() => openModal("skills")}>open-skills</button>
-      <button onClick={() => openModal("scheduled")}>open-scheduled</button>
-      <button onClick={() => openModal("integrations")}>
-        open-integrations
-      </button>
-      <button onClick={() => openModal("connect")}>open-connect</button>
+      <button onClick={openSkills}>open-skills</button>
+      <button onClick={openScheduled}>open-scheduled</button>
+      <button onClick={openIntegrations}>open-integrations</button>
+      <button onClick={openConnect}>open-connect</button>
       <CopilotModals />
     </>
   );
@@ -99,10 +123,56 @@ describe("CopilotModals", () => {
   });
 
   test("opens the connect dialog directly, without the credentials list", async () => {
+    server.use(
+      getGetV1ListProvidersMockHandler([
+        {
+          name: "github",
+          description: "Issues and PRs",
+          supported_auth_types: ["oauth2", "api_key"],
+        },
+      ]),
+    );
     render(<Harness />);
     fireEvent.click(screen.getByText("open-connect"));
 
-    expect(await screen.findByText("Connect a service")).toBeDefined();
-    expect(screen.queryByText("Third Party Integrations")).toBeNull();
+    const dialog = await screen.findByRole("dialog");
+    expect(await within(dialog).findByText("Issues and PRs")).toBeDefined();
+    expect(screen.queryByText("No integration connected")).toBeNull();
+  });
+
+  test("renders the connect dialog from a ?modal=connect deep link", async () => {
+    render(
+      <NuqsTestingAdapter searchParams="?modal=connect">
+        <Harness />
+      </NuqsTestingAdapter>,
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Connect a service")).toBeDefined();
+  });
+
+  test("closing the connect dialog clears the modal query param", async () => {
+    const onUrlUpdate = vi.fn();
+    render(
+      <NuqsTestingAdapter
+        searchParams="?modal=connect"
+        onUrlUpdate={onUrlUpdate}
+      >
+        <Harness />
+      </NuqsTestingAdapter>,
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    await vi.waitFor(() => {
+      expect(
+        onUrlUpdate.mock.calls.at(-1)?.[0].searchParams.get("modal"),
+      ).toBeNull();
+      expect(onUrlUpdate).toHaveBeenCalled();
+    });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/__tests__/CopilotModals.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/__tests__/CopilotModals.test.tsx
@@ -20,6 +20,7 @@ function Harness() {
       <button onClick={() => openModal("integrations")}>
         open-integrations
       </button>
+      <button onClick={() => openModal("connect")}>open-connect</button>
       <CopilotModals />
     </>
   );
@@ -95,5 +96,13 @@ describe("CopilotModals", () => {
     expect(
       (await screen.findAllByText("Connect Service")).length,
     ).toBeGreaterThan(0);
+  });
+
+  test("opens the connect dialog directly, without the credentials list", async () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByText("open-connect"));
+
+    expect(await screen.findByText("Connect a service")).toBeDefined();
+    expect(screen.queryByText("Third Party Integrations")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotModal.ts
@@ -1,6 +1,11 @@
 import { parseAsStringLiteral, useQueryState } from "nuqs";
 
-export const COPILOT_MODALS = ["integrations", "skills", "scheduled"] as const;
+export const COPILOT_MODALS = [
+  "integrations",
+  "connect",
+  "skills",
+  "scheduled",
+] as const;
 export type CopilotModalType = (typeof COPILOT_MODALS)[number];
 
 export function useCopilotModal() {


### PR DESCRIPTION
### Why / What / How

**Why:** The composer `+` menu in CoPilot had an item labelled **"Integrations"** that opened the *Third Party Integrations* panel — a list of credentials the user has **already** connected. That's the wrong destination for the intent behind the click. Someone opening that menu mid-conversation wants to *add* a service so AutoPilot can use it, not audit what they already have. The action they actually wanted sat two clicks deep, behind a "Connect Service" button inside the panel.

There was a structural problem behind that button too. `ConnectServiceDialog` is rendered inside `IntegrationsPanel`, so opening it from the CoPilot modal meant a Radix Dialog nested inside another Radix Dialog — sharing `z-50` for both overlay and content (`components/styles.ts:5-12`), inside the outer `DismissableLayer` and `RemoveScroll`. The inner dialog only landed on top by portal insertion order. On `/settings/integrations` the same panel renders at top level with no outer dialog, which is why that path never showed the problem and why the nested path had no test coverage.

**What:** The `+` menu now opens **Connect a service** directly, as a top-level dialog.

**How:** Added a `connect` entry to `COPILOT_MODALS`, so the dialog is driven by the same `?modal=` query state as skills/scheduled and is deep-linkable. `ConnectServiceDialog` already takes `open` / `onOpenChange`, so it drops into `CopilotModals` as a sibling of the other dialogs with no changes to the component itself.

Rendering it as a sibling rather than nested is the point: it is no longer inside the integrations dialog's portal, so the stacking and dismissal ambiguity described above cannot occur on this path.

The existing `integrations` modal is left wired, so `/copilot?modal=integrations` still opens the credentials panel for anyone with that link.

### Changes 🏗️

**`useCopilotModal.ts`**
- Added `"connect"` to `COPILOT_MODALS` alongside `integrations` / `skills` / `scheduled`

**`CopilotModals.tsx`**
- Renders `<ConnectServiceDialog>` at the top level, gated on `modal === "connect"`, reusing the shared `handleOpenChange`

**`ComposerPlusMenu.tsx`**
- The menu item now calls `openModal("connect")` and is relabelled **"Connect service"**. The old "Integrations" label no longer described what the item opens; leaving it would have been a worse lie than before.

**Tests**
- `CopilotModals.test.tsx` — new case: opening `connect` shows "Connect a service" and does *not* render the "Third Party Integrations" panel
- `ComposerPlusMenu.test.tsx` — updated the menu-order fixtures and the modal-target assertion to the new label and `connect` target

### Behaviour note for reviewers

The credentials list is no longer reachable from the CoPilot `+` menu. That is the intended change, but worth naming explicitly:

- Still available at `/settings/integrations`
- Still available via the `/copilot?modal=integrations` deep link

If we want it back in-product from CoPilot, the natural follow-up is a "Manage connections" link inside the Connect dialog rather than a second menu item.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm test:unit` — `CopilotModals.test.tsx` + `ComposerPlusMenu.test.tsx` pass (12 cases)
  - [x] `pnpm types` clean, `pnpm format` / `pnpm lint` clean
  - [ ] `/copilot` → `+` → menu reads: Attach file, Connect service, Skills, Scheduled
  - [ ] Click **Connect service** → "Connect a service" dialog opens, URL becomes `?modal=connect`
  - [ ] Provider list renders, search filters it, clicking a provider shows the detail view with OAuth / API-key tabs
  - [ ] Completing a connection closes the dialog and clears the `modal` param
  - [ ] Escape and outside-click both dismiss cleanly, with no stuck overlay or lost scroll
  - [ ] `/copilot?modal=integrations` still opens the credentials panel
  - [ ] Skills and Scheduled modals still open from the same menu
  - [ ] Below 1024px the dialog renders as a drawer and still behaves

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
