### PR TITLE
perf(platform): cache shared subscription tier lookups

### DIFF
--- a/autogpt_platform/backend/backend/api/conftest.py
+++ b/autogpt_platform/backend/backend/api/conftest.py
@@ -88,7 +88,7 @@ def _bypass_paywall(mocker):
     raise ``UserPaywalledError`` from ``add_graph_execution`` once the
     paywall is wired up. Tests that specifically exercise the paywall
     (e.g. ``TestEnforcePaymentPaywall``, ``TestIsUserPaywalled``) live
-    in ``rate_limit_test.py`` and patch ``_fetch_user_tier`` directly,
+    in ``rate_limit_test.py`` and patch ``get_user_subscription_tier`` directly,
     bypassing this helper.
     """
     paywall_off = mocker.AsyncMock(return_value=False)

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -54,47 +54,28 @@ boundary above is the contract.
 import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
-from enum import Enum
 
 import fastapi
 from autogpt_libs.auth.dependencies import get_user_id
-from prisma.models import User as PrismaUser
+from prisma.enums import SubscriptionTier
 from pydantic import BaseModel, Field
 from redis.exceptions import RedisClusterException, RedisError
 
-from backend.data.db_accessors import credit_db, user_db
+from backend.data.db_accessors import credit_db
 from backend.data.redis_client import AsyncRedisClient, get_redis_async
 from backend.data.user import get_user_by_id
 from backend.util.cache import cached
 from backend.util.feature_flag import Flag, get_feature_flag_value, is_feature_enabled
+from backend.util.subscription_tiers import (
+    SubscriptionTierUserNotFoundError,
+    get_user_subscription_tier,
+)
 
 logger = logging.getLogger(__name__)
 
 # "copilot:cost" (not the legacy "copilot:usage") so stale token-based
 # counters are not misread as microdollars.
 _USAGE_KEY_PREFIX = "copilot:cost"
-
-
-# ---------------------------------------------------------------------------
-# Subscription tier definitions
-# ---------------------------------------------------------------------------
-
-
-class SubscriptionTier(str, Enum):
-    """Subscription tiers with increasing cost allowances.
-
-    Mirrors the ``SubscriptionTier`` enum in ``schema.prisma``.
-    Once ``prisma generate`` is run, this can be replaced with::
-
-        from prisma.enums import SubscriptionTier
-    """
-
-    NO_TIER = "NO_TIER"
-    BASIC = "BASIC"
-    PRO = "PRO"
-    MAX = "MAX"
-    BUSINESS = "BUSINESS"
-    ENTERPRISE = "ENTERPRISE"
 
 
 # Default multiplier applied to the base cost limits (from LD / config) for each
@@ -911,39 +892,6 @@ async def _decr_counter_floor_zero(
     await redis.eval(_DECR_FLOOR_ZERO_SCRIPT, 1, key, delta)
 
 
-class _UserNotFoundError(Exception):
-    """Raised when a user record is missing or has no subscription tier.
-
-    Raising (rather than returning ``DEFAULT_TIER``) prevents ``@cached``
-    from persisting the fallback, which would otherwise keep serving FREE
-    for up to the TTL after the user's real tier is set.
-    """
-
-
-@cached(maxsize=1000, ttl_seconds=300, shared_cache=True)
-async def _fetch_user_tier(user_id: str) -> SubscriptionTier:
-    """Fetch the user's rate-limit tier, cached across pods.
-
-    Only successful lookups are cached. Missing users raise
-    ``_UserNotFoundError`` so ``@cached`` never stores the fallback.
-
-    Distinguishes "row genuinely missing" (``user_db().get_user_by_id``
-    raises ``ValueError``) from "transient DB / Prisma error" (other
-    exceptions propagate as-is). Without this distinction a Supabase
-    blip would silently degrade every paying user to NO_TIER and
-    ``enforce_payment_paywall`` would 402 them — contradicting its
-    503-on-blip contract.
-    """
-    try:
-        user = await user_db().get_user_by_id(user_id)
-    except ValueError:
-        # ValueError = "User not found" per get_user_by_id's contract.
-        raise _UserNotFoundError(user_id)
-    if user.subscription_tier:
-        return SubscriptionTier(user.subscription_tier)
-    raise _UserNotFoundError(user_id)
-
-
 _STRIPE_RECONCILE_PREFIX = "stripe_reconcile:"
 _STRIPE_RECONCILE_TTL = 300  # seconds — matches the tier cache TTL
 
@@ -986,7 +934,7 @@ async def _maybe_reconcile_stripe_tier(user_id: str) -> bool:
 async def get_user_tier(user_id: str) -> SubscriptionTier:
     """Look up the user's rate-limit tier from the database.
 
-    Successful results are cached for 5 minutes (via ``_fetch_user_tier``)
+    Successful results are cached for 5 minutes by the shared tier resolver
     to avoid a DB round-trip on every rate-limit check.
 
     Falls back to ``DEFAULT_TIER`` **without caching** when the DB is
@@ -999,9 +947,9 @@ async def get_user_tier(user_id: str) -> SubscriptionTier:
     """
     tier_from_db = True
     try:
-        tier = await _fetch_user_tier(user_id)
-    except _UserNotFoundError:
-        # Row missing or tier is NULL — DB-confirmed NO_TIER, eligible for reconciliation.
+        tier = await get_user_subscription_tier(user_id)
+    except SubscriptionTierUserNotFoundError:
+        # A missing row is eligible for Stripe reconciliation as NO_TIER.
         tier = SubscriptionTier.NO_TIER
     except Exception as exc:
         logger.warning(
@@ -1018,7 +966,7 @@ async def get_user_tier(user_id: str) -> SubscriptionTier:
 
     if tier_from_db and await _maybe_reconcile_stripe_tier(user_id):
         try:
-            return await _fetch_user_tier(user_id)
+            return await get_user_subscription_tier(user_id)
         except Exception as exc:
             logger.warning(
                 "get_user_tier: tier re-read failed after reconciliation for %s: %s",
@@ -1029,10 +977,8 @@ async def get_user_tier(user_id: str) -> SubscriptionTier:
     return tier
 
 
-# Expose cache management on the public function so callers (including tests)
-# never need to reach into the private ``_fetch_user_tier``.
-get_user_tier.cache_clear = _fetch_user_tier.cache_clear  # type: ignore[attr-defined]
-get_user_tier.cache_delete = _fetch_user_tier.cache_delete  # type: ignore[attr-defined]
+get_user_tier.cache_clear = get_user_subscription_tier.cache_clear  # type: ignore[attr-defined]
+get_user_tier.cache_delete = get_user_subscription_tier.cache_delete  # type: ignore[attr-defined]
 
 
 async def get_workspace_storage_limit_bytes(user_id: str) -> int:
@@ -1059,19 +1005,17 @@ async def set_user_tier(user_id: str, tier: SubscriptionTier) -> None:
     Raises:
         prisma.errors.RecordNotFoundError: If the user does not exist.
     """
-    await PrismaUser.prisma().update(
-        where={"id": user_id},
-        data={"subscriptionTier": tier.value},
-    )
-    get_user_tier.cache_delete(user_id)  # type: ignore[attr-defined]
-    # Local import: backend.data.credit imports from this module.
-    from backend.data.credit import get_pending_subscription_change
-
-    get_user_by_id.cache_delete(user_id)  # type: ignore[attr-defined]
-    get_pending_subscription_change.cache_delete(user_id)  # type: ignore[attr-defined]
+    await _persist_user_subscription_tier(user_id, tier)
 
     # Fire-and-forget drift check so admin bulk ops don't wait on Stripe.
     asyncio.ensure_future(_drift_check_background(user_id, tier))
+
+
+async def _persist_user_subscription_tier(user_id: str, tier: SubscriptionTier) -> None:
+    # Importing credit here avoids its block-catalog dependency during module startup.
+    from backend.data.credit import set_subscription_tier
+
+    await set_subscription_tier(user_id, tier)
 
 
 async def _drift_check_background(user_id: str, tier: SubscriptionTier) -> None:
@@ -1293,7 +1237,7 @@ def _weekly_reset_time(now: datetime | None = None) -> datetime:
 async def is_user_paywalled(user_id: str) -> bool:
     """Return ``True`` if the user has no entitlement to paywalled features.
 
-    A user with no DB tier record (``_UserNotFoundError`` — fresh signup
+    A user with no DB tier record (``SubscriptionTierUserNotFoundError`` — fresh signup
     that hasn't been provisioned yet, or row missing) is treated as
     ``NO_TIER`` here: paywalled iff ``ENABLE_PLATFORM_PAYMENT`` is on.
     Without this branch the missing-tier case would propagate as a 500
@@ -1304,8 +1248,8 @@ async def is_user_paywalled(user_id: str) -> bool:
     background job → fail-open).
     """
     try:
-        tier = await _fetch_user_tier(user_id)
-    except _UserNotFoundError:
+        tier = await get_user_subscription_tier(user_id)
+    except SubscriptionTierUserNotFoundError:
         # No DB row / no subscription_tier set — fresh signup that hasn't
         # been provisioned yet, or row missing entirely. Logged at debug
         # so ops can correlate "402s on fresh signups" with provisioning

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -1,10 +1,14 @@
 """Unit tests for CoPilot rate limiting."""
 
+import asyncio
 from datetime import UTC, datetime, timedelta
+from typing import Any, Coroutine
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from redis.exceptions import RedisClusterException, RedisError
+
+from backend.util.subscription_tiers import SubscriptionTierUserNotFoundError
 
 from .rate_limit import (
     _DEFAULT_TIER_MULTIPLIERS,
@@ -407,7 +411,7 @@ class TestCoPilotUsagePublicFromStatus:
 
 class TestEnforcePaymentPaywall:
     """The dep bypasses ``get_user_tier``'s fail-open default and goes
-    through ``_fetch_user_tier`` directly so a transient DB blip raises
+    through ``get_user_subscription_tier`` directly so a transient DB blip raises
     503 instead of silently 402-ing every paid user."""
 
     @pytest.mark.asyncio
@@ -418,7 +422,7 @@ class TestEnforcePaymentPaywall:
         this to HTTP 402 — the dep itself doesn't construct an
         HTTPException so all gates share the same exception type."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -435,7 +439,7 @@ class TestEnforcePaymentPaywall:
     async def test_allows_no_tier_user_when_flag_off(self, mocker):
         """Beta cohort: flag off → NO_TIER user passes through (no exception)."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -460,7 +464,7 @@ class TestEnforcePaymentPaywall:
     async def test_allows_paid_tier_even_when_flag_on(self, mocker, tier):
         """Even with the flag on, paid tiers must never be blocked."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=tier),
         )
         is_feature_enabled_mock = mocker.patch(
@@ -484,7 +488,7 @@ class TestIsUserPaywalled:
     @pytest.mark.asyncio
     async def test_no_tier_with_flag_on_is_paywalled(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -498,7 +502,7 @@ class TestIsUserPaywalled:
     @pytest.mark.asyncio
     async def test_no_tier_with_flag_off_is_not_paywalled(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -522,7 +526,7 @@ class TestIsUserPaywalled:
     )
     async def test_paid_tier_short_circuits_without_flag_lookup(self, mocker, tier):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=tier),
         )
         flag_mock = mocker.patch(
@@ -540,7 +544,7 @@ class TestIsUserPaywalled:
         decide. The route-dep maps to 503; background callers
         (add_graph_execution) fail open."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(side_effect=RuntimeError("DB down")),
         )
         from .rate_limit import is_user_paywalled
@@ -550,15 +554,14 @@ class TestIsUserPaywalled:
 
     @pytest.mark.asyncio
     async def test_user_not_found_treated_as_no_tier_when_flag_on(self, mocker):
-        """``_UserNotFoundError`` (no DB row, or no ``subscription_tier``
-        set yet on a fresh signup) is treated as NO_TIER so callers without
+        """A missing DB user is treated as NO_TIER so callers without
         a generic ``except`` (e.g. the external API ``execute_graph_block``
         route) get a real 402 instead of a leaked 500."""
-        from .rate_limit import _UserNotFoundError, is_user_paywalled
+        from .rate_limit import is_user_paywalled
 
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
-            new=AsyncMock(side_effect=_UserNotFoundError(_USER)),
+            "backend.copilot.rate_limit.get_user_subscription_tier",
+            new=AsyncMock(side_effect=SubscriptionTierUserNotFoundError(_USER)),
         )
         mocker.patch(
             "backend.copilot.rate_limit.is_feature_enabled",
@@ -570,11 +573,11 @@ class TestIsUserPaywalled:
     async def test_user_not_found_treated_as_no_tier_when_flag_off(self, mocker):
         """Beta cohort: missing tier + flag off → not paywalled (same
         passthrough as a real NO_TIER user with the flag off)."""
-        from .rate_limit import _UserNotFoundError, is_user_paywalled
+        from .rate_limit import is_user_paywalled
 
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
-            new=AsyncMock(side_effect=_UserNotFoundError(_USER)),
+            "backend.copilot.rate_limit.get_user_subscription_tier",
+            new=AsyncMock(side_effect=SubscriptionTierUserNotFoundError(_USER)),
         )
         mocker.patch(
             "backend.copilot.rate_limit.is_feature_enabled",
@@ -595,63 +598,6 @@ class TestUserPaywalledError:
         assert str(UserPaywalledError("custom")) == "custom"
 
 
-class TestFetchUserTierErrorPropagation:
-    """``_fetch_user_tier`` must distinguish "row missing" (raises
-    ``ValueError`` via ``get_user_by_id``) from "transient DB error"
-    (Prisma connection failure etc). Without this distinction a
-    Supabase blip would silently degrade every paying user to NO_TIER
-    and ``enforce_payment_paywall`` would 402 them — contradicting its
-    503-on-blip contract. Regression locked here."""
-
-    @pytest.fixture(autouse=True)
-    def _clear_cache(self):
-        from .rate_limit import _fetch_user_tier
-
-        _fetch_user_tier.cache_clear()  # type: ignore[attr-defined]
-
-    @pytest.mark.asyncio
-    async def test_value_error_collapses_to_user_not_found(self, mocker):
-        """ValueError from get_user_by_id is the documented "missing user"
-        signal — it's correct to map this to NO_TIER (via
-        _UserNotFoundError → caught in is_user_paywalled)."""
-        mock_db = mocker.MagicMock()
-        mock_db.get_user_by_id = AsyncMock(side_effect=ValueError("User not found"))
-        mocker.patch("backend.copilot.rate_limit.user_db", return_value=mock_db)
-        from .rate_limit import _fetch_user_tier, _UserNotFoundError
-
-        with pytest.raises(_UserNotFoundError):
-            await _fetch_user_tier(_USER)
-
-    @pytest.mark.asyncio
-    async def test_db_outage_propagates(self, mocker):
-        """Non-ValueError exceptions (Prisma connection failure, generic
-        RuntimeError) propagate as-is so route layer can map to 503."""
-        mock_db = mocker.MagicMock()
-        mock_db.get_user_by_id = AsyncMock(side_effect=RuntimeError("Prisma down"))
-        mocker.patch("backend.copilot.rate_limit.user_db", return_value=mock_db)
-        from .rate_limit import _fetch_user_tier
-
-        with pytest.raises(RuntimeError, match="Prisma down"):
-            await _fetch_user_tier(_USER)
-
-    @pytest.mark.asyncio
-    async def test_db_outage_does_not_collapse_to_402_for_paying_user(self, mocker):
-        """End-to-end: a Supabase blip during enforce_payment_paywall
-        for any user (paying or not) maps to 503, NOT 402. Locks the
-        contract advertised in enforce_payment_paywall's docstring."""
-        mock_db = mocker.MagicMock()
-        mock_db.get_user_by_id = AsyncMock(side_effect=RuntimeError("Supabase blip"))
-        mocker.patch("backend.copilot.rate_limit.user_db", return_value=mock_db)
-        from fastapi import HTTPException
-
-        from .rate_limit import enforce_payment_paywall
-
-        with pytest.raises(HTTPException) as exc_info:
-            await enforce_payment_paywall(_USER)
-        assert exc_info.value.status_code == 503  # not 402
-        assert exc_info.value.headers.get("Retry-After") == "30"
-
-
 class TestEnforcePaymentPaywallInline:
     """``enforce_payment_paywall`` doubles as both a JWT route dep AND an
     inline call from non-JWT routes (external API graph + block execute).
@@ -661,7 +607,7 @@ class TestEnforcePaymentPaywallInline:
     @pytest.mark.asyncio
     async def test_blocks_paywalled_user(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -676,7 +622,7 @@ class TestEnforcePaymentPaywallInline:
     @pytest.mark.asyncio
     async def test_passes_paid_user(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(return_value=SubscriptionTier.PRO),
         )
         from .rate_limit import enforce_payment_paywall
@@ -689,7 +635,7 @@ class TestEnforcePaymentPaywallInline:
         the asymmetry fix: external API + internal graph routes used to
         fail-open via the deep gate; now they fail-closed at the route."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(side_effect=RuntimeError("DB down")),
         )
         from fastapi import HTTPException
@@ -715,7 +661,7 @@ class TestEnforcePaymentPaywallContinued:
         header so the client retries shortly instead of treating the
         outage as a permanent paywall."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit.get_user_subscription_tier",
             new=AsyncMock(side_effect=RuntimeError("DB down")),
         )
         is_feature_enabled_mock = mocker.patch(
@@ -1278,53 +1224,55 @@ class TestGetGlobalRateLimitsCostLimitsFlag:
 
 
 class TestGetUserTier:
-    @pytest.fixture(autouse=True)
-    def _clear_tier_cache(self):
-        """Clear the get_user_tier cache before each test."""
-        get_user_tier.cache_clear()  # type: ignore[attr-defined]
-
-    def _mock_user_db(
-        self, subscription_tier: str | None = None, raises: Exception | None = None
-    ):
-        """Return a patched user_db() whose get_user_by_id behaves as specified."""
-        mock_db = AsyncMock()
-        if raises is not None:
-            mock_db.get_user_by_id = AsyncMock(side_effect=raises)
-        else:
-            mock_user = MagicMock()
-            mock_user.subscription_tier = subscription_tier
-            mock_db.get_user_by_id = AsyncMock(return_value=mock_user)
-        return mock_db
-
     @pytest.mark.asyncio
     async def test_returns_tier_from_db(self):
         """Should return the tier stored in the user record."""
-        mock_db = self._mock_user_db(subscription_tier="PRO")
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with patch(
+            "backend.copilot.rate_limit.get_user_subscription_tier",
+            new=AsyncMock(return_value=SubscriptionTier.PRO),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == SubscriptionTier.PRO
 
     @pytest.mark.asyncio
     async def test_returns_default_when_user_not_found(self):
         """Should return DEFAULT_TIER when user is not in the DB."""
-        mock_db = self._mock_user_db(raises=Exception("not found"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_subscription_tier",
+                new=AsyncMock(side_effect=SubscriptionTierUserNotFoundError(_USER)),
+            ),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
     @pytest.mark.asyncio
     async def test_returns_default_when_tier_is_none(self):
         """Should return DEFAULT_TIER when subscription_tier is None."""
-        mock_db = self._mock_user_db(subscription_tier=None)
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with (
+            patch(
+                "backend.copilot.rate_limit.get_user_subscription_tier",
+                new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
+            ),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
     @pytest.mark.asyncio
     async def test_returns_default_on_db_error(self):
         """Should fall back to DEFAULT_TIER when DB raises."""
-        mock_db = self._mock_user_db(raises=Exception("DB down"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with patch(
+            "backend.copilot.rate_limit.get_user_subscription_tier",
+            new=AsyncMock(side_effect=RuntimeError("DB down")),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
@@ -1335,24 +1283,22 @@ class TestGetUserTier:
         Regression test: a transient DB failure previously cached DEFAULT_TIER
         for 5 minutes, incorrectly downgrading higher-tier users until expiry.
         """
-        failing_db = self._mock_user_db(raises=Exception("DB down"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=failing_db):
+        fetch = AsyncMock(side_effect=[RuntimeError("DB down"), SubscriptionTier.PRO])
+        with patch("backend.copilot.rate_limit.get_user_subscription_tier", new=fetch):
             tier1 = await get_user_tier(_USER)
-        assert tier1 == DEFAULT_TIER
-
-        # Now DB recovers and returns PRO
-        ok_db = self._mock_user_db(subscription_tier="PRO")
-        with patch("backend.copilot.rate_limit.user_db", return_value=ok_db):
             tier2 = await get_user_tier(_USER)
 
-        # Should get PRO now — the error result was not cached
+        assert tier1 == DEFAULT_TIER
         assert tier2 == SubscriptionTier.PRO
+        assert fetch.await_count == 2
 
     @pytest.mark.asyncio
     async def test_returns_default_on_invalid_tier_value(self):
         """Should fall back to DEFAULT_TIER when stored value is invalid."""
-        mock_db = self._mock_user_db(subscription_tier="invalid-tier")
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with patch(
+            "backend.copilot.rate_limit.get_user_subscription_tier",
+            new=AsyncMock(side_effect=ValueError("invalid tier")),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
@@ -1365,19 +1311,39 @@ class TestGetUserTier:
         newly created user with a higher tier (e.g. PRO) would receive the
         stale cached BASIC tier for up to 5 minutes.
         """
-        # First call: user does not exist yet
-        missing_db = self._mock_user_db(raises=Exception("not found"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=missing_db):
+        fetch = AsyncMock(
+            side_effect=[SubscriptionTierUserNotFoundError(_USER), SubscriptionTier.PRO]
+        )
+        with (
+            patch("backend.copilot.rate_limit.get_user_subscription_tier", new=fetch),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
             tier1 = await get_user_tier(_USER)
-        assert tier1 == DEFAULT_TIER
-
-        # Second call: user now exists with PRO tier
-        ok_db = self._mock_user_db(subscription_tier="PRO")
-        with patch("backend.copilot.rate_limit.user_db", return_value=ok_db):
             tier2 = await get_user_tier(_USER)
 
-        # Should get PRO — the not-found result was not cached
+        assert tier1 == DEFAULT_TIER
         assert tier2 == SubscriptionTier.PRO
+        assert fetch.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_recovered_tier_after_successful_reconciliation(self):
+        fetch = AsyncMock(side_effect=[SubscriptionTier.NO_TIER, SubscriptionTier.PRO])
+        reconcile = AsyncMock(return_value=True)
+        with (
+            patch("backend.copilot.rate_limit.get_user_subscription_tier", new=fetch),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=reconcile,
+            ),
+        ):
+            tier = await get_user_tier(_USER)
+
+        assert tier == SubscriptionTier.PRO
+        assert fetch.await_count == 2
+        reconcile.assert_awaited_once_with(_USER)
 
 
 # ---------------------------------------------------------------------------
@@ -1459,15 +1425,13 @@ class TestMaybeReconcileStripeTier:
     async def test_get_user_tier_survives_reconcile_failure(self):
         """Reconcile failure stays non-fatal for rate limiting: get_user_tier
         still resolves the DB-confirmed NO_TIER instead of raising."""
-        get_user_tier.cache_clear()  # type: ignore[attr-defined]
-        mock_user = MagicMock()
-        mock_user.subscription_tier = None
-        mock_db = AsyncMock()
-        mock_db.get_user_by_id = AsyncMock(return_value=mock_user)
         redis = self._mock_redis()
         accessor = self._mock_credit_db(raises=RuntimeError("RPC unavailable"))
         with (
-            patch("backend.copilot.rate_limit.user_db", return_value=mock_db),
+            patch(
+                "backend.copilot.rate_limit.get_user_subscription_tier",
+                new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
+            ),
             patch(
                 "backend.copilot.rate_limit.get_redis_async",
                 AsyncMock(return_value=redis),
@@ -1485,156 +1449,91 @@ class TestMaybeReconcileStripeTier:
 
 
 class TestSetUserTier:
-    @pytest.fixture(autouse=True)
-    def _clear_tier_cache(self):
-        """Clear the get_user_tier cache before each test."""
-        get_user_tier.cache_clear()  # type: ignore[attr-defined]
-
     @pytest.mark.asyncio
-    async def test_updates_db_and_invalidates_cache(self):
-        """set_user_tier should persist to DB and invalidate the tier cache."""
-        mock_prisma = AsyncMock()
-        mock_prisma.update = AsyncMock(return_value=None)
+    async def test_persist_user_subscription_tier_calls_billing_writer(self):
+        from backend.copilot.rate_limit import _persist_user_subscription_tier
 
         with patch(
-            "backend.copilot.rate_limit.PrismaUser.prisma",
-            return_value=mock_prisma,
+            "backend.data.credit.set_subscription_tier",
+            new_callable=AsyncMock,
+        ) as set_tier:
+            await _persist_user_subscription_tier(_USER, SubscriptionTier.PRO)
+
+        set_tier.assert_awaited_once_with(_USER, SubscriptionTier.PRO)
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_canonical_writer(self):
+        def schedule(coroutine):
+            coroutine.close()
+
+        with (
+            patch(
+                "backend.copilot.rate_limit._persist_user_subscription_tier",
+                new_callable=AsyncMock,
+            ) as set_tier,
+            patch(
+                "backend.copilot.rate_limit.asyncio.ensure_future",
+                side_effect=schedule,
+            ) as ensure_future,
         ):
             await set_user_tier(_USER, SubscriptionTier.PRO)
 
-        mock_prisma.update.assert_awaited_once_with(
-            where={"id": _USER},
-            data={"subscriptionTier": "PRO"},
-        )
+        set_tier.assert_awaited_once_with(_USER, SubscriptionTier.PRO)
+        ensure_future.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_record_not_found_propagates(self):
-        """RecordNotFoundError from Prisma should propagate to callers."""
+    async def test_writer_error_propagates_without_scheduling_drift_check(self):
         import prisma.errors
 
-        mock_prisma = AsyncMock()
-        mock_prisma.update = AsyncMock(
-            side_effect=prisma.errors.RecordNotFoundError(
-                {"error": "Record not found"}
+        with (
+            patch(
+                "backend.copilot.rate_limit._persist_user_subscription_tier",
+                new_callable=AsyncMock,
+                side_effect=prisma.errors.RecordNotFoundError(
+                    {"error": "Record not found"}
+                ),
             ),
-        )
-
-        with patch(
-            "backend.copilot.rate_limit.PrismaUser.prisma",
-            return_value=mock_prisma,
+            patch(
+                "backend.copilot.rate_limit.asyncio.ensure_future",
+            ) as ensure_future,
         ):
             with pytest.raises(prisma.errors.RecordNotFoundError):
                 await set_user_tier(_USER, SubscriptionTier.ENTERPRISE)
+        ensure_future.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cache_invalidated_after_set(self):
-        """After set_user_tier, get_user_tier should query DB again (not cache)."""
-        # First, populate the cache with BUSINESS via user_db() mock
-        mock_db_biz = AsyncMock()
-        mock_user_biz = MagicMock()
-        mock_user_biz.subscription_tier = "BUSINESS"
-        mock_db_biz.get_user_by_id = AsyncMock(return_value=mock_user_biz)
-
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db_biz):
-            tier_before = await get_user_tier(_USER)
-        assert tier_before == SubscriptionTier.BUSINESS
-
-        # Now set tier to ENTERPRISE via PrismaUser.prisma (set_user_tier still
-        # uses Prisma directly since it's only called from admin API where Prisma
-        # is connected).
-        mock_prisma_set = AsyncMock()
-        mock_prisma_set.update = AsyncMock(return_value=None)
+    async def test_drift_check_background_swallows_failure(self, caplog):
+        from backend.copilot.rate_limit import _drift_check_background
 
         with patch(
-            "backend.copilot.rate_limit.PrismaUser.prisma",
-            return_value=mock_prisma_set,
+            "backend.copilot.rate_limit._warn_if_stripe_subscription_drifts",
+            new=AsyncMock(side_effect=RuntimeError("drift unavailable")),
         ):
-            await set_user_tier(_USER, SubscriptionTier.ENTERPRISE)
+            await _drift_check_background(_USER, SubscriptionTier.PRO)
 
-        # Now get_user_tier should hit DB again (cache was invalidated)
-        mock_db_ent = AsyncMock()
-        mock_user_ent = MagicMock()
-        mock_user_ent.subscription_tier = "ENTERPRISE"
-        mock_db_ent.get_user_by_id = AsyncMock(return_value=mock_user_ent)
-
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db_ent):
-            tier_after = await get_user_tier(_USER)
-
-        assert tier_after == SubscriptionTier.ENTERPRISE
+        assert "drift check background task failed" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_drift_check_swallows_launchdarkly_failure(self):
-        """LaunchDarkly price-id lookup failures inside the drift check must
-        never bubble up and 500 the admin tier write — the DB update is
-        already committed by the time we check drift."""
-        mock_prisma = AsyncMock()
-        mock_prisma.update = AsyncMock(return_value=None)
+    async def test_drift_check_background_timeout_is_bounded(self, caplog):
+        from backend.copilot.rate_limit import _drift_check_background
 
-        mock_user = MagicMock()
-        mock_user.stripe_customer_id = "cus_abc"
-
-        mock_sub = MagicMock()
-        mock_sub.id = "sub_abc"
-        mock_sub["items"].data = [MagicMock(price=MagicMock(id="price_mismatch"))]
+        async def timeout(
+            coroutine: Coroutine[Any, Any, None], *, timeout: float
+        ) -> None:
+            assert timeout == 5.0
+            coroutine.close()
+            raise asyncio.TimeoutError
 
         with (
-            patch(
-                "backend.copilot.rate_limit.PrismaUser.prisma",
-                return_value=mock_prisma,
-            ),
-            patch(
-                "backend.copilot.rate_limit.get_user_by_id",
-                new_callable=AsyncMock,
-                return_value=mock_user,
-            ),
-            patch(
-                "backend.data.credit._get_active_subscription",
-                new_callable=AsyncMock,
-                return_value=mock_sub,
-            ),
-            patch(
-                "backend.data.credit.get_subscription_price_id",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("LD SDK not initialized"),
-            ),
-        ):
-            # Must NOT raise — drift check is best-effort diagnostic only.
-            await set_user_tier(_USER, SubscriptionTier.PRO)
-
-        mock_prisma.update.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_drift_check_timeout_is_bounded(self):
-        """A Stripe call that stalls on the 80s SDK default must not block the
-        admin tier write — set_user_tier wraps the drift check in a 5s timeout
-        and logs + returns on TimeoutError."""
-        import asyncio as _asyncio
-
-        mock_prisma = AsyncMock()
-        mock_prisma.update = AsyncMock(return_value=None)
-
-        async def _never_returns(_user_id: str, _tier):
-            await _asyncio.sleep(60)
-
-        with (
-            patch(
-                "backend.copilot.rate_limit.PrismaUser.prisma",
-                return_value=mock_prisma,
-            ),
             patch(
                 "backend.copilot.rate_limit._warn_if_stripe_subscription_drifts",
-                side_effect=_never_returns,
-            ),
-            patch(
-                "backend.copilot.rate_limit.asyncio.wait_for",
                 new_callable=AsyncMock,
-                side_effect=_asyncio.TimeoutError,
             ),
+            patch("backend.copilot.rate_limit.asyncio.wait_for", new=timeout),
         ):
-            await set_user_tier(_USER, SubscriptionTier.PRO)
+            await _drift_check_background(_USER, SubscriptionTier.PRO)
 
-        # Set_user_tier still completed — the drift timeout did not propagate.
-        mock_prisma.update.assert_awaited_once()
+        assert "drift check timed out" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -48,6 +48,10 @@ from backend.util.metrics import DiscordChannel, discord_send_alert
 from backend.util.models import Pagination
 from backend.util.retry import func_retry
 from backend.util.settings import Settings
+from backend.util.subscription_tiers import (
+    invalidate_user_subscription_tier,
+    subscription_tier_rank,
+)
 
 if TYPE_CHECKING:
     from backend.blocks._base import Block, BlockCost
@@ -1520,27 +1524,33 @@ async def set_auto_top_up(user_id: str, config: AutoTopUpConfig):
     get_user_by_id.cache_delete(user_id)
 
 
+def _invalidate_subscription_caches(user_id: str) -> None:
+    for cache_name, cache_delete in (
+        ("subscription tier", invalidate_user_subscription_tier),
+        ("user", get_user_by_id.cache_delete),
+        ("pending subscription change", get_pending_subscription_change.cache_delete),
+    ):
+        try:
+            cache_delete(user_id)
+        except Exception:
+            logger.warning(
+                "Failed to invalidate %s cache for user %s",
+                cache_name,
+                user_id[:8],
+                exc_info=True,
+            )
+
+
 async def set_subscription_tier(
     user_id: str,
     tier: SubscriptionTier,
 ) -> None:
-    """Set the user's subscription tier."""
+    """Set the tier and best-effort evict every tier-derived user cache."""
     data: UserUpdateInput = {
         "subscriptionTier": tier,
     }
     await User.prisma().update(where={"id": user_id}, data=data)
-    get_user_by_id.cache_delete(user_id)
-    # Also invalidate the rate-limit tier cache so CoPilot picks up the new
-    # tier immediately rather than waiting up to 5 minutes for the TTL to expire.
-    from backend.copilot.rate_limit import get_user_tier  # local import avoids circular
-
-    get_user_tier.cache_delete(user_id)  # type: ignore[attr-defined]
-    # Invalidate the pending-change cache too — an admin tier override or the
-    # webhook-driven phase transition means any cached pending-change state
-    # (schedule, cancel_at_period_end) is likely stale. Without this the
-    # billing page can show a pending change for up to 30s after the tier
-    # has already flipped.
-    get_pending_subscription_change.cache_delete(user_id)
+    await run_in_threadpool(_invalidate_subscription_caches, user_id)
 
 
 async def _cancel_customer_subscriptions(
@@ -1699,29 +1709,12 @@ async def get_proration_credit_cents(user_id: str, monthly_cost_cents: int) -> i
         return 0
 
 
-# Ordered from least- to most-privileged. Used to distinguish upgrades
-# (move right) from downgrades (move left); ENTERPRISE is admin-managed and
-# never reached via self-service flows.
-_TIER_ORDER: tuple[SubscriptionTier, ...] = (
-    SubscriptionTier.NO_TIER,
-    SubscriptionTier.BASIC,
-    SubscriptionTier.PRO,
-    SubscriptionTier.MAX,
-    SubscriptionTier.BUSINESS,
-    SubscriptionTier.ENTERPRISE,
-)
-
-
-def _tier_rank(tier: SubscriptionTier) -> int:
-    return _TIER_ORDER.index(tier)
-
-
 def is_tier_upgrade(current: SubscriptionTier, target: SubscriptionTier) -> bool:
-    return _tier_rank(target) > _tier_rank(current)
+    return subscription_tier_rank(target) > subscription_tier_rank(current)
 
 
 def is_tier_downgrade(current: SubscriptionTier, target: SubscriptionTier) -> bool:
-    return _tier_rank(target) < _tier_rank(current)
+    return subscription_tier_rank(target) < subscription_tier_rank(current)
 
 
 class PendingChangeUnknown(Exception):
@@ -2819,9 +2812,6 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
                 "billing_cycle": billing_cycle,
             },
         )
-    # Tier changed — bust any cached pending-change view so the next
-    # dashboard fetch reflects the new state immediately.
-    get_pending_subscription_change.cache_delete(user.id)
 
 
 async def sync_subscription_schedule_from_stripe(stripe_schedule: dict) -> None:

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -51,25 +51,45 @@ async def test_set_subscription_tier_updates_db():
             "backend.data.credit.User.prisma",
             return_value=MagicMock(update=AsyncMock()),
         ) as mock_prisma,
-        patch("backend.data.credit.get_user_by_id"),
+        patch("backend.data.credit.get_user_by_id", new=MagicMock()),
+        patch("backend.data.credit.invalidate_user_subscription_tier") as invalidate,
+        patch.object(get_pending_subscription_change, "cache_delete"),
     ):
         await set_subscription_tier("user-1", SubscriptionTier.PRO)
         update_call = mock_prisma.return_value.update.await_args
         assert update_call.kwargs["where"] == {"id": "user-1"}
         assert update_call.kwargs["data"]["subscriptionTier"] == SubscriptionTier.PRO
+        invalidate.assert_called_once_with("user-1")
 
 
 @pytest.mark.asyncio
-async def test_set_subscription_tier_downgrade():
+async def test_set_subscription_tier_cache_failures_are_best_effort():
+    tier_cache_delete = MagicMock(side_effect=RuntimeError("redis unavailable"))
+    user_cache_delete = MagicMock(side_effect=RuntimeError("redis unavailable"))
+    pending_cache_delete = MagicMock(side_effect=RuntimeError("redis unavailable"))
+    user_getter = MagicMock(cache_delete=user_cache_delete)
+
     with (
         patch(
             "backend.data.credit.User.prisma",
             return_value=MagicMock(update=AsyncMock()),
         ),
-        patch("backend.data.credit.get_user_by_id"),
+        patch("backend.data.credit.get_user_by_id", user_getter),
+        patch(
+            "backend.data.credit.invalidate_user_subscription_tier",
+            tier_cache_delete,
+        ),
+        patch.object(
+            get_pending_subscription_change,
+            "cache_delete",
+            pending_cache_delete,
+        ),
     ):
-        # Downgrade to BASIC should not raise
-        await set_subscription_tier("user-1", SubscriptionTier.BASIC)
+        await set_subscription_tier("user-1", SubscriptionTier.PRO)
+
+    tier_cache_delete.assert_called_once_with("user-1")
+    user_cache_delete.assert_called_once_with("user-1")
+    pending_cache_delete.assert_called_once_with("user-1")
 
 
 def _make_user(
@@ -122,9 +142,14 @@ async def test_sync_subscription_from_stripe_active():
         patch(
             "backend.data.credit.set_subscription_tier", new_callable=AsyncMock
         ) as mock_set,
+        patch.object(
+            get_pending_subscription_change,
+            "cache_delete",
+        ) as pending_cache_delete,
     ):
         await sync_subscription_from_stripe(stripe_sub)
         mock_set.assert_awaited_once_with("user-1", SubscriptionTier.PRO)
+        pending_cache_delete.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -409,16 +434,11 @@ async def test_sync_subscription_from_stripe_cancelled_applies_no_tier_storage_l
                 "ENTERPRISE": 15 * 1024,
             },
         ),
-        patch.object(
-            get_pending_subscription_change,
-            "cache_delete",
-        ) as mock_pending_cache_delete,
     ):
         await sync_subscription_from_stripe(stripe_sub)
         result = await get_workspace_storage_limit_bytes("user-1")
 
     assert result == 250 * 1024 * 1024
-    mock_pending_cache_delete.assert_called_once_with("user-1")
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -26,6 +26,7 @@ from backend.data.credit import (
     log_tier_reconciliation_discrepancy,
     set_subscription_tier,
 )
+from backend.util.subscription_tiers import subscription_tier_rank
 
 logger = logging.getLogger(__name__)
 
@@ -262,15 +263,7 @@ def _record_subscription(
     if tier is None:
         return
     existing = tiers.get(customer)
-    if existing is None or _TIER_RANK[tier] > _TIER_RANK[existing]:
+    if existing is None or subscription_tier_rank(tier) > subscription_tier_rank(
+        existing
+    ):
         tiers[customer] = tier
-
-
-_TIER_RANK: dict[SubscriptionTier, int] = {
-    SubscriptionTier.NO_TIER: 0,
-    SubscriptionTier.BASIC: 1,
-    SubscriptionTier.PRO: 2,
-    SubscriptionTier.MAX: 3,
-    SubscriptionTier.BUSINESS: 4,
-    SubscriptionTier.ENTERPRISE: 5,
-}

--- a/autogpt_platform/backend/backend/util/cache.py
+++ b/autogpt_platform/backend/backend/util/cache.py
@@ -17,11 +17,16 @@ import logging
 import pickle
 import threading
 import time
+import weakref
+from contextlib import suppress
 from dataclasses import dataclass
 from functools import cache, wraps
 from typing import Any, Callable, ParamSpec, Protocol, TypeVar, cast, runtime_checkable
 
+from redis.backoff import NoBackoff
 from redis.cluster import ClusterNode, RedisCluster
+from redis.exceptions import RedisError
+from redis.retry import Retry
 
 from backend.util.retry import conn_retry
 from backend.util.settings import Settings
@@ -36,6 +41,13 @@ settings = Settings()
 
 # Length of the HMAC-SHA256 signature prefix on cached values.
 _HMAC_SIG_LEN = 32
+_SHARED_CACHE_REDIS_TIMEOUT_SECONDS = 1.0
+_SHARED_CACHE_REDIS_COOLDOWN_SECONDS = 1.0
+_SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS = 1.0
+_shared_cache_redis: RedisCluster | None = None
+_shared_cache_redis_init_lock = threading.Lock()
+_shared_cache_redis_retry_at = 0.0
+_monotonic = time.monotonic
 
 # RECOMMENDED REDIS CONFIGURATION FOR PRODUCTION:
 # Configure Redis with the following settings for optimal caching performance:
@@ -44,10 +56,8 @@ _HMAC_SIG_LEN = 32
 #   save ""                         # Disable persistence if using Redis purely for caching
 
 
-@cache
-@conn_retry("Redis", "Acquiring cache connection")
-def _get_redis() -> RedisCluster:
-    """Lazily-initialized shared-cache Redis Cluster client (singleton)."""
+@conn_retry("Redis", "Acquiring cache connection", max_retry=0)
+def _create_redis() -> RedisCluster:
     # Local import breaks the redis_client <-> cache module cycle.
     from backend.data.redis_client import _address_remap
 
@@ -59,12 +69,65 @@ def _get_redis() -> RedisCluster:
         decode_responses=False,  # Binary mode for pickle
         max_connections=50,
         socket_keepalive=True,
-        socket_connect_timeout=5,
-        retry_on_timeout=True,
+        socket_connect_timeout=_SHARED_CACHE_REDIS_TIMEOUT_SECONDS,
+        socket_timeout=_SHARED_CACHE_REDIS_TIMEOUT_SECONDS,
+        retry=Retry(NoBackoff(), retries=0),
         address_remap=_address_remap,
     )
-    c.ping()
+    try:
+        c.ping()
+    except Exception:
+        with suppress(Exception):
+            c.close()
+        raise
     return c
+
+
+def _get_redis() -> RedisCluster:
+    """Lazily initialize the best-effort shared-cache Redis client once."""
+    global _shared_cache_redis, _shared_cache_redis_retry_at
+
+    if _shared_cache_redis is not None:
+        return _shared_cache_redis
+    if _monotonic() < _shared_cache_redis_retry_at:
+        raise ConnectionError("Shared-cache Redis initialization is cooling down")
+
+    with _shared_cache_redis_init_lock:
+        if _shared_cache_redis is None:
+            if _monotonic() < _shared_cache_redis_retry_at:
+                raise ConnectionError(
+                    "Shared-cache Redis initialization is cooling down"
+                )
+            try:
+                _shared_cache_redis = _create_redis()
+            except Exception:
+                _shared_cache_redis_retry_at = (
+                    _monotonic() + _SHARED_CACHE_REDIS_COOLDOWN_SECONDS
+                )
+                raise
+            _shared_cache_redis_retry_at = 0.0
+        return _shared_cache_redis
+
+
+def _redis_cooldown_is_open() -> bool:
+    return _shared_cache_redis is None and _monotonic() < _shared_cache_redis_retry_at
+
+
+def _mark_redis_unavailable(failed_client: RedisCluster) -> bool:
+    """Open the short cache circuit if the active client failed."""
+    global _shared_cache_redis, _shared_cache_redis_retry_at
+
+    with _shared_cache_redis_init_lock:
+        if _shared_cache_redis is not failed_client:
+            return False
+        _shared_cache_redis = None
+        _shared_cache_redis_retry_at = (
+            _monotonic() + _SHARED_CACHE_REDIS_COOLDOWN_SECONDS
+        )
+
+    with suppress(Exception):
+        failed_client.close()
+    return True
 
 
 class _MissingType:
@@ -92,12 +155,38 @@ class _MissingType:
 _MISSING = _MissingType()
 
 
+class _UnavailableType:
+    """Sentinel returned when the shared cache cannot be reached."""
+
+
+_UNAVAILABLE = _UnavailableType()
+
+
 @dataclass
 class CachedValue:
     """Wrapper for cached values with timestamp to avoid tuple ambiguity."""
 
     result: Any
     timestamp: float
+
+
+class _AsyncKeyedLockPool:
+    """Keep one live asyncio lock per event loop and cache key."""
+
+    def __init__(self) -> None:
+        self._locks: weakref.WeakValueDictionary[
+            tuple[asyncio.AbstractEventLoop, tuple[Any, ...]], asyncio.Lock
+        ] = weakref.WeakValueDictionary()
+        self._mutex = threading.Lock()
+
+    def get(self, key: tuple[Any, ...]) -> asyncio.Lock:
+        pool_key = (asyncio.get_running_loop(), key)
+        with self._mutex:
+            lock = self._locks.get(pool_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[pool_key] = lock
+            return lock
 
 
 def _make_hashable_key(
@@ -191,6 +280,8 @@ def cached(
         maxsize: Maximum number of cached entries (only for in-memory cache)
         ttl_seconds: Time to live in seconds. Required - entries must expire.
         shared_cache: If True, use Redis for cross-process caching
+            and reuse freshly computed local values for up to one second only
+            while the shared Redis circuit is open.
         refresh_ttl_on_get: If True, refresh TTL when cache entry is accessed (LRU behavior)
         cache_none: If True (default) ``None`` is cached like any other value.
             Set to ``False`` for functions that return ``None`` to signal a
@@ -219,7 +310,7 @@ def cached(
     def decorator(target_func: Callable[P, R]) -> CachedFunction[P, R]:
         func_name = target_func.__name__
         cache_storage: dict[tuple, CachedValue] = {}
-        _event_loop_locks: dict[Any, asyncio.Lock] = {}
+        async_lock_pool = _AsyncKeyedLockPool()
 
         def _get_from_redis(redis_key: str) -> Any:
             """Get value from Redis, optionally refreshing TTL.
@@ -234,11 +325,13 @@ def cached(
             discarded and treated as cache misses, so the caller recomputes and
             re-stores them with a valid signature.
             """
+            client: RedisCluster | None = None
             try:
+                client = _get_redis()
                 if refresh_ttl_on_get:
-                    cached_bytes = _get_redis().getex(redis_key, ex=ttl_seconds)
+                    cached_bytes = client.getex(redis_key, ex=ttl_seconds)
                 else:
-                    cached_bytes = _get_redis().get(redis_key)
+                    cached_bytes = client.get(redis_key)
 
                 if cached_bytes and isinstance(cached_bytes, bytes):
                     payload = _verify_and_strip(cached_bytes)
@@ -250,19 +343,30 @@ def cached(
                         )
                         return _MISSING
                     return pickle.loads(payload)
+            except (OSError, RedisError) as e:
+                if client is not None and _mark_redis_unavailable(client):
+                    logger.error(f"Redis error during cache check for {func_name}: {e}")
+                return _UNAVAILABLE
             except Exception as e:
                 logger.error(f"Redis error during cache check for {func_name}: {e}")
             return _MISSING
 
-        def _set_to_redis(redis_key: str, value: Any) -> None:
+        def _set_to_redis(redis_key: str, value: Any) -> bool:
             """Set HMAC-signed pickled value in Redis with TTL."""
+            client: RedisCluster | None = None
             try:
                 pickled = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
-                _get_redis().setex(redis_key, ttl_seconds, _sign_payload(pickled))
+                client = _get_redis()
+                client.setex(redis_key, ttl_seconds, _sign_payload(pickled))
+                return True
+            except (OSError, RedisError) as e:
+                if client is not None and _mark_redis_unavailable(client):
+                    logger.error(f"Redis error storing cache for {func_name}: {e}")
             except Exception as e:
                 logger.error(f"Redis error storing cache for {func_name}: {e}")
+            return False
 
-        def _get_from_memory(key: tuple) -> Any:
+        def _get_from_memory(key: tuple, max_age_seconds: float = ttl_seconds) -> Any:
             """Get value from in-memory cache, checking TTL.
 
             Returns the cached value (which may be ``None``) on a hit, or the
@@ -271,7 +375,7 @@ def cached(
             """
             if key in cache_storage:
                 cached_data = cache_storage[key]
-                if time.time() - cached_data.timestamp < ttl_seconds:
+                if time.time() - cached_data.timestamp < max_age_seconds:
                     logger.debug(
                         f"Cache hit for {func_name} args: {key[0]} kwargs: {key[1]}"
                     )
@@ -291,26 +395,27 @@ def cached(
 
         if inspect.iscoroutinefunction(target_func):
 
-            def _get_cache_lock():
-                """Get or create an asyncio.Lock for the current event loop."""
-                try:
-                    loop = asyncio.get_running_loop()
-                except RuntimeError:
-                    loop = None
-
-                if loop not in _event_loop_locks:
-                    return _event_loop_locks.setdefault(loop, asyncio.Lock())
-                return _event_loop_locks[loop]
-
             @wraps(target_func)
             async def async_wrapper(*args: P.args, **kwargs: P.kwargs):
                 key = _make_hashable_key(args, kwargs)
                 redis_key = _make_redis_key(key, func_name) if shared_cache else ""
+                redis_unavailable = False
 
                 # Fast path: check cache without lock
                 if shared_cache:
-                    result = _get_from_redis(redis_key)
-                    if result is not _MISSING:
+                    if _redis_cooldown_is_open():
+                        redis_unavailable = True
+                        result = _get_from_memory(
+                            key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                        )
+                    else:
+                        result = await asyncio.to_thread(_get_from_redis, redis_key)
+                        if result is _UNAVAILABLE:
+                            redis_unavailable = True
+                            result = _get_from_memory(
+                                key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                            )
+                    if result is not _MISSING and result is not _UNAVAILABLE:
                         return result
                 else:
                     result = _get_from_memory(key)
@@ -318,11 +423,22 @@ def cached(
                         return result
 
                 # Slow path: acquire lock for cache miss/expiry
-                async with _get_cache_lock():
+                async with async_lock_pool.get(key):
                     # Double-check: another coroutine might have populated cache
                     if shared_cache:
-                        result = _get_from_redis(redis_key)
-                        if result is not _MISSING:
+                        if redis_unavailable or _redis_cooldown_is_open():
+                            redis_unavailable = True
+                            result = _get_from_memory(
+                                key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                            )
+                        else:
+                            result = await asyncio.to_thread(_get_from_redis, redis_key)
+                            if result is _UNAVAILABLE:
+                                redis_unavailable = True
+                                result = _get_from_memory(
+                                    key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                                )
+                        if result is not _MISSING and result is not _UNAVAILABLE:
                             return result
                     else:
                         result = _get_from_memory(key)
@@ -337,7 +453,10 @@ def cached(
                     # caching it — used for transient-error sentinels).
                     if cache_none or result is not None:
                         if shared_cache:
-                            _set_to_redis(redis_key, result)
+                            if redis_unavailable or not await asyncio.to_thread(
+                                _set_to_redis, redis_key, result
+                            ):
+                                _set_to_memory(key, result)
                         else:
                             _set_to_memory(key, result)
 
@@ -353,11 +472,17 @@ def cached(
             def sync_wrapper(*args: P.args, **kwargs: P.kwargs):
                 key = _make_hashable_key(args, kwargs)
                 redis_key = _make_redis_key(key, func_name) if shared_cache else ""
+                redis_unavailable = False
 
                 # Fast path: check cache without lock
                 if shared_cache:
                     result = _get_from_redis(redis_key)
-                    if result is not _MISSING:
+                    if result is _UNAVAILABLE:
+                        redis_unavailable = True
+                        result = _get_from_memory(
+                            key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                        )
+                    if result is not _MISSING and result is not _UNAVAILABLE:
                         return result
                 else:
                     result = _get_from_memory(key)
@@ -368,8 +493,19 @@ def cached(
                 with cache_lock:
                     # Double-check: another thread might have populated cache
                     if shared_cache:
-                        result = _get_from_redis(redis_key)
-                        if result is not _MISSING:
+                        if redis_unavailable or _redis_cooldown_is_open():
+                            redis_unavailable = True
+                            result = _get_from_memory(
+                                key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                            )
+                        else:
+                            result = _get_from_redis(redis_key)
+                            if result is _UNAVAILABLE:
+                                redis_unavailable = True
+                                result = _get_from_memory(
+                                    key, _SHARED_CACHE_LOCAL_FALLBACK_TTL_SECONDS
+                                )
+                        if result is not _MISSING and result is not _UNAVAILABLE:
                             return result
                     else:
                         result = _get_from_memory(key)
@@ -384,7 +520,10 @@ def cached(
                     # caching it — used for transient-error sentinels).
                     if cache_none or result is not None:
                         if shared_cache:
-                            _set_to_redis(redis_key, result)
+                            if redis_unavailable or not _set_to_redis(
+                                redis_key, result
+                            ):
+                                _set_to_memory(key, result)
                         else:
                             _set_to_memory(key, result)
 
@@ -396,6 +535,7 @@ def cached(
         def cache_clear(pattern: str | None = None) -> None:
             """Clear cache entries. If pattern provided, clear matching entries."""
             if shared_cache:
+                cache_storage.clear()
                 # SCAN must fan out across every primary on a cluster — without
                 # target_nodes the scan only walks the shard the client is
                 # bound to, leaving stale keys on the other shards.
@@ -447,15 +587,20 @@ def cached(
         def cache_delete(*args, **kwargs) -> bool:
             """Delete a specific cache entry. Returns True if entry existed."""
             key = _make_hashable_key(args, kwargs)
+            local_deleted = cache_storage.pop(key, _MISSING) is not _MISSING
             if shared_cache:
                 redis_key = _make_redis_key(key, func_name)
-                deleted_count = cast(int, _get_redis().delete(redis_key))
-                return deleted_count > 0
+                client: RedisCluster | None = None
+                try:
+                    client = _get_redis()
+                    deleted_count = cast(int, client.delete(redis_key))
+                except (OSError, RedisError):
+                    if client is not None:
+                        _mark_redis_unavailable(client)
+                    raise
+                return deleted_count > 0 or local_deleted
             else:
-                if key in cache_storage:
-                    del cache_storage[key]
-                    return True
-                return False
+                return local_deleted
 
         setattr(wrapper, "cache_clear", cache_clear)
         setattr(wrapper, "cache_info", cache_info)

--- a/autogpt_platform/backend/backend/util/cache_test.py
+++ b/autogpt_platform/backend/backend/util/cache_test.py
@@ -12,9 +12,10 @@ import asyncio
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from backend.util.cache import cached, clear_thread_cache, thread_cached
 
@@ -428,6 +429,31 @@ class TestCache:
         # Only one coroutine should have executed the expensive operation
         assert call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_async_single_flight_is_scoped_to_cache_key(self):
+        started: set[str] = set()
+        both_started = asyncio.Event()
+        release = asyncio.Event()
+        call_counts: dict[str, int] = {}
+
+        @cached(ttl_seconds=300)
+        async def cached_function(key: str) -> str:
+            call_counts[key] = call_counts.get(key, 0) + 1
+            started.add(key)
+            if started == {"a", "b"}:
+                both_started.set()
+            await release.wait()
+            return key
+
+        tasks = [
+            asyncio.create_task(cached_function(key)) for key in ("a", "a", "b", "b")
+        ]
+        await asyncio.wait_for(both_started.wait(), timeout=1)
+        release.set()
+
+        assert await asyncio.gather(*tasks) == ["a", "a", "b", "b"]
+        assert call_counts == {"a": 1, "b": 1}
+
     def test_ttl_functionality(self):
         """Test TTL functionality with sync function."""
         call_count = 0
@@ -679,6 +705,73 @@ class TestCache:
 class TestSharedCache:
     """Tests for shared_cache (Redis-backed) functionality."""
 
+    def test_shared_cache_connection_is_bounded_and_not_retried(self, monkeypatch):
+        from backend.util import cache as cache_module
+
+        client = Mock()
+        client.ping.side_effect = ConnectionError("redis unavailable")
+        redis_cluster = Mock(return_value=client)
+        monkeypatch.setattr(cache_module, "RedisCluster", redis_cluster)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", None)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+        monkeypatch.setattr(cache_module, "_monotonic", lambda: 100.0)
+        with pytest.raises(ConnectionError, match="redis unavailable"):
+            cache_module._get_redis()
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            attempts = [executor.submit(cache_module._get_redis) for _ in range(8)]
+            for attempt in attempts:
+                with pytest.raises(ConnectionError, match="cooling down"):
+                    attempt.result(timeout=1)
+
+        redis_cluster.assert_called_once()
+        client.close.assert_called_once()
+        kwargs = redis_cluster.call_args.kwargs
+        assert kwargs["socket_connect_timeout"] == 1.0
+        assert kwargs["socket_timeout"] == 1.0
+        assert kwargs["retry"].get_retries() == 0
+        assert "cluster_error_retry_attempts" not in kwargs
+
+    def test_shared_cache_connection_initializes_once_under_contention(
+        self, monkeypatch
+    ):
+        from backend.util import cache as cache_module
+
+        workers = 8
+        start = threading.Barrier(workers + 1)
+        ping_entered = threading.Event()
+        release_ping = threading.Event()
+        client = Mock()
+
+        def ping() -> bool:
+            ping_entered.set()
+            assert release_ping.wait(timeout=1)
+            return True
+
+        client.ping.side_effect = ping
+        redis_cluster = Mock(return_value=client)
+        monkeypatch.setattr(cache_module, "RedisCluster", redis_cluster)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", None)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+
+        def get_client():
+            start.wait()
+            return cache_module._get_redis()
+
+        try:
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                futures = [executor.submit(get_client) for _ in range(workers)]
+                start.wait()
+                assert ping_entered.wait(timeout=1)
+                time.sleep(0.05)
+                redis_cluster.assert_called_once()
+                release_ping.set()
+                assert {id(future.result(timeout=1)) for future in futures} == {
+                    id(client)
+                }
+        finally:
+            release_ping.set()
+
     def test_sync_shared_cache_basic(self):
         """Test basic shared cache functionality with sync function."""
         call_count = 0
@@ -742,6 +835,187 @@ class TestSharedCache:
 
         # Cleanup
         shared_async_function.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_async_shared_cache_does_not_block_event_loop(self, monkeypatch):
+        redis_entered = threading.Event()
+        release_redis = threading.Event()
+        event_loop_progressed = threading.Event()
+        progress_seen_while_blocked: list[bool] = []
+
+        class BlockingRedis:
+            def get(self, _key: str):
+                redis_entered.set()
+                release_redis.wait(timeout=1)
+                progress_seen_while_blocked.append(event_loop_progressed.is_set())
+                return None
+
+            def setex(self, _key: str, _ttl: int, _value: bytes):
+                return True
+
+        monkeypatch.setattr(
+            "backend.util.cache._get_redis",
+            lambda: BlockingRedis(),
+        )
+
+        @cached(ttl_seconds=30, shared_cache=True)
+        async def cached_function() -> str:
+            return "value"
+
+        async def mark_event_loop_progress() -> None:
+            await asyncio.sleep(0)
+            event_loop_progressed.set()
+
+        release_timer = threading.Timer(0.2, release_redis.set)
+        release_timer.start()
+        try:
+            cache_task = asyncio.create_task(cached_function())
+            progress_task = asyncio.create_task(mark_event_loop_progress())
+            assert await cache_task == "value"
+            await progress_task
+        finally:
+            release_redis.set()
+            release_timer.join()
+
+        assert redis_entered.is_set()
+        assert progress_seen_while_blocked[0] is True
+
+    @pytest.mark.asyncio
+    async def test_async_shared_cache_command_outage_collapses_database_work(
+        self, monkeypatch
+    ):
+        from backend.util import cache as cache_module
+
+        class UnavailableRedis:
+            def __init__(self) -> None:
+                self.get_calls = 0
+                self.setex_calls = 0
+                self.close_calls = 0
+
+            def get(self, _key: str):
+                self.get_calls += 1
+                raise RedisConnectionError("redis unavailable")
+
+            def setex(self, _key: str, _ttl: int, _value: bytes):
+                self.setex_calls += 1
+                raise AssertionError("circuit-open calls must not write to Redis")
+
+            def close(self) -> None:
+                self.close_calls += 1
+
+        redis = UnavailableRedis()
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", redis)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+        monkeypatch.setattr(cache_module, "_monotonic", lambda: 100.0)
+        call_count = 0
+
+        @cached(ttl_seconds=30, shared_cache=True)
+        async def cached_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return "value"
+
+        results = await asyncio.gather(*(cached_function() for _ in range(8)))
+
+        assert results == ["value"] * 8
+        assert call_count == 1
+        assert redis.get_calls >= 1
+        assert redis.setex_calls == 0
+        assert redis.close_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_async_shared_cache_open_circuit_skips_thread_dispatch(
+        self, monkeypatch
+    ):
+        from backend.util import cache as cache_module
+
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", None)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 101.0)
+        monkeypatch.setattr(cache_module, "_monotonic", lambda: 100.0)
+        monkeypatch.setattr(
+            cache_module.asyncio,
+            "to_thread",
+            AsyncMock(side_effect=AssertionError("thread dispatch during cooldown")),
+        )
+        call_count = 0
+
+        @cached(ttl_seconds=30, shared_cache=True)
+        async def cached_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            return "value"
+
+        assert await cached_function() == "value"
+        assert await cached_function() == "value"
+        assert call_count == 1
+
+    def test_shared_cache_cooldown_is_not_extended_by_traffic(self, monkeypatch):
+        from backend.util import cache as cache_module
+
+        clock = [100.0]
+        redis = Mock()
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", redis)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+        monkeypatch.setattr(cache_module, "_monotonic", lambda: clock[0])
+
+        assert cache_module._mark_redis_unavailable(redis) is True
+        assert cache_module._shared_cache_redis_retry_at == 101.0
+
+        clock[0] = 100.5
+        assert cache_module._mark_redis_unavailable(redis) is False
+        assert cache_module._shared_cache_redis_retry_at == 101.0
+
+        replacement = Mock()
+        create_redis = Mock(return_value=replacement)
+        monkeypatch.setattr(cache_module, "_create_redis", create_redis)
+        clock[0] = 101.1
+
+        assert cache_module._get_redis() is replacement
+        create_redis.assert_called_once_with()
+
+    def test_late_failure_from_old_client_does_not_close_replacement(self, monkeypatch):
+        from backend.util import cache as cache_module
+
+        clock = [100.0]
+        old_client = Mock()
+        new_client = Mock()
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", old_client)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+        monkeypatch.setattr(cache_module, "_monotonic", lambda: clock[0])
+
+        assert cache_module._mark_redis_unavailable(old_client) is True
+        clock[0] = 101.1
+        monkeypatch.setattr(
+            cache_module, "_create_redis", Mock(return_value=new_client)
+        )
+        assert cache_module._get_redis() is new_client
+
+        assert cache_module._mark_redis_unavailable(old_client) is False
+        assert cache_module._shared_cache_redis is new_client
+        assert cache_module._shared_cache_redis_retry_at == 0.0
+        new_client.close.assert_not_called()
+
+    def test_shared_cache_delete_failure_opens_circuit(self, monkeypatch):
+        from backend.util import cache as cache_module
+
+        redis = Mock()
+        redis.delete.side_effect = RedisConnectionError("redis unavailable")
+        monkeypatch.setattr(cache_module, "_shared_cache_redis", redis)
+        monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+        monkeypatch.setattr(cache_module, "_monotonic", lambda: 100.0)
+
+        @cached(ttl_seconds=30, shared_cache=True)
+        def cached_function(user_id: str) -> str:
+            return user_id
+
+        with pytest.raises(RedisConnectionError, match="redis unavailable"):
+            cached_function.cache_delete("user-1")
+        with pytest.raises(ConnectionError, match="cooling down"):
+            cached_function.cache_delete("user-2")
+
+        redis.delete.assert_called_once()
+        redis.close.assert_called_once()
 
     def test_shared_cache_ttl_refresh(self):
         """Test TTL refresh functionality with shared cache."""

--- a/autogpt_platform/backend/backend/util/entitlements.py
+++ b/autogpt_platform/backend/backend/util/entitlements.py
@@ -5,8 +5,12 @@ from typing import Mapping
 from prisma.enums import SubscriptionTier
 from pydantic import BaseModel, ConfigDict
 
-from backend.util.clients import get_database_manager_async_client
 from backend.util.settings import BehaveAs, Settings
+from backend.util.subscription_tiers import (
+    SubscriptionTierUserNotFoundError,
+    get_user_subscription_tier,
+    subscription_tier_at_least,
+)
 
 
 class Entitlement(str, Enum):
@@ -29,16 +33,6 @@ ENTITLEMENT_POLICIES: Mapping[Entitlement, EntitlementPolicy] = MappingProxyType
     }
 )
 
-_TIER_ORDER = (
-    SubscriptionTier.NO_TIER,
-    SubscriptionTier.BASIC,
-    SubscriptionTier.PRO,
-    SubscriptionTier.MAX,
-    SubscriptionTier.BUSINESS,
-    SubscriptionTier.ENTERPRISE,
-)
-_TIER_RANK = {tier: rank for rank, tier in enumerate(_TIER_ORDER)}
-
 settings = Settings()
 
 
@@ -51,29 +45,17 @@ class EntitlementRequiredError(Exception):
         )
 
 
-async def _get_user_subscription_tier(user_id: str) -> SubscriptionTier:
-    """Resolve a tier through DatabaseManager without caching this result.
-
-    A missing user has no entitlement. Other database and transport failures
-    propagate so callers can retry instead of treating an outage as a denial.
-    """
-    try:
-        tier = await get_database_manager_async_client().get_user_subscription_tier(
-            user_id
-        )
-    except ValueError:
-        return SubscriptionTier.NO_TIER
-    return SubscriptionTier(tier)
-
-
 async def has_entitlement(user_id: str, entitlement: Entitlement) -> bool:
-    """Check one centralized entitlement policy against the user's DB tier."""
+    """Check policy against a shared tier cached for at most five minutes."""
     policy = ENTITLEMENT_POLICIES[entitlement]
     if policy.allow_local and settings.config.behave_as == BehaveAs.LOCAL:
         return True
 
-    tier = await _get_user_subscription_tier(user_id)
-    return _TIER_RANK[tier] >= _TIER_RANK[policy.minimum_tier]
+    try:
+        tier = await get_user_subscription_tier(user_id)
+    except SubscriptionTierUserNotFoundError:
+        tier = SubscriptionTier.NO_TIER
+    return subscription_tier_at_least(tier, policy.minimum_tier)
 
 
 async def require_entitlement(user_id: str, entitlement: Entitlement) -> None:

--- a/autogpt_platform/backend/backend/util/entitlements_test.py
+++ b/autogpt_platform/backend/backend/util/entitlements_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from prisma.enums import SubscriptionTier
@@ -6,19 +6,15 @@ from prisma.enums import SubscriptionTier
 from backend.util import entitlements
 from backend.util.entitlements import Entitlement, EntitlementRequiredError
 from backend.util.settings import BehaveAs
-
-
-def _database_client(*tiers: SubscriptionTier | Exception):
-    client = MagicMock()
-    client.get_user_subscription_tier = AsyncMock(side_effect=tiers)
-    return client
+from backend.util.subscription_tiers import SubscriptionTierUserNotFoundError
 
 
 @pytest.mark.asyncio
 async def test_local_entitlement_bypasses_database_manager():
+    tier_lookup = AsyncMock()
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.LOCAL),
-        patch.object(entitlements, "get_database_manager_async_client") as get_db,
+        patch.object(entitlements, "get_user_subscription_tier", tier_lookup),
     ):
         assert await entitlements.has_entitlement(
             "user-1",
@@ -29,7 +25,7 @@ async def test_local_entitlement_bypasses_database_manager():
             Entitlement.CODEX_SUBSCRIPTION_TRANSPORT,
         )
 
-    get_db.assert_not_called()
+    tier_lookup.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -48,14 +44,10 @@ async def test_cloud_entitlement_uses_minimum_tier_order(
     tier: SubscriptionTier,
     allowed: bool,
 ):
-    client = _database_client(tier)
+    tier_lookup = AsyncMock(return_value=tier)
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
-        patch.object(
-            entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
-        ),
+        patch.object(entitlements, "get_user_subscription_tier", tier_lookup),
     ):
         result = await entitlements.has_entitlement(
             "user-1",
@@ -63,44 +55,15 @@ async def test_cloud_entitlement_uses_minimum_tier_order(
         )
 
     assert result is allowed
-    client.get_user_subscription_tier.assert_awaited_once_with("user-1")
-
-
-@pytest.mark.asyncio
-async def test_repeated_checks_repeat_database_manager_lookup():
-    client = _database_client(SubscriptionTier.MAX, SubscriptionTier.PRO)
-    with (
-        patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
-        patch.object(
-            entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
-        ),
-    ):
-        first = await entitlements.has_entitlement(
-            "user-1",
-            Entitlement.CODEX_SUBSCRIPTION_TRANSPORT,
-        )
-        second = await entitlements.has_entitlement(
-            "user-1",
-            Entitlement.CODEX_SUBSCRIPTION_TRANSPORT,
-        )
-
-    assert first is True
-    assert second is False
-    assert client.get_user_subscription_tier.await_count == 2
+    tier_lookup.assert_awaited_once_with("user-1")
 
 
 @pytest.mark.asyncio
 async def test_require_entitlement_raises_below_minimum_tier():
-    client = _database_client(SubscriptionTier.PRO)
+    tier_lookup = AsyncMock(return_value=SubscriptionTier.PRO)
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
-        patch.object(
-            entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
-        ),
+        patch.object(entitlements, "get_user_subscription_tier", tier_lookup),
     ):
         with pytest.raises(EntitlementRequiredError) as exc_info:
             await entitlements.require_entitlement(
@@ -114,14 +77,10 @@ async def test_require_entitlement_raises_below_minimum_tier():
 
 @pytest.mark.asyncio
 async def test_database_manager_error_propagates():
-    client = _database_client(RuntimeError("database unavailable"))
+    tier_lookup = AsyncMock(side_effect=RuntimeError("database unavailable"))
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
-        patch.object(
-            entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
-        ),
+        patch.object(entitlements, "get_user_subscription_tier", tier_lookup),
     ):
         with pytest.raises(RuntimeError, match="database unavailable"):
             await entitlements.has_entitlement(
@@ -132,14 +91,10 @@ async def test_database_manager_error_propagates():
 
 @pytest.mark.asyncio
 async def test_missing_user_is_treated_as_no_tier():
-    client = _database_client(ValueError("User not found"))
+    tier_lookup = AsyncMock(side_effect=SubscriptionTierUserNotFoundError("missing"))
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
-        patch.object(
-            entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
-        ),
+        patch.object(entitlements, "get_user_subscription_tier", tier_lookup),
     ):
         allowed = await entitlements.has_entitlement(
             "missing-user",

--- a/autogpt_platform/backend/backend/util/subscription_tiers.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers.py
@@ -1,0 +1,76 @@
+"""Authoritative subscription-tier lookup and ordering policy."""
+
+import logging
+
+from prisma.enums import SubscriptionTier
+
+from backend.util.cache import cached
+from backend.util.clients import get_database_manager_async_client
+from backend.util.service import UnhealthyServiceError
+
+logger = logging.getLogger(__name__)
+
+# Ordered from least to most privileged for minimum-tier checks.
+SUBSCRIPTION_TIER_ORDER = (
+    SubscriptionTier.NO_TIER,
+    SubscriptionTier.BASIC,
+    SubscriptionTier.PRO,
+    SubscriptionTier.MAX,
+    SubscriptionTier.BUSINESS,
+    SubscriptionTier.ENTERPRISE,
+)
+_SUBSCRIPTION_TIER_RANK = {
+    tier: rank for rank, tier in enumerate(SUBSCRIPTION_TIER_ORDER)
+}
+
+
+class SubscriptionTierUserNotFoundError(Exception):
+    """Raised when Database Manager confirms that the user does not exist."""
+
+
+@cached(maxsize=1000, ttl_seconds=300, shared_cache=True)
+async def _fetch_user_tier(user_id: str) -> SubscriptionTier:
+    """Fetch one authoritative tier; failed lookups are not cached."""
+    try:
+        tier = await get_database_manager_async_client().get_user_subscription_tier(
+            user_id
+        )
+    except UnhealthyServiceError:
+        # This subclasses ValueError, so it must precede missing-user translation.
+        raise
+    except ValueError as exc:
+        raise SubscriptionTierUserNotFoundError(user_id) from exc
+    return SubscriptionTier(tier)
+
+
+async def get_user_subscription_tier(user_id: str) -> SubscriptionTier:
+    """Resolve the authoritative tier through the shared cache."""
+    tier = await _fetch_user_tier(user_id)
+    # Older pods cached their module-local enum under this same Redis key.
+    return SubscriptionTier(tier.value)
+
+
+get_user_subscription_tier.cache_clear = _fetch_user_tier.cache_clear  # type: ignore[attr-defined]
+get_user_subscription_tier.cache_delete = _fetch_user_tier.cache_delete  # type: ignore[attr-defined]
+
+
+def invalidate_user_subscription_tier(user_id: str) -> None:
+    """Best-effort eviction after an authoritative tier write."""
+    try:
+        _fetch_user_tier.cache_delete(user_id)
+    except Exception:
+        logger.warning(
+            "Failed to invalidate subscription tier cache for user %s",
+            user_id[:8],
+            exc_info=True,
+        )
+
+
+def subscription_tier_rank(tier: SubscriptionTier) -> int:
+    return _SUBSCRIPTION_TIER_RANK[SubscriptionTier(tier)]
+
+
+def subscription_tier_at_least(
+    tier: SubscriptionTier, minimum_tier: SubscriptionTier
+) -> bool:
+    return subscription_tier_rank(tier) >= subscription_tier_rank(minimum_tier)

--- a/autogpt_platform/backend/backend/util/subscription_tiers_test.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers_test.py
@@ -1,0 +1,288 @@
+import asyncio
+import pickle
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from prisma.enums import SubscriptionTier
+
+from backend.util import cache as cache_module
+from backend.util import subscription_tiers
+from backend.util.cache import _make_hashable_key, _make_redis_key, _sign_payload
+from backend.util.service import UnhealthyServiceError
+
+
+class _MemoryRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, bytes] = {}
+        self.fail_reads = False
+        self.fail_writes = False
+        self.fail_delete = False
+        self.delete_calls = 0
+
+    def get(self, key: str) -> bytes | None:
+        if self.fail_reads:
+            raise ConnectionError("Redis unavailable")
+        return self.values.get(key)
+
+    def setex(self, key: str, _ttl: int, value: bytes) -> bool:
+        if self.fail_writes:
+            raise ConnectionError("Redis unavailable")
+        self.values[key] = value
+        return True
+
+    def delete(self, key: str) -> int:
+        self.delete_calls += 1
+        if self.fail_delete:
+            raise ConnectionError("Redis unavailable")
+        return int(self.values.pop(key, None) is not None)
+
+
+@pytest.fixture
+def tier_cache(monkeypatch: pytest.MonkeyPatch) -> _MemoryRedis:
+    redis = _MemoryRedis()
+    monkeypatch.setattr(cache_module, "_get_redis", lambda: redis)
+    monkeypatch.setattr(cache_module, "_shared_cache_redis", None)
+    monkeypatch.setattr(cache_module, "_shared_cache_redis_retry_at", 0.0)
+    return redis
+
+
+def _database_client(*tiers: SubscriptionTier | Exception) -> MagicMock:
+    client = MagicMock()
+    client.get_user_subscription_tier = AsyncMock(side_effect=tiers)
+    return client
+
+
+def test_subscription_tier_order_covers_every_tier_once():
+    assert len(subscription_tiers.SUBSCRIPTION_TIER_ORDER) == len(
+        set(subscription_tiers.SUBSCRIPTION_TIER_ORDER)
+    )
+    assert set(subscription_tiers.SUBSCRIPTION_TIER_ORDER) == set(SubscriptionTier)
+
+
+def test_subscription_tier_at_least_uses_canonical_order():
+    assert subscription_tiers.subscription_tier_at_least(
+        SubscriptionTier.MAX, SubscriptionTier.MAX
+    )
+    assert subscription_tiers.subscription_tier_at_least(
+        SubscriptionTier.ENTERPRISE, SubscriptionTier.MAX
+    )
+    assert not subscription_tiers.subscription_tier_at_least(
+        SubscriptionTier.PRO, SubscriptionTier.MAX
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_lookup_is_cached_for_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    client = _database_client(SubscriptionTier.MAX)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    results = await asyncio.gather(
+        *(subscription_tiers.get_user_subscription_tier("user-1") for _ in range(8))
+    )
+
+    assert results == [SubscriptionTier.MAX] * 8
+    client.get_user_subscription_tier.assert_awaited_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_missing_users_and_outages_are_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    client = _database_client(
+        ValueError("missing"),
+        UnhealthyServiceError("Database Manager unavailable"),
+        SubscriptionTier.BUSINESS,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    with pytest.raises(subscription_tiers.SubscriptionTierUserNotFoundError):
+        await subscription_tiers.get_user_subscription_tier("user-1")
+    with pytest.raises(UnhealthyServiceError):
+        await subscription_tiers.get_user_subscription_tier("user-1")
+    assert (
+        await subscription_tiers.get_user_subscription_tier("user-1")
+        == SubscriptionTier.BUSINESS
+    )
+    assert client.get_user_subscription_tier.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unexpected_database_error_propagates_and_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    client = _database_client(RuntimeError("database failed"), SubscriptionTier.MAX)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    with pytest.raises(RuntimeError, match="database failed"):
+        await subscription_tiers.get_user_subscription_tier("user-1")
+    assert (
+        await subscription_tiers.get_user_subscription_tier("user-1")
+        == SubscriptionTier.MAX
+    )
+    assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_redis_outage_uses_short_local_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    tier_cache.fail_reads = True
+    tier_cache.fail_writes = True
+    client = _database_client(SubscriptionTier.MAX)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    assert (
+        await subscription_tiers.get_user_subscription_tier("user-1")
+        == SubscriptionTier.MAX
+    )
+    assert (
+        await subscription_tiers.get_user_subscription_tier("user-1")
+        == SubscriptionTier.MAX
+    )
+    assert client.get_user_subscription_tier.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_outage_local_fallback_expires_after_one_second(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    clock = [100.0]
+    monkeypatch.setattr(cache_module.time, "time", lambda: clock[0])
+    tier_cache.fail_reads = True
+    tier_cache.fail_writes = True
+    client = _database_client(SubscriptionTier.MAX, SubscriptionTier.PRO)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    assert (
+        await subscription_tiers.get_user_subscription_tier("fallback-expiry-user")
+        == SubscriptionTier.MAX
+    )
+    clock[0] = 101.1
+    assert (
+        await subscription_tiers.get_user_subscription_tier("fallback-expiry-user")
+        == SubscriptionTier.PRO
+    )
+    assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidation_is_user_specific(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    values = {
+        "changed": [SubscriptionTier.MAX, SubscriptionTier.PRO],
+        "stable": [SubscriptionTier.BUSINESS],
+    }
+
+    async def read_tier(user_id: str) -> SubscriptionTier:
+        return values[user_id].pop(0)
+
+    client = MagicMock()
+    client.get_user_subscription_tier = AsyncMock(side_effect=read_tier)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    assert (
+        await subscription_tiers.get_user_subscription_tier("changed")
+        == SubscriptionTier.MAX
+    )
+    assert (
+        await subscription_tiers.get_user_subscription_tier("stable")
+        == SubscriptionTier.BUSINESS
+    )
+
+    subscription_tiers.invalidate_user_subscription_tier("changed")
+
+    assert (
+        await subscription_tiers.get_user_subscription_tier("changed")
+        == SubscriptionTier.PRO
+    )
+    assert (
+        await subscription_tiers.get_user_subscription_tier("stable")
+        == SubscriptionTier.BUSINESS
+    )
+    assert client.get_user_subscription_tier.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_existing_cache_namespace_and_enum_payload_are_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+    tier_cache: _MemoryRedis,
+):
+    from enum import Enum
+
+    from backend.copilot import rate_limit
+
+    current_tier_enum = rate_limit.SubscriptionTier
+    legacy_tier_enum = Enum(
+        "SubscriptionTier",
+        {"MAX": "MAX"},
+        type=str,
+        module=rate_limit.__name__,
+    )
+    monkeypatch.setattr(rate_limit, "SubscriptionTier", legacy_tier_enum)
+    try:
+        legacy_payload = pickle.dumps(legacy_tier_enum.MAX)
+    finally:
+        monkeypatch.setattr(rate_limit, "SubscriptionTier", current_tier_enum)
+
+    key = _make_hashable_key(("user-1",), {})
+    redis_key = _make_redis_key(key, "_fetch_user_tier")
+    tier_cache.values[redis_key] = _sign_payload(legacy_payload)
+    get_db = MagicMock()
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        get_db,
+    )
+
+    assert (
+        await subscription_tiers.get_user_subscription_tier("user-1")
+        == SubscriptionTier.MAX
+    )
+    assert redis_key.startswith("cache:_fetch_user_tier:")
+    get_db.assert_not_called()
+
+
+def test_invalidation_is_best_effort_when_redis_is_unavailable(
+    tier_cache: _MemoryRedis,
+    caplog: pytest.LogCaptureFixture,
+):
+    tier_cache.fail_delete = True
+
+    with caplog.at_level("WARNING"):
+        subscription_tiers.invalidate_user_subscription_tier("user-1")
+
+    assert tier_cache.delete_calls == 1
+    assert "Failed to invalidate subscription tier cache" in caplog.text

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -24559,8 +24559,7 @@
       "SubscriptionTier": {
         "type": "string",
         "enum": ["NO_TIER", "BASIC", "PRO", "MAX", "BUSINESS", "ENTERPRISE"],
-        "title": "SubscriptionTier",
-        "description": "Subscription tiers with increasing cost allowances.\n\nMirrors the ``SubscriptionTier`` enum in ``schema.prisma``.\nOnce ``prisma generate`` is run, this can be replaced with::\n\n    from prisma.enums import SubscriptionTier"
+        "title": "SubscriptionTier"
       },
       "SubscriptionTierRequest": {
         "properties": {


### PR DESCRIPTION
### Why / What / How

**Why:** Entitlement checks queried Database Manager on every call while rate limiting maintained a separate five-minute tier cache, enum, ordering table, and write path. The shared-cache helper also serialized unrelated cache misses and could perform blocking Redis work on the async event loop.

**What:** This PR replaces those parallel paths with one cached subscription-tier resolver and one billing-owned writer shared by entitlements, paywall checks, and rate limiting.

**How:** The resolver preserves the existing `_fetch_user_tier(user_id)` Redis namespace, so old and new pods share entries during an ordinary rolling deploy. Successful reads cache for five minutes; missing users and service failures do not. Per-key single-flight collapses identical misses without serializing different users. Redis work runs off-loop behind a one-second, zero-retry circuit, with a one-second local fallback that prevents same-user database stampedes while Redis is unavailable.

### Changes 🏗️

- Use Prisma's canonical `SubscriptionTier` and one exhaustive ordering table.
- Route entitlement, paywall, and rate-limit reads through one Database Manager-backed cache.
- Route every in-repo tier write through the existing billing-owned writer.
- Scope async single-flight locks by full cache key.
- Bound Redis connection and command attempts to one second, disable both retry layers, and skip thread dispatch while the circuit is open.
- Recover after a fixed one-second cooldown without traffic extending it or stale clients closing replacements. The circuit is process-wide for every shared-cache consumer (including store/search, builder, full-user, pending-billing, organization-credit, and subscription-tier caches); its one-second fallback remains inside their existing 30–3600 second cache TTLs.
- Run all post-commit tier-derived evictions as one cancellation-safe, user-specific, best-effort batch.
- Sync generated OpenAPI after removing the duplicate Python enum; enum values and client shape are unchanged.

### Behavior and rollout

- Local entitlement bypass happens before Redis or Database Manager access.
- Entitlements propagate service outages; rate limiting keeps its existing fallback and Stripe-reconciliation policy; HTTP paywall checks map outages to 503.
- Redis read or write failures bypass the shared cache. Invalidation failures are logged and do not turn a committed tier update into a failed request.
- Entitlement authorization **now adopts** a bounded-staleness contract. A failed eviction or read racing a tier write can preserve the prior tier for at most the five-minute TTL. This PR does not claim hard immediate revocation.
- All production tier mutations in this repository use the canonical writer and attempt eviction immediately. Out-of-band database edits remain TTL-bounded.
- Rollout and rollback are ordinary deploys. There is no migration, feature flag, configuration change, or ordered multi-PR protocol.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Subscription resolver and entitlement behavior: 21 passed on Python 3.11
  - [x] Shared-cache concurrency, bounded outage, recovery, and invalidation: 10 passed on Python 3.11
  - [x] Paywall, rate-limit, tier-writer, and drift-check behavior: 34 tests collected; focused changed branches passed on Python 3.11
  - [x] Billing writer and Stripe webhook ownership: focused changed branches passed on Python 3.11
  - [x] Ruff, Black, isort, and `git diff --check` are clean
  - [x] Generated OpenAPI JSON parses and its only schema change is removal of the obsolete duplicate-enum description
  - [ ] Exact-head GitHub backend matrix, frontend integration, API sync, and single-container checks complete green

#### For configuration changes:
- [x] No configuration changes; `.env.default` is already compatible
- [x] No configuration changes; `docker-compose.yml` is already compatible
- [x] No configuration changes to list

### Review guide

Start with `backend/util/subscription_tiers.py`, then the keyed single-flight and bounded Redis circuit in `backend/util/cache.py`, and finally the caller-specific policies in `backend/copilot/rate_limit.py`, `backend/util/entitlements.py`, and `backend/data/credit.py`.