### PR TITLE
perf(platform): cache authoritative subscription tier reads

### DIFF
--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -68,6 +68,8 @@ from backend.data.user import get_user_by_id
 from backend.util.cache import cached
 from backend.util.feature_flag import Flag, get_feature_flag_value, is_feature_enabled
 from backend.util.subscription_tiers import (
+    SubscriptionTierUserNotFoundError,
+    get_authoritative_subscription_tier,
     invalidate_subscription_tier_auxiliary_caches,
     invalidate_subscription_tier_caches,
 )
@@ -915,27 +917,20 @@ async def _decr_counter_floor_zero(
     await redis.eval(_DECR_FLOOR_ZERO_SCRIPT, 1, key, delta)
 
 
-class _UserNotFoundError(Exception):
-    """Raised when a user record is missing or has no subscription tier.
+class _UserNotFoundError(SubscriptionTierUserNotFoundError):
+    """Raised when the authoritative user record is missing.
 
-    Raising prevents ``@cached`` from persisting the fallback, which would
-    otherwise keep serving NO_TIER after the user's real tier is set.
+    The local subtype preserves the rate-limit helper's existing contract.
     """
 
 
 @cached(maxsize=1000, ttl_seconds=300, shared_cache=True)
 async def _fetch_user_tier(user_id: str) -> SubscriptionTier:
-    """Fetch the user's rate-limit tier, cached across pods.
+    """Legacy rollout cache retained only so mixed-version pods can evict it.
 
-    Only successful lookups are cached. Missing users raise
-    ``_UserNotFoundError`` so ``@cached`` never stores the fallback.
-
-    Distinguishes "row genuinely missing" (``user_db().get_user_by_id``
-    raises ``ValueError``) from "transient DB / Prisma error" (other
-    exceptions propagate as-is). Without this distinction a Supabase
-    blip would silently degrade every paying user to NO_TIER and
-    ``enforce_payment_paywall`` would 402 them — contradicting its
-    503-on-blip contract.
+    New reads use the canonical generation-fenced cache below. This function's
+    name and key format remain during the rollout so writers can invalidate
+    entries still consumed by phase-one or rolled-back pods.
     """
     try:
         user = await user_db().get_user_by_id(user_id)
@@ -945,6 +940,14 @@ async def _fetch_user_tier(user_id: str) -> SubscriptionTier:
     if user.subscription_tier:
         return SubscriptionTier(user.subscription_tier)
     raise _UserNotFoundError(user_id)
+
+
+async def _fetch_authoritative_user_tier(user_id: str) -> SubscriptionTier:
+    try:
+        tier = await get_authoritative_subscription_tier(user_id)
+    except SubscriptionTierUserNotFoundError as exc:
+        raise _UserNotFoundError(user_id) from exc
+    return SubscriptionTier(tier.value)
 
 
 _STRIPE_RECONCILE_PREFIX = "stripe_reconcile:"
@@ -989,8 +992,8 @@ async def _maybe_reconcile_stripe_tier(user_id: str) -> bool:
 async def get_user_tier(user_id: str) -> SubscriptionTier:
     """Look up the user's rate-limit tier from the database.
 
-    Successful results are cached for 5 minutes (via ``_fetch_user_tier``)
-    to avoid a DB round-trip on every rate-limit check.
+    Successful results share the canonical generation-fenced cache with
+    entitlement checks, avoiding duplicate DB lookups and cache decisions.
 
     Falls back to ``DEFAULT_TIER`` **without caching** when the DB is
     unreachable or returns an unrecognised value, so the next call retries
@@ -1002,7 +1005,7 @@ async def get_user_tier(user_id: str) -> SubscriptionTier:
     """
     tier_from_db = True
     try:
-        tier = await _fetch_user_tier(user_id)
+        tier = await _fetch_authoritative_user_tier(user_id)
     except _UserNotFoundError:
         # Row missing or tier is NULL — DB-confirmed NO_TIER, eligible for reconciliation.
         tier = SubscriptionTier.NO_TIER
@@ -1021,7 +1024,7 @@ async def get_user_tier(user_id: str) -> SubscriptionTier:
 
     if tier_from_db and await _maybe_reconcile_stripe_tier(user_id):
         try:
-            return await _fetch_user_tier(user_id)
+            return await _fetch_authoritative_user_tier(user_id)
         except Exception as exc:
             logger.warning(
                 "get_user_tier: tier re-read failed after reconciliation for %s: %s",
@@ -1311,7 +1314,7 @@ async def is_user_paywalled(user_id: str) -> bool:
     background job → fail-open).
     """
     try:
-        tier = await _fetch_user_tier(user_id)
+        tier = await _fetch_authoritative_user_tier(user_id)
     except _UserNotFoundError:
         # No DB row / no subscription_tier set — fresh signup that hasn't
         # been provisioned yet, or row missing entirely. Logged at debug
@@ -1348,7 +1351,7 @@ async def enforce_payment_paywall(
     exception handler → HTTP 402) if the user is on NO_TIER with
     ``ENABLE_PLATFORM_PAYMENT`` on. Tier-lookup failures map to
     **HTTP 503 + Retry-After** so the client retries instead of
-    treating a transient Supabase / LD blip as a permanent paywall.
+    treating a transient Database Manager / LD blip as a permanent paywall.
 
     Background callers (scheduled cron, webhook handlers, copilot
     internal tools) skip this function and call :func:`is_user_paywalled`

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -926,11 +926,10 @@ class _UserNotFoundError(SubscriptionTierUserNotFoundError):
 
 @cached(maxsize=1000, ttl_seconds=300, shared_cache=True)
 async def _fetch_user_tier(user_id: str) -> SubscriptionTier:
-    """Legacy rollout cache retained only so mixed-version pods can evict it.
+    """Compatibility cache for readers deployed before generation fencing.
 
-    New reads use the canonical generation-fenced cache below. This function's
-    name and key format remain during the rollout so writers can invalidate
-    entries still consumed by phase-one or rolled-back pods.
+    Its stable name and key format let writers evict entries that may still be
+    consumed by older or rolled-back pods. New reads use the canonical cache.
     """
     try:
         user = await user_db().get_user_by_id(user_id)

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -606,9 +606,7 @@ class TestFetchAuthoritativeUserTierErrorPropagation:
 
     @pytest.mark.asyncio
     async def test_missing_user_collapses_to_local_user_not_found(self, mocker):
-        from backend.util.subscription_tiers import (
-            SubscriptionTierUserNotFoundError,
-        )
+        from backend.util.subscription_tiers import SubscriptionTierUserNotFoundError
 
         from .rate_limit import _fetch_authoritative_user_tier, _UserNotFoundError
 

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -1365,6 +1365,46 @@ class TestGetUserTier:
         assert tier1 == DEFAULT_TIER
         assert tier2 == SubscriptionTier.PRO
 
+    @pytest.mark.asyncio
+    async def test_successful_reconcile_rereads_recovered_tier(self):
+        lookup = AsyncMock(side_effect=[SubscriptionTier.NO_TIER, SubscriptionTier.PRO])
+        reconcile = AsyncMock(return_value=True)
+        with (
+            patch(
+                "backend.copilot.rate_limit._fetch_authoritative_user_tier", new=lookup
+            ),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=reconcile,
+            ),
+        ):
+            tier = await get_user_tier(_USER)
+
+        assert tier == SubscriptionTier.PRO
+        assert lookup.await_count == 2
+        reconcile.assert_awaited_once_with(_USER)
+
+    @pytest.mark.asyncio
+    async def test_successful_reconcile_tolerates_reread_failure(self):
+        lookup = AsyncMock(
+            side_effect=[SubscriptionTier.NO_TIER, RuntimeError("DB unavailable")]
+        )
+        reconcile = AsyncMock(return_value=True)
+        with (
+            patch(
+                "backend.copilot.rate_limit._fetch_authoritative_user_tier", new=lookup
+            ),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=reconcile,
+            ),
+        ):
+            tier = await get_user_tier(_USER)
+
+        assert tier == SubscriptionTier.NO_TIER
+        assert lookup.await_count == 2
+        reconcile.assert_awaited_once_with(_USER)
+
 
 # ---------------------------------------------------------------------------
 # _maybe_reconcile_stripe_tier
@@ -1539,6 +1579,96 @@ class TestSetUserTier:
             await set_user_tier(_USER, SubscriptionTier.PRO)
 
         assert events == ["db", "security-caches"]
+
+    @pytest.mark.asyncio
+    async def test_set_user_tier_fences_next_canonical_read(self):
+        from backend.util import subscription_tiers
+
+        value_cache: dict[str, bytes] = {}
+        value_redis = MagicMock()
+        value_redis.get.side_effect = value_cache.get
+        value_redis.setex.side_effect = lambda key, _ttl, value: (
+            value_cache.__setitem__(key, value)
+        )
+        value_redis.delete.side_effect = lambda key: int(
+            value_cache.pop(key, None) is not None
+        )
+
+        generations: dict[str, str] = {}
+        generation_redis = MagicMock()
+
+        async def get_or_create_generation(
+            _script: str,
+            _num_keys: int,
+            key: str,
+            candidate: str,
+            _ttl: int,
+        ) -> str:
+            return generations.setdefault(key, candidate)
+
+        async def rotate_generation(key: str, value: str, *, ex: int) -> bool:
+            assert ex == subscription_tiers.SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS
+            generations[key] = value
+            return True
+
+        generation_redis.eval = AsyncMock(side_effect=get_or_create_generation)
+        generation_redis.set = AsyncMock(side_effect=rotate_generation)
+
+        async def get_generation_redis():
+            return generation_redis
+
+        tier_state = {"value": SubscriptionTier.BUSINESS.value}
+        database_manager = MagicMock()
+        database_manager.get_user_subscription_tier = AsyncMock(
+            side_effect=lambda _user_id: tier_state["value"]
+        )
+        mock_prisma = MagicMock()
+
+        async def update_tier(*, where, data):
+            assert where == {"id": _USER}
+            tier_state["value"] = data["subscriptionTier"]
+
+        mock_prisma.update = AsyncMock(side_effect=update_tier)
+
+        def close_scheduled_coroutine(coroutine):
+            coroutine.close()
+
+        with (
+            patch("backend.util.cache._get_redis", return_value=value_redis),
+            patch(
+                "backend.util.subscription_tiers.get_redis_async",
+                new=get_generation_redis,
+            ),
+            patch(
+                "backend.util.subscription_tiers.get_database_manager_async_client",
+                return_value=database_manager,
+            ),
+            patch(
+                "backend.copilot.rate_limit.PrismaUser.prisma",
+                return_value=mock_prisma,
+            ),
+            patch(
+                "backend.copilot.rate_limit.invalidate_subscription_tier_caches",
+                new=subscription_tiers.invalidate_subscription_tier_caches,
+            ),
+            patch(
+                "backend.copilot.rate_limit.invalidate_subscription_tier_auxiliary_caches"
+            ),
+            patch(
+                "backend.copilot.rate_limit.asyncio.ensure_future",
+                side_effect=close_scheduled_coroutine,
+            ),
+        ):
+            assert await get_user_tier(_USER) == SubscriptionTier.BUSINESS
+            generation_before = next(iter(generations.values()))
+
+            await set_user_tier(_USER, SubscriptionTier.ENTERPRISE)
+
+            assert next(iter(generations.values())) != generation_before
+            assert await get_user_tier(_USER) == SubscriptionTier.ENTERPRISE
+
+        assert database_manager.get_user_subscription_tier.await_count == 2
+        generation_redis.set.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_security_invalidation_failure_surfaces_after_commit(self):

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -408,8 +408,8 @@ class TestCoPilotUsagePublicFromStatus:
 
 class TestEnforcePaymentPaywall:
     """The dep bypasses ``get_user_tier``'s fail-open default and goes
-    through ``_fetch_user_tier`` directly so a transient DB blip raises
-    503 instead of silently 402-ing every paid user."""
+    through the canonical authoritative tier reader so a transient DB blip
+    raises 503 instead of silently 402-ing every paid user."""
 
     @pytest.mark.asyncio
     async def test_blocks_no_tier_user_when_flag_on(self, mocker):
@@ -419,7 +419,7 @@ class TestEnforcePaymentPaywall:
         this to HTTP 402 — the dep itself doesn't construct an
         HTTPException so all gates share the same exception type."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -436,7 +436,7 @@ class TestEnforcePaymentPaywall:
     async def test_allows_no_tier_user_when_flag_off(self, mocker):
         """Beta cohort: flag off → NO_TIER user passes through (no exception)."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -461,7 +461,7 @@ class TestEnforcePaymentPaywall:
     async def test_allows_paid_tier_even_when_flag_on(self, mocker, tier):
         """Even with the flag on, paid tiers must never be blocked."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=tier),
         )
         is_feature_enabled_mock = mocker.patch(
@@ -485,7 +485,7 @@ class TestIsUserPaywalled:
     @pytest.mark.asyncio
     async def test_no_tier_with_flag_on_is_paywalled(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -499,7 +499,7 @@ class TestIsUserPaywalled:
     @pytest.mark.asyncio
     async def test_no_tier_with_flag_off_is_not_paywalled(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -523,7 +523,7 @@ class TestIsUserPaywalled:
     )
     async def test_paid_tier_short_circuits_without_flag_lookup(self, mocker, tier):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=tier),
         )
         flag_mock = mocker.patch(
@@ -541,7 +541,7 @@ class TestIsUserPaywalled:
         decide. The route-dep maps to 503; background callers
         (add_graph_execution) fail open."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(side_effect=RuntimeError("DB down")),
         )
         from .rate_limit import is_user_paywalled
@@ -558,7 +558,7 @@ class TestIsUserPaywalled:
         from .rate_limit import _UserNotFoundError, is_user_paywalled
 
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(side_effect=_UserNotFoundError(_USER)),
         )
         mocker.patch(
@@ -574,7 +574,7 @@ class TestIsUserPaywalled:
         from .rate_limit import _UserNotFoundError, is_user_paywalled
 
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(side_effect=_UserNotFoundError(_USER)),
         )
         mocker.patch(
@@ -596,53 +596,54 @@ class TestUserPaywalledError:
         assert str(UserPaywalledError("custom")) == "custom"
 
 
-class TestFetchUserTierErrorPropagation:
-    """``_fetch_user_tier`` must distinguish "row missing" (raises
-    ``ValueError`` via ``get_user_by_id``) from "transient DB error"
-    (Prisma connection failure etc). Without this distinction a
-    Supabase blip would silently degrade every paying user to NO_TIER
-    and ``enforce_payment_paywall`` would 402 them — contradicting its
-    503-on-blip contract. Regression locked here."""
+class TestFetchAuthoritativeUserTierErrorPropagation:
+    """The canonical reader keeps missing users distinct from DB outages.
 
-    @pytest.fixture(autouse=True)
-    def _clear_cache(self):
-        from .rate_limit import _fetch_user_tier
-
-        _fetch_user_tier.cache_clear()  # type: ignore[attr-defined]
+    Missing rows become ``_UserNotFoundError`` for the paywall's established
+    NO_TIER policy, while transient Database Manager failures still propagate
+    so HTTP callers return 503 instead of incorrectly paywalling paid users.
+    """
 
     @pytest.mark.asyncio
-    async def test_value_error_collapses_to_user_not_found(self, mocker):
-        """ValueError from get_user_by_id is the documented "missing user"
-        signal — it's correct to map this to NO_TIER (via
-        _UserNotFoundError → caught in is_user_paywalled)."""
-        mock_db = mocker.MagicMock()
-        mock_db.get_user_by_id = AsyncMock(side_effect=ValueError("User not found"))
-        mocker.patch("backend.copilot.rate_limit.user_db", return_value=mock_db)
-        from .rate_limit import _fetch_user_tier, _UserNotFoundError
+    async def test_missing_user_collapses_to_local_user_not_found(self, mocker):
+        from backend.util.subscription_tiers import (
+            SubscriptionTierUserNotFoundError,
+        )
+
+        from .rate_limit import _fetch_authoritative_user_tier, _UserNotFoundError
+
+        mocker.patch(
+            "backend.copilot.rate_limit.get_authoritative_subscription_tier",
+            new=AsyncMock(side_effect=SubscriptionTierUserNotFoundError(_USER)),
+        )
 
         with pytest.raises(_UserNotFoundError):
-            await _fetch_user_tier(_USER)
+            await _fetch_authoritative_user_tier(_USER)
 
     @pytest.mark.asyncio
     async def test_db_outage_propagates(self, mocker):
-        """Non-ValueError exceptions (Prisma connection failure, generic
-        RuntimeError) propagate as-is so route layer can map to 503."""
-        mock_db = mocker.MagicMock()
-        mock_db.get_user_by_id = AsyncMock(side_effect=RuntimeError("Prisma down"))
-        mocker.patch("backend.copilot.rate_limit.user_db", return_value=mock_db)
-        from .rate_limit import _fetch_user_tier
+        from backend.util.service import UnhealthyServiceError
 
-        with pytest.raises(RuntimeError, match="Prisma down"):
-            await _fetch_user_tier(_USER)
+        mocker.patch(
+            "backend.copilot.rate_limit.get_authoritative_subscription_tier",
+            new=AsyncMock(side_effect=UnhealthyServiceError("Database Manager down")),
+        )
+        from .rate_limit import _fetch_authoritative_user_tier
+
+        with pytest.raises(UnhealthyServiceError, match="Database Manager down"):
+            await _fetch_authoritative_user_tier(_USER)
 
     @pytest.mark.asyncio
     async def test_db_outage_does_not_collapse_to_402_for_paying_user(self, mocker):
-        """End-to-end: a Supabase blip during enforce_payment_paywall
+        """End-to-end: a Database Manager blip during enforce_payment_paywall
         for any user (paying or not) maps to 503, NOT 402. Locks the
         contract advertised in enforce_payment_paywall's docstring."""
-        mock_db = mocker.MagicMock()
-        mock_db.get_user_by_id = AsyncMock(side_effect=RuntimeError("Supabase blip"))
-        mocker.patch("backend.copilot.rate_limit.user_db", return_value=mock_db)
+        from backend.util.service import UnhealthyServiceError
+
+        mocker.patch(
+            "backend.copilot.rate_limit.get_authoritative_subscription_tier",
+            new=AsyncMock(side_effect=UnhealthyServiceError("Database Manager blip")),
+        )
         from fastapi import HTTPException
 
         from .rate_limit import enforce_payment_paywall
@@ -662,7 +663,7 @@ class TestEnforcePaymentPaywallInline:
     @pytest.mark.asyncio
     async def test_blocks_paywalled_user(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
         )
         mocker.patch(
@@ -677,7 +678,7 @@ class TestEnforcePaymentPaywallInline:
     @pytest.mark.asyncio
     async def test_passes_paid_user(self, mocker):
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(return_value=SubscriptionTier.PRO),
         )
         from .rate_limit import enforce_payment_paywall
@@ -690,7 +691,7 @@ class TestEnforcePaymentPaywallInline:
         the asymmetry fix: external API + internal graph routes used to
         fail-open via the deep gate; now they fail-closed at the route."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(side_effect=RuntimeError("DB down")),
         )
         from fastapi import HTTPException
@@ -716,7 +717,7 @@ class TestEnforcePaymentPaywallContinued:
         header so the client retries shortly instead of treating the
         outage as a permanent paywall."""
         mocker.patch(
-            "backend.copilot.rate_limit._fetch_user_tier",
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
             new=AsyncMock(side_effect=RuntimeError("DB down")),
         )
         is_feature_enabled_mock = mocker.patch(
@@ -1279,105 +1280,91 @@ class TestGetGlobalRateLimitsCostLimitsFlag:
 
 
 class TestGetUserTier:
-    @pytest.fixture(autouse=True)
-    def _clear_tier_cache(self):
-        """Clear the get_user_tier cache before each test."""
-        clear_legacy_user_tier_cache()
-
-    def _mock_user_db(
-        self, subscription_tier: str | None = None, raises: Exception | None = None
-    ):
-        """Return a patched user_db() whose get_user_by_id behaves as specified."""
-        mock_db = AsyncMock()
-        if raises is not None:
-            mock_db.get_user_by_id = AsyncMock(side_effect=raises)
-        else:
-            mock_user = MagicMock()
-            mock_user.subscription_tier = subscription_tier
-            mock_db.get_user_by_id = AsyncMock(return_value=mock_user)
-        return mock_db
-
     @pytest.mark.asyncio
     async def test_returns_tier_from_db(self):
-        """Should return the tier stored in the user record."""
-        mock_db = self._mock_user_db(subscription_tier="PRO")
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with patch(
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
+            new=AsyncMock(return_value=SubscriptionTier.PRO),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == SubscriptionTier.PRO
 
     @pytest.mark.asyncio
     async def test_returns_default_when_user_not_found(self):
-        """Should return DEFAULT_TIER when user is not in the DB."""
-        mock_db = self._mock_user_db(raises=Exception("not found"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        from .rate_limit import _UserNotFoundError
+
+        with patch(
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
+            new=AsyncMock(side_effect=_UserNotFoundError(_USER)),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
     @pytest.mark.asyncio
     async def test_returns_default_when_tier_is_none(self):
-        """Should return DEFAULT_TIER when subscription_tier is None."""
-        mock_db = self._mock_user_db(subscription_tier=None)
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with (
+            patch(
+                "backend.copilot.rate_limit._fetch_authoritative_user_tier",
+                new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
+            ),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
     @pytest.mark.asyncio
     async def test_returns_default_on_db_error(self):
-        """Should fall back to DEFAULT_TIER when DB raises."""
-        mock_db = self._mock_user_db(raises=Exception("DB down"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with patch(
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
+            new=AsyncMock(side_effect=RuntimeError("DB down")),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
     @pytest.mark.asyncio
     async def test_db_error_is_not_cached(self):
-        """Transient DB errors should NOT cache the default tier.
-
-        Regression test: a transient DB failure previously cached DEFAULT_TIER
-        for 5 minutes, incorrectly downgrading higher-tier users until expiry.
-        """
-        failing_db = self._mock_user_db(raises=Exception("DB down"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=failing_db):
+        lookup = AsyncMock(side_effect=[RuntimeError("DB down"), SubscriptionTier.PRO])
+        with patch(
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier", new=lookup
+        ):
             tier1 = await get_user_tier(_USER)
-        assert tier1 == DEFAULT_TIER
-
-        # Now DB recovers and returns PRO
-        ok_db = self._mock_user_db(subscription_tier="PRO")
-        with patch("backend.copilot.rate_limit.user_db", return_value=ok_db):
             tier2 = await get_user_tier(_USER)
 
-        # Should get PRO now — the error result was not cached
+        assert tier1 == DEFAULT_TIER
         assert tier2 == SubscriptionTier.PRO
 
     @pytest.mark.asyncio
     async def test_returns_default_on_invalid_tier_value(self):
-        """Should fall back to DEFAULT_TIER when stored value is invalid."""
-        mock_db = self._mock_user_db(subscription_tier="invalid-tier")
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db):
+        with patch(
+            "backend.copilot.rate_limit._fetch_authoritative_user_tier",
+            new=AsyncMock(side_effect=ValueError("invalid-tier")),
+        ):
             tier = await get_user_tier(_USER)
         assert tier == DEFAULT_TIER
 
     @pytest.mark.asyncio
     async def test_user_not_found_is_not_cached(self):
-        """Non-existent user should NOT cache DEFAULT_TIER.
+        from .rate_limit import _UserNotFoundError
 
-        Regression test: when ``get_user_tier`` is called before a user record
-        exists, the DEFAULT_TIER fallback must not be cached.  Otherwise, a
-        newly created user with a higher tier (e.g. PRO) would receive the
-        stale cached BASIC tier for up to 5 minutes.
-        """
-        # First call: user does not exist yet
-        missing_db = self._mock_user_db(raises=Exception("not found"))
-        with patch("backend.copilot.rate_limit.user_db", return_value=missing_db):
+        lookup = AsyncMock(
+            side_effect=[_UserNotFoundError(_USER), SubscriptionTier.PRO]
+        )
+        with (
+            patch(
+                "backend.copilot.rate_limit._fetch_authoritative_user_tier", new=lookup
+            ),
+            patch(
+                "backend.copilot.rate_limit._maybe_reconcile_stripe_tier",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
             tier1 = await get_user_tier(_USER)
-        assert tier1 == DEFAULT_TIER
-
-        # Second call: user now exists with PRO tier
-        ok_db = self._mock_user_db(subscription_tier="PRO")
-        with patch("backend.copilot.rate_limit.user_db", return_value=ok_db):
             tier2 = await get_user_tier(_USER)
 
-        # Should get PRO — the not-found result was not cached
+        assert tier1 == DEFAULT_TIER
         assert tier2 == SubscriptionTier.PRO
 
 
@@ -1460,15 +1447,13 @@ class TestMaybeReconcileStripeTier:
     async def test_get_user_tier_survives_reconcile_failure(self):
         """Reconcile failure stays non-fatal for rate limiting: get_user_tier
         still resolves the DB-confirmed NO_TIER instead of raising."""
-        clear_legacy_user_tier_cache()
-        mock_user = MagicMock()
-        mock_user.subscription_tier = None
-        mock_db = AsyncMock()
-        mock_db.get_user_by_id = AsyncMock(return_value=mock_user)
         redis = self._mock_redis()
         accessor = self._mock_credit_db(raises=RuntimeError("RPC unavailable"))
         with (
-            patch("backend.copilot.rate_limit.user_db", return_value=mock_db),
+            patch(
+                "backend.copilot.rate_limit._fetch_authoritative_user_tier",
+                new=AsyncMock(return_value=SubscriptionTier.NO_TIER),
+            ),
             patch(
                 "backend.copilot.rate_limit.get_redis_async",
                 AsyncMock(return_value=redis),
@@ -1651,42 +1636,6 @@ class TestSetUserTier:
         ):
             with pytest.raises(prisma.errors.RecordNotFoundError):
                 await set_user_tier(_USER, SubscriptionTier.ENTERPRISE)
-
-    @pytest.mark.asyncio
-    async def test_cache_invalidated_after_set(self):
-        """After set_user_tier, get_user_tier should query DB again (not cache)."""
-        # First, populate the cache with BUSINESS via user_db() mock
-        mock_db_biz = AsyncMock()
-        mock_user_biz = MagicMock()
-        mock_user_biz.subscription_tier = "BUSINESS"
-        mock_db_biz.get_user_by_id = AsyncMock(return_value=mock_user_biz)
-
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db_biz):
-            tier_before = await get_user_tier(_USER)
-        assert tier_before == SubscriptionTier.BUSINESS
-
-        # Now set tier to ENTERPRISE via PrismaUser.prisma (set_user_tier still
-        # uses Prisma directly since it's only called from admin API where Prisma
-        # is connected).
-        mock_prisma_set = AsyncMock()
-        mock_prisma_set.update = AsyncMock(return_value=None)
-
-        with patch(
-            "backend.copilot.rate_limit.PrismaUser.prisma",
-            return_value=mock_prisma_set,
-        ):
-            await set_user_tier(_USER, SubscriptionTier.ENTERPRISE)
-
-        # Now get_user_tier should hit DB again (cache was invalidated)
-        mock_db_ent = AsyncMock()
-        mock_user_ent = MagicMock()
-        mock_user_ent.subscription_tier = "ENTERPRISE"
-        mock_db_ent.get_user_by_id = AsyncMock(return_value=mock_user_ent)
-
-        with patch("backend.copilot.rate_limit.user_db", return_value=mock_db_ent):
-            tier_after = await get_user_tier(_USER)
-
-        assert tier_after == SubscriptionTier.ENTERPRISE
 
     @pytest.mark.asyncio
     async def test_drift_check_swallows_launchdarkly_failure(self):

--- a/autogpt_platform/backend/backend/util/entitlements.py
+++ b/autogpt_platform/backend/backend/util/entitlements.py
@@ -5,9 +5,12 @@ from typing import Mapping
 from prisma.enums import SubscriptionTier
 from pydantic import BaseModel, ConfigDict
 
-from backend.util.clients import get_database_manager_async_client
 from backend.util.settings import BehaveAs, Settings
 from backend.util.subscription_tier_order import subscription_tier_at_least
+from backend.util.subscription_tiers import (
+    SubscriptionTierUserNotFoundError,
+    get_authoritative_subscription_tier,
+)
 
 
 class Entitlement(str, Enum):
@@ -43,18 +46,10 @@ class EntitlementRequiredError(Exception):
 
 
 async def _get_user_subscription_tier(user_id: str) -> SubscriptionTier:
-    """Resolve a tier through DatabaseManager without caching this result.
-
-    A missing user has no entitlement. Other database and transport failures
-    propagate so callers can retry instead of treating an outage as a denial.
-    """
     try:
-        tier = await get_database_manager_async_client().get_user_subscription_tier(
-            user_id
-        )
-    except ValueError:
+        return await get_authoritative_subscription_tier(user_id)
+    except SubscriptionTierUserNotFoundError:
         return SubscriptionTier.NO_TIER
-    return SubscriptionTier(tier)
 
 
 async def has_entitlement(user_id: str, entitlement: Entitlement) -> bool:

--- a/autogpt_platform/backend/backend/util/entitlements_test.py
+++ b/autogpt_platform/backend/backend/util/entitlements_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from prisma.enums import SubscriptionTier
@@ -6,19 +6,14 @@ from prisma.enums import SubscriptionTier
 from backend.util import entitlements
 from backend.util.entitlements import Entitlement, EntitlementRequiredError
 from backend.util.settings import BehaveAs
-
-
-def _database_client(*tiers: SubscriptionTier | Exception):
-    client = MagicMock()
-    client.get_user_subscription_tier = AsyncMock(side_effect=tiers)
-    return client
+from backend.util.subscription_tiers import SubscriptionTierUserNotFoundError
 
 
 @pytest.mark.asyncio
-async def test_local_entitlement_bypasses_database_manager():
+async def test_local_entitlement_bypasses_tier_resolver():
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.LOCAL),
-        patch.object(entitlements, "get_database_manager_async_client") as get_db,
+        patch.object(entitlements, "get_authoritative_subscription_tier") as resolve,
     ):
         assert await entitlements.has_entitlement(
             "user-1",
@@ -29,7 +24,7 @@ async def test_local_entitlement_bypasses_database_manager():
             Entitlement.CODEX_SUBSCRIPTION_TRANSPORT,
         )
 
-    get_db.assert_not_called()
+    resolve.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -48,13 +43,12 @@ async def test_cloud_entitlement_uses_minimum_tier_order(
     tier: SubscriptionTier,
     allowed: bool,
 ):
-    client = _database_client(tier)
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
         patch.object(
             entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
+            "get_authoritative_subscription_tier",
+            new=AsyncMock(return_value=tier),
         ),
     ):
         result = await entitlements.has_entitlement(
@@ -63,43 +57,16 @@ async def test_cloud_entitlement_uses_minimum_tier_order(
         )
 
     assert result is allowed
-    client.get_user_subscription_tier.assert_awaited_once_with("user-1")
-
-
-@pytest.mark.asyncio
-async def test_repeated_checks_repeat_database_manager_lookup():
-    client = _database_client(SubscriptionTier.MAX, SubscriptionTier.PRO)
-    with (
-        patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
-        patch.object(
-            entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
-        ),
-    ):
-        first = await entitlements.has_entitlement(
-            "user-1",
-            Entitlement.CODEX_SUBSCRIPTION_TRANSPORT,
-        )
-        second = await entitlements.has_entitlement(
-            "user-1",
-            Entitlement.CODEX_SUBSCRIPTION_TRANSPORT,
-        )
-
-    assert first is True
-    assert second is False
-    assert client.get_user_subscription_tier.await_count == 2
 
 
 @pytest.mark.asyncio
 async def test_require_entitlement_raises_below_minimum_tier():
-    client = _database_client(SubscriptionTier.PRO)
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
         patch.object(
             entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
+            "get_authoritative_subscription_tier",
+            new=AsyncMock(return_value=SubscriptionTier.PRO),
         ),
     ):
         with pytest.raises(EntitlementRequiredError) as exc_info:
@@ -114,13 +81,12 @@ async def test_require_entitlement_raises_below_minimum_tier():
 
 @pytest.mark.asyncio
 async def test_database_manager_error_propagates():
-    client = _database_client(RuntimeError("database unavailable"))
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
         patch.object(
             entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
+            "get_authoritative_subscription_tier",
+            new=AsyncMock(side_effect=RuntimeError("database unavailable")),
         ),
     ):
         with pytest.raises(RuntimeError, match="database unavailable"):
@@ -132,13 +98,12 @@ async def test_database_manager_error_propagates():
 
 @pytest.mark.asyncio
 async def test_missing_user_is_treated_as_no_tier():
-    client = _database_client(ValueError("User not found"))
     with (
         patch.object(entitlements.settings.config, "behave_as", BehaveAs.CLOUD),
         patch.object(
             entitlements,
-            "get_database_manager_async_client",
-            return_value=client,
+            "get_authoritative_subscription_tier",
+            new=AsyncMock(side_effect=SubscriptionTierUserNotFoundError("missing")),
         ),
     ):
         allowed = await entitlements.has_entitlement(

--- a/autogpt_platform/backend/backend/util/subscription_tiers.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers.py
@@ -5,12 +5,27 @@ import uuid
 from collections.abc import Callable
 from typing import Any, cast
 
+from prisma.enums import SubscriptionTier
+
 from backend.data.redis_client import get_redis_async
+from backend.util.cache import cached
+from backend.util.clients import get_database_manager_async_client
+from backend.util.service import UnhealthyServiceError
 
 logger = logging.getLogger(__name__)
 
+SUBSCRIPTION_TIER_CACHE_TTL_SECONDS = 300
 SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS = 3600
 _GENERATION_KEY_PREFIX = "subscription-tier-cache:generation:"
+_GET_OR_CREATE_GENERATION_SCRIPT = """
+local generation = redis.call("GET", KEYS[1])
+if generation then
+    redis.call("EXPIRE", KEYS[1], ARGV[2])
+    return generation
+end
+redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[2])
+return ARGV[1]
+"""
 
 
 class SubscriptionTierCacheInvalidationError(RuntimeError):
@@ -22,6 +37,10 @@ class SubscriptionTierCacheInvalidationError(RuntimeError):
             "Subscription tier was updated, but cache invalidation failed for: "
             + ", ".join(failed_caches)
         )
+
+
+class SubscriptionTierUserNotFoundError(Exception):
+    pass
 
 
 def _generation_key(user_id: str) -> str:
@@ -41,6 +60,71 @@ async def _rotate_subscription_tier_generation(user_id: str) -> None:
     )
     if not written:
         raise RuntimeError("Redis did not acknowledge the generation update")
+
+
+async def _read_subscription_tier_generation(user_id: str) -> str | None:
+    try:
+        redis = await get_redis_async()
+        generation = await cast(Any, redis.eval)(
+            _GET_OR_CREATE_GENERATION_SCRIPT,
+            1,
+            _generation_key(user_id),
+            uuid.uuid4().hex,
+            SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS,
+        )
+        if isinstance(generation, bytes):
+            generation = generation.decode()
+        if not isinstance(generation, str) or not generation:
+            raise RuntimeError("Redis returned an invalid tier-cache generation")
+        return generation
+    except Exception as exc:
+        logger.warning(
+            "Subscription-tier cache generation unavailable for user %s; "
+            "bypassing cache: %s",
+            user_id[:8],
+            exc,
+        )
+        return None
+
+
+async def _load_authoritative_subscription_tier(
+    user_id: str,
+) -> SubscriptionTier:
+    try:
+        tier = await get_database_manager_async_client().get_user_subscription_tier(
+            user_id
+        )
+    except UnhealthyServiceError:
+        raise
+    except ValueError as exc:
+        raise SubscriptionTierUserNotFoundError(user_id) from exc
+    return SubscriptionTier(tier)
+
+
+@cached(
+    maxsize=1000,
+    ttl_seconds=SUBSCRIPTION_TIER_CACHE_TTL_SECONDS,
+    shared_cache=True,
+)
+async def _fetch_subscription_tier_for_generation(
+    user_id: str,
+    generation: str,
+) -> SubscriptionTier:
+    del generation
+    return await _load_authoritative_subscription_tier(user_id)
+
+
+async def get_authoritative_subscription_tier(user_id: str) -> SubscriptionTier:
+    """Return the DB-backed tier while sharing successful reads across processes.
+
+    Cache availability never becomes an authorization dependency. A generation
+    lookup failure bypasses both cache reads and writes, and missing users or DB
+    failures are raised without populating the value cache.
+    """
+    generation = await _read_subscription_tier_generation(user_id)
+    if generation is None:
+        return await _load_authoritative_subscription_tier(user_id)
+    return await _fetch_subscription_tier_for_generation(user_id, generation)
 
 
 async def _run_dual_cache_invalidation(

--- a/autogpt_platform/backend/backend/util/subscription_tiers.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers.py
@@ -40,7 +40,7 @@ class SubscriptionTierCacheInvalidationError(RuntimeError):
 
 
 class SubscriptionTierUserNotFoundError(Exception):
-    pass
+    """Raised when the authoritative subscription-tier user record is missing."""
 
 
 def _generation_key(user_id: str) -> str:
@@ -110,6 +110,7 @@ async def _fetch_subscription_tier_for_generation(
     user_id: str,
     generation: str,
 ) -> SubscriptionTier:
+    # The generation is a cache-key fence even though the loader does not read it.
     del generation
     return await _load_authoritative_subscription_tier(user_id)
 
@@ -119,7 +120,9 @@ async def get_authoritative_subscription_tier(user_id: str) -> SubscriptionTier:
 
     Cache availability never becomes an authorization dependency. A generation
     lookup failure bypasses both cache reads and writes, and missing users or DB
-    failures are raised without populating the value cache.
+    failures are raised without populating the value cache. Healthy cached reads
+    intentionally resolve the generation before the value, paying two serial
+    Redis operations so a concurrent tier write can fence stale values safely.
     """
     generation = await _read_subscription_tier_generation(user_id)
     if generation is None:

--- a/autogpt_platform/backend/backend/util/subscription_tiers.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers.py
@@ -95,6 +95,7 @@ async def _load_authoritative_subscription_tier(
             user_id
         )
     except UnhealthyServiceError:
+        # This subclasses ValueError; preserve outages before mapping missing users.
         raise
     except ValueError as exc:
         raise SubscriptionTierUserNotFoundError(user_id) from exc

--- a/autogpt_platform/backend/backend/util/subscription_tiers_test.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers_test.py
@@ -38,7 +38,6 @@ class _MemoryGenerationRedis:
     def __init__(self) -> None:
         self.values: dict[str, str] = {}
         self.fail_read = False
-        self.fail_write = False
 
     async def eval(
         self,
@@ -55,8 +54,6 @@ class _MemoryGenerationRedis:
         return self.values[key]
 
     async def set(self, key: str, value: str, *, ex: int) -> bool:
-        if self.fail_write:
-            raise ConnectionError("Redis unavailable")
         assert ex == SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS
         self.values[key] = value
         return True
@@ -506,3 +503,70 @@ async def test_generation_read_failure_bypasses_value_cache(
     )
     assert values.values == {}
     assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_bytes_generation_is_decoded_before_value_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    redis = MagicMock()
+    redis.eval = AsyncMock(return_value=b"byte-generation")
+
+    async def get_generation_redis():
+        return redis
+
+    fetch_tier = AsyncMock(return_value=SubscriptionTier.MAX)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_redis_async",
+        get_generation_redis,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "_fetch_subscription_tier_for_generation",
+        fetch_tier,
+    )
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("bytes-user")
+        == SubscriptionTier.MAX
+    )
+    fetch_tier.assert_awaited_once_with("bytes-user", "byte-generation")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_generation", [None, "", b""])
+async def test_invalid_generation_bypasses_value_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_generation: str | bytes | None,
+):
+    redis = MagicMock()
+    redis.eval = AsyncMock(return_value=invalid_generation)
+
+    async def get_generation_redis():
+        return redis
+
+    load_tier = AsyncMock(return_value=SubscriptionTier.PRO)
+    fetch_tier = AsyncMock()
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_redis_async",
+        get_generation_redis,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "_load_authoritative_subscription_tier",
+        load_tier,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "_fetch_subscription_tier_for_generation",
+        fetch_tier,
+    )
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("invalid-user")
+        == SubscriptionTier.PRO
+    )
+    load_tier.assert_awaited_once_with("invalid-user")
+    fetch_tier.assert_not_awaited()

--- a/autogpt_platform/backend/backend/util/subscription_tiers_test.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers_test.py
@@ -1,17 +1,23 @@
 import asyncio
+import socket
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import AsyncMock, MagicMock, call, patch
+from uuid import uuid4
 
 import pytest
 from prisma.enums import SubscriptionTier
 
 from backend.util import cache as cache_module
 from backend.util import subscription_tiers
+from backend.util.service import UnhealthyServiceError
 from backend.util.subscription_tier_order import (
     SUBSCRIPTION_TIER_ORDER,
     subscription_tier_at_least,
     subscription_tier_rank,
 )
 from backend.util.subscription_tiers import (
+    _GET_OR_CREATE_GENERATION_SCRIPT,
     SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS,
     SubscriptionTierCacheInvalidationError,
     SubscriptionTierUserNotFoundError,
@@ -19,7 +25,6 @@ from backend.util.subscription_tiers import (
     invalidate_subscription_tier_auxiliary_caches,
     invalidate_subscription_tier_caches,
 )
-from backend.util.service import UnhealthyServiceError
 
 
 class _MemoryValueRedis:
@@ -80,6 +85,73 @@ def _database_client(*tiers: SubscriptionTier | Exception):
     client = MagicMock()
     client.get_user_subscription_tier = AsyncMock(side_effect=tiers)
     return client
+
+
+def test_generation_lua_contract_against_live_redis_cluster():
+    """Execute the fencing primitive against the configured Redis cluster."""
+    from backend.data import redis_client
+
+    try:
+        with socket.create_connection(
+            (redis_client.HOST, redis_client.PORT), timeout=0.25
+        ):
+            pass
+    except OSError:
+        pytest.skip("local Redis cluster is unavailable")
+
+    client = redis_client.connect()
+    user_id = f"subscription-tier-lua-{uuid4().hex}"
+    key = _generation_key(user_id)
+    ttl_seconds = 10
+    candidates = [uuid4().hex for _ in range(8)]
+    barrier = Barrier(len(candidates))
+
+    def get_or_create(candidate: str) -> str:
+        barrier.wait()
+        return client.eval(
+            _GET_OR_CREATE_GENERATION_SCRIPT,
+            1,
+            key,
+            candidate,
+            ttl_seconds,
+        )
+
+    try:
+        client.delete(key)
+        with ThreadPoolExecutor(max_workers=len(candidates)) as executor:
+            generations = list(executor.map(get_or_create, candidates))
+
+        assert len(set(generations)) == 1
+        original = generations[0]
+        assert original in candidates
+        assert 0 < client.ttl(key) <= ttl_seconds
+
+        client.expire(key, 1)
+        hit = client.eval(
+            _GET_OR_CREATE_GENERATION_SCRIPT,
+            1,
+            key,
+            uuid4().hex,
+            ttl_seconds,
+        )
+        assert hit == original
+        assert client.ttl(key) >= ttl_seconds - 1
+
+        client.delete(key)
+        replacement = uuid4().hex
+        miss = client.eval(
+            _GET_OR_CREATE_GENERATION_SCRIPT,
+            1,
+            key,
+            replacement,
+            ttl_seconds,
+        )
+        assert miss == replacement
+        assert miss != original
+        assert 0 < client.ttl(key) <= ttl_seconds
+    finally:
+        client.delete(key)
+        client.close()
 
 
 def test_subscription_tier_order_covers_every_enum_value_once():

--- a/autogpt_platform/backend/backend/util/subscription_tiers_test.py
+++ b/autogpt_platform/backend/backend/util/subscription_tiers_test.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 from prisma.enums import SubscriptionTier
 
+from backend.util import cache as cache_module
+from backend.util import subscription_tiers
 from backend.util.subscription_tier_order import (
     SUBSCRIPTION_TIER_ORDER,
     subscription_tier_at_least,
@@ -12,10 +14,75 @@ from backend.util.subscription_tier_order import (
 from backend.util.subscription_tiers import (
     SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS,
     SubscriptionTierCacheInvalidationError,
+    SubscriptionTierUserNotFoundError,
     _generation_key,
     invalidate_subscription_tier_auxiliary_caches,
     invalidate_subscription_tier_caches,
 )
+from backend.util.service import UnhealthyServiceError
+
+
+class _MemoryValueRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, bytes] = {}
+
+    def get(self, key: str) -> bytes | None:
+        return self.values.get(key)
+
+    def setex(self, key: str, _ttl: int, value: bytes) -> bool:
+        self.values[key] = value
+        return True
+
+
+class _MemoryGenerationRedis:
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+        self.fail_read = False
+        self.fail_write = False
+
+    async def eval(
+        self,
+        script: str,
+        _num_keys: int,
+        key: str,
+        value: str,
+        _ttl: int,
+    ) -> str:
+        if self.fail_read:
+            raise ConnectionError("Redis unavailable")
+        assert 'redis.call("GET"' in script
+        self.values.setdefault(key, value)
+        return self.values[key]
+
+    async def set(self, key: str, value: str, *, ex: int) -> bool:
+        if self.fail_write:
+            raise ConnectionError("Redis unavailable")
+        assert ex == SUBSCRIPTION_TIER_GENERATION_TTL_SECONDS
+        self.values[key] = value
+        return True
+
+
+@pytest.fixture
+def isolated_tier_cache(monkeypatch: pytest.MonkeyPatch):
+    values = _MemoryValueRedis()
+    generations = _MemoryGenerationRedis()
+
+    async def get_generation_redis() -> _MemoryGenerationRedis:
+        return generations
+
+    monkeypatch.setattr(cache_module, "_get_redis", lambda: values)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_redis_async",
+        get_generation_redis,
+    )
+    return values, generations
+
+
+def _database_client(*tiers: SubscriptionTier | Exception):
+    client = MagicMock()
+    client.get_user_subscription_tier = AsyncMock(side_effect=tiers)
+    return client
 
 
 def test_subscription_tier_order_covers_every_enum_value_once():
@@ -200,3 +267,242 @@ def test_generation_key_hides_user_id_and_is_user_specific():
     assert "person@example.com" not in first
     assert first == _generation_key("person@example.com")
     assert first != second
+
+
+@pytest.mark.asyncio
+async def test_successful_lookup_is_shared_across_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    client = _database_client(SubscriptionTier.MAX)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    results = await asyncio.gather(
+        *(
+            subscription_tiers.get_authoritative_subscription_tier("same-user")
+            for _ in range(8)
+        )
+    )
+
+    assert results == [SubscriptionTier.MAX] * 8
+    client.get_user_subscription_tier.assert_awaited_once_with("same-user")
+
+
+@pytest.mark.asyncio
+async def test_different_users_are_cached_without_cross_user_leakage(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    async def read_tier(user_id: str) -> SubscriptionTier:
+        return {
+            "max-user": SubscriptionTier.MAX,
+            "pro-user": SubscriptionTier.PRO,
+        }[user_id]
+
+    client = MagicMock()
+    client.get_user_subscription_tier = AsyncMock(side_effect=read_tier)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    first = await asyncio.gather(
+        subscription_tiers.get_authoritative_subscription_tier("max-user"),
+        subscription_tiers.get_authoritative_subscription_tier("pro-user"),
+    )
+    second = await asyncio.gather(
+        subscription_tiers.get_authoritative_subscription_tier("max-user"),
+        subscription_tiers.get_authoritative_subscription_tier("pro-user"),
+    )
+
+    assert first == second == [SubscriptionTier.MAX, SubscriptionTier.PRO]
+    assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_user_and_transient_failure_are_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    client = _database_client(
+        ValueError("missing"),
+        RuntimeError("database unavailable"),
+        SubscriptionTier.BUSINESS,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    with pytest.raises(SubscriptionTierUserNotFoundError):
+        await subscription_tiers.get_authoritative_subscription_tier("retry-user")
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await subscription_tiers.get_authoritative_subscription_tier("retry-user")
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("retry-user")
+        == SubscriptionTier.BUSINESS
+    )
+    assert client.get_user_subscription_tier.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_database_manager_is_not_mapped_to_missing_user(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    client = _database_client(
+        UnhealthyServiceError("database manager unavailable"),
+        SubscriptionTier.MAX,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    with pytest.raises(UnhealthyServiceError, match="database manager unavailable"):
+        await subscription_tiers.get_authoritative_subscription_tier("health-outage")
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("health-outage")
+        == SubscriptionTier.MAX
+    )
+    assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidation_is_selective(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    client = _database_client(
+        SubscriptionTier.MAX,
+        SubscriptionTier.BUSINESS,
+        SubscriptionTier.PRO,
+    )
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("changed-user")
+        == SubscriptionTier.MAX
+    )
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("stable-user")
+        == SubscriptionTier.BUSINESS
+    )
+
+    legacy_delete = MagicMock()
+    await invalidate_subscription_tier_caches("changed-user", legacy_delete)
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("changed-user")
+        == SubscriptionTier.PRO
+    )
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("stable-user")
+        == SubscriptionTier.BUSINESS
+    )
+    legacy_delete.assert_called_once_with("changed-user")
+    assert client.get_user_subscription_tier.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_invalidation_fences_an_in_flight_stale_fill(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    first_read_started = asyncio.Event()
+    release_first_read = asyncio.Event()
+    calls = 0
+
+    async def read_tier(_user_id: str) -> SubscriptionTier:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_read_started.set()
+            await release_first_read.wait()
+            return SubscriptionTier.MAX
+        return SubscriptionTier.PRO
+
+    client = MagicMock()
+    client.get_user_subscription_tier = AsyncMock(side_effect=read_tier)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    stale_read = asyncio.create_task(
+        subscription_tiers.get_authoritative_subscription_tier("downgraded-user")
+    )
+    await first_read_started.wait()
+    await invalidate_subscription_tier_caches("downgraded-user", MagicMock())
+    release_first_read.set()
+
+    assert await stale_read == SubscriptionTier.MAX
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("downgraded-user")
+        == SubscriptionTier.PRO
+    )
+    assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_evicted_generation_never_reuses_an_old_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    client = _database_client(SubscriptionTier.MAX, SubscriptionTier.PRO)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("evicted-user")
+        == SubscriptionTier.MAX
+    )
+    _, generations = isolated_tier_cache
+    generations.values.clear()
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("evicted-user")
+        == SubscriptionTier.PRO
+    )
+    assert client.get_user_subscription_tier.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generation_read_failure_bypasses_value_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_tier_cache,
+):
+    client = _database_client(SubscriptionTier.MAX, SubscriptionTier.PRO)
+    monkeypatch.setattr(
+        subscription_tiers,
+        "get_database_manager_async_client",
+        lambda: client,
+    )
+    values, generations = isolated_tier_cache
+    generations.fail_read = True
+
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("redis-down")
+        == SubscriptionTier.MAX
+    )
+    assert (
+        await subscription_tiers.get_authoritative_subscription_tier("redis-down")
+        == SubscriptionTier.PRO
+    )
+    assert values.values == {}
+    assert client.get_user_subscription_tier.await_count == 2


### PR DESCRIPTION
### Why / What / How

Stacked on #14009, which is stacked on #14004.

This is phase 3 of the subscription-tier cache rollout. It activates one canonical, Database Manager-backed tier reader for entitlements, rate limiting, and the shared platform paywall. Successful lookups are shared through Redis for five minutes; missing users and transient service failures are never cached.

Each cached value is keyed by a per-user generation token. A committed tier change rotates that token, so an older in-flight read can only populate an obsolete generation that future callers will not consult.

### Changes 🏗️

- Add a canonical authoritative subscription-tier loader backed by Database Manager.
- Atomically get or create a random per-user cache generation with Redis Lua.
- Cache successful `(user_id, generation)` tier reads across processes for five minutes.
- Bypass both cache reads and writes when the generation store is unavailable, falling back to the authoritative database lookup.
- Keep missing-user results and transient Database Manager failures out of the cache.
- Preserve `UnhealthyServiceError` as a retryable service outage rather than misclassifying it as an absent user/tier.
- Route entitlement checks, rate-limit tier resolution, and `is_user_paywalled` through the same canonical reader while preserving each caller's existing failure policy.
- Preserve the local/self-host entitlement bypass before any Redis or database access.
- Retain the legacy reader key only for rolling-deployment eviction/rollback compatibility; it no longer serves production checks after this phase.
- Cover production bytes-generation decoding and invalid/empty-generation cache bypass.
- Execute the exact generation-fencing Lua script against a configured live Redis cluster, covering concurrent get-or-create convergence, hit TTL refresh, and miss-time `SET EX` behavior. The standard backend CI provisions that cluster; unconfigured local runs skip this integration contract.
- Cover the complete admin write → generation rotation → canonical rate-limit read boundary so a committed tier change is proven fresh on the next read.
- Cover successful Stripe reconciliation re-reads and graceful degradation if that re-read fails.
- Document the generation argument's load-bearing cache-key role and the intentional two-Redis-operation fencing tradeoff.

### Required rollout order

Do not deploy this PR until #14004 has been fully deployed to every process that can write `subscriptionTier`. Pre-#14004 writers do not rotate the generation token, so activating readers early can expose a stale authorization value during a mixed-version rollout.

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Python 3.11 tier/entitlement suite after final stack restack: 34 passed, 1 expected local skip because no Redis cluster was configured
  - [x] Python 3.11 focused rate-limit/paywall suite: 12 passed
  - [x] Python 3.11 authoritative-reader, reconciliation, and write-to-read boundary suite: 6 passed
  - [x] Generation eviction/recreation and in-flight stale-fill regressions
  - [x] Production bytes decode and invalid/empty-generation bypass regressions
  - [x] Missing-user versus transient-outage regressions
  - [x] isort, Ruff check, and Ruff format check
  - [x] Pyright: 0 errors, 0 warnings
  - [x] `git diff --check`

Broader CI on the exact stacked head is authoritative. The live Redis Lua contract executes in the standard backend CI matrix, which provisions a three-shard Redis 7 cluster before pytest.

#### For configuration changes:

- [x] `.env.default` is already compatible; no configuration is added
- [x] `docker-compose.yml` is already compatible; existing Redis is reused
- [x] No deployment configuration changes are required
