### PR TITLE
fix(blocks): parse structured JSON response types

### DIFF
--- a/autogpt_platform/backend/backend/blocks/http.py
+++ b/autogpt_platform/backend/backend/blocks/http.py
@@ -207,7 +207,10 @@ class SendWebRequestBlock(Block):
         )
 
         # Decide how to parse the response
-        if response.headers.get("content-type", "").startswith("application/json"):
+        content_type = (
+            response.headers.get("content-type", "").partition(";")[0].strip().lower()
+        )
+        if content_type == "application/json" or content_type.endswith("+json"):
             result = None if response.status == 204 else response.json()
         else:
             result = response.text()

--- a/autogpt_platform/backend/backend/blocks/test/test_http.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_http.py
@@ -29,11 +29,23 @@ def make_test_context(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "application/problem+json; charset=utf-8",
+        " APPLICATION/PROBLEM+JSON ; charset=utf-8",
+        "application/json; charset=utf-8",
+        "application/vnd.api+json",
+    ],
+)
 @patch("backend.blocks.http.Requests")
-async def test_http_block_parses_structured_json_response(mock_requests_class):
+async def test_http_block_parses_structured_json_response(
+    mock_requests_class,
+    content_type,
+):
     response = MagicMock(spec=Response)
     response.status = 400
-    response.headers = {"content-type": "application/problem+json; charset=utf-8"}
+    response.headers = {"content-type": content_type}
     response.json.return_value = {
         "type": "https://example.com/problems/invalid-request",
         "title": "Invalid request",

--- a/autogpt_platform/backend/backend/blocks/test/test_http.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_http.py
@@ -10,6 +10,7 @@ from backend.blocks.http import (
     HttpCredentials,
     HttpMethod,
     SendAuthenticatedWebRequestBlock,
+    SendWebRequestBlock,
 )
 from backend.data.execution import ExecutionContext
 from backend.data.model import HostScopedCredentials
@@ -25,6 +26,48 @@ def make_test_context(
         user_id=user_id,
         graph_exec_id=graph_exec_id,
     )
+
+
+@pytest.mark.asyncio
+@patch("backend.blocks.http.Requests")
+async def test_http_block_parses_structured_json_response(mock_requests_class):
+    response = MagicMock(spec=Response)
+    response.status = 400
+    response.headers = {"content-type": "application/problem+json; charset=utf-8"}
+    response.json.return_value = {
+        "type": "https://example.com/problems/invalid-request",
+        "title": "Invalid request",
+    }
+    response.text.return_value = (
+        '{"type":"https://example.com/problems/invalid-request",'
+        '"title":"Invalid request"}'
+    )
+    mock_requests = AsyncMock()
+    mock_requests.request.return_value = response
+    mock_requests_class.return_value = mock_requests
+
+    outputs = [
+        output
+        async for output in SendWebRequestBlock().run(
+            SendWebRequestBlock.Input(
+                url="https://api.example.com/data",
+                method=HttpMethod.GET,
+            ),
+            execution_context=make_test_context(),
+        )
+    ]
+
+    assert outputs == [
+        (
+            "client_error",
+            {
+                "type": "https://example.com/problems/invalid-request",
+                "title": "Invalid request",
+            },
+        )
+    ]
+    response.json.assert_called_once_with()
+    response.text.assert_not_called()
 
 
 class TestHttpBlockWithHostScopedCredentials:


### PR DESCRIPTION
### Why / What / How

**Why:** `SendWebRequestBlock` only recognized response media types beginning with `application/json`. Standards-based JSON types such as `application/problem+json` were therefore returned as strings, preventing downstream blocks from accessing their structured fields.

**What:** Parse `application/json` and media types using the `+json` structured syntax suffix as JSON responses.

**How:** Normalize the response `Content-Type` by removing parameters, whitespace, and case differences before checking for the exact JSON media type or a `+json` suffix. Existing 204 and non-JSON behavior is unchanged.

Closes #14007.

### Changes 🏗️

- Normalize response media types before choosing the response parser.
- Recognize structured JSON media types such as `application/problem+json`.
- Add a mocked regression test proving 4xx problem-details responses remain JSON objects.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Confirmed the regression test was `XFAIL` before the implementation.
  - [x] `poetry run pytest backend/blocks/test/test_http.py -q` — 8 passed.
  - [x] Black and isort checks passed for both changed files.
  - [x] Ruff passed for both changed files.
  - [x] Pyright passed for both changed files with 0 errors.

#### For configuration changes:

- [x] `.env.default` is already compatible; no environment changes are required.
- [x] `docker-compose.yml` is already compatible; no service changes are required.
- [x] No configuration changes are included in this PR.
