### PR TITLE
fix(backend): aggregate sub-graph credentials in copilot run/trigger tools

### DIFF
--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -347,20 +347,27 @@ async def get_store_agent_details(
 
 @overload
 async def get_available_graph(
-    store_listing_version_id: str, hide_nodes: Literal[False]
+    store_listing_version_id: str,
+    hide_nodes: Literal[False],
+    include_subgraphs: bool = False,
 ) -> GraphModel: ...
 
 
 @overload
 async def get_available_graph(
-    store_listing_version_id: str, hide_nodes: Literal[True] = True
+    store_listing_version_id: str,
+    hide_nodes: Literal[True] = True,
+    include_subgraphs: bool = False,
 ) -> GraphModelWithoutNodes: ...
 
 
 async def get_available_graph(
     store_listing_version_id: str,
     hide_nodes: bool = True,
+    include_subgraphs: bool = False,
 ) -> GraphModelWithoutNodes | GraphModel:
+    """``include_subgraphs`` is required for a complete
+    `credentials_input_schema`, which aggregates sub-graph credentials too."""
     try:
         # Get avaialble, non-deleted store listing version
         store_listing_version = (
@@ -380,7 +387,12 @@ async def get_available_graph(
             )
 
         return (GraphModelWithoutNodes if hide_nodes else GraphModel).from_db(
-            store_listing_version.AgentGraph
+            store_listing_version.AgentGraph,
+            sub_graphs=(
+                await get_sub_graphs(store_listing_version.AgentGraph)
+                if include_subgraphs
+                else None
+            ),
         )
 
     except Exception as e:

--- a/autogpt_platform/backend/backend/copilot/tools/_test_data.py
+++ b/autogpt_platform/backend/backend/copilot/tools/_test_data.py
@@ -17,7 +17,7 @@ from backend.blocks.llm import AITextGeneratorBlock
 from backend.copilot.model import ChatMessage, ChatSession
 from backend.data import db as db_module
 from backend.data.db import prisma
-from backend.data.graph import Graph, Link, Node, create_graph
+from backend.data.graph import Graph, GraphModel, Link, Node, create_graph
 from backend.data.model import APIKeyCredentials
 from backend.data.user import get_or_create_user
 from backend.integrations.credentials_store import IntegrationCredentialsStore
@@ -106,33 +106,7 @@ async def setup_test_data(server):
     await _ensure_db_connected()
 
     # 1. Create a test user
-    user_data = {
-        "sub": f"test-user-{uuid.uuid4()}",
-        "email": f"test-{uuid.uuid4()}@example.com",
-    }
-    user = await get_or_create_user(user_data)
-
-    # 1b. Create a profile with username for the user (required for store agent lookup)
-    username = user.email.split("@")[0]
-    await prisma.profile.upsert(
-        where={"userId": user.id},
-        data={
-            # get_or_create_user auto-creates a default profile; tests need
-            # this specific username for store agent lookups.
-            "create": ProfileCreateInput(
-                userId=user.id,
-                username=username,
-                name=f"Test User {username}",
-                description="Test user profile",
-                links=[],
-            ),
-            "update": {
-                "username": username,
-                "name": f"Test User {username}",
-                "description": "Test user profile",
-            },
-        },
-    )
+    user = await _create_user_with_profile("Test user profile")
 
     # 2. Create a test graph with agent input -> agent output
     graph_id = str(uuid.uuid4())
@@ -192,29 +166,15 @@ async def setup_test_data(server):
 
     created_graph = await create_graph(graph, user.id)
 
-    # 3. Create a store listing and store listing version for the agent
-    # Use unique slug to avoid constraint violations
-    unique_slug = f"test-agent-{str(uuid.uuid4())[:8]}"
-    store_submission = await store_db.create_store_submission(
-        user_id=user.id,
-        graph_id=created_graph.id,
-        graph_version=created_graph.version,
-        slug=unique_slug,
+    # 3. Create and approve a store listing
+    store_submission = await _publish_to_store(
+        user.id,
+        created_graph,
+        slug_prefix="test-agent",
         name="Test Agent",
         description="A simple test agent",
         sub_heading="Test agent for unit tests",
         categories=["testing"],
-        image_urls=["https://example.com/image.jpg"],
-    )
-
-    assert store_submission.listing_version_id is not None
-    # 4. Approve the store listing version
-    await store_db.review_store_submission(
-        store_listing_version_id=store_submission.listing_version_id,
-        is_approved=True,
-        external_comments="Approved for testing",
-        internal_comments="Test approval",
-        reviewer_id=user.id,
     )
 
     return {
@@ -242,33 +202,7 @@ async def setup_llm_test_data(server):
         return pytest.skip("OPENAI_API_KEY is not set")
 
     # 1. Create a test user
-    user_data = {
-        "sub": f"test-user-{uuid.uuid4()}",
-        "email": f"test-{uuid.uuid4()}@example.com",
-    }
-    user = await get_or_create_user(user_data)
-
-    # 1b. Create a profile with username for the user (required for store agent lookup)
-    username = user.email.split("@")[0]
-    await prisma.profile.upsert(
-        where={"userId": user.id},
-        data={
-            # get_or_create_user auto-creates a default profile; tests need
-            # this specific username for store agent lookups.
-            "create": ProfileCreateInput(
-                userId=user.id,
-                username=username,
-                name=f"Test User {username}",
-                description="Test user profile for LLM tests",
-                links=[],
-            ),
-            "update": {
-                "username": username,
-                "name": f"Test User {username}",
-                "description": "Test user profile for LLM tests",
-            },
-        },
-    )
+    user = await _create_user_with_profile("Test user profile for LLM tests")
 
     # 2. Create test OpenAI credentials for the user
     credentials = APIKeyCredentials(
@@ -373,25 +307,14 @@ async def setup_llm_test_data(server):
     created_graph = await create_graph(graph, user.id)
 
     # 4. Create and approve a store listing
-    unique_slug = f"llm-test-agent-{str(uuid.uuid4())[:8]}"
-    store_submission = await store_db.create_store_submission(
-        user_id=user.id,
-        graph_id=created_graph.id,
-        graph_version=created_graph.version,
-        slug=unique_slug,
+    store_submission = await _publish_to_store(
+        user.id,
+        created_graph,
+        slug_prefix="llm-test-agent",
         name="LLM Test Agent",
         description="An agent with LLM capabilities",
         sub_heading="Test agent with OpenAI integration",
         categories=["testing", "ai"],
-        image_urls=["https://example.com/image.jpg"],
-    )
-    assert store_submission.listing_version_id is not None
-    await store_db.review_store_submission(
-        store_listing_version_id=store_submission.listing_version_id,
-        is_approved=True,
-        external_comments="Approved for testing",
-        internal_comments="Test approval for LLM agent",
-        reviewer_id=user.id,
     )
 
     return {
@@ -415,33 +338,7 @@ async def setup_firecrawl_test_data(server):
     await _ensure_db_connected()
 
     # 1. Create a test user
-    user_data = {
-        "sub": f"test-user-{uuid.uuid4()}",
-        "email": f"test-{uuid.uuid4()}@example.com",
-    }
-    user = await get_or_create_user(user_data)
-
-    # 1b. Create a profile with username for the user (required for store agent lookup)
-    username = user.email.split("@")[0]
-    await prisma.profile.upsert(
-        where={"userId": user.id},
-        data={
-            # get_or_create_user auto-creates a default profile; tests need
-            # this specific username for store agent lookups.
-            "create": ProfileCreateInput(
-                userId=user.id,
-                username=username,
-                name=f"Test User {username}",
-                description="Test user profile for Firecrawl tests",
-                links=[],
-            ),
-            "update": {
-                "username": username,
-                "name": f"Test User {username}",
-                "description": "Test user profile for Firecrawl tests",
-            },
-        },
-    )
+    user = await _create_user_with_profile("Test user profile for Firecrawl tests")
 
     # NOTE: We deliberately do NOT create Firecrawl credentials for this user
     # This tests the scenario where required credentials are missing
@@ -456,25 +353,14 @@ async def setup_firecrawl_test_data(server):
     )
 
     # 3. Create and approve a store listing
-    unique_slug = f"firecrawl-test-agent-{str(uuid.uuid4())[:8]}"
-    store_submission = await store_db.create_store_submission(
-        user_id=user.id,
-        graph_id=created_graph.id,
-        graph_version=created_graph.version,
-        slug=unique_slug,
+    store_submission = await _publish_to_store(
+        user.id,
+        created_graph,
+        slug_prefix="firecrawl-test-agent",
         name="Firecrawl Test Agent",
         description="An agent with Firecrawl integration (no credentials)",
         sub_heading="Test agent requiring Firecrawl credentials",
         categories=["testing", "scraping"],
-        image_urls=["https://example.com/image.jpg"],
-    )
-    assert store_submission.listing_version_id is not None
-    await store_db.review_store_submission(
-        store_listing_version_id=store_submission.listing_version_id,
-        is_approved=True,
-        external_comments="Approved for testing",
-        internal_comments="Test approval for Firecrawl agent",
-        reviewer_id=user.id,
     )
 
     return {
@@ -497,30 +383,7 @@ async def setup_subagent_test_data(server):
     await _ensure_db_connected()
 
     # 1. Create a test user (deliberately without Firecrawl credentials)
-    user_data = {
-        "sub": f"test-user-{uuid.uuid4()}",
-        "email": f"test-{uuid.uuid4()}@example.com",
-    }
-    user = await get_or_create_user(user_data)
-
-    username = user.email.split("@")[0]
-    await prisma.profile.upsert(
-        where={"userId": user.id},
-        data={
-            "create": ProfileCreateInput(
-                userId=user.id,
-                username=username,
-                name=f"Test User {username}",
-                description="Test user profile for sub-agent tests",
-                links=[],
-            ),
-            "update": {
-                "username": username,
-                "name": f"Test User {username}",
-                "description": "Test user profile for sub-agent tests",
-            },
-        },
-    )
+    user = await _create_user_with_profile("Test user profile for sub-agent tests")
 
     # 2. Create the Firecrawl sub-graph
     sub_graph = await create_graph(
@@ -614,24 +477,14 @@ async def setup_subagent_test_data(server):
     assert len(library_agents) == 1
 
     # 4b. Create and approve a store listing (the marketplace slug run path)
-    store_submission = await store_db.create_store_submission(
-        user_id=user.id,
-        graph_id=parent_graph.id,
-        graph_version=parent_graph.version,
-        slug=f"subagent-test-agent-{str(uuid.uuid4())[:8]}",
+    store_submission = await _publish_to_store(
+        user.id,
+        parent_graph,
+        slug_prefix="subagent-test-agent",
         name="Sub-Agent Orchestrator",
         description="An agent whose only credentials live in its sub-agent",
         sub_heading="Test agent requiring sub-agent credentials",
         categories=["testing"],
-        image_urls=["https://example.com/image.jpg"],
-    )
-    assert store_submission.listing_version_id is not None
-    await store_db.review_store_submission(
-        store_listing_version_id=store_submission.listing_version_id,
-        is_approved=True,
-        external_comments="Approved for testing",
-        internal_comments="Test approval for sub-agent orchestrator",
-        reviewer_id=user.id,
     )
 
     return {
@@ -641,6 +494,71 @@ async def setup_subagent_test_data(server):
         "library_agent": library_agents[0],
         "store_submission": store_submission,
     }
+
+
+async def _create_user_with_profile(profile_description: str):
+    """Create a test user + profile. The username is required for store lookups."""
+    user = await get_or_create_user(
+        {
+            "sub": f"test-user-{uuid.uuid4()}",
+            "email": f"test-{uuid.uuid4()}@example.com",
+        }
+    )
+    username = user.email.split("@")[0]
+    await prisma.profile.upsert(
+        where={"userId": user.id},
+        data={
+            # get_or_create_user auto-creates a default profile; tests need
+            # this specific username for store agent lookups.
+            "create": ProfileCreateInput(
+                userId=user.id,
+                username=username,
+                name=f"Test User {username}",
+                description=profile_description,
+                links=[],
+            ),
+            "update": {
+                "username": username,
+                "name": f"Test User {username}",
+                "description": profile_description,
+            },
+        },
+    )
+    return user
+
+
+async def _publish_to_store(
+    user_id: str,
+    graph: GraphModel,
+    *,
+    slug_prefix: str,
+    name: str,
+    description: str,
+    sub_heading: str,
+    categories: list[str],
+):
+    """Submit `graph` to the store and approve it. The slug gets a random
+    suffix to avoid constraint violations across runs."""
+    submission = await store_db.create_store_submission(
+        user_id=user_id,
+        graph_id=graph.id,
+        graph_version=graph.version,
+        slug=f"{slug_prefix}-{str(uuid.uuid4())[:8]}",
+        name=name,
+        description=description,
+        sub_heading=sub_heading,
+        categories=categories,
+        image_urls=["https://example.com/image.jpg"],
+    )
+    assert submission.listing_version_id is not None
+    await store_db.review_store_submission(
+        store_listing_version_id=submission.listing_version_id,
+        is_approved=True,
+        external_comments="Approved for testing",
+        internal_comments=f"Test approval for {name}",
+        reviewer_id=user_id,
+    )
+    return submission
 
 
 def _build_firecrawl_graph(name: str, description: str) -> Graph:

--- a/autogpt_platform/backend/backend/copilot/tools/_test_data.py
+++ b/autogpt_platform/backend/backend/copilot/tools/_test_data.py
@@ -8,7 +8,9 @@ import pytest_asyncio
 from prisma.types import ProfileCreateInput
 from pydantic import SecretStr
 
+from backend.api.features.library import db as library_db
 from backend.api.features.store import db as store_db
+from backend.blocks.agent import AgentExecutorBlock
 from backend.blocks.firecrawl.scrape import FirecrawlScrapeBlock
 from backend.blocks.io import AgentInputBlock, AgentOutputBlock
 from backend.blocks.llm import AITextGeneratorBlock
@@ -445,94 +447,13 @@ async def setup_firecrawl_test_data(server):
     # This tests the scenario where required credentials are missing
 
     # 2. Create a test graph with input -> Firecrawl block -> output
-    graph_id = str(uuid.uuid4())
-
-    # Create input node for the URL
-    input_node_id = str(uuid.uuid4())
-    input_block = AgentInputBlock()
-    input_node = Node(
-        id=input_node_id,
-        block_id=input_block.id,
-        input_default={
-            "name": "url",
-            "title": "URL to Scrape",
-            "value": "",
-            "advanced": False,
-            "description": "URL for Firecrawl to scrape",
-        },
-        metadata={"position": {"x": 0, "y": 0}},
+    created_graph = await create_graph(
+        _build_firecrawl_graph(
+            name="Firecrawl Test Agent",
+            description="An agent that uses Firecrawl to scrape websites",
+        ),
+        user.id,
     )
-
-    # Create Firecrawl block node
-    firecrawl_node_id = str(uuid.uuid4())
-    firecrawl_block = FirecrawlScrapeBlock()
-    firecrawl_node = Node(
-        id=firecrawl_node_id,
-        block_id=firecrawl_block.id,
-        input_default={
-            "limit": 10,
-            "only_main_content": True,
-            "max_age": 3600000,
-            "wait_for": 200,
-            "formats": ["markdown"],
-            "credentials": {
-                "provider": "firecrawl",
-                "id": "test-firecrawl-id",
-                "type": "api_key",
-                "title": "Firecrawl API Key",
-            },
-        },
-        metadata={"position": {"x": 300, "y": 0}},
-    )
-
-    # Create output node
-    output_node_id = str(uuid.uuid4())
-    output_block = AgentOutputBlock()
-    output_node = Node(
-        id=output_node_id,
-        block_id=output_block.id,
-        input_default={
-            "name": "scraped_data",
-            "title": "Scraped Data",
-            "value": "",
-            "format": "",
-            "advanced": False,
-            "description": "Data scraped by Firecrawl",
-        },
-        metadata={"position": {"x": 600, "y": 0}},
-    )
-
-    # Create links
-    # Link input.result -> firecrawl.url
-    link1 = Link(
-        source_id=input_node_id,
-        sink_id=firecrawl_node_id,
-        source_name="result",
-        sink_name="url",
-        is_static=True,
-    )
-
-    # Link firecrawl.markdown -> output.value
-    link2 = Link(
-        source_id=firecrawl_node_id,
-        sink_id=output_node_id,
-        source_name="markdown",
-        sink_name="value",
-        is_static=False,
-    )
-
-    # Create the graph
-    graph = Graph(
-        id=graph_id,
-        version=1,
-        is_active=True,
-        name="Firecrawl Test Agent",
-        description="An agent that uses Firecrawl to scrape websites",
-        nodes=[input_node, firecrawl_node, output_node],
-        links=[link1, link2],
-    )
-
-    created_graph = await create_graph(graph, user.id)
 
     # 3. Create and approve a store listing
     unique_slug = f"firecrawl-test-agent-{str(uuid.uuid4())[:8]}"
@@ -561,3 +482,239 @@ async def setup_firecrawl_test_data(server):
         "graph": created_graph,
         "store_submission": store_submission,
     }
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def setup_subagent_test_data(server):
+    """
+    Orchestrator agent (input -> AgentExecutorBlock -> output) wrapping a
+    Firecrawl sub-graph, for a user without Firecrawl credentials. The parent
+    has NO credential fields of its own; all of them live in the sub-graph.
+
+    Registered both in the library and the store, to cover both run paths.
+    Depends on ``server`` to ensure Prisma is connected.
+    """
+    await _ensure_db_connected()
+
+    # 1. Create a test user (deliberately without Firecrawl credentials)
+    user_data = {
+        "sub": f"test-user-{uuid.uuid4()}",
+        "email": f"test-{uuid.uuid4()}@example.com",
+    }
+    user = await get_or_create_user(user_data)
+
+    username = user.email.split("@")[0]
+    await prisma.profile.upsert(
+        where={"userId": user.id},
+        data={
+            "create": ProfileCreateInput(
+                userId=user.id,
+                username=username,
+                name=f"Test User {username}",
+                description="Test user profile for sub-agent tests",
+                links=[],
+            ),
+            "update": {
+                "username": username,
+                "name": f"Test User {username}",
+                "description": "Test user profile for sub-agent tests",
+            },
+        },
+    )
+
+    # 2. Create the Firecrawl sub-graph
+    sub_graph = await create_graph(
+        _build_firecrawl_graph(
+            name="Firecrawl Sub-Agent",
+            description="Sub-agent that scrapes a website with Firecrawl",
+        ),
+        user.id,
+    )
+
+    # 3. Create the parent graph: input -> sub-agent -> output
+    input_node_id = str(uuid.uuid4())
+    input_node = Node(
+        id=input_node_id,
+        block_id=AgentInputBlock().id,
+        input_default={
+            "name": "url",
+            "title": "URL to Scrape",
+            "value": "",
+            "advanced": False,
+            "description": "URL to hand to the sub-agent",
+        },
+        metadata={"position": {"x": 0, "y": 0}},
+    )
+
+    sub_agent_node_id = str(uuid.uuid4())
+    sub_agent_node = Node(
+        id=sub_agent_node_id,
+        block_id=AgentExecutorBlock().id,
+        input_default={
+            # Placeholders filled at execution time, as the builder persists them
+            "user_id": "",
+            "inputs": {},
+            "graph_id": sub_graph.id,
+            "graph_version": sub_graph.version,
+            "input_schema": sub_graph.input_schema,
+            "output_schema": sub_graph.output_schema,
+        },
+        metadata={"position": {"x": 300, "y": 0}},
+    )
+
+    output_node_id = str(uuid.uuid4())
+    output_node = Node(
+        id=output_node_id,
+        block_id=AgentOutputBlock().id,
+        input_default={
+            "name": "scraped_data",
+            "title": "Scraped Data",
+            "value": "",
+            "format": "",
+            "advanced": False,
+            "description": "Data scraped by the sub-agent",
+        },
+        metadata={"position": {"x": 600, "y": 0}},
+    )
+
+    parent_graph = await create_graph(
+        Graph(
+            id=str(uuid.uuid4()),
+            version=1,
+            is_active=True,
+            name="Sub-Agent Orchestrator",
+            description="An agent whose only credentials live in its sub-agent",
+            nodes=[input_node, sub_agent_node, output_node],
+            links=[
+                Link(
+                    source_id=input_node_id,
+                    sink_id=sub_agent_node_id,
+                    source_name="result",
+                    sink_name="url",
+                    is_static=True,
+                ),
+                Link(
+                    source_id=sub_agent_node_id,
+                    sink_id=output_node_id,
+                    source_name="scraped_data",
+                    sink_name="value",
+                    is_static=False,
+                ),
+            ],
+        ),
+        user.id,
+    )
+
+    # 4a. Add the parent to the user's library (the library_agent_id run path)
+    library_agents = await library_db.create_library_agent(
+        graph=parent_graph,
+        user_id=user.id,
+        create_library_agents_for_sub_graphs=False,
+    )
+    assert len(library_agents) == 1
+
+    # 4b. Create and approve a store listing (the marketplace slug run path)
+    store_submission = await store_db.create_store_submission(
+        user_id=user.id,
+        graph_id=parent_graph.id,
+        graph_version=parent_graph.version,
+        slug=f"subagent-test-agent-{str(uuid.uuid4())[:8]}",
+        name="Sub-Agent Orchestrator",
+        description="An agent whose only credentials live in its sub-agent",
+        sub_heading="Test agent requiring sub-agent credentials",
+        categories=["testing"],
+        image_urls=["https://example.com/image.jpg"],
+    )
+    assert store_submission.listing_version_id is not None
+    await store_db.review_store_submission(
+        store_listing_version_id=store_submission.listing_version_id,
+        is_approved=True,
+        external_comments="Approved for testing",
+        internal_comments="Test approval for sub-agent orchestrator",
+        reviewer_id=user.id,
+    )
+
+    return {
+        "user": user,
+        "graph": parent_graph,
+        "sub_graph": sub_graph,
+        "library_agent": library_agents[0],
+        "store_submission": store_submission,
+    }
+
+
+def _build_firecrawl_graph(name: str, description: str) -> Graph:
+    """input -> FirecrawlScrapeBlock -> output; needs a Firecrawl API key."""
+    input_node_id = str(uuid.uuid4())
+    input_node = Node(
+        id=input_node_id,
+        block_id=AgentInputBlock().id,
+        input_default={
+            "name": "url",
+            "title": "URL to Scrape",
+            "value": "",
+            "advanced": False,
+            "description": "URL for Firecrawl to scrape",
+        },
+        metadata={"position": {"x": 0, "y": 0}},
+    )
+
+    firecrawl_node_id = str(uuid.uuid4())
+    firecrawl_node = Node(
+        id=firecrawl_node_id,
+        block_id=FirecrawlScrapeBlock().id,
+        input_default={
+            "limit": 10,
+            "only_main_content": True,
+            "max_age": 3600000,
+            "wait_for": 200,
+            "formats": ["markdown"],
+            "credentials": {
+                "provider": "firecrawl",
+                "id": "test-firecrawl-id",
+                "type": "api_key",
+                "title": "Firecrawl API Key",
+            },
+        },
+        metadata={"position": {"x": 300, "y": 0}},
+    )
+
+    output_node_id = str(uuid.uuid4())
+    output_node = Node(
+        id=output_node_id,
+        block_id=AgentOutputBlock().id,
+        input_default={
+            "name": "scraped_data",
+            "title": "Scraped Data",
+            "value": "",
+            "format": "",
+            "advanced": False,
+            "description": "Data scraped by Firecrawl",
+        },
+        metadata={"position": {"x": 600, "y": 0}},
+    )
+
+    return Graph(
+        id=str(uuid.uuid4()),
+        version=1,
+        is_active=True,
+        name=name,
+        description=description,
+        nodes=[input_node, firecrawl_node, output_node],
+        links=[
+            Link(
+                source_id=input_node_id,
+                sink_id=firecrawl_node_id,
+                source_name="result",
+                sink_name="url",
+                is_static=True,
+            ),
+            Link(
+                source_id=firecrawl_node_id,
+                sink_id=output_node_id,
+                source_name="markdown",
+                sink_name="value",
+                is_static=False,
+            ),
+        ],
+    )

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent.py
@@ -320,8 +320,7 @@ class RunAgentTool(BaseTool):
                         message=f"Library agent '{params.library_agent_id}' not found",
                         session_id=session_id,
                     )
-                # Sub-graphs are needed to aggregate the full set of required
-                # credentials; an orchestrator agent has none of its own.
+                # Sub-graphs are needed to aggregate the full set of required credentials.
                 graph = await graph_db().get_graph(
                     library_agent.graph_id,
                     library_agent.graph_version,

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent.py
@@ -320,11 +320,13 @@ class RunAgentTool(BaseTool):
                         message=f"Library agent '{params.library_agent_id}' not found",
                         session_id=session_id,
                     )
-                # Get the graph from the library agent
+                # Sub-graphs are needed to aggregate the full set of required
+                # credentials; an orchestrator agent has none of its own.
                 graph = await graph_db().get_graph(
                     library_agent.graph_id,
                     library_agent.graph_version,
                     user_id=user_id,
+                    include_subgraphs=True,
                 )
             else:
                 # Fetch from marketplace slug
@@ -767,7 +769,10 @@ class RunAgentTool(BaseTool):
                 session_id=session_id,
             )
         graph = await graph_db().get_graph(
-            preset.graph_id, preset.graph_version, user_id=user_id
+            preset.graph_id,
+            preset.graph_version,
+            user_id=user_id,
+            include_subgraphs=True,  # needed for full credentials aggregation
         )
         if not graph:
             return ErrorResponse(

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
@@ -16,6 +16,7 @@ from ._test_data import (
     make_session,
     setup_firecrawl_test_data,
     setup_llm_test_data,
+    setup_subagent_test_data,
     setup_test_data,
 )
 from .models import ErrorResponse, ExecutionStartedResponse, SetupRequirementsResponse
@@ -25,6 +26,7 @@ from .run_agent import RunAgentInput, RunAgentTool
 setup_llm_test_data = setup_llm_test_data
 setup_test_data = setup_test_data
 setup_firecrawl_test_data = setup_firecrawl_test_data
+setup_subagent_test_data = setup_subagent_test_data
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -299,6 +301,72 @@ async def test_run_agent_missing_credentials(setup_firecrawl_test_data):
     assert "user_readiness" in setup_info
     assert setup_info["user_readiness"]["has_all_credentials"] is False
     assert len(setup_info["user_readiness"]["missing_credentials"]) > 0
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_run_agent_missing_sub_agent_credentials(setup_subagent_test_data):
+    """An orchestrator agent must surface the credentials its SUB-agents need,
+    instead of starting a run in which every sub-agent fails."""
+    user = setup_subagent_test_data["user"]
+    library_agent = setup_subagent_test_data["library_agent"]
+
+    tool = RunAgentTool()
+    session = make_session(user_id=user.id)
+
+    response = await tool.execute(
+        user_id=user.id,
+        session_id=str(uuid.uuid4()),
+        tool_call_id=str(uuid.uuid4()),
+        library_agent_id=library_agent.id,
+        inputs={"url": "https://example.com"},
+        dry_run=False,
+        session=session,
+    )
+
+    assert response is not None
+    assert isinstance(response.output, str)
+    result_data = orjson.loads(response.output)
+
+    assert result_data.get("type") == "setup_requirements", (
+        "Expected the inline setup card for the sub-agent's Firecrawl "
+        f"credentials, got: {result_data.get('type')}"
+    )
+    missing = result_data["setup_info"]["user_readiness"]["missing_credentials"]
+    assert [c["provider"] for c in missing.values()] == ["firecrawl"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_run_marketplace_agent_missing_sub_agent_credentials(
+    setup_subagent_test_data,
+):
+    """Same as above via the marketplace slug path, which resolves the graph
+    through the store."""
+    user = setup_subagent_test_data["user"]
+    store_submission = setup_subagent_test_data["store_submission"]
+
+    tool = RunAgentTool()
+    session = make_session(user_id=user.id)
+
+    response = await tool.execute(
+        user_id=user.id,
+        session_id=str(uuid.uuid4()),
+        tool_call_id=str(uuid.uuid4()),
+        username_agent_slug=f"{user.email.split('@')[0]}/{store_submission.slug}",
+        inputs={"url": "https://example.com"},
+        dry_run=False,
+        session=session,
+    )
+
+    assert response is not None
+    assert isinstance(response.output, str)
+    result_data = orjson.loads(response.output)
+
+    assert result_data.get("type") == "setup_requirements", (
+        "Expected the inline setup card for the sub-agent's Firecrawl "
+        f"credentials, got: {result_data.get('type')}"
+    )
+    missing = result_data["setup_info"]["user_readiness"]["missing_credentials"]
+    assert [c["provider"] for c in missing.values()] == ["firecrawl"]
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/autogpt_platform/backend/backend/copilot/tools/setup_agent_webhook_trigger.py
+++ b/autogpt_platform/backend/backend/copilot/tools/setup_agent_webhook_trigger.py
@@ -275,7 +275,11 @@ class SetupAgentWebhookTriggerTool(BaseTool):
             graph_id = library_agent.graph_id
             graph_version = library_agent.graph_version
 
-        graph = await graph_db().get_graph(graph_id, graph_version, user_id=user_id)
+        # Sub-graphs are needed to aggregate the full set of required
+        # credentials; an agent that delegates to sub-agents has none of its own.
+        graph = await graph_db().get_graph(
+            graph_id, graph_version, user_id=user_id, include_subgraphs=True
+        )
         if not graph:
             return None, ErrorResponse(
                 message=f"Agent graph '{graph_id}' not found.",

--- a/autogpt_platform/backend/backend/copilot/tools/setup_agent_webhook_trigger.py
+++ b/autogpt_platform/backend/backend/copilot/tools/setup_agent_webhook_trigger.py
@@ -275,8 +275,7 @@ class SetupAgentWebhookTriggerTool(BaseTool):
             graph_id = library_agent.graph_id
             graph_version = library_agent.graph_version
 
-        # Sub-graphs are needed to aggregate the full set of required
-        # credentials; an agent that delegates to sub-agents has none of its own.
+        # Sub-graphs are needed to aggregate the full set of required credentials.
         graph = await graph_db().get_graph(
             graph_id, graph_version, user_id=user_id, include_subgraphs=True
         )

--- a/autogpt_platform/backend/backend/copilot/tools/setup_agent_webhook_trigger_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/setup_agent_webhook_trigger_test.py
@@ -101,9 +101,13 @@ def _make_preset(*, provider: str, url: str):
     return preset
 
 
-def _patches(graph, *, matched=None, available=None, preset=None):
-    """Patch graph resolution + credential matching + DB calls for the tool."""
-    mock_graph_db = MagicMock()
+def _patches(graph, *, matched=None, available=None, preset=None, graph_db_mock=None):
+    """Patch graph resolution + credential matching + DB calls for the tool.
+
+    Pass ``graph_db_mock`` to keep a reference for asserting how the graph was
+    loaded.
+    """
+    mock_graph_db = graph_db_mock or MagicMock()
     mock_graph_db.get_graph = AsyncMock(return_value=graph)
     mock_triggers = MagicMock()
     mock_triggers.setup_triggered_preset = AsyncMock(return_value=preset)
@@ -150,6 +154,25 @@ async def test_no_webhook_node(tool, session):
         )
     assert isinstance(result, ErrorResponse)
     assert result.error == "no_webhook_trigger"
+
+
+@pytest.mark.asyncio
+async def test_graph_is_loaded_with_subgraphs(tool, session):
+    """Without sub-graphs, a sub-agent's credentials are missing from the card
+    and the registered trigger fails on every firing."""
+    graph = _make_graph(manual=True, regular_credentials={})
+    preset = _make_preset(
+        provider="generic_webhook",
+        url="https://backend.agpt.co/api/integrations/generic_webhook/webhooks/wh-1/ingress",
+    )
+    graph_db_mock = MagicMock()
+    ctxs, _ = _patches(graph, preset=preset, graph_db_mock=graph_db_mock)
+    with ctxs[0], ctxs[1], ctxs[2], ctxs[3], ctxs[4]:
+        await tool._execute(
+            user_id=_USER, session=session, name="My Trigger", graph_id="graph-1"
+        )
+
+    assert graph_db_mock.get_graph.await_args.kwargs["include_subgraphs"] is True
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/tools/utils.py
+++ b/autogpt_platform/backend/backend/copilot/tools/utils.py
@@ -65,9 +65,11 @@ async def fetch_graph_from_store_slug(
     except NotFoundError:
         return None, None
 
-    # Get the graph from store listing version
+    # Sub-graphs are needed to aggregate the full set of required credentials.
     graph = await sdb.get_available_graph(
-        store_agent.store_listing_version_id, hide_nodes=False
+        store_agent.store_listing_version_id,
+        hide_nodes=False,
+        include_subgraphs=True,
     )
     return graph, store_agent
 


### PR DESCRIPTION
### Why / What / How

**Why:** Running an orchestrator agent through AutoPilot fails: the agent starts, then every sub-agent dies on missing required credentials, with no setup card offered beforehand. Reproduced on Dev in copilot session `5ad245eb-f94f-4977-a24c-8c21b6cd70b1`.

Credential requirements are aggregated over a graph **and its sub-graphs** (`GraphModel.aggregate_credentials_inputs()` iterates `[self] + self.sub_graphs`), so the result depends entirely on whether the graph was loaded with `include_subgraphs=True`. `run_agent` and `setup_agent_webhook_trigger` both loaded graphs without it, so they only ever saw top-level nodes.

For an orchestrator — AgentInput/AgentOutput plus a few `AgentExecutorBlock`s, i.e. **no credential fields of its own** — that means:

1. `graph.regular_credentials_inputs` is `{}`, so `match_user_credentials_to_graph` short-circuits and never even reads the user's credentials
2. no missing credentials → no setup card → straight to execute
3. `add_graph_execution` receives an empty credentials map, and parent-level validation only walks top-level nodes, so the run starts happily
4. each `AgentExecutorBlock` then starts its child with an empty input mask → every sub-agent fails validation

The `_handle_graph_validation_race` safety net does not catch this, because the parent's own validation passes — the failure only lands once the children start.

Running the same agent from the Library UI works, because `GET /graphs/{id}` builds `credentials_input_schema` with `include_subgraphs=True` and the frontend sends the full map. This is copilot-only.

**What:** Load sub-graphs on every copilot path that derives credentials from a graph it loaded itself.

**How:** `include_subgraphs=True` on the three `get_graph` calls (run_agent library + preset paths, webhook trigger tool). The marketplace path needed more: `store_db.get_available_graph` never loaded sub-graphs at all, so it gained an opt-in `include_subgraphs` parameter (default `False`, so the one other caller is unchanged) which `fetch_graph_from_store_slug` passes.

Also checked and found clean: `agent_search` (loads with `for_export=True`, which implies sub-graphs, and strips credentials anyway), `manage_presets` (no graph load — it carries `preset.credentials` forward), `find_library_agent` (no credential handling), `agent_generator` and `agent_output` (read no credentials). Outside copilot, `library/db.py` already passes `include_subgraphs=True` and `library/model.py` only populates `credentials_input_schema` when sub-graphs were loaded.

### Changes 🏗️

- `copilot/tools/run_agent.py` — `include_subgraphs=True` on the library-agent and preset graph loads
- `copilot/tools/setup_agent_webhook_trigger.py` — same on its graph load; without it a trigger is registered with a preset that fails on every firing
- `api/features/store/db.py` — `get_available_graph` gained an opt-in `include_subgraphs` (default `False`)
- `copilot/tools/utils.py` — `fetch_graph_from_store_slug` requests sub-graphs
- `copilot/tools/_test_data.py` — new `setup_subagent_test_data` fixture: orchestrator parent wrapping a Firecrawl sub-graph, for a user without Firecrawl credentials, registered in both the library and the store. Extracted `_build_firecrawl_graph` so this and the existing Firecrawl fixture share one definition.
- `copilot/tools/run_agent_test.py` — two tests asserting the setup card lists the sub-agent's `firecrawl` credential, one per run path
- `copilot/tools/setup_agent_webhook_trigger_test.py` — test asserting the graph is loaded with sub-graphs (that file is mock-based, so the load kwargs are what can be pinned); `_patches` gained an optional `graph_db_mock`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New tests fail without the fix and pass with it. Pre-fix, both `run_agent` tests fail *by starting a real run* — the orchestrator graph accumulated 5 `AgentGraphExecution` rows across pre-fix runs while the top-level-credentials Firecrawl agent has 0. Post-fix the count stays put: no run is started. The trigger test fails pre-fix with `KeyError: 'include_subgraphs'`.
  - [x] `run_agent_test.py`, `utils_test.py`, `setup_agent_webhook_trigger_test.py`: 64 passed
  - [x] `store/db_test.py`, `store/routes_test.py`: 54 passed (covers the `get_available_graph` signature change)
  - [ ] Not verified locally — 4 tests that start real executions (`test_run_agent`, `test_run_agent_with_llm_credentials`, `test_run_agent_with_use_defaults`, `test_run_preset_executes_with_merged_inputs`) block on a RabbitMQ reconnect loop in my local env; leaving these to CI. The last one covers the preset path this PR changes.
  - [ ] Manual: run an orchestrator agent via AutoPilot on Dev and confirm the credentials card lists the sub-agents' providers before the run starts

> [!NOTE]
> Presets and schedules created by copilot for orchestrator agents before this fix have an empty/partial credentials map persisted (`preset.credentials` is used verbatim on re-run), so they keep failing until re-saved.
