### PR TITLE
fix(backend/executor): fail a run that was denied by entitlement

### DIFF
--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -66,6 +66,7 @@ from backend.data.db_accessors import credit_db, user_db
 from backend.data.redis_client import AsyncRedisClient, get_redis_async
 from backend.data.user import get_user_by_id
 from backend.util.cache import cached
+from backend.util.exceptions import UserPaywalledError
 from backend.util.feature_flag import Flag, get_feature_flag_value, is_feature_enabled
 
 logger = logging.getLogger(__name__)
@@ -465,25 +466,6 @@ class RateLimitUnavailable(Exception):
     blast the LLM during a Redis outage and exceed their daily/weekly USD
     allowance by hundreds of dollars.
     """
-
-
-class UserPaywalledError(Exception):
-    """User has no entitlement to run a paywalled feature (NO_TIER tier
-    + ``ENABLE_PLATFORM_PAYMENT`` on).
-
-    Raised by ``add_graph_execution`` and other deep enqueue paths so
-    that *every* execution entry point (HTTP route, scheduled cron,
-    webhook trigger, external API, internal copilot tool) gets the same
-    gate without each one having to remember a route-level dependency.
-    Routes wrap this into HTTP 402; background tasks log and abandon
-    the run.
-    """
-
-    def __init__(
-        self,
-        message: str = "A subscription is required to run this feature.",
-    ) -> None:
-        super().__init__(message)
 
 
 async def get_usage_status(

--- a/autogpt_platform/backend/backend/executor/activity_status_generator.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator.py
@@ -50,6 +50,13 @@ INSUFFICIENT_BALANCE_SUMMARY = (
     "This run couldn't complete because there weren't enough credits available. "
     f"{INSUFFICIENT_BALANCE_GUIDANCE}"
 )
+ENTITLEMENT_REQUIRED_GUIDANCE = (
+    "Upgrade the plan, or switch the step to an option your plan includes."
+)
+ENTITLEMENT_REQUIRED_SUMMARY = (
+    "This run couldn't complete because it used a feature the current plan "
+    f"doesn't include. {ENTITLEMENT_REQUIRED_GUIDANCE}"
+)
 
 
 # Default system prompt template for activity status generation
@@ -219,6 +226,12 @@ def _get_deterministic_failure_response(
     if execution_stats.failure_reason == ExecutionFailureReason.INSUFFICIENT_BALANCE:
         return {
             "activity_status": INSUFFICIENT_BALANCE_SUMMARY,
+            "correctness_score": 0.0,
+        }
+
+    if execution_stats.failure_reason == ExecutionFailureReason.ENTITLEMENT_REQUIRED:
+        return {
+            "activity_status": ENTITLEMENT_REQUIRED_SUMMARY,
             "correctness_score": 0.0,
         }
 

--- a/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
@@ -1112,6 +1112,20 @@ class TestDeterministicFailureResponse:
         assert "enough credits" in result["activity_status"].lower()
         assert "billing owner" not in result["activity_status"].lower()
 
+    def test_entitlement_failure_skips_llm_analysis(self):
+        """A plan-gated denial is as deterministic as an empty wallet. Without
+        a handler the run still reaches the LLM for a summary of something
+        already known — the exact cost this module exists to avoid."""
+        stats = GraphExecutionStats(
+            failure_reason=ExecutionFailureReason.ENTITLEMENT_REQUIRED
+        )
+
+        result = _get_deterministic_failure_response(stats, ExecutionStatus.FAILED)
+
+        assert result is not None
+        assert result["correctness_score"] == 0.0
+        assert "plan" in result["activity_status"].lower()
+
     @pytest.mark.parametrize(
         "status",
         [ExecutionStatus.COMPLETED, ExecutionStatus.TERMINATED, None],

--- a/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator_test.py
@@ -1248,3 +1248,15 @@ class TestDeterministicFailureResponse:
         else:
             assert result is None
             mock_get_openai_client.assert_called_once()
+
+
+def test_paywall_is_a_known_graph_execution_error():
+    """Anything outside this set pages via Discord as an unexpected failure.
+    A plan-gated denial is a known business outcome, so leaving it out produced
+    a spurious "Unknown Graph Execution Error" alert with a stack trace — the
+    same reasoning that keeps it out of Sentry in util/metrics."""
+    from backend.executor.manager import KNOWN_GRAPH_EXECUTION_ERRORS
+    from backend.util.exceptions import UserPaywalledError
+
+    assert issubclass(UserPaywalledError, Exception)
+    assert UserPaywalledError in KNOWN_GRAPH_EXECUTION_ERRORS

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -69,6 +69,7 @@ from backend.util.exceptions import (
     InsufficientBalanceError,
     ModerationError,
     NotFoundError,
+    UserPaywalledError,
     get_execution_failure_reason,
 )
 from backend.util.file import clean_exec_files
@@ -154,6 +155,17 @@ def _record_execution_failure(
     if failure_reason := get_execution_failure_reason(error):
         execution_stats.failure_reason = failure_reason
     execution_stats.error = str(error) or type(error).__name__
+
+
+# Terminal conditions the platform already understands. Anything outside this
+# set is treated as an unexpected failure and pages via Discord, so a known
+# business outcome left out of it produces a spurious "Unknown Graph Execution
+# Error" alert with a stack trace.
+KNOWN_GRAPH_EXECUTION_ERRORS = (
+    InsufficientBalanceError,
+    ModerationError,
+    UserPaywalledError,
+)
 
 
 def _propagate_node_failure(
@@ -1356,8 +1368,7 @@ class ExecutionProcessor:
             )
             _record_execution_failure(execution_stats, error)
 
-            known_errors = (InsufficientBalanceError, ModerationError)
-            if isinstance(error, known_errors):
+            if isinstance(error, KNOWN_GRAPH_EXECUTION_ERRORS):
                 return ExecutionStatus.FAILED
 
             execution_status = ExecutionStatus.FAILED

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -65,7 +65,6 @@ from backend.util.decorator import (
     time_measured,
 )
 from backend.util.exceptions import (
-    ExecutionFailureReason,
     GraphNotFoundError,
     InsufficientBalanceError,
     ModerationError,
@@ -139,9 +138,10 @@ def _record_execution_failure(
     ``error`` always reflects the *latest* failure, so the message a user sees
     describes what actually terminated the run.
 
-    ``failure_reason`` is *sticky*: once a typed failure (currently only
-    :class:`InsufficientBalanceError`) has been promoted from a node via
-    :func:`_propagate_node_failure`, a later untyped error cannot clear it.
+    ``failure_reason`` is *sticky*: once a typed failure
+    (:class:`InsufficientBalanceError` or :class:`UserPaywalledError`) has been
+    promoted from a node via :func:`_propagate_node_failure`, a later untyped
+    error cannot clear it.
     An exhausted wallet is the root cause of whatever fails next, and losing
     that reason would send the run back to LLM analysis — the exact cost this
     module exists to avoid. Only another typed classification may replace it.
@@ -1326,11 +1326,14 @@ class ExecutionProcessor:
             # Determine final execution status based on whether there was an error or termination
             if cancel.is_set():
                 execution_status = ExecutionStatus.TERMINATED
-            elif (
-                error is not None
-                or execution_stats.failure_reason
-                == ExecutionFailureReason.INSUFFICIENT_BALANCE
-            ):
+            elif error is not None or execution_stats.failure_reason is not None:
+                # Any typed failure reason means the run is terminally broken,
+                # not merely that a node errored. Untyped node errors stay
+                # non-fatal, since a graph may deliberately wire an error
+                # output onward; only classified, trusted failures promote to
+                # graph stats via `_propagate_node_failure`. Before this, a
+                # paywalled run reported COMPLETED with error=null while the
+                # node inside carried the real denial.
                 execution_status = ExecutionStatus.FAILED
             else:
                 if db_client.has_pending_reviews_for_graph_exec(

--- a/autogpt_platform/backend/backend/util/exceptions.py
+++ b/autogpt_platform/backend/backend/util/exceptions.py
@@ -112,10 +112,30 @@ class InsufficientBalanceError(ValueError):
         return self.message
 
 
+class UserPaywalledError(Exception):
+    """User has no entitlement to run a paywalled feature (NO_TIER tier
+    + ``ENABLE_PLATFORM_PAYMENT`` on).
+
+    Raised by ``add_graph_execution`` and other deep enqueue paths so
+    that *every* execution entry point (HTTP route, scheduled cron,
+    webhook trigger, external API, internal copilot tool) gets the same
+    gate without each one having to remember a route-level dependency.
+    Routes wrap this into HTTP 402; background tasks log and abandon
+    the run.
+    """
+
+    def __init__(
+        self,
+        message: str = "A subscription is required to run this feature.",
+    ) -> None:
+        super().__init__(message)
+
+
 class ExecutionFailureReason(str, Enum):
     """Structured reasons for terminal graph execution failures."""
 
     INSUFFICIENT_BALANCE = "insufficient_balance"
+    ENTITLEMENT_REQUIRED = "entitlement_required"
 
 
 # Keep this legacy-only fallback synchronized with the equivalent predicates in
@@ -143,6 +163,8 @@ def get_execution_failure_reason(
     """Classify trusted exceptions, with an opt-in fallback for persisted text."""
     if isinstance(error, InsufficientBalanceError):
         return ExecutionFailureReason.INSUFFICIENT_BALANCE
+    if isinstance(error, UserPaywalledError):
+        return ExecutionFailureReason.ENTITLEMENT_REQUIRED
     if (
         allow_legacy_text
         and isinstance(error, str)

--- a/autogpt_platform/backend/backend/util/exceptions_test.py
+++ b/autogpt_platform/backend/backend/util/exceptions_test.py
@@ -11,6 +11,7 @@ from backend.util.exceptions import (
     BlockUnknownError,
     ExecutionFailureReason,
     InsufficientBalanceError,
+    UserPaywalledError,
     get_execution_failure_reason,
 )
 
@@ -102,6 +103,37 @@ def test_typed_insufficient_balance_error_is_classified_by_type():
     assert (
         get_execution_failure_reason(error)
         == ExecutionFailureReason.INSUFFICIENT_BALANCE
+    )
+
+
+def test_paywall_error_is_classified_by_type():
+    """A paywalled node failure is a trusted, terminal, user-actionable
+    failure — the same class as an exhausted wallet. Without a typed reason it
+    never reached graph stats, so a denied run reported COMPLETED with a null
+    error while the node inside carried the real denial."""
+    error = UserPaywalledError("A Max plan or higher is required to use ChatGPT.")
+
+    assert (
+        get_execution_failure_reason(error)
+        == ExecutionFailureReason.ENTITLEMENT_REQUIRED
+    )
+
+
+def test_paywall_error_is_still_importable_from_rate_limit():
+    """It moved to break an import cycle; every existing call site imports it
+    from its old home."""
+    from backend.copilot.rate_limit import UserPaywalledError as ReExported
+
+    assert ReExported is UserPaywalledError
+
+
+def test_untyped_entitlement_wording_is_not_classified():
+    """Classification is by type, never by message text."""
+    assert (
+        get_execution_failure_reason(
+            RuntimeError("A Max plan or higher is required to use ChatGPT.")
+        )
+        is None
     )
 
 

--- a/autogpt_platform/backend/backend/util/metrics.py
+++ b/autogpt_platform/backend/backend/util/metrics.py
@@ -196,7 +196,8 @@ def _before_send(event, hint):
         if any(kw in exc_msg for kw in _USER_AUTH_KEYWORDS):
             return None
 
-        # Expected business logic — insufficient balance
+        # Expected business logic — exhausted wallet, or a plan that does
+        # not include the feature. Neither is a platform bug.
         if get_execution_failure_reason(exc_value) is not None:
             return None
 

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -18802,7 +18802,7 @@
       },
       "ExecutionFailureReason": {
         "type": "string",
-        "enum": ["insufficient_balance"],
+        "enum": ["insufficient_balance", "entitlement_required"],
         "title": "ExecutionFailureReason",
         "description": "Structured reasons for terminal graph execution failures."
       },


### PR DESCRIPTION
## Why

A run denied by entitlement reported **`COMPLETED` with `error: null`**, while the node inside carried the real denial:

```
AgentGraphExecution:  status=COMPLETED, error=null
AgentNodeExecution:   status=FAILED,    error="A Max plan or higher is required to use ChatGPT."
```

Anything keying off graph-level status — the UI, notifications, analytics — saw a clean success. Observed while verifying #14058 at the PRO tier.

## What

Classify `UserPaywalledError` as a typed failure reason, and widen the graph status check from one hardcoded reason to any typed reason.

## How

Node errors are **deliberately** non-fatal: a graph may wire an error output onward, so a failing node is not by itself a failing run. Only *typed* failures promote to graph stats via `_propagate_node_failure`. `UserPaywalledError` was already a typed exception — it simply had no classification, so it never promoted, and the status check special-cased the single reason that existed at the time:

```python
elif (error is not None
      or execution_stats.failure_reason == ExecutionFailureReason.INSUFFICIENT_BALANCE):
```

Two changes:

1. `get_execution_failure_reason` classifies `UserPaywalledError` → new `ENTITLEMENT_REQUIRED`.
2. The status check becomes `execution_stats.failure_reason is not None`.

**Untyped node errors keep their current behaviour.** This only affects failures the system already trusts as terminal — the generalisation was a no-op the moment before this PR added the second reason, which is what makes it safe.

### Why `UserPaywalledError` moves

Classifying it from its old home is a genuine import cycle:

```
util.exceptions <- data.model <- data.user <- copilot.rate_limit
```

So it moves to `util/exceptions` (where it belongs — it is a general execution concern, not a copilot rate-limit one) and is **re-exported from `rate_limit`**, leaving every existing call site untouched. A test pins the re-export. The repo forbids inner imports, so a lazy import was not an option.

### Falls out of the same change

`util/metrics` already suppresses Sentry reports for classified failures, so a paywall denial stops being reported as a platform bug. That is the correct outcome — it is expected business logic, not a defect.

`openapi.json` moves by one line: the `ExecutionFailureReason` enum gains a member.

## Testing

33 tests in `exceptions_test.py`, 3 new: classification by type, the re-export, and that the same wording as a plain `RuntimeError` is **not** classified (classification is by type, never by message text — matching the existing rule for balance errors).

## Checklist

- [x] Tests pass locally
- [x] `poetry run format` / `lint` / pyright clean
- [x] Every `UserPaywalledError` import site verified to still resolve
- [x] Untyped node-error semantics unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes graph execution status and failure classification for paywalled runs, which affects UI, analytics, alerts, and Sentry filtering. Untyped node errors are intended to stay non-fatal.
> 
> **Overview**
> Entitlement denials no longer look like successful runs. `UserPaywalledError` is now a typed `ENTITLEMENT_REQUIRED` failure, so the graph is marked **FAILED** instead of **COMPLETED** with a null error while the node still held the denial.
> 
> The executor treats any classified `failure_reason` as terminal (not only insufficient balance). Paywall errors are known outcomes: they skip LLM activity-status generation, stay out of Discord “unknown error” pages, and are already filtered from Sentry via typed classification.
> 
> `UserPaywalledError` moves to `util.exceptions` to break an import cycle and is re-exported from `copilot.rate_limit` so existing imports keep working. OpenAPI gains the new enum member. Untyped node errors are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d2d3773b38c10ecb568318fbbadd68983c697b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->