### PR TITLE
feat(backend): name the model each quality tier resolves to

### DIFF
--- a/autogpt_platform/backend/backend/copilot/engine.py
+++ b/autogpt_platform/backend/backend/copilot/engine.py
@@ -1,0 +1,41 @@
+"""Which execution engine runs a turn.
+
+Lives apart from the processor so the answer can be read without importing
+the engines themselves: the processor pulls in both services at module
+level, and the API layer needs this decision to describe a connection
+before any turn exists.
+"""
+
+import logging
+
+from backend.util.feature_flag import Flag, is_feature_enabled
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_use_sdk(
+    user_id: str | None,
+    *,
+    use_claude_code_subscription: bool,
+    config_default: bool,
+    thinking_available: bool = True,
+) -> bool:
+    """Pick the SDK vs baseline engine.
+
+    Entirely the server's call: the Claude Code subscription override, then
+    the ``COPILOT_SDK`` LaunchDarkly flag, then the config default. Callers
+    used to be able to name an engine per request; nothing can now, so this
+    is one decision rather than a request overriding it — which is also what
+    makes it answerable ahead of a turn.
+
+    ``thinking_available`` is the kill-switch for deployments where the SDK
+    transport simply cannot run (today: ``CHAT_USE_LOCAL=true`` — Ollama
+    doesn't speak Anthropic's wire protocol).
+    """
+    if not thinking_available:
+        return False
+    return use_claude_code_subscription or await is_feature_enabled(
+        Flag.COPILOT_SDK,
+        user_id or "anonymous",
+        default=config_default,
+    )

--- a/autogpt_platform/backend/backend/copilot/executor/processor.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Callable, cast
 
 from backend.copilot import stream_registry
 from backend.copilot.baseline import stream_chat_completion_baseline
+from backend.copilot.engine import resolve_use_sdk
 from backend.copilot.config import ChatConfig
 from backend.copilot.expert_context import (
     EXPERT_SESSION_MISSING_MESSAGE,
@@ -32,7 +33,6 @@ from backend.util.exceptions import (
     ExpertNotFoundError,
     ExpertPrivateTenancyNotFoundError,
 )
-from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.logging import TruncatedLogger, configure_logging
 from backend.util.process import set_service_name
 from backend.util.retry import func_retry
@@ -133,33 +133,6 @@ def sync_fail_close_session(
 
 
 # ============ Mode Routing ============ #
-
-
-async def resolve_use_sdk(
-    user_id: str | None,
-    *,
-    use_claude_code_subscription: bool,
-    config_default: bool,
-    thinking_available: bool = True,
-) -> bool:
-    """Pick the SDK vs baseline engine for a single turn.
-
-    The engine is entirely the server's call: the Claude Code subscription
-    override, then the ``COPILOT_SDK`` LaunchDarkly flag, then the config
-    default. Callers used to be able to name an engine per request; nothing
-    can now, so there is one decision here instead of a request overriding it.
-
-    ``thinking_available`` is the kill-switch for deployments where the SDK
-    transport simply cannot run (today: ``CHAT_USE_LOCAL=true`` — Ollama
-    doesn't speak Anthropic's wire protocol).
-    """
-    if not thinking_available:
-        return False
-    return use_claude_code_subscription or await is_feature_enabled(
-        Flag.COPILOT_SDK,
-        user_id or "anonymous",
-        default=config_default,
-    )
 
 
 # ============ Module Entry Points ============ #

--- a/autogpt_platform/backend/backend/copilot/executor/processor_test.py
+++ b/autogpt_platform/backend/backend/copilot/executor/processor_test.py
@@ -17,11 +17,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from backend.copilot.engine import resolve_use_sdk
 from backend.copilot.executor.processor import (
     _CODEX_CREDENTIAL_ACQUIRE_TIMEOUT_SECONDS,
     CoPilotProcessor,
     _normalize_private_expert_session_tenancy,
-    resolve_use_sdk,
     sync_fail_close_session,
 )
 from backend.copilot.executor.utils import CoPilotExecutionEntry, CoPilotLogMetadata
@@ -49,7 +49,7 @@ class TestResolveUseSdk:
     @pytest.mark.asyncio
     async def test_subscription_override_routes_to_sdk(self):
         with patch(
-            "backend.copilot.executor.processor.is_feature_enabled",
+            "backend.copilot.engine.is_feature_enabled",
             new=AsyncMock(return_value=False),
         ):
             assert (
@@ -64,7 +64,7 @@ class TestResolveUseSdk:
     @pytest.mark.asyncio
     async def test_feature_flag_routes_to_sdk(self):
         with patch(
-            "backend.copilot.executor.processor.is_feature_enabled",
+            "backend.copilot.engine.is_feature_enabled",
             new=AsyncMock(return_value=True),
         ):
             assert (
@@ -84,7 +84,7 @@ class TestResolveUseSdk:
             captured["default"] = default
             return default
 
-        with patch("backend.copilot.executor.processor.is_feature_enabled", new=_flag):
+        with patch("backend.copilot.engine.is_feature_enabled", new=_flag):
             assert (
                 await resolve_use_sdk(
                     "user-1",
@@ -98,7 +98,7 @@ class TestResolveUseSdk:
     @pytest.mark.asyncio
     async def test_everything_disabled_routes_to_baseline(self):
         with patch(
-            "backend.copilot.executor.processor.is_feature_enabled",
+            "backend.copilot.engine.is_feature_enabled",
             new=AsyncMock(return_value=False),
         ):
             assert (
@@ -119,7 +119,7 @@ class TestResolveUseSdk:
         wire protocol.
         """
         with patch(
-            "backend.copilot.executor.processor.is_feature_enabled",
+            "backend.copilot.engine.is_feature_enabled",
             new=AsyncMock(return_value=True),
         ):
             assert (
@@ -135,7 +135,7 @@ class TestResolveUseSdk:
     @pytest.mark.asyncio
     async def test_anonymous_user_is_routable(self):
         with patch(
-            "backend.copilot.executor.processor.is_feature_enabled",
+            "backend.copilot.engine.is_feature_enabled",
             new=AsyncMock(return_value=False),
         ):
             assert (

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -14,7 +14,9 @@ import logging
 
 from pydantic import BaseModel
 
-from backend.copilot.config import CopilotLlmAuthProvider, CopilotLLMModel
+from backend.copilot.config import ChatConfig, CopilotLlmAuthProvider, CopilotLLMModel
+from backend.copilot.engine import resolve_use_sdk
+from backend.copilot.model_router import resolve_model_route
 from backend.copilot.transports import (
     ChatTransportResponse,
     get_chat_transports,
@@ -36,15 +38,20 @@ TIER_LABELS: dict[CopilotLLMModel, str] = {
 class ConnectionTier(BaseModel):
     """One quality level on a connection.
 
-    ``display_model`` is deliberately absent. Naming the model a tier will
-    resolve to needs the execution path, which is decided per turn by which
-    service handles it — and on ChatGPT it needs a live call against the
-    account. A name that is right half the time is worse here than no name.
+    ``display_model`` is the model this tier resolves to, run through the
+    same router the turn will use — LaunchDarkly cell, then registry, then
+    config — so it cannot drift from what actually answers.
+
+    It is ``None`` on a ChatGPT connection. Naming that model means asking
+    the account what it advertises, which takes a runtime lease against the
+    provider; doing that once per credential to render a list is the cost
+    this endpoint exists to avoid.
     """
 
     tier: CopilotLLMModel
     label: str
     selectable: bool
+    display_model: str | None = None
 
 
 class AIConnectionOffer(BaseModel):
@@ -67,7 +74,50 @@ class AIConnectionOffersResponse(BaseModel):
 
 
 async def get_connection_offers(user_id: str) -> list[AIConnectionOffer]:
-    return [_offer(transport) for transport in await get_chat_transports(user_id)]
+    """Describe every connection, naming the models where they are knowable.
+
+    The engine is resolved once for the user rather than per offer: it is a
+    property of the deployment and the user, not of which connection they
+    pick.
+    """
+    config = ChatConfig()
+    models = await _platform_tier_models(user_id, config)
+    return [
+        _offer(transport, models) for transport in await get_chat_transports(user_id)
+    ]
+
+
+async def _platform_tier_models(
+    user_id: str, config: ChatConfig
+) -> dict[CopilotLLMModel, str | None]:
+    """Resolve each tier against the engine this user's turns will run on.
+
+    Answerable at all only because nothing can name an engine per request
+    any more — the decision is the server's, so it can be made before a turn
+    exists rather than during one.
+    """
+    use_sdk = await resolve_use_sdk(
+        user_id,
+        use_claude_code_subscription=config.use_claude_code_subscription,
+        config_default=config.use_claude_agent_sdk,
+        thinking_available=config.thinking_available,
+    )
+    mode = "thinking" if use_sdk else "fast"
+    resolved: dict[CopilotLLMModel, str | None] = {}
+    for tier in TIER_LABELS:
+        try:
+            route = await resolve_model_route(mode, tier, user_id, config=config)
+            resolved[tier] = route.model
+        except Exception:
+            # A tier that cannot be resolved is described without a name
+            # rather than failing the whole list.
+            logger.warning(
+                "Could not resolve the %s model for the platform connection",
+                tier,
+                exc_info=True,
+            )
+            resolved[tier] = None
+    return resolved
 
 
 def offer_id_for(transport: ChatTransportResponse) -> str:
@@ -79,7 +129,10 @@ def offer_id_for(transport: ChatTransportResponse) -> str:
     return f"{transport.auth_provider}:{transport.credential_id or 'deployment'}"
 
 
-def _offer(transport: ChatTransportResponse) -> AIConnectionOffer:
+def _offer(
+    transport: ChatTransportResponse,
+    platform_models: dict[CopilotLLMModel, str | None],
+) -> AIConnectionOffer:
     return AIConnectionOffer(
         offer_id=offer_id_for(transport),
         provider_family=_provider_family(transport.auth_provider),
@@ -92,7 +145,16 @@ def _offer(transport: ChatTransportResponse) -> AIConnectionOffer:
         selectable=transport.available,
         is_default=transport.default,
         tiers=[
-            ConnectionTier(tier=tier, label=label, selectable=transport.available)
+            ConnectionTier(
+                tier=tier,
+                label=label,
+                selectable=transport.available,
+                display_model=(
+                    platform_models.get(tier)
+                    if transport.auth_provider == "platform"
+                    else None
+                ),
+            )
             for tier, label in TIER_LABELS.items()
         ],
         limitations=_limitations(transport),

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -1,5 +1,6 @@
 """The server-owned description of an AI connection."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -33,6 +34,16 @@ def _transport(
 def hosted(mocker: pytest_mock.MockerFixture):
     mocker.patch.object(offers.settings.config, "behave_as", BehaveAs.CLOUD)
     mocker.patch.object(transports.settings.config, "behave_as", BehaveAs.CLOUD)
+    mocker.patch.object(offers, "resolve_use_sdk", new=AsyncMock(return_value=False))
+    mocker.patch.object(
+        offers,
+        "resolve_model_route",
+        new=AsyncMock(
+            side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
+                model=f"{mode}-{tier}-model", source="config"
+            )
+        ),
+    )
 
 
 def _mock_transports(
@@ -104,17 +115,64 @@ async def test_offer_ids_are_stable_and_per_account(
 
 
 @pytest.mark.asyncio
-async def test_tiers_are_labelled_but_never_named_with_a_model(
+async def test_tiers_name_the_model_they_resolve_to(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    """Naming the model needs the execution path, decided per turn."""
     _mock_transports(mocker, [_transport(default=True)])
 
     (offer,) = await get_connection_offers(USER_ID)
 
     assert [tier.label for tier in offer.tiers] == ["Balanced", "Advanced"]
-    assert [tier.tier for tier in offer.tiers] == ["standard", "advanced"]
-    assert not any(hasattr(tier, "display_model") for tier in offer.tiers)
+    assert [tier.display_model for tier in offer.tiers] == [
+        "fast-standard-model",
+        "fast-advanced-model",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tiers_follow_the_engine_the_user_will_actually_run_on(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """The engine is the server's decision, so it is knowable before a turn."""
+    mocker.patch.object(offers, "resolve_use_sdk", new=AsyncMock(return_value=True))
+    _mock_transports(mocker, [_transport(default=True)])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert [tier.display_model for tier in offer.tiers] == [
+        "thinking-standard-model",
+        "thinking-advanced-model",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_tiers_are_not_named(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """Naming them means leasing a runtime per credential to render a list."""
+    _mock_transports(mocker, [_transport("codex", "cred-1", "ChatGPT")])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert all(tier.display_model is None for tier in offer.tiers)
+    assert [tier.label for tier in offer.tiers] == ["Balanced", "Advanced"]
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_tier_is_described_without_a_name(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch.object(
+        offers,
+        "resolve_model_route",
+        new=AsyncMock(side_effect=RuntimeError("registry down")),
+    )
+    _mock_transports(mocker, [_transport(default=True)])
+
+    (offer,) = await get_connection_offers(USER_ID)
+
+    assert all(tier.display_model is None for tier in offer.tiers)
+    assert offer.state == "ready"
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -17283,12 +17283,16 @@
             "title": "Tier"
           },
           "label": { "type": "string", "title": "Label" },
-          "selectable": { "type": "boolean", "title": "Selectable" }
+          "selectable": { "type": "boolean", "title": "Selectable" },
+          "display_model": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Display Model"
+          }
         },
         "type": "object",
         "required": ["tier", "label", "selectable"],
         "title": "ConnectionTier",
-        "description": "One quality level on a connection.\n\n``display_model`` is deliberately absent. Naming the model a tier will\nresolve to needs the execution path, which is decided per turn by which\nservice handles it — and on ChatGPT it needs a live call against the\naccount. A name that is right half the time is worse here than no name."
+        "description": "One quality level on a connection.\n\n``display_model`` is the model this tier resolves to, run through the\nsame router the turn will use — LaunchDarkly cell, then registry, then\nconfig — so it cannot drift from what actually answers.\n\nIt is ``None`` on a ChatGPT connection. Naming that model means asking\nthe account what it advertises, which takes a runtime lease against the\nprovider; doing that once per credential to render a list is the cost\nthis endpoint exists to avoid."
       },
       "ContentType": {
         "type": "string",


### PR DESCRIPTION
### Why / What / How

**Why.** The connection offer said a connection has **Balanced** and **Advanced** and stopped. I left the model name out of #14082 on purpose: resolving a tier to a model needed the execution engine, and the engine was decided *per turn* by whichever service took the request. A name that is right half the time is worse than no name.

**Removing the Fast/Thinking control changed that.** Nothing can name an engine per request any more, so `resolve_use_sdk` is a property of the deployment and the user rather than of a turn — and can be answered *before* a turn exists. That is what makes this possible; there is no new routing machinery here.

**What.** `ConnectionTier.display_model` — the model each tier resolves to, on connections where that is knowable without a provider call.

**How.** The engine decision moves out of `executor/processor.py` into **`copilot/engine.py`**. The processor imports both services at module level; pulling that into a request path to answer one boolean would be the wrong trade, and duplicating the decision would give two sources of truth for something that decides who pays. One function, two importers.

Each tier then goes through **the same router the turn will use** — LaunchDarkly cell → registry → config — so the name shown cannot drift from the model that answers. The engine is resolved once per request, not once per offer: it is a property of the user, not of which connection they pick.

#### ChatGPT tiers stay unnamed

Naming those means asking the account what it advertises, which takes a **runtime lease against the provider**. Doing that once per credential to render a list is precisely the cost this endpoint exists to avoid — the same reasoning that keeps the account snapshot behind the Manage dialog in #14081. It belongs on that on-demand call, not here.

#### Failure is a missing label, not a failed page

A tier that cannot be resolved is described without a name and logged. A registry outage or a bad LaunchDarkly slug costs a label; the connection list still renders and stays selectable.

### Changes 🏗️

- `copilot/engine.py` — `resolve_use_sdk`, extracted so it is readable without importing the engines
- `ConnectionTier.display_model`, resolved through `resolve_model_route`
- `openapi.json` regenerated (+6/−2)

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] 11 tests in `offers_test.py`, 4 of them new: tiers name the model they resolve to; the names follow the engine the user will actually run on (baseline vs SDK); ChatGPT tiers stay unnamed; an unresolvable tier is described without a name and does not fail the list
  - [x] `processor_test.py` patch targets follow the symbol to `copilot.engine` — mocking where it is used, not where it was
  - [x] `ruff`, `black` clean; `pyright` 0 errors on every changed file
  - [x] `openapi.json` regenerates to exactly the new field
  - [ ] Not run locally — async backend tests deadlock on this Windows host. CI is the check.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes — no new configuration
- [x] `docker-compose.yml` is updated or already compatible with my changes — unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible connection metadata and centralizes engine selection; routing logic is reused rather than duplicated, with broad test coverage, but mis-resolution could show wrong model names before chat starts.
> 
> **Overview**
> Connection offers now expose **`ConnectionTier.display_model`** for platform (AutoGPT) connections: each **Balanced** / **Advanced** tier shows the model name that will actually run, using the same **`resolve_model_route`** path as a turn (LaunchDarkly → registry → config).
> 
> **`resolve_use_sdk`** moves from **`executor/processor.py`** into **`copilot/engine.py`** so the API can pick SDK vs baseline once per user before any turn exists—without pulling the full executor stack. The processor still calls it when routing a turn.
> 
> ChatGPT (**codex**) tiers keep **`display_model` as `None`** (no per-credential runtime lease to list models). If a tier cannot be resolved, that label is omitted and the offer list still returns **`ready`**. OpenAPI **`ConnectionTier`** schema is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a475631162d9d7018ec73632b4dc56220b364e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->