### PR TITLE
fix(copilot): re-enable CLAUDE.md/AGENTS.md loading in SDK subprocess

### DIFF
--- a/.github/workflows/platform-single-container-docker.yml
+++ b/.github/workflows/platform-single-container-docker.yml
@@ -1,0 +1,22 @@
+# Registration-only on master; selecting dev loads the publishing workflow from dev.
+name: AutoGPT Platform - Single-container image
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the current dev commit to Docker Hub (select dev as the ref)
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  registration-placeholder:
+    # workflow_dispatch always supplies a SHA, so this never allocates a runner.
+    if: ${{ github.sha == '' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - run: ":"

--- a/autogpt_platform/backend/backend/copilot/sdk/env.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/env.py
@@ -110,10 +110,11 @@ def build_sdk_env(
     if sdk_cwd:
         env["CLAUDE_CODE_TMPDIR"] = sdk_cwd
 
-    # Harden multi-tenant deployment: prevent loading untrusted workspace
-    # .claude.md files, writing auto-memory, and sending non-essential
-    # telemetry traffic.
-    env["CLAUDE_CODE_DISABLE_CLAUDE_MDS"] = "1"
+    # Harden multi-tenant deployment: prevent writing auto-memory and
+    # sending non-essential telemetry traffic. CLAUDE.md/AGENTS.md loading
+    # is intentionally left enabled (see PR description) so project
+    # instructions in cloned repos are respected, matching interactive
+    # Claude Code behavior.
     env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"
     env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
     # Strip Anthropic-specific beta headers that OpenRouter rejects.

--- a/autogpt_platform/backend/backend/copilot/sdk/p0_guardrails_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/p0_guardrails_test.py
@@ -114,7 +114,6 @@ class TestResolveFallbackModel:
 
 
 _SECURITY_VARS = (
-    "CLAUDE_CODE_DISABLE_CLAUDE_MDS",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
 )
@@ -167,6 +166,18 @@ class TestSecurityEnvVars:
 
         for var in _SECURITY_VARS:
             assert env.get(var) == "1", f"{var} not set in subscription mode"
+
+    def test_claude_md_loading_not_disabled(self):
+        """CLAUDE_CODE_DISABLE_CLAUDE_MDS must not be set — project CLAUDE.md
+        / AGENTS.md instructions should be respected, matching interactive
+        Claude Code behavior."""
+        cfg = _make_config(use_claude_code_subscription=False, use_openrouter=False)
+        with patch(f"{_ENV}.config", cfg):
+            from backend.copilot.sdk.env import build_sdk_env
+
+            env = build_sdk_env()
+
+        assert "CLAUDE_CODE_DISABLE_CLAUDE_MDS" not in env
 
     def test_tmpdir_set_when_sdk_cwd_provided(self):
         """CLAUDE_CODE_TMPDIR must be set when sdk_cwd is provided."""


### PR DESCRIPTION
## What

Removes the unconditional `CLAUDE_CODE_DISABLE_CLAUDE_MDS=1` set in `build_sdk_env()` (`sdk/env.py`), which silently disabled Claude Code's auto-discovery of `CLAUDE.md`/`AGENTS.md` project instruction files for every repo the copilot SDK operates on. `CLAUDE_CODE_DISABLE_AUTO_MEMORY` and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` are left in place.

## Why

Interactive Claude Code respects `CLAUDE.md`/`AGENTS.md` project instructions; our SDK subprocess was silently diverging from that, so agents ignore repo-specific conventions in cloned codebases even when the user/repo maintainer explicitly wrote them for the agent.

Traced the rationale for this flag back through history: it originally applied only in the OpenRouter auth path, then #12636 ("P0 guardrails, transient retry, and security hardening") extended it to all three auth modes for **consistency across modes**, not because of any specific documented exploit/incident against `CLAUDE.md` loading itself — it was bundled defensively alongside real hardening (auto-memory writes, non-essential telemetry). `CLAUDE.md` content isn't meaningfully more untrusted than the rest of the cloned repo the agent already reads/executes against, so disabling it trades away real functionality for marginal, non-specific hardening.

## Test plan

- Updated `p0_guardrails_test.py`: dropped `CLAUDE_CODE_DISABLE_CLAUDE_MDS` from the shared `_SECURITY_VARS` tuple asserted across all 3 auth-mode tests, and added `test_claude_md_loading_not_disabled` asserting the var is absent from the built env.
- CI will run the full suite; requesting a preview deploy via `!deploy` to manually verify an agent now picks up a test repo's `CLAUDE.md` instructions.