### PR TITLE
perf(backend): avoid a second JSON encoder walk

### DIFF
--- a/autogpt_platform/backend/backend/util/json.py
+++ b/autogpt_platform/backend/backend/util/json.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 # Precompiled regex to remove PostgreSQL-incompatible control characters
 # Removes \u0000-\u0008, \u000B-\u000C, \u000E-\u001F, \u007F (keeps tab \u0009, newline \u000A, carriage return \u000D)
 POSTGRES_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]")
+_has_control_chars = POSTGRES_CONTROL_CHARS.search
+_strip_control_chars = POSTGRES_CONTROL_CHARS.sub
 
 
 def dumps(
@@ -151,16 +153,44 @@ def sanitize_string(value: str) -> str:
     newline, and carriage return.  Use this before inserting free-form text
     into PostgreSQL text/varchar columns.
     """
-    return POSTGRES_CONTROL_CHARS.sub("", value)
+    # Nearly all strings contain nothing to strip, and on a miss re.sub returns
+    # the string it was given rather than a copy, so the search costs the same
+    # scan and skips the substitution machinery.
+    if type(value) is str and not _has_control_chars(value):
+        return value
+    return _strip_control_chars("", value)
+
+
+def _sanitize_encoded(value: Any) -> Any:
+    """Strip control characters from a structure `to_dict` has already encoded.
+
+    Everything here is a plain dict, list, str, int, float, bool or None, so
+    this only has to walk the tree; it does not need to repeat the type
+    conversion `to_dict` just did.
+    """
+    kind = type(value)
+    if kind is str:
+        return _strip_control_chars("", value) if _has_control_chars(value) else value
+    if kind is dict:
+        return {_sanitize_encoded(k): _sanitize_encoded(v) for k, v in value.items()}
+    if kind is list:
+        return [_sanitize_encoded(v) for v in value]
+    if isinstance(value, str):
+        # A str subclass. re.sub returns a plain str, which is what the second
+        # to_dict pass used to produce here, so keep it unconditional.
+        return _strip_control_chars("", value)
+    return value
 
 
 def sanitize_json(data: Any) -> Any:
     try:
-        # Use two-pass approach for consistent string sanitization:
-        # 1. First convert to basic JSON-serializable types (handles Pydantic models)
-        # 2. Then sanitize strings in the result
-        basic_result = to_dict(data)
-        return to_dict(basic_result, custom_encoder={str: sanitize_string})
+        # Two passes, as before:
+        # 1. to_dict converts Pydantic models and other complex types to basic
+        #    JSON-serializable types.
+        # 2. Walk that result and sanitize its strings. This used to be a second
+        #    to_dict call, which redid the full type dispatch on every node just
+        #    to run a regex over the strings.
+        return _sanitize_encoded(to_dict(data))
     except Exception as e:
         # Log the failure and fall back to string representation
         logger.error(

--- a/autogpt_platform/backend/backend/util/test_json.py
+++ b/autogpt_platform/backend/backend/util/test_json.py
@@ -4,7 +4,7 @@ from typing import Any, Optional, cast
 from prisma import Json
 from pydantic import BaseModel
 
-from backend.util.json import SafeJson
+from backend.util.json import SafeJson, _sanitize_encoded, sanitize_string
 
 
 class SamplePydanticModel(BaseModel):
@@ -18,6 +18,44 @@ class SampleModelWithNonSerializable(BaseModel):
     name: str
     func: Any = None  # Could contain non-serializable data
     data: Optional[dict] = None
+
+
+class StringSubclass(str):
+    pass
+
+
+def test_sanitize_string_handles_clean_control_and_subclass_values():
+    clean = "plain text"
+
+    assert sanitize_string(clean) is clean
+    assert sanitize_string("null\x00bell\x07tab\t") == "nullbelltab\t"
+
+    sanitized_subclass = sanitize_string(StringSubclass("clean subclass"))
+    assert sanitized_subclass == "clean subclass"
+    assert type(sanitized_subclass) is str
+
+
+def test_sanitize_encoded_recurses_through_keys_lists_and_subclasses():
+    nested_list = [
+        "clean value",
+        StringSubclass("clean subclass"),
+        {"dirty\x00key": StringSubclass("dirty\x07value")},
+    ]
+    data = {"top\x00key": nested_list, "count": 1}
+
+    result = _sanitize_encoded(data)
+
+    assert result == {
+        "topkey": [
+            "clean value",
+            "clean subclass",
+            {"dirtykey": "dirtyvalue"},
+        ],
+        "count": 1,
+    }
+    assert result is not data
+    assert result["topkey"] is not nested_list
+    assert type(result["topkey"][1]) is str
 
 
 class TestSafeJson:


### PR DESCRIPTION
### Why / What / How

`sanitize_json` runs `jsonable_encoder` over the payload twice:

```python
basic_result = to_dict(data)
return to_dict(basic_result, custom_encoder={str: sanitize_string})
```

The first call is the one that does the work. Pydantic models, dataclasses,
`Enum`, `datetime`, `Decimal`, `UUID`, `PurePath`, `bytes`, sets and tuples all
become plain JSON types. The second call walks that already-plain result again,
redoing the full type dispatch on every node, and the only thing it changes is
that `sanitize_string` runs on each string.

Counted over the 678 node `input_default` and `metadata` values checked into
`autogpt_platform/backend/agents/*.json`, which is what `SafeJson` is handed at
`data/graph.py:1848-1849`, that second call costs **12,376 `jsonable_encoder`
invocations per pass against the 6,188 a single walk needs**, exactly 2x.

This replaces the second `to_dict` call with `_sanitize_encoded`, a walk over
the plain structure that only strips control characters. Two smaller changes go
with it: `sanitize_string` checks whether there is anything to strip before
substituting, and the compiled pattern's `search`/`sub` are bound to module
names so the walk skips two attribute lookups per string.

The `search` check is worth stating, because it looks redundant. On a miss
`re.sub` returns the string it was given rather than a copy, so both forms scan
once, but the search skips the substitution machinery. It matters because
almost no strings contain a control character. `str.translate` was the obvious
alternative and it is slower here: it allocates a new string every time, and
across thousands of short clean strings that costs more than it saves. I
measured it at 18.7 ms against 15.8 ms for the unchanged code.

### Measurements

Wall time, median of 9 repetitions, on an otherwise idle host under an
exclusive CPU lock. `upstream` is this branch's merge base.

| payload | upstream | this branch | |
| --- | --- | --- | --- |
| the 678 shipped node input/metadata values | 7.683 ms | 4.875 ms | 1.58x |
| block output, 40-record list, 10,111 bytes | 0.363 ms | 0.245 ms | 1.48x |
| block output, 40-record list, 100,441 bytes | 3.539 ms | 2.441 ms | 1.45x |
| block output, 40-record list, 502,146 bytes | 17.500 ms | 12.121 ms | 1.44x |
| block output, one string, 10,016 bytes | 0.040 ms | 0.039 ms | 1.03x |
| block output, one string, 100,016 bytes | 0.372 ms | 0.365 ms | 1.02x |
| block output, one string, 500,016 bytes | 1.839 ms | 1.832 ms | 1.00x |

Per call over the shipped values that is 0.0113 ms down to 0.0072 ms.

**There is no improvement on a payload that is one large string**, and the last
three rows are the honest version of that. A single string has almost no tree
to walk, so both versions spend their time in the same regex scan. The win is
on structured payloads, which is what `upsert_execution_input` and
`upsert_execution_output` mostly store.

Instruction counts, measured with Callgrind because the machine was shared,
over a fixed 224-payload corpus: **189.24 M down to 134.6 M retired
instructions per pass, a 1.41x reduction**. Three repetitions of the patched
code gave 134.5925 / 134.6500 / 134.6636, a spread of 0.053%.

### Where this runs

`SafeJson` has 73 non-test call sites. Two are per-node-execution:
`data/execution.py:1010` in `upsert_execution_input`, once per node input, and
`:1059` in `upsert_execution_output`, once per node output. Both execute inside
the shared `DatabaseManager` service, and `sanitize_json` is a synchronous
`def` reached from `async` endpoints there, so the cost is on that service's
throughput as well as on individual write latency. Nothing truncates before
these writes; `truncate()` runs on the event-publish path at
`data/execution.py:1551-1555`.

I want to be plain about the size of this. Per call on the small constant
inputs the saving is 4 microseconds, in front of a Postgres insert. The
argument for the change is the large end and the shared service, not the small
end.

### Changes 🏗️

- `backend/util/json.py`: added `_sanitize_encoded`, a recursive walk over the
  output of `to_dict` that strips control characters without repeating the type
  conversion, and used it in place of the second `to_dict` call.
- `backend/util/json.py`: `sanitize_string` returns its argument unchanged when
  the pattern does not match. Also used by `backend/copilot/db.py` on chat
  message content, so that path benefits too.
- `backend/util/json.py`: bound `POSTGRES_CONTROL_CHARS.search` and `.sub` to
  module-level names.

Behaviour is unchanged, including the parts that are easy to lose:
`jsonable_encoder` drops string keys beginning with `_sa`, which the first pass
still does; dict keys are sanitized as well as values; `True` stays a `bool`
and not `1`; a `str` subclass comes back as a plain `str` whether or not it
contained anything to strip; and the `except` branch and its return value are
untouched.

### Test plan

- [x] `poetry run pytest backend/util/test_json.py` — 32 passed, before and
      after the change
- [x] `backend/util/type_test.py` — 51 passed
- [x] Differential check against the unmodified module over an adversarial
      battery plus randomly generated payloads: `_sa`-prefixed keys, non-string
      dict keys, `NaN`/`Inf`, bool-versus-int, `str` subclasses with and
      without control characters, control characters in keys, nested Pydantic
      models, dataclasses, `Enum`, `datetime`, `Decimal`, `UUID`, `PurePath`,
      `bytes`, sets, tuples, deques, 40-deep nesting, and the inputs that make
      `jsonable_encoder` raise so the `except` branch runs. Results compared
      with type-strict equality, since `True == 1` and `1 == 1.0`.
- [x] Checked that the returned structure shares no `dict` or `list` object
      with the argument, so mutating the argument afterwards cannot change a
      value already handed to Prisma
- [x] `black`, `isort --profile black`, `ruff check` clean on the changed file
- [x] `pyright` reports 0 errors and 0 warnings on the changed file at
      `--pythonversion` 3.11, 3.12 and 3.13

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

---

### AI and optimization assistance

Weco, using Gemini, generated and evaluated candidate variants. I reviewed the
trajectory, selected the smaller step-9 mechanism, adapted it for readability,
and independently replayed the submitted diff on current `dev`. Codex assisted
with current-head revalidation and PR preparation. This is not a raw generated
candidate.

The anonymous Weco trajectory is at
https://dashboard.weco.ai/share/6aaQwzAQFB3kygmRM90TnFPSfmMHEbrq — 13 valid
scalar records, most worse than the baseline. The submitted patch is a simpler
variant of the best step: that one reached 132.23 M instructions against this
branch's 134.6 M, a further 1.8%, by inlining string handling into the dict and
list comprehensions, which was not worth the readability cost.

This touches the same file as #13749, which caches the jsonschema validator in
`validate_with_jsonschema`. The two changes are in different functions on
different call paths and only overlap in the import block. Happy to rebase
whichever lands second.
