### PR TITLE
perf(platform): scope async cache locks by key

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes.py
@@ -18,6 +18,7 @@ from backend.copilot.rate_limit import (
     set_user_tier,
 )
 from backend.data.user import get_user_by_email, get_user_email_by_id, search_users
+from backend.util.subscription_tiers import SubscriptionTierCacheInvalidationError
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +235,16 @@ async def set_user_rate_limit_tier(
     )
     try:
         await set_user_tier(request.user_id, request.tier)
+    except SubscriptionTierCacheInvalidationError as e:
+        logger.exception(
+            "User tier committed, but cache propagation failed for user %s",
+            request.user_id,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Tier updated, but cache propagation failed; retry to repair",
+            headers={"Retry-After": "1"},
+        ) from e
     except Exception as e:
         logger.exception("Failed to set user tier")
         raise HTTPException(status_code=500, detail="Failed to set tier") from e

--- a/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/rate_limit_admin_routes_test.py
@@ -10,6 +10,7 @@ from autogpt_libs.auth.jwt_utils import get_jwt_payload
 from pytest_snapshot.plugin import Snapshot
 
 from backend.copilot.rate_limit import CoPilotUsageStatus, SubscriptionTier, UsageWindow
+from backend.util.subscription_tiers import SubscriptionTierCacheInvalidationError
 
 from .rate_limit_admin_routes import router as rate_limit_admin_router
 
@@ -491,6 +492,38 @@ def test_set_user_tier_db_failure(
     )
 
     assert response.status_code == 500
+
+
+def test_set_user_tier_cache_failure_reports_committed_update(
+    mocker: pytest_mock.MockerFixture,
+    target_user_id: str,
+) -> None:
+    mocker.patch(
+        f"{_MOCK_MODULE}.get_user_email_by_id",
+        new_callable=AsyncMock,
+        return_value=_TARGET_EMAIL,
+    )
+    mocker.patch(
+        f"{_MOCK_MODULE}.get_user_tier",
+        new_callable=AsyncMock,
+        return_value=SubscriptionTier.BASIC,
+    )
+    mocker.patch(
+        f"{_MOCK_MODULE}.set_user_tier",
+        new_callable=AsyncMock,
+        side_effect=SubscriptionTierCacheInvalidationError(("generation",)),
+    )
+
+    response = client.post(
+        "/admin/rate_limit/tier",
+        json={"user_id": target_user_id, "tier": "PRO"},
+    )
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "1"
+    assert response.json() == {
+        "detail": "Tier updated, but cache propagation failed; retry to repair"
+    }
 
 
 def test_tier_endpoints_require_admin_role(mock_jwt_user) -> None:

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -67,6 +67,10 @@ from backend.data.redis_client import AsyncRedisClient, get_redis_async
 from backend.data.user import get_user_by_id
 from backend.util.cache import cached
 from backend.util.feature_flag import Flag, get_feature_flag_value, is_feature_enabled
+from backend.util.subscription_tiers import (
+    invalidate_subscription_tier_auxiliary_caches,
+    invalidate_subscription_tier_caches,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -914,9 +918,8 @@ async def _decr_counter_floor_zero(
 class _UserNotFoundError(Exception):
     """Raised when a user record is missing or has no subscription tier.
 
-    Raising (rather than returning ``DEFAULT_TIER``) prevents ``@cached``
-    from persisting the fallback, which would otherwise keep serving FREE
-    for up to the TTL after the user's real tier is set.
+    Raising prevents ``@cached`` from persisting the fallback, which would
+    otherwise keep serving NO_TIER after the user's real tier is set.
     """
 
 
@@ -1029,10 +1032,12 @@ async def get_user_tier(user_id: str) -> SubscriptionTier:
     return tier
 
 
-# Expose cache management on the public function so callers (including tests)
-# never need to reach into the private ``_fetch_user_tier``.
-get_user_tier.cache_clear = _fetch_user_tier.cache_clear  # type: ignore[attr-defined]
-get_user_tier.cache_delete = _fetch_user_tier.cache_delete  # type: ignore[attr-defined]
+def clear_legacy_user_tier_cache() -> None:
+    _fetch_user_tier.cache_clear()
+
+
+def invalidate_legacy_user_tier_cache(user_id: str) -> None:
+    _fetch_user_tier.cache_delete(user_id)
 
 
 async def get_workspace_storage_limit_bytes(user_id: str) -> int:
@@ -1063,15 +1068,17 @@ async def set_user_tier(user_id: str, tier: SubscriptionTier) -> None:
         where={"id": user_id},
         data={"subscriptionTier": tier.value},
     )
-    get_user_tier.cache_delete(user_id)  # type: ignore[attr-defined]
-    # Local import: backend.data.credit imports from this module.
-    from backend.data.credit import get_pending_subscription_change
 
-    get_user_by_id.cache_delete(user_id)  # type: ignore[attr-defined]
-    get_pending_subscription_change.cache_delete(user_id)  # type: ignore[attr-defined]
-
-    # Fire-and-forget drift check so admin bulk ops don't wait on Stripe.
-    asyncio.ensure_future(_drift_check_background(user_id, tier))
+    try:
+        await invalidate_subscription_tier_caches(
+            user_id,
+            invalidate_legacy_user_tier_cache,
+        )
+    finally:
+        invalidate_subscription_tier_auxiliary_caches(user_id)
+        # The DB write committed, so run diagnostics even when cache propagation
+        # failed and the caller is asked to retry the fence.
+        asyncio.ensure_future(_drift_check_background(user_id, tier))
 
 
 async def _drift_check_background(user_id: str, tier: SubscriptionTier) -> None:

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -29,6 +29,7 @@ from .rate_limit import (
     acquire_reset_lock,
     build_budget_ctx,
     check_rate_limit,
+    clear_legacy_user_tier_cache,
     get_daily_reset_count,
     get_global_rate_limits,
     get_remaining_usd_budget,
@@ -1281,7 +1282,7 @@ class TestGetUserTier:
     @pytest.fixture(autouse=True)
     def _clear_tier_cache(self):
         """Clear the get_user_tier cache before each test."""
-        get_user_tier.cache_clear()  # type: ignore[attr-defined]
+        clear_legacy_user_tier_cache()
 
     def _mock_user_db(
         self, subscription_tier: str | None = None, raises: Exception | None = None
@@ -1459,7 +1460,7 @@ class TestMaybeReconcileStripeTier:
     async def test_get_user_tier_survives_reconcile_failure(self):
         """Reconcile failure stays non-fatal for rate limiting: get_user_tier
         still resolves the DB-confirmed NO_TIER instead of raising."""
-        get_user_tier.cache_clear()  # type: ignore[attr-defined]
+        clear_legacy_user_tier_cache()
         mock_user = MagicMock()
         mock_user.subscription_tier = None
         mock_db = AsyncMock()
@@ -1488,7 +1489,30 @@ class TestSetUserTier:
     @pytest.fixture(autouse=True)
     def _clear_tier_cache(self):
         """Clear the get_user_tier cache before each test."""
-        get_user_tier.cache_clear()  # type: ignore[attr-defined]
+        values: dict[object, object] = {}
+        redis = MagicMock()
+        redis.scan_iter.return_value = []
+        redis.get.side_effect = values.get
+        redis.getex.side_effect = lambda key, **_kwargs: values.get(key)
+        redis.setex.side_effect = lambda key, _ttl, value: values.__setitem__(
+            key, value
+        )
+        redis.delete.side_effect = lambda key: int(values.pop(key, None) is not None)
+
+        with patch("backend.util.cache._get_redis", return_value=redis):
+            clear_legacy_user_tier_cache()
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _stub_generation_invalidation(self):
+        async def invalidate(_user_id: str, legacy_cache_delete):
+            legacy_cache_delete(_user_id)
+
+        with patch(
+            "backend.copilot.rate_limit.invalidate_subscription_tier_caches",
+            side_effect=invalidate,
+        ):
+            yield
 
     @pytest.mark.asyncio
     async def test_updates_db_and_invalidates_cache(self):
@@ -1506,6 +1530,108 @@ class TestSetUserTier:
             where={"id": _USER},
             data={"subscriptionTier": "PRO"},
         )
+
+    @pytest.mark.asyncio
+    async def test_security_invalidation_runs_after_db_commit(self):
+        events: list[str] = []
+        mock_prisma = AsyncMock()
+
+        async def update(**_kwargs):
+            events.append("db")
+
+        async def invalidate(_user_id: str, _legacy_cache_delete):
+            events.append("security-caches")
+
+        mock_prisma.update = AsyncMock(side_effect=update)
+        with (
+            patch(
+                "backend.copilot.rate_limit.PrismaUser.prisma",
+                return_value=mock_prisma,
+            ),
+            patch(
+                "backend.copilot.rate_limit.invalidate_subscription_tier_caches",
+                side_effect=invalidate,
+            ),
+        ):
+            await set_user_tier(_USER, SubscriptionTier.PRO)
+
+        assert events == ["db", "security-caches"]
+
+    @pytest.mark.asyncio
+    async def test_security_invalidation_failure_surfaces_after_commit(self):
+        from backend.util.subscription_tiers import (
+            SubscriptionTierCacheInvalidationError,
+        )
+
+        mock_prisma = AsyncMock()
+        mock_prisma.update = AsyncMock(return_value=None)
+        auxiliary_delete = MagicMock()
+        pending_delete = MagicMock()
+        drift_check = AsyncMock()
+
+        def close_scheduled_coroutine(coroutine):
+            coroutine.close()
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.PrismaUser.prisma",
+                return_value=mock_prisma,
+            ),
+            patch(
+                "backend.copilot.rate_limit.invalidate_subscription_tier_caches",
+                new=AsyncMock(
+                    side_effect=SubscriptionTierCacheInvalidationError(("generation",))
+                ),
+            ),
+            patch(
+                "backend.copilot.rate_limit.get_user_by_id.cache_delete",
+                new=auxiliary_delete,
+            ),
+            patch(
+                "backend.data.credit.get_pending_subscription_change.cache_delete",
+                new=pending_delete,
+            ),
+            patch(
+                "backend.copilot.rate_limit._drift_check_background",
+                new=drift_check,
+            ),
+            patch(
+                "backend.copilot.rate_limit.asyncio.ensure_future",
+                side_effect=close_scheduled_coroutine,
+            ) as ensure_future,
+        ):
+            with pytest.raises(SubscriptionTierCacheInvalidationError):
+                await set_user_tier(_USER, SubscriptionTier.PRO)
+
+        mock_prisma.update.assert_awaited_once()
+        auxiliary_delete.assert_called_once_with(_USER)
+        pending_delete.assert_called_once_with(_USER)
+        drift_check.assert_called_once_with(_USER, SubscriptionTier.PRO)
+        ensure_future.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auxiliary_cache_failures_are_independent_and_best_effort(self):
+        mock_prisma = AsyncMock()
+        mock_prisma.update = AsyncMock(return_value=None)
+        pending_delete = MagicMock()
+
+        with (
+            patch(
+                "backend.copilot.rate_limit.PrismaUser.prisma",
+                return_value=mock_prisma,
+            ),
+            patch(
+                "backend.copilot.rate_limit.get_user_by_id.cache_delete",
+                side_effect=ConnectionError("auxiliary cache down"),
+            ),
+            patch(
+                "backend.data.credit.get_pending_subscription_change.cache_delete",
+                new=pending_delete,
+            ),
+        ):
+            await set_user_tier(_USER, SubscriptionTier.PRO)
+
+        pending_delete.assert_called_once_with(_USER)
 
     @pytest.mark.asyncio
     async def test_record_not_found_propagates(self):
@@ -1572,6 +1698,8 @@ class TestSetUserTier:
 
         mock_user = MagicMock()
         mock_user.stripe_customer_id = "cus_abc"
+        get_user = AsyncMock(return_value=mock_user)
+        get_user.cache_delete = MagicMock()
 
         mock_sub = MagicMock()
         mock_sub.id = "sub_abc"
@@ -1584,8 +1712,7 @@ class TestSetUserTier:
             ),
             patch(
                 "backend.copilot.rate_limit.get_user_by_id",
-                new_callable=AsyncMock,
-                return_value=mock_user,
+                new=get_user,
             ),
             patch(
                 "backend.data.credit._get_active_subscription",

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -48,6 +48,12 @@ from backend.util.metrics import DiscordChannel, discord_send_alert
 from backend.util.models import Pagination
 from backend.util.retry import func_retry
 from backend.util.settings import Settings
+from backend.util.subscription_tier_order import subscription_tier_rank
+from backend.util.subscription_tiers import (
+    SubscriptionTierCacheInvalidationError,
+    invalidate_subscription_tier_auxiliary_caches,
+    invalidate_subscription_tier_caches,
+)
 
 if TYPE_CHECKING:
     from backend.blocks._base import Block, BlockCost
@@ -1520,6 +1526,16 @@ async def set_auto_top_up(user_id: str, config: AutoTopUpConfig):
     get_user_by_id.cache_delete(user_id)
 
 
+async def _invalidate_subscription_tier_security_caches(user_id: str) -> None:
+    # Local import avoids a credit <-> rate_limit cycle at module load.
+    from backend.copilot.rate_limit import invalidate_legacy_user_tier_cache
+
+    await invalidate_subscription_tier_caches(
+        user_id,
+        invalidate_legacy_user_tier_cache,
+    )
+
+
 async def set_subscription_tier(
     user_id: str,
     tier: SubscriptionTier,
@@ -1529,18 +1545,10 @@ async def set_subscription_tier(
         "subscriptionTier": tier,
     }
     await User.prisma().update(where={"id": user_id}, data=data)
-    get_user_by_id.cache_delete(user_id)
-    # Also invalidate the rate-limit tier cache so CoPilot picks up the new
-    # tier immediately rather than waiting up to 5 minutes for the TTL to expire.
-    from backend.copilot.rate_limit import get_user_tier  # local import avoids circular
-
-    get_user_tier.cache_delete(user_id)  # type: ignore[attr-defined]
-    # Invalidate the pending-change cache too — an admin tier override or the
-    # webhook-driven phase transition means any cached pending-change state
-    # (schedule, cancel_at_period_end) is likely stale. Without this the
-    # billing page can show a pending change for up to 30s after the tier
-    # has already flipped.
-    get_pending_subscription_change.cache_delete(user_id)
+    try:
+        await _invalidate_subscription_tier_security_caches(user_id)
+    finally:
+        invalidate_subscription_tier_auxiliary_caches(user_id)
 
 
 async def _cancel_customer_subscriptions(
@@ -1702,26 +1710,12 @@ async def get_proration_credit_cents(user_id: str, monthly_cost_cents: int) -> i
 # Ordered from least- to most-privileged. Used to distinguish upgrades
 # (move right) from downgrades (move left); ENTERPRISE is admin-managed and
 # never reached via self-service flows.
-_TIER_ORDER: tuple[SubscriptionTier, ...] = (
-    SubscriptionTier.NO_TIER,
-    SubscriptionTier.BASIC,
-    SubscriptionTier.PRO,
-    SubscriptionTier.MAX,
-    SubscriptionTier.BUSINESS,
-    SubscriptionTier.ENTERPRISE,
-)
-
-
-def _tier_rank(tier: SubscriptionTier) -> int:
-    return _TIER_ORDER.index(tier)
-
-
 def is_tier_upgrade(current: SubscriptionTier, target: SubscriptionTier) -> bool:
-    return _tier_rank(target) > _tier_rank(current)
+    return subscription_tier_rank(target) > subscription_tier_rank(current)
 
 
 def is_tier_downgrade(current: SubscriptionTier, target: SubscriptionTier) -> bool:
-    return _tier_rank(target) < _tier_rank(current)
+    return subscription_tier_rank(target) < subscription_tier_rank(current)
 
 
 class PendingChangeUnknown(Exception):
@@ -2098,6 +2092,16 @@ async def modify_stripe_subscription_for_tier(
         try:
             await set_subscription_tier(user_id, tier)
             db_flip_succeeded = True
+        except SubscriptionTierCacheInvalidationError:
+            db_flip_succeeded = True
+            logger.exception(
+                "modify_stripe_subscription_for_tier: Stripe modify and DB tier"
+                " flip on sub %s succeeded for user %s → %s, but the cache"
+                " fence failed; the Stripe webhook retry will repair it",
+                sub_id,
+                user_id,
+                tier,
+            )
         except (PrismaError, ConnectionError, asyncio.TimeoutError):
             logger.exception(
                 "modify_stripe_subscription_for_tier: Stripe modify on sub %s"
@@ -2780,9 +2784,10 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
             return
         tier = SubscriptionTier.NO_TIER
     # Idempotency: Stripe retries webhooks on delivery failure, and several event
-    # types map to the same final tier. Skip the DB write + cache invalidation
-    # when the tier is already correct to avoid redundant writes on replay.
+    # types map to the same final tier. Skip the redundant DB write, but re-run
+    # cache invalidation in case a prior post-commit fence failed.
     if current_tier == tier:
+        await _invalidate_subscription_tier_security_caches(user.id)
         return
     # When a new subscription becomes active (e.g. paid-to-paid tier upgrade
     # via a fresh Checkout Session), cancel any OTHER active subscriptions for
@@ -2805,7 +2810,11 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         # A future improvement would be to write the new tier first, then
         # cancel the old sub.
         await _cleanup_stale_subscriptions(customer_id, new_sub_id)
-    await set_subscription_tier(user.id, tier)
+    cache_invalidation_error: SubscriptionTierCacheInvalidationError | None = None
+    try:
+        await set_subscription_tier(user.id, tier)
+    except SubscriptionTierCacheInvalidationError as exc:
+        cache_invalidation_error = exc
     if is_tier_upgrade(current_tier, tier):
         billing_cycle = (
             metadata.get("billing_cycle") if isinstance(metadata, dict) else None
@@ -2822,6 +2831,8 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
     # Tier changed — bust any cached pending-change view so the next
     # dashboard fetch reflects the new state immediately.
     get_pending_subscription_change.cache_delete(user.id)
+    if cache_invalidation_error is not None:
+        raise cache_invalidation_error
 
 
 async def sync_subscription_schedule_from_stripe(stripe_schedule: dict) -> None:

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -29,6 +29,7 @@ from backend.data.credit import (
     sync_subscription_from_stripe,
     sync_subscription_schedule_from_stripe,
 )
+from backend.util.subscription_tiers import SubscriptionTierCacheInvalidationError
 
 
 class _CacheClearable(Protocol):
@@ -44,32 +45,143 @@ def _clear_cache(fn: _CacheClearable) -> None:
     fn.cache_clear()
 
 
+@pytest.fixture
+def mock_pending_tier_cache_delete():
+    cache_delete = MagicMock()
+    with patch(
+        "backend.data.credit.get_pending_subscription_change.cache_delete",
+        new=cache_delete,
+    ):
+        yield cache_delete
+
+
 @pytest.mark.asyncio
-async def test_set_subscription_tier_updates_db():
+async def test_set_subscription_tier_updates_db(mock_pending_tier_cache_delete):
     with (
         patch(
             "backend.data.credit.User.prisma",
             return_value=MagicMock(update=AsyncMock()),
         ) as mock_prisma,
-        patch("backend.data.credit.get_user_by_id"),
+        patch("backend.data.credit.get_user_by_id", new=MagicMock()),
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            new_callable=AsyncMock,
+        ) as invalidate_tier,
     ):
         await set_subscription_tier("user-1", SubscriptionTier.PRO)
         update_call = mock_prisma.return_value.update.await_args
         assert update_call.kwargs["where"] == {"id": "user-1"}
         assert update_call.kwargs["data"]["subscriptionTier"] == SubscriptionTier.PRO
+        invalidate_tier.assert_awaited_once_with("user-1")
+        mock_pending_tier_cache_delete.assert_called_once_with("user-1")
 
 
 @pytest.mark.asyncio
-async def test_set_subscription_tier_downgrade():
+async def test_set_subscription_tier_downgrade(mock_pending_tier_cache_delete):
     with (
         patch(
             "backend.data.credit.User.prisma",
             return_value=MagicMock(update=AsyncMock()),
         ),
-        patch("backend.data.credit.get_user_by_id"),
+        patch("backend.data.credit.get_user_by_id", new=MagicMock()),
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            new_callable=AsyncMock,
+        ),
     ):
         # Downgrade to BASIC should not raise
         await set_subscription_tier("user-1", SubscriptionTier.BASIC)
+        mock_pending_tier_cache_delete.assert_called_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_set_subscription_tier_fences_security_caches_after_commit(
+    mock_pending_tier_cache_delete,
+):
+    events: list[str] = []
+
+    async def update(**_kwargs):
+        events.append("db")
+
+    async def invalidate(_user_id: str):
+        events.append("security-caches")
+
+    with (
+        patch(
+            "backend.data.credit.User.prisma",
+            return_value=MagicMock(update=AsyncMock(side_effect=update)),
+        ),
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            side_effect=invalidate,
+        ),
+        patch("backend.data.credit.get_user_by_id", new=MagicMock()),
+    ):
+        await set_subscription_tier("user-1", SubscriptionTier.PRO)
+
+    assert events == ["db", "security-caches"]
+    mock_pending_tier_cache_delete.assert_called_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_set_subscription_tier_surfaces_post_commit_cache_failure():
+    update = AsyncMock()
+    auxiliary_delete = MagicMock()
+    pending_delete = MagicMock()
+
+    with (
+        patch(
+            "backend.data.credit.User.prisma",
+            return_value=MagicMock(update=update),
+        ),
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            new=AsyncMock(
+                side_effect=SubscriptionTierCacheInvalidationError(("legacy",))
+            ),
+        ),
+        patch(
+            "backend.data.credit.get_user_by_id.cache_delete",
+            new=auxiliary_delete,
+        ),
+        patch(
+            "backend.data.credit.get_pending_subscription_change.cache_delete",
+            new=pending_delete,
+        ),
+    ):
+        with pytest.raises(SubscriptionTierCacheInvalidationError):
+            await set_subscription_tier("user-1", SubscriptionTier.PRO)
+
+    update.assert_awaited_once()
+    auxiliary_delete.assert_called_once_with("user-1")
+    pending_delete.assert_called_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_set_subscription_tier_auxiliary_failures_are_independent():
+    pending_delete = MagicMock()
+
+    with (
+        patch(
+            "backend.data.credit.User.prisma",
+            return_value=MagicMock(update=AsyncMock()),
+        ),
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.data.credit.get_user_by_id.cache_delete",
+            side_effect=ConnectionError("auxiliary cache down"),
+        ),
+        patch(
+            "backend.data.credit.get_pending_subscription_change.cache_delete",
+            new=pending_delete,
+        ),
+    ):
+        await set_subscription_tier("user-1", SubscriptionTier.PRO)
+
+    pending_delete.assert_called_once_with("user-1")
 
 
 def _make_user(
@@ -263,9 +375,121 @@ async def test_sync_subscription_from_stripe_idempotent_no_write_if_unchanged():
         patch(
             "backend.data.credit.set_subscription_tier", new_callable=AsyncMock
         ) as mock_set,
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            new_callable=AsyncMock,
+        ) as repair_caches,
     ):
         await sync_subscription_from_stripe(stripe_sub)
         mock_set.assert_not_awaited()
+        repair_caches.assert_awaited_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_sync_subscription_from_stripe_retries_failed_idempotent_cache_repair():
+    mock_user = _make_user(tier=SubscriptionTier.PRO)
+    stripe_sub = {
+        "id": "sub_new",
+        "customer": "cus_123",
+        "status": "active",
+        "items": {"data": [{"price": {"id": "price_pro_monthly"}}]},
+    }
+
+    async def mock_price_id(
+        tier: SubscriptionTier, billing_cycle: str = "monthly"
+    ) -> str | None:
+        if tier == SubscriptionTier.PRO and billing_cycle == "monthly":
+            return "price_pro_monthly"
+        return None
+
+    with (
+        patch(
+            "backend.data.credit.User.prisma",
+            return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
+        ),
+        patch(
+            "backend.data.credit.get_subscription_price_id",
+            side_effect=mock_price_id,
+        ),
+        patch(
+            "backend.data.credit._invalidate_subscription_tier_security_caches",
+            new=AsyncMock(
+                side_effect=SubscriptionTierCacheInvalidationError(("legacy",))
+            ),
+        ),
+        patch(
+            "backend.data.credit.set_subscription_tier",
+            new_callable=AsyncMock,
+        ) as mock_set,
+    ):
+        with pytest.raises(SubscriptionTierCacheInvalidationError):
+            await sync_subscription_from_stripe(stripe_sub)
+
+    mock_set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_subscription_from_stripe_emits_once_before_retrying_cache_fence():
+    mock_user = _make_user(tier=SubscriptionTier.PRO)
+    stripe_sub = {
+        "id": "sub_new",
+        "customer": "cus_123",
+        "status": "active",
+        "metadata": {"billing_cycle": "monthly"},
+        "items": {"data": [{"price": {"id": "price_biz_monthly"}}]},
+    }
+
+    async def mock_price_id(
+        tier: SubscriptionTier, billing_cycle: str = "monthly"
+    ) -> str | None:
+        if tier == SubscriptionTier.BUSINESS and billing_cycle == "monthly":
+            return "price_biz_monthly"
+        return None
+
+    empty_list = MagicMock()
+    empty_list.data = []
+    empty_list.has_more = False
+    track_event = MagicMock()
+    pending_delete = MagicMock()
+
+    with (
+        patch(
+            "backend.data.credit.User.prisma",
+            return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
+        ),
+        patch(
+            "backend.data.credit.get_subscription_price_id",
+            side_effect=mock_price_id,
+        ),
+        patch(
+            "backend.data.credit.stripe.Subscription.list",
+            return_value=empty_list,
+        ),
+        patch(
+            "backend.data.credit.set_subscription_tier",
+            new=AsyncMock(
+                side_effect=SubscriptionTierCacheInvalidationError(("generation",))
+            ),
+        ),
+        patch("backend.data.credit._track_billing_event", new=track_event),
+        patch(
+            "backend.data.credit.get_pending_subscription_change.cache_delete",
+            new=pending_delete,
+        ),
+    ):
+        with pytest.raises(SubscriptionTierCacheInvalidationError):
+            await sync_subscription_from_stripe(stripe_sub)
+
+    track_event.assert_called_once_with(
+        "subscription_upgraded",
+        "user-1",
+        {
+            "previous_subscription_tier": SubscriptionTier.PRO.value,
+            "subscription_tier": SubscriptionTier.BUSINESS.value,
+            "billing_cycle": "monthly",
+        },
+    )
+    pending_delete.assert_called_once_with("user-1")
 
 
 @pytest.mark.asyncio
@@ -2846,6 +3070,65 @@ async def test_modify_stripe_subscription_skips_emit_when_db_flip_fails():
 
     assert result is True
     track_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modify_stripe_subscription_succeeds_when_post_commit_cache_fence_fails():
+    """A cache fence error means the DB commit landed, so a charged upgrade is
+    successful and may emit analytics; the Stripe webhook repairs the cache."""
+    mock_sub = stripe.Subscription.construct_from(
+        {
+            "id": "sub_pro",
+            "items": {"data": [{"id": "si_pro", "price": {"id": "price_pro"}}]},
+            "schedule": None,
+            "cancel_at_period_end": False,
+        },
+        "k",
+    )
+    mock_list = MagicMock()
+    mock_list.data = [mock_sub]
+    mock_user = MagicMock(spec=User)
+    mock_user.stripe_customer_id = "cus_abc"
+    mock_user.subscription_tier = SubscriptionTier.PRO
+    track_mock = MagicMock()
+
+    with (
+        patch(
+            "backend.data.credit.get_subscription_price_id",
+            new_callable=AsyncMock,
+            return_value="price_biz_monthly",
+        ),
+        patch(
+            "backend.data.credit.get_user_by_id",
+            new_callable=AsyncMock,
+            return_value=mock_user,
+        ),
+        patch(
+            "backend.data.credit.stripe.Subscription.list_async",
+            new_callable=AsyncMock,
+            return_value=mock_list,
+        ),
+        patch(
+            "backend.data.credit.stripe.Subscription.modify_async",
+            new_callable=AsyncMock,
+        ) as modify,
+        patch(
+            "backend.data.credit.set_subscription_tier",
+            new=AsyncMock(
+                side_effect=SubscriptionTierCacheInvalidationError(("legacy",))
+            ),
+        ),
+        patch("backend.data.credit.settings.secrets.posthog_api_key", new="phc_test"),
+        patch("backend.data.credit.posthog.capture", new=track_mock),
+        patch.object(get_pending_subscription_change, "cache_delete"),
+    ):
+        result = await modify_stripe_subscription_for_tier(
+            "user-1", SubscriptionTier.BUSINESS
+        )
+
+    assert result is True
+    modify.assert_awaited_once()
+    track_mock.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -26,6 +26,7 @@ from backend.data.credit import (
     log_tier_reconciliation_discrepancy,
     set_subscription_tier,
 )
+from backend.util.subscription_tier_order import subscription_tier_rank
 
 logger = logging.getLogger(__name__)
 
@@ -262,15 +263,7 @@ def _record_subscription(
     if tier is None:
         return
     existing = tiers.get(customer)
-    if existing is None or _TIER_RANK[tier] > _TIER_RANK[existing]:
+    if existing is None or subscription_tier_rank(tier) > subscription_tier_rank(
+        existing
+    ):
         tiers[customer] = tier
-
-
-_TIER_RANK: dict[SubscriptionTier, int] = {
-    SubscriptionTier.NO_TIER: 0,
-    SubscriptionTier.BASIC: 1,
-    SubscriptionTier.PRO: 2,
-    SubscriptionTier.MAX: 3,
-    SubscriptionTier.BUSINESS: 4,
-    SubscriptionTier.ENTERPRISE: 5,
-}

--- a/autogpt_platform/backend/backend/util/cache.py
+++ b/autogpt_platform/backend/backend/util/cache.py
@@ -17,6 +17,7 @@ import logging
 import pickle
 import threading
 import time
+import weakref
 from dataclasses import dataclass
 from functools import cache, wraps
 from typing import Any, Callable, ParamSpec, Protocol, TypeVar, cast, runtime_checkable
@@ -98,6 +99,28 @@ class CachedValue:
 
     result: Any
     timestamp: float
+
+
+class _AsyncKeyedLockPool:
+    """Keep one live asyncio lock per event loop and cache key."""
+
+    def __init__(self) -> None:
+        self._locks: weakref.WeakValueDictionary[
+            tuple[asyncio.AbstractEventLoop, tuple[Any, ...]], asyncio.Lock
+        ] = weakref.WeakValueDictionary()
+        self._mutex = threading.Lock()
+
+    def get(self, key: tuple[Any, ...]) -> asyncio.Lock:
+        pool_key = (asyncio.get_running_loop(), key)
+        with self._mutex:
+            lock = self._locks.get(pool_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[pool_key] = lock
+            return lock
+
+    def __len__(self) -> int:
+        return len(self._locks)
 
 
 def _make_hashable_key(
@@ -219,7 +242,7 @@ def cached(
     def decorator(target_func: Callable[P, R]) -> CachedFunction[P, R]:
         func_name = target_func.__name__
         cache_storage: dict[tuple, CachedValue] = {}
-        _event_loop_locks: dict[Any, asyncio.Lock] = {}
+        async_lock_pool = _AsyncKeyedLockPool()
 
         def _get_from_redis(redis_key: str) -> Any:
             """Get value from Redis, optionally refreshing TTL.
@@ -291,17 +314,6 @@ def cached(
 
         if inspect.iscoroutinefunction(target_func):
 
-            def _get_cache_lock():
-                """Get or create an asyncio.Lock for the current event loop."""
-                try:
-                    loop = asyncio.get_running_loop()
-                except RuntimeError:
-                    loop = None
-
-                if loop not in _event_loop_locks:
-                    return _event_loop_locks.setdefault(loop, asyncio.Lock())
-                return _event_loop_locks[loop]
-
             @wraps(target_func)
             async def async_wrapper(*args: P.args, **kwargs: P.kwargs):
                 key = _make_hashable_key(args, kwargs)
@@ -318,7 +330,7 @@ def cached(
                         return result
 
                 # Slow path: acquire lock for cache miss/expiry
-                async with _get_cache_lock():
+                async with async_lock_pool.get(key):
                     # Double-check: another coroutine might have populated cache
                     if shared_cache:
                         result = _get_from_redis(redis_key)

--- a/autogpt_platform/backend/backend/util/cache_test.py
+++ b/autogpt_platform/backend/backend/util/cache_test.py
@@ -518,6 +518,38 @@ class TestCache:
         assert await surviving_waiter == "same"
         assert call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_async_single_flight_recovers_from_leader_cancellation(self):
+        first_call_started = asyncio.Event()
+        replacement_call_started = asyncio.Event()
+        release_replacement = asyncio.Event()
+        call_count = 0
+
+        @cached(ttl_seconds=300)
+        async def cached_function(key: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_call_started.set()
+                await asyncio.Event().wait()
+            replacement_call_started.set()
+            await release_replacement.wait()
+            return key
+
+        leader = asyncio.create_task(cached_function("same"))
+        await first_call_started.wait()
+        surviving_waiter = asyncio.create_task(cached_function("same"))
+
+        leader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await leader
+
+        await asyncio.wait_for(replacement_call_started.wait(), timeout=1)
+        release_replacement.set()
+
+        assert await surviving_waiter == "same"
+        assert call_count == 2
+
     def test_ttl_functionality(self):
         """Test TTL functionality with sync function."""
         call_count = 0

--- a/autogpt_platform/backend/backend/util/cache_test.py
+++ b/autogpt_platform/backend/backend/util/cache_test.py
@@ -476,6 +476,19 @@ class TestCache:
         assert lock_ref() is None
         assert len(pool) == 0
 
+    def test_async_keyed_lock_pool_isolates_event_loops(self):
+        pool = _AsyncKeyedLockPool()
+        key = (("key",), ())
+
+        async def get_lock() -> asyncio.Lock:
+            return pool.get(key)
+
+        first_loop_lock = asyncio.run(get_lock())
+        second_loop_lock = asyncio.run(get_lock())
+
+        assert first_loop_lock is not second_loop_lock
+        assert len(pool) == 2
+
     @pytest.mark.asyncio
     async def test_async_single_flight_survives_waiter_cancellation(self):
         leader_started = asyncio.Event()

--- a/autogpt_platform/backend/backend/util/cache_test.py
+++ b/autogpt_platform/backend/backend/util/cache_test.py
@@ -476,6 +476,31 @@ class TestCache:
         assert lock_ref() is None
         assert len(pool) == 0
 
+    @pytest.mark.asyncio
+    async def test_async_single_flight_survives_gc_during_contention(self):
+        leader_started = asyncio.Event()
+        release_leader = asyncio.Event()
+        call_count = 0
+
+        @cached(ttl_seconds=300)
+        async def cached_function(key: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            leader_started.set()
+            await release_leader.wait()
+            return key
+
+        leader = asyncio.create_task(cached_function("same"))
+        await leader_started.wait()
+        waiters = [asyncio.create_task(cached_function("same")) for _ in range(10)]
+        await asyncio.sleep(0)
+
+        gc.collect()
+        release_leader.set()
+
+        assert await asyncio.gather(leader, *waiters) == ["same"] * 11
+        assert call_count == 1
+
     def test_async_keyed_lock_pool_isolates_event_loops(self):
         pool = _AsyncKeyedLockPool()
         key = (("key",), ())

--- a/autogpt_platform/backend/backend/util/cache_test.py
+++ b/autogpt_platform/backend/backend/util/cache_test.py
@@ -550,6 +550,42 @@ class TestCache:
         assert await surviving_waiter == "same"
         assert call_count == 2
 
+    @pytest.mark.asyncio
+    async def test_async_single_flight_recovers_when_leader_raises(self):
+        first_call_started = asyncio.Event()
+        raise_from_first_call = asyncio.Event()
+        replacement_call_started = asyncio.Event()
+        release_replacement = asyncio.Event()
+        call_count = 0
+
+        @cached(ttl_seconds=300)
+        async def cached_function(key: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_call_started.set()
+                await raise_from_first_call.wait()
+                raise ValueError("leader failed")
+            replacement_call_started.set()
+            await release_replacement.wait()
+            return key
+
+        leader = asyncio.create_task(cached_function("same"))
+        await first_call_started.wait()
+        waiters = [asyncio.create_task(cached_function("same")) for _ in range(2)]
+        await asyncio.sleep(0)
+
+        raise_from_first_call.set()
+        with pytest.raises(ValueError, match="leader failed"):
+            await leader
+
+        await asyncio.wait_for(replacement_call_started.wait(), timeout=1)
+        release_replacement.set()
+
+        assert await asyncio.gather(*waiters) == ["same", "same"]
+        assert await cached_function("same") == "same"
+        assert call_count == 2
+
     def test_ttl_functionality(self):
         """Test TTL functionality with sync function."""
         call_count = 0
@@ -1155,6 +1191,7 @@ class TestSharedCache:
     @pytest.mark.asyncio
     async def test_shared_cache_concurrent_different_keys(self):
         """Different keys do not wait behind one function-wide lock."""
+        keys = ["a", "b", "c", "d", "e"]
         call_counts = {}
         all_keys_started = asyncio.Event()
 
@@ -1172,7 +1209,6 @@ class TestSharedCache:
         multi_key_function.cache_clear()
 
         # Launch concurrent tasks with different keys
-        keys = ["a", "b", "c", "d", "e"]
         tasks = []
         for key in keys:
             # Multiple calls per key

--- a/autogpt_platform/backend/backend/util/cache_test.py
+++ b/autogpt_platform/backend/backend/util/cache_test.py
@@ -9,14 +9,21 @@ This module tests the thread-local caching functionality including:
 """
 
 import asyncio
+import gc
 import threading
 import time
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import Mock
 
 import pytest
 
-from backend.util.cache import cached, clear_thread_cache, thread_cached
+from backend.util.cache import (
+    _AsyncKeyedLockPool,
+    cached,
+    clear_thread_cache,
+    thread_cached,
+)
 
 
 class TestThreadCached:
@@ -426,6 +433,76 @@ class TestCache:
         # All results should be the same
         assert all(result == 49 for result in results)
         # Only one coroutine should have executed the expensive operation
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_single_flight_is_scoped_to_cache_key(self):
+        entered: set[str] = set()
+        release = asyncio.Event()
+        both_keys_entered = asyncio.Event()
+        call_counts: dict[str, int] = {}
+
+        @cached(ttl_seconds=300)
+        async def keyed_function(key: str) -> str:
+            call_counts[key] = call_counts.get(key, 0) + 1
+            entered.add(key)
+            if entered == {"a", "b"}:
+                both_keys_entered.set()
+            await release.wait()
+            return key
+
+        tasks = [
+            asyncio.create_task(keyed_function(key))
+            for key in ("a", "a", "a", "b", "b", "b")
+        ]
+        await asyncio.wait_for(both_keys_entered.wait(), timeout=1)
+        release.set()
+
+        assert await asyncio.gather(*tasks) == ["a", "a", "a", "b", "b", "b"]
+        assert call_counts == {"a": 1, "b": 1}
+
+    @pytest.mark.asyncio
+    async def test_async_keyed_lock_pool_releases_idle_locks(self):
+        pool = _AsyncKeyedLockPool()
+        lock = pool.get((("key",), ()))
+        lock_ref = weakref.ref(lock)
+
+        async with lock:
+            assert len(pool) == 1
+
+        del lock
+        gc.collect()
+
+        assert lock_ref() is None
+        assert len(pool) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_single_flight_survives_waiter_cancellation(self):
+        leader_started = asyncio.Event()
+        release_leader = asyncio.Event()
+        call_count = 0
+
+        @cached(ttl_seconds=300)
+        async def cached_function(key: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            leader_started.set()
+            await release_leader.wait()
+            return key
+
+        leader = asyncio.create_task(cached_function("same"))
+        await leader_started.wait()
+        canceled_waiter = asyncio.create_task(cached_function("same"))
+        surviving_waiter = asyncio.create_task(cached_function("same"))
+        await asyncio.sleep(0)
+
+        canceled_waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await canceled_waiter
+
+        release_leader.set()
+        assert await leader == "same"
+        assert await surviving_waiter == "same"
         assert call_count == 1
 
     def test_ttl_functionality(self):
@@ -1032,15 +1109,18 @@ class TestSharedCache:
 
     @pytest.mark.asyncio
     async def test_shared_cache_concurrent_different_keys(self):
-        """Test that concurrent calls with different keys work correctly."""
+        """Different keys do not wait behind one function-wide lock."""
         call_counts = {}
+        all_keys_started = asyncio.Event()
 
         @cached(ttl_seconds=30, shared_cache=True)
         async def multi_key_function(key: str) -> str:
             if key not in call_counts:
                 call_counts[key] = 0
             call_counts[key] += 1
-            await asyncio.sleep(0.05)
+            if len(call_counts) == len(keys):
+                all_keys_started.set()
+            await asyncio.wait_for(all_keys_started.wait(), timeout=1)
             return f"result_{key}"
 
         # Clear cache

--- a/autogpt_platform/backend/backend/util/entitlements.py
+++ b/autogpt_platform/backend/backend/util/entitlements.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict
 
 from backend.util.clients import get_database_manager_async_client
 from backend.util.settings import BehaveAs, Settings
+from backend.util.subscription_tier_order import subscription_tier_at_least
 
 
 class Entitlement(str, Enum):
@@ -28,16 +29,6 @@ ENTITLEMENT_POLICIES: Mapping[Entitlement, EntitlementPolicy] = MappingProxyType
         ),
     }
 )
-
-_TIER_ORDER = (
-    SubscriptionTier.NO_TIER,
-    SubscriptionTier.BASIC,
-    SubscriptionTier.PRO,
-    SubscriptionTier.MAX,
-    SubscriptionTier.BUSINESS,
-    SubscriptionTier.ENTERPRISE,
-)
-_TIER_RANK = {tier: rank for rank, tier in enumerate(_TIER_ORDER)}
 
 settings = Settings()
 
@@ -73,7 +64,7 @@ async def has_entitlement(user_id: str, entitlement: Entitlement) -> bool:
         return True
 
     tier = await _get_user_subscription_tier(user_id)
-    return _TIER_RANK[tier] >= _TIER_RANK[policy.minimum_tier]
+    return subscription_tier_at_least(tier, policy.minimum_tier)
 
 
 async def require_entitlement(user_id: str, entitlement: Entitlement) -> None:

--- a/autogpt_platform/backend/backend/util/subscription_tier_order.py
+++ b/autogpt_platform/backend/backend/util/subscription_tier_order.py
@@ -1,0 +1,24 @@
+from prisma.enums import SubscriptionTier
+
+SUBSCRIPTION_TIER_ORDER = (
+    SubscriptionTier.NO_TIER,
+    SubscriptionTier.BASIC,
+    SubscriptionTier.PRO,
+    SubscriptionTier.MAX,
+    SubscriptionTier.BUSINESS,
+    SubscriptionTier.ENTERPRISE,
+)
+_SUBSCRIPTION_TIER_RANK = {
+    tier: rank for rank, tier in enumerate(SUBSCRIPTION_TIER_ORDER)
+}
+
+
+def subscription_tier_rank(tier: SubscriptionTier) -> int:
+    return _SUBSCRIPTION_TIER_RANK[tier]
+
+
+def subscription_tier_at_least(
+    tier: SubscriptionTier,
+    minimum_tier: SubscriptionTier,
+) -> bool:
+    return subscription_tier_rank(tier) >= subscription_tier_rank(minimum_tier)

--- a/autogpt_platform/backend/backend/util/subscription_tiers.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers.py
@@ -1,0 +1,129 @@
+import asyncio
+import hashlib
+import logging
+import uuid
+from collections.abc import Callable
+from typing import Any, cast
+
+from backend.data.redis_client import get_redis_async
+
+logger = logging.getLogger(__name__)
+
+SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS = 3600
+_GENERATION_KEY_PREFIX = "subscription-tier-cache:generation:"
+
+
+class SubscriptionTierCacheInvalidationError(RuntimeError):
+    """Raised after a committed tier write when a security cache was not fenced."""
+
+    def __init__(self, failed_caches: tuple[str, ...]):
+        self.failed_caches = failed_caches
+        super().__init__(
+            "Subscription tier was updated, but cache invalidation failed for: "
+            + ", ".join(failed_caches)
+        )
+
+
+def _generation_key(user_id: str) -> str:
+    # Normalize the key length and avoid plaintext identifiers in Redis key scans.
+    # This digest is namespacing, not a confidentiality boundary.
+    digest = hashlib.sha256(user_id.encode()).hexdigest()
+    return f"{_GENERATION_KEY_PREFIX}{digest}"
+
+
+async def _rotate_subscription_tier_generation(user_id: str) -> None:
+    redis = await get_redis_async()
+    # The redis client protocol omits keyword overloads supported at runtime.
+    written = await cast(Any, redis.set)(
+        _generation_key(user_id),
+        uuid.uuid4().hex,
+        ex=SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS,
+    )
+    if not written:
+        raise RuntimeError("Redis did not acknowledge the generation update")
+
+
+async def _run_dual_cache_invalidation(
+    user_id: str,
+    legacy_cache_delete: Callable[[str], object],
+) -> None:
+    failures: list[str] = []
+
+    try:
+        await _rotate_subscription_tier_generation(user_id)
+    except Exception:
+        failures.append("generation")
+        logger.exception(
+            "Failed to rotate subscription-tier generation for user %s",
+            user_id[:8],
+        )
+
+    try:
+        legacy_cache_delete(user_id)
+    except Exception:
+        failures.append("legacy")
+        logger.exception(
+            "Failed to evict legacy subscription-tier cache for user %s",
+            user_id[:8],
+        )
+
+    if failures:
+        raise SubscriptionTierCacheInvalidationError(tuple(failures))
+
+
+def invalidate_subscription_tier_auxiliary_caches(user_id: str) -> None:
+    """Best-effort eviction for non-authoritative subscription-tier views."""
+    # Local imports keep subscription-tier policy below its billing consumers.
+    from backend.data.credit import get_pending_subscription_change, get_user_by_id
+
+    for cache_delete in (
+        get_user_by_id.cache_delete,  # type: ignore[attr-defined]
+        get_pending_subscription_change.cache_delete,  # type: ignore[attr-defined]
+    ):
+        try:
+            cache_delete(user_id)
+        except Exception:
+            logger.exception(
+                "Subscription tier updated for user %s, but an auxiliary cache "
+                "could not be cleared",
+                user_id[:8],
+            )
+
+
+async def invalidate_subscription_tier_caches(
+    user_id: str,
+    legacy_cache_delete: Callable[[str], object],
+) -> None:
+    """Fence future tier readers and evict the cache used by deployed readers.
+
+    Both invalidations finish even when the caller is cancelled after its DB
+    commit. The caller's cancellation is restored once the cache fence ends.
+    """
+    invalidation = asyncio.create_task(
+        _run_dual_cache_invalidation(user_id, legacy_cache_delete)
+    )
+    cancellation: asyncio.CancelledError | None = None
+    while not invalidation.done():
+        try:
+            await asyncio.shield(invalidation)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+        except Exception:
+            # ``invalidation.result()`` below preserves and raises this error.
+            break
+
+    try:
+        invalidation.result()
+    except Exception:
+        if cancellation is not None:
+            logger.exception(
+                "Subscription-tier cache invalidation failed while caller was "
+                "cancelled for user %s",
+                user_id[:8],
+            )
+            raise cancellation
+        raise
+
+    if cancellation is not None:
+        raise cancellation

--- a/autogpt_platform/backend/backend/util/subscription_tiers_test.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers_test.py
@@ -1,0 +1,202 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from prisma.enums import SubscriptionTier
+
+from backend.util.subscription_tier_order import (
+    SUBSCRIPTION_TIER_ORDER,
+    subscription_tier_at_least,
+    subscription_tier_rank,
+)
+from backend.util.subscription_tiers import (
+    SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS,
+    SubscriptionTierCacheInvalidationError,
+    _generation_key,
+    invalidate_subscription_tier_auxiliary_caches,
+    invalidate_subscription_tier_caches,
+)
+
+
+def test_subscription_tier_order_covers_every_enum_value_once():
+    assert len(SUBSCRIPTION_TIER_ORDER) == len(set(SUBSCRIPTION_TIER_ORDER))
+    assert set(SUBSCRIPTION_TIER_ORDER) == set(SubscriptionTier)
+    assert [subscription_tier_rank(tier) for tier in SUBSCRIPTION_TIER_ORDER] == list(
+        range(len(SUBSCRIPTION_TIER_ORDER))
+    )
+
+
+def test_subscription_tier_at_least_uses_canonical_order():
+    assert subscription_tier_at_least(SubscriptionTier.MAX, SubscriptionTier.MAX)
+    assert subscription_tier_at_least(SubscriptionTier.ENTERPRISE, SubscriptionTier.MAX)
+    assert not subscription_tier_at_least(SubscriptionTier.PRO, SubscriptionTier.MAX)
+
+
+@pytest.mark.asyncio
+async def test_dual_invalidation_rotates_generation_and_deletes_legacy_cache():
+    redis = MagicMock()
+    redis.set = AsyncMock(return_value=True)
+    legacy_delete = MagicMock(return_value=False)
+
+    with patch(
+        "backend.util.subscription_tiers.get_redis_async",
+        new=AsyncMock(return_value=redis),
+    ):
+        await invalidate_subscription_tier_caches("user-1", legacy_delete)
+
+    redis.set.assert_awaited_once()
+    args, kwargs = redis.set.await_args
+    assert args[0] == _generation_key("user-1")
+    assert isinstance(args[1], str) and len(args[1]) == 32
+    assert kwargs == {"ex": SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS}
+    legacy_delete.assert_called_once_with("user-1")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generation_error", "legacy_error", "failed_caches"),
+    [
+        (ConnectionError("generation down"), None, ("generation",)),
+        (None, ConnectionError("legacy down"), ("legacy",)),
+        (
+            ConnectionError("generation down"),
+            ConnectionError("legacy down"),
+            ("generation", "legacy"),
+        ),
+    ],
+)
+async def test_dual_invalidation_attempts_both_legs_before_raising(
+    generation_error: Exception | None,
+    legacy_error: Exception | None,
+    failed_caches: tuple[str, ...],
+):
+    events = MagicMock()
+    redis = MagicMock()
+
+    async def set_generation(*_args, **_kwargs):
+        events("generation")
+        if generation_error:
+            raise generation_error
+        return True
+
+    def delete_legacy(_user_id: str):
+        events("legacy")
+        if legacy_error:
+            raise legacy_error
+        return False
+
+    redis.set = AsyncMock(side_effect=set_generation)
+    with patch(
+        "backend.util.subscription_tiers.get_redis_async",
+        new=AsyncMock(return_value=redis),
+    ):
+        with pytest.raises(SubscriptionTierCacheInvalidationError) as exc_info:
+            await invalidate_subscription_tier_caches("user-1", delete_legacy)
+
+    assert exc_info.value.failed_caches == failed_caches
+    assert events.call_args_list == [call("generation"), call("legacy")]
+
+
+@pytest.mark.asyncio
+async def test_unacknowledged_generation_write_is_a_failure_but_legacy_is_attempted():
+    redis = MagicMock()
+    redis.set = AsyncMock(return_value=False)
+    legacy_delete = MagicMock(return_value=False)
+
+    with patch(
+        "backend.util.subscription_tiers.get_redis_async",
+        new=AsyncMock(return_value=redis),
+    ):
+        with pytest.raises(SubscriptionTierCacheInvalidationError) as exc_info:
+            await invalidate_subscription_tier_caches("user-1", legacy_delete)
+
+    assert exc_info.value.failed_caches == ("generation",)
+    legacy_delete.assert_called_once_with("user-1")
+
+
+def test_auxiliary_invalidation_attempts_every_cache_after_failure():
+    first_delete = MagicMock(side_effect=ConnectionError("first cache down"))
+    second_delete = MagicMock()
+    credit_module = MagicMock()
+    credit_module.get_user_by_id.cache_delete = first_delete
+    credit_module.get_pending_subscription_change.cache_delete = second_delete
+
+    with patch.dict("sys.modules", {"backend.data.credit": credit_module}):
+        invalidate_subscription_tier_auxiliary_caches("user-1")
+
+    first_delete.assert_called_once_with("user-1")
+    second_delete.assert_called_once_with("user-1")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_waits_for_both_invalidations_then_propagates():
+    generation_started = asyncio.Event()
+    finish_generation = asyncio.Event()
+    events: list[str] = []
+
+    async def rotate(_user_id: str) -> None:
+        events.append("generation-started")
+        generation_started.set()
+        await finish_generation.wait()
+        events.append("generation-finished")
+
+    def delete_legacy(_user_id: str) -> None:
+        events.append("legacy")
+
+    with patch(
+        "backend.util.subscription_tiers._rotate_subscription_tier_generation",
+        side_effect=rotate,
+    ):
+        caller = asyncio.create_task(
+            invalidate_subscription_tier_caches("user-1", delete_legacy)
+        )
+        await generation_started.wait()
+        caller.cancel()
+        await asyncio.sleep(0)
+        caller.cancel()
+        await asyncio.sleep(0)
+
+        assert not caller.done()
+        finish_generation.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+
+    assert events == ["generation-started", "generation-finished", "legacy"]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_wins_when_invalidation_also_fails():
+    generation_started = asyncio.Event()
+    fail_generation = asyncio.Event()
+    legacy_delete = MagicMock()
+
+    async def rotate(_user_id: str) -> None:
+        generation_started.set()
+        await fail_generation.wait()
+        raise ConnectionError("generation down")
+
+    with patch(
+        "backend.util.subscription_tiers._rotate_subscription_tier_generation",
+        side_effect=rotate,
+    ):
+        caller = asyncio.create_task(
+            invalidate_subscription_tier_caches("user-1", legacy_delete)
+        )
+        await generation_started.wait()
+        caller.cancel()
+        fail_generation.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+
+    legacy_delete.assert_called_once_with("user-1")
+
+
+def test_generation_key_hides_user_id_and_is_user_specific():
+    first = _generation_key("person@example.com")
+    second = _generation_key("someone-else@example.com")
+
+    assert "person@example.com" not in first
+    assert first == _generation_key("person@example.com")
+    assert first != second


### PR DESCRIPTION
### Why / What / How

Stacked on #14004.

The async `@cached` wrapper currently has one single-flight lock per decorated function and event loop. A cold lookup for one key therefore blocks cold lookups for every other key. The subscription-tier reader stack would turn that into cross-user head-of-line blocking around a Database Manager call.

This PR scopes async single-flight locks to the full cache key while preserving the existing double-check behavior. Calls for the same key still collapse to one underlying computation; unrelated keys can proceed concurrently.

### Changes 🏗️

- Add a private per-decorator async keyed-lock pool.
- Key locks by both the running event loop and the full hashable cache key.
- Hold locks weakly so idle user/key entries are garbage-collected rather than accumulating.
- Preserve same-key single-flight, synchronous-cache locking, Redis key format, and cross-process behavior.
- Add deterministic tests for:
  - concurrent cold misses on different keys;
  - same-key collapse;
  - isolation of the same key across different event loops;
  - idle-lock garbage collection;
  - cancellation of a waiting caller without disrupting the surviving waiter;
  - cancellation of the lock-holding leader, with exactly one waiter taking over and recomputing;
  - an exception from the lock-holding leader, with queued waiters recovering without deadlock or caching the exception.

This PR intentionally does not migrate the synchronous Redis client calls inside async wrappers. That pre-existing event-loop blocking risk requires a separate compatibility-focused change because shared cache values use a binary signed-pickle format.

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Python 3.11 targeted keyed-lock tests: 7 passed
  - [x] Ruff check and format check
  - [x] Pyright: 0 errors
  - [x] `git diff --check`

#### For configuration changes:

- [x] `.env.default` is already compatible; no configuration is added
- [x] `docker-compose.yml` is already compatible
- [x] No deployment configuration changes are required
