### PR TITLE
fix(frontend): render array items with a known object shape as a real sub-form

### DIFF
--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/generate-ui-schema.test.ts
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/__tests__/generate-ui-schema.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { RJSFSchema } from "@rjsf/utils";
+import { generateUiSchemaForCustomFields } from "../utils/generate-ui-schema";
+import { JSON_TEXT_FIELD_ID } from "../custom/custom-registry";
+
+function arrayOf(items: RJSFSchema): RJSFSchema {
+  return {
+    type: "object",
+    properties: {
+      filters: { type: "array", title: "Filters", items },
+    },
+  };
+}
+
+describe("generateUiSchemaForCustomFields — array items", () => {
+  it("renders items with named properties as a sub-form, not a JSON textarea", () => {
+    // A block input like `filters: list[FilterCondition]`, where the condition
+    // has an enum column. Rendering this as JSON forces users to hand-type
+    // values from a 40+ member enum.
+    const ui = generateUiSchemaForCustomFields(
+      arrayOf({
+        type: "object",
+        title: "FilterCondition",
+        properties: {
+          column: { type: "string", enum: ["current_title", "first_name"] },
+          operator: { type: "string", enum: ["=", "like"] },
+          value: { type: "string" },
+        },
+      }),
+    );
+
+    expect((ui.filters as any)?.items?.["ui:field"]).not.toBe(
+      JSON_TEXT_FIELD_ID,
+    );
+  });
+
+  it("still falls back to a JSON textarea for free-form dict items", () => {
+    const ui = generateUiSchemaForCustomFields(
+      arrayOf({ type: "object", additionalProperties: true }),
+    );
+
+    expect((ui.filters as any).items["ui:field"]).toBe(JSON_TEXT_FIELD_ID);
+  });
+
+  it("still falls back to a JSON textarea for nested array items", () => {
+    const ui = generateUiSchemaForCustomFields(
+      arrayOf({ type: "array", items: { type: "string" } }),
+    );
+
+    expect((ui.filters as any).items["ui:field"]).toBe(JSON_TEXT_FIELD_ID);
+  });
+
+  it("leaves arrays of primitives alone", () => {
+    const ui = generateUiSchemaForCustomFields(
+      arrayOf({ type: "string", enum: ["markdown", "html"] }),
+    );
+
+    expect((ui.filters as any)?.items?.["ui:field"]).toBeUndefined();
+  });
+
+  it("keeps routing item-level custom fields ahead of the object check", () => {
+    const ui = generateUiSchemaForCustomFields(
+      arrayOf({
+        type: "object",
+        credentials_provider: ["openai"],
+        properties: { id: { type: "string" } },
+      } as RJSFSchema),
+    );
+
+    expect((ui.filters as any).items["ui:field"]).toBe(
+      "custom/credential_field",
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/utils/generate-ui-schema.ts
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/utils/generate-ui-schema.ts
@@ -8,6 +8,21 @@ function isComplexType(schema: RJSFSchema): boolean {
   return schema.type === "object" || schema.type === "array";
 }
 
+/**
+ * True for object schemas that describe a known shape (a model with named
+ * properties), as opposed to a free-form dict. These can be rendered as a real
+ * sub-form — each property gets its proper widget, so enums become dropdowns
+ * instead of hand-typed JSON.
+ */
+function hasNamedProperties(schema: RJSFSchema): boolean {
+  return (
+    schema.type === "object" &&
+    !!schema.properties &&
+    typeof schema.properties === "object" &&
+    Object.keys(schema.properties).length > 0
+  );
+}
+
 function hasComplexAnyOfOptions(schema: RJSFSchema): boolean {
   const options = schema.anyOf || schema.oneOf;
   if (!Array.isArray(options)) return false;
@@ -25,6 +40,10 @@ function hasComplexAnyOfOptions(schema: RJSFSchema): boolean {
  *
  * Nested complex types (arrays/objects inside arrays/objects) are rendered as JsonTextField
  * to avoid deeply nested form UIs. Users can enter raw JSON for these fields.
+ *
+ * Exception: array items that describe a known object shape (named properties) are
+ * rendered as a real sub-form, one row per item, so each property keeps its proper
+ * widget — an enum property becomes a dropdown rather than hand-typed JSON.
  *
  * @param schema - The JSON schema
  * @param existingUiSchema - Existing uiSchema to merge with
@@ -114,8 +133,14 @@ export function generateUiSchemaForCustomFields(
                   "ui:field": itemsCustomFieldId,
                 },
               };
-            } else if (isComplexType(itemsSchema)) {
-              // Array items that are complex types become JsonTextField
+            } else if (
+              isComplexType(itemsSchema) &&
+              !hasNamedProperties(itemsSchema)
+            ) {
+              // Array items that are complex types *without* a known shape —
+              // free-form dicts, arrays of arrays — stay as JsonTextField.
+              // Items that do have named properties fall through to the
+              // recursion below so each property keeps its real widget.
               uiSchema[key] = {
                 ...(uiSchema[key] as object),
                 items: {


### PR DESCRIPTION
## Why

Any block input shaped `list[SomeModel]` currently renders as a **raw JSON textarea per row** in the builder. Enum properties lose their dropdowns entirely, so authoring a structured repeated input means hand-typing values with no validation until the request fails.

This surfaced while reviewing the DataForB2B blocks in #13383. That provider wants five filter slots expressed as `list[FilterCondition]` (column + operator + value). Attempting it produced a JSON blob per filter, where `column` is a 41-member enum — unusable. #13383 therefore keeps 15 flat `filter_N_*` fields, purely because that is the only shape the renderer gives real dropdowns to. Gmail and Google Sheets `operations` hit the same path today.

## What

Narrow the `JsonTextField` fallback for array items so it applies only to items with **no known shape** — free-form dicts and nested arrays. Items describing a named-property object fall through to the existing recursion and render as a real sub-form, each property keeping its proper widget.

## How

`generate-ui-schema.ts` already had a branch written for this case:

```ts
} else if (itemsSchema.properties) {
  // Recurse into object items (but they're now inside a complex type)
```

It was unreachable. The branch above it tests `isComplexType(itemsSchema)`, which matches `type: "object"` regardless of whether the schema has properties, so it always won first.

The fix adds a `hasNamedProperties()` guard to that earlier branch, making the recursion reachable. No new rendering machinery — it enables a path that was already written and tested for.

Behaviour preserved for everything else, covered by the new tests:
- free-form dict items (`additionalProperties: true`) → still `JsonTextField`
- nested array items → still `JsonTextField`
- arrays of primitives/enums → untouched
- item-level custom fields (credentials, Drive picker) → still matched first

**Not covered:** the `anyOf`/`oneOf` array path still forces `JsonTextField`, so `Optional[list[Model]]` is unchanged. Worth a follow-up if it bites.

## Relationship to #13383

Independent — zero file overlap, so this can merge in either order. #13383 ships the DataForB2B blocks with flat filter slots and a note explaining why. Once this lands, those slots can collapse into a single `filters: list[FilterCondition]` input: unlimited filters, one row each, real dropdowns.

## Checklist

- [x] Unit tests added for the changed branch and each preserved fallback
- [x] No new dependencies
- [ ] Visual check in the builder against a block with a list-of-model input (Gmail, Sheets)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, test-covered change to frontend UI schema generation for block inputs; no auth, API, or data-layer impact.
> 
> **Overview**
> **Block inputs shaped as `list[Model]`** no longer default every array row to a raw JSON textarea. `generateUiSchemaForCustomFields` now only assigns `JsonTextField` to array items that are complex **without** a fixed object shape (free-form dicts, nested arrays). Items with named `properties` skip that branch and use the existing recursion so each field keeps its widget (e.g. enums as dropdowns).
> 
> Behavior for primitives, credential-style custom item fields, and unstructured complex items is unchanged; new Vitest cases lock in those paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c812a8ec5c720d47a60890abfd748c92168f6226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->