### PR TITLE
ci(platform): flag-off regression guarantee

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -71,7 +71,11 @@ from backend.copilot.pending_messages import (
     drain_pending_messages,
     format_pending_as_user_message,
 )
-from backend.copilot.prompting import SHARED_TOOL_NOTES, get_graphiti_supplement
+from backend.copilot.prompting import (
+    SHARED_TOOL_NOTES,
+    compose_system_prompt,
+    get_graphiti_supplement,
+)
 from backend.copilot.rate_limit import build_budget_ctx
 from backend.copilot.response_model import (
     StreamBaseResponse,
@@ -1784,12 +1788,12 @@ async def stream_chat_completion_baseline(
     expert_session_suffix = await build_expert_identity_suffix(
         session.user_id, session.expert_id
     )
-    system_prompt = (
-        base_system_prompt
-        + SHARED_TOOL_NOTES
-        + graphiti_supplement
-        + builder_session_suffix
-        + expert_session_suffix
+    system_prompt = compose_system_prompt(
+        base_system_prompt,
+        SHARED_TOOL_NOTES,
+        graphiti_supplement,
+        builder_session_suffix,
+        expert_session_suffix,
     )
 
     # Warm context: pre-load relevant facts from Graphiti on first turn.

--- a/autogpt_platform/backend/backend/copilot/flag_off_prompt_test.py
+++ b/autogpt_platform/backend/backend/copilot/flag_off_prompt_test.py
@@ -1,16 +1,21 @@
 """Flag-off regression guarantee for the copilot system prompt.
 
 When the ``hire-experts`` flag is OFF a user can never open an expert session,
-so ``expert_id`` is always ``None`` and the copilot must serve the exact
-pre-experts system prompt. This suite pins the SHA-256 of the prompt a PLAIN
-session (no expert) receives, so any edit that would change flag-off behavior
-fails CI loudly.
+so ``expert_id`` is always ``None`` and both engines must serve the exact
+pre-experts system prompt. This suite composes the plain-session prompt through
+``compose_system_prompt`` — the single composition point all three production
+call sites use (SDK main turn, SDK building-mode restart, baseline) — with the
+real expert-suffix builder, and pins the SHA-256 for every deterministic engine
+configuration (``use_e2b`` and Graphiti are orthogonal toggles that exist
+flag-off too, so each combination is pinned). Any edit that changes flag-off
+prompt bytes fails CI loudly.
 
-Sibling coverage: ``expert_context_test.py`` pins the base
-``_CACHEABLE_SYSTEM_PROMPT`` constant in isolation. This suite pins the
-*composed* plain-session prompt (base + the expert-identity suffix a plain
-session actually gets), so it also fails if the experts feature ever leaks a
-non-empty suffix into the no-expert path.
+Scope, stated honestly: in production ``_build_system_prompt`` may source the
+base prompt from Langfuse at runtime; that content lives outside this repo and
+cannot be pinned by CI. This suite pins the in-repo fallback base
+(``CACHEABLE_SYSTEM_PROMPT`` — the exact base whenever Langfuse is
+unconfigured, itself snapshot-pinned in ``expert_context_test.py``); flag-off
+parity of a Langfuse-hosted base must be maintained in the Langfuse template.
 """
 
 import hashlib
@@ -18,18 +23,23 @@ import hashlib
 import pytest
 
 from backend.copilot.expert_context import build_expert_identity_suffix
-from backend.copilot.service import CACHEABLE_SYSTEM_PROMPT
-
-# SHA-256 of the prompt a PLAIN copilot session (no expert) receives:
-#   CACHEABLE_SYSTEM_PROMPT + build_expert_identity_suffix(user, expert_id=None)
-# Flag-off = byte-identical prod behavior.
-_FLAG_OFF_PLAIN_PROMPT_SHA256 = (
-    "22d1897a44ec751b36e4938f087dc49ad9dcae6c452842ed057ba7ebe3de4545"
+from backend.copilot.prompting import (
+    SHARED_TOOL_NOTES,
+    compose_system_prompt,
+    get_graphiti_supplement,
+    get_sdk_supplement,
 )
+from backend.copilot.service import CACHEABLE_SYSTEM_PROMPT
 
 _FLAG_OFF_CHANGED_MSG = (
     "flag-off prompt changed; if intentional, update hash + call out in PR description"
 )
+
+
+def _engine_supplement(engine: str, use_e2b: bool) -> str:
+    if engine == "sdk":
+        return get_sdk_supplement(use_e2b=use_e2b)
+    return SHARED_TOOL_NOTES
 
 
 class TestFlagOffPlainSessionPrompt:
@@ -40,8 +50,61 @@ class TestFlagOffPlainSessionPrompt:
         assert suffix == "", _FLAG_OFF_CHANGED_MSG
 
     @pytest.mark.asyncio
-    async def test_plain_session_prompt_hash_is_pinned(self):
-        suffix = await build_expert_identity_suffix("flag-off-user", None)
-        plain_prompt = CACHEABLE_SYSTEM_PROMPT + suffix
+    @pytest.mark.parametrize(
+        "engine,use_e2b,graphiti_enabled,expected_sha256",
+        [
+            (
+                "sdk",
+                False,
+                False,
+                "ccd74050220a0aa4fba9edefeba283d737540558d3de1ddf21cf01c0a7529aec",
+            ),
+            (
+                "sdk",
+                False,
+                True,
+                "a50dacd30e9f15a2b55e6764d526074b2dba038fd42846f29814143fd0376a07",
+            ),
+            (
+                "sdk",
+                True,
+                False,
+                "7a8a11acfd42edc87a8bfe9eec5c54bc5d88716b46e17c7cf5af6a1d60fdf453",
+            ),
+            (
+                "sdk",
+                True,
+                True,
+                "31e2058efd71bc6df46bab58b2cbc0950ed125d07c4c221012e6b3481706fd06",
+            ),
+            (
+                "baseline",
+                False,
+                False,
+                "99d8c272de5c3b8fe8c4cd1546bed8a186b218c789c7e4ad545fa91dc9282b02",
+            ),
+            (
+                "baseline",
+                False,
+                True,
+                "9aa9eee140ef64210ecddba44ed67ceeb759fea7e3f8d00c9e9ea74586cfa7c2",
+            ),
+        ],
+    )
+    async def test_plain_session_prompt_hash_is_pinned(
+        self,
+        engine: str,
+        use_e2b: bool,
+        graphiti_enabled: bool,
+        expected_sha256: str,
+    ):
+        expert_suffix = await build_expert_identity_suffix("flag-off-user", None)
+        plain_prompt = compose_system_prompt(
+            CACHEABLE_SYSTEM_PROMPT,
+            _engine_supplement(engine, use_e2b),
+            get_graphiti_supplement() if graphiti_enabled else "",
+            "",
+            expert_suffix,
+        )
         digest = hashlib.sha256(plain_prompt.encode("utf-8")).hexdigest()
-        assert digest == _FLAG_OFF_PLAIN_PROMPT_SHA256, _FLAG_OFF_CHANGED_MSG
+        assert digest == expected_sha256, _FLAG_OFF_CHANGED_MSG

--- a/autogpt_platform/backend/backend/copilot/flag_off_prompt_test.py
+++ b/autogpt_platform/backend/backend/copilot/flag_off_prompt_test.py
@@ -1,0 +1,47 @@
+"""Flag-off regression guarantee for the copilot system prompt.
+
+When the ``hire-experts`` flag is OFF a user can never open an expert session,
+so ``expert_id`` is always ``None`` and the copilot must serve the exact
+pre-experts system prompt. This suite pins the SHA-256 of the prompt a PLAIN
+session (no expert) receives, so any edit that would change flag-off behavior
+fails CI loudly.
+
+Sibling coverage: ``expert_context_test.py`` pins the base
+``_CACHEABLE_SYSTEM_PROMPT`` constant in isolation. This suite pins the
+*composed* plain-session prompt (base + the expert-identity suffix a plain
+session actually gets), so it also fails if the experts feature ever leaks a
+non-empty suffix into the no-expert path.
+"""
+
+import hashlib
+
+import pytest
+
+from backend.copilot.expert_context import build_expert_identity_suffix
+from backend.copilot.service import CACHEABLE_SYSTEM_PROMPT
+
+# SHA-256 of the prompt a PLAIN copilot session (no expert) receives:
+#   CACHEABLE_SYSTEM_PROMPT + build_expert_identity_suffix(user, expert_id=None)
+# Flag-off = byte-identical prod behavior.
+_FLAG_OFF_PLAIN_PROMPT_SHA256 = (
+    "22d1897a44ec751b36e4938f087dc49ad9dcae6c452842ed057ba7ebe3de4545"
+)
+
+_FLAG_OFF_CHANGED_MSG = (
+    "flag-off prompt changed; if intentional, update hash + call out in PR description"
+)
+
+
+class TestFlagOffPlainSessionPrompt:
+    @pytest.mark.asyncio
+    async def test_plain_session_expert_suffix_is_empty(self):
+        # hire-experts OFF -> no expert_id -> experts contributes nothing.
+        suffix = await build_expert_identity_suffix("flag-off-user", None)
+        assert suffix == "", _FLAG_OFF_CHANGED_MSG
+
+    @pytest.mark.asyncio
+    async def test_plain_session_prompt_hash_is_pinned(self):
+        suffix = await build_expert_identity_suffix("flag-off-user", None)
+        plain_prompt = CACHEABLE_SYSTEM_PROMPT + suffix
+        digest = hashlib.sha256(plain_prompt.encode("utf-8")).hexdigest()
+        assert digest == _FLAG_OFF_PLAIN_PROMPT_SHA256, _FLAG_OFF_CHANGED_MSG

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -619,6 +619,33 @@ def get_sdk_supplement(use_e2b: bool) -> str:
     return base + _USER_FOLLOW_UP_NOTE
 
 
+def compose_system_prompt(
+    base: str,
+    engine_supplement: str,
+    graphiti_supplement: str = "",
+    builder_session_suffix: str = "",
+    expert_session_suffix: str = "",
+) -> str:
+    """Single composition point for the copilot system prompt.
+
+    Both engines assemble their system prompt through this function — the SDK
+    engine passes ``get_sdk_supplement(...)`` and the baseline engine passes
+    ``SHARED_TOOL_NOTES`` as *engine_supplement*; the remaining components are
+    ``""`` when absent. Component order is part of the prompt-cache contract
+    (byte-identical prompts across turns/users), and the flag-off regression
+    suite (``flag_off_prompt_test.py``) pins SHA-256 digests of this function's
+    plain-session output, so any reordering or new component must go through
+    here and will surface in that suite.
+    """
+    return (
+        base
+        + engine_supplement
+        + graphiti_supplement
+        + builder_session_suffix
+        + expert_session_suffix
+    )
+
+
 def get_graphiti_supplement() -> str:
     """Get the memory system instructions to append when Graphiti is enabled.
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -100,7 +100,11 @@ from ..permissions import (
     all_known_tool_names,
     apply_tool_permissions,
 )
-from ..prompting import get_graphiti_supplement, get_sdk_supplement
+from ..prompting import (
+    compose_system_prompt,
+    get_graphiti_supplement,
+    get_sdk_supplement,
+)
 from ..rate_limit import (
     get_global_rate_limits,
     get_remaining_usd_budget,
@@ -1577,12 +1581,12 @@ async def _apply_building_mode_restart(
     expert_session_suffix = await build_expert_identity_suffix(
         session.user_id, session.expert_id
     )
-    system_prompt = (
-        base_system_prompt
-        + get_sdk_supplement(use_e2b=use_e2b)
-        + graphiti_supplement
-        + building_suffix
-        + expert_session_suffix
+    system_prompt = compose_system_prompt(
+        base_system_prompt,
+        get_sdk_supplement(use_e2b=use_e2b),
+        graphiti_supplement,
+        building_suffix,
+        expert_session_suffix,
     )
     sdk_options_restart = copy(sdk_options)
     sdk_options_restart.system_prompt = _build_system_prompt_value(
@@ -4294,12 +4298,12 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         expert_session_suffix = await build_expert_identity_suffix(
             session.user_id, session.expert_id
         )
-        system_prompt = (
-            base_system_prompt
-            + get_sdk_supplement(use_e2b=use_e2b)
-            + graphiti_supplement
-            + builder_session_suffix
-            + expert_session_suffix
+        system_prompt = compose_system_prompt(
+            base_system_prompt,
+            get_sdk_supplement(use_e2b=use_e2b),
+            graphiti_supplement,
+            builder_session_suffix,
+            expert_session_suffix,
         )
 
         transcript_content = _restore.transcript_content

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/InstallOnExpertButton/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/InstallOnExpertButton/__tests__/main.test.tsx
@@ -1,0 +1,95 @@
+import { getListExpertsMockHandler } from "@/app/api/__generated__/endpoints/experts/experts.msw";
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { InstallOnExpertButton } from "../InstallOnExpertButton";
+
+const flagState = vi.hoisted(() => ({ hireExperts: false }));
+
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    useGetFlag: (flag: string) =>
+      flag === actual.Flag.HIRE_EXPERTS
+        ? flagState.hireExperts
+        : actual.useGetFlag(flag as never),
+  };
+});
+
+// Signed-in on purpose: flag-off must hide the action and skip the experts
+// request even for a logged-in user with hired experts.
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => ({ isLoggedIn: true }),
+}));
+
+vi.mock(
+  "@/components/molecules/InstallWorkflowPicker/InstallWorkflowPicker",
+  () => ({
+    InstallWorkflowPicker: () => null,
+  }),
+);
+
+const hiredExpert: Expert = {
+  id: "expert-1",
+  name: "Maria",
+  avatar_url: null,
+  role: "Marketing Strategist",
+  bio: null,
+  skills: [],
+  tagline: null,
+  identity: "You are Maria.",
+  voice_preferences: "Warm and direct.",
+  boundaries: "Ask before external actions.",
+  protected_soul_rules: [],
+  is_template: false,
+  source_template_id: null,
+  is_archived: false,
+  workflows: [],
+};
+
+describe("InstallOnExpertButton", () => {
+  beforeEach(() => {
+    flagState.hireExperts = false;
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  test("flag-off: renders no action and fires no experts request for a signed-in user with hired experts", async () => {
+    const expertsSpy = vi.fn(() => [hiredExpert]);
+    server.use(getListExpertsMockHandler(expertsSpy));
+
+    render(<InstallOnExpertButton storeListingVersionId="slv-1" />);
+
+    // Poll for a full window (same pipeline latency the flag-on test needs)
+    // so a wrongly-enabled query + rendered action cannot slip past a
+    // too-early assertion; findByRole must time out for the gate to hold.
+    await expect(
+      screen.findByRole(
+        "button",
+        { name: /install on expert/i },
+        { timeout: 1000 },
+      ),
+    ).rejects.toThrow();
+    expect(expertsSpy).not.toHaveBeenCalled();
+  });
+
+  test("flag-on: fetches experts and renders the action for the same signed-in user", async () => {
+    flagState.hireExperts = true;
+    const expertsSpy = vi.fn(() => [hiredExpert]);
+    server.use(getListExpertsMockHandler(expertsSpy));
+
+    render(<InstallOnExpertButton storeListingVersionId="slv-1" />);
+
+    expect(
+      await screen.findByRole("button", { name: /install on expert/i }),
+    ).toBeDefined();
+    expect(expertsSpy).toHaveBeenCalled();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/__tests__/main.test.tsx
@@ -12,6 +12,21 @@ vi.mock("../useMainMarketplacePage", () => ({
   useMainMarketplacePage: mockUseMainMarketplacePage,
 }));
 
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    // Force hire-experts OFF for this suite; delegate every other flag.
+    useGetFlag: (flag: string) =>
+      flag === actual.Flag.HIRE_EXPERTS
+        ? false
+        : actual.useGetFlag(flag as never),
+  };
+});
+
 describe("MainMarketplacePage", () => {
   beforeEach(() => {
     mockUseMainMarketplacePage.mockReturnValue({
@@ -60,5 +75,14 @@ describe("MainMarketplacePage", () => {
     expect(
       screen.getByRole("button", { name: "Become a Creator" }),
     ).toBeDefined();
+  });
+
+  test("flag-off: hides the Meet the AI Experts section", () => {
+    render(<MainMarkeplacePage />);
+
+    // ExpertsSection is gated on hire-experts; flag-off renders the
+    // pre-experts marketplace (workflows + creators) with no experts surface.
+    expect(screen.queryByText("Meet the AI Experts")).toBeNull();
+    expect(screen.getByText("All AI Workflows")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/__tests__/main.test.tsx
@@ -7,6 +7,7 @@ import { MainMarkeplacePage } from "../MainMarketplacePage";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mockUseMainMarketplacePage = vi.hoisted(() => vi.fn());
+const flagState = vi.hoisted(() => ({ hireExperts: false }));
 
 vi.mock("../useMainMarketplacePage", () => ({
   useMainMarketplacePage: mockUseMainMarketplacePage,
@@ -19,16 +20,23 @@ vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
     >();
   return {
     ...actual,
-    // Force hire-experts OFF for this suite; delegate every other flag.
     useGetFlag: (flag: string) =>
       flag === actual.Flag.HIRE_EXPERTS
-        ? false
+        ? flagState.hireExperts
         : actual.useGetFlag(flag as never),
   };
 });
 
+// Sentinel: ExpertsSection renders null for signed-out users, so asserting on
+// its copy would pass even if the page's flag gate were deleted. Mocking it as
+// an always-visible marker makes mounted-vs-not the thing under test.
+vi.mock("../../ExpertsSection/ExpertsSection", () => ({
+  ExpertsSection: () => <div data-testid="experts-section-sentinel" />,
+}));
+
 describe("MainMarketplacePage", () => {
   beforeEach(() => {
+    flagState.hireExperts = false;
     mockUseMainMarketplacePage.mockReturnValue({
       featuredAgents: getGetV2ListStoreAgentsResponseMock({
         agents: [
@@ -77,12 +85,28 @@ describe("MainMarketplacePage", () => {
     ).toBeDefined();
   });
 
-  test("flag-off: hides the Meet the AI Experts section", () => {
+  test("flag-off: does not mount ExpertsSection and keeps the pre-experts subtitle", () => {
     render(<MainMarkeplacePage />);
 
-    // ExpertsSection is gated on hire-experts; flag-off renders the
-    // pre-experts marketplace (workflows + creators) with no experts surface.
-    expect(screen.queryByText("Meet the AI Experts")).toBeNull();
-    expect(screen.getByText("All AI Workflows")).toBeDefined();
+    expect(screen.queryByTestId("experts-section-sentinel")).toBeNull();
+    expect(
+      screen.getByText("Ready-made automations from the community."),
+    ).toBeDefined();
+    expect(
+      screen.queryByText("Install one on an Expert, or run it standalone."),
+    ).toBeNull();
+  });
+
+  test("flag-on: mounts ExpertsSection and swaps the workflows subtitle", () => {
+    flagState.hireExperts = true;
+    render(<MainMarkeplacePage />);
+
+    expect(screen.getByTestId("experts-section-sentinel")).toBeDefined();
+    expect(
+      screen.getByText("Install one on an Expert, or run it standalone."),
+    ).toBeDefined();
+    expect(
+      screen.queryByText("Ready-made automations from the community."),
+    ).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/main.test.tsx
@@ -190,4 +190,18 @@ describe("ExpertDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Resume schedules" }));
     await waitFor(() => expect(resumeSpy).toHaveBeenCalled());
   });
+
+  test("flag-off: calls notFound() when hire-experts is disabled", () => {
+    setFlagStatusMock.mockReturnValue({ enabled: false, ready: true });
+    notFoundMock.mockClear();
+
+    try {
+      render(<ExpertDetailPage />);
+    } catch {
+      // notFound() throws NEXT_NOT_FOUND to halt the render; the assertion
+      // below is what we actually care about.
+    }
+
+    expect(notFoundMock).toHaveBeenCalled();
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/main.test.tsx
@@ -191,17 +191,28 @@ describe("ExpertDetailPage", () => {
     await waitFor(() => expect(resumeSpy).toHaveBeenCalled());
   });
 
-  test("flag-off: calls notFound() when hire-experts is disabled", () => {
+  test("flag-off: calls notFound() and fires no expert or schedule requests", async () => {
+    const expertSpy = vi.fn(() => maria);
+    const schedulesSpy = vi.fn(() => [mariaSchedule]);
+    server.use(
+      getGetExpertMockHandler(expertSpy),
+      getGetV1ListExecutionSchedulesForAUserMockHandler(schedulesSpy),
+    );
     setFlagStatusMock.mockReturnValue({ enabled: false, ready: true });
     notFoundMock.mockClear();
 
     try {
       render(<ExpertDetailPage />);
     } catch {
-      // notFound() throws NEXT_NOT_FOUND to halt the render; the assertion
-      // below is what we actually care about.
+      // notFound() throws NEXT_NOT_FOUND to halt the render; the assertions
+      // below are what we actually care about.
     }
 
     expect(notFoundMock).toHaveBeenCalled();
+    // Settle window long enough for a wrongly-started fetch to reach MSW
+    // (a 0ms flush can miss the interceptor's async dispatch chain).
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(expertSpy).not.toHaveBeenCalled();
+    expect(schedulesSpy).not.toHaveBeenCalled();
   });
 });

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/__tests__/AppSidebar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/__tests__/AppSidebar.test.tsx
@@ -67,6 +67,15 @@ describe("AppSidebar", () => {
     expect(screen.queryByText("Home")).toBeNull();
   });
 
+  it("flag-off: omits both the Home entry and the Team row (pre-experts nav)", () => {
+    renderSidebar();
+    // Both /home and /team 404 without hire-experts, so neither may be offered.
+    expect(screen.queryByText("Home")).toBeNull();
+    expect(screen.queryByText("Team")).toBeNull();
+    // The pre-experts workspace root ("Agents") stays in their place.
+    expect(screen.getByText("Agents")).toBeDefined();
+  });
+
   it("shows Team instead of Agents when the hire-experts flag is on", () => {
     useGetFlagMock.mockReturnValue(true);
     renderSidebar();

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/__tests__/AppSidebar.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/__tests__/AppSidebar.test.tsx
@@ -1,5 +1,6 @@
 import { getGetV2ListSessionsMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
 import { server } from "@/mocks/mock-server";
+import { Flag } from "@/services/feature-flags/use-get-flag";
 import { render, screen } from "@/tests/integrations/test-utils";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import type { ReactNode } from "react";
@@ -26,7 +27,10 @@ vi.mock("next/link", () => ({
   useLinkStatus: () => ({ pending: false }),
 }));
 
-const useGetFlagMock = vi.hoisted(() => vi.fn(() => false));
+// Flag-keyed map so each test controls HIRE_EXPERTS and ONBOARDING_BRAIN_DUMP
+// independently — an unkeyed boolean would keep these tests green even if the
+// nav were gated on the wrong flag.
+const flagValues = vi.hoisted(() => ({ map: new Map<string, boolean>() }));
 
 vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
   const actual =
@@ -35,7 +39,7 @@ vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
     >();
   return {
     ...actual,
-    useGetFlag: () => useGetFlagMock(),
+    useGetFlag: (flag: string) => flagValues.map.get(flag) ?? false,
   };
 });
 
@@ -48,7 +52,7 @@ function renderSidebar() {
 }
 
 beforeEach(() => {
-  useGetFlagMock.mockReturnValue(false);
+  flagValues.map.clear();
   server.use(getGetV2ListSessionsMockHandler200({ sessions: [], total: 0 }));
 });
 
@@ -76,16 +80,24 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Agents")).toBeDefined();
   });
 
+  it("flag-off: keeps experts nav hidden when only other flags are on (HIRE_EXPERTS=false, ONBOARDING_BRAIN_DUMP=true)", () => {
+    flagValues.map.set(Flag.ONBOARDING_BRAIN_DUMP, true);
+    renderSidebar();
+    expect(screen.queryByText("Home")).toBeNull();
+    expect(screen.queryByText("Team")).toBeNull();
+    expect(screen.getByText("Agents")).toBeDefined();
+  });
+
   it("shows Team instead of Agents when the hire-experts flag is on", () => {
-    useGetFlagMock.mockReturnValue(true);
+    flagValues.map.set(Flag.HIRE_EXPERTS, true);
     renderSidebar();
     const teamLink = screen.getByRole("link", { name: /team/i });
     expect(teamLink.getAttribute("href")).toBe("/team");
     expect(screen.queryByText("Agents")).toBeNull();
   });
 
-  it("adds a Home link when the hire-experts flag is on", () => {
-    useGetFlagMock.mockReturnValue(true);
+  it("adds a Home link when only the hire-experts flag is on", () => {
+    flagValues.map.set(Flag.HIRE_EXPERTS, true);
     renderSidebar();
     const homeLink = screen.getByRole("link", { name: /home/i });
     expect(homeLink.getAttribute("href")).toBe("/home");

--- a/autogpt_platform/frontend/src/services/feature-flags/__tests__/flag-defaults.test.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/__tests__/flag-defaults.test.ts
@@ -77,3 +77,27 @@ describe("onboarding flag defaults fail closed", () => {
     expect(result.current).toBe(true);
   });
 });
+
+// HIRE_EXPERTS must fail closed: a LaunchDarkly-less environment (local dev,
+// CI, Playwright) has to render the pre-experts UI, not a half-gated experts
+// surface. This is the flag-off root guarantee — /home and /team 404, the
+// sidebar drops the Home + Team entries, marketplace hides ExpertsSection, and
+// the copilot shows its baseline empty state — all keyed off this default.
+describe("hire-experts flag default fails closed (flag-off baseline)", () => {
+  beforeEach(() => {
+    Object.keys(process.env)
+      .filter((k) => k.startsWith("NEXT_PUBLIC_FORCE_FLAG_"))
+      .forEach((k) => delete process.env[k]);
+  });
+
+  it("resolves HIRE_EXPERTS to false when LaunchDarkly has not answered, so the experts surface stays hidden", () => {
+    const { result } = renderHook(() => useGetFlag(Flag.HIRE_EXPERTS));
+    expect(result.current).toBe(false);
+  });
+
+  it("still lets local dev force-enable experts via the env override", () => {
+    process.env.NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS = "true";
+    const { result } = renderHook(() => useGetFlag(Flag.HIRE_EXPERTS));
+    expect(result.current).toBe(true);
+  });
+});

--- a/docs/platform/SUMMARY.md
+++ b/docs/platform/SUMMARY.md
@@ -38,3 +38,4 @@
 ## Contributing
 
 * [Managing LLM Models](contributing/managing-llm-models.md)
+* [Flag-off Smoke Checklist](flag-off-smoke.md)

--- a/docs/platform/flag-off-smoke.md
+++ b/docs/platform/flag-off-smoke.md
@@ -1,0 +1,56 @@
+# Flag-off smoke checklist
+
+**Contract:** with the experts/onboarding feature flags **OFF**, the platform must
+behave **byte-identically to pre-experts production**. A new feature ships behind a
+flag; flipping that flag off must return the exact prior UX and the exact prior
+copilot system prompt.
+
+Automated regression suites already enforce this in CI — they run in the normal
+Vitest/pytest pipeline and are discoverable with `grep -rn flag-off`. This page is
+the manual pre-release smoke pass **and** the map of what each surface guarantees,
+so a reviewer can tell at a glance which test fails if a flag-off promise breaks.
+
+## Flags covered
+
+| Flag value | Enum | Default |
+| --- | --- | --- |
+| `hire-experts` | `Flag.HIRE_EXPERTS` | `false` (fail-closed) |
+| `onboarding-brain-dump` | `Flag.ONBOARDING_BRAIN_DUMP` | `false` (fail-closed) |
+
+Both resolve to `false` whenever LaunchDarkly is unconfigured or silent (local dev,
+CI, Playwright), so the default environment is already the flag-off environment. To
+force a value explicitly, set `NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS=false` /
+`NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP=false`.
+
+## Smoke steps — `hire-experts` OFF
+
+| Surface | Expected flag-off behavior | Automated guard |
+| --- | --- | --- |
+| **Copilot** empty state | Pre-experts pulse strip renders; no briefing recap; no `/briefing` request | `copilot/components/CopilotHome/__tests__/flag-off.test.tsx` |
+| **Marketplace** | No "Meet the AI Experts" section; pre-experts subtitle copy | `marketplace/components/MainMarketplacePage/__tests__/main.test.tsx` |
+| **Library / sidebar** | Sidebar keeps the **Agents** entry; no **Home** entry and no **Team** row | `components/layout/AppSidebar/__tests__/AppSidebar.test.tsx` |
+| `/home` | `notFound()` (404) | `app/(platform)/home/__tests__/main.test.tsx` |
+| `/team` and `/team/[expertId]` | `notFound()` (404); no expert queries fire | `app/(platform)/team/__tests__/main.test.tsx`, `app/(platform)/team/[expertId]/__tests__/main.test.tsx` |
+| **Copilot system prompt** (plain session, no expert) | Byte-identical to the pre-experts prompt; pinned SHA-256 | `backend/copilot/flag_off_prompt_test.py`, `backend/copilot/expert_context_test.py` |
+| Flag default | `HIRE_EXPERTS` resolves to `false` when LaunchDarkly is silent | `services/feature-flags/__tests__/flag-defaults.test.ts` |
+
+## Smoke steps — `onboarding-brain-dump` OFF
+
+| Surface | Expected flag-off behavior | Automated guard |
+| --- | --- | --- |
+| Onboarding pain-points step | Legacy `PainPointsStep` renders (not the brain-dump step); step indices/URL unchanged | `app/(no-navbar)/onboarding/__tests__/brain-dump.test.tsx` |
+| Preparing step copy | Generic checklist copy on the flag-off path | `app/(no-navbar)/onboarding/steps/__tests__/usePreparingStep.test.ts` |
+| Flag default | `ONBOARDING_BRAIN_DUMP` resolves to `false` when LaunchDarkly is silent | `services/feature-flags/__tests__/flag-defaults.test.ts` |
+
+## When a guard fails
+
+The backend prompt-hash guard fails with:
+
+> `flag-off prompt changed; if intentional, update hash + call out in PR description`
+
+If the change to the plain-session system prompt was **intentional**, update the
+pinned SHA-256 in `backend/copilot/flag_off_prompt_test.py` (and the base-constant
+snapshot in `backend/copilot/expert_context_test.py`) and call it out in the PR
+description so reviewers know the cacheable prompt moved. If it was **not**
+intentional, the flag-off path has drifted from production — fix the code, not the
+test.

--- a/docs/platform/flag-off-smoke.md
+++ b/docs/platform/flag-off-smoke.md
@@ -27,11 +27,12 @@ force a value explicitly, set `NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS=false` /
 | Surface | Expected flag-off behavior | Automated guard |
 | --- | --- | --- |
 | **Copilot** empty state | Pre-experts pulse strip renders; no briefing recap; no `/briefing` request | `copilot/components/CopilotHome/__tests__/flag-off.test.tsx` |
-| **Marketplace** | No "Meet the AI Experts" section; pre-experts subtitle copy | `marketplace/components/MainMarketplacePage/__tests__/main.test.tsx` |
-| **Library / sidebar** | Sidebar keeps the **Agents** entry; no **Home** entry and no **Team** row | `components/layout/AppSidebar/__tests__/AppSidebar.test.tsx` |
+| **Marketplace** | `ExpertsSection` not mounted; pre-experts workflows subtitle ("Ready-made automations from the community.") | `marketplace/components/MainMarketplacePage/__tests__/main.test.tsx` |
+| **Marketplace agent page** | No "Install on Expert…" action and no `/api/experts` request, even signed-in with hired experts | `marketplace/components/InstallOnExpertButton/__tests__/main.test.tsx` |
+| **Library / sidebar** | Sidebar keeps the **Agents** entry; no **Home** entry and no **Team** row — including when other flags (e.g. brain dump) are on | `components/layout/AppSidebar/__tests__/AppSidebar.test.tsx` |
 | `/home` | `notFound()` (404) | `app/(platform)/home/__tests__/main.test.tsx` |
-| `/team` and `/team/[expertId]` | `notFound()` (404); no expert queries fire | `app/(platform)/team/__tests__/main.test.tsx`, `app/(platform)/team/[expertId]/__tests__/main.test.tsx` |
-| **Copilot system prompt** (plain session, no expert) | Byte-identical to the pre-experts prompt; pinned SHA-256 | `backend/copilot/flag_off_prompt_test.py`, `backend/copilot/expert_context_test.py` |
+| `/team` and `/team/[expertId]` | `notFound()` (404); no expert or schedule requests fire | `app/(platform)/team/__tests__/main.test.tsx`, `app/(platform)/team/[expertId]/__tests__/main.test.tsx` |
+| **Copilot system prompt** (plain session, no expert) | Byte-identical to the pre-experts prompt for both engines (SDK and baseline) in every deterministic config (`use_e2b` × Graphiti); pinned SHA-256 digests of the shared `compose_system_prompt` output | `backend/copilot/flag_off_prompt_test.py`, `backend/copilot/expert_context_test.py` |
 | Flag default | `HIRE_EXPERTS` resolves to `false` when LaunchDarkly is silent | `services/feature-flags/__tests__/flag-defaults.test.ts` |
 
 ## Smoke steps — `onboarding-brain-dump` OFF
@@ -49,8 +50,17 @@ The backend prompt-hash guard fails with:
 > `flag-off prompt changed; if intentional, update hash + call out in PR description`
 
 If the change to the plain-session system prompt was **intentional**, update the
-pinned SHA-256 in `backend/copilot/flag_off_prompt_test.py` (and the base-constant
-snapshot in `backend/copilot/expert_context_test.py`) and call it out in the PR
-description so reviewers know the cacheable prompt moved. If it was **not**
-intentional, the flag-off path has drifted from production — fix the code, not the
-test.
+pinned SHA-256 digests in `backend/copilot/flag_off_prompt_test.py` (and the
+base-constant snapshot in `backend/copilot/expert_context_test.py`) and call it
+out in the PR description so reviewers know the cacheable prompt moved. If it was
+**not** intentional, the flag-off path has drifted from production — fix the code,
+not the test.
+
+Both engines assemble their system prompt through `compose_system_prompt` in
+`backend/copilot/prompting.py`; add any new prompt component there so the pinned
+digests catch it.
+
+Scope note: production may source the base prompt from Langfuse at runtime. That
+content lives outside the repo, so CI pins the in-repo fallback composition
+(`CACHEABLE_SYSTEM_PROMPT`); flag-off parity of a Langfuse-hosted base must be
+maintained in the Langfuse template itself.


### PR DESCRIPTION
### Why / What / How

**Why:** The experts and brain-dump onboarding features ship behind the `hire-experts` and `onboarding-brain-dump` flags. When those flags are OFF the platform must behave **byte-identically to pre-experts production** — same UX, same copilot system prompt. That guarantee was only partially covered by tests, so a future edit could silently change flag-off behavior and no CI check would catch it.

**What:** A flag-off regression guarantee — a small set of colocated tests (backend pytest + frontend Vitest) that pin the flag-off behavior, plus a release smoke checklist doc. No product code changes.

**How:** Inventory existing flag-off protections first, then fill only the gaps. All new tests use a greppable `flag-off` naming convention and run in the normal PR pipeline (no skip markers, no workflow YAML changes). The backend pins the SHA-256 of the plain-session (no expert) system prompt so any drift fails loudly with an actionable message.

### Changes 🏗️

**Backend**
- `backend/copilot/flag_off_prompt_test.py` (new): pins the SHA-256 of the copilot system prompt a **plain session (no expert)** receives — `CACHEABLE_SYSTEM_PROMPT` + the empty expert-identity suffix. Failure message: `flag-off prompt changed; if intentional, update hash + call out in PR description`. Complements the existing base-constant snapshot in `expert_context_test.py` by also catching an expert suffix leaking into the no-expert path.

**Frontend (gaps filled — the rest already existed)**
- `marketplace/.../MainMarketplacePage/__tests__/main.test.tsx`: assert the "Meet the AI Experts" section is absent with `hire-experts` off.
- `components/layout/AppSidebar/__tests__/AppSidebar.test.tsx`: assert the sidebar omits **both** the Home entry and the Team row when off (Team-row absence was previously only inferred).
- `team/[expertId]/__tests__/main.test.tsx`: assert `notFound()` fires when `hire-experts` is disabled (scaffolding existed, case was missing).
- `services/feature-flags/__tests__/flag-defaults.test.ts`: pin `HIRE_EXPERTS` default-false when LaunchDarkly is silent (only the onboarding/dream/graphiti families were covered).

**Docs**
- `docs/platform/flag-off-smoke.md` (new): release smoke checklist mapping each guarded surface (copilot, marketplace, library, home, team, onboarding) to the automated test that enforces it, plus what to do when the prompt-hash guard fails. Registered in `docs/platform/SUMMARY.md`.

**Consciously left out:** behaviors already guarded by existing colocated flag-off tests were left untouched (`/home` notFound, `/team` notFound, sidebar no-Home, copilot baseline empty state, onboarding legacy step, base-prompt SHA-256). No consolidated duplicate smoke file was created — that would re-test passing suites and bloat the diff. No CI workflow YAML changes were needed since these are ordinary Vitest/pytest files that already run in the default PR pipeline.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/flag_off_prompt_test.py` — 2 passed
  - [x] `pnpm vitest run` on the 4 changed frontend suites — 27 passed
  - [x] `pnpm format` (clean), `pnpm lint` (clean), `pnpm types` (clean), `poetry run format` (clean)
  - [x] Temporarily editing `CACHEABLE_SYSTEM_PROMPT` makes `flag_off_prompt_test.py` fail with the intended message (reverted)
