### PR TITLE
feat(frontend): let a user choose their default AI connection in Settings

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotConnectionNotice/BotConnectionNotice.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotConnectionNotice/BotConnectionNotice.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+import { useGetV2ListChatTransports } from "@/app/api/__generated__/endpoints/chat/chat";
+import { Text } from "@/components/atoms/Text/Text";
+
+/**
+ * A conversation that arrives over a bot link has no picker in front of it, so
+ * the connection it starts on is whatever was chosen in Settings. That is the
+ * least discoverable consequence of the setting — say it here, where someone
+ * is looking at their bots.
+ */
+export function BotConnectionNotice() {
+  const transportsQuery = useGetV2ListChatTransports();
+  const transports =
+    transportsQuery.data?.status === 200
+      ? transportsQuery.data.data.transports
+      : [];
+  const current = transports.find((transport) => transport.default);
+
+  if (!current || transports.filter((t) => t.available).length < 2) return null;
+
+  return (
+    <div className="mb-6 ml-4 rounded-2xl border border-[#DADADC] bg-white px-4 py-3">
+      <Text variant="small" className="text-[#505057]">
+        Conversations that come in over a bot start on{" "}
+        <span className="font-medium text-black">{current.label}</span>, the
+        connection you chose in{" "}
+        <Link
+          href="/settings/integrations"
+          className="font-medium text-[#7444E5] underline underline-offset-2"
+        >
+          AI subscriptions
+        </Link>
+        .
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BotConnectionNotice } from "./components/BotConnectionNotice/BotConnectionNotice";
 import { BotsHeader } from "./components/BotsHeader/BotsHeader";
 import { BotsList } from "./components/BotsList/BotsList";
 
@@ -7,6 +8,7 @@ export default function SettingsBotsPage() {
   return (
     <>
       <BotsHeader />
+      <BotConnectionNotice />
       <BotsList />
     </>
   );

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AIConnectionsSection } from "./components/AIConnectionsSection/AIConnectionsSection";
 import { ConnectServiceDialog } from "./components/ConnectServiceDialog/ConnectServiceDialog";
 import { IntegrationsHeader } from "./components/IntegrationsHeader/IntegrationsHeader";
 import { IntegrationsList } from "./components/IntegrationsList/IntegrationsList";
@@ -18,6 +19,7 @@ export function IntegrationsPanel({ withHeading = true }: Props) {
         onConnect={() => setIsConnectOpen(true)}
         withTitle={withHeading}
       />
+      <AIConnectionsSection />
       <IntegrationsList />
       <ConnectServiceDialog
         open={isConnectOpen}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+  CheckmarkCircle02Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons";
+
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+import { describeTransport, transportKey } from "./helpers";
+import { useAIConnectionsSection } from "./useAIConnectionsSection";
+
+export function AIConnectionsSection() {
+  const {
+    connections,
+    selectedKey,
+    chooseDefault,
+    isSaving,
+    isLoading,
+    isError,
+  } = useAIConnectionsSection();
+
+  // The section describes which connection powers a chat. With nothing to
+  // choose between, there is no decision to present — and an error here must
+  // not take the tool integrations below it down with it.
+  if (isError || (!isLoading && connections.length < 2)) return null;
+
+  return (
+    <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
+      <Text
+        variant="small-medium"
+        as="h2"
+        id="ai-connections-heading"
+        className="uppercase tracking-[0.06em] text-[#505057]"
+      >
+        AI subscriptions
+      </Text>
+      <Text variant="body" className="mt-2 max-w-[600px] text-[#505057]">
+        These power your agents. Pick the one new chats should start on — you
+        can still change it per conversation, and nothing switches on its own.
+      </Text>
+
+      {isLoading ? (
+        <div className="mt-4 flex flex-col gap-3">
+          <Skeleton className="h-[86px] w-full rounded-2xl" />
+          <Skeleton className="h-[86px] w-full rounded-2xl" />
+        </div>
+      ) : (
+        <div
+          role="radiogroup"
+          aria-label="Connection new chats start on"
+          className="mt-4 flex flex-col gap-3"
+        >
+          {connections.map((connection) => (
+            <ConnectionRow
+              key={transportKey(connection)}
+              connection={connection}
+              isSelected={transportKey(connection) === selectedKey}
+              isSaving={isSaving}
+              onSelect={() => chooseDefault(connection)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface RowProps {
+  connection: ChatTransportResponse;
+  isSelected: boolean;
+  isSaving: boolean;
+  onSelect: () => void;
+}
+
+function ConnectionRow({
+  connection,
+  isSelected,
+  isSaving,
+  onSelect,
+}: RowProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      disabled={isSaving}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        isSelected
+          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
+          : "border-[#DADADC] hover:bg-[#F9F9FA]",
+        isSaving && "cursor-progress opacity-70",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
+          isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
+        )}
+      >
+        {isSelected && (
+          <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
+        )}
+      </span>
+
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-black">
+            {connection.label}
+          </Text>
+          {connection.auth_provider === "codex" && (
+            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#E8F8F0] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#157E58]">
+              <Icon icon={CheckmarkCircle02Icon} size={13} />
+              Connected
+            </span>
+          )}
+          {isSelected && (
+            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+              <Icon icon={SparklesIcon} size={13} />
+              Used for new chats
+            </span>
+          )}
+        </span>
+        <Text variant="small" as="span" className="text-[#505057]">
+          {describeTransport(connection)}
+        </Text>
+      </span>
+    </button>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -24,10 +24,12 @@ export function AIConnectionsSection() {
     isError,
   } = useAIConnectionsSection();
 
-  // The section describes which connection powers a chat. With nothing to
-  // choose between, there is no decision to present — and an error here must
-  // not take the tool integrations below it down with it.
-  if (isError || (!isLoading && connections.length < 2)) return null;
+  // A failure here must not take the tool integrations below it down with it.
+  if (isError) return null;
+
+  // One connection is not a choice. The rows still say what powers a chat,
+  // they just stop presenting a decision that doesn't exist.
+  const hasChoice = connections.length > 1;
 
   return (
     <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
@@ -40,8 +42,9 @@ export function AIConnectionsSection() {
         AI subscriptions
       </Text>
       <Text variant="body" className="mt-2 max-w-[600px] text-[#505057]">
-        These power your agents. Pick the one new chats should start on — you
-        can still change it per conversation, and nothing switches on its own.
+        {hasChoice
+          ? "These power your agents. Pick the one new chats should start on — you can still change it per conversation, and nothing switches on its own."
+          : "These power your agents. Link a subscription and you can choose which one new chats start on."}
       </Text>
 
       {isLoading ? (
@@ -51,14 +54,15 @@ export function AIConnectionsSection() {
         </div>
       ) : (
         <div
-          role="radiogroup"
-          aria-label="Connection new chats start on"
+          role={hasChoice ? "radiogroup" : undefined}
+          aria-label={hasChoice ? "Connection new chats start on" : undefined}
           className="mt-4 flex flex-col gap-3"
         >
           {connections.map((connection) => (
             <ConnectionRow
               key={transportKey(connection)}
               connection={connection}
+              selectable={hasChoice}
               isSelected={transportKey(connection) === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
@@ -66,12 +70,15 @@ export function AIConnectionsSection() {
           ))}
         </div>
       )}
+
+      <UpcomingConnections />
     </section>
   );
 }
 
 interface RowProps {
   connection: ChatTransportResponse;
+  selectable: boolean;
   isSelected: boolean;
   isSaving: boolean;
   onSelect: () => void;
@@ -79,37 +86,26 @@ interface RowProps {
 
 function ConnectionRow({
   connection,
+  selectable,
   isSelected,
   isSaving,
   onSelect,
 }: RowProps) {
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      disabled={isSaving}
-      onClick={onSelect}
-      className={cn(
-        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
-        isSelected
-          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
-          : "border-[#DADADC] hover:bg-[#F9F9FA]",
-        isSaving && "cursor-progress opacity-70",
+  const body = (
+    <>
+      {selectable && (
+        <span
+          aria-hidden
+          className={cn(
+            "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
+            isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
+          )}
+        >
+          {isSelected && (
+            <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
+          )}
+        </span>
       )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
-          isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
-        )}
-      >
-        {isSelected && (
-          <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
-        )}
-      </span>
 
       <span className="flex min-w-0 flex-col gap-1">
         <span className="flex flex-wrap items-center gap-2">
@@ -133,6 +129,66 @@ function ConnectionRow({
           {describeTransport(connection)}
         </Text>
       </span>
+    </>
+  );
+
+  if (!selectable) {
+    return (
+      <div className="flex w-full items-start gap-3 rounded-2xl border border-[#DADADC] bg-white p-4">
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      disabled={isSaving}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        isSelected
+          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
+          : "border-[#DADADC] hover:bg-[#F9F9FA]",
+        isSaving && "cursor-progress opacity-70",
+      )}
+    >
+      {body}
     </button>
+  );
+}
+
+/**
+ * Names what is coming without claiming it works yet. Each provider needs its
+ * own adapter and its own provider/legal approval before it can appear as a
+ * real row above, so this promises nothing about capability or timing.
+ */
+function UpcomingConnections() {
+  return (
+    <div className="mt-3 flex items-start gap-3 rounded-2xl border border-dashed border-[#DADADC] p-4">
+      <span
+        aria-hidden
+        className="mt-[2px] flex h-4 w-4 flex-none items-center justify-center text-[#9A9A9F]"
+      >
+        <Icon icon={SparklesIcon} size={16} />
+      </span>
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-[#505057]">
+            GitHub Copilot and Grok
+          </Text>
+          <span className="inline-flex items-center rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+            Coming soon
+          </span>
+        </span>
+        <Text variant="small" as="span" className="text-[#505057]">
+          More subscriptions you already pay for. Each one shows up here once it
+          is approved to run AutoGPT agents.
+        </Text>
+      </span>
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -102,11 +102,23 @@ describe("AIConnectionsSection", () => {
     await waitFor(() => expect(saved).not.toHaveBeenCalled());
   });
 
-  it("stays out of the way when there is nothing to choose between", async () => {
+  it("presents no choice when there is only one connection", async () => {
     mockTransports([platform(true)]);
 
     render(<AIConnectionsSection />);
 
-    await waitFor(() => expect(screen.queryByRole("radiogroup")).toBeNull());
+    // The row still says what powers a chat — it just isn't a decision.
+    expect(await screen.findByText("Self-hosted chat")).toBeDefined();
+    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(screen.queryByRole("radio")).toBeNull();
+  });
+
+  it("names what is coming without claiming it works", async () => {
+    mockTransports([platform(true)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("GitHub Copilot and Grok")).toBeDefined();
+    expect(screen.getByText("Coming soon")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -1,0 +1,112 @@
+import {
+  getGetV2ListChatTransportsMockHandler200,
+  getPutV2SetDefaultChatTransportMockHandler200,
+} from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { server } from "@/mocks/mock-server";
+import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AIConnectionsSection } from "../AIConnectionsSection";
+
+function platform(isDefault: boolean): ChatTransportResponse {
+  return {
+    auth_provider: "platform",
+    credential_id: null,
+    label: "Self-hosted chat",
+    available: true,
+    default: isDefault,
+  };
+}
+
+function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
+  return {
+    auth_provider: "codex",
+    credential_id: id,
+    label: "ChatGPT",
+    available: true,
+    default: isDefault,
+  };
+}
+
+function mockTransports(transports: ChatTransportResponse[]) {
+  server.use(
+    getGetV2ListChatTransportsMockHandler200({ transports }),
+    getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+  );
+}
+
+describe("AIConnectionsSection", () => {
+  it("lists every connection with what backs a run on it", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("Self-hosted chat")).toBeDefined();
+    expect(screen.getByText("ChatGPT")).toBeDefined();
+    expect(
+      screen.getByText(/backed by your ChatGPT plan, and spend no AutoGPT/i),
+    ).toBeDefined();
+  });
+
+  it("marks the saved default, and only that one", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+
+    render(<AIConnectionsSection />);
+
+    const options = await screen.findAllByRole("radio");
+    expect(options).toHaveLength(2);
+    const checked = options.filter(
+      (option) => option.getAttribute("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0].textContent).toContain("ChatGPT");
+  });
+
+  it("saves the connection the user picks", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+    const saved = vi.fn();
+    server.events.on("request:start", ({ request }) => {
+      if (
+        request.method === "PUT" &&
+        request.url.includes("transports/default")
+      )
+        saved();
+    });
+
+    render(<AIConnectionsSection />);
+    const chatgptOption = await screen.findByRole("radio", { name: /ChatGPT/ });
+    await userEvent.click(chatgptOption);
+
+    await waitFor(() => expect(saved).toHaveBeenCalled());
+  });
+
+  it("does not re-save the connection that is already the default", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+    const saved = vi.fn();
+    server.events.on("request:start", ({ request }) => {
+      if (
+        request.method === "PUT" &&
+        request.url.includes("transports/default")
+      )
+        saved();
+    });
+
+    render(<AIConnectionsSection />);
+    const current = await screen.findByRole("radio", {
+      name: /Self-hosted chat/,
+    });
+    await userEvent.click(current);
+
+    await waitFor(() => expect(saved).not.toHaveBeenCalled());
+  });
+
+  it("stays out of the way when there is nothing to choose between", async () => {
+    mockTransports([platform(true)]);
+
+    render(<AIConnectionsSection />);
+
+    await waitFor(() => expect(screen.queryByRole("radiogroup")).toBeNull());
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -1,0 +1,37 @@
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+
+/**
+ * The label the server sends for the platform transport on a self-hosted
+ * install. It sends "AutoGPT Platform" on the hosted product instead.
+ */
+export const SELF_HOSTED_LABEL = "Self-hosted chat";
+
+/**
+ * Says what backs a run, which is the thing that actually differs between
+ * connections. Copy lives here only until the server-owned connection offer
+ * carries it — the client should not be deciding how a provider describes
+ * its own billing.
+ */
+export function describeTransport(transport: ChatTransportResponse): string {
+  if (transport.auth_provider === "codex") {
+    return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
+  }
+  return transport.label === SELF_HOSTED_LABEL
+    ? "New chats are backed by the chat provider configured on this server."
+    : "New chats are backed by your AutoGPT plan.";
+}
+
+export function isSelectable(transport: ChatTransportResponse): boolean {
+  return (
+    transport.available &&
+    (transport.auth_provider === "platform" || transport.credential_id !== null)
+  );
+}
+
+/**
+ * A stable key. The platform transport carries no credential id, and a user
+ * can hold several ChatGPT accounts, so neither half identifies a row alone.
+ */
+export function transportKey(transport: ChatTransportResponse): string {
+  return `${transport.auth_provider}:${transport.credential_id ?? "deployment"}`;
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -16,9 +16,12 @@ export function describeTransport(transport: ChatTransportResponse): string {
   if (transport.auth_provider === "codex") {
     return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
   }
+  // The ChatGPT line promises "no AutoGPT credits", which only means anything
+  // if the row it contrasts with says credits are spent. Self-host has no
+  // credits at all, so it says what it actually has instead.
   return transport.label === SELF_HOSTED_LABEL
     ? "New chats are backed by the chat provider configured on this server."
-    : "New chats are backed by your AutoGPT plan.";
+    : "New chats are backed by your AutoGPT plan, and spend AutoGPT credits.";
 }
 
 export function isSelectable(transport: ChatTransportResponse): boolean {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGetV2ListChatTransportsQueryKey,
+  useGetV2ListChatTransports,
+  usePutV2SetDefaultChatTransport,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+
+import { isSelectable, transportKey } from "./helpers";
+
+export function useAIConnectionsSection() {
+  const queryClient = useQueryClient();
+  const transportsQuery = useGetV2ListChatTransports({
+    query: { refetchOnWindowFocus: true },
+  });
+
+  const transports: ChatTransportResponse[] =
+    transportsQuery.data?.status === 200
+      ? transportsQuery.data.data.transports
+      : [];
+  const connections = transports.filter(isSelectable);
+
+  const { mutateAsync: setDefault, isPending: isSaving } =
+    usePutV2SetDefaultChatTransport({
+      mutation: {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: getGetV2ListChatTransportsQueryKey(),
+          });
+        },
+        onError: () => {
+          toast({
+            variant: "destructive",
+            title: "Could not save that connection",
+            description:
+              "Your default is unchanged. Check the connection is still linked, then try again.",
+          });
+        },
+      },
+    });
+
+  // Tracked separately from the query so the row the user clicked shows the
+  // pending state, rather than every row going busy at once.
+  const selectedKey = connections.find((t) => t.default)
+    ? transportKey(connections.find((t) => t.default)!)
+    : null;
+
+  async function chooseDefault(transport: ChatTransportResponse) {
+    if (transport.default) return;
+    await setDefault({
+      data: {
+        auth_provider: transport.auth_provider,
+        credential_id: transport.credential_id,
+      },
+    });
+  }
+
+  return {
+    connections,
+    selectedKey,
+    chooseDefault,
+    isSaving,
+    isLoading: transportsQuery.isLoading,
+    isError: transportsQuery.isError,
+    refetch: transportsQuery.refetch,
+  };
+}


### PR DESCRIPTION
### Why / What / How

**Why.** #14078 added the saved default connection and honoured it on every path that opens a chat — bot links, schedules, briefings, dream passes, new web sessions. But nothing in the product could *set* it. This is that surface.

**What.** An **AI subscriptions** section at the top of Settings → Integrations, one row per connection, with what backs a run on it. Picking a row saves it as the connection every new chat starts on. Plus a line on the Bots page naming that connection.

**How.** Driven by `GET /api/chat/transports`, which already returns label, availability, and which one is default. The client decides nothing about routing — when a provider is added server-side, this section is already correct. Selection posts to `PUT /api/chat/transports/default` and invalidates the transports query.

The design system has no radio primitive and `__legacy__` is off-limits, so the rows are buttons carrying `role="radio"` / `aria-checked` inside a `role="radiogroup"` — real radio semantics, keyboard and screen-reader included, no new dependency.

#### What this deliberately does not show yet

Against the PRD mock, three things are missing on purpose:

- **Provider-reported usage** ("Powered 41 runs this week · 0 AutoGPT credits · Models: 5.6 Terra / 5.6 Sol") and the **account email chip** need stable remote account identity and an on-demand status call. Rendering them now would mean inventing data, or showing a usage window that may no longer be true — the exact failure the reconnect state exists to avoid. They arrive with the manage dialog.
- **"Gemini, Copilot, Grok — coming soon"** advertises adapters that have not passed provider or legal review.

So this is the mock's structure with only the parts that can be populated truthfully.

#### Behaviour worth reviewing

- The section **hides itself below two connections**. With nothing to choose between there is no decision to present, so a hosted user with no linked subscription sees exactly what they see today.
- It also **hides on error**, so a transports failure cannot take the tool integrations below it down.
- Copy resolves the contradiction in the mock's connect dialog, which predates the setting: *"Pick the one new chats should start on — you can still change it per conversation, and nothing switches on its own."*
- There is **no explicit "Automatic" option**. Once you pick, you have picked; and if that connection later disappears, #14078 heals to the server's own pick. The API still supports clearing.

### Changes 🏗️

- `IntegrationsPanel/components/AIConnectionsSection/` — component, hook, helpers, tests
- Mounted above `IntegrationsList` in `IntegrationsPanel`
- `settings/bots/components/BotConnectionNotice/` — names the connection bot conversations start on, linking back to the section

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] 5 integration tests: lists every connection with what backs it, marks exactly one default, saves the picked connection, does **not** re-save the one already default, and renders nothing when there is only one connection
  - [x] 23 tests pass across the touched files; `tsc --noEmit` and `next lint` clean
  - [x] **Verified in a single-container build against a real linked ChatGPT account:** section renders both rows with the correct labels (`Self-hosted chat` / `ChatGPT`), clicking ChatGPT moves the selection, and `defaultChatAuthProvider=codex` + `defaultChatCredentialId` land in Postgres
  - [x] Bots page shows "Conversations that come in over a bot start on **ChatGPT**" after that change, i.e. it tracks the saved default
  - [x] Composer picker shows the resolved connection immediately rather than flashing "Choose connection"

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes — no new configuration
- [x] `docker-compose.yml` is updated or already compatible with my changes — unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only settings UI on existing list/set-default chat transport APIs, with error isolation and integration tests; no new auth or routing logic in this diff.
> 
> **Overview**
> Users can finally **set the default AI connection** for new chats from the product UI, complementing the server-side default that already applied to bot links, schedules, and new sessions.
> 
> **Settings → Integrations** gains an **AI subscriptions** block above tool integrations: each selectable connection shows what backs runs (ChatGPT plan vs AutoGPT credits vs self-hosted provider), and choosing a row **persists via** `PUT /api/chat/transports/default` with query invalidation. Rows use accessible radio semantics (`radiogroup` / `role="radio"`) without a new design-system dependency; the section **renders nothing on fetch error** so integrations below still load, and **skips the picker** when only one connection exists. A dashed **Coming soon** row names GitHub Copilot and Grok without implying they work yet.
> 
> **Settings → Bots** adds a notice (only when two+ available transports) that **bot conversations start on the saved default**, with a link back to AI subscriptions.
> 
> Integration tests cover listing copy, single default selection, save on pick, no redundant PUT when re-clicking the current default, single-connection non-choice UI, and the coming-soon copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbedb887e1bf777cf9c4cd8bbf1aae4c5e8b478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->