### PR TITLE
ci: debounce CLA label demotion in cla-label-sync.yml

### DIFF
--- a/.github/workflows/cla-label-sync.yml
+++ b/.github/workflows/cla-label-sync.yml
@@ -43,6 +43,13 @@ env:
   REMINDER_DAYS: 7        # Days before first reminder
   CLOSE_WARNING_DAYS: 23  # Days before "closing soon" warning
   CLOSE_DAYS: 30          # Days before auto-close
+  # Debounce before demoting cla:signed -> cla:pending. CLA-assistant
+  # re-verifies per commit SHA, so an already-signed contributor's status can
+  # transiently flip to pending/failure on repeated status events for the
+  # same commit. Waiting this long and re-checking filters that noise while
+  # still catching a genuinely new unsigned commit (e.g. pushed under a
+  # different git identity).
+  DEMOTE_DEBOUNCE_SECONDS: 75
 
 jobs:
   sync-labels:
@@ -93,12 +100,14 @@ jobs:
             const REMINDER_DAYS = parseInt(process.env.REMINDER_DAYS);
             const CLOSE_WARNING_DAYS = parseInt(process.env.CLOSE_WARNING_DAYS);
             const CLOSE_DAYS = parseInt(process.env.CLOSE_DAYS);
+            const DEMOTE_DEBOUNCE_SECONDS = parseInt(process.env.DEMOTE_DEBOUNCE_SECONDS);
             
             // Validate timing configuration
-            if ([REMINDER_DAYS, CLOSE_WARNING_DAYS, CLOSE_DAYS].some(Number.isNaN)) {
-              core.setFailed('Invalid timing configuration — REMINDER_DAYS, CLOSE_WARNING_DAYS, and CLOSE_DAYS must be numeric.');
+            if ([REMINDER_DAYS, CLOSE_WARNING_DAYS, CLOSE_DAYS, DEMOTE_DEBOUNCE_SECONDS].some(Number.isNaN)) {
+              core.setFailed('Invalid timing configuration — REMINDER_DAYS, CLOSE_WARNING_DAYS, CLOSE_DAYS, and DEMOTE_DEBOUNCE_SECONDS must be numeric.');
               return;
             }
+            const DEMOTE_DEBOUNCE_MS = DEMOTE_DEBOUNCE_SECONDS * 1000;
             if (!(REMINDER_DAYS < CLOSE_WARNING_DAYS && CLOSE_WARNING_DAYS < CLOSE_DAYS)) {
               core.warning(`Timing order looks odd: REMINDER(${REMINDER_DAYS}) < WARNING(${CLOSE_WARNING_DAYS}) < CLOSE(${CLOSE_DAYS}) expected.`);
             }
@@ -267,12 +276,29 @@ jobs:
                   }
                 }
                 
-                const claStatus = await getClaStatus(pr.head.sha);
+                let claStatus = await getClaStatus(pr.head.sha);
                 const hasPending = currentLabels.includes(LABEL_PENDING);
                 const hasSigned = currentLabels.includes(LABEL_SIGNED);
                 const prAgeDays = daysSince(pr.created_at);
                 
                 console.log(`PR #${prNumber}: CLA ${claStatus.passed ? 'passed' : 'pending'} (${claStatus.state}), age: ${prAgeDays} days`);
+                
+                // Debounce demotion: if this PR was previously confirmed signed
+                // but the latest check no longer shows a pass, wait and re-check
+                // before treating it as a real demotion. CLA-assistant
+                // re-verifies per commit SHA, so an already-signed contributor's
+                // status can transiently flip to pending/failure on repeated
+                // status events for the same commit — without this, that flip
+                // causes an immediate label add/remove + possible comment churn.
+                // A genuinely new unsigned commit (e.g. pushed under a different,
+                // unsigned git identity) still shows unsigned after the delay, so
+                // it's still demoted correctly below.
+                if (hasSigned && !claStatus.passed) {
+                  console.log(`PR #${prNumber}: was signed but now shows ${claStatus.state} — debouncing ${DEMOTE_DEBOUNCE_SECONDS}s before demoting`);
+                  await new Promise(resolve => setTimeout(resolve, DEMOTE_DEBOUNCE_MS));
+                  claStatus = await getClaStatus(pr.head.sha);
+                  console.log(`PR #${prNumber}: post-debounce CLA ${claStatus.passed ? 'passed' : 'still ' + claStatus.state}`);
+                }
                 
                 if (claStatus.passed) {
                   // ✅ CLA signed - add signed label, remove pending

--- a/.github/workflows/cla-label-sync.yml
+++ b/.github/workflows/cla-label-sync.yml
@@ -100,11 +100,15 @@ jobs:
             const REMINDER_DAYS = parseInt(process.env.REMINDER_DAYS);
             const CLOSE_WARNING_DAYS = parseInt(process.env.CLOSE_WARNING_DAYS);
             const CLOSE_DAYS = parseInt(process.env.CLOSE_DAYS);
-            const DEMOTE_DEBOUNCE_SECONDS = parseInt(process.env.DEMOTE_DEBOUNCE_SECONDS);
+            const DEMOTE_DEBOUNCE_SECONDS = Number(process.env.DEMOTE_DEBOUNCE_SECONDS);
             
             // Validate timing configuration
-            if ([REMINDER_DAYS, CLOSE_WARNING_DAYS, CLOSE_DAYS, DEMOTE_DEBOUNCE_SECONDS].some(Number.isNaN)) {
-              core.setFailed('Invalid timing configuration — REMINDER_DAYS, CLOSE_WARNING_DAYS, CLOSE_DAYS, and DEMOTE_DEBOUNCE_SECONDS must be numeric.');
+            if ([REMINDER_DAYS, CLOSE_WARNING_DAYS, CLOSE_DAYS].some(Number.isNaN)) {
+              core.setFailed('Invalid timing configuration — REMINDER_DAYS, CLOSE_WARNING_DAYS, and CLOSE_DAYS must be numeric.');
+              return;
+            }
+            if (!Number.isInteger(DEMOTE_DEBOUNCE_SECONDS) || DEMOTE_DEBOUNCE_SECONDS < 0) {
+              core.setFailed('Invalid timing configuration — DEMOTE_DEBOUNCE_SECONDS must be a non-negative integer.');
               return;
             }
             const DEMOTE_DEBOUNCE_MS = DEMOTE_DEBOUNCE_SECONDS * 1000;
@@ -235,7 +239,7 @@ jobs:
             for (const prNumber of prsToCheck) {
               try {
                 // Get PR details
-                const { data: pr } = await github.rest.pulls.get({
+                let { data: pr } = await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: prNumber
@@ -254,7 +258,7 @@ jobs:
                 }
                 
                 // Skip if PR already has cla: signed label (optimization for scheduled sweeps)
-                const currentLabels = pr.labels.map(l => l.name);
+                let currentLabels = pr.labels.map(l => l.name);
                 const knownPlatformPR = currentLabels.includes(LABEL_SIGNED) || currentLabels.includes(LABEL_PENDING);
                 
                 // Skip listFiles if we've already labelled this PR (a previous run verified it touches platform code)
@@ -277,8 +281,8 @@ jobs:
                 }
                 
                 let claStatus = await getClaStatus(pr.head.sha);
-                const hasPending = currentLabels.includes(LABEL_PENDING);
-                const hasSigned = currentLabels.includes(LABEL_SIGNED);
+                let hasPending = currentLabels.includes(LABEL_PENDING);
+                let hasSigned = currentLabels.includes(LABEL_SIGNED);
                 const prAgeDays = daysSince(pr.created_at);
                 
                 console.log(`PR #${prNumber}: CLA ${claStatus.passed ? 'passed' : 'pending'} (${claStatus.state}), age: ${prAgeDays} days`);
@@ -296,7 +300,26 @@ jobs:
                 if (hasSigned && !claStatus.passed) {
                   console.log(`PR #${prNumber}: was signed but now shows ${claStatus.state} — debouncing ${DEMOTE_DEBOUNCE_SECONDS}s before demoting`);
                   await new Promise(resolve => setTimeout(resolve, DEMOTE_DEBOUNCE_MS));
-                  claStatus = await getClaStatus(pr.head.sha);
+                  
+                  // Re-fetch the PR — a new commit could have been pushed, or the
+                  // PR closed, while we were waiting. Evaluate the refreshed state
+                  // rather than the one captured before the delay.
+                  const { data: refreshedPr } = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber
+                  });
+                  
+                  if (refreshedPr.state !== 'open') {
+                    console.log(`PR #${prNumber}: no longer open after debounce — skipping`);
+                    continue;
+                  }
+                  
+                  pr = refreshedPr;
+                  currentLabels = refreshedPr.labels.map(l => l.name);
+                  hasPending = currentLabels.includes(LABEL_PENDING);
+                  hasSigned = currentLabels.includes(LABEL_SIGNED);
+                  claStatus = await getClaStatus(refreshedPr.head.sha);
                   console.log(`PR #${prNumber}: post-debounce CLA ${claStatus.passed ? 'passed' : 'still ' + claStatus.state}`);
                 }
                 


### PR DESCRIPTION
## Problem

CLA-assistant re-verifies the `license/cla` status **per commit SHA**, not per person/PR. For an already-signed contributor, that status can transiently flip through pending/failure states before settling back to success on every push.

`cla-label-sync.yml` (introduced in #12002) reacts to every `status` event, so it was flipping `cla: signed` off and `cla: pending` on for these transient states, then flipping back moments later — visible as rapid label churn on PRs. Reported by @Bentlybro on #13999.

## Fix

Add a `DEMOTE_DEBOUNCE_SECONDS` (default 75s) debounce before demoting a PR that's currently labeled `cla: signed`:

- If the latest CLA check for a previously-signed PR doesn't pass, wait `DEMOTE_DEBOUNCE_SECONDS` and re-check once before actually removing `cla: signed` / adding `cla: pending`.
- If the re-check now passes, skip the demotion — this filters the same-commit transient noise.
- If it's still failing after the delay, demote as before. This still correctly handles a genuinely new unsigned commit (e.g. pushed under a different git identity), since that state persists well past the debounce window rather than resolving.

Promotions (`cla: pending` → `cla: signed`) are unaffected and remain instant.

## Why this approach

Considered "once signed, never auto-demote except via the scheduled sweep," but that would mask a new commit pushed under a different, unsigned identity for up to a day. The debounce preserves correctness for that case while removing the flip-flop noise for the common transient case.

cc @ntindle @0ubbe — flagging since you were involved in #12002.