### PR TITLE
feat(backend): describe an AI connection on the server that enforces it

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -52,6 +52,7 @@ from backend.copilot.model import (
     update_session_pinned,
     update_session_title,
 )
+from backend.copilot.offers import AIConnectionOffersResponse, get_connection_offers
 from backend.copilot.pending_message_helpers import (
     QueuePendingMessageResponse,
     StreamRegistryUnavailable,
@@ -552,6 +553,23 @@ async def list_chat_transports(
     Settings, or the server's own pick when they haven't chosen one.
     """
     return ChatTransportsResponse(transports=await get_chat_transports(user_id))
+
+
+@router.get(
+    "/connections",
+    dependencies=[Security(auth.requires_user)],
+)
+async def list_chat_connections(
+    user_id: Annotated[str, Security(auth.get_user_id)],
+) -> AIConnectionOffersResponse:
+    """Every AI connection the user can chat over, described by the server.
+
+    Additive alongside ``GET /transports``, which keeps its shape. This
+    carries what a client would otherwise have to infer — provider family,
+    what backs a run, the quality tiers, and the limitations that apply —
+    so product and billing statements come from the side that enforces them.
+    """
+    return AIConnectionOffersResponse(offers=await get_connection_offers(user_id))
 
 
 class SetDefaultTransportRequest(BaseModel):

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -1,0 +1,147 @@
+"""Server-owned description of the AI connections a user can chat over.
+
+``transports`` answers "which routes exist and which is default". That is
+enough to route a turn, but not enough to render one: the client has been
+deciding what a connection is called, what backs it, and which provider it
+belongs to. Those are product and billing statements, and a client that
+computes them drifts from the server that enforces them.
+
+This module states them once, on the side that knows. It is additive —
+``GET /transports`` keeps its shape, so nothing has to migrate at once.
+"""
+
+import logging
+
+from pydantic import BaseModel
+
+from backend.copilot.config import CopilotLlmAuthProvider, CopilotLLMModel
+from backend.copilot.transports import (
+    ChatTransportResponse,
+    get_chat_transports,
+    is_deployment_chat_available,
+    settings,
+)
+from backend.util.settings import BehaveAs
+
+logger = logging.getLogger(__name__)
+
+# Product vocabulary. "Fast" and "Thinking" are execution paths, not tiers a
+# user picks between; the two labels below are what the product exposes.
+TIER_LABELS: dict[CopilotLLMModel, str] = {
+    "standard": "Balanced",
+    "advanced": "Advanced",
+}
+
+
+class ConnectionTier(BaseModel):
+    """One quality level on a connection.
+
+    ``display_model`` is deliberately absent. Naming the model a tier will
+    resolve to needs the execution path, which is decided per turn by which
+    service handles it — and on ChatGPT it needs a live call against the
+    account. A name that is right half the time is worse here than no name.
+    """
+
+    tier: CopilotLLMModel
+    label: str
+    selectable: bool
+
+
+class AIConnectionOffer(BaseModel):
+    offer_id: str
+    provider_family: str
+    display_name: str
+    auth_method: str
+    credential_id: str | None
+    backed_by_label: str
+    description: str
+    state: str
+    selectable: bool
+    is_default: bool
+    tiers: list[ConnectionTier]
+    limitations: list[str]
+
+
+class AIConnectionOffersResponse(BaseModel):
+    offers: list[AIConnectionOffer]
+
+
+async def get_connection_offers(user_id: str) -> list[AIConnectionOffer]:
+    return [_offer(transport) for transport in await get_chat_transports(user_id)]
+
+
+def offer_id_for(transport: ChatTransportResponse) -> str:
+    """Stable across requests, and unique per account.
+
+    The platform route carries no credential, and a user may hold several
+    ChatGPT accounts, so neither half identifies an offer on its own.
+    """
+    return f"{transport.auth_provider}:{transport.credential_id or 'deployment'}"
+
+
+def _offer(transport: ChatTransportResponse) -> AIConnectionOffer:
+    return AIConnectionOffer(
+        offer_id=offer_id_for(transport),
+        provider_family=_provider_family(transport.auth_provider),
+        display_name=transport.label,
+        auth_method=_auth_method(transport.auth_provider),
+        credential_id=transport.credential_id,
+        backed_by_label=_backed_by_label(transport),
+        description=_description(transport),
+        state="ready" if transport.available else "unavailable",
+        selectable=transport.available,
+        is_default=transport.default,
+        tiers=[
+            ConnectionTier(tier=tier, label=label, selectable=transport.available)
+            for tier, label in TIER_LABELS.items()
+        ],
+        limitations=_limitations(transport),
+    )
+
+
+def _provider_family(auth_provider: CopilotLlmAuthProvider) -> str:
+    # Presentation grouping, not the credential discriminator: ChatGPT OAuth
+    # and an OpenAI API key are one family and two very different credentials.
+    return "openai" if auth_provider == "codex" else "autogpt"
+
+
+def _auth_method(auth_provider: CopilotLlmAuthProvider) -> str:
+    return "chatgpt_oauth" if auth_provider == "codex" else "deployment"
+
+
+def _is_hosted() -> bool:
+    return settings.config.behave_as == BehaveAs.CLOUD
+
+
+def _backed_by_label(transport: ChatTransportResponse) -> str:
+    if transport.auth_provider == "codex":
+        return "Your ChatGPT plan"
+    return "Your AutoGPT plan" if _is_hosted() else "This server's chat provider"
+
+
+def _description(transport: ChatTransportResponse) -> str:
+    """What backs a run, in the user's terms.
+
+    The credits contrast only means something where credits exist, so the
+    self-hosted line says what it actually has instead of denying something
+    that was never there.
+    """
+    if transport.auth_provider == "codex":
+        return (
+            "New chats are backed by your ChatGPT plan, and spend no "
+            "AutoGPT credits."
+        )
+    if _is_hosted():
+        return "New chats are backed by your AutoGPT plan, and spend AutoGPT credits."
+    return "New chats are backed by the chat provider configured on this server."
+
+
+def _limitations(transport: ChatTransportResponse) -> list[str]:
+    limitations: list[str] = []
+    if transport.auth_provider == "codex":
+        # Stated because it is a real edge a user can hit, not a policy note:
+        # the builder panel rejects a codex route outright.
+        limitations.append("The agent builder's chat panel always runs on AutoGPT.")
+    if transport.auth_provider == "platform" and not is_deployment_chat_available():
+        limitations.append("No chat provider is configured on this server yet.")
+    return limitations

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -1,0 +1,164 @@
+"""The server-owned description of an AI connection."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_mock
+
+from backend.copilot import offers, transports
+from backend.copilot.offers import get_connection_offers, offer_id_for
+from backend.copilot.transports import ChatTransportResponse
+from backend.util.settings import BehaveAs
+
+USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
+
+
+def _transport(
+    auth_provider: str = "platform",
+    credential_id: str | None = None,
+    label: str = "AutoGPT Platform",
+    available: bool = True,
+    default: bool = False,
+) -> ChatTransportResponse:
+    return ChatTransportResponse(
+        auth_provider=auth_provider,  # type: ignore[arg-type]
+        credential_id=credential_id,
+        label=label,
+        available=available,
+        default=default,
+    )
+
+
+@pytest.fixture(autouse=True)
+def hosted(mocker: pytest_mock.MockerFixture):
+    mocker.patch.object(offers.settings.config, "behave_as", BehaveAs.CLOUD)
+    mocker.patch.object(transports.settings.config, "behave_as", BehaveAs.CLOUD)
+
+
+def _mock_transports(
+    mocker: pytest_mock.MockerFixture, transport_list: list[ChatTransportResponse]
+) -> None:
+    mocker.patch.object(
+        offers,
+        "get_chat_transports",
+        new=AsyncMock(return_value=transport_list),
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_offer_says_what_backs_a_run(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    _mock_transports(
+        mocker,
+        [_transport(default=True), _transport("codex", "cred-1", "ChatGPT")],
+    )
+
+    platform, chatgpt = await get_connection_offers(USER_ID)
+
+    assert platform.backed_by_label == "Your AutoGPT plan"
+    assert "spend AutoGPT credits" in platform.description
+    assert chatgpt.backed_by_label == "Your ChatGPT plan"
+    assert "spend no AutoGPT credits" in chatgpt.description
+
+
+@pytest.mark.asyncio
+async def test_self_host_does_not_deny_credits_it_never_had(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch.object(offers.settings.config, "behave_as", BehaveAs.LOCAL)
+    _mock_transports(mocker, [_transport(label="Self-hosted chat", default=True)])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert offer.backed_by_label == "This server's chat provider"
+    assert "credits" not in offer.description
+
+
+@pytest.mark.asyncio
+async def test_provider_family_groups_without_becoming_the_credential(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    _mock_transports(mocker, [_transport(), _transport("codex", "cred-1", "ChatGPT")])
+
+    platform, chatgpt = await get_connection_offers(USER_ID)
+
+    assert platform.provider_family == "autogpt"
+    assert chatgpt.provider_family == "openai"
+    assert chatgpt.auth_method == "chatgpt_oauth"
+    assert chatgpt.credential_id == "cred-1"
+
+
+@pytest.mark.asyncio
+async def test_offer_ids_are_stable_and_per_account(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    first = _transport("codex", "cred-1", "ChatGPT")
+    second = _transport("codex", "cred-2", "ChatGPT")
+    _mock_transports(mocker, [_transport(), first, second])
+
+    ids = [offer.offer_id for offer in await get_connection_offers(USER_ID)]
+
+    assert ids == ["platform:deployment", "codex:cred-1", "codex:cred-2"]
+    assert offer_id_for(first) == offer_id_for(first)
+
+
+@pytest.mark.asyncio
+async def test_tiers_are_labelled_but_never_named_with_a_model(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Naming the model needs the execution path, decided per turn."""
+    _mock_transports(mocker, [_transport(default=True)])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert [tier.label for tier in offer.tiers] == ["Balanced", "Advanced"]
+    assert [tier.tier for tier in offer.tiers] == ["standard", "advanced"]
+    assert not any(hasattr(tier, "display_model") for tier in offer.tiers)
+
+
+@pytest.mark.asyncio
+async def test_an_unavailable_connection_is_not_selectable(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch.object(offers.settings.config, "behave_as", BehaveAs.LOCAL)
+    chat_config = MagicMock()
+    chat_config.test_mode = False
+    chat_config.use_claude_code_subscription = False
+    chat_config.main_client_credentials = (None, "https://api.anthropic.com/v1/")
+    mocker.patch.object(transports, "config", chat_config)
+    _mock_transports(mocker, [_transport(label="Self-hosted chat", available=False)])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert offer.state == "unavailable"
+    assert offer.selectable is False
+    assert all(tier.selectable is False for tier in offer.tiers)
+    assert "No chat provider is configured on this server yet." in offer.limitations
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_states_the_edge_a_user_can_actually_hit(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    _mock_transports(mocker, [_transport("codex", "cred-1", "ChatGPT")])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert offer.limitations == [
+        "The agent builder's chat panel always runs on AutoGPT."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_offer_is_the_default(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    _mock_transports(
+        mocker,
+        [_transport(default=True), _transport("codex", "cred-1", "ChatGPT")],
+    )
+
+    offer_list = await get_connection_offers(USER_ID)
+
+    assert [offer.is_default for offer in offer_list].count(True) == 1

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotConnectionNotice/BotConnectionNotice.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/components/BotConnectionNotice/BotConnectionNotice.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+
+import { useGetV2ListChatTransports } from "@/app/api/__generated__/endpoints/chat/chat";
+import { Text } from "@/components/atoms/Text/Text";
+
+/**
+ * A conversation that arrives over a bot link has no picker in front of it, so
+ * the connection it starts on is whatever was chosen in Settings. That is the
+ * least discoverable consequence of the setting — say it here, where someone
+ * is looking at their bots.
+ */
+export function BotConnectionNotice() {
+  const transportsQuery = useGetV2ListChatTransports();
+  const transports =
+    transportsQuery.data?.status === 200
+      ? transportsQuery.data.data.transports
+      : [];
+  const current = transports.find((transport) => transport.default);
+
+  if (!current || transports.filter((t) => t.available).length < 2) return null;
+
+  return (
+    <div className="mb-6 ml-4 rounded-2xl border border-[#DADADC] bg-white px-4 py-3">
+      <Text variant="small" className="text-[#505057]">
+        Conversations that come in over a bot start on{" "}
+        <span className="font-medium text-black">{current.label}</span>, the
+        connection you chose in{" "}
+        <Link
+          href="/settings/integrations"
+          className="font-medium text-[#7444E5] underline underline-offset-2"
+        >
+          AI subscriptions
+        </Link>
+        .
+      </Text>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/bots/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { BotConnectionNotice } from "./components/BotConnectionNotice/BotConnectionNotice";
 import { BotsHeader } from "./components/BotsHeader/BotsHeader";
 import { BotsList } from "./components/BotsList/BotsList";
 
@@ -7,6 +8,7 @@ export default function SettingsBotsPage() {
   return (
     <>
       <BotsHeader />
+      <BotConnectionNotice />
       <BotsList />
     </>
   );

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -3699,6 +3699,30 @@
         }
       }
     },
+    "/api/chat/connections": {
+      "get": {
+        "tags": ["v2", "chat", "chat"],
+        "summary": "List Chat Connections",
+        "description": "Every AI connection the user can chat over, described by the server.\n\nAdditive alongside ``GET /transports``, which keeps its shape. This\ncarries what a client would otherwise have to infer — provider family,\nwhat backs a run, the quality tiers, and the limitations that apply —\nso product and billing statements come from the side that enforces them.",
+        "operationId": "getV2ListChatConnections",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AIConnectionOffersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
     "/api/chat/health": {
       "get": {
         "tags": ["v2", "chat", "chat"],
@@ -15017,6 +15041,61 @@
   },
   "components": {
     "schemas": {
+      "AIConnectionOffer": {
+        "properties": {
+          "offer_id": { "type": "string", "title": "Offer Id" },
+          "provider_family": { "type": "string", "title": "Provider Family" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "auth_method": { "type": "string", "title": "Auth Method" },
+          "credential_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Credential Id"
+          },
+          "backed_by_label": { "type": "string", "title": "Backed By Label" },
+          "description": { "type": "string", "title": "Description" },
+          "state": { "type": "string", "title": "State" },
+          "selectable": { "type": "boolean", "title": "Selectable" },
+          "is_default": { "type": "boolean", "title": "Is Default" },
+          "tiers": {
+            "items": { "$ref": "#/components/schemas/ConnectionTier" },
+            "type": "array",
+            "title": "Tiers"
+          },
+          "limitations": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Limitations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "offer_id",
+          "provider_family",
+          "display_name",
+          "auth_method",
+          "credential_id",
+          "backed_by_label",
+          "description",
+          "state",
+          "selectable",
+          "is_default",
+          "tiers",
+          "limitations"
+        ],
+        "title": "AIConnectionOffer"
+      },
+      "AIConnectionOffersResponse": {
+        "properties": {
+          "offers": {
+            "items": { "$ref": "#/components/schemas/AIConnectionOffer" },
+            "type": "array",
+            "title": "Offers"
+          }
+        },
+        "type": "object",
+        "required": ["offers"],
+        "title": "AIConnectionOffersResponse"
+      },
       "APIKeyCredentials": {
         "properties": {
           "id": { "type": "string", "title": "Id" },
@@ -17399,6 +17478,21 @@
         "type": "object",
         "required": ["success", "platform", "platform_user_id"],
         "title": "ConfirmUserLinkResponse"
+      },
+      "ConnectionTier": {
+        "properties": {
+          "tier": {
+            "type": "string",
+            "enum": ["standard", "advanced"],
+            "title": "Tier"
+          },
+          "label": { "type": "string", "title": "Label" },
+          "selectable": { "type": "boolean", "title": "Selectable" }
+        },
+        "type": "object",
+        "required": ["tier", "label", "selectable"],
+        "title": "ConnectionTier",
+        "description": "One quality level on a connection.\n\n``display_model`` is deliberately absent. Naming the model a tier will\nresolve to needs the execution path, which is decided per turn by which\nservice handles it — and on ChatGPT it needs a live call against the\naccount. A name that is right half the time is worse here than no name."
       },
       "ContentType": {
         "type": "string",

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { AIConnectionsSection } from "./components/AIConnectionsSection/AIConnectionsSection";
 import { ConnectServiceDialog } from "./components/ConnectServiceDialog/ConnectServiceDialog";
 import { IntegrationsHeader } from "./components/IntegrationsHeader/IntegrationsHeader";
 import { IntegrationsList } from "./components/IntegrationsList/IntegrationsList";
@@ -18,6 +19,7 @@ export function IntegrationsPanel({ withHeading = true }: Props) {
         onConnect={() => setIsConnectOpen(true)}
         withTitle={withHeading}
       />
+      <AIConnectionsSection />
       <IntegrationsList />
       <ConnectServiceDialog
         open={isConnectOpen}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -1,28 +1,33 @@
 "use client";
 
+import { useState } from "react";
 import {
   CheckmarkCircle02Icon,
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
 
+import { ManageConnectionDialog } from "./ManageConnectionDialog";
 import { describeTransport, transportKey } from "./helpers";
 import { useAIConnectionsSection } from "./useAIConnectionsSection";
 
 export function AIConnectionsSection() {
   const {
     connections,
+    accountFor,
     selectedKey,
     chooseDefault,
     isSaving,
     isLoading,
     isError,
   } = useAIConnectionsSection();
+  const [managing, setManaging] = useState<ChatTransportResponse | null>(null);
 
   // A failure here must not take the tool integrations below it down with it.
   if (isError) return null;
@@ -62,34 +67,52 @@ export function AIConnectionsSection() {
             <ConnectionRow
               key={transportKey(connection)}
               connection={connection}
+              account={accountFor(connection)}
               selectable={hasChoice}
               isSelected={transportKey(connection) === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
+              onManage={
+                connection.auth_provider === "codex"
+                  ? () => setManaging(connection)
+                  : undefined
+              }
             />
           ))}
         </div>
       )}
 
       <UpcomingConnections />
+
+      <ManageConnectionDialog
+        connection={managing}
+        account={managing ? accountFor(managing) : undefined}
+        onOpenChange={(open) => {
+          if (!open) setManaging(null);
+        }}
+      />
     </section>
   );
 }
 
 interface RowProps {
   connection: ChatTransportResponse;
+  account?: string;
   selectable: boolean;
   isSelected: boolean;
   isSaving: boolean;
   onSelect: () => void;
+  onManage?: () => void;
 }
 
 function ConnectionRow({
   connection,
+  account,
   selectable,
   isSelected,
   isSaving,
   onSelect,
+  onManage,
 }: RowProps) {
   const body = (
     <>
@@ -118,6 +141,11 @@ function ConnectionRow({
               Connected
             </span>
           )}
+          {account && (
+            <span className="max-w-full truncate rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+              {account}
+            </span>
+          )}
           {isSelected && (
             <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
               <Icon icon={SparklesIcon} size={13} />
@@ -132,32 +160,51 @@ function ConnectionRow({
     </>
   );
 
+  const manage = onManage ? (
+    <Button
+      variant="secondary"
+      size="small"
+      className="ml-auto flex-none self-center"
+      onClick={onManage}
+    >
+      Manage
+    </Button>
+  ) : null;
+
   if (!selectable) {
     return (
       <div className="flex w-full items-start gap-3 rounded-2xl border border-[#DADADC] bg-white p-4">
         {body}
+        {manage}
       </div>
     );
   }
 
   return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      disabled={isSaving}
-      onClick={onSelect}
+    <div
       className={cn(
-        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        "flex w-full items-start rounded-2xl border bg-white pr-4 transition-colors",
         isSelected
           ? "border-[#7444E5] ring-1 ring-[#7444E5]"
           : "border-[#DADADC] hover:bg-[#F9F9FA]",
-        isSaving && "cursor-progress opacity-70",
       )}
     >
-      {body}
-    </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        disabled={isSaving}
+        onClick={onSelect}
+        className={cn(
+          "flex min-w-0 flex-1 items-start gap-3 rounded-2xl p-4 text-left",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5]",
+          isSaving && "cursor-progress opacity-70",
+        )}
+      >
+        {body}
+      </button>
+      {manage}
+    </div>
   );
 }
 

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+  CheckmarkCircle02Icon,
+  SparklesIcon,
+} from "@hugeicons/core-free-icons";
+
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+
+import { describeTransport, transportKey } from "./helpers";
+import { useAIConnectionsSection } from "./useAIConnectionsSection";
+
+export function AIConnectionsSection() {
+  const {
+    connections,
+    selectedKey,
+    chooseDefault,
+    isSaving,
+    isLoading,
+    isError,
+  } = useAIConnectionsSection();
+
+  // The section describes which connection powers a chat. With nothing to
+  // choose between, there is no decision to present — and an error here must
+  // not take the tool integrations below it down with it.
+  if (isError || (!isLoading && connections.length < 2)) return null;
+
+  return (
+    <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
+      <Text
+        variant="small-medium"
+        as="h2"
+        id="ai-connections-heading"
+        className="uppercase tracking-[0.06em] text-[#505057]"
+      >
+        AI subscriptions
+      </Text>
+      <Text variant="body" className="mt-2 max-w-[600px] text-[#505057]">
+        These power your agents. Pick the one new chats should start on — you
+        can still change it per conversation, and nothing switches on its own.
+      </Text>
+
+      {isLoading ? (
+        <div className="mt-4 flex flex-col gap-3">
+          <Skeleton className="h-[86px] w-full rounded-2xl" />
+          <Skeleton className="h-[86px] w-full rounded-2xl" />
+        </div>
+      ) : (
+        <div
+          role="radiogroup"
+          aria-label="Connection new chats start on"
+          className="mt-4 flex flex-col gap-3"
+        >
+          {connections.map((connection) => (
+            <ConnectionRow
+              key={transportKey(connection)}
+              connection={connection}
+              isSelected={transportKey(connection) === selectedKey}
+              isSaving={isSaving}
+              onSelect={() => chooseDefault(connection)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface RowProps {
+  connection: ChatTransportResponse;
+  isSelected: boolean;
+  isSaving: boolean;
+  onSelect: () => void;
+}
+
+function ConnectionRow({
+  connection,
+  isSelected,
+  isSaving,
+  onSelect,
+}: RowProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      disabled={isSaving}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        isSelected
+          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
+          : "border-[#DADADC] hover:bg-[#F9F9FA]",
+        isSaving && "cursor-progress opacity-70",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
+          isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
+        )}
+      >
+        {isSelected && (
+          <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
+        )}
+      </span>
+
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-black">
+            {connection.label}
+          </Text>
+          {connection.auth_provider === "codex" && (
+            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#E8F8F0] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#157E58]">
+              <Icon icon={CheckmarkCircle02Icon} size={13} />
+              Connected
+            </span>
+          )}
+          {isSelected && (
+            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+              <Icon icon={SparklesIcon} size={13} />
+              Used for new chats
+            </span>
+          )}
+        </span>
+        <Text variant="small" as="span" className="text-[#505057]">
+          {describeTransport(connection)}
+        </Text>
+      </span>
+    </button>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -24,10 +24,12 @@ export function AIConnectionsSection() {
     isError,
   } = useAIConnectionsSection();
 
-  // The section describes which connection powers a chat. With nothing to
-  // choose between, there is no decision to present — and an error here must
-  // not take the tool integrations below it down with it.
-  if (isError || (!isLoading && connections.length < 2)) return null;
+  // A failure here must not take the tool integrations below it down with it.
+  if (isError) return null;
+
+  // One connection is not a choice. The rows still say what powers a chat,
+  // they just stop presenting a decision that doesn't exist.
+  const hasChoice = connections.length > 1;
 
   return (
     <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
@@ -40,8 +42,9 @@ export function AIConnectionsSection() {
         AI subscriptions
       </Text>
       <Text variant="body" className="mt-2 max-w-[600px] text-[#505057]">
-        These power your agents. Pick the one new chats should start on — you
-        can still change it per conversation, and nothing switches on its own.
+        {hasChoice
+          ? "These power your agents. Pick the one new chats should start on — you can still change it per conversation, and nothing switches on its own."
+          : "These power your agents. Link a subscription and you can choose which one new chats start on."}
       </Text>
 
       {isLoading ? (
@@ -51,14 +54,15 @@ export function AIConnectionsSection() {
         </div>
       ) : (
         <div
-          role="radiogroup"
-          aria-label="Connection new chats start on"
+          role={hasChoice ? "radiogroup" : undefined}
+          aria-label={hasChoice ? "Connection new chats start on" : undefined}
           className="mt-4 flex flex-col gap-3"
         >
           {connections.map((connection) => (
             <ConnectionRow
               key={transportKey(connection)}
               connection={connection}
+              selectable={hasChoice}
               isSelected={transportKey(connection) === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
@@ -66,12 +70,15 @@ export function AIConnectionsSection() {
           ))}
         </div>
       )}
+
+      <UpcomingConnections />
     </section>
   );
 }
 
 interface RowProps {
   connection: ChatTransportResponse;
+  selectable: boolean;
   isSelected: boolean;
   isSaving: boolean;
   onSelect: () => void;
@@ -79,37 +86,26 @@ interface RowProps {
 
 function ConnectionRow({
   connection,
+  selectable,
   isSelected,
   isSaving,
   onSelect,
 }: RowProps) {
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      disabled={isSaving}
-      onClick={onSelect}
-      className={cn(
-        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
-        isSelected
-          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
-          : "border-[#DADADC] hover:bg-[#F9F9FA]",
-        isSaving && "cursor-progress opacity-70",
+  const body = (
+    <>
+      {selectable && (
+        <span
+          aria-hidden
+          className={cn(
+            "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
+            isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
+          )}
+        >
+          {isSelected && (
+            <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
+          )}
+        </span>
       )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          "mt-[3px] flex h-4 w-4 flex-none items-center justify-center rounded-full border",
-          isSelected ? "border-[#7444E5]" : "border-[#9A9A9F]",
-        )}
-      >
-        {isSelected && (
-          <span className="h-2 w-2 rounded-full bg-[#7444E5]" aria-hidden />
-        )}
-      </span>
 
       <span className="flex min-w-0 flex-col gap-1">
         <span className="flex flex-wrap items-center gap-2">
@@ -133,6 +129,66 @@ function ConnectionRow({
           {describeTransport(connection)}
         </Text>
       </span>
+    </>
+  );
+
+  if (!selectable) {
+    return (
+      <div className="flex w-full items-start gap-3 rounded-2xl border border-[#DADADC] bg-white p-4">
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      disabled={isSaving}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-3 rounded-2xl border bg-white p-4 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7444E5] focus-visible:ring-offset-2",
+        isSelected
+          ? "border-[#7444E5] ring-1 ring-[#7444E5]"
+          : "border-[#DADADC] hover:bg-[#F9F9FA]",
+        isSaving && "cursor-progress opacity-70",
+      )}
+    >
+      {body}
     </button>
+  );
+}
+
+/**
+ * Names what is coming without claiming it works yet. Each provider needs its
+ * own adapter and its own provider/legal approval before it can appear as a
+ * real row above, so this promises nothing about capability or timing.
+ */
+function UpcomingConnections() {
+  return (
+    <div className="mt-3 flex items-start gap-3 rounded-2xl border border-dashed border-[#DADADC] p-4">
+      <span
+        aria-hidden
+        className="mt-[2px] flex h-4 w-4 flex-none items-center justify-center text-[#9A9A9F]"
+      >
+        <Icon icon={SparklesIcon} size={16} />
+      </span>
+      <span className="flex min-w-0 flex-col gap-1">
+        <span className="flex flex-wrap items-center gap-2">
+          <Text variant="body-medium" as="span" className="text-[#505057]">
+            GitHub Copilot and Grok
+          </Text>
+          <span className="inline-flex items-center rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+            Coming soon
+          </span>
+        </span>
+        <Text variant="small" as="span" className="text-[#505057]">
+          More subscriptions you already pay for. Each one shows up here once it
+          is approved to run AutoGPT agents.
+        </Text>
+      </span>
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { getGetV2ListChatTransportsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
+import { useGetV1CodexAccount } from "@/app/api/__generated__/endpoints/integrations/integrations";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+
+import { useOAuthConnect } from "../ConnectServiceDialog/components/DetailView/useOAuthConnect";
+import { useDeleteIntegration } from "../hooks/useDeleteIntegration";
+
+interface Props {
+  connection: ChatTransportResponse | null;
+  account?: string;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Single-account first pass. Deliberately shows no usage figure and no reset
+ * window: the only numbers available would be from whenever they were last
+ * observed, and a stale window presented as current is worse than none —
+ * especially on the reconnect path, where authorization is already invalid.
+ */
+export function ManageConnectionDialog({
+  connection,
+  account,
+  onOpenChange,
+}: Props) {
+  const queryClient = useQueryClient();
+  const credentialId = connection?.credential_id ?? null;
+
+  // Asked for only while this dialog is open. Reading it leases a runtime
+  // against the provider, so it must never run on the list behind — and it
+  // means what is shown was true a moment ago rather than whenever the
+  // connection was last used.
+  const accountQuery = useGetV1CodexAccount(credentialId ?? "", {
+    query: { enabled: credentialId !== null, staleTime: 0, retry: false },
+  });
+  const snapshot =
+    accountQuery.data?.status === 200 ? accountQuery.data.data : undefined;
+
+  const { connect, isPending: isReconnecting } = useOAuthConnect({
+    provider: "codex",
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: getGetV2ListChatTransportsQueryKey(),
+      });
+      onOpenChange(false);
+    },
+  });
+
+  const { remove, isPending: isDisconnecting } = useDeleteIntegration();
+
+  async function disconnect() {
+    if (!credentialId) return;
+    await remove([
+      { id: credentialId, provider: "codex", name: account ?? "ChatGPT" },
+    ]);
+    queryClient.invalidateQueries({
+      queryKey: getGetV2ListChatTransportsQueryKey(),
+    });
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog
+      title="ChatGPT"
+      styling={{ maxWidth: "28rem" }}
+      controlled={{ isOpen: connection !== null, set: onOpenChange }}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <Text variant="small" className="text-[#8A8A90]">
+              Connected account
+            </Text>
+            <Text variant="body-medium" className="text-black">
+              {snapshot?.email ?? account ?? "Your ChatGPT account"}
+            </Text>
+            {accountQuery.isLoading ? (
+              <Text variant="small" className="text-[#8A8A90]">
+                Checking with ChatGPT…
+              </Text>
+            ) : accountQuery.isError ? (
+              <Text variant="small" className="text-[#8A8A90]">
+                Could not reach ChatGPT to confirm the plan on this account.
+              </Text>
+            ) : (
+              (snapshot?.plan_type || snapshot?.account_type) && (
+                <span className="mt-1 flex flex-wrap gap-2">
+                  {snapshot.plan_type && (
+                    <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+                      {snapshot.plan_type} plan
+                    </span>
+                  )}
+                  {snapshot.account_type && (
+                    <span className="rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
+                      {snapshot.account_type} workspace
+                    </span>
+                  )}
+                </span>
+              )
+            )}
+          </div>
+
+          <Text variant="small" className="text-[#505057]">
+            {connection?.default
+              ? "New chats start on this connection and run on your ChatGPT plan."
+              : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
+          </Text>
+
+          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={connect}
+              loading={isReconnecting}
+              disabled={isDisconnecting}
+            >
+              Reconnect
+            </Button>
+            <Button
+              variant="destructive"
+              size="small"
+              onClick={disconnect}
+              loading={isDisconnecting}
+              disabled={isReconnecting}
+            >
+              Disconnect
+            </Button>
+          </div>
+
+          <Text variant="small" className="text-[#8A8A90]">
+            Disconnecting stops new chats running on your ChatGPT plan. Your
+            chat history is kept, and your other integrations are unaffected.
+          </Text>
+        </div>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { getGetV2ListChatTransportsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
@@ -10,6 +11,7 @@ import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
 
 import { useOAuthConnect } from "../ConnectServiceDialog/components/DetailView/useOAuthConnect";
+import { DeleteConfirmDialog } from "../DeleteConfirmDialog/DeleteConfirmDialog";
 import { useDeleteIntegration } from "../hooks/useDeleteIntegration";
 
 interface Props {
@@ -31,6 +33,7 @@ export function ManageConnectionDialog({
 }: Props) {
   const queryClient = useQueryClient();
   const credentialId = connection?.credential_id ?? null;
+  const [forceMessage, setForceMessage] = useState<string | null>(null);
 
   // Asked for only while this dialog is open. Reading it leases a runtime
   // against the provider, so it must never run on the list behind — and it
@@ -39,8 +42,16 @@ export function ManageConnectionDialog({
   const accountQuery = useGetV1CodexAccount(credentialId ?? "", {
     query: { enabled: credentialId !== null, staleTime: 0, retry: false },
   });
-  const snapshot =
+  const accountResponse =
     accountQuery.data?.status === 200 ? accountQuery.data.data : undefined;
+  const snapshot = accountResponse?.connected ? accountResponse : undefined;
+  const requiresReconnect =
+    accountResponse !== undefined && !accountResponse.connected;
+
+  function setManageOpen(open: boolean) {
+    if (!open) setForceMessage(null);
+    onOpenChange(open);
+  }
 
   const { connect, isPending: isReconnecting } = useOAuthConnect({
     provider: "codex",
@@ -48,95 +59,133 @@ export function ManageConnectionDialog({
       queryClient.invalidateQueries({
         queryKey: getGetV2ListChatTransportsQueryKey(),
       });
-      onOpenChange(false);
+      setManageOpen(false);
     },
   });
 
   const { remove, isPending: isDisconnecting } = useDeleteIntegration();
 
-  async function disconnect() {
+  async function disconnect(force = false) {
     if (!credentialId) return;
-    await remove([
-      { id: credentialId, provider: "codex", name: account ?? "ChatGPT" },
-    ]);
-    queryClient.invalidateQueries({
+    const target = {
+      id: credentialId,
+      provider: "codex",
+      name: account ?? "ChatGPT",
+    };
+    const result = await remove([target], force);
+    const confirmation = result.needsConfirmation[0];
+    if (confirmation) {
+      setForceMessage(confirmation.message);
+      return;
+    }
+    if (result.succeeded.length === 0) return;
+
+    setForceMessage(null);
+    await queryClient.invalidateQueries({
       queryKey: getGetV2ListChatTransportsQueryKey(),
     });
-    onOpenChange(false);
+    setManageOpen(false);
   }
 
   return (
-    <Dialog
-      title="ChatGPT"
-      styling={{ maxWidth: "28rem" }}
-      controlled={{ isOpen: connection !== null, set: onOpenChange }}
-    >
-      <Dialog.Content>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1">
-            <Text variant="small" className="text-[#8A8A90]">
-              Connected account
-            </Text>
-            <Text variant="body-medium" className="text-black">
-              {snapshot?.email ?? account ?? "Your ChatGPT account"}
-            </Text>
-            {accountQuery.isLoading ? (
+    <>
+      <Dialog
+        title="ChatGPT"
+        styling={{ maxWidth: "28rem" }}
+        controlled={{
+          isOpen: connection !== null && forceMessage === null,
+          set: (open) => {
+            // Opening the force-confirmation dialog intentionally hides this
+            // one. Radix reports that controlled close through this callback;
+            // keep the connection selected so Cancel can return here.
+            if (!open && forceMessage !== null) return;
+            setManageOpen(open);
+          },
+        }}
+      >
+        <Dialog.Content>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
               <Text variant="small" className="text-[#8A8A90]">
-                Checking with ChatGPT…
+                Connected account
               </Text>
-            ) : accountQuery.isError ? (
-              <Text variant="small" className="text-[#8A8A90]">
-                Could not reach ChatGPT to confirm the plan on this account.
+              <Text variant="body-medium" className="text-black">
+                {snapshot?.email ?? account ?? "Your ChatGPT account"}
               </Text>
-            ) : (
-              snapshot?.plan_type && (
-                <span className="mt-1 flex flex-wrap gap-2">
-                  <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
-                    {snapshot.plan_type} plan
+              {accountQuery.isLoading ? (
+                <Text variant="small" className="text-[#8A8A90]">
+                  Checking with ChatGPT…
+                </Text>
+              ) : accountQuery.isError ? (
+                <Text variant="small" className="text-[#8A8A90]">
+                  Could not reach ChatGPT to confirm the plan on this account.
+                </Text>
+              ) : requiresReconnect ? (
+                <Text variant="small" className="text-amber-700">
+                  ChatGPT says this connection needs to be reconnected.
+                </Text>
+              ) : (
+                snapshot?.plan_type && (
+                  <span className="mt-1 flex flex-wrap gap-2">
+                    <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+                      {snapshot.plan_type} plan
+                    </span>
                   </span>
-                </span>
-              )
-            )}
+                )
+              )}
+            </div>
+
+            <Text variant="small" className="text-[#8A8A90]">
+              ChatGPT identifies the workspace behind this connection only by an
+              internal id, so it cannot be named here yet.
+            </Text>
+
+            <Text variant="small" className="text-[#505057]">
+              {connection?.default
+                ? "New chats start on this connection and run on your ChatGPT plan."
+                : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
+            </Text>
+
+            <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
+              <Button
+                variant="secondary"
+                size="small"
+                onClick={connect}
+                loading={isReconnecting}
+                disabled={isDisconnecting}
+              >
+                Reconnect
+              </Button>
+              <Button
+                variant="destructive"
+                size="small"
+                onClick={() => void disconnect()}
+                loading={isDisconnecting}
+                disabled={isReconnecting}
+              >
+                Disconnect
+              </Button>
+            </div>
+
+            <Text variant="small" className="text-[#8A8A90]">
+              Disconnecting stops new chats running on your ChatGPT plan. Your
+              chat history is kept, and your other integrations are unaffected.
+            </Text>
           </div>
+        </Dialog.Content>
+      </Dialog>
 
-          <Text variant="small" className="text-[#8A8A90]">
-            ChatGPT identifies the workspace behind this connection only by an
-            internal id, so it cannot be named here yet.
-          </Text>
-
-          <Text variant="small" className="text-[#505057]">
-            {connection?.default
-              ? "New chats start on this connection and run on your ChatGPT plan."
-              : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
-          </Text>
-
-          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
-            <Button
-              variant="secondary"
-              size="small"
-              onClick={connect}
-              loading={isReconnecting}
-              disabled={isDisconnecting}
-            >
-              Reconnect
-            </Button>
-            <Button
-              variant="destructive"
-              size="small"
-              onClick={disconnect}
-              loading={isDisconnecting}
-              disabled={isReconnecting}
-            >
-              Disconnect
-            </Button>
-          </div>
-
-          <Text variant="small" className="text-[#8A8A90]">
-            Disconnecting stops new chats running on your ChatGPT plan. Your
-            chat history is kept, and your other integrations are unaffected.
-          </Text>
-        </div>
-      </Dialog.Content>
-    </Dialog>
+      <DeleteConfirmDialog
+        open={forceMessage !== null}
+        onOpenChange={(open) => {
+          if (!open) setForceMessage(null);
+        }}
+        itemNames={[account ?? "ChatGPT"]}
+        isPending={isDisconnecting}
+        onConfirm={() => void disconnect(true)}
+        variant="force"
+        notice={forceMessage ?? undefined}
+      />
+    </>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -40,7 +40,15 @@ export function ManageConnectionDialog({
   // means what is shown was true a moment ago rather than whenever the
   // connection was last used.
   const accountQuery = useGetV1CodexAccount(credentialId ?? "", {
-    query: { enabled: credentialId !== null, staleTime: 0, retry: false },
+    query: {
+      enabled: credentialId !== null,
+      staleTime: 0,
+      retry: false,
+      // A window-focus refetch would lease another provider runtime while
+      // the same snapshot is already visible. Reopening Manage is the user's
+      // explicit refresh boundary.
+      refetchOnWindowFocus: false,
+    },
   });
   const accountResponse =
     accountQuery.data?.status === 200 ? accountQuery.data.data : undefined;

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -89,22 +89,20 @@ export function ManageConnectionDialog({
                 Could not reach ChatGPT to confirm the plan on this account.
               </Text>
             ) : (
-              (snapshot?.plan_type || snapshot?.account_type) && (
+              snapshot?.plan_type && (
                 <span className="mt-1 flex flex-wrap gap-2">
-                  {snapshot.plan_type && (
-                    <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
-                      {snapshot.plan_type} plan
-                    </span>
-                  )}
-                  {snapshot.account_type && (
-                    <span className="rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
-                      {snapshot.account_type} workspace
-                    </span>
-                  )}
+                  <span className="rounded-[10px] bg-[#F1EBFF] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#4A25AD]">
+                    {snapshot.plan_type} plan
+                  </span>
                 </span>
               )
             )}
           </div>
+
+          <Text variant="small" className="text-[#8A8A90]">
+            ChatGPT identifies the workspace behind this connection only by an
+            internal id, so it cannot be named here yet.
+          </Text>
 
           <Text variant="small" className="text-[#505057]">
             {connection?.default

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -102,11 +102,23 @@ describe("AIConnectionsSection", () => {
     await waitFor(() => expect(saved).not.toHaveBeenCalled());
   });
 
-  it("stays out of the way when there is nothing to choose between", async () => {
+  it("presents no choice when there is only one connection", async () => {
     mockTransports([platform(true)]);
 
     render(<AIConnectionsSection />);
 
-    await waitFor(() => expect(screen.queryByRole("radiogroup")).toBeNull());
+    // The row still says what powers a chat — it just isn't a decision.
+    expect(await screen.findByText("Self-hosted chat")).toBeDefined();
+    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(screen.queryByRole("radio")).toBeNull();
+  });
+
+  it("names what is coming without claiming it works", async () => {
+    mockTransports([platform(true)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("GitHub Copilot and Grok")).toBeDefined();
+    expect(screen.getByText("Coming soon")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -2,7 +2,12 @@ import {
   getGetV2ListChatTransportsMockHandler200,
   getPutV2SetDefaultChatTransportMockHandler200,
 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
-import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
+import {
+  getDeleteV1DeleteCredentialsMockHandler200,
+  getDeleteV1DeleteCredentialsMockHandler401,
+  getGetV1CodexAccountMockHandler200,
+  getGetV1ListCredentialsMockHandler200,
+} from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
@@ -73,6 +78,89 @@ describe("AIConnectionsSection", () => {
     render(<AIConnectionsSection />);
 
     expect(await screen.findByText("nick@example.com")).toBeDefined();
+  });
+
+  it("treats a disconnected account snapshot as requiring reconnect", async () => {
+    mockTransports(
+      [platform(false), chatgpt(true)],
+      [{ id: "cred-1", username: "stored@example.com" }],
+    );
+    server.use(
+      getGetV1CodexAccountMockHandler200({
+        connected: false,
+        requires_openai_auth: true,
+        email: "stale@example.com",
+        plan_type: "Plus",
+      }),
+    );
+
+    render(<AIConnectionsSection />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Manage" }),
+    );
+
+    expect(
+      await screen.findByText(/connection needs to be reconnected/i),
+    ).toBeDefined();
+    expect(screen.getAllByText("stored@example.com")).toHaveLength(2);
+    expect(screen.queryByText("stale@example.com")).toBeNull();
+    expect(screen.queryByText("Plus plan")).toBeNull();
+  });
+
+  it("keeps the manage dialog open when disconnect fails", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+    server.use(
+      getGetV1CodexAccountMockHandler200({
+        connected: true,
+        requires_openai_auth: false,
+      }),
+      getDeleteV1DeleteCredentialsMockHandler401({ detail: "Not authorized" }),
+    );
+
+    render(<AIConnectionsSection />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Manage" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Disconnect" })).toBeDefined(),
+    );
+  });
+
+  it("asks before force-removing an in-use connection", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+    server.use(
+      getGetV1CodexAccountMockHandler200({
+        connected: true,
+        requires_openai_auth: false,
+      }),
+      getDeleteV1DeleteCredentialsMockHandler200(({ request }) =>
+        new URL(request.url).searchParams.get("force") === "true"
+          ? { deleted: true, revoked: true }
+          : {
+              deleted: false,
+              need_confirmation: true,
+              message: "Used by an active schedule",
+            },
+      ),
+    );
+
+    render(<AIConnectionsSection />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Manage" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Force remove" }),
+    ).toBeDefined();
+    expect(await screen.findByText("Used by an active schedule")).toBeDefined();
+    await userEvent.click(screen.getByRole("button", { name: "Force remove" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull(),
+    );
   });
 
   it("marks the saved default, and only that one", async () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -2,6 +2,7 @@ import {
   getGetV2ListChatTransportsMockHandler200,
   getPutV2SetDefaultChatTransportMockHandler200,
 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
@@ -30,10 +31,23 @@ function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
   };
 }
 
-function mockTransports(transports: ChatTransportResponse[]) {
+function mockTransports(
+  transports: ChatTransportResponse[],
+  credentials: { id: string; username: string }[] = [],
+) {
   server.use(
     getGetV2ListChatTransportsMockHandler200({ transports }),
     getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+    getGetV1ListCredentialsMockHandler200(
+      credentials.map((credential) => ({
+        id: credential.id,
+        provider: "codex",
+        type: "oauth2" as const,
+        title: "ChatGPT for Codex",
+        scopes: [],
+        username: credential.username,
+      })),
+    ),
   );
 }
 
@@ -48,6 +62,17 @@ describe("AIConnectionsSection", () => {
     expect(
       screen.getByText(/backed by your ChatGPT plan, and spend no AutoGPT/i),
     ).toBeDefined();
+  });
+
+  it("names the account a connection runs as", async () => {
+    mockTransports(
+      [platform(false), chatgpt(true)],
+      [{ id: "cred-1", username: "nick@example.com" }],
+    );
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("nick@example.com")).toBeDefined();
   });
 
   it("marks the saved default, and only that one", async () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -1,0 +1,112 @@
+import {
+  getGetV2ListChatTransportsMockHandler200,
+  getPutV2SetDefaultChatTransportMockHandler200,
+} from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { server } from "@/mocks/mock-server";
+import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AIConnectionsSection } from "../AIConnectionsSection";
+
+function platform(isDefault: boolean): ChatTransportResponse {
+  return {
+    auth_provider: "platform",
+    credential_id: null,
+    label: "Self-hosted chat",
+    available: true,
+    default: isDefault,
+  };
+}
+
+function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
+  return {
+    auth_provider: "codex",
+    credential_id: id,
+    label: "ChatGPT",
+    available: true,
+    default: isDefault,
+  };
+}
+
+function mockTransports(transports: ChatTransportResponse[]) {
+  server.use(
+    getGetV2ListChatTransportsMockHandler200({ transports }),
+    getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+  );
+}
+
+describe("AIConnectionsSection", () => {
+  it("lists every connection with what backs a run on it", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("Self-hosted chat")).toBeDefined();
+    expect(screen.getByText("ChatGPT")).toBeDefined();
+    expect(
+      screen.getByText(/backed by your ChatGPT plan, and spend no AutoGPT/i),
+    ).toBeDefined();
+  });
+
+  it("marks the saved default, and only that one", async () => {
+    mockTransports([platform(false), chatgpt(true)]);
+
+    render(<AIConnectionsSection />);
+
+    const options = await screen.findAllByRole("radio");
+    expect(options).toHaveLength(2);
+    const checked = options.filter(
+      (option) => option.getAttribute("aria-checked") === "true",
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0].textContent).toContain("ChatGPT");
+  });
+
+  it("saves the connection the user picks", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+    const saved = vi.fn();
+    server.events.on("request:start", ({ request }) => {
+      if (
+        request.method === "PUT" &&
+        request.url.includes("transports/default")
+      )
+        saved();
+    });
+
+    render(<AIConnectionsSection />);
+    const chatgptOption = await screen.findByRole("radio", { name: /ChatGPT/ });
+    await userEvent.click(chatgptOption);
+
+    await waitFor(() => expect(saved).toHaveBeenCalled());
+  });
+
+  it("does not re-save the connection that is already the default", async () => {
+    mockTransports([platform(true), chatgpt(false)]);
+    const saved = vi.fn();
+    server.events.on("request:start", ({ request }) => {
+      if (
+        request.method === "PUT" &&
+        request.url.includes("transports/default")
+      )
+        saved();
+    });
+
+    render(<AIConnectionsSection />);
+    const current = await screen.findByRole("radio", {
+      name: /Self-hosted chat/,
+    });
+    await userEvent.click(current);
+
+    await waitFor(() => expect(saved).not.toHaveBeenCalled());
+  });
+
+  it("stays out of the way when there is nothing to choose between", async () => {
+    mockTransports([platform(true)]);
+
+    render(<AIConnectionsSection />);
+
+    await waitFor(() => expect(screen.queryByRole("radiogroup")).toBeNull());
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -1,0 +1,37 @@
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+
+/**
+ * The label the server sends for the platform transport on a self-hosted
+ * install. It sends "AutoGPT Platform" on the hosted product instead.
+ */
+export const SELF_HOSTED_LABEL = "Self-hosted chat";
+
+/**
+ * Says what backs a run, which is the thing that actually differs between
+ * connections. Copy lives here only until the server-owned connection offer
+ * carries it — the client should not be deciding how a provider describes
+ * its own billing.
+ */
+export function describeTransport(transport: ChatTransportResponse): string {
+  if (transport.auth_provider === "codex") {
+    return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
+  }
+  return transport.label === SELF_HOSTED_LABEL
+    ? "New chats are backed by the chat provider configured on this server."
+    : "New chats are backed by your AutoGPT plan.";
+}
+
+export function isSelectable(transport: ChatTransportResponse): boolean {
+  return (
+    transport.available &&
+    (transport.auth_provider === "platform" || transport.credential_id !== null)
+  );
+}
+
+/**
+ * A stable key. The platform transport carries no credential id, and a user
+ * can hold several ChatGPT accounts, so neither half identifies a row alone.
+ */
+export function transportKey(transport: ChatTransportResponse): string {
+  return `${transport.auth_provider}:${transport.credential_id ?? "deployment"}`;
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -16,9 +16,12 @@ export function describeTransport(transport: ChatTransportResponse): string {
   if (transport.auth_provider === "codex") {
     return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
   }
+  // The ChatGPT line promises "no AutoGPT credits", which only means anything
+  // if the row it contrasts with says credits are spent. Self-host has no
+  // credits at all, so it says what it actually has instead.
   return transport.label === SELF_HOSTED_LABEL
     ? "New chats are backed by the chat provider configured on this server."
-    : "New chats are backed by your AutoGPT plan.";
+    : "New chats are backed by your AutoGPT plan, and spend AutoGPT credits.";
 }
 
 export function isSelectable(transport: ChatTransportResponse): boolean {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -45,7 +45,7 @@ export function useAIConnectionsSection() {
     return accountByCredentialId.get(transport.credential_id);
   }
 
-  const { mutateAsync: setDefault, isPending: isSaving } =
+  const { mutate: setDefault, isPending: isSaving } =
     usePutV2SetDefaultChatTransport({
       mutation: {
         onSuccess: () => {
@@ -70,9 +70,9 @@ export function useAIConnectionsSection() {
     ? transportKey(connections.find((t) => t.default)!)
     : null;
 
-  async function chooseDefault(transport: ChatTransportResponse) {
+  function chooseDefault(transport: ChatTransportResponse) {
     if (transport.default) return;
-    await setDefault({
+    setDefault({
       data: {
         auth_provider: transport.auth_provider,
         credential_id: transport.credential_id,

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGetV2ListChatTransportsQueryKey,
+  useGetV2ListChatTransports,
+  usePutV2SetDefaultChatTransport,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+
+import { isSelectable, transportKey } from "./helpers";
+
+export function useAIConnectionsSection() {
+  const queryClient = useQueryClient();
+  const transportsQuery = useGetV2ListChatTransports({
+    query: { refetchOnWindowFocus: true },
+  });
+
+  const transports: ChatTransportResponse[] =
+    transportsQuery.data?.status === 200
+      ? transportsQuery.data.data.transports
+      : [];
+  const connections = transports.filter(isSelectable);
+
+  const { mutateAsync: setDefault, isPending: isSaving } =
+    usePutV2SetDefaultChatTransport({
+      mutation: {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: getGetV2ListChatTransportsQueryKey(),
+          });
+        },
+        onError: () => {
+          toast({
+            variant: "destructive",
+            title: "Could not save that connection",
+            description:
+              "Your default is unchanged. Check the connection is still linked, then try again.",
+          });
+        },
+      },
+    });
+
+  // Tracked separately from the query so the row the user clicked shows the
+  // pending state, rather than every row going busy at once.
+  const selectedKey = connections.find((t) => t.default)
+    ? transportKey(connections.find((t) => t.default)!)
+    : null;
+
+  async function chooseDefault(transport: ChatTransportResponse) {
+    if (transport.default) return;
+    await setDefault({
+      data: {
+        auth_provider: transport.auth_provider,
+        credential_id: transport.credential_id,
+      },
+    });
+  }
+
+  return {
+    connections,
+    selectedKey,
+    chooseDefault,
+    isSaving,
+    isLoading: transportsQuery.isLoading,
+    isError: transportsQuery.isError,
+    refetch: transportsQuery.refetch,
+  };
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -7,6 +7,7 @@ import {
   useGetV2ListChatTransports,
   usePutV2SetDefaultChatTransport,
 } from "@/app/api/__generated__/endpoints/chat/chat";
+import { useGetV1ListCredentials } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
 import { toast } from "@/components/molecules/Toast/use-toast";
 
@@ -23,6 +24,26 @@ export function useAIConnectionsSection() {
       ? transportsQuery.data.data.transports
       : [];
   const connections = transports.filter(isSelectable);
+
+  // The account a connection runs as. Read from the stored credential rather
+  // than asked of the provider: this is the identity the user linked, so it is
+  // true without a live call, and it cannot go stale the way a usage window
+  // can.
+  const credentialsQuery = useGetV1ListCredentials({
+    query: {
+      select: (response) => (response.status === 200 ? response.data : []),
+    },
+  });
+  const accountByCredentialId = new Map(
+    (credentialsQuery.data ?? [])
+      .filter((credential) => credential.username)
+      .map((credential) => [credential.id, credential.username as string]),
+  );
+
+  function accountFor(transport: ChatTransportResponse): string | undefined {
+    if (!transport.credential_id) return undefined;
+    return accountByCredentialId.get(transport.credential_id);
+  }
 
   const { mutateAsync: setDefault, isPending: isSaving } =
     usePutV2SetDefaultChatTransport({
@@ -61,6 +82,7 @@ export function useAIConnectionsSection() {
 
   return {
     connections,
+    accountFor,
     selectedKey,
     chooseDefault,
     isSaving,

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  ArrowDataTransferHorizontalIcon,
+  ShieldKeyIcon,
+  SparklesIcon,
+  Target02Icon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Point {
+  icon: IconSvgElement;
+  title: string;
+  body: string;
+}
+
+/**
+ * Linking a ChatGPT plan changes who pays for a run, so the four questions
+ * that implies get answered on screen before the OAuth window opens rather
+ * than after the user has committed.
+ *
+ * Deliberately claims nothing about specific models or about pausing and
+ * resuming a run at a provider limit: the model catalog is server-owned, and
+ * same-chat recovery is not built yet. Both land with their own work.
+ */
+const POINTS: Point[] = [
+  {
+    icon: ArrowDataTransferHorizontalIcon,
+    title: "What it does.",
+    body: "Chats routed to ChatGPT run on your ChatGPT plan instead of AutoGPT credits. Every new chat starts on the connection you choose in Settings, and you can change it per conversation — nothing switches on its own.",
+  },
+  {
+    icon: Target02Icon,
+    title: "What it costs.",
+    body: "Usage counts toward your ChatGPT plan's own limits. Those runs spend zero AutoGPT credits, and AutoGPT never adds a charge on top.",
+  },
+  {
+    icon: SparklesIcon,
+    title: "What you get.",
+    body: "The models your ChatGPT plan already includes, at no extra cost from AutoGPT.",
+  },
+  {
+    icon: ShieldKeyIcon,
+    title: "Stay in control.",
+    body: "A chat stays on the connection it started with, so a run is never moved onto your AutoGPT credits without asking. Disconnect any time in Settings.",
+  },
+];
+
+export function ChatGPTConnectExplainer() {
+  return (
+    <div className="divide-y divide-[#DADADC] rounded-2xl border border-[#DADADC] bg-[#FBFBFC]">
+      {POINTS.map((point) => (
+        <div key={point.title} className="flex items-start gap-3 p-4">
+          <span
+            aria-hidden
+            className="mt-[2px] flex h-6 w-6 flex-none items-center justify-center rounded-lg bg-[#F1EBFF] text-[#7444E5]"
+          >
+            <Icon icon={point.icon} size={14} />
+          </span>
+          <Text variant="small" className="text-[#505057]">
+            <span className="font-medium text-black">{point.title}</span>{" "}
+            {point.body}
+          </Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../helpers";
 import { ApiKeyConnectForm } from "./ApiKeyConnectForm";
 import { DeviceAuthConnectButton } from "@/components/contextual/DeviceAuth/DeviceAuthConnectButton";
+import { ChatGPTConnectExplainer } from "./ChatGPTConnectExplainer";
 import { OAuthConnectButton } from "./OAuthConnectButton";
 import { UnsupportedNotice } from "./UnsupportedNotice";
 
@@ -31,12 +32,16 @@ export function MethodPanel({ method, provider, onSuccess }: Props) {
   if (method === AuthType.oauth2) {
     const isChatGPT = authProvider === "codex";
     return (
-      <OAuthConnectButton
-        provider={authProvider}
-        providerName={isChatGPT ? "ChatGPT" : provider.name}
-        buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
-        onSuccess={onSuccess}
-      />
+      <div className="flex flex-col gap-4">
+        {isChatGPT && <ChatGPTConnectExplainer />}
+        <OAuthConnectButton
+          provider={authProvider}
+          providerName={isChatGPT ? "ChatGPT" : provider.name}
+          buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
+          termsNotice={isChatGPT}
+          onSuccess={onSuccess}
+        />
+      </div>
     );
   }
   if (method === AuthType.api_key) {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
@@ -12,6 +12,9 @@ interface Props {
   provider: string;
   providerName: string;
   buttonLabel?: string;
+  /** Say whose terms a linked run falls under. Only true where runs execute
+   *  on the provider's own account rather than on AutoGPT's. */
+  termsNotice?: boolean;
   onSuccess: (credential?: CredentialsMetaResponse) => void;
 }
 
@@ -19,6 +22,7 @@ export function OAuthConnectButton({
   provider,
   providerName,
   buttonLabel,
+  termsNotice = false,
   onSuccess,
 }: Props) {
   const { connect, isPending } = useOAuthConnect({ provider, onSuccess });
@@ -39,6 +43,12 @@ export function OAuthConnectButton({
       >
         {buttonLabel ?? `Continue with ${providerName}`}
       </Button>
+      {termsNotice && (
+        <Text variant="small" className="text-[#8A8A90]">
+          Linked runs are sent to {providerName} under your own account and
+          follow {providerName}&apos;s terms.
+        </Text>
+      )}
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
@@ -35,4 +35,54 @@ describe("MethodPanel", () => {
       expect.objectContaining({ provider: "codex" }),
     );
   });
+
+  test("answers what linking a ChatGPT plan means before the OAuth window", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("What it does.")).toBeDefined();
+    expect(screen.getByText("What it costs.")).toBeDefined();
+    expect(screen.getByText("What you get.")).toBeDefined();
+    expect(screen.getByText("Stay in control.")).toBeDefined();
+    expect(screen.getByText(/spend zero AutoGPT credits/i)).toBeDefined();
+    expect(screen.getByText(/follow ChatGPT's terms/i)).toBeDefined();
+  });
+
+  test("claims nothing it cannot back up", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // Model names are server-owned, and pause-and-resume at a provider limit
+    // is not built yet — neither may be promised here.
+    expect(screen.queryByText(/5\.6|Terra|Sol|Balanced|Advanced/)).toBeNull();
+    expect(screen.queryByText(/the run pauses/i)).toBeNull();
+  });
+
+  test("does not show the ChatGPT explainer for an unrelated provider", () => {
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={{
+          id: "notion",
+          name: "Notion",
+          description: "Notion",
+          supportedAuthTypes: [AuthType.oauth2],
+        }}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("What it costs.")).toBeNull();
+    expect(screen.queryByText(/follow Notion's terms/i)).toBeNull();
+  });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/DeleteConfirmDialog/DeleteConfirmDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/DeleteConfirmDialog/DeleteConfirmDialog.tsx
@@ -11,6 +11,9 @@ interface Props {
   isPending?: boolean;
   onConfirm: () => void;
   variant?: "remove" | "force";
+  /** Provider-specific consequence, when the generic wording would overstate
+   *  or understate what actually stops working. */
+  notice?: string;
 }
 
 export function DeleteConfirmDialog({
@@ -20,6 +23,7 @@ export function DeleteConfirmDialog({
   isPending = false,
   onConfirm,
   variant = "remove",
+  notice,
 }: Props) {
   const count = itemNames.length;
   const isBulk = count > 1;
@@ -51,6 +55,12 @@ export function DeleteConfirmDialog({
           <Text variant="body" className="text-zinc-800">
             {message}
           </Text>
+
+          {notice && (
+            <Text variant="small" className="text-[#505057]">
+              {notice}
+            </Text>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsList/IntegrationsList.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsList/IntegrationsList.tsx
@@ -75,12 +75,17 @@ export function IntegrationsList() {
     await requestDelete(ids, true);
   }
 
-  const pendingNames = buildTargets(pendingDeleteIds).map(
-    (t) => t.name ?? t.provider,
-  );
+  const pendingTargets = buildTargets(pendingDeleteIds);
+  const pendingNames = pendingTargets.map((t) => t.name ?? t.provider);
   const pendingForceNames = buildTargets(pendingForceIds).map(
     (t) => t.name ?? t.provider,
   );
+  // The generic warning talks about agents losing access, which is not what
+  // removing a ChatGPT connection does: it stops new ChatGPT-backed chats and
+  // leaves everything already said in them alone.
+  const pendingNotice = pendingTargets.some((t) => t.provider === "codex")
+    ? "New chats can no longer run on your ChatGPT plan — they fall back to the connection AutoGPT picks. Your chat history is kept, and your other integrations are unaffected."
+    : undefined;
 
   if (isLoading) {
     return (
@@ -181,6 +186,7 @@ export function IntegrationsList() {
           if (!open) setPendingDeleteIds([]);
         }}
         itemNames={pendingNames}
+        notice={pendingNotice}
         isPending={isDeleting}
         onConfirm={confirmDelete}
       />


### PR DESCRIPTION
### Why / What / How

**Why.** `GET /transports` answers *which routes exist and which is default*. That is enough to **route** a turn and not enough to **render** one — so the client has been deciding what a connection is called, what backs it, which provider family it belongs to, and what limitations apply. Those are product and billing statements. A client that computes them drifts from the server that enforces them, and every new surface re-derives the same copy.

**What.** `GET /api/chat/connections` returns an `AIConnectionOffer` per connection: stable offer id, provider family, auth method, credential id, backed-by label, description, state, selectability, whether it is the default, quality tiers, and limitations.

**How.** Built on the existing transport list, so there is one source of truth for *which* routes exist and this adds only *how to describe* them. **Additive** — `/transports` keeps its exact shape, so nothing has to migrate at once and a client that cannot reach the new endpoint still has the old one.

Offer ids are `{auth_provider}:{credential_id or "deployment"}`. The platform route carries no credential and a user may hold several ChatGPT accounts, so neither half identifies an offer alone.

#### Two things it deliberately does not carry

**No model names on the tiers.** Tiers are labelled Balanced and Advanced, and stop there. Resolving a tier to a model needs the execution path — decided per turn by whether the baseline or SDK service takes it (`resolve_model_route("fast" | "thinking", …)`) — and on ChatGPT it needs a live call against the account, the same runtime lease the account snapshot takes. A name that is right half the time is worse than no name, especially on a list endpoint that would then have to take a provider lease per credential. The catalog is separate work; a test pins the absence so it cannot creep back as a guess.

**No invented lock.** Advanced is offered wherever the connection is, because nothing gates it today. `lock_reason` will mean something when something actually locks it.

#### Where the copy came from

`_description` is the wording already agreed in this stack, moved server-side: the credits contrast is stated **only where credits exist**, so self-host says what it has rather than denying something it never had. The frontend's local copy map (which carries a comment saying exactly this belongs on the server) can now be deleted — a follow-up, kept out of here so this PR stays additive.

Limitations are real edges a user can hit, not policy notes — the builder panel rejects a codex route outright, so that is stated.

### Changes 🏗️

- `backend/copilot/offers.py` — the offer contract, built on `transports`
- `GET /api/chat/connections`
- `openapi.json` regenerated (+94 lines, no deletions)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] 8 unit tests: what backs a run on each connection, self-host not denying credits it never had, provider family grouping without becoming the credential, stable per-account offer ids, tiers labelled but never model-named, an unavailable connection being unselectable with a reason, the ChatGPT builder limitation, and exactly one default
  - [x] `openapi.json` regenerates with the endpoint and schemas and **no deletions**, which also proves the route and models wire up
  - [x] `ruff`, `black`, `isort` clean; `pyright` 0 errors on every changed file
  - [ ] Not run locally — every async backend test deadlocks on this Windows host (`backend/conftest.py`'s session-scoped autouse `graph_cleanup(server)` boots `SpinTestServer`; an untouched async test file hangs identically). CI is the check.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes — no new configuration
- [x] `docker-compose.yml` is updated or already compatible with my changes — unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only authenticated endpoint layered on existing transport discovery; no changes to routing, billing enforcement, or `/transports` contract.
> 
> **Overview**
> Adds **`GET /api/chat/connections`**, an additive companion to **`GET /transports`**, so clients can render connection pickers from server-authored product and billing copy instead of inferring it locally.
> 
> Each **`AIConnectionOffer`** is built from the existing transport list via **`get_connection_offers`**: stable **`offer_id`** (`auth_provider:credential_id|deployment`), provider family, auth method, backed-by label and description (hosted vs self-host, ChatGPT vs AutoGPT credits), ready/unavailable state, default flag, **Balanced/Advanced** tiers (no model names), and user-facing **limitations** (e.g. builder always on AutoGPT, missing deployment provider).
> 
> **`openapi.json`** gains the route and **`AIConnectionOffer`**, **`ConnectionTier`**, and **`AIConnectionOffersResponse`** schemas; **`offers_test.py`** covers the mapping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3dff7f29583823252f1d131dca8195d292ff40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->