### PR TITLE
fix(frontend): preserve native undo in editable fields

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/UndoRedoButtons.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/UndoRedoButtons.tsx
@@ -20,6 +20,15 @@ export const UndoRedoButtons = () => {
   // Keyboard shortcuts for undo and redo
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement && target.isContentEditable)
+      ) {
+        return;
+      }
+
       const isMac = /Mac/i.test(navigator.userAgent);
       const isCtrlOrCmd = isMac ? event.metaKey : event.ctrlKey;
 

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/__tests__/UndoRedoButtons.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/__tests__/UndoRedoButtons.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
+import { describe, expect, test, vi } from "vitest";
+
+const { undo } = vi.hoisted(() => ({ undo: vi.fn() }));
+
+vi.mock("../../../stores/historyStore", () => ({
+  useHistoryStore: () => ({
+    undo,
+    redo: vi.fn(),
+    canUndo: () => true,
+    canRedo: () => true,
+  }),
+}));
+
+import { UndoRedoButtons } from "../UndoRedoButtons";
+
+describe("UndoRedoButtons", () => {
+  test("leaves undo shortcuts to editable controls", () => {
+    render(
+      <>
+        <UndoRedoButtons />
+        <textarea aria-label="Expanded input" />
+      </>,
+    );
+
+    fireEvent.keyDown(screen.getByLabelText("Expanded input"), {
+      key: "z",
+      ctrlKey: true,
+    });
+    expect(undo).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    expect(undo).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
### Why / What / How

Fixes #10476.

The builder's window-level graph undo shortcut called `preventDefault()` for every Ctrl/Cmd+Z event, including events from the expanded input textarea. That suppressed the browser's native text undo and ran graph undo instead.

This change leaves undo/redo key events from inputs, textareas, and content-editable elements to the browser while preserving graph undo/redo everywhere else.

### Changes 🏗️

- Skip graph undo/redo shortcuts when focus is in an editable element.
- Add a regression test covering textarea undo and the existing graph shortcut.
- No configuration changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm exec vitest run <UndoRedoButtons test> <TextInputExpanderModal test>` (5 passed)
  - [x] `pnpm exec eslint <changed files>`
  - [x] `pnpm exec prettier --check <changed files>`
  - [x] `pnpm run types`

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
