### PR TITLE
fix(platform): stop codex transport reaching non-entitled users

### DIFF
--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -389,6 +389,28 @@ class GraphMeta(GraphBaseMeta):
         )
 
 
+def _mappable_discriminator_default(
+    input_schema: "AnyBlockSchema",
+    field_info: CredentialsFieldInfo,
+) -> Any:
+    """The discriminator's schema default, or None if it can't discriminate.
+
+    Read from the serialized schema rather than the model field so the value is
+    a plain JSON scalar matching `discriminator_mapping` keys instead of a
+    Python enum member. Returns None unless the default is actually present in
+    the mapping, because `discriminate()` raises on unknown values and this
+    runs inside a computed_field where raising would break schema generation.
+    """
+    discriminator = field_info.discriminator
+    mapping = field_info.discriminator_mapping
+    if not discriminator or not mapping:
+        return None
+
+    field_schema = input_schema.jsonschema()["properties"].get(discriminator, {})
+    default = field_schema.get("default")
+    return default if default in mapping else None
+
+
 class GraphModel(Graph, GraphMeta):
     """
     Full graph model representing an existing graph from the database.
@@ -575,6 +597,26 @@ class GraphModel(Graph, GraphMeta):
                         continue
 
                     discriminator_value = node.input_default.get(discriminator)
+                    if (
+                        discriminator_value is None
+                        and field_info.discriminator_type_mapping
+                    ):
+                        # The node hasn't pinned the discriminator, but the
+                        # executor will: it builds `input_schema(**input_default)`,
+                        # so pydantic fills the schema default. Resolve it the
+                        # same way here.
+                        #
+                        # Only when the credential TYPE depends on the
+                        # discriminator. There the un-discriminated union is a
+                        # cross-product that asserts pairs which don't exist
+                        # (e.g. codex+api_key, openai+oauth2). For mapping-only
+                        # discriminators the type set is a singleton, so the
+                        # union is faithful and is left alone — its slot key is
+                        # what persisted preset/schedule credentials are keyed by.
+                        discriminator_value = _mappable_discriminator_default(
+                            node.block.input_schema, field_info
+                        )
+
                     if discriminator_value is None:
                         node_credential_data.append((field_info, (node.id, field_name)))
                         continue

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -2373,3 +2373,210 @@ async def test_get_graph_without_org_keeps_strict_ownership(mocker):
     where = mock_client.find_first.call_args.kwargs["where"]
     assert where["userId"] == "u-1"
     assert "AND" not in where
+
+
+# ============================================================================
+# Tests for discriminated credentials aggregation (codex transport hotfix)
+#
+# A node that has not pinned its discriminator still resolves it at execution
+# time: blocks/_base.py builds `self.input_schema(**input_default)`, so pydantic
+# fills the schema default. Aggregation must resolve it the same way, or the
+# graph advertises credentials the node can never actually use.
+#
+# The fallback is scoped to fields whose credential TYPE depends on the
+# discriminator (discriminator_type_mapping). For those, the un-discriminated
+# union is a cross-product that asserts invalid pairs — e.g. (codex, api_key)
+# and (openai, oauth2) — neither of which exists. For mapping-only
+# discriminators the type set is a singleton, so the union is faithful and is
+# deliberately left alone: its aggregated slot key is load-bearing for
+# persisted preset and schedule credentials.
+# ============================================================================
+
+CODEX_CODEGEN_BLOCK_ID = "86a2a099-30df-47b4-b7e4-34ae5f83e0d5"
+AUTOPILOT_BLOCK_ID = "c069dc6b-c3ed-4c12-b6e5-d47361e64ce6"
+
+
+def _graph_with(nodes: list[NodeModel]) -> GraphModel:
+    from datetime import datetime, timezone
+
+    return GraphModel(
+        id="agg-graph",
+        version=1,
+        name="Aggregation",
+        description="",
+        user_id="u-1",
+        created_at=datetime.now(timezone.utc),
+        nodes=nodes,
+        links=[],
+    )
+
+
+def _node(node_id: str, block_id: str, input_default: dict[str, Any]) -> NodeModel:
+    return NodeModel(
+        id=node_id,
+        block_id=block_id,
+        input_default=input_default,
+        graph_id="agg-graph",
+        graph_version=1,
+    )
+
+
+def _slots(graph: GraphModel) -> dict[str, tuple[set[str], set[str], bool]]:
+    schema = graph.credentials_input_schema
+    required = set(schema["required"])
+    return {
+        key: (
+            {getattr(p, "value", p) for p in prop["credentials_provider"]},
+            set(prop["credentials_types"]),
+            key in required,
+        )
+        for key, prop in schema["properties"].items()
+    }
+
+
+def test_codegen_without_transport_resolves_to_schema_default():
+    """The discriminator defaults to openai_api, so the slot must be OpenAI
+    only. Advertising codex here let a non-entitled user see a required
+    credential for a plan-gated provider they cannot connect."""
+    graph = _graph_with([_node("n1", CODEX_CODEGEN_BLOCK_ID, {"prompt": "hi"})])
+
+    assert _slots(graph) == {
+        "openai_api_key_credentials": ({"openai"}, {"api_key"}, True)
+    }
+
+
+def test_codegen_with_explicit_openai_transport_matches_default_case():
+    graph = _graph_with(
+        [
+            _node(
+                "n1",
+                CODEX_CODEGEN_BLOCK_ID,
+                {"prompt": "hi", "transport": "openai_api"},
+            )
+        ]
+    )
+
+    assert _slots(graph) == {
+        "openai_api_key_credentials": ({"openai"}, {"api_key"}, True)
+    }
+
+
+def test_codegen_with_codex_transport_yields_codex_slot():
+    graph = _graph_with(
+        [
+            _node(
+                "n1",
+                CODEX_CODEGEN_BLOCK_ID,
+                {"prompt": "hi", "transport": "codex_app_server"},
+            )
+        ]
+    )
+
+    assert _slots(graph) == {"codex_oauth2_credentials": ({"codex"}, {"oauth2"}, True)}
+
+
+def test_autopilot_codex_credentials_slot_is_not_required():
+    """AutoPilot's codex_credentials declares default=None, so the graph must
+    not demand it — the block falls back to the platform transport."""
+    graph = _graph_with([_node("n1", AUTOPILOT_BLOCK_ID, {"prompt": "hi"})])
+
+    assert _slots(graph) == {"codex_oauth2_credentials": ({"codex"}, {"oauth2"}, False)}
+
+
+def test_codex_transport_node_merges_with_autopilot_codex_slot():
+    """Both resolve to (codex, oauth2), so they share one slot instead of
+    presenting the user two separate codex rows."""
+    graph = _graph_with(
+        [
+            _node("n1", AUTOPILOT_BLOCK_ID, {"prompt": "hi"}),
+            _node(
+                "n2",
+                CODEX_CODEGEN_BLOCK_ID,
+                {"prompt": "hi", "transport": "codex_app_server"},
+            ),
+        ]
+    )
+
+    slots = _slots(graph)
+    assert list(slots) == ["codex_oauth2_credentials"]
+    # Required because the CodeGen node requires it, even though AutoPilot's is optional.
+    assert slots["codex_oauth2_credentials"] == ({"codex"}, {"oauth2"}, True)
+
+
+def test_llm_block_union_is_left_intact_without_model():
+    """Regression guard: mapping-only discriminators keep their union slot key.
+    Persisted preset/schedule credentials are keyed by this name, so collapsing
+    it would silently orphan them."""
+    from backend.blocks.llm import AITextGeneratorBlock
+
+    graph = _graph_with([_node("n1", AITextGeneratorBlock().id, {"prompt": "hi"})])
+
+    slots = _slots(graph)
+    assert list(slots) == [
+        "aiml_api-anthropic-groq-llama_api-ollama-open_router-openai-v0_api_key_credentials"
+    ]
+    providers, types, required = slots[list(slots)[0]]
+    assert len(providers) == 8
+    assert types == {"api_key"}
+    assert required is True
+
+
+def test_llm_block_with_model_discriminates_normally():
+    from backend.blocks.llm import AITextGeneratorBlock
+
+    graph = _graph_with(
+        [_node("n1", AITextGeneratorBlock().id, {"prompt": "hi", "model": "gpt-4o"})]
+    )
+
+    assert _slots(graph) == {
+        "openai_api_key_credentials": ({"openai"}, {"api_key"}, True)
+    }
+
+
+def test_only_known_blocks_use_discriminator_type_mapping():
+    """Guard on the fallback's trigger condition. If a new block adds
+    discriminator_type_mapping, it silently inherits schema-default
+    discrimination — this test forces that to be a conscious decision."""
+    from backend.blocks import load_all_blocks
+
+    users = set()
+    for block_cls in load_all_blocks().values():
+        try:
+            block = block_cls()
+        except Exception:
+            continue
+        rendered = block.input_schema.get_credentials_fields()
+        for name, info in block.input_schema.get_credentials_fields_info().items():
+            if name in rendered and info.discriminator_type_mapping:
+                users.add((block.name, name))
+
+    assert users == {("CodeGenerationBlock", "credentials")}
+
+
+def test_graph_credential_slots_agree_with_executor_defaults():
+    """The graph schema must not advertise a provider the executor cannot
+    select. For every discriminated credentials field, the providers offered
+    for an unpinned node must be reachable from the block's own default."""
+    from backend.blocks import load_all_blocks
+
+    for block_cls in load_all_blocks().values():
+        try:
+            block = block_cls()
+        except Exception:
+            continue
+        rendered = block.input_schema.get_credentials_fields()
+        info = block.input_schema.get_credentials_fields_info()
+        for name in rendered:
+            field = info[name]
+            if not field.discriminator_type_mapping:
+                continue
+            default = block.input_schema.jsonschema()["properties"][
+                field.discriminator
+            ].get("default")
+            expected = field.discriminate(default)
+            graph = _graph_with([_node("n1", block.id, {})])
+            for providers, types, _ in _slots(graph).values():
+                assert providers == {
+                    getattr(p, "value", p) for p in expected.provider
+                }, f"{block.name}.{name} advertises unreachable providers"
+                assert types == set(expected.supported_types)

--- a/autogpt_platform/backend/backend/integrations/webhooks/graph_lifecycle_hooks.py
+++ b/autogpt_platform/backend/backend/integrations/webhooks/graph_lifecycle_hooks.py
@@ -205,12 +205,17 @@ async def on_graph_deactivate(graph: "GraphModel", user_id: str):
 
         node_credentials = None
         for creds_field_name in block_input_schema.get_credentials_fields().keys():
-            if (creds_meta := node.input_default.get(creds_field_name)) and not (
-                node_credentials := await get_credentials(creds_meta["id"])
-            ):
+            # Same shape guard as activation: a meta without `id` means no
+            # credential was selected, and indexing it would raise KeyError.
+            # Graphs saved before that guard existed still carry this shape,
+            # so deactivation has to tolerate it.
+            creds_meta = node.input_default.get(creds_field_name)
+            if not creds_meta or not (creds_id := creds_meta.get("id")):
+                continue
+            if not (node_credentials := await get_credentials(creds_id)):
                 logger.warning(
                     f"Node #{node.id} input '{creds_field_name}' referenced "
-                    f"non-existent credentials #{creds_meta['id']}"
+                    f"non-existent credentials #{creds_id}"
                 )
 
         updated_node = await on_node_deactivate(

--- a/autogpt_platform/backend/backend/integrations/webhooks/graph_lifecycle_hooks.py
+++ b/autogpt_platform/backend/backend/integrations/webhooks/graph_lifecycle_hooks.py
@@ -71,7 +71,12 @@ async def _before_graph_activate(graph: "BaseGraph | GraphModel", user_id: str):
         block_input_schema = cast(BlockSchema, new_node.block.input_schema)
         for creds_field_name in block_input_schema.get_credentials_fields().keys():
             creds_meta = new_node.input_default.get(creds_field_name)
-            if not creds_meta:
+            # A meta without `id` means no credential was selected. The form
+            # can emit provider/type on their own, so this shape is reachable
+            # without any user action; treat it as unset instead of indexing
+            # it. Required-but-unset is caught by execution-time validation,
+            # which can name the block and field.
+            if not creds_meta or not creds_meta.get("id"):
                 continue
             refs.append((new_node, creds_field_name, creds_meta, block_input_schema))
 

--- a/autogpt_platform/backend/backend/integrations/webhooks/graph_lifecycle_hooks_test.py
+++ b/autogpt_platform/backend/backend/integrations/webhooks/graph_lifecycle_hooks_test.py
@@ -120,3 +120,23 @@ async def test_before_graph_activate_succeeds_when_credentials_resolve():
         await _before_graph_activate(graph, "user-1")
 
     assert node.input_default["credentials"]["id"] == "cred-1"
+
+
+@pytest.mark.asyncio
+async def test_before_graph_activate_ignores_credential_meta_without_id():
+    """A credentials value that is truthy but carries no `id` means "nothing
+    selected", not "resolve this". It must be skipped like an absent field
+    rather than indexed — indexing raised KeyError('id'), surfacing to the user
+    as a bare 500 on POST /api/graphs that named neither block nor field."""
+    node = _make_node(creds_field="codex_credentials", required=False)
+    node.input_default = {"codex_credentials": {"provider": "codex", "type": "oauth2"}}
+    graph = MagicMock(nodes=[node])
+
+    getter = AsyncMock(return_value=MagicMock())
+    with patch(
+        "backend.integrations.webhooks.graph_lifecycle_hooks.credentials_manager"
+    ) as mgr:
+        mgr.cached_getter.return_value = getter
+        await _before_graph_activate(graph, "user-1")
+
+    getter.assert_not_awaited()

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/FormCreator.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/FormCreator.tsx
@@ -1,9 +1,11 @@
 import { RJSFSchema } from "@rjsf/utils";
-import React from "react";
+import React, { useContext } from "react";
 import { uiSchema } from "./uiSchema";
 import { useNodeStore } from "../../../stores/nodeStore";
 import { BlockUIType } from "../../types";
 import { FormRenderer } from "@/components/renderers/InputRenderer/FormRenderer";
+import { CredentialsProvidersContext } from "@/providers/agent-credentials/credentials-provider";
+import { gateDiscriminatorOptions } from "@/components/renderers/InputRenderer/custom/CredentialField/gateDiscriminatorOptions";
 
 interface FormCreatorProps {
   jsonSchema: RJSFSchema;
@@ -29,6 +31,8 @@ export const FormCreator: React.FC<FormCreatorProps> = React.memo(
     const getHardCodedValues = useNodeStore(
       (state) => state.getHardCodedValues,
     );
+
+    const credentialsProviders = useContext(CredentialsProvidersContext);
 
     const isAgent = uiType === BlockUIType.AGENT;
 
@@ -85,13 +89,19 @@ export const FormCreator: React.FC<FormCreatorProps> = React.memo(
       initialValues = hardcodedValues;
     }
 
+    const gatedSchema = gateDiscriminatorOptions(
+      jsonSchema,
+      credentialsProviders,
+      initialValues,
+    );
+
     return (
       <div
         className={className}
         data-id={`form-creator-container-${nodeId}-node`}
       >
         <FormRenderer
-          jsonSchema={jsonSchema}
+          jsonSchema={gatedSchema}
           handleChange={handleChange}
           uiSchema={uiSchema}
           initialValues={initialValues}

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/FormCreator.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/FormCreator.tsx
@@ -33,8 +33,17 @@ export const FormCreator: React.FC<FormCreatorProps> = React.memo(
     const isAgent = uiType === BlockUIType.AGENT;
 
     const handleChange = ({ formData }: any) => {
-      if ("credentials" in formData && !formData.credentials?.id) {
-        delete formData.credentials;
+      // RJSF seeds `const` provider/type into default form state, so an
+      // untouched credential field arrives as {provider, type} with no id.
+      // That half object must never reach input_default: graph activation
+      // indexes creds_meta["id"] and would raise KeyError. Field names follow
+      // the backend rule in data/model.py:is_credentials_field_name.
+      for (const key of Object.keys(formData)) {
+        const isCredentialField =
+          key === "credentials" || key.endsWith("_credentials");
+        if (isCredentialField && !formData[key]?.id) {
+          delete formData[key];
+        }
       }
 
       let updatedValues;

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/__tests__/FormCreator.credentials.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/__tests__/FormCreator.credentials.test.tsx
@@ -1,0 +1,421 @@
+import { BlockUIType } from "@/app/(platform)/build/components/types";
+import { FormCreator } from "@/app/(platform)/build/components/FlowEditor/nodes/FormCreator";
+import type { CustomNode } from "@/app/(platform)/build/components/FlowEditor/nodes/CustomNode/CustomNode";
+import { useEdgeStore } from "@/app/(platform)/build/stores/edgeStore";
+import { useHistoryStore } from "@/app/(platform)/build/stores/historyStore";
+import { useNodeStore } from "@/app/(platform)/build/stores/nodeStore";
+import {
+  CredentialsProvidersContext,
+  type CredentialsProvidersContextType,
+} from "@/providers/agent-credentials/credentials-provider";
+import { render } from "@/tests/integrations/test-utils";
+import { screen, waitFor } from "@testing-library/react";
+import type { RJSFSchema } from "@rjsf/utils";
+import React from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// Mirrors AutoPilotBlock.codex_credentials: optional (default null), rendered on
+// the block face, and — critically — provider/type are `const` in the subschema
+// while `id` is not. RJSF seeds const values into default form state, so this
+// field materializes as {provider, type} with no id and no user interaction.
+const autopilotSchema = {
+  type: "object",
+  properties: {
+    prompt: { advanced: false, title: "Prompt", type: "string" },
+    codex_credentials: {
+      advanced: false,
+      credentials_provider: ["codex"],
+      credentials_types: ["oauth2"],
+      default: null,
+      properties: {
+        id: { title: "Id", type: "string" },
+        provider: { const: "codex", title: "Provider", type: "string" },
+        type: { const: "oauth2", title: "Type", type: "string" },
+      },
+      required: ["id", "provider", "type"],
+      secret: true,
+      title: "ChatGPT / Codex connection",
+      type: "object",
+    },
+  },
+  required: ["prompt"],
+} as unknown as RJSFSchema;
+
+function makeNode(schema: RJSFSchema): CustomNode {
+  return {
+    id: "autopilot-node",
+    type: "custom",
+    position: { x: 0, y: 0 },
+    data: {
+      hardcodedValues: {},
+      title: "AutoPilot",
+      description: "Run an autopilot task",
+      inputSchema: schema,
+      outputSchema: {},
+      uiType: BlockUIType.STANDARD,
+      block_id: "c069dc6b-c3ed-4c12-b6e5-d47361e64ce6",
+      costs: [],
+      categories: [],
+    },
+  } as unknown as CustomNode;
+}
+
+function makeProviders(...names: string[]): CredentialsProvidersContextType {
+  const entries = names.map((name) => [
+    name,
+    {
+      provider: name,
+      providerName: name,
+      savedCredentials: [],
+      isSystemProvider: false,
+    },
+  ]);
+  return Object.fromEntries(entries) as CredentialsProvidersContextType;
+}
+
+function renderNode(providers: CredentialsProvidersContextType) {
+  useNodeStore.setState({
+    nodes: [makeNode(autopilotSchema)],
+    nodeAdvancedStates: {},
+  });
+  useEdgeStore.setState({ edges: [] });
+  useHistoryStore.setState({ past: [], future: [] });
+
+  return render(
+    <CredentialsProvidersContext.Provider value={providers}>
+      <FormCreator
+        jsonSchema={autopilotSchema}
+        nodeId="autopilot-node"
+        uiType={BlockUIType.STANDARD}
+        showHandles={false}
+      />
+    </CredentialsProvidersContext.Provider>,
+  );
+}
+
+beforeEach(() => {
+  useNodeStore.setState({ nodes: [], nodeAdvancedStates: {} });
+});
+
+describe("FormCreator credential emission", () => {
+  // Regression: a non-entitled user has no `codex` provider (the backend strips
+  // it from /integrations/providers), so this field can never be filled. Before
+  // the fix the node still persisted {provider, type} with no id, which reached
+  // input_default and made POST /api/graphs return 500 with detail "'id'" from
+  // graph_lifecycle_hooks._before_graph_activate.
+  it("never persists a credential field that has no id", async () => {
+    renderNode({});
+
+    await waitFor(() => {
+      expect(
+        useNodeStore.getState().getHardCodedValues("autopilot-node"),
+      ).toBeDefined();
+    });
+
+    const stored = useNodeStore
+      .getState()
+      .getHardCodedValues("autopilot-node") as Record<string, unknown>;
+
+    expect(stored).not.toHaveProperty("codex_credentials");
+  });
+
+  it("keeps a credential field once it carries an id", async () => {
+    renderNode({});
+
+    await waitFor(() => {
+      expect(
+        useNodeStore.getState().getHardCodedValues("autopilot-node"),
+      ).toBeDefined();
+    });
+
+    useNodeStore.getState().updateNodeData("autopilot-node", {
+      hardcodedValues: {
+        codex_credentials: {
+          id: "codex-oauth-1",
+          provider: "codex",
+          type: "oauth2",
+          title: "ChatGPT for Codex",
+        },
+      },
+    });
+
+    const stored = useNodeStore
+      .getState()
+      .getHardCodedValues("autopilot-node") as Record<string, unknown>;
+
+    expect(stored.codex_credentials).toMatchObject({ id: "codex-oauth-1" });
+  });
+});
+
+// MCPToolBlock is the other block with a schema-optional rendered credential
+// field (default={}), so it exercises the same star path under the literal
+// `credentials` name rather than a `*_credentials` one.
+const mcpToolSchema = {
+  type: "object",
+  properties: {
+    server_url: { advanced: false, title: "Server Url", type: "string" },
+    credentials: {
+      advanced: false,
+      credentials_provider: ["mcp"],
+      credentials_types: ["oauth2"],
+      default: {},
+      discriminator: "server_url",
+      properties: {
+        id: { title: "Id", type: "string" },
+        provider: { const: "mcp", title: "Provider", type: "string" },
+        type: { const: "oauth2", title: "Type", type: "string" },
+      },
+      required: ["id", "provider", "type"],
+      title: "Credentials",
+      type: "object",
+    },
+  },
+  required: ["server_url"],
+} as unknown as RJSFSchema;
+
+describe("unavailable provider", () => {
+  // The backend omits providers the user isn't entitled to, so CredentialsInput
+  // renders no control. An optional field then has nothing actionable in it.
+  it("hides an optional credential row whose provider the user cannot use", async () => {
+    renderNode(makeProviders("openai"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Prompt")).toBeDefined();
+    });
+
+    expect(screen.queryByText("OpenAI credential")).toBeNull();
+  });
+
+  it("shows the row once the provider becomes available", async () => {
+    renderNode(makeProviders("codex"));
+
+    expect(await screen.findByText("OpenAI credential")).toBeDefined();
+  });
+
+  // null context means the fetches haven't settled. Treating that as
+  // unavailable would hide the row from entitled users on every page load.
+  it("does not hide the row while providers are still loading", async () => {
+    renderNode(null as unknown as CredentialsProvidersContextType);
+
+    expect(await screen.findByText("OpenAI credential")).toBeDefined();
+  });
+
+  // Found in manual E2E: a PRO user selecting the codex transport on Code
+  // Generation saw "Not available on your account." under a field still marked
+  // required. The field can't be hidden (the schema requires a credential) but
+  // the star demands something the UI offers no way to supply.
+  it("does not star a required field whose provider is unavailable", async () => {
+    const requiredUnavailableSchema = {
+      type: "object",
+      properties: {
+        prompt: { advanced: false, title: "Prompt", type: "string" },
+        credentials: {
+          advanced: false,
+          credentials_provider: ["codex"],
+          credentials_types: ["oauth2"],
+          properties: {
+            id: { title: "Id", type: "string" },
+            provider: { const: "codex", title: "Provider", type: "string" },
+            type: { const: "oauth2", title: "Type", type: "string" },
+          },
+          required: ["id", "provider", "type"],
+          title: "Credentials",
+          type: "object",
+        },
+      },
+      required: ["prompt", "credentials"],
+    } as unknown as RJSFSchema;
+
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...makeNode(requiredUnavailableSchema),
+          id: "req-node",
+        } as unknown as CustomNode,
+      ],
+      nodeAdvancedStates: {},
+    });
+    useEdgeStore.setState({ edges: [] });
+    useHistoryStore.setState({ past: [], future: [] });
+
+    render(
+      <CredentialsProvidersContext.Provider value={makeProviders("openai")}>
+        <FormCreator
+          jsonSchema={requiredUnavailableSchema}
+          nodeId="req-node"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
+
+    const title = await screen.findByText("OpenAI credential");
+
+    expect(title.parentElement?.textContent).not.toContain("*");
+  });
+
+  it("still stars a required field whose provider IS available", async () => {
+    const requiredAvailableSchema = {
+      type: "object",
+      properties: {
+        credentials: {
+          advanced: false,
+          credentials_provider: ["github"],
+          credentials_types: ["api_key"],
+          properties: {
+            id: { title: "Id", type: "string" },
+            provider: { const: "github", title: "Provider", type: "string" },
+            type: { const: "api_key", title: "Type", type: "string" },
+          },
+          required: ["id", "provider", "type"],
+          title: "Credentials",
+          type: "object",
+        },
+      },
+      required: ["credentials"],
+    } as unknown as RJSFSchema;
+
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...makeNode(requiredAvailableSchema),
+          id: "gh-avail",
+        } as unknown as CustomNode,
+      ],
+      nodeAdvancedStates: {},
+    });
+    useEdgeStore.setState({ edges: [] });
+    useHistoryStore.setState({ past: [], future: [] });
+
+    render(
+      <CredentialsProvidersContext.Provider value={makeProviders("github")}>
+        <FormCreator
+          jsonSchema={requiredAvailableSchema}
+          nodeId="gh-avail"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
+
+    const title = await screen.findByText("Github credential");
+
+    expect(title.parentElement?.textContent).toContain("*");
+  });
+});
+
+describe("credential field required marker", () => {
+  // The builder used to derive the marker purely from the node-level
+  // credentials_optional toggle, so a schema-optional credential field was
+  // still starred. codex_credentials is absent from the schema's `required`
+  // array, so it must render without one.
+  it("does not star a credential field the schema declares optional", async () => {
+    renderNode(makeProviders("codex"));
+
+    const title = await screen.findByText("OpenAI credential");
+
+    expect(title.parentElement?.textContent).not.toContain("*");
+  });
+
+  it("still stars a genuinely required field", async () => {
+    renderNode(makeProviders("codex"));
+
+    const title = await screen.findByText("Prompt");
+
+    expect(title.parentElement?.textContent).toContain("*");
+  });
+
+  it("does not star MCP Tool's schema-optional credentials either", async () => {
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...makeNode(mcpToolSchema),
+          id: "mcp-node",
+        } as unknown as CustomNode,
+      ],
+      nodeAdvancedStates: {},
+    });
+    useEdgeStore.setState({ edges: [] });
+    useHistoryStore.setState({ past: [], future: [] });
+
+    render(
+      <CredentialsProvidersContext.Provider value={makeProviders("mcp")}>
+        <FormCreator
+          jsonSchema={mcpToolSchema}
+          nodeId="mcp-node"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
+
+    const title = await screen.findByText("Mcp credential");
+
+    expect(title.parentElement?.textContent).not.toContain("*");
+  });
+
+  it("keeps the node-level toggle able to relax a required credential", async () => {
+    // The toggle may only relax, never tighten. A schema-required credential
+    // with credentials_optional set must lose its star, which is the feature
+    // the optional-credentials flag added.
+    const requiredCredsSchema = {
+      type: "object",
+      properties: {
+        credentials: {
+          advanced: false,
+          credentials_provider: ["github"],
+          credentials_types: ["api_key"],
+          properties: {
+            id: { title: "Id", type: "string" },
+            provider: { const: "github", title: "Provider", type: "string" },
+            type: { const: "api_key", title: "Type", type: "string" },
+          },
+          required: ["id", "provider", "type"],
+          title: "Credentials",
+          type: "object",
+        },
+      },
+      required: ["credentials"],
+    } as unknown as RJSFSchema;
+
+    useNodeStore.setState({
+      nodes: [
+        {
+          id: "gh-node",
+          type: "custom",
+          position: { x: 0, y: 0 },
+          data: {
+            hardcodedValues: {},
+            title: "GitHub",
+            description: "d",
+            inputSchema: requiredCredsSchema,
+            outputSchema: {},
+            uiType: BlockUIType.STANDARD,
+            block_id: "gh",
+            costs: [],
+            categories: [],
+            metadata: { credentials_optional: true },
+          },
+        } as unknown as CustomNode,
+      ],
+      nodeAdvancedStates: {},
+    });
+    useEdgeStore.setState({ edges: [] });
+    useHistoryStore.setState({ past: [], future: [] });
+
+    render(
+      <CredentialsProvidersContext.Provider value={makeProviders("github")}>
+        <FormCreator
+          jsonSchema={requiredCredsSchema}
+          nodeId="gh-node"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
+
+    const title = await screen.findByText("Github credential");
+
+    expect(title.parentElement?.textContent).not.toContain("*");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/__tests__/FormCreator.credentials.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/nodes/__tests__/FormCreator.credentials.test.tsx
@@ -119,24 +119,47 @@ describe("FormCreator credential emission", () => {
     expect(stored).not.toHaveProperty("codex_credentials");
   });
 
+  // Seeded as an initial value so the credential travels through FormCreator's
+  // handleChange — the same path that strips id-less objects. Writing straight
+  // to the store after render would bypass the code under test entirely.
   it("keeps a credential field once it carries an id", async () => {
-    renderNode({});
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...makeNode(autopilotSchema),
+          data: {
+            ...makeNode(autopilotSchema).data,
+            hardcodedValues: {
+              codex_credentials: {
+                id: "codex-oauth-1",
+                provider: "codex",
+                type: "oauth2",
+                title: "ChatGPT for Codex",
+              },
+            },
+          },
+        } as unknown as CustomNode,
+      ],
+      nodeAdvancedStates: {},
+    });
+    useEdgeStore.setState({ edges: [] });
+    useHistoryStore.setState({ past: [], future: [] });
+
+    render(
+      <CredentialsProvidersContext.Provider value={makeProviders("codex")}>
+        <FormCreator
+          jsonSchema={autopilotSchema}
+          nodeId="autopilot-node"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
 
     await waitFor(() => {
       expect(
         useNodeStore.getState().getHardCodedValues("autopilot-node"),
       ).toBeDefined();
-    });
-
-    useNodeStore.getState().updateNodeData("autopilot-node", {
-      hardcodedValues: {
-        codex_credentials: {
-          id: "codex-oauth-1",
-          provider: "codex",
-          type: "oauth2",
-          title: "ChatGPT for Codex",
-        },
-      },
     });
 
     const stored = useNodeStore
@@ -171,6 +194,27 @@ const mcpToolSchema = {
     },
   },
   required: ["server_url"],
+} as unknown as RJSFSchema;
+
+const requiredCodexSchema = {
+  type: "object",
+  properties: {
+    prompt: { advanced: false, title: "Prompt", type: "string" },
+    credentials: {
+      advanced: false,
+      credentials_provider: ["codex"],
+      credentials_types: ["oauth2"],
+      properties: {
+        id: { title: "Id", type: "string" },
+        provider: { const: "codex", title: "Provider", type: "string" },
+        type: { const: "oauth2", title: "Type", type: "string" },
+      },
+      required: ["id", "provider", "type"],
+      title: "Credentials",
+      type: "object",
+    },
+  },
+  required: ["prompt", "credentials"],
 } as unknown as RJSFSchema;
 
 describe("unavailable provider", () => {
@@ -301,6 +345,44 @@ describe("unavailable provider", () => {
     const title = await screen.findByText("Github credential");
 
     expect(title.parentElement?.textContent).toContain("*");
+  });
+});
+
+describe("unavailable required field", () => {
+  // Regression for the toggle trap: the hide condition must key off the schema's
+  // own `required`, not the toggle-adjusted value. Otherwise turning "Optional"
+  // on for a required gated field hides the row AND its toggle, with no way back.
+  it("keeps a required-but-unavailable row visible when marked optional", async () => {
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...makeNode(requiredCodexSchema),
+          id: "toggle-node",
+          data: {
+            ...makeNode(requiredCodexSchema).data,
+            metadata: { credentials_optional: true },
+          },
+        } as unknown as CustomNode,
+      ],
+      nodeAdvancedStates: {},
+    });
+    useEdgeStore.setState({ edges: [] });
+    useHistoryStore.setState({ past: [], future: [] });
+
+    render(
+      <CredentialsProvidersContext.Provider value={makeProviders("openai")}>
+        <FormCreator
+          jsonSchema={requiredCodexSchema}
+          nodeId="toggle-node"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
+
+    // The row survives so the toggle stays reachable, but carries no star.
+    const title = await screen.findByText("OpenAI credential");
+    expect(title.parentElement?.textContent).not.toContain("*");
   });
 });
 

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/CodeGenerationTransport.test.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/CodeGenerationTransport.test.tsx
@@ -207,3 +207,155 @@ describe("Code Generation transport fields", () => {
     });
   });
 });
+
+function renderTransport(
+  providers: Record<string, CredentialsProviderData> | null,
+) {
+  return render(
+    <CredentialsProvidersContext.Provider value={providers}>
+      <FormCreator
+        jsonSchema={codeGenerationSchema}
+        nodeId="code-generation-node"
+        uiType={BlockUIType.STANDARD}
+        showHandles={false}
+      />
+    </CredentialsProvidersContext.Provider>,
+  );
+}
+
+function transportOptionLabels() {
+  const select = screen.getByLabelText("agpt_%_transport");
+  return Array.from(select.querySelectorAll("option")).map(
+    (option) => option.textContent,
+  );
+}
+
+describe("Transport options gated by provider entitlement", () => {
+  it("hides the codex transport when the provider is not on the account", () => {
+    renderTransport({ openai: makeProvider("openai", "OpenAI", []) });
+
+    expect(transportOptionLabels()).toEqual(["openai_api"]);
+  });
+
+  it("offers the codex transport when the provider is on the account", () => {
+    renderTransport({
+      openai: makeProvider("openai", "OpenAI", []),
+      codex: makeProvider("codex", "Codex", [codexCredential]),
+    });
+
+    expect(transportOptionLabels()).toEqual(["openai_api", "codex_app_server"]);
+  });
+
+  it("leaves options alone while the provider map is still loading", () => {
+    renderTransport(null);
+
+    expect(transportOptionLabels()).toEqual(["openai_api", "codex_app_server"]);
+  });
+
+  it("keeps a saved codex transport selectable after entitlement is lost", () => {
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...createCodeGenerationNode(),
+          data: {
+            ...createCodeGenerationNode().data,
+            hardcodedValues: {
+              prompt: "Write a hello-world function",
+              transport: "codex_app_server",
+            },
+          },
+        },
+      ],
+      nodeAdvancedStates: {},
+    });
+
+    renderTransport({ openai: makeProvider("openai", "OpenAI", []) });
+
+    expect(transportOptionLabels()).toEqual(["openai_api", "codex_app_server"]);
+  });
+
+  it("does not touch the model dropdown, which no credential discriminates on", () => {
+    renderTransport({ openai: makeProvider("openai", "OpenAI", []) });
+
+    const model = screen.getByLabelText("agpt_%_model");
+    expect(
+      Array.from(model.querySelectorAll("option")).map((o) => o.textContent),
+    ).toEqual(["gpt-5.3-codex", "gpt-5.1-codex"]);
+  });
+});
+
+describe("LLM blocks keep every model option", () => {
+  const llmSchema = {
+    type: "object",
+    properties: {
+      prompt: { advanced: false, title: "Prompt", type: "string" },
+      model: {
+        advanced: false,
+        default: "gpt-4o",
+        enum: ["gpt-4o", "claude-opus-4-5-20251101", "llama3.3"],
+        title: "Model",
+        type: "string",
+      },
+      credentials: {
+        credentials_provider: ["openai", "anthropic", "ollama"],
+        credentials_types: ["api_key"],
+        discriminator: "model",
+        discriminator_mapping: {
+          "gpt-4o": "openai",
+          "claude-opus-4-5-20251101": "anthropic",
+          "llama3.3": "ollama",
+        },
+        properties: {
+          id: { type: "string" },
+          provider: {
+            enum: ["openai", "anthropic", "ollama"],
+            type: "string",
+          },
+          type: { const: "api_key", type: "string" },
+        },
+        required: ["id", "provider", "type"],
+        title: "Credentials",
+        type: "object",
+      },
+    },
+    required: ["prompt", "credentials"],
+  } as unknown as RJSFSchema;
+
+  it("keeps all models when every LLM provider is present, as list_providers guarantees", () => {
+    useNodeStore.setState({
+      nodes: [
+        {
+          ...createCodeGenerationNode(),
+          data: {
+            ...createCodeGenerationNode().data,
+            hardcodedValues: { prompt: "hi", model: "gpt-4o" },
+            inputSchema: llmSchema,
+          },
+        },
+      ],
+      nodeAdvancedStates: {},
+    });
+
+    render(
+      <CredentialsProvidersContext.Provider
+        value={{
+          openai: makeProvider("openai", "OpenAI", []),
+          anthropic: makeProvider("anthropic", "Anthropic", []),
+          ollama: makeProvider("ollama", "Ollama", []),
+        }}
+      >
+        <FormCreator
+          jsonSchema={llmSchema}
+          nodeId="code-generation-node"
+          uiType={BlockUIType.STANDARD}
+          showHandles={false}
+        />
+      </CredentialsProvidersContext.Provider>,
+    );
+
+    const model = screen.getByLabelText("agpt_%_model");
+    expect(
+      Array.from(model.querySelectorAll("option")).map((o) => o.textContent),
+    ).toEqual(["gpt-4o", "claude-opus-4-5-20251101", "llama3.3"]);
+  });
+});

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/CredentialField.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/CredentialField.tsx
@@ -85,7 +85,12 @@ export const CredentialsField = (props: FieldProps) => {
   // CredentialsInput renders nothing when the provider is missing from the
   // providers map, which used to leave a bare title with no control under it.
   // An optional field then has nothing actionable in it at all, so drop the row.
-  if (isUnavailable && !schemaRequired) {
+  //
+  // Keyed off the schema's own `required`, not `schemaRequired` above: the
+  // node-level toggle also feeds that value, so turning "Optional" on for a
+  // required gated field would hide the row and the toggle along with it,
+  // leaving no way to turn it back off.
+  if (isUnavailable && !required) {
     return null;
   }
 

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/CredentialField.tsx
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/CredentialField.tsx
@@ -5,10 +5,12 @@ import {
   BlockIOCredentialsSubSchema,
   CredentialsMetaInput,
 } from "@/lib/autogpt-server-api";
+import { Text } from "@/components/atoms/Text/Text";
 import { FieldProps, getUiOptions } from "@rjsf/utils";
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { CredentialFieldTitle } from "./components/CredentialFieldTitle";
+import { useCredentialAvailability } from "./useCredentialAvailability";
 
 export const CredentialsField = (props: FieldProps) => {
   const { formData, onChange, schema, registry, fieldPathId, required } = props;
@@ -67,9 +69,31 @@ export const CredentialsField = (props: FieldProps) => {
     [formData?.id, formData?.provider, formData?.title, formData?.type],
   );
 
-  // In builder canvas (nodeId exists): show star based on credentialsOptional toggle
-  // In run dialogs (no nodeId): show star based on schema's required array
-  const isRequired = nodeId ? !credentialsOptional : required;
+  // The schema's `required` array is authoritative in both surfaces. In the
+  // builder canvas the node-level toggle can additionally relax a required
+  // field to optional, but it must never mark a schema-optional field
+  // required — blocks declaring an optional credential (default=None) would
+  // otherwise render an unfillable star.
+  const schemaRequired = nodeId ? !credentialsOptional && required : required;
+
+  const availability = useCredentialAvailability(
+    schema as BlockIOCredentialsSubSchema,
+    hardcodedValues,
+  );
+  const isUnavailable = availability === "unavailable";
+
+  // CredentialsInput renders nothing when the provider is missing from the
+  // providers map, which used to leave a bare title with no control under it.
+  // An optional field then has nothing actionable in it at all, so drop the row.
+  if (isUnavailable && !schemaRequired) {
+    return null;
+  }
+
+  // A provider this user cannot connect is not actionable, so the required
+  // marker only misleads: it demands something the UI gives no way to supply.
+  // The schema still requires it and execution-time validation still enforces
+  // that — this only suppresses the star on a field that cannot be filled.
+  const isRequired = isUnavailable ? false : schemaRequired;
 
   return (
     <div className="flex flex-col gap-2">
@@ -80,6 +104,11 @@ export const CredentialsField = (props: FieldProps) => {
         schema={schema}
         required={isRequired}
       />
+      {availability === "unavailable" && (
+        <Text variant="small" className="text-zinc-500">
+          Not available on your account.
+        </Text>
+      )}
       <CredentialsInput
         schema={schema as BlockIOCredentialsSubSchema}
         selectedCredentials={selectedCredentials}

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/gateDiscriminatorOptions.ts
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/gateDiscriminatorOptions.ts
@@ -1,0 +1,90 @@
+import { RJSFSchema } from "@rjsf/utils";
+import { CredentialsProvidersContextType } from "@/providers/agent-credentials/credentials-provider";
+
+/**
+ * Drop discriminator enum options whose credential provider this user cannot
+ * connect.
+ *
+ * A block like Code Generation declares `credentials.discriminator = "transport"`
+ * plus a `discriminator_mapping` of enum value -> provider. Offering a value
+ * whose provider is gated lets the user select a transport they can never
+ * satisfy: the credential row then renders "Not available on your account" and
+ * execution is rejected server-side. Removing the option says the same thing
+ * up front.
+ *
+ * Only ever narrows options for providers absent from the user's provider map.
+ * `list_providers` filters exactly one provider (codex, on non-entitled
+ * accounts) and returns every other provider unconditionally, so LLM blocks —
+ * which discriminate on `model` across eight always-present providers — keep
+ * every option.
+ */
+export function gateDiscriminatorOptions(
+  schema: RJSFSchema,
+  providers: CredentialsProvidersContextType | null,
+  currentValues: Record<string, unknown>,
+): RJSFSchema {
+  // null means the provider map has not loaded. Filtering against it would
+  // briefly drop every option, so leave the schema alone until it arrives.
+  if (!providers) return schema;
+
+  const properties = schema.properties;
+  if (!properties) return schema;
+
+  const blockedByField = collectBlockedValues(properties, providers);
+  if (blockedByField.size === 0) return schema;
+
+  const gatedProperties: NonNullable<RJSFSchema["properties"]> = {
+    ...properties,
+  };
+  let changed = false;
+
+  for (const [fieldName, blocked] of blockedByField) {
+    const fieldSchema = properties[fieldName];
+    if (!isRecord(fieldSchema) || !Array.isArray(fieldSchema.enum)) continue;
+
+    const kept = fieldSchema.enum.filter(
+      (option) =>
+        !blocked.has(String(option)) ||
+        // Never drop the value a graph is already saved with; hiding it would
+        // silently rewrite the node on the next change.
+        option === currentValues[fieldName],
+    );
+    if (kept.length === fieldSchema.enum.length) continue;
+    // An empty dropdown is worse than an unusable option.
+    if (kept.length === 0) continue;
+
+    gatedProperties[fieldName] = { ...fieldSchema, enum: kept };
+    changed = true;
+  }
+
+  return changed ? { ...schema, properties: gatedProperties } : schema;
+}
+
+function collectBlockedValues(
+  properties: Record<string, unknown>,
+  providers: CredentialsProvidersContextType,
+): Map<string, Set<string>> {
+  const blockedByField = new Map<string, Set<string>>();
+
+  for (const propSchema of Object.values(properties)) {
+    if (!isRecord(propSchema)) continue;
+    if (!("credentials_provider" in propSchema)) continue;
+
+    const discriminator = propSchema.discriminator;
+    const mapping = propSchema.discriminator_mapping;
+    if (typeof discriminator !== "string" || !isRecord(mapping)) continue;
+
+    for (const [value, provider] of Object.entries(mapping)) {
+      if (typeof provider !== "string" || providers[provider]) continue;
+      const blocked = blockedByField.get(discriminator) ?? new Set<string>();
+      blocked.add(value);
+      blockedByField.set(discriminator, blocked);
+    }
+  }
+
+  return blockedByField;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/useCredentialAvailability.ts
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/useCredentialAvailability.ts
@@ -1,0 +1,31 @@
+import { BlockIOCredentialsSubSchema } from "@/lib/autogpt-server-api";
+import { CredentialsProvidersContext } from "@/providers/agent-credentials/credentials-provider";
+import { useContext } from "react";
+import { getCredentialProviderFromSchema } from "./helpers";
+
+type Availability = "loading" | "available" | "unavailable";
+
+/**
+ * Whether this field's provider is usable by the current user.
+ *
+ * The providers map is null until the provider-name and credential fetches
+ * settle, and the backend omits providers the user isn't entitled to (e.g.
+ * codex below the MAX tier). Those are different states: null means "unknown
+ * yet", a loaded map missing the key means "this user cannot connect it".
+ * Collapsing them would flash an unavailable state at entitled users on every
+ * page load.
+ */
+export function useCredentialAvailability(
+  schema: BlockIOCredentialsSubSchema,
+  formData: Record<string, unknown>,
+): Availability {
+  const providers = useContext(CredentialsProvidersContext);
+  const provider = getCredentialProviderFromSchema(formData, schema);
+
+  if (providers === null) return "loading";
+  // A multi-provider field with no discriminator value yet resolves to null;
+  // nothing is decided, so don't claim unavailability.
+  if (!provider) return "loading";
+
+  return providers[provider] ? "available" : "unavailable";
+}

--- a/autogpt_platform/frontend/src/providers/agent-credentials/credentials-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/agent-credentials/credentials-provider.tsx
@@ -287,12 +287,22 @@ export default function CredentialsProvider({
 
   const loadCredentials = useCallback(() => {
     if (!isLoggedIn || providerNames.length === 0) {
-      // Only publish the empty map once auth has actually settled. isLoggedIn
-      // is false while the auth store initializes, so publishing here made a
-      // logged-in user's context briefly non-null and empty — indistinguishable
-      // from "loaded, and this provider is not available to you". null stays
-      // the sole loading sentinel.
-      if (!isUserLoading && !isLoggedIn) setProviders({});
+      // null is the sole "still loading" sentinel; an empty object means
+      // "loaded, and this user has no providers". Keeping those distinct
+      // matters because consumers render an unavailable state from the
+      // latter, and showing that to an entitled user is wrong.
+      //
+      // Logged out, once auth has settled: genuinely empty. isLoggedIn is
+      // false while the auth store initializes too, hence the isUserLoading
+      // guard — without it a logged-in user briefly gets the empty map.
+      if (!isUserLoading && !isLoggedIn) {
+        setProviders({});
+        return;
+      }
+      // Logged in but provider names haven't arrived yet. If a previous
+      // logout left the empty map published, clear it back to null so this
+      // reads as loading rather than "nothing is available to you".
+      if (isLoggedIn) setProviders(null);
       return;
     }
 

--- a/autogpt_platform/frontend/src/providers/agent-credentials/credentials-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/agent-credentials/credentials-provider.tsx
@@ -121,7 +121,7 @@ export default function CredentialsProvider({
   const [systemProviders, setSystemProviders] = useState<Set<string>>(
     new Set(),
   );
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isUserLoading } = useAuth();
   const api = useBackendAPI();
   const onFailToast = useToastOnFail();
   const queryClient = useQueryClient();
@@ -287,7 +287,12 @@ export default function CredentialsProvider({
 
   const loadCredentials = useCallback(() => {
     if (!isLoggedIn || providerNames.length === 0) {
-      if (isLoggedIn == false) setProviders({});
+      // Only publish the empty map once auth has actually settled. isLoggedIn
+      // is false while the auth store initializes, so publishing here made a
+      // logged-in user's context briefly non-null and empty — indistinguishable
+      // from "loaded, and this provider is not available to you". null stays
+      // the sole loading sentinel.
+      if (!isUserLoading && !isLoggedIn) setProviders({});
       return;
     }
 
@@ -342,6 +347,7 @@ export default function CredentialsProvider({
   }, [
     api,
     isLoggedIn,
+    isUserLoading,
     providerNames,
     systemProviders,
     createAPIKeyCredentials,

--- a/autogpt_platform/single-container/entrypoint.sh
+++ b/autogpt_platform/single-container/entrypoint.sh
@@ -157,7 +157,12 @@ configure_environment() {
   export BATCH_EXECUTOR_PORT="${AUTOGPT_BATCH_EXECUTOR_PORT}"
   # Keep self-hosted product behavior without enabling LOCAL-only API docs and
   # asyncio debug mode on the public REST process.
-  export APP_ENV=dev BEHAVE_AS=local ENABLE_AUTH=true
+  # BEHAVE_AS defaults to local (self-hosted product behavior) but stays
+  # overridable: entitlement policies with allow_local=True grant every user
+  # access under `local`, so gating cannot be exercised without injecting
+  # `cloud`. APP_ENV stays dev to keep LOCAL-only API docs and asyncio debug
+  # mode off the public REST process.
+  export APP_ENV=dev BEHAVE_AS="${BEHAVE_AS:-local}" ENABLE_AUTH=true
 
   export BETTER_AUTH_URL="${AUTOGPT_PUBLIC_URL}"
   export BETTER_AUTH_INTERNAL_URL=http://127.0.0.1:3001


### PR DESCRIPTION
## Why

The ChatGPT/Codex transport is gated to Max and above, but it was reaching users below that tier. While investigating, a worse symptom turned up: **the AutoPilot block was unusable for everyone** — adding it to a canvas and saving returned `HTTP 500` with a body of just `'id'`.

That second one is not limited to non-entitled users. A paying Max customer hits it the moment they add an AutoPilot block without having connected ChatGPT, because the form emits a half-populated credential object with no user interaction at all.

## What

Five distinct defects. **Only #3 is codex-specific** — the rest are general bugs the codex work happened to trip first.

| # | Defect | File | Blast radius |
|---|---|---|---|
| 1 | Graph activation indexed `creds_meta["id"]` on a meta that had none | `graph_lifecycle_hooks.py` | every AutoPilot save |
| 2 | Builder stripped only the literal key `credentials`, not `*_credentials` | `FormCreator.tsx` | 5 blocks, 9 fields |
| 3 | Aggregation fell back to an un-discriminated union, advertising codex as required | `data/graph.py` | `CodeGenerationBlock` |
| 4 | Required asterisk came from a node toggle instead of the schema | `CredentialField.tsx` | AutoPilot + MCP Tool |
| 5 | An unavailable provider left a titled row with no control beneath it | `CredentialField.tsx` | any gated provider |

Plus an auth-bootstrap fix that #5 depends on: the credentials provider published an empty map while `isLoggedIn` was still false during auth init, making "loading" and "not available to you" indistinguishable — entitled users saw a flash of the wrong state on every page load.

## How

**#3 is the subtle one.** `combine()` flattens a *dependent* pair into a cross-product. Code Generation's credential is the coupled set `{(openai, api_key), (codex, oauth2)}`, but the un-discriminated union advertises `{codex, openai} × {api_key, oauth2}` — asserting two pairs that don't exist. The fix resolves the discriminator from the block's schema default, which is what the executor already does at run time (`blocks/_base.py` builds `input_schema(**input_default)`, so pydantic fills it).

Deliberately scoped to fields where the credential **type** depends on the discriminator. For mapping-only discriminators — every LLM block — the type set is a singleton, product equals sum, and the union is faithful. Those keep their aggregated slot key, which matters because **persisted presets and schedules are stored under it**; collapsing it would silently orphan them. A test asserts exactly one block satisfies the trigger condition today, so the next block to add `discriminator_type_mapping` inherits this consciously.

**Runtime enforcement is untouched** and remains the security boundary. Everything here is UX.

`single-container/entrypoint.sh` makes `BEHAVE_AS` overridable (same `local` default). It was hardcoded and overrode `docker run -e`, leaving the image unable to exercise any entitlement-gated feature.

## Verification

Tests: **4882 frontend** (467 files), **97 backend** across touched areas. 15 new tests; every fix has one that fails without it.

Also verified manually against a running single-container build at three subscription tiers, each confirmed in the database:

| Surface | NO_TIER | PRO | MAX |
|---|---|---|---|
| AutoPilot codex field | absent | absent | present, no asterisk |
| Select codex transport | — | "Not available on your account." | "Sign in with ChatGPT" |
| Settings → Integrations | — | no match | OpenAI / ChatGPT |
| Copilot chat transport | platform only | platform only | platform + ChatGPT |
| `has_codex_access` | False | False | True |
| Save a graph | 200 | 200 | 200 |

Key assertions:

- **The persisted record, not the toast.** A save can return 200 while still writing the malformed object, so the node row was read back: no `codex_credentials` key. The field *is* in the schema with `advanced: false`, so its absence is the fix rather than the field being missing.
- **The union is gone from the run dialog.** A default-transport Code Generation graph asks for OpenAI only. A single row accepting both openai and codex — the bug in its user-facing form — was never observed on any account.
- **Runtime enforcement still denies.** Proven at PRO (clears the general paywall, below the codex gate): a real queued execution failed with `"A Max plan or higher is required to use ChatGPT."`
- **Self-hosters unaffected.** Under `BEHAVE_AS=local`, `has_codex_access` returns True for NO_TIER and PRO — the `allow_local` carve-out, the exact inverse of the cloud result.

The manual pass earned its keep by finding a bug in the fix itself: non-entitled users selecting the codex transport got the "not available" explanation under a field **still marked required**, because the hide-logic only covered the optional case. Fixed, with tests pinning both directions.

## Known gaps

- **MCP Tool asterisk, E2E** — untested; the block only instantiates after a live MCP server handshake. Unit-covered against its exact schema shape, and the same optional-credential class is demonstrated in the UI by AutoPilot.
- **Marketplace install** — not exercised.
- **Counterfactual E2E** — the fixed build is proven correct end to end; that the *unfixed* build fails rests on unit tests reproducing `KeyError: 'id'`, not a second container built from master.

## Follow-ups (not in this PR)

1. **Codex reconnect mints a new credential id.** `credentials_from_bundle()` builds without an `id`, so reconnecting breaks every graph referencing the old one. AutoPilot's optional field fails *silently* — the stale ref is cleared and the node falls back to the platform transport, so the user reconnects, sees a connected account, and their agent quietly stops using their ChatGPT plan. `checkpoint_credentials_from_bundle` already preserves the id for token rotation; login just doesn't reuse that path.
2. **A denied run reports success.** `AgentGraphExecution` shows `COMPLETED` / `error: null` while the node inside carries the real paywall failure. Anything keying off graph-level status misses the denial.

## Checklist

- [x] Tests pass locally (frontend 4882, backend 97)
- [x] `pnpm format` / `pnpm lint` / `pnpm types` clean
- [x] Manually verified at three subscription tiers
- [x] Follow-ups identified and scoped out

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches graph credential aggregation, graph activation hooks, and persisted `input_default` shapes; runtime auth enforcement is unchanged but save/UX paths are widely used.
> 
> **Overview**
> Stops **gated Codex transport** and broken **credential handling** from blocking graph saves and misleading users who cannot connect plan-gated providers.
> 
> **Backend:** Graph credential aggregation now resolves unpinned discriminators from the block schema default (matching executor behavior) for fields with `discriminator_type_mapping`, so Code Generation no longer advertises invalid provider/type pairs or required Codex for users on the default OpenAI transport. Graph activate/deactivate skips credential metadata without an `id` instead of raising `KeyError` on save.
> 
> **Frontend:** `FormCreator` strips any `*_credentials` object lacking `id` (RJSF const-seeded placeholders), applies `gateDiscriminatorOptions` to hide transports the account cannot use, and wires provider-aware availability in `CredentialField` (hide optional empty rows, drop misleading required stars, show “Not available on your account”). The credentials provider keeps `null` vs `{}` distinct during auth bootstrap so entitled users do not flash unavailable state.
> 
> **Ops:** `single-container/entrypoint.sh` allows overriding `BEHAVE_AS` for entitlement testing while defaulting to `local`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158507ade6fd8bfc3bdfc975175caec79ff5d922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->