### PR TITLE
feat(frontend): show which ChatGPT account a connection runs as

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotConnectionNotice/BotConnectionNotice.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotConnectionNotice/BotConnectionNotice.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+import { useGetV2ListChatTransports } from "@/app/api/__generated__/endpoints/chat/chat";
+import { Text } from "@/components/atoms/Text/Text";
+
+/**
+ * A conversation that arrives over a bot link has no picker in front of it, so
+ * the connection it starts on is whatever was chosen in Settings. That is the
+ * least discoverable consequence of the setting — say it here, where someone
+ * is looking at their bots.
+ */
+export function BotConnectionNotice() {
+  const transportsQuery = useGetV2ListChatTransports();
+  const transports =
+    transportsQuery.data?.status === 200
+      ? transportsQuery.data.data.transports
+      : [];
+  const current = transports.find((transport) => transport.default);
+
+  if (!current || transports.filter((t) => t.available).length < 2) return null;
+
+  return (
+    <div className="mb-6 ml-4 rounded-2xl border border-[#DADADC] bg-white px-4 py-3">
+      <Text variant="small" className="text-[#505057]">
+        Conversations that come in over a bot start on{" "}
+        <span className="font-medium text-black">{current.label}</span>, the
+        connection you chose in{" "}
+        <Link
+          href="/settings/integrations"
+          className="font-medium text-[#7444E5] underline underline-offset-2"
+        >
+          AI subscriptions
+        </Link>
+        .
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BotConnectionNotice } from "./components/BotConnectionNotice/BotConnectionNotice";
 import { BotsHeader } from "./components/BotsHeader/BotsHeader";
 import { BotsList } from "./components/BotsList/BotsList";
 
@@ -7,6 +8,7 @@ export default function SettingsBotsPage() {
   return (
     <>
       <BotsHeader />
+      <BotConnectionNotice />
       <BotsList />
     </>
   );

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AIConnectionsSection } from "./components/AIConnectionsSection/AIConnectionsSection";
 import { ConnectServiceDialog } from "./components/ConnectServiceDialog/ConnectServiceDialog";
 import { IntegrationsHeader } from "./components/IntegrationsHeader/IntegrationsHeader";
 import { IntegrationsList } from "./components/IntegrationsList/IntegrationsList";
@@ -18,6 +19,7 @@ export function IntegrationsPanel({ withHeading = true }: Props) {
         onConnect={() => setIsConnectOpen(true)}
         withTitle={withHeading}
       />
+      <AIConnectionsSection />
       <IntegrationsList />
       <ConnectServiceDialog
         open={isConnectOpen}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -1,28 +1,33 @@
 "use client";
 
+import { useState } from "react";
 import {
   CheckmarkCircle02Icon,
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
 
+import { ManageConnectionDialog } from "./ManageConnectionDialog";
 import { describeTransport, transportKey } from "./helpers";
 import { useAIConnectionsSection } from "./useAIConnectionsSection";
 
 export function AIConnectionsSection() {
   const {
     connections,
+    accountFor,
     selectedKey,
     chooseDefault,
     isSaving,
     isLoading,
     isError,
   } = useAIConnectionsSection();
+  const [managing, setManaging] = useState<ChatTransportResponse | null>(null);
 
   // A failure here must not take the tool integrations below it down with it.
   if (isError) return null;
@@ -62,34 +67,52 @@ export function AIConnectionsSection() {
             <ConnectionRow
               key={transportKey(connection)}
               connection={connection}
+              account={accountFor(connection)}
               selectable={hasChoice}
               isSelected={transportKey(connection) === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
+              onManage={
+                connection.auth_provider === "codex"
+                  ? () => setManaging(connection)
+                  : undefined
+              }
             />
           ))}
         </div>
       )}
 
       <UpcomingConnections />
+
+      <ManageConnectionDialog
+        connection={managing}
+        account={managing ? accountFor(managing) : undefined}
+        onOpenChange={(open) => {
+          if (!open) setManaging(null);
+        }}
+      />
     </section>
   );
 }
 
 interface RowProps {
   connection: ChatTransportResponse;
+  account?: string;
   selectable: boolean;
   isSelected: boolean;
   isSaving: boolean;
   onSelect: () => void;
+  onManage?: () => void;
 }
 
 function ConnectionRow({
   connection,
+  account,
   selectable,
   isSelected,
   isSaving,
   onSelect,
+  onManage,
 }: RowProps) {
   const body = (
     <>
@@ -118,6 +141,11 @@ function ConnectionRow({
               Connected
             </span>
           )}
+          {account && (
+            <span className="max-w-full truncate rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+              {account}
+            </span>
+          )}
           {isSelected && (
             <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
               <Icon icon={SparklesIcon} size={13} />
@@ -132,32 +160,51 @@ function ConnectionRow({
     </>
   );
 
+  const manage = onManage ? (
+    <Button
+      variant="secondary"
+      size="small"
+      className="ml-auto flex-none self-center"
+      onClick={onManage}
+    >
+      Manage
+    </Button>
+  ) : null;
+
   if (!selectable) {
     return (
       <div className="flex w-full items-start gap-3 rounded-2xl border border-[#DADADC] bg-white p-4">
         {body}
+        {manage}
       </div>
     );
   }
 
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      disabled={isSaving}
-      onClick={onSelect}
+    <div
       className={cn(
-        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        "flex w-full items-start rounded-2xl border bg-white pr-4 transition-colors",
         isSelected
           ? "border-[#7444E5] ring-1 ring-[#7444E5]"
           : "border-[#DADADC] hover:bg-[#F9F9FA]",
-        isSaving && "cursor-progress opacity-70",
       )}
     >
-      {body}
-    </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        disabled={isSaving}
+        onClick={onSelect}
+        className={cn(
+          "flex min-w-0 flex-1 items-start gap-3 rounded-2xl p-4 text-left",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5]",
+          isSaving && "cursor-progress opacity-70",
+        )}
+      >
+        {body}
+      </button>
+      {manage}
+    </div>
   );
 }
 

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+  CheckmarkCircle02Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons";
+
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+import { describeTransport, transportKey } from "./helpers";
+import { useAIConnectionsSection } from "./useAIConnectionsSection";
+
+export function AIConnectionsSection() {
+  const {
+    connections,
+    selectedKey,
+    chooseDefault,
+    isSaving,
+    isLoading,
+    isError,
+  } = useAIConnectionsSection();
+
+  // The section describes which connection powers a chat. With nothing to
+  // choose between, there is no decision to present — and an error here must
+  // not take the tool integrations below it down with it.
+  if (isError || (!isLoading && connections.length < 2)) return null;
+
+  return (
+    <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
+      <Text
+        variant="small-medium"
+        as="h2"
+        id="ai-connections-heading"
+        className="uppercase tracking-[0.06em] text-[#505057]"
+      >
+        AI subscriptions
+      </Text>
+      <Text variant="body" className="mt-2 max-w-[600px] text-[#505057]">
+        These power your agents. Pick the one new chats should start on — you
+        can still change it per conversation, and nothing switches on its own.
+      </Text>
+
+      {isLoading ? (
+        <div className="mt-4 flex flex-col gap-3">
+          <Skeleton className="h-[86px] w-full rounded-2xl" />
+          <Skeleton className="h-[86px] w-full rounded-2xl" />
+        </div>
+      ) : (
+        <div
+          role="radiogroup"
+          aria-label="Connection new chats start on"
+          className="mt-4 flex flex-col gap-3"
+        >
+          {connections.map((connection) => (
+            <ConnectionRow
+              key={transportKey(connection)}
+              connection={connection}
+              isSelected={transportKey(connection) === selectedKey}
+              isSaving={isSaving}
+              onSelect={() => chooseDefault(connection)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface RowProps {
+  connection: ChatTransportResponse;
+  isSelected: boolean;
+  isSaving: boolean;
+  onSelect: () => void;
+}
+
+function ConnectionRow({
+  connection,
+  isSelected,
+  isSaving,
+  onSelect,
+}: RowProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      disabled={isSaving}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        isSelected
+          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
+          : "border-[#DADADC] hover:bg-[#F9F9FA]",
+        isSaving && "cursor-progress opacity-70",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
+          isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
+        )}
+      >
+        {isSelected && (
+          <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
+        )}
+      </span>
+
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-black">
+            {connection.label}
+          </Text>
+          {connection.auth_provider === "codex" && (
+            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#E8F8F0] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#157E58]">
+              <Icon icon={CheckmarkCircle02Icon} size={13} />
+              Connected
+            </span>
+          )}
+          {isSelected && (
+            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+              <Icon icon={SparklesIcon} size={13} />
+              Used for new chats
+            </span>
+          )}
+        </span>
+        <Text variant="small" as="span" className="text-[#505057]">
+          {describeTransport(connection)}
+        </Text>
+      </span>
+    </button>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -24,10 +24,12 @@ export function AIConnectionsSection() {
     isError,
   } = useAIConnectionsSection();
 
-  // The section describes which connection powers a chat. With nothing to
-  // choose between, there is no decision to present — and an error here must
-  // not take the tool integrations below it down with it.
-  if (isError || (!isLoading && connections.length < 2)) return null;
+  // A failure here must not take the tool integrations below it down with it.
+  if (isError) return null;
+
+  // One connection is not a choice. The rows still say what powers a chat,
+  // they just stop presenting a decision that doesn't exist.
+  const hasChoice = connections.length > 1;
 
   return (
     <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
@@ -40,8 +42,9 @@ export function AIConnectionsSection() {
         AI subscriptions
       </Text>
       <Text variant="body" className="mt-2 max-w-[600px] text-[#505057]">
-        These power your agents. Pick the one new chats should start on — you
-        can still change it per conversation, and nothing switches on its own.
+        {hasChoice
+          ? "These power your agents. Pick the one new chats should start on — you can still change it per conversation, and nothing switches on its own."
+          : "These power your agents. Link a subscription and you can choose which one new chats start on."}
       </Text>
 
       {isLoading ? (
@@ -51,14 +54,15 @@ export function AIConnectionsSection() {
         </div>
       ) : (
         <div
-          role="radiogroup"
-          aria-label="Connection new chats start on"
+          role={hasChoice ? "radiogroup" : undefined}
+          aria-label={hasChoice ? "Connection new chats start on" : undefined}
           className="mt-4 flex flex-col gap-3"
         >
           {connections.map((connection) => (
             <ConnectionRow
               key={transportKey(connection)}
               connection={connection}
+              selectable={hasChoice}
               isSelected={transportKey(connection) === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
@@ -66,12 +70,15 @@ export function AIConnectionsSection() {
           ))}
         </div>
       )}
+
+      <UpcomingConnections />
     </section>
   );
 }
 
 interface RowProps {
   connection: ChatTransportResponse;
+  selectable: boolean;
   isSelected: boolean;
   isSaving: boolean;
   onSelect: () => void;
@@ -79,37 +86,26 @@ interface RowProps {
 
 function ConnectionRow({
   connection,
+  selectable,
   isSelected,
   isSaving,
   onSelect,
 }: RowProps) {
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      disabled={isSaving}
-      onClick={onSelect}
-      className={cn(
-        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
-        isSelected
-          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
-          : "border-[#DADADC] hover:bg-[#F9F9FA]",
-        isSaving && "cursor-progress opacity-70",
+  const body = (
+    <>
+      {selectable && (
+        <span
+          aria-hidden
+          className={cn(
+            "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
+            isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
+          )}
+        >
+          {isSelected && (
+            <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
+          )}
+        </span>
       )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
-          isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
-        )}
-      >
-        {isSelected && (
-          <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
-        )}
-      </span>
 
       <span className="flex min-w-0 flex-col gap-1">
         <span className="flex flex-wrap items-center gap-2">
@@ -133,6 +129,66 @@ function ConnectionRow({
           {describeTransport(connection)}
         </Text>
       </span>
+    </>
+  );
+
+  if (!selectable) {
+    return (
+      <div className="flex w-full items-start gap-3 rounded-2xl border border-[#DADADC] bg-white p-4">
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      disabled={isSaving}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        isSelected
+          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
+          : "border-[#DADADC] hover:bg-[#F9F9FA]",
+        isSaving && "cursor-progress opacity-70",
+      )}
+    >
+      {body}
     </button>
+  );
+}
+
+/**
+ * Names what is coming without claiming it works yet. Each provider needs its
+ * own adapter and its own provider/legal approval before it can appear as a
+ * real row above, so this promises nothing about capability or timing.
+ */
+function UpcomingConnections() {
+  return (
+    <div className="mt-3 flex items-start gap-3 rounded-2xl border border-dashed border-[#DADADC] p-4">
+      <span
+        aria-hidden
+        className="mt-[2px] flex h-4 w-4 flex-none items-center justify-center text-[#9A9A9F]"
+      >
+        <Icon icon={SparklesIcon} size={16} />
+      </span>
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-[#505057]">
+            GitHub Copilot and Grok
+          </Text>
+          <span className="inline-flex items-center rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+            Coming soon
+          </span>
+        </span>
+        <Text variant="small" as="span" className="text-[#505057]">
+          More subscriptions you already pay for. Each one shows up here once it
+          is approved to run AutoGPT agents.
+        </Text>
+      </span>
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { getGetV2ListChatTransportsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
+import { useGetV1CodexAccount } from "@/app/api/__generated__/endpoints/integrations/integrations";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+
+import { useOAuthConnect } from "../ConnectServiceDialog/components/DetailView/useOAuthConnect";
+import { useDeleteIntegration } from "../hooks/useDeleteIntegration";
+
+interface Props {
+  connection: ChatTransportResponse | null;
+  account?: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Single-account first pass. Deliberately shows no usage figure and no reset
+ * window: the only numbers available would be from whenever they were last
+ * observed, and a stale window presented as current is worse than none —
+ * especially on the reconnect path, where authorization is already invalid.
+ */
+export function ManageConnectionDialog({
+  connection,
+  account,
+  onOpenChange,
+}: Props) {
+  const queryClient = useQueryClient();
+  const credentialId = connection?.credential_id ?? null;
+
+  // Asked for only while this dialog is open. Reading it leases a runtime
+  // against the provider, so it must never run on the list behind — and it
+  // means what is shown was true a moment ago rather than whenever the
+  // connection was last used.
+  const accountQuery = useGetV1CodexAccount(credentialId ?? "", {
+    query: { enabled: credentialId !== null, staleTime: 0, retry: false },
+  });
+  const snapshot =
+    accountQuery.data?.status === 200 ? accountQuery.data.data : undefined;
+
+  const { connect, isPending: isReconnecting } = useOAuthConnect({
+    provider: "codex",
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: getGetV2ListChatTransportsQueryKey(),
+      });
+      onOpenChange(false);
+    },
+  });
+
+  const { remove, isPending: isDisconnecting } = useDeleteIntegration();
+
+  async function disconnect() {
+    if (!credentialId) return;
+    await remove([
+      { id: credentialId, provider: "codex", name: account ?? "ChatGPT" },
+    ]);
+    queryClient.invalidateQueries({
+      queryKey: getGetV2ListChatTransportsQueryKey(),
+    });
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog
+      title="ChatGPT"
+      styling={{ maxWidth: "28rem" }}
+      controlled={{ isOpen: connection !== null, set: onOpenChange }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <Text variant="small" className="text-[#8A8A90]">
+              Connected account
+            </Text>
+            <Text variant="body-medium" className="text-black">
+              {snapshot?.email ?? account ?? "Your ChatGPT account"}
+            </Text>
+            {accountQuery.isLoading ? (
+              <Text variant="small" className="text-[#8A8A90]">
+                Checking with ChatGPT…
+              </Text>
+            ) : accountQuery.isError ? (
+              <Text variant="small" className="text-[#8A8A90]">
+                Could not reach ChatGPT to confirm the plan on this account.
+              </Text>
+            ) : (
+              (snapshot?.plan_type || snapshot?.account_type) && (
+                <span className="mt-1 flex flex-wrap gap-2">
+                  {snapshot.plan_type && (
+                    <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+                      {snapshot.plan_type} plan
+                    </span>
+                  )}
+                  {snapshot.account_type && (
+                    <span className="rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+                      {snapshot.account_type} workspace
+                    </span>
+                  )}
+                </span>
+              )
+            )}
+          </div>
+
+          <Text variant="small" className="text-[#505057]">
+            {connection?.default
+              ? "New chats start on this connection and run on your ChatGPT plan."
+              : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
+          </Text>
+
+          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={connect}
+              loading={isReconnecting}
+              disabled={isDisconnecting}
+            >
+              Reconnect
+            </Button>
+            <Button
+              variant="destructive"
+              size="small"
+              onClick={disconnect}
+              loading={isDisconnecting}
+              disabled={isReconnecting}
+            >
+              Disconnect
+            </Button>
+          </div>
+
+          <Text variant="small" className="text-[#8A8A90]">
+            Disconnecting stops new chats running on your ChatGPT plan. Your
+            chat history is kept, and your other integrations are unaffected.
+          </Text>
+        </div>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { getGetV2ListChatTransportsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
@@ -10,6 +11,7 @@ import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
 
 import { useOAuthConnect } from "../ConnectServiceDialog/components/DetailView/useOAuthConnect";
+import { DeleteConfirmDialog } from "../DeleteConfirmDialog/DeleteConfirmDialog";
 import { useDeleteIntegration } from "../hooks/useDeleteIntegration";
 
 interface Props {
@@ -31,6 +33,7 @@ export function ManageConnectionDialog({
 }: Props) {
   const queryClient = useQueryClient();
   const credentialId = connection?.credential_id ?? null;
+  const [forceMessage, setForceMessage] = useState<string | null>(null);
 
   // Asked for only while this dialog is open. Reading it leases a runtime
   // against the provider, so it must never run on the list behind — and it
@@ -39,8 +42,16 @@ export function ManageConnectionDialog({
   const accountQuery = useGetV1CodexAccount(credentialId ?? "", {
     query: { enabled: credentialId !== null, staleTime: 0, retry: false },
   });
-  const snapshot =
+  const accountResponse =
     accountQuery.data?.status === 200 ? accountQuery.data.data : undefined;
+  const snapshot = accountResponse?.connected ? accountResponse : undefined;
+  const requiresReconnect =
+    accountResponse !== undefined && !accountResponse.connected;
+
+  function setManageOpen(open: boolean) {
+    if (!open) setForceMessage(null);
+    onOpenChange(open);
+  }
 
   const { connect, isPending: isReconnecting } = useOAuthConnect({
     provider: "codex",
@@ -48,95 +59,133 @@ export function ManageConnectionDialog({
       queryClient.invalidateQueries({
         queryKey: getGetV2ListChatTransportsQueryKey(),
       });
-      onOpenChange(false);
+      setManageOpen(false);
     },
   });
 
   const { remove, isPending: isDisconnecting } = useDeleteIntegration();
 
-  async function disconnect() {
+  async function disconnect(force = false) {
     if (!credentialId) return;
-    await remove([
-      { id: credentialId, provider: "codex", name: account ?? "ChatGPT" },
-    ]);
-    queryClient.invalidateQueries({
+    const target = {
+      id: credentialId,
+      provider: "codex",
+      name: account ?? "ChatGPT",
+    };
+    const result = await remove([target], force);
+    const confirmation = result.needsConfirmation[0];
+    if (confirmation) {
+      setForceMessage(confirmation.message);
+      return;
+    }
+    if (result.succeeded.length === 0) return;
+
+    setForceMessage(null);
+    await queryClient.invalidateQueries({
       queryKey: getGetV2ListChatTransportsQueryKey(),
     });
-    onOpenChange(false);
+    setManageOpen(false);
   }
 
   return (
-    <Dialog
-      title="ChatGPT"
-      styling={{ maxWidth: "28rem" }}
-      controlled={{ isOpen: connection !== null, set: onOpenChange }}
-    >
-      <Dialog.Content>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1">
-            <Text variant="small" className="text-[#8A8A90]">
-              Connected account
-            </Text>
-            <Text variant="body-medium" className="text-black">
-              {snapshot?.email ?? account ?? "Your ChatGPT account"}
-            </Text>
-            {accountQuery.isLoading ? (
+    <>
+      <Dialog
+        title="ChatGPT"
+        styling={{ maxWidth: "28rem" }}
+        controlled={{
+          isOpen: connection !== null && forceMessage === null,
+          set: (open) => {
+            // Opening the force-confirmation dialog intentionally hides this
+            // one. Radix reports that controlled close through this callback;
+            // keep the connection selected so Cancel can return here.
+            if (!open && forceMessage !== null) return;
+            setManageOpen(open);
+          },
+        }}
+      >
+        <Dialog.Content>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
               <Text variant="small" className="text-[#8A8A90]">
-                Checking with ChatGPT…
+                Connected account
               </Text>
-            ) : accountQuery.isError ? (
-              <Text variant="small" className="text-[#8A8A90]">
-                Could not reach ChatGPT to confirm the plan on this account.
+              <Text variant="body-medium" className="text-black">
+                {snapshot?.email ?? account ?? "Your ChatGPT account"}
               </Text>
-            ) : (
-              snapshot?.plan_type && (
-                <span className="mt-1 flex flex-wrap gap-2">
-                  <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
-                    {snapshot.plan_type} plan
+              {accountQuery.isLoading ? (
+                <Text variant="small" className="text-[#8A8A90]">
+                  Checking with ChatGPT…
+                </Text>
+              ) : accountQuery.isError ? (
+                <Text variant="small" className="text-[#8A8A90]">
+                  Could not reach ChatGPT to confirm the plan on this account.
+                </Text>
+              ) : requiresReconnect ? (
+                <Text variant="small" className="text-amber-700">
+                  ChatGPT says this connection needs to be reconnected.
+                </Text>
+              ) : (
+                snapshot?.plan_type && (
+                  <span className="mt-1 flex flex-wrap gap-2">
+                    <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+                      {snapshot.plan_type} plan
+                    </span>
                   </span>
-                </span>
-              )
-            )}
+                )
+              )}
+            </div>
+
+            <Text variant="small" className="text-[#8A8A90]">
+              ChatGPT identifies the workspace behind this connection only by an
+              internal id, so it cannot be named here yet.
+            </Text>
+
+            <Text variant="small" className="text-[#505057]">
+              {connection?.default
+                ? "New chats start on this connection and run on your ChatGPT plan."
+                : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
+            </Text>
+
+            <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={connect}
+                loading={isReconnecting}
+                disabled={isDisconnecting}
+              >
+                Reconnect
+              </Button>
+              <Button
+                variant="destructive"
+                size="small"
+                onClick={() => void disconnect()}
+                loading={isDisconnecting}
+                disabled={isReconnecting}
+              >
+                Disconnect
+              </Button>
+            </div>
+
+            <Text variant="small" className="text-[#8A8A90]">
+              Disconnecting stops new chats running on your ChatGPT plan. Your
+              chat history is kept, and your other integrations are unaffected.
+            </Text>
           </div>
+        </Dialog.Content>
+      </Dialog>
 
-          <Text variant="small" className="text-[#8A8A90]">
-            ChatGPT identifies the workspace behind this connection only by an
-            internal id, so it cannot be named here yet.
-          </Text>
-
-          <Text variant="small" className="text-[#505057]">
-            {connection?.default
-              ? "New chats start on this connection and run on your ChatGPT plan."
-              : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
-          </Text>
-
-          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="secondary"
-              size="small"
-              onClick={connect}
-              loading={isReconnecting}
-              disabled={isDisconnecting}
-            >
-              Reconnect
-            </Button>
-            <Button
-              variant="destructive"
-              size="small"
-              onClick={disconnect}
-              loading={isDisconnecting}
-              disabled={isReconnecting}
-            >
-              Disconnect
-            </Button>
-          </div>
-
-          <Text variant="small" className="text-[#8A8A90]">
-            Disconnecting stops new chats running on your ChatGPT plan. Your
-            chat history is kept, and your other integrations are unaffected.
-          </Text>
-        </div>
-      </Dialog.Content>
-    </Dialog>
+      <DeleteConfirmDialog
+        open={forceMessage !== null}
+        onOpenChange={(open) => {
+          if (!open) setForceMessage(null);
+        }}
+        itemNames={[account ?? "ChatGPT"]}
+        isPending={isDisconnecting}
+        onConfirm={() => void disconnect(true)}
+        variant="force"
+        notice={forceMessage ?? undefined}
+      />
+    </>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -40,7 +40,15 @@ export function ManageConnectionDialog({
   // means what is shown was true a moment ago rather than whenever the
   // connection was last used.
   const accountQuery = useGetV1CodexAccount(credentialId ?? "", {
-    query: { enabled: credentialId !== null, staleTime: 0, retry: false },
+    query: {
+      enabled: credentialId !== null,
+      staleTime: 0,
+      retry: false,
+      // A window-focus refetch would lease another provider runtime while
+      // the same snapshot is already visible. Reopening Manage is the user's
+      // explicit refresh boundary.
+      refetchOnWindowFocus: false,
+    },
   });
   const accountResponse =
     accountQuery.data?.status === 200 ? accountQuery.data.data : undefined;

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -89,22 +89,20 @@ export function ManageConnectionDialog({
                 Could not reach ChatGPT to confirm the plan on this account.
               </Text>
             ) : (
-              (snapshot?.plan_type || snapshot?.account_type) && (
+              snapshot?.plan_type && (
                 <span className="mt-1 flex flex-wrap gap-2">
-                  {snapshot.plan_type && (
-                    <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
-                      {snapshot.plan_type} plan
-                    </span>
-                  )}
-                  {snapshot.account_type && (
-                    <span className="rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
-                      {snapshot.account_type} workspace
-                    </span>
-                  )}
+                  <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+                    {snapshot.plan_type} plan
+                  </span>
                 </span>
               )
             )}
           </div>
+
+          <Text variant="small" className="text-[#8A8A90]">
+            ChatGPT identifies the workspace behind this connection only by an
+            internal id, so it cannot be named here yet.
+          </Text>
 
           <Text variant="small" className="text-[#505057]">
             {connection?.default

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -102,11 +102,23 @@ describe("AIConnectionsSection", () => {
     await waitFor(() => expect(saved).not.toHaveBeenCalled());
   });
 
-  it("stays out of the way when there is nothing to choose between", async () => {
+  it("presents no choice when there is only one connection", async () => {
     mockTransports([platform(true)]);
 
     render(<AIConnectionsSection />);
 
-    await waitFor(() => expect(screen.queryByRole("radiogroup")).toBeNull());
+    // The row still says what powers a chat — it just isn't a decision.
+    expect(await screen.findByText("Self-hosted chat")).toBeDefined();
+    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(screen.queryByRole("radio")).toBeNull();
+  });
+
+  it("names what is coming without claiming it works", async () => {
+    mockTransports([platform(true)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("GitHub Copilot and Grok")).toBeDefined();
+    expect(screen.getByText("Coming soon")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -2,7 +2,12 @@ import {
   getGetV2ListChatTransportsMockHandler200,
   getPutV2SetDefaultChatTransportMockHandler200,
 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
-import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
+import {
+  getDeleteV1DeleteCredentialsMockHandler200,
+  getDeleteV1DeleteCredentialsMockHandler401,
+  getGetV1CodexAccountMockHandler200,
+  getGetV1ListCredentialsMockHandler200,
+} from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
@@ -73,6 +78,89 @@ describe("AIConnectionsSection", () => {
     render(<AIConnectionsSection />);
 
     expect(await screen.findByText("nick@example.com")).toBeDefined();
+  });
+
+  it("treats a disconnected account snapshot as requiring reconnect", async () => {
+    mockTransports(
+      [platform(false), chatgpt(true)],
+      [{ id: "cred-1", username: "stored@example.com" }],
+    );
+    server.use(
+      getGetV1CodexAccountMockHandler200({
+        connected: false,
+        requires_openai_auth: true,
+        email: "stale@example.com",
+        plan_type: "Plus",
+      }),
+    );
+
+    render(<AIConnectionsSection />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Manage" }),
+    );
+
+    expect(
+      await screen.findByText(/connection needs to be reconnected/i),
+    ).toBeDefined();
+    expect(screen.getAllByText("stored@example.com")).toHaveLength(2);
+    expect(screen.queryByText("stale@example.com")).toBeNull();
+    expect(screen.queryByText("Plus plan")).toBeNull();
+  });
+
+  it("keeps the manage dialog open when disconnect fails", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+    server.use(
+      getGetV1CodexAccountMockHandler200({
+        connected: true,
+        requires_openai_auth: false,
+      }),
+      getDeleteV1DeleteCredentialsMockHandler401({ detail: "Not authorized" }),
+    );
+
+    render(<AIConnectionsSection />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Manage" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Disconnect" })).toBeDefined(),
+    );
+  });
+
+  it("asks before force-removing an in-use connection", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+    server.use(
+      getGetV1CodexAccountMockHandler200({
+        connected: true,
+        requires_openai_auth: false,
+      }),
+      getDeleteV1DeleteCredentialsMockHandler200(({ request }) =>
+        new URL(request.url).searchParams.get("force") === "true"
+          ? { deleted: true, revoked: true }
+          : {
+              deleted: false,
+              need_confirmation: true,
+              message: "Used by an active schedule",
+            },
+      ),
+    );
+
+    render(<AIConnectionsSection />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Manage" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Force remove" }),
+    ).toBeDefined();
+    expect(await screen.findByText("Used by an active schedule")).toBeDefined();
+    await userEvent.click(screen.getByRole("button", { name: "Force remove" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull(),
+    );
   });
 
   it("marks the saved default, and only that one", async () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -2,6 +2,7 @@ import {
   getGetV2ListChatTransportsMockHandler200,
   getPutV2SetDefaultChatTransportMockHandler200,
 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
@@ -30,10 +31,23 @@ function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
   };
 }
 
-function mockTransports(transports: ChatTransportResponse[]) {
+function mockTransports(
+  transports: ChatTransportResponse[],
+  credentials: { id: string; username: string }[] = [],
+) {
   server.use(
     getGetV2ListChatTransportsMockHandler200({ transports }),
     getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+    getGetV1ListCredentialsMockHandler200(
+      credentials.map((credential) => ({
+        id: credential.id,
+        provider: "codex",
+        type: "oauth2" as const,
+        title: "ChatGPT for Codex",
+        scopes: [],
+        username: credential.username,
+      })),
+    ),
   );
 }
 
@@ -48,6 +62,17 @@ describe("AIConnectionsSection", () => {
     expect(
       screen.getByText(/backed by your ChatGPT plan, and spend no AutoGPT/i),
     ).toBeDefined();
+  });
+
+  it("names the account a connection runs as", async () => {
+    mockTransports(
+      [platform(false), chatgpt(true)],
+      [{ id: "cred-1", username: "nick@example.com" }],
+    );
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("nick@example.com")).toBeDefined();
   });
 
   it("marks the saved default, and only that one", async () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -1,0 +1,112 @@
+import {
+  getGetV2ListChatTransportsMockHandler200,
+  getPutV2SetDefaultChatTransportMockHandler200,
+} from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { server } from "@/mocks/mock-server";
+import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AIConnectionsSection } from "../AIConnectionsSection";
+
+function platform(isDefault: boolean): ChatTransportResponse {
+  return {
+    auth_provider: "platform",
+    credential_id: null,
+    label: "Self-hosted chat",
+    available: true,
+    default: isDefault,
+  };
+}
+
+function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
+  return {
+    auth_provider: "codex",
+    credential_id: id,
+    label: "ChatGPT",
+    available: true,
+    default: isDefault,
+  };
+}
+
+function mockTransports(transports: ChatTransportResponse[]) {
+  server.use(
+    getGetV2ListChatTransportsMockHandler200({ transports }),
+    getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+  );
+}
+
+describe("AIConnectionsSection", () => {
+  it("lists every connection with what backs a run on it", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("Self-hosted chat")).toBeDefined();
+    expect(screen.getByText("ChatGPT")).toBeDefined();
+    expect(
+      screen.getByText(/backed by your ChatGPT plan, and spend no AutoGPT/i),
+    ).toBeDefined();
+  });
+
+  it("marks the saved default, and only that one", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+
+    render(<AIConnectionsSection />);
+
+    const options = await screen.findAllByRole("radio");
+    expect(options).toHaveLength(2);
+    const checked = options.filter(
+      (option) => option.getAttribute("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0].textContent).toContain("ChatGPT");
+  });
+
+  it("saves the connection the user picks", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+    const saved = vi.fn();
+    server.events.on("request:start", ({ request }) => {
+      if (
+        request.method === "PUT" &&
+        request.url.includes("transports/default")
+      )
+        saved();
+    });
+
+    render(<AIConnectionsSection />);
+    const chatgptOption = await screen.findByRole("radio", { name: /ChatGPT/ });
+    await userEvent.click(chatgptOption);
+
+    await waitFor(() => expect(saved).toHaveBeenCalled());
+  });
+
+  it("does not re-save the connection that is already the default", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+    const saved = vi.fn();
+    server.events.on("request:start", ({ request }) => {
+      if (
+        request.method === "PUT" &&
+        request.url.includes("transports/default")
+      )
+        saved();
+    });
+
+    render(<AIConnectionsSection />);
+    const current = await screen.findByRole("radio", {
+      name: /Self-hosted chat/,
+    });
+    await userEvent.click(current);
+
+    await waitFor(() => expect(saved).not.toHaveBeenCalled());
+  });
+
+  it("stays out of the way when there is nothing to choose between", async () => {
+    mockTransports([platform(true)]);
+
+    render(<AIConnectionsSection />);
+
+    await waitFor(() => expect(screen.queryByRole("radiogroup")).toBeNull());
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -1,0 +1,37 @@
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+
+/**
+ * The label the server sends for the platform transport on a self-hosted
+ * install. It sends "AutoGPT Platform" on the hosted product instead.
+ */
+export const SELF_HOSTED_LABEL = "Self-hosted chat";
+
+/**
+ * Says what backs a run, which is the thing that actually differs between
+ * connections. Copy lives here only until the server-owned connection offer
+ * carries it — the client should not be deciding how a provider describes
+ * its own billing.
+ */
+export function describeTransport(transport: ChatTransportResponse): string {
+  if (transport.auth_provider === "codex") {
+    return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
+  }
+  return transport.label === SELF_HOSTED_LABEL
+    ? "New chats are backed by the chat provider configured on this server."
+    : "New chats are backed by your AutoGPT plan.";
+}
+
+export function isSelectable(transport: ChatTransportResponse): boolean {
+  return (
+    transport.available &&
+    (transport.auth_provider === "platform" || transport.credential_id !== null)
+  );
+}
+
+/**
+ * A stable key. The platform transport carries no credential id, and a user
+ * can hold several ChatGPT accounts, so neither half identifies a row alone.
+ */
+export function transportKey(transport: ChatTransportResponse): string {
+  return `${transport.auth_provider}:${transport.credential_id ?? "deployment"}`;
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -16,9 +16,12 @@ export function describeTransport(transport: ChatTransportResponse): string {
   if (transport.auth_provider === "codex") {
     return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
   }
+  // The ChatGPT line promises "no AutoGPT credits", which only means anything
+  // if the row it contrasts with says credits are spent. Self-host has no
+  // credits at all, so it says what it actually has instead.
   return transport.label === SELF_HOSTED_LABEL
     ? "New chats are backed by the chat provider configured on this server."
-    : "New chats are backed by your AutoGPT plan.";
+    : "New chats are backed by your AutoGPT plan, and spend AutoGPT credits.";
 }
 
 export function isSelectable(transport: ChatTransportResponse): boolean {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -45,7 +45,7 @@ export function useAIConnectionsSection() {
     return accountByCredentialId.get(transport.credential_id);
   }
 
-  const { mutateAsync: setDefault, isPending: isSaving } =
+  const { mutate: setDefault, isPending: isSaving } =
     usePutV2SetDefaultChatTransport({
       mutation: {
         onSuccess: () => {
@@ -70,9 +70,9 @@ export function useAIConnectionsSection() {
     ? transportKey(connections.find((t) => t.default)!)
     : null;
 
-  async function chooseDefault(transport: ChatTransportResponse) {
+  function chooseDefault(transport: ChatTransportResponse) {
     if (transport.default) return;
-    await setDefault({
+    setDefault({
       data: {
         auth_provider: transport.auth_provider,
         credential_id: transport.credential_id,

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGetV2ListChatTransportsQueryKey,
+  useGetV2ListChatTransports,
+  usePutV2SetDefaultChatTransport,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+
+import { isSelectable, transportKey } from "./helpers";
+
+export function useAIConnectionsSection() {
+  const queryClient = useQueryClient();
+  const transportsQuery = useGetV2ListChatTransports({
+    query: { refetchOnWindowFocus: true },
+  });
+
+  const transports: ChatTransportResponse[] =
+    transportsQuery.data?.status === 200
+      ? transportsQuery.data.data.transports
+      : [];
+  const connections = transports.filter(isSelectable);
+
+  const { mutateAsync: setDefault, isPending: isSaving } =
+    usePutV2SetDefaultChatTransport({
+      mutation: {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: getGetV2ListChatTransportsQueryKey(),
+          });
+        },
+        onError: () => {
+          toast({
+            variant: "destructive",
+            title: "Could not save that connection",
+            description:
+              "Your default is unchanged. Check the connection is still linked, then try again.",
+          });
+        },
+      },
+    });
+
+  // Tracked separately from the query so the row the user clicked shows the
+  // pending state, rather than every row going busy at once.
+  const selectedKey = connections.find((t) => t.default)
+    ? transportKey(connections.find((t) => t.default)!)
+    : null;
+
+  async function chooseDefault(transport: ChatTransportResponse) {
+    if (transport.default) return;
+    await setDefault({
+      data: {
+        auth_provider: transport.auth_provider,
+        credential_id: transport.credential_id,
+      },
+    });
+  }
+
+  return {
+    connections,
+    selectedKey,
+    chooseDefault,
+    isSaving,
+    isLoading: transportsQuery.isLoading,
+    isError: transportsQuery.isError,
+    refetch: transportsQuery.refetch,
+  };
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -7,6 +7,7 @@ import {
   useGetV2ListChatTransports,
   usePutV2SetDefaultChatTransport,
 } from "@/app/api/__generated__/endpoints/chat/chat";
+import { useGetV1ListCredentials } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
 import { toast } from "@/components/molecules/Toast/use-toast";
 
@@ -23,6 +24,26 @@ export function useAIConnectionsSection() {
       ? transportsQuery.data.data.transports
       : [];
   const connections = transports.filter(isSelectable);
+
+  // The account a connection runs as. Read from the stored credential rather
+  // than asked of the provider: this is the identity the user linked, so it is
+  // true without a live call, and it cannot go stale the way a usage window
+  // can.
+  const credentialsQuery = useGetV1ListCredentials({
+    query: {
+      select: (response) => (response.status === 200 ? response.data : []),
+    },
+  });
+  const accountByCredentialId = new Map(
+    (credentialsQuery.data ?? [])
+      .filter((credential) => credential.username)
+      .map((credential) => [credential.id, credential.username as string]),
+  );
+
+  function accountFor(transport: ChatTransportResponse): string | undefined {
+    if (!transport.credential_id) return undefined;
+    return accountByCredentialId.get(transport.credential_id);
+  }
 
   const { mutateAsync: setDefault, isPending: isSaving } =
     usePutV2SetDefaultChatTransport({
@@ -61,6 +82,7 @@ export function useAIConnectionsSection() {
 
   return {
     connections,
+    accountFor,
     selectedKey,
     chooseDefault,
     isSaving,

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  ArrowDataTransferHorizontalIcon,
+  ShieldKeyIcon,
+  SparklesIcon,
+  Target02Icon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Point {
+  icon: IconSvgElement;
+  title: string;
+  body: string;
+}
+
+/**
+ * Linking a ChatGPT plan changes who pays for a run, so the four questions
+ * that implies get answered on screen before the OAuth window opens rather
+ * than after the user has committed.
+ *
+ * Deliberately claims nothing about specific models or about pausing and
+ * resuming a run at a provider limit: the model catalog is server-owned, and
+ * same-chat recovery is not built yet. Both land with their own work.
+ */
+const POINTS: Point[] = [
+  {
+    icon: ArrowDataTransferHorizontalIcon,
+    title: "What it does.",
+    body: "Chats routed to ChatGPT run on your ChatGPT plan instead of AutoGPT credits. Every new chat starts on the connection you choose in Settings, and you can change it per conversation — nothing switches on its own.",
+  },
+  {
+    icon: Target02Icon,
+    title: "What it costs.",
+    body: "Usage counts toward your ChatGPT plan's own limits. Those runs spend zero AutoGPT credits, and AutoGPT never adds a charge on top.",
+  },
+  {
+    icon: SparklesIcon,
+    title: "What you get.",
+    body: "The models your ChatGPT plan already includes, at no extra cost from AutoGPT.",
+  },
+  {
+    icon: ShieldKeyIcon,
+    title: "Stay in control.",
+    body: "A chat stays on the connection it started with, so a run is never moved onto your AutoGPT credits without asking. Disconnect any time in Settings.",
+  },
+];
+
+export function ChatGPTConnectExplainer() {
+  return (
+    <div className="divide-y divide-[#DADADC] rounded-2xl border border-[#DADADC] bg-[#FBFBFC]">
+      {POINTS.map((point) => (
+        <div key={point.title} className="flex items-start gap-3 p-4">
+          <span
+            aria-hidden
+            className="mt-[2px] flex h-6 w-6 flex-none items-center justify-center rounded-lg bg-[#F1EBFF] text-[#7444E5]"
+          >
+            <Icon icon={point.icon} size={14} />
+          </span>
+          <Text variant="small" className="text-[#505057]">
+            <span className="font-medium text-black">{point.title}</span>{" "}
+            {point.body}
+          </Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../helpers";
 import { ApiKeyConnectForm } from "./ApiKeyConnectForm";
 import { DeviceAuthConnectButton } from "@/components/contextual/DeviceAuth/DeviceAuthConnectButton";
+import { ChatGPTConnectExplainer } from "./ChatGPTConnectExplainer";
 import { OAuthConnectButton } from "./OAuthConnectButton";
 import { UnsupportedNotice } from "./UnsupportedNotice";
 
@@ -31,12 +32,16 @@ export function MethodPanel({ method, provider, onSuccess }: Props) {
   if (method === AuthType.oauth2) {
     const isChatGPT = authProvider === "codex";
     return (
-      <OAuthConnectButton
-        provider={authProvider}
-        providerName={isChatGPT ? "ChatGPT" : provider.name}
-        buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
-        onSuccess={onSuccess}
-      />
+      <div className="flex flex-col gap-4">
+        {isChatGPT && <ChatGPTConnectExplainer />}
+        <OAuthConnectButton
+          provider={authProvider}
+          providerName={isChatGPT ? "ChatGPT" : provider.name}
+          buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
+          termsNotice={isChatGPT}
+          onSuccess={onSuccess}
+        />
+      </div>
     );
   }
   if (method === AuthType.api_key) {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
@@ -12,6 +12,9 @@ interface Props {
   provider: string;
   providerName: string;
   buttonLabel?: string;
+  /** Say whose terms a linked run falls under. Only true where runs execute
+   *  on the provider's own account rather than on AutoGPT's. */
+  termsNotice?: boolean;
   onSuccess: (credential?: CredentialsMetaResponse) => void;
 }
 
@@ -19,6 +22,7 @@ export function OAuthConnectButton({
   provider,
   providerName,
   buttonLabel,
+  termsNotice = false,
   onSuccess,
 }: Props) {
   const { connect, isPending } = useOAuthConnect({ provider, onSuccess });
@@ -39,6 +43,12 @@ export function OAuthConnectButton({
       >
         {buttonLabel ?? `Continue with ${providerName}`}
       </Button>
+      {termsNotice && (
+        <Text variant="small" className="text-[#8A8A90]">
+          Linked runs are sent to {providerName} under your own account and
+          follow {providerName}&apos;s terms.
+        </Text>
+      )}
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
@@ -35,4 +35,54 @@ describe("MethodPanel", () => {
       expect.objectContaining({ provider: "codex" }),
     );
   });
+
+  test("answers what linking a ChatGPT plan means before the OAuth window", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("What it does.")).toBeDefined();
+    expect(screen.getByText("What it costs.")).toBeDefined();
+    expect(screen.getByText("What you get.")).toBeDefined();
+    expect(screen.getByText("Stay in control.")).toBeDefined();
+    expect(screen.getByText(/spend zero AutoGPT credits/i)).toBeDefined();
+    expect(screen.getByText(/follow ChatGPT's terms/i)).toBeDefined();
+  });
+
+  test("claims nothing it cannot back up", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // Model names are server-owned, and pause-and-resume at a provider limit
+    // is not built yet — neither may be promised here.
+    expect(screen.queryByText(/5\.6|Terra|Sol|Balanced|Advanced/)).toBeNull();
+    expect(screen.queryByText(/the run pauses/i)).toBeNull();
+  });
+
+  test("does not show the ChatGPT explainer for an unrelated provider", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={{
+          id: "notion",
+          name: "Notion",
+          description: "Notion",
+          supportedAuthTypes: [AuthType.oauth2],
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("What it costs.")).toBeNull();
+    expect(screen.queryByText(/follow Notion's terms/i)).toBeNull();
+  });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/DeleteConfirmDialog/DeleteConfirmDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/DeleteConfirmDialog/DeleteConfirmDialog.tsx
@@ -11,6 +11,9 @@ interface Props {
   isPending?: boolean;
   onConfirm: () => void;
   variant?: "remove" | "force";
+  /** Provider-specific consequence, when the generic wording would overstate
+   *  or understate what actually stops working. */
+  notice?: string;
 }
 
 export function DeleteConfirmDialog({
@@ -20,6 +23,7 @@ export function DeleteConfirmDialog({
   isPending = false,
   onConfirm,
   variant = "remove",
+  notice,
 }: Props) {
   const count = itemNames.length;
   const isBulk = count > 1;
@@ -51,6 +55,12 @@ export function DeleteConfirmDialog({
           <Text variant="body" className="text-zinc-800">
             {message}
           </Text>
+
+          {notice && (
+            <Text variant="small" className="text-[#505057]">
+              {notice}
+            </Text>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsList/IntegrationsList.tsx
@@ -75,12 +75,17 @@ export function IntegrationsList() {
     await requestDelete(ids, true);
   }
 
-  const pendingNames = buildTargets(pendingDeleteIds).map(
-    (t) => t.name ?? t.provider,
-  );
+  const pendingTargets = buildTargets(pendingDeleteIds);
+  const pendingNames = pendingTargets.map((t) => t.name ?? t.provider);
   const pendingForceNames = buildTargets(pendingForceIds).map(
     (t) => t.name ?? t.provider,
   );
+  // The generic warning talks about agents losing access, which is not what
+  // removing a ChatGPT connection does: it stops new ChatGPT-backed chats and
+  // leaves everything already said in them alone.
+  const pendingNotice = pendingTargets.some((t) => t.provider === "codex")
+    ? "New chats can no longer run on your ChatGPT plan — they fall back to the connection AutoGPT picks. Your chat history is kept, and your other integrations are unaffected."
+    : undefined;
 
   if (isLoading) {
     return (
@@ -181,6 +186,7 @@ export function IntegrationsList() {
           if (!open) setPendingDeleteIds([]);
         }}
         itemNames={pendingNames}
+        notice={pendingNotice}
         isPending={isDeleting}
         onConfirm={confirmDelete}
       />


### PR DESCRIPTION
### Why / What / How

**Why.** The connection row said "ChatGPT" and nothing else. That is fine with one linked account and useless with two — and two is coming, because **one ChatGPT account can belong to several workspaces, each with its own subscription**.

**What.** The row names the account. **Manage** opens a dialog that asks ChatGPT for the plan and workspace type on that account, and offers Reconnect / Disconnect.

**How — two different sources, on purpose.**

- **The account on the row** comes from the stored credential's `username`. It is the identity the user linked, so it is true without a live call and cannot go stale.
- **Plan and workspace type** come from `GET /credentials/{id}/account`, asked for **only while the dialog is open**. That call leases a runtime against the provider, so it must never run behind a list — and because it is made on open, what it shows was true a moment ago rather than whenever the connection was last used. If the call fails, the dialog says so rather than rendering a figure it cannot stand behind.

Manage sits **outside** the radio target, so opening it never changes which connection new chats start on.

#### Still no usage figure or reset window

ChatGPT reports usage against a window that would have to be rendered as current. Showing a window observed at some earlier point — especially on the reconnect path, where authorization is already invalid — is precisely the failure the reconnect state exists to avoid. The endpoint for it exists (`/rate-limits`); wiring it needs a decision about how to present freshness, which is its own change.

#### On workspaces

The ChatGPT token carries `chatgpt_account_id`, `chatgpt_user_id`, `email` and `plan_type` — but **no workspace name**. `account_type` from the live snapshot is the closest available signal, so that is what the dialog shows. A human-readable workspace name would need a provider lookup that does not exist yet.

This matters beyond a label: since one account can hold several workspaces each with its own subscription, **allowing more than one ChatGPT connection per user is not the credential-sharing question it looked like**. It is the same person and the same account, selecting between workspaces they already pay for — a materially weaker legal objection than the multi-user sharing case. Tracked as follow-up work; the contracts here are already collection-shaped, so it needs no breaking change.

### Changes 🏗️

- `AIConnectionsSection` — account chip on the row, Manage button for ChatGPT connections
- `ManageConnectionDialog` — live plan/workspace snapshot, Reconnect, Disconnect
- `useAIConnectionsSection` — joins transports to stored credentials for the account label

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] The row names the account a connection runs as
  - [x] 7 tests green in the section suite; `tsc --noEmit` clean
  - [ ] End-to-end against the real linked ChatGPT account — pending a container rebuild

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes — no new configuration
- [x] `docker-compose.yml` is updated or already compatible with my changes — unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI drives default chat transport and credential disconnect/reconnect; mistakes could confuse billing routing or remove in-use ChatGPT links, but changes are frontend-only on existing APIs.
> 
> **Overview**
> Adds an **AI subscriptions** block at the top of Integrations so users can see which connection backs new chats, pick the default via chat transport APIs, and (for ChatGPT) open **Manage** without changing the default radio selection.
> 
> ChatGPT rows now show the linked account from stored credential `username`; **Manage** loads a live Codex account snapshot only while the dialog is open (plan, reconnect state), with reconnect, disconnect, and force-remove confirmation. Linking ChatGPT in the connect dialog gets a pre-OAuth explainer plus terms copy; removing Codex credentials uses tailored delete notices instead of generic “agents lose access” wording.
> 
> **Settings → Bots** gains **BotConnectionNotice** when multiple transports exist, stating that inbound bot conversations use the default chosen under AI subscriptions. Tests cover the new section and ChatGPT connect panel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e769e7224f0c5fcd862019f2b3c4076b321cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->