### PR TITLE
feat(frontend): answer what linking a ChatGPT plan means before the OAuth window

### DIFF
--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  ArrowDataTransferHorizontalIcon,
+  ShieldKeyIcon,
+  SparklesIcon,
+  Target02Icon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Point {
+  icon: IconSvgElement;
+  title: string;
+  body: string;
+}
+
+/**
+ * Linking a ChatGPT plan changes who pays for a run, so the four questions
+ * that implies get answered on screen before the OAuth window opens rather
+ * than after the user has committed.
+ *
+ * Deliberately claims nothing about specific models or about pausing and
+ * resuming a run at a provider limit: the model catalog is server-owned, and
+ * same-chat recovery is not built yet. Both land with their own work.
+ */
+const POINTS: Point[] = [
+  {
+    icon: ArrowDataTransferHorizontalIcon,
+    title: "What it does.",
+    body: "Chats routed to ChatGPT run on your ChatGPT plan instead of AutoGPT credits. Every new chat starts on the connection you choose in Settings, and you can change it per conversation — nothing switches on its own.",
+  },
+  {
+    icon: Target02Icon,
+    title: "What it costs.",
+    body: "Usage counts toward your ChatGPT plan's own limits. Those runs spend zero AutoGPT credits, and AutoGPT never adds a charge on top.",
+  },
+  {
+    icon: SparklesIcon,
+    title: "What you get.",
+    body: "The models your ChatGPT plan already includes, at no extra cost from AutoGPT.",
+  },
+  {
+    icon: ShieldKeyIcon,
+    title: "Stay in control.",
+    body: "A chat stays on the connection it started with, so a run is never moved onto your AutoGPT credits without asking. Disconnect any time in Settings.",
+  },
+];
+
+export function ChatGPTConnectExplainer() {
+  return (
+    <div className="divide-y divide-[#DADADC] rounded-2xl border border-[#DADADC] bg-[#FBFBFC]">
+      {POINTS.map((point) => (
+        <div key={point.title} className="flex items-start gap-3 p-4">
+          <span
+            aria-hidden
+            className="mt-[2px] flex h-6 w-6 flex-none items-center justify-center rounded-lg bg-[#F1EBFF] text-[#7444E5]"
+          >
+            <Icon icon={point.icon} size={14} />
+          </span>
+          <Text variant="small" className="text-[#505057]">
+            <span className="font-medium text-black">{point.title}</span>{" "}
+            {point.body}
+          </Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
@@ -7,6 +7,7 @@ import {
 } from "../../helpers";
 import { ApiKeyConnectForm } from "./ApiKeyConnectForm";
 import { DeviceAuthConnectButton } from "@/components/contextual/DeviceAuth/DeviceAuthConnectButton";
+import { ChatGPTConnectExplainer } from "./ChatGPTConnectExplainer";
 import { OAuthConnectButton } from "./OAuthConnectButton";
 import { UnsupportedNotice } from "./UnsupportedNotice";
 
@@ -29,12 +30,16 @@ export function MethodPanel({ method, provider, onSuccess }: Props) {
   if (method === AuthType.oauth2) {
     const isChatGPT = authProvider === "codex";
     return (
-      <OAuthConnectButton
-        provider={authProvider}
-        providerName={isChatGPT ? "ChatGPT" : provider.name}
-        buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
-        onSuccess={onSuccess}
-      />
+      <div className="flex flex-col gap-4">
+        {isChatGPT && <ChatGPTConnectExplainer />}
+        <OAuthConnectButton
+          provider={authProvider}
+          providerName={isChatGPT ? "ChatGPT" : provider.name}
+          buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
+          termsNotice={isChatGPT}
+          onSuccess={onSuccess}
+        />
+      </div>
     );
   }
   if (method === AuthType.api_key) {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
@@ -10,6 +10,9 @@ interface Props {
   provider: string;
   providerName: string;
   buttonLabel?: string;
+  /** Say whose terms a linked run falls under. Only true where runs execute
+   *  on the provider's own account rather than on AutoGPT's. */
+  termsNotice?: boolean;
   onSuccess: () => void;
 }
 
@@ -17,6 +20,7 @@ export function OAuthConnectButton({
   provider,
   providerName,
   buttonLabel,
+  termsNotice = false,
   onSuccess,
 }: Props) {
   const { connect, isPending } = useOAuthConnect({ provider, onSuccess });
@@ -37,6 +41,12 @@ export function OAuthConnectButton({
       >
         {buttonLabel ?? `Continue with ${providerName}`}
       </Button>
+      {termsNotice && (
+        <Text variant="small" className="text-[#8A8A90]">
+          Linked runs are sent to {providerName} under your own account and
+          follow {providerName}&apos;s terms.
+        </Text>
+      )}
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
@@ -35,4 +35,54 @@ describe("MethodPanel", () => {
       expect.objectContaining({ provider: "codex" }),
     );
   });
+
+  test("answers what linking a ChatGPT plan means before the OAuth window", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("What it does.")).toBeDefined();
+    expect(screen.getByText("What it costs.")).toBeDefined();
+    expect(screen.getByText("What you get.")).toBeDefined();
+    expect(screen.getByText("Stay in control.")).toBeDefined();
+    expect(screen.getByText(/spend zero AutoGPT credits/i)).toBeDefined();
+    expect(screen.getByText(/follow ChatGPT's terms/i)).toBeDefined();
+  });
+
+  test("claims nothing it cannot back up", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // Model names are server-owned, and pause-and-resume at a provider limit
+    // is not built yet — neither may be promised here.
+    expect(screen.queryByText(/5\.6|Terra|Sol|Balanced|Advanced/)).toBeNull();
+    expect(screen.queryByText(/the run pauses/i)).toBeNull();
+  });
+
+  test("does not show the ChatGPT explainer for an unrelated provider", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={{
+          id: "notion",
+          name: "Notion",
+          description: "Notion",
+          supportedAuthTypes: [AuthType.oauth2],
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("What it costs.")).toBeNull();
+    expect(screen.queryByText(/follow Notion's terms/i)).toBeNull();
+  });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/DeleteConfirmDialog/DeleteConfirmDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/DeleteConfirmDialog/DeleteConfirmDialog.tsx
@@ -11,6 +11,9 @@ interface Props {
   isPending?: boolean;
   onConfirm: () => void;
   variant?: "remove" | "force";
+  /** Provider-specific consequence, when the generic wording would overstate
+   *  or understate what actually stops working. */
+  notice?: string;
 }
 
 export function DeleteConfirmDialog({
@@ -20,6 +23,7 @@ export function DeleteConfirmDialog({
   isPending = false,
   onConfirm,
   variant = "remove",
+  notice,
 }: Props) {
   const count = itemNames.length;
   const isBulk = count > 1;
@@ -51,6 +55,12 @@ export function DeleteConfirmDialog({
           <Text variant="body" className="text-zinc-800">
             {message}
           </Text>
+
+          {notice && (
+            <Text variant="small" className="text-[#505057]">
+              {notice}
+            </Text>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsList/IntegrationsList.tsx
@@ -75,12 +75,17 @@ export function IntegrationsList() {
     await requestDelete(ids, true);
   }
 
-  const pendingNames = buildTargets(pendingDeleteIds).map(
-    (t) => t.name ?? t.provider,
-  );
+  const pendingTargets = buildTargets(pendingDeleteIds);
+  const pendingNames = pendingTargets.map((t) => t.name ?? t.provider);
   const pendingForceNames = buildTargets(pendingForceIds).map(
     (t) => t.name ?? t.provider,
   );
+  // The generic warning talks about agents losing access, which is not what
+  // removing a ChatGPT connection does: it stops new ChatGPT-backed chats and
+  // leaves everything already said in them alone.
+  const pendingNotice = pendingTargets.some((t) => t.provider === "codex")
+    ? "New chats can no longer run on your ChatGPT plan — they fall back to the connection AutoGPT picks. Your chat history is kept, and your other integrations are unaffected."
+    : undefined;
 
   if (isLoading) {
     return (
@@ -181,6 +186,7 @@ export function IntegrationsList() {
           if (!open) setPendingDeleteIds([]);
         }}
         itemNames={pendingNames}
+        notice={pendingNotice}
         isPending={isDeleting}
         onConfirm={confirmDelete}
       />


### PR DESCRIPTION
### Why / What / How

**Why.** Linking ChatGPT changes **who pays for a run**. The dialog said one line about that:

> We'll open a ChatGPT sign-in window. Approve access there to finish connecting.

What it does, what it costs, what you get, and how to undo it were all discoverable only *after* committing. Disconnect had the same problem in reverse: the generic warning claims agents lose access, which is not what removing a ChatGPT connection does.

**What.** The four questions answered on screen before the OAuth window opens, a terms line under the button, and disconnect copy that describes what actually stops.

**How.** `ChatGPTConnectExplainer` renders above the button, scoped to the ChatGPT method — an unrelated OAuth provider renders exactly as before, pinned by a test. `OAuthConnectButton` gains an opt-in `termsNotice` for providers whose runs execute on the user's own account. `DeleteConfirmDialog` gains an optional `notice`, and `IntegrationsList` supplies it when the pending removal includes a `codex` credential.

The OpenAI grouping this depends on already existed — `codex` OAuth and `openai` API key have merged into one "OpenAI" surface for a while. This PR is the content, not the plumbing.

#### Two claims from the mock are deliberately absent

A test pins their absence, because both would be easy to add back by accident:

- **Specific model names** ("5.6 Terra", "5.6 Sol"). The model catalog is server-owned; hardcoding names in the client means they go stale silently.
- **"If your plan hits its limit, the run pauses and tells you."** That describes same-chat recovery at a provider limit, which is not built yet. What *is* true today is that a chat stays on the connection it started on, so that is what it says: *"A chat stays on the connection it started with, so a run is never moved onto your AutoGPT credits without asking."*

The "what it does" line also carries the wording we settled on for the setting: *"Every new chat starts on the connection you choose in Settings, and you can change it per conversation — nothing switches on its own."* The mock's original said routing is picked purely per conversation, which stopped being true once the default existed.

#### Disconnect

Generic: *"Agents using this credential will lose access immediately."* For ChatGPT that both overstates (other integrations are fine) and understates (it is chats, not agents). Now adds:

> New chats can no longer run on your ChatGPT plan — they fall back to the connection AutoGPT picks. Your chat history is kept, and your other integrations are unaffected.

### Changes 🏗️

- `ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx` — the four points
- `OAuthConnectButton` — optional `termsNotice`
- `DeleteConfirmDialog` — optional `notice`; `IntegrationsList` supplies it for `codex`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] The four points and the terms line render for the ChatGPT method
  - [x] A test asserts model names and the pause-and-resume claim are **not** present
  - [x] An unrelated OAuth provider shows neither the explainer nor a terms line
  - [x] OAuth still routes to the `codex` backend provider under ChatGPT branding (pre-existing test, still green)
  - [x] 78 tests pass across the 12 touched files; `tsc --noEmit` clean

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes — no new configuration
- [x] `docker-compose.yml` is updated or already compatible with my changes — unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and conditional UI only in the integrations connect/disconnect flows; no auth, API, or billing logic changes.
> 
> **Overview**
> **ChatGPT OAuth connect** now shows a four-point explainer (billing, credits, models, control) above **Sign in with ChatGPT**, plus a footnote that linked runs use the user’s account and provider terms. Other OAuth providers are unchanged.
> 
> **Disconnect** for `codex` credentials adds a tailored notice in the remove dialog: new chats stop using the ChatGPT plan and fall back to AutoGPT’s default; history and other integrations stay put. `DeleteConfirmDialog` accepts an optional `notice`; `OAuthConnectButton` accepts optional `termsNotice`.
> 
> Tests cover the new copy, assert model names and pause-at-limit claims are **not** shown, and that Notion OAuth does not get ChatGPT UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dbab1be182d29e7c3c20283cf6c92c2c24871cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->