### PR TITLE
docs(platform): document the cache and coordination engine (Redis / Valkey)

### DIFF
--- a/docs/platform/advanced_setup.md
+++ b/docs/platform/advanced_setup.md
@@ -69,13 +69,13 @@ prisma migrate dev --schema postgres/schema.prisma
 
 Alongside PostgreSQL and RabbitMQ, the platform depends on a Redis-compatible engine for caching, distributed locking, rate limiting, spend and usage counters, session metadata, pending-message buffers, and the server-sent-event streams that carry agent output to the browser.
 
-Redis is the default. **Valkey is a tested alternative:** it is the engine inside the single-container image, and the Compose stack can be pointed at it with a single variable. Valkey forked from Redis 7.2 and speaks the same protocol — nothing the backend does distinguishes the two.
+Redis is the default. **Valkey is a tested alternative:** it is the engine inside the single-container image, which CI builds and smoke-tests on every change to the platform. Valkey forked from Redis 7.2 and speaks the same protocol — nothing the backend does distinguishes the two.
 
 | | Redis | Valkey |
 |---|---|---|
-| Docker Compose stack | Default (`redis:7`) | Opt-in, via `REDIS_IMAGE` |
+| Docker Compose stack | Default (`redis:7`) | Opt-in, via a Compose override |
 | Single-container image | Not used | The engine it ships |
-| Backend CI | Every test leg | One additional, advisory leg |
+| CI coverage | Every backend test leg | The single-container image build and smoke test |
 | Connection settings | `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` | Identical — nothing to change |
 
 There is no functional reason to prefer one over the other for this workload: both clear the [version floor](#engine-version-floor) below, and the platform uses no Redis modules. Choose on operational grounds — which engine your managed provider offers, and which licence terms you want. The two projects' licences differ and the Redis side has changed more than once, so check the licence of the specific tag you pin.
@@ -88,7 +88,7 @@ The self-hosting distributions each bring up a three-shard, no-replica cluster o
 
 | Distribution | Engine | How the cluster is formed |
 |---|---|---|
-| Docker Compose stack (`autogpt_platform/docker-compose.platform.yml`) | `redis:7`, or whatever `REDIS_IMAGE` names | Three `redis-server` containers plus a one-shot `redis-init` sidecar that runs `redis-cli --cluster create`. Each shard announces its own Compose hostname. |
+| Docker Compose stack (`autogpt_platform/docker-compose.platform.yml`) | `redis:7` by default | Three `redis-server` containers plus a one-shot `redis-init` sidecar that runs `redis-cli --cluster create`. Each shard announces its own Compose hostname. |
 | Single-container image (`autogpt_platform/single-container`) | Valkey | Three supervised `valkey-server` processes inside the container, formed by `valkey-cli --cluster create`. Each shard announces `127.0.0.1`. |
 
 {% hint style="info" %}
@@ -99,24 +99,38 @@ FalkorDB is a separate service that also speaks the Redis protocol, but it is th
 
 ### Switching the Compose stack to Valkey
 
-`REDIS_IMAGE` sets the image for all three shards and the init sidecar:
+The shard image is set in `docker-compose.platform.yml`, which is a tracked file. To run the cluster on Valkey without editing it, override the image for all three shards and the init sidecar in `autogpt_platform/docker-compose.override.yml`:
+
+```yaml
+services:
+  redis-0:
+    image: valkey/valkey:8.1
+    user: "999:999"
+  redis-1:
+    image: valkey/valkey:8.1
+    user: "999:999"
+  redis-2:
+    image: valkey/valkey:8.1
+    user: "999:999"
+  redis-init:
+    image: valkey/valkey:8.1
+    user: "999:999"
+```
+
+Then bring the dependencies up as usual:
 
 ```bash
 cd autogpt_platform/
-REDIS_IMAGE=valkey/valkey:8.1 docker compose up -d deps
+docker compose up -d deps
 ```
 
-To make it permanent, set it in `autogpt_platform/.env` — the file `make init-env` creates from `.env.default`, where `REDIS_IMAGE` is listed commented out. Note that this is the file Compose interpolates from; `backend/.env` is passed *into* the containers and cannot reach it.
+{% hint style="warning" %}
+`user: "999:999"` is not optional, and omitting it fails quietly. Valkey's entrypoint only drops privileges when it is invoked as `valkey-server`, and the Compose command lines call the `redis-server` symlink — so an override that sets `image:` alone runs the shards as **root**. Stock `redis:7` drops to uid 999 on its own, so this is a difference you only hit after switching engines.
+
+The one numeric value is correct for either engine: uid 999 is `redis` in `redis:7` and `valkey` in `valkey/valkey:8.1`, and it owns the `/data` workdir where `nodes.conf` is written.
+{% endhint %}
 
 Nothing else changes. Connection settings are engine-neutral — `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD` mean the same thing to both engines. (`REDIS_CLUSTER_HOST` and `REDIS_CLUSTER_PORT` take precedence over the first two when they are set.) The service names stay `redis-0`/`redis-1`/`redis-2` with the `redis-init` sidecar, and the Valkey image ships `redis-server` and `redis-cli` as symlinks, so the cluster command lines and health checks in the Compose file work unaltered.
-
-{% hint style="info" %}
-The shards run as uid 999 under either engine, pinned in the Compose file. This matters if you write your own override: Valkey's entrypoint only drops privileges when it is invoked as `valkey-server`, and the Compose command lines call the `redis-server` symlink — so an override that sets `image:` without also setting `user: "999:999"` runs the shards as root.
-{% endhint %}
-
-{% hint style="warning" %}
-`REDIS_IMAGE` arrived with this page. On an earlier checkout the same substitution needs a `docker-compose.override.yml` setting `image:` and `user: "999:999"` on `redis-0`, `redis-1`, `redis-2` and `redis-init`.
-{% endhint %}
 
 ### Using a managed or external deployment
 

--- a/docs/platform/advanced_setup.md
+++ b/docs/platform/advanced_setup.md
@@ -65,6 +65,100 @@ cd ../backend
 prisma migrate dev --schema postgres/schema.prisma
 ```
 
+## Cache and coordination engine
+
+Alongside PostgreSQL and RabbitMQ, the platform depends on a Redis-compatible engine for caching, distributed locking, rate limiting, spend and usage counters, session metadata, pending-message buffers, and the server-sent-event streams that carry agent output to the browser.
+
+The Docker Compose stack ships `redis:7`; the single-container image runs Valkey. Either engine serves this workload. The sections below cover the topology both must provide, how to substitute Valkey into the Compose stack, and what a managed deployment has to support.
+
+### Cluster mode is required
+
+The backend always connects with a cluster client, so **a single standalone node will not work** — regardless of which engine you pick. Local development deliberately runs a real multi-shard cluster so that cross-slot bugs surface on a laptop rather than in production.
+
+The self-hosting distributions each bring up a three-shard, no-replica cluster on ports `17000`, `17001` and `17002` (cluster bus ports `27000`–`27002`):
+
+| Distribution | Engine | How the cluster is formed |
+|---|---|---|
+| Docker Compose stack (`autogpt_platform/docker-compose.platform.yml`) | `redis:7` | Three `redis-server` containers plus a one-shot `redis-init` sidecar that runs `redis-cli --cluster create`. Each shard announces its own Compose hostname. |
+| Single-container image (`autogpt_platform/single-container`) | Valkey | Three supervised `valkey-server` processes inside the container, formed by `valkey-cli --cluster create`. Each shard announces `127.0.0.1`. |
+
+{% hint style="info" %}
+`make start-core` brings up this cluster along with the platform's other dependencies — PostgreSQL, RabbitMQ, FalkorDB, ClamAV and the database migration job — not a single cache node.
+{% endhint %}
+
+FalkorDB is a separate service that also speaks the Redis protocol, but it is the CoPilot graph store and depends on the FalkorDB graph module. It is not part of the cache and coordination layer, and Redis or Valkey cannot serve it.
+
+### Running the Compose stack on Valkey
+
+Connection settings are engine-neutral: `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD` mean the same thing for both engines and need no change. (`REDIS_CLUSTER_HOST` and `REDIS_CLUSTER_PORT` take precedence over the first two when they are set.) The Valkey image ships `redis-server` and `redis-cli` as symlinks, so the cluster command lines and health checks in the Compose file work unaltered.
+
+Create a Compose override file in `autogpt_platform/`:
+
+```yaml
+# autogpt_platform/docker-compose.override.yml
+x-valkey-node: &valkey-node
+  image: valkey/valkey:8.1
+  # The Valkey entrypoint only drops privileges when it is invoked as
+  # `valkey-server`, and the Compose command lines call the `redis-server`
+  # symlink — so pin the unprivileged account explicitly. 999:999 is
+  # `valkey` in the Valkey image and `redis` in the Redis image.
+  user: "999:999"
+
+services:
+  redis-0: *valkey-node
+  redis-1: *valkey-node
+  redis-2: *valkey-node
+  redis-init: *valkey-node
+```
+
+Then bring the stack up as usual — Docker Compose merges `docker-compose.override.yml` automatically:
+
+```bash
+cd autogpt_platform/
+docker compose up -d deps
+```
+
+The service names stay `redis-0`/`redis-1`/`redis-2` and the sidecar stays `redis-init`.
+
+{% hint style="warning" %}
+Omit the `user:` line and the shards run as root, which the stock `redis:7` image does not do. Keep it unless you have a reason not to.
+{% endhint %}
+
+### Using a managed or external deployment
+
+For a cluster you run yourself — Amazon ElastiCache for Valkey, Google Memorystore for Valkey, or a self-managed cluster — the deployment must provide:
+
+- **Cluster mode enabled.** A single-node or cluster-mode-disabled deployment cannot serve this platform, because the backend speaks only the cluster protocol.
+- **Sharded pub/sub** (`SPUBLISH`, `SSUBSCRIBE`, `SUNSUBSCRIBE`). Agent output streaming and websocket reconnection depend on it; it is not optional.
+- **Announced shard addresses that resolve from the platform**, together with `REDIS_USE_ANNOUNCED_ADDRESS=true`. Without that variable the backend rewrites every shard address to the seed host, keeping only the announced port. Managed clusters give each shard a distinct hostname on a shared port, so the rewrite collapses all shards onto one node and sharded pub/sub is pinned to the wrong shard. The Compose stack already sets this variable; set it yourself if you run the backend outside Compose.
+
+To point the Compose stack at an external cluster, change `REDIS_HOST` and `REDIS_PORT` in the `x-backend-env` block of `docker-compose.platform.yml`. The backend services take their values from there, so editing `backend/.env` alone will not move them. `REDIS_PASSWORD` is the exception: it is absent from that block, so `backend/.env` does set it.
+
+If you would rather not edit a tracked file, set the same variables per backend service in `docker-compose.override.yml` — a service-level `environment:` entry overrides the value merged in from `x-backend-env`. You have to list every backend service you run, which is why the block above is the shorter route.
+
+Then start the dependencies you still need directly instead of through `deps`, which always brings up the bundled shards:
+
+```bash
+docker compose up -d db rabbitmq clamav falkordb migrate
+```
+
+### Engine version floor
+
+The commands the backend issues imply these minimums, for either engine:
+
+| Requirement | Commands |
+|---|---|
+| Redis 7.0-equivalent semantics | Sharded pub/sub (`SPUBLISH`/`SSUBSCRIBE`/`SUNSUBSCRIBE`), `EXPIRE … NX` |
+| Redis 6.2-equivalent semantics | `LPOP` with a `count` argument, `GETEX` |
+
+Valkey 8.1 and Redis 7 both clear this floor.
+
+The cache and coordination layer uses **no Redis modules** — no `FT.*`, `JSON.*`, `BF.*` or `TS.*` commands appear in the backend — so there is no module bundle to install or license on either engine. It does rely on Redis Streams, server-side Lua (`EVAL`), and transactions within a single hash slot, which a thin protocol proxy may not implement in full.
+
+{% hint style="warning" %}
+This guidance covers self-hosting and local development. Behaviour under sustained production load, failover and persistence tuning depends on how you size and operate the deployment, and is outside the scope of these instructions.
+{% endhint %}
+
 ## AutoGPT Agent Server Advanced set up
 
 This guide walks you through a dockerized set up, with an external DB (postgres)

--- a/docs/platform/advanced_setup.md
+++ b/docs/platform/advanced_setup.md
@@ -69,7 +69,16 @@ prisma migrate dev --schema postgres/schema.prisma
 
 Alongside PostgreSQL and RabbitMQ, the platform depends on a Redis-compatible engine for caching, distributed locking, rate limiting, spend and usage counters, session metadata, pending-message buffers, and the server-sent-event streams that carry agent output to the browser.
 
-The Docker Compose stack ships `redis:7`; the single-container image runs Valkey. Either engine serves this workload. The sections below cover the topology both must provide, how to substitute Valkey into the Compose stack, and what a managed deployment has to support.
+Redis is the default. **Valkey is a tested alternative:** it is the engine inside the single-container image, and the Compose stack can be pointed at it with a single variable. Valkey forked from Redis 7.2 and speaks the same protocol — nothing the backend does distinguishes the two.
+
+| | Redis | Valkey |
+|---|---|---|
+| Docker Compose stack | Default (`redis:7`) | Opt-in, via `REDIS_IMAGE` |
+| Single-container image | Not used | The engine it ships |
+| Backend CI | Every test leg | One additional, advisory leg |
+| Connection settings | `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` | Identical — nothing to change |
+
+There is no functional reason to prefer one over the other for this workload: both clear the [version floor](#engine-version-floor) below, and the platform uses no Redis modules. Choose on operational grounds — which engine your managed provider offers, and which licence terms you want. The two projects' licences differ and the Redis side has changed more than once, so check the licence of the specific tag you pin.
 
 ### Cluster mode is required
 
@@ -79,7 +88,7 @@ The self-hosting distributions each bring up a three-shard, no-replica cluster o
 
 | Distribution | Engine | How the cluster is formed |
 |---|---|---|
-| Docker Compose stack (`autogpt_platform/docker-compose.platform.yml`) | `redis:7` | Three `redis-server` containers plus a one-shot `redis-init` sidecar that runs `redis-cli --cluster create`. Each shard announces its own Compose hostname. |
+| Docker Compose stack (`autogpt_platform/docker-compose.platform.yml`) | `redis:7`, or whatever `REDIS_IMAGE` names | Three `redis-server` containers plus a one-shot `redis-init` sidecar that runs `redis-cli --cluster create`. Each shard announces its own Compose hostname. |
 | Single-container image (`autogpt_platform/single-container`) | Valkey | Three supervised `valkey-server` processes inside the container, formed by `valkey-cli --cluster create`. Each shard announces `127.0.0.1`. |
 
 {% hint style="info" %}
@@ -88,45 +97,30 @@ The self-hosting distributions each bring up a three-shard, no-replica cluster o
 
 FalkorDB is a separate service that also speaks the Redis protocol, but it is the CoPilot graph store and depends on the FalkorDB graph module. It is not part of the cache and coordination layer, and Redis or Valkey cannot serve it.
 
-### Running the Compose stack on Valkey
+### Switching the Compose stack to Valkey
 
-Connection settings are engine-neutral: `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD` mean the same thing for both engines and need no change. (`REDIS_CLUSTER_HOST` and `REDIS_CLUSTER_PORT` take precedence over the first two when they are set.) The Valkey image ships `redis-server` and `redis-cli` as symlinks, so the cluster command lines and health checks in the Compose file work unaltered.
-
-Create a Compose override file in `autogpt_platform/`:
-
-```yaml
-# autogpt_platform/docker-compose.override.yml
-x-valkey-node: &valkey-node
-  image: valkey/valkey:8.1
-  # The Valkey entrypoint only drops privileges when it is invoked as
-  # `valkey-server`, and the Compose command lines call the `redis-server`
-  # symlink — so pin the unprivileged account explicitly. 999:999 is
-  # `valkey` in the Valkey image and `redis` in the Redis image.
-  user: "999:999"
-
-services:
-  redis-0: *valkey-node
-  redis-1: *valkey-node
-  redis-2: *valkey-node
-  redis-init: *valkey-node
-```
-
-Then bring the stack up as usual — Docker Compose merges `docker-compose.override.yml` automatically:
+`REDIS_IMAGE` sets the image for all three shards and the init sidecar:
 
 ```bash
 cd autogpt_platform/
-docker compose up -d deps
+REDIS_IMAGE=valkey/valkey:8.1 docker compose up -d deps
 ```
 
-The service names stay `redis-0`/`redis-1`/`redis-2` and the sidecar stays `redis-init`.
+To make it permanent, set it in `autogpt_platform/.env` — the file `make init-env` creates from `.env.default`, where `REDIS_IMAGE` is listed commented out. Note that this is the file Compose interpolates from; `backend/.env` is passed *into* the containers and cannot reach it.
+
+Nothing else changes. Connection settings are engine-neutral — `REDIS_HOST`, `REDIS_PORT` and `REDIS_PASSWORD` mean the same thing to both engines. (`REDIS_CLUSTER_HOST` and `REDIS_CLUSTER_PORT` take precedence over the first two when they are set.) The service names stay `redis-0`/`redis-1`/`redis-2` with the `redis-init` sidecar, and the Valkey image ships `redis-server` and `redis-cli` as symlinks, so the cluster command lines and health checks in the Compose file work unaltered.
+
+{% hint style="info" %}
+The shards run as uid 999 under either engine, pinned in the Compose file. This matters if you write your own override: Valkey's entrypoint only drops privileges when it is invoked as `valkey-server`, and the Compose command lines call the `redis-server` symlink — so an override that sets `image:` without also setting `user: "999:999"` runs the shards as root.
+{% endhint %}
 
 {% hint style="warning" %}
-Omit the `user:` line and the shards run as root, which the stock `redis:7` image does not do. Keep it unless you have a reason not to.
+`REDIS_IMAGE` arrived with this page. On an earlier checkout the same substitution needs a `docker-compose.override.yml` setting `image:` and `user: "999:999"` on `redis-0`, `redis-1`, `redis-2` and `redis-init`.
 {% endhint %}
 
 ### Using a managed or external deployment
 
-For a cluster you run yourself — Amazon ElastiCache for Valkey, Google Memorystore for Valkey, or a self-managed cluster — the deployment must provide:
+For a cluster you buy or run yourself — Amazon ElastiCache or Google Memorystore, both of which offer Redis- and Valkey-flavoured clusters, or a self-managed cluster of either engine — the deployment must provide:
 
 - **Cluster mode enabled.** A single-node or cluster-mode-disabled deployment cannot serve this platform, because the backend speaks only the cluster protocol.
 - **Sharded pub/sub** (`SPUBLISH`, `SSUBSCRIBE`, `SUNSUBSCRIBE`). Agent output streaming and websocket reconnection depend on it; it is not optional.

--- a/docs/platform/getting-started.md
+++ b/docs/platform/getting-started.md
@@ -121,7 +121,7 @@ Inside the `autogpt_platform` directory, you can use:
 | Command                | What it Does                                                                 |
 |------------------------|-------------------------------------------------------------------------------|
 | `make init-env`        | Create missing `.env` files from `.env.default` (`autogpt_platform`, `backend`, and `frontend`) |
-| `make start-core`      | Start just the dependency services (PostgreSQL, the three-shard cache cluster, RabbitMQ, FalkorDB, ClamAV) and run migrations, in background |
+| `make start-core`      | Start dependency services (PostgreSQL, cache cluster, RabbitMQ, FalkorDB, ClamAV) and run migrations, in background |
 | `make stop-core`       | Stop the core services                                                        |
 | `make logs-core`       | Tail the logs for core services                                               |
 | `make format`          | Format & lint backend (Python) and frontend (TypeScript) code                 |

--- a/docs/platform/getting-started.md
+++ b/docs/platform/getting-started.md
@@ -121,7 +121,7 @@ Inside the `autogpt_platform` directory, you can use:
 | Command                | What it Does                                                                 |
 |------------------------|-------------------------------------------------------------------------------|
 | `make init-env`        | Create missing `.env` files from `.env.default` (`autogpt_platform`, `backend`, and `frontend`) |
-| `make start-core`      | Start just the core services (Postgres, Redis, RabbitMQ) in background        |
+| `make start-core`      | Start just the dependency services (PostgreSQL, the three-shard cache cluster, RabbitMQ, FalkorDB, ClamAV) and run migrations, in background |
 | `make stop-core`       | Stop the core services                                                        |
 | `make logs-core`       | Tail the logs for core services                                               |
 | `make format`          | Format & lint backend (Python) and frontend (TypeScript) code                 |


### PR DESCRIPTION
### Why / What / How

**Why.** The self-hosting docs never described the Redis-compatible engine the platform depends on for caching, distributed locking, rate limiting, spend counters and the SSE streams that carry agent output to the browser. Two consequences were invisible to self-hosters:

- **The backend always connects with a cluster client.** `backend/data/redis_client.py` sets `RedisClient = RedisCluster` unconditionally, so a single standalone node cannot work. Nothing in the docs said so, and the failure mode is an opaque connection error.
- **The two distributions already run different engines.** The Compose stack ships `redis:7`; the single-container image runs Valkey. That was only discoverable by reading `docker-compose.platform.yml` and `single-container/entrypoint.sh`.

A self-hoster pointing the platform at ElastiCache, Memorystore or any single-node instance currently has to read the client, the Compose file and the entrypoint to discover all of this.

**What.** Adds a **Cache and coordination engine** section to Advanced Setup, between *Database selection* and *AutoGPT Agent Server Advanced set up*.

**How.** The section is organised around what a reader actually has to decide: which engine, what topology it must provide, how to select it locally, and what a managed deployment has to support. Everything it describes works on `dev` as it stands today — no accompanying code change is required.

### Changes 🏗️

`docs/platform/advanced_setup.md` — new **Cache and coordination engine** section covering:

- Redis as the default and **Valkey as a tested alternative**, with a table of where each engine is used today (Compose stack, single-container image, CI coverage, connection settings) and the operational — not functional — grounds on which to choose
- **Cluster mode is required** — the topology both engines must provide, and which distribution forms it how
- **Switching the Compose stack to Valkey** with a `docker-compose.override.yml`, including the uid 999 requirement below
- **Using a managed or external deployment** — cluster mode, sharded pub/sub, announced addresses + `REDIS_USE_ANNOUNCED_ADDRESS`, and which file the backend actually reads `REDIS_HOST`/`REDIS_PORT` from
- **Engine version floor** implied by the commands the backend actually issues

The page does not claim Valkey is better, and does not assert specific licence terms — both projects' licensing has changed, so it tells readers to check the licence of the tag they pin. `redis:7` remains the Compose default and the engine every backend CI leg covers.

`docs/platform/getting-started.md` — the `make start-core` row claimed it starts "Postgres, Redis, RabbitMQ". It actually starts PostgreSQL, the three-shard cache cluster, RabbitMQ, FalkorDB and ClamAV, and runs migrations.

No code or Compose changes here; this PR is docs only.

#### The one sharp edge, and why it's a warning block

Switching the shard image alone silently runs the cluster as **root**. Both images gate their privilege drop on being invoked as their *own* server binary — `redis-server` for Redis, `valkey-server` for Valkey — and the Compose command lines call `redis-server`, which is a symlink under Valkey. Stock `redis:7` drops to uid 999 by itself, so this only bites after switching engines, and nothing surfaces it. The override snippet therefore carries `user: "999:999"` on all four services, with a warning explaining why. uid 999 is `redis` in `redis:7` and `valkey` in `valkey/valkey:8.1` and owns the `/data` workdir where `nodes.conf` is written, so the single numeric value is correct for either engine.

### Checklist 📋

#### For code changes:

Docs-only PR — no code, Compose or configuration changes. Every load-bearing claim was still verified against a running stack rather than read off the source.

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] The documented override really points all three shards and the init sidecar at Valkey, and the cluster forms — `docker compose up -d redis-0 redis-1 redis-2 redis-init` reaches `cluster_state:ok` on Valkey, `uid=999`, `nodes.conf` written and correctly owned, seed healthcheck `healthy`
  - [x] The override YAML parses, and `user: "999:999"` must stay quoted — unquoted it is a YAML 1.1 sexagesimal integer, not the string Compose needs
  - [x] Without `user:`, the shards run as **root** on Valkey; stock `redis:7` drops to uid 999 unaided. Verified `getent passwd 999` → `redis` in `redis:7`, `valkey` in `valkey/valkey:8.1`, and ran both under `--user 999:999` with the real cluster command line
  - [x] The Valkey image ships `redis-server`/`redis-cli` as symlinks, so the Compose command lines and health checks work unaltered
  - [x] `REDIS_HOST`/`REDIS_PORT` must be changed in the `x-backend-env` block — they are hardcoded there, so Compose's shell-environment precedence does not apply. All nine services that read them take them from that block and none sets them separately
  - [x] `REDIS_PASSWORD` *does* work from `backend/.env` — it is absent from `x-backend-env` and commented out in `.env.default`
  - [x] `docker compose up -d db rabbitmq clamav falkordb migrate` avoids the bundled shards — merged `depends_on` for those five references no `redis-*`, and none carries a `profiles:` key
  - [x] Valkey's stated CI coverage is real — `platform-single-container-docker.yml` builds and smoke-tests the single-container image on every push and PR touching `autogpt_platform/**`
  - [x] Sharded pub/sub, `EXPIRE … NX`, `LPOP count`, `GETEX` set the version floor; no Redis modules are used — command inventory across the backend, plus a 46-command compatibility run on a Valkey 8.1 three-shard cluster against a `redis:7.4.10` control showing zero Valkey-only failures
  - [x] One near-miss checked and cleared: Valkey renames `redis_mode` → `server_mode` in `INFO server`. Nothing in this repo or in redis-py 5.3.1 reads either field
  - [x] GitBook syntax: `{% hint %}`/`{% endhint %}` balanced (3 open, 3 close, valid styles), all three tables well-formed, and the `#engine-version-floor` cross-reference resolves
  - [x] Rebased onto current `gitbook` after #14019; no new page added, so no `SUMMARY.md` change is needed

#### For configuration changes:

Not applicable — no configuration changes in this PR.

### Related

- Part of #14012.
- #14047 (→ `dev`) proposes a `REDIS_IMAGE` variable that would reduce the override in *Switching the Compose stack to Valkey* to a single environment variable, and adds a Valkey leg to backend CI. **This PR does not depend on it** — it documents the override that works today. If #14047 lands, that subsection wants a short follow-up to lead with the one-liner, and the CI row in the comparison table can then credit the backend leg too. The two PRs can be reviewed and merged in either order.
- Overlaps with #13760, which documents the single-container distribution's Valkey topology — worth coordinating. Happy to rework against whatever lands there first.

### Base branch

Targets `gitbook`, per `docs/content/contribute/index.md` ("create a pull request targeting the `gitbook` branch"). Retargeting to `dev` isn't an option for this diff — `docs/platform/` differs between the two branches, so the change is written against the `gitbook` layout.

### Follow-up, deliberately out of scope

The same stale `start-core` description lives in code, in `autogpt_platform/Makefile` (the header comment and the `help` text). Not touched here because this branch is docs-only and targets `gitbook`.
