### PR TITLE
feat(blocks): add WaveSpeed AI image/video generation block

### DIFF
--- a/autogpt_platform/backend/backend/blocks/wavespeed/_auth.py
+++ b/autogpt_platform/backend/backend/blocks/wavespeed/_auth.py
@@ -1,0 +1,36 @@
+from typing import Literal
+
+from pydantic import SecretStr
+
+from backend.data.model import APIKeyCredentials, CredentialsField, CredentialsMetaInput
+from backend.integrations.providers import ProviderName
+
+WaveSpeedCredentials = APIKeyCredentials
+WaveSpeedCredentialsInput = CredentialsMetaInput[
+    Literal[ProviderName.WAVESPEED],
+    Literal["api_key"],
+]
+
+TEST_CREDENTIALS = APIKeyCredentials(
+    id="01234567-89ab-cdef-0123-456789abcdef",
+    provider="wavespeed",
+    api_key=SecretStr("mock-wavespeed-api-key"),
+    title="Mock WaveSpeed API key",
+    expires_at=None,
+)
+TEST_CREDENTIALS_INPUT = {
+    "provider": TEST_CREDENTIALS.provider,
+    "id": TEST_CREDENTIALS.id,
+    "type": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.title,
+}
+
+
+def WaveSpeedCredentialsField() -> WaveSpeedCredentialsInput:
+    """
+    Creates a WaveSpeed credentials input on a block.
+    """
+    return CredentialsField(
+        description="The WaveSpeed integration can be used with an API Key. "
+        "You can obtain one from https://wavespeed.ai.",
+    )

--- a/autogpt_platform/backend/backend/blocks/wavespeed/_config.py
+++ b/autogpt_platform/backend/backend/blocks/wavespeed/_config.py
@@ -1,0 +1,10 @@
+"""Provider registration for WaveSpeed — metadata only (auth lives in ``_auth.py``)."""
+
+from backend.sdk import ProviderBuilder
+
+wavespeed = (
+    ProviderBuilder("wavespeed")
+    .with_description("Fast hosted image and video model inference")
+    .with_supported_auth_types("api_key")
+    .build()
+)

--- a/autogpt_platform/backend/backend/blocks/wavespeed/ai_media_generator.py
+++ b/autogpt_platform/backend/backend/blocks/wavespeed/ai_media_generator.py
@@ -1,0 +1,202 @@
+import asyncio
+import logging
+from typing import Any
+
+from backend.blocks._base import (
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+)
+from backend.blocks.wavespeed._auth import (
+    TEST_CREDENTIALS,
+    TEST_CREDENTIALS_INPUT,
+    WaveSpeedCredentials,
+    WaveSpeedCredentialsField,
+    WaveSpeedCredentialsInput,
+)
+from backend.data.execution import ExecutionContext
+from backend.data.model import SchemaField
+from backend.util.file import store_media_file
+from backend.util.request import ClientResponseError, Requests
+from backend.util.type import MediaFileType
+
+logger = logging.getLogger(__name__)
+
+WAVESPEED_API_BASE = "https://api.wavespeed.ai/api/v3"
+
+
+class AIMediaGeneratorBlock(Block):
+    """
+    Block for running any image or video model on the WaveSpeed catalog.
+
+    This block allows you to:
+    - Run any model from the live wavespeed.ai catalog (Seedream, Seedance,
+      FLUX, Wan, ...)
+    - Pass a text prompt plus arbitrary extra model inputs
+    - Get back the generated media URL(s)
+    """
+
+    class Input(BlockSchemaInput):
+        credentials: WaveSpeedCredentialsInput = WaveSpeedCredentialsField()
+        model: str = SchemaField(
+            description="The WaveSpeed model ID (format: 'owner/model-name'). "
+            "See https://wavespeed.ai for the full catalog.",
+            default="bytedance/seedream-v5.0-pro",
+            placeholder="bytedance/seedream-v5.0-pro",
+            advanced=False,
+        )
+        prompt: str = SchemaField(
+            description="Text prompt describing the image or video to generate.",
+            placeholder="A serene mountain lake at sunrise, ultra detailed.",
+            advanced=False,
+        )
+        extra_inputs: dict[str, Any] = SchemaField(
+            default={},
+            description=(
+                "Additional model-specific inputs to include in the request "
+                "body, e.g. size, seed, or an image URL for image-to-image / "
+                "image-to-video models. Check the model's page on wavespeed.ai "
+                "for its input schema."
+            ),
+            placeholder='{"size": "2048*2048", "seed": -1}',
+            advanced=True,
+        )
+
+    class Output(BlockSchemaOutput):
+        media_url: str = SchemaField(
+            description="The URL of the (first) generated image or video."
+        )
+        media_urls: list[str] = SchemaField(
+            description="URLs of all generated outputs."
+        )
+        error: str = SchemaField(description="Error message if generation failed.")
+
+    def __init__(self):
+        super().__init__(
+            id="b9030fff-6434-48b9-9618-9e65044185fd",
+            description="Generate images and videos using WaveSpeed AI models.",
+            categories={BlockCategory.AI},
+            input_schema=self.Input,
+            output_schema=self.Output,
+            test_input={
+                "model": "bytedance/seedream-v5.0-pro",
+                "prompt": "A serene mountain lake at sunrise.",
+                "credentials": TEST_CREDENTIALS_INPUT,
+            },
+            test_credentials=TEST_CREDENTIALS,
+            test_output=[
+                # Output will be a workspace ref or data URI depending on context
+                ("media_url", lambda x: x.startswith(("workspace://", "data:"))),
+                (
+                    "media_urls",
+                    lambda x: all(
+                        url.startswith(("workspace://", "data:")) for url in x
+                    ),
+                ),
+            ],
+            test_mock={
+                # Use data URIs to avoid HTTP requests during tests
+                "generate_media": lambda *args, **kwargs: [
+                    "data:image/png;base64,iVBORw0KGgo="
+                ]
+            },
+        )
+
+    def _get_headers(self, api_key: str) -> dict[str, str]:
+        """Get headers for WaveSpeed API requests."""
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def generate_media(
+        self, input_data: Input, credentials: WaveSpeedCredentials
+    ) -> list[str]:
+        """Run the specified WaveSpeed model and return the output URLs."""
+        api_key = credentials.api_key.get_secret_value()
+        headers = self._get_headers(api_key)
+
+        # Submit the generation request
+        submit_url = f"{WAVESPEED_API_BASE}/{input_data.model}"
+        submit_body: dict[str, Any] = {
+            **input_data.extra_inputs,
+            "prompt": input_data.prompt,
+        }
+
+        try:
+            submit_response = await Requests().post(
+                submit_url, headers=headers, json=submit_body
+            )
+            submit_data = submit_response.json()
+        except ClientResponseError as e:
+            logger.error(f"WaveSpeed API request failed: {str(e)}")
+            raise RuntimeError(f"Failed to submit request: {str(e)}")
+
+        prediction_id = (submit_data.get("data") or {}).get("id")
+        if not prediction_id or not isinstance(prediction_id, str):
+            raise ValueError(
+                f"Missing prediction ID in submission response: "
+                f"{submit_data.get('message') or submit_data}"
+            )
+
+        # Poll for the result until a terminal status is reached
+        result_url = f"{WAVESPEED_API_BASE}/predictions/{prediction_id}/result"
+        max_attempts = 120
+        poll_interval = 2
+
+        for _attempt in range(max_attempts):
+            try:
+                result_response = await Requests().get(result_url, headers=headers)
+                result_data = result_response.json()
+            except ClientResponseError as e:
+                logger.error(f"Failed to get prediction result: {str(e)}")
+                raise RuntimeError(f"Failed to get prediction result: {str(e)}")
+
+            prediction = result_data.get("data") or {}
+            status = prediction.get("status")
+
+            if status == "completed":
+                outputs = [
+                    output
+                    for output in prediction.get("outputs") or []
+                    if isinstance(output, str)
+                ]
+                if not outputs:
+                    raise ValueError("No valid output URLs in response")
+                return outputs
+            elif status in ("failed", "cancelled", "timeout"):
+                error_msg = prediction.get("error") or "No error details provided"
+                raise RuntimeError(f"Generation {status}: {error_msg}")
+            else:
+                logger.debug(f"[WaveSpeed Generation] Status: {status}")
+
+            await asyncio.sleep(poll_interval)
+
+        raise RuntimeError("Maximum polling attempts reached")
+
+    async def run(
+        self,
+        input_data: Input,
+        *,
+        credentials: WaveSpeedCredentials,
+        execution_context: ExecutionContext,
+        **kwargs,
+    ) -> BlockOutput:
+        try:
+            output_urls = await self.generate_media(input_data, credentials)
+            # Store the generated media to the user's workspace for persistence
+            stored_urls = [
+                await store_media_file(
+                    file=MediaFileType(url),
+                    execution_context=execution_context,
+                    return_format="for_block_output",
+                )
+                for url in output_urls
+            ]
+            yield "media_url", stored_urls[0]
+            yield "media_urls", stored_urls
+        except Exception as e:
+            error_message = str(e)
+            yield "error", error_message

--- a/autogpt_platform/backend/backend/blocks/wavespeed/ai_media_generator_test.py
+++ b/autogpt_platform/backend/backend/blocks/wavespeed/ai_media_generator_test.py
@@ -1,0 +1,277 @@
+"""Tests for AIMediaGeneratorBlock: the submit/poll loop and every way it can
+fail. The block's own test_mock replaces generate_media wholesale, so the
+request building, the polling state machine and the error branches are only
+reachable from here."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from backend.blocks.wavespeed._auth import TEST_CREDENTIALS, TEST_CREDENTIALS_INPUT
+from backend.blocks.wavespeed.ai_media_generator import (
+    WAVESPEED_API_BASE,
+    AIMediaGeneratorBlock,
+)
+
+
+def _response(payload: dict) -> MagicMock:
+    """Stand-in for backend.util.request.Response — json() is sync there."""
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def _submitted(prediction_id: str = "pred-123") -> dict:
+    return {"data": {"id": prediction_id}}
+
+
+def _client_error(message: str = "boom") -> aiohttp.ClientResponseError:
+    return aiohttp.ClientResponseError(
+        request_info=MagicMock(), history=(), status=500, message=message
+    )
+
+
+def _input(**overrides) -> AIMediaGeneratorBlock.Input:
+    kwargs: dict = {
+        "credentials": TEST_CREDENTIALS_INPUT,
+        "model": "bytedance/seedream-v5.0-pro",
+        "prompt": "A serene mountain lake at sunrise.",
+    }
+    kwargs.update(overrides)
+    return AIMediaGeneratorBlock.Input(**kwargs)
+
+
+def _patch_requests(post=None, get=None):
+    """Patch the Requests class so every Requests() instance shares our mocks."""
+    instance = MagicMock()
+    instance.post = post or AsyncMock()
+    instance.get = get or AsyncMock()
+    return (
+        patch(
+            "backend.blocks.wavespeed.ai_media_generator.Requests",
+            return_value=instance,
+        ),
+        instance,
+    )
+
+
+def test_get_headers_carries_the_bearer_token():
+    headers = AIMediaGeneratorBlock()._get_headers("secret-key")
+    assert headers == {
+        "Authorization": "Bearer secret-key",
+        "Content-Type": "application/json",
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_media_submits_prompt_merged_with_extra_inputs():
+    """extra_inputs is spread into the body, but prompt must win — otherwise a
+    stray "prompt" key in extra_inputs would silently replace the real one."""
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(
+        return_value=_response(
+            {"data": {"status": "completed", "outputs": ["https://cdn/a.png"]}}
+        )
+    )
+    patcher, _ = _patch_requests(post, get)
+    with patcher:
+        outputs = await AIMediaGeneratorBlock().generate_media(
+            _input(extra_inputs={"size": "2048*2048", "prompt": "ignored"}),
+            TEST_CREDENTIALS,
+        )
+
+    assert outputs == ["https://cdn/a.png"]
+    assert post.await_args.args[0] == (
+        f"{WAVESPEED_API_BASE}/bytedance/seedream-v5.0-pro"
+    )
+    assert post.await_args.kwargs["json"] == {
+        "size": "2048*2048",
+        "prompt": "A serene mountain lake at sunrise.",
+    }
+    assert get.await_args.args[0] == (
+        f"{WAVESPEED_API_BASE}/predictions/pred-123/result"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_media_polls_until_the_status_is_terminal():
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(
+        side_effect=[
+            _response({"data": {"status": "created"}}),
+            _response({"data": {"status": "processing"}}),
+            _response(
+                {"data": {"status": "completed", "outputs": ["https://cdn/b.mp4"]}}
+            ),
+        ]
+    )
+    patcher, _ = _patch_requests(post, get)
+    with patcher, patch(
+        "backend.blocks.wavespeed.ai_media_generator.asyncio.sleep", new=AsyncMock()
+    ) as sleep:
+        outputs = await AIMediaGeneratorBlock().generate_media(
+            _input(), TEST_CREDENTIALS
+        )
+
+    assert outputs == ["https://cdn/b.mp4"]
+    assert get.await_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_media_keeps_only_string_outputs():
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(
+        return_value=_response(
+            {
+                "data": {
+                    "status": "completed",
+                    "outputs": ["https://cdn/a.png", None, {"url": "x"}, 7],
+                }
+            }
+        )
+    )
+    patcher, _ = _patch_requests(post, get)
+    with patcher:
+        outputs = await AIMediaGeneratorBlock().generate_media(
+            _input(), TEST_CREDENTIALS
+        )
+
+    assert outputs == ["https://cdn/a.png"]
+
+
+@pytest.mark.asyncio
+async def test_generate_media_raises_when_the_submission_call_fails():
+    post = AsyncMock(side_effect=_client_error("submit exploded"))
+    patcher, _ = _patch_requests(post)
+    with patcher, pytest.raises(RuntimeError, match="Failed to submit request"):
+        await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"message": "quota exceeded"},
+        {"data": {}},
+        {"data": {"id": 12345}},
+        {"data": None},
+    ],
+)
+async def test_generate_media_raises_without_a_usable_prediction_id(payload):
+    """A non-string or absent id must fail before polling, not build a URL like
+    /predictions/None/result and burn 120 polls on it."""
+    post = AsyncMock(return_value=_response(payload))
+    get = AsyncMock()
+    patcher, _ = _patch_requests(post, get)
+    with patcher, pytest.raises(ValueError, match="Missing prediction ID"):
+        await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+    get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generate_media_raises_when_polling_fails():
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(side_effect=_client_error("poll exploded"))
+    patcher, _ = _patch_requests(post, get)
+    with patcher, pytest.raises(RuntimeError, match="Failed to get prediction result"):
+        await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+
+@pytest.mark.asyncio
+async def test_generate_media_raises_when_a_completed_run_has_no_urls():
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(
+        return_value=_response({"data": {"status": "completed", "outputs": []}})
+    )
+    patcher, _ = _patch_requests(post, get)
+    with patcher, pytest.raises(ValueError, match="No valid output URLs"):
+        await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["failed", "cancelled", "timeout"])
+async def test_generate_media_surfaces_terminal_failure_statuses(status):
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(
+        return_value=_response(
+            {"data": {"status": status, "error": "upstream said no"}}
+        )
+    )
+    patcher, _ = _patch_requests(post, get)
+    with patcher, pytest.raises(RuntimeError, match=f"Generation {status}"):
+        await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+
+@pytest.mark.asyncio
+async def test_generate_media_reports_missing_error_details():
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(return_value=_response({"data": {"status": "failed"}}))
+    patcher, _ = _patch_requests(post, get)
+    with patcher, pytest.raises(RuntimeError, match="No error details provided"):
+        await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+
+@pytest.mark.asyncio
+async def test_generate_media_gives_up_after_the_polling_budget():
+    post = AsyncMock(return_value=_response(_submitted()))
+    get = AsyncMock(return_value=_response({"data": {"status": "processing"}}))
+    patcher, _ = _patch_requests(post, get)
+    with patcher, patch(
+        "backend.blocks.wavespeed.ai_media_generator.asyncio.sleep", new=AsyncMock()
+    ):
+        with pytest.raises(RuntimeError, match="Maximum polling attempts reached"):
+            await AIMediaGeneratorBlock().generate_media(_input(), TEST_CREDENTIALS)
+
+    assert get.await_count == 120
+
+
+@pytest.mark.asyncio
+async def test_run_stores_every_output_and_yields_the_first():
+    stored = AsyncMock(side_effect=lambda **kw: f"workspace://{kw['file']}")
+    with patch.object(
+        AIMediaGeneratorBlock,
+        "generate_media",
+        new=AsyncMock(return_value=["https://cdn/a.png", "https://cdn/b.png"]),
+    ), patch(
+        "backend.blocks.wavespeed.ai_media_generator.store_media_file", new=stored
+    ):
+        outputs = [
+            item
+            async for item in AIMediaGeneratorBlock().run(
+                _input(),
+                credentials=TEST_CREDENTIALS,
+                execution_context=MagicMock(),
+            )
+        ]
+
+    assert outputs == [
+        ("media_url", "workspace://https://cdn/a.png"),
+        (
+            "media_urls",
+            ["workspace://https://cdn/a.png", "workspace://https://cdn/b.png"],
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_yields_error_instead_of_raising():
+    """Errors have to come back on the error pin; a raise would abort the whole
+    graph run rather than letting the user branch on it."""
+    with patch.object(
+        AIMediaGeneratorBlock,
+        "generate_media",
+        new=AsyncMock(side_effect=RuntimeError("Generation failed: upstream said no")),
+    ):
+        outputs = [
+            item
+            async for item in AIMediaGeneratorBlock().run(
+                _input(),
+                credentials=TEST_CREDENTIALS,
+                execution_context=MagicMock(),
+            )
+        ]
+
+    assert outputs == [("error", "Generation failed: upstream said no")]

--- a/autogpt_platform/backend/backend/blocks/wavespeed/conftest.py
+++ b/autogpt_platform/backend/backend/blocks/wavespeed/conftest.py
@@ -1,0 +1,20 @@
+"""Keep the WaveSpeed unit tests independent of platform services.
+
+Mirrors backend/blocks/dataforb2b/conftest.py: these tests only exercise the
+block's request building and polling logic, so they have no reason to spin up
+a test server or touch the database.
+"""
+
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def server() -> None:
+    return None
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
+async def graph_cleanup() -> AsyncIterator[None]:
+    yield

--- a/autogpt_platform/backend/backend/integrations/providers.py
+++ b/autogpt_platform/backend/backend/integrations/providers.py
@@ -57,6 +57,7 @@ class ProviderName(str, Enum):
     TODOIST = "todoist"
     UNREAL_SPEECH = "unreal_speech"
     V0 = "v0"
+    WAVESPEED = "wavespeed"
     WEBSHARE_PROXY = "webshare_proxy"
     ZEROBOUNCE = "zerobounce"
 

--- a/autogpt_platform/frontend/src/components/contextual/CredentialsInput/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/CredentialsInput/helpers.ts
@@ -57,6 +57,7 @@ export const providerIcons: Partial<
   replicate: fallbackIcon,
   reddit: fallbackIcon,
   fal: fallbackIcon,
+  wavespeed: fallbackIcon,
   revid: fallbackIcon,
   twitter: FaTwitter,
   unreal_speech: fallbackIcon,

--- a/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/helpers.ts
+++ b/autogpt_platform/frontend/src/components/renderers/InputRenderer/custom/CredentialField/helpers.ts
@@ -123,6 +123,7 @@ export const providerIcons: Partial<Record<string, IconSvgElement>> = {
   replicate: LockKeyIcon,
   reddit: LockKeyIcon,
   fal: LockKeyIcon,
+  wavespeed: LockKeyIcon,
   revid: LockKeyIcon,
   twitter: TwitterIcon,
   unreal_speech: LockKeyIcon,

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -226,6 +226,7 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [AI Image Editor](block-integrations/llm.md#ai-image-editor) | Edit images using Flux Kontext or Google Nano Banana models |
 | [AI Image Generator](block-integrations/llm.md#ai-image-generator) | Generate images using various AI models through a unified interface |
 | [AI List Generator](block-integrations/llm.md#ai-list-generator) | A block that creates lists of items based on prompts using a Large Language Model (LLM), with optional source data for context |
+| [AI Media Generator](block-integrations/wavespeed/ai_media_generator.md#ai-media-generator) | Generate images and videos using WaveSpeed AI models |
 | [AI Music Generator](block-integrations/llm.md#ai-music-generator) | This block generates music using Meta's MusicGen model on Replicate |
 | [AI Screenshot To Video Ad](block-integrations/llm.md#ai-screenshot-to-video-ad) | Turns a screenshot into an engaging, avatar‑narrated video advert |
 | [AI Shortform Video Creator](block-integrations/llm.md#ai-shortform-video-creator) | Creates a shortform video using revid |

--- a/docs/integrations/SUMMARY.md
+++ b/docs/integrations/SUMMARY.md
@@ -167,5 +167,6 @@
 * [Video Loop](block-integrations/video/loop.md)
 * [Video Narration](block-integrations/video/narration.md)
 * [Video Text Overlay](block-integrations/video/text_overlay.md)
+* [Wavespeed AI Media Generator](block-integrations/wavespeed/ai_media_generator.md)
 * [Wolfram LLM API](block-integrations/wolfram/llm_api.md)
 * [Zerobounce Validate Emails](block-integrations/zerobounce/validate_emails.md)

--- a/docs/integrations/block-integrations/wavespeed/ai_media_generator.md
+++ b/docs/integrations/block-integrations/wavespeed/ai_media_generator.md
@@ -1,0 +1,39 @@
+# Wavespeed AI Media Generator
+<!-- MANUAL: file_description -->
+Blocks for generating AI images and videos using WaveSpeed models.
+<!-- END MANUAL -->
+
+## AI Media Generator
+
+### What it is
+Generate images and videos using WaveSpeed AI models.
+
+### How it works
+<!-- MANUAL: how_it_works -->
+This block runs any image or video generation model on the live WaveSpeed catalog, including Seedream, Seedance, FLUX, and Wan. Pick a model ID from wavespeed.ai, describe what you want to generate, and optionally pass model-specific parameters (size, seed, an input image URL, ...) via the extra inputs field.
+
+The block submits the generation request, polls until the prediction completes, and returns the generated media URL(s).
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| model | The WaveSpeed model ID (format: 'owner/model-name'). See https://wavespeed.ai for the full catalog. | str | No |
+| prompt | Text prompt describing the image or video to generate. | str | Yes |
+| extra_inputs | Additional model-specific inputs to include in the request body, e.g. size, seed, or an image URL for image-to-image / image-to-video models. Check the model's page on wavespeed.ai for its input schema. | Dict[str, Any] | No |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| error | Error message if generation failed. | str |
+| media_url | The URL of the (first) generated image or video. | str |
+| media_urls | URLs of all generated outputs. | List[str] |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+Generate product imagery with Seedream for a marketing agent, or turn a still image into a short video clip with Seedance as part of a content pipeline.
+<!-- END MANUAL -->
+
+---


### PR DESCRIPTION
### Why / What / How

**Why:** WaveSpeed (https://wavespeed.ai) is a hosted inference platform for image and video generation models (Seedream, Seedance, FLUX, Wan, and more). This PR adds it as a generation provider alongside the existing FAL, Replicate, and Ideogram blocks, so agents can run any model on the live WaveSpeed catalog.

**What:** A new `AIMediaGeneratorBlock` (`backend/blocks/wavespeed/`) that runs any image/video model on wavespeed.ai, plus the standard provider registration (provider enum, `ProviderBuilder` config, frontend credential icons).

**How:** The block mirrors the FAL block pattern: submit `POST https://api.wavespeed.ai/api/v3/{model}` with the prompt and any extra model-specific inputs, then poll `GET /api/v3/predictions/{id}/result` until the prediction reaches a terminal status, and store the resulting media URL(s) to the user's workspace via `store_media_file`. Credentials use the standard `APIKeyCredentials` / `CredentialsField` pattern (API key from wavespeed.ai).

### Changes 🏗️

- `backend/blocks/wavespeed/ai_media_generator.py` — new `AIMediaGeneratorBlock`: inputs are `model` (any catalog model ID, default `bytedance/seedream-v5.0-pro`), `prompt`, and an advanced `extra_inputs` dict for model-specific parameters (size, seed, input image URL, ...); outputs are `media_url` / `media_urls`. Includes `test_input` / `test_output` / `test_mock` following the block auto-test convention.
- `backend/blocks/wavespeed/_auth.py` — WaveSpeed API-key credentials helpers + test credentials (mirrors `blocks/fal/_auth.py`).
- `backend/blocks/wavespeed/_config.py` — `ProviderBuilder("wavespeed")` registration (mirrors `blocks/fal/_config.py`).
- `backend/integrations/providers.py` — added `WAVESPEED = "wavespeed"` to `ProviderName`.
- `frontend/.../CredentialsInput/helpers.ts`, `frontend/.../CredentialField/helpers.ts` — fallback/lock icons for the `wavespeed` provider (same as other API-key providers).
- `docs/integrations/...` — regenerated block docs (`scripts/generate_block_docs.py`).

No configuration, `.env.default`, or `docker-compose.yml` changes — users bring their own API key from wavespeed.ai.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run black --check` / `ruff check` / `isort --check` pass on the new files
  - [x] Block auto-test (`backend/blocks/test/test_block.py`) executes the new block against its mocked `generate_media`, verifying schema, credentials wiring, and outputs
  - [x] Verified request/response handling against the live WaveSpeed API v3 contract (submit → `data.id`, poll `predictions/{id}/result` → `data.status` / `data.outputs` / `data.error`)

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJJXU9zyoDSBjApcUpteDt
