### PR TITLE
feat(platform): say which provider failure happened, and what fixes it

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -79,6 +79,7 @@ from backend.copilot.prompting import (
     get_delegation_supplement,
     get_graphiti_supplement,
 )
+from backend.copilot.provider_failure import classify as classify_provider_failure
 from backend.copilot.rate_limit import build_budget_ctx
 from backend.copilot.response_model import (
     StreamBaseResponse,
@@ -86,6 +87,7 @@ from backend.copilot.response_model import (
     StreamFinish,
     StreamFinishStep,
     StreamModeChanged,
+    StreamProviderFailure,
     StreamStart,
     StreamStartStep,
     StreamStatus,
@@ -2435,7 +2437,19 @@ async def stream_chat_completion_baseline(
             evt = state.pending_events.get_nowait()
             if evt is not None:
                 yield evt
-        yield StreamError(errorText=error_msg, code="baseline_error")
+        failure = classify_provider_failure(
+            e,
+            auth_provider=session.metadata.llm_auth_provider if session else None,
+            credential_id=session.metadata.llm_credential_id if session else None,
+            message=error_msg,
+        )
+        if failure is not None:
+            # Before the error, so a client that acts on the envelope has it
+            # in hand by the time the turn is reported failed.
+            yield StreamProviderFailure(failure=failure.as_part())
+            yield StreamError(errorText=error_msg, code=failure.kind.value)
+        else:
+            yield StreamError(errorText=error_msg, code="baseline_error")
         # Still persist whatever we got
     finally:
         # Cancel the inner task if we're unwinding early (client disconnect,

--- a/autogpt_platform/backend/backend/copilot/provider_failure.py
+++ b/autogpt_platform/backend/backend/copilot/provider_failure.py
@@ -1,0 +1,226 @@
+"""What went wrong with the provider behind a turn, said precisely.
+
+Every provider failure currently reaches the client as one opaque
+``baseline_error`` carrying a stringified exception. An expired ChatGPT
+login, a monthly usage limit, a retired model and a policy refusal are all
+the same event to the UI, so it can only offer the same useless advice --
+"Press Try Again" -- to three failures where trying again cannot work.
+
+This module names the difference once, at the boundary where the provider
+exception is still intact, and hands the caller something a UI can act on:
+whether retrying is pointless, whether reconnecting would help, and when
+the limit actually lifts.
+
+``resets_at`` is deliberately ``None`` unless the provider reported a real
+timestamp. An invented "try again in an hour" that turns out to be wrong is
+worse than saying nothing, because the user plans around it.
+"""
+
+import logging
+import re
+import time
+from enum import Enum
+from typing import Any
+
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+from pydantic import BaseModel, Field
+
+from backend.copilot.rate_limit import UserPaywalledError
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderFailureKind(str, Enum):
+    """Why a provider refused, in terms that imply what to do about it."""
+
+    # The credential was understood and rejected -- reconnecting fixes it.
+    AUTH_EXPIRED = "auth_expired"
+    # The credential is malformed or unusable; reconnecting fixes it.
+    INVALID_CREDENTIAL = "invalid_credential"
+    # A quota is spent. Waiting fixes it; retrying now does not.
+    USAGE_LIMIT = "usage_limit"
+    # The model is gone or not available to this account.
+    MODEL_UNAVAILABLE = "model_unavailable"
+    # The provider refused on policy grounds. Retrying is pointless.
+    POLICY_DENIED = "policy_denied"
+    # The user's plan does not include this route.
+    #
+    # Shares its value with ``ExecutionFailureReason.ENTITLEMENT_REQUIRED``
+    # on purpose: the same denial can terminate a graph run or a chat turn,
+    # and two names for it would split every downstream count in half.
+    ENTITLEMENT_REQUIRED = "entitlement_required"
+    # Anything that might genuinely succeed on a second attempt.
+    TRANSIENT = "transient"
+
+
+# Retrying the same turn is only honest for a failure that could resolve
+# itself. Everything else needs the user to do something first.
+_RETRYABLE = frozenset({ProviderFailureKind.TRANSIENT})
+
+# The kinds a reconnect would actually clear.
+_RECONNECTABLE = frozenset(
+    {
+        ProviderFailureKind.AUTH_EXPIRED,
+        ProviderFailureKind.INVALID_CREDENTIAL,
+    }
+)
+
+
+class ProviderFailure(BaseModel):
+    """One provider refusal, carried whole from the runtime to the client."""
+
+    kind: ProviderFailureKind
+    message: str = Field(description="What to tell the user, already humanized")
+    auth_provider: str | None = Field(
+        default=None, description="Which connection failed: platform or codex"
+    )
+    credential_id: str | None = None
+    resets_at: int | None = Field(
+        default=None,
+        description=(
+            "Unix seconds, only when the provider reported one. Never guessed."
+        ),
+    )
+
+    @property
+    def retryable(self) -> bool:
+        return self.kind in _RETRYABLE
+
+    @property
+    def reconnect_fixes_it(self) -> bool:
+        return self.kind in _RECONNECTABLE
+
+    def as_part(self) -> dict[str, Any]:
+        """The payload carried on the stream, including derived advice.
+
+        ``retryable`` is computed here rather than left to the client so a
+        second implementation of "is this worth retrying" cannot drift from
+        this one.
+        """
+        return {
+            "kind": self.kind.value,
+            "message": self.message,
+            "authProvider": self.auth_provider,
+            "credentialId": self.credential_id,
+            "resetsAt": self.resets_at,
+            "retryable": self.retryable,
+            "reconnectFixesIt": self.reconnect_fixes_it,
+        }
+
+
+def classify(
+    exc: BaseException,
+    *,
+    auth_provider: str | None = None,
+    credential_id: str | None = None,
+    message: str | None = None,
+) -> ProviderFailure | None:
+    """Name the failure, or return ``None`` if it is not the provider's.
+
+    ``None`` means "not recognisably a provider refusal" and leaves the
+    caller's existing behaviour untouched. That matters: a bug in our own
+    code dressed up as a provider failure would send the user to reconnect
+    an account that was never broken.
+    """
+    kind = _kind_of(exc)
+    if kind is None:
+        return None
+    return ProviderFailure(
+        kind=kind,
+        message=message or str(exc) or type(exc).__name__,
+        auth_provider=auth_provider,
+        credential_id=credential_id,
+        resets_at=_resets_at(exc),
+    )
+
+
+def _kind_of(exc: BaseException) -> ProviderFailureKind | None:
+    if isinstance(exc, UserPaywalledError):
+        return ProviderFailureKind.ENTITLEMENT_REQUIRED
+    if isinstance(exc, AuthenticationError):
+        return ProviderFailureKind.AUTH_EXPIRED
+    if isinstance(exc, PermissionDeniedError):
+        return ProviderFailureKind.POLICY_DENIED
+    if isinstance(exc, RateLimitError):
+        return ProviderFailureKind.USAGE_LIMIT
+    if isinstance(exc, NotFoundError):
+        return ProviderFailureKind.MODEL_UNAVAILABLE
+    if isinstance(exc, (APIConnectionError, APITimeoutError, InternalServerError)):
+        return ProviderFailureKind.TRANSIENT
+    if isinstance(exc, APIStatusError):
+        # Any other 5xx is worth another attempt; a 4xx we have not named
+        # above is a request we built wrong, which is ours, not the
+        # provider's, and must not be dressed up as a provider refusal.
+        return ProviderFailureKind.TRANSIENT if exc.status_code >= 500 else None
+    return None
+
+
+def _resets_at(exc: BaseException) -> int | None:
+    """A reset time only if the provider actually sent one.
+
+    Read from the standard ``x-ratelimit-reset-*`` response headers. Anything
+    unparseable is dropped rather than approximated -- a wrong time is worse
+    than no time, because the user schedules around it.
+    """
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    raw = headers.get("x-ratelimit-reset-requests") or headers.get(
+        "x-ratelimit-reset-tokens"
+    )
+    if not raw:
+        return None
+    try:
+        return _to_unix_seconds(str(raw))
+    except (ValueError, TypeError):
+        logger.debug("Unparseable rate-limit reset header: %r", raw)
+        return None
+
+
+def _to_unix_seconds(raw: str) -> int | None:
+    """Absolute epoch seconds, or ``None`` for a shape we do not understand.
+
+    OpenAI sends a duration like ``60s`` / ``1m30s`` / ``6m0s`` / ``2h``;
+    some compatible servers send an absolute epoch instead. A duration is
+    still the provider reporting a reset -- "60 seconds from now" is a fact,
+    not a guess -- so it is anchored to the current clock. What is refused is
+    inventing a reset the provider never mentioned at all.
+    """
+    value = raw.strip().lower()
+    if not value:
+        return None
+    if value.isdigit():
+        seconds = int(value)
+        # Below this, it is a duration in seconds rather than an epoch:
+        # 10**9 seconds is 2001, so no real reset epoch is ever smaller.
+        return seconds if seconds > 10**9 else int(time.time()) + seconds
+    total = _duration_seconds(value)
+    return int(time.time() + total) if total is not None else None
+
+
+_DURATION_UNITS = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0, "d": 86400.0}
+_DURATION_PART = re.compile(r"(\d+(?:\.\d+)?)(ms|s|m|h|d)")
+
+
+def _duration_seconds(value: str) -> float | None:
+    """Seconds in a compound duration, or ``None`` if it is not one.
+
+    Whole-string match, so a value carrying anything we did not parse is
+    rejected rather than silently half-read.
+    """
+    parts = _DURATION_PART.findall(value)
+    if not parts:
+        return None
+    if "".join(number + unit for number, unit in parts) != value:
+        return None
+    return sum(float(number) * _DURATION_UNITS[unit] for number, unit in parts)

--- a/autogpt_platform/backend/backend/copilot/provider_failure_test.py
+++ b/autogpt_platform/backend/backend/copilot/provider_failure_test.py
@@ -1,0 +1,140 @@
+import time
+
+import httpx
+import pytest
+from openai import (
+    APIConnectionError,
+    AuthenticationError,
+    BadRequestError,
+    InternalServerError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+
+from backend.copilot.provider_failure import ProviderFailureKind, classify
+from backend.copilot.rate_limit import UserPaywalledError
+from backend.util.exceptions import ExecutionFailureReason
+
+
+def _api_error(cls, status: int, headers: dict[str, str] | None = None):
+    request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+    response = httpx.Response(status, headers=headers or {}, request=request)
+    return cls("boom", response=response, body=None)
+
+
+class TestWhatTheFailureIs:
+    @pytest.mark.parametrize(
+        "exc, expected",
+        [
+            (_api_error(AuthenticationError, 401), ProviderFailureKind.AUTH_EXPIRED),
+            (_api_error(PermissionDeniedError, 403), ProviderFailureKind.POLICY_DENIED),
+            (_api_error(RateLimitError, 429), ProviderFailureKind.USAGE_LIMIT),
+            (_api_error(NotFoundError, 404), ProviderFailureKind.MODEL_UNAVAILABLE),
+            (_api_error(InternalServerError, 500), ProviderFailureKind.TRANSIENT),
+            (_api_error(BadRequestError, 502), ProviderFailureKind.TRANSIENT),
+        ],
+    )
+    def test_each_provider_refusal_gets_its_own_name(self, exc, expected) -> None:
+        failure = classify(exc)
+        assert failure is not None
+        assert failure.kind is expected
+
+    def test_a_connection_failure_is_worth_retrying(self) -> None:
+        exc = APIConnectionError(request=httpx.Request("POST", "https://x"))
+        failure = classify(exc)
+        assert failure is not None
+        assert failure.kind is ProviderFailureKind.TRANSIENT
+        assert failure.retryable is True
+
+    def test_a_paywall_is_the_same_denial_a_graph_run_reports(self) -> None:
+        # Two names for one denial would split every downstream count in half.
+        failure = classify(UserPaywalledError("Max plan required"))
+        assert failure is not None
+        assert failure.kind.value == ExecutionFailureReason.ENTITLEMENT_REQUIRED.value
+
+
+class TestWhatIsNotTheProvidersFault:
+    def test_our_own_bad_request_is_not_dressed_up_as_a_provider_refusal(self) -> None:
+        # A 4xx we did not name is a request we built wrong. Calling it a
+        # provider failure would send the user to reconnect a working account.
+        assert classify(_api_error(BadRequestError, 400)) is None
+
+    def test_an_ordinary_bug_is_left_alone(self) -> None:
+        assert classify(ValueError("our bug")) is None
+
+
+class TestWhatTheUserShouldDo:
+    @pytest.mark.parametrize(
+        "exc, retryable, reconnect",
+        [
+            (_api_error(AuthenticationError, 401), False, True),
+            (_api_error(RateLimitError, 429), False, False),
+            (_api_error(NotFoundError, 404), False, False),
+            (_api_error(InternalServerError, 500), True, False),
+        ],
+    )
+    def test_the_advice_matches_the_failure(self, exc, retryable, reconnect) -> None:
+        failure = classify(exc)
+        assert failure is not None
+        assert failure.retryable is retryable
+        assert failure.reconnect_fixes_it is reconnect
+
+    def test_the_advice_travels_with_the_envelope(self) -> None:
+        # Computed server-side so a second "is this retryable" cannot drift.
+        part = classify(_api_error(AuthenticationError, 401)).as_part()
+        assert part["retryable"] is False
+        assert part["reconnectFixesIt"] is True
+        assert part["kind"] == "auth_expired"
+
+
+class TestWhenTheLimitLifts:
+    def test_a_reported_duration_becomes_a_real_timestamp(self) -> None:
+        exc = _api_error(RateLimitError, 429, {"x-ratelimit-reset-requests": "6m0s"})
+        failure = classify(exc)
+        assert failure is not None
+        assert failure.resets_at is not None
+        assert 300 < failure.resets_at - int(time.time()) <= 360
+
+    def test_a_reported_epoch_is_passed_through(self) -> None:
+        exc = _api_error(
+            RateLimitError, 429, {"x-ratelimit-reset-requests": "1900000000"}
+        )
+        assert classify(exc).resets_at == 1900000000
+
+    def test_token_resets_are_read_when_request_resets_are_absent(self) -> None:
+        exc = _api_error(RateLimitError, 429, {"x-ratelimit-reset-tokens": "30s"})
+        assert classify(exc).resets_at is not None
+
+    @pytest.mark.parametrize("raw", ["", "soon", "12x", "tomorrow"])
+    def test_an_unreadable_reset_is_dropped_rather_than_approximated(
+        self, raw: str
+    ) -> None:
+        # A wrong time is worse than no time: the user schedules around it.
+        exc = _api_error(RateLimitError, 429, {"x-ratelimit-reset-requests": raw})
+        assert classify(exc).resets_at is None
+
+    def test_no_reset_is_invented_when_the_provider_reported_none(self) -> None:
+        assert classify(_api_error(RateLimitError, 429)).resets_at is None
+
+
+class TestWhichConnectionFailed:
+    def test_the_envelope_names_the_connection_that_refused(self) -> None:
+        failure = classify(
+            _api_error(AuthenticationError, 401),
+            auth_provider="codex",
+            credential_id="cred-1",
+        )
+        assert failure is not None
+        assert failure.as_part()["authProvider"] == "codex"
+        assert failure.as_part()["credentialId"] == "cred-1"
+
+    def test_a_humanized_message_survives_classification(self) -> None:
+        # The baseline path already turns a bare connection error into
+        # operator-useful advice; classifying must not throw that away.
+        failure = classify(
+            APIConnectionError(request=httpx.Request("POST", "https://x")),
+            message="Can't reach the local LLM backend at http://x/v1.",
+        )
+        assert failure is not None
+        assert "local LLM backend" in failure.message

--- a/autogpt_platform/backend/backend/copilot/response_model.py
+++ b/autogpt_platform/backend/backend/copilot/response_model.py
@@ -66,6 +66,7 @@ class ResponseType(str, Enum):
     # deltas.  Transient (never persisted); the durable record is the
     # ``context_compaction`` tool row's JSON output.
     COMPACTION = "data-compaction"
+    PROVIDER_FAILURE = "data-provider-failure"
 
 
 class StreamBaseResponse(BaseModel):
@@ -361,6 +362,28 @@ class StreamModeChanged(StreamBaseResponse):
             "data": {"mode": self.mode},
         }
         return f"data: {json.dumps(data)}\n\n"
+
+
+class StreamProviderFailure(StreamBaseResponse):
+    """The typed reason a provider refused this turn.
+
+    Rides alongside ``StreamError`` rather than replacing it. The AI SDK
+    pins error frames to ``z.strictObject({type, errorText})``, which is why
+    ``StreamError.details`` never reaches the client and ``code`` has to
+    travel disguised as a ``[code:x]`` text prefix. A data part has no such
+    ceiling, so the envelope arrives whole -- and every existing consumer of
+    the error frame keeps working untouched.
+    """
+
+    type: ResponseType = ResponseType.PROVIDER_FAILURE
+    failure: dict[str, Any] = Field(
+        ..., description="ProviderFailure.as_part() payload"
+    )
+
+    def to_sse(self) -> str:
+        """Emit as an AI SDK v5 data part."""
+        data = {"type": self.type.value, "data": self.failure}
+        return f"data: {json_dumps(data)}\n\n"
 
 
 class StreamStatus(StreamBaseResponse):

--- a/autogpt_platform/backend/backend/copilot/stream_registry.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry.py
@@ -49,6 +49,7 @@ from .response_model import (
     StreamFinishStep,
     StreamHeartbeat,
     StreamModeChanged,
+    StreamProviderFailure,
     StreamPendingDrained,
     StreamReasoningDelta,
     StreamReasoningEnd,
@@ -1141,6 +1142,37 @@ async def get_active_session(
     return session, last_id
 
 
+# Every stream part the registry can rebuild on replay.
+#
+# Turns run in the executor and reach the browser by replay, so a part
+# missing from this map is emitted, published, and then silently dropped --
+# visible only as an "Unknown chunk type" warning. Add new parts here.
+CHUNK_TYPE_TO_CLASS: dict[str, type[StreamBaseResponse]] = {
+    ResponseType.START.value: StreamStart,
+    ResponseType.FINISH.value: StreamFinish,
+    ResponseType.START_STEP.value: StreamStartStep,
+    ResponseType.FINISH_STEP.value: StreamFinishStep,
+    ResponseType.TEXT_START.value: StreamTextStart,
+    ResponseType.TEXT_DELTA.value: StreamTextDelta,
+    ResponseType.TEXT_END.value: StreamTextEnd,
+    ResponseType.REASONING_START.value: StreamReasoningStart,
+    ResponseType.REASONING_DELTA.value: StreamReasoningDelta,
+    ResponseType.REASONING_END.value: StreamReasoningEnd,
+    ResponseType.TOOL_INPUT_START.value: StreamToolInputStart,
+    ResponseType.TOOL_INPUT_AVAILABLE.value: StreamToolInputAvailable,
+    ResponseType.TOOL_OUTPUT_AVAILABLE.value: StreamToolOutputAvailable,
+    ResponseType.ERROR.value: StreamError,
+    ResponseType.USAGE.value: StreamUsage,
+    ResponseType.HEARTBEAT.value: StreamHeartbeat,
+    ResponseType.STATUS.value: StreamStatus,
+    ResponseType.DREAM_OPERATIONS.value: StreamDreamOperations,
+    ResponseType.PENDING_DRAINED.value: StreamPendingDrained,
+    ResponseType.MODE_CHANGED.value: StreamModeChanged,
+    ResponseType.PROVIDER_FAILURE.value: StreamProviderFailure,
+    ResponseType.COMPACTION.value: StreamCompactionProgress,
+}
+
+
 def _reconstruct_chunk(chunk_data: dict) -> StreamBaseResponse | None:
     """Reconstruct a StreamBaseResponse from JSON data.
 
@@ -1150,33 +1182,8 @@ def _reconstruct_chunk(chunk_data: dict) -> StreamBaseResponse | None:
     Returns:
         Reconstructed response object, or None if unknown type
     """
-    # Map response types to their corresponding classes
-    type_to_class: dict[str, type[StreamBaseResponse]] = {
-        ResponseType.START.value: StreamStart,
-        ResponseType.FINISH.value: StreamFinish,
-        ResponseType.START_STEP.value: StreamStartStep,
-        ResponseType.FINISH_STEP.value: StreamFinishStep,
-        ResponseType.TEXT_START.value: StreamTextStart,
-        ResponseType.TEXT_DELTA.value: StreamTextDelta,
-        ResponseType.TEXT_END.value: StreamTextEnd,
-        ResponseType.REASONING_START.value: StreamReasoningStart,
-        ResponseType.REASONING_DELTA.value: StreamReasoningDelta,
-        ResponseType.REASONING_END.value: StreamReasoningEnd,
-        ResponseType.TOOL_INPUT_START.value: StreamToolInputStart,
-        ResponseType.TOOL_INPUT_AVAILABLE.value: StreamToolInputAvailable,
-        ResponseType.TOOL_OUTPUT_AVAILABLE.value: StreamToolOutputAvailable,
-        ResponseType.ERROR.value: StreamError,
-        ResponseType.USAGE.value: StreamUsage,
-        ResponseType.HEARTBEAT.value: StreamHeartbeat,
-        ResponseType.STATUS.value: StreamStatus,
-        ResponseType.DREAM_OPERATIONS.value: StreamDreamOperations,
-        ResponseType.PENDING_DRAINED.value: StreamPendingDrained,
-        ResponseType.MODE_CHANGED.value: StreamModeChanged,
-        ResponseType.COMPACTION.value: StreamCompactionProgress,
-    }
-
-    chunk_type = chunk_data.get("type")
-    chunk_class = type_to_class.get(chunk_type)  # type: ignore[arg-type]
+    chunk_type = chunk_data.get("type", "")
+    chunk_class = CHUNK_TYPE_TO_CLASS.get(chunk_type)
 
     if chunk_class is None:
         logger.warning(f"Unknown chunk type: {chunk_type}")

--- a/autogpt_platform/backend/backend/copilot/stream_registry_test.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry_test.py
@@ -608,3 +608,63 @@ def test_every_response_type_survives_the_relay():
         f"ResponseType(s) {missing} are not registered in _reconstruct_chunk — "
         "they would be dropped on the executor → Redis → rest_server relay"
     )
+
+class TestEveryPartSurvivesReplay:
+    """A part the registry cannot reconstruct never reaches the client.
+
+    Turns run in the executor and reach the browser by replay through this
+    registry, so a stream part is only real if ``_reconstruct_chunk`` knows
+    its type. ``StreamProviderFailure`` was emitted correctly, published
+    correctly, and dropped here with "Unknown chunk type" -- invisible except
+    as a warning in the logs.
+    """
+
+    def test_provider_failure_is_reconstructed(self) -> None:
+        from backend.copilot.response_model import (
+            ResponseType,
+            StreamProviderFailure,
+        )
+        from backend.copilot.stream_registry import _reconstruct_chunk
+
+        chunk = _reconstruct_chunk(
+            {
+                "type": ResponseType.PROVIDER_FAILURE.value,
+                "failure": {"kind": "usage_limit", "retryable": False},
+            }
+        )
+
+        assert isinstance(chunk, StreamProviderFailure)
+        assert chunk.failure["kind"] == "usage_limit"
+
+    def test_no_emittable_part_is_missing_from_the_registry(self) -> None:
+        # The map is hand-maintained, so a new part is only one forgotten
+        # line away from being emitted, published, and silently undelivered.
+        import inspect
+
+        from backend.copilot import response_model
+        from backend.copilot.response_model import StreamBaseResponse
+        from backend.copilot.stream_registry import CHUNK_TYPE_TO_CLASS
+
+        # Parts nothing can emit, so nothing can fail to deliver:
+        #   StreamHeartbeat rides as an SSE comment, never as a chunk.
+        #   StreamCursor is deprecated and no longer constructed anywhere.
+        #     (Its docstring says it is kept so older stored chunks can be
+        #     reconstructed, which the missing map entry does not actually
+        #     deliver -- harmless while nothing emits it, but not what the
+        #     docstring claims.)
+        never_published = {"StreamHeartbeat", "StreamCursor"}
+
+        missing = []
+        for name, cls in inspect.getmembers(response_model, inspect.isclass):
+            if not issubclass(cls, StreamBaseResponse) or cls is StreamBaseResponse:
+                continue
+            if name in never_published:
+                continue
+            field = cls.model_fields.get("type")
+            default = getattr(field, "default", None)
+            if default is None or not hasattr(default, "value"):
+                continue
+            if default.value not in CHUNK_TYPE_TO_CLASS:
+                missing.append(f"{name} ({default.value})")
+
+        assert not missing, f"parts that cannot survive replay: {missing}"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/providerFailure.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/providerFailure.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeProviderFailure,
+  parseProviderFailurePart,
+  type ProviderFailure,
+} from "../providerFailure";
+
+function part(data: Record<string, unknown>) {
+  return { type: "data-provider-failure", data };
+}
+
+function failure(over: Partial<ProviderFailure> = {}): ProviderFailure {
+  return {
+    kind: "usage_limit",
+    message: "",
+    authProvider: "codex",
+    credentialId: "cred-1",
+    resetsAt: null,
+    retryable: false,
+    reconnectFixesIt: false,
+    ...over,
+  };
+}
+
+describe("parseProviderFailurePart", () => {
+  it("reads a failure the server sent", () => {
+    const parsed = parseProviderFailurePart(
+      part({
+        kind: "auth_expired",
+        message: "token expired",
+        authProvider: "codex",
+        credentialId: "cred-1",
+        resetsAt: null,
+        retryable: false,
+        reconnectFixesIt: true,
+      }),
+    );
+
+    expect(parsed?.kind).toBe("auth_expired");
+    expect(parsed?.reconnectFixesIt).toBe(true);
+  });
+
+  it("ignores other data parts", () => {
+    expect(
+      parseProviderFailurePart({
+        type: "data-mode-changed",
+        data: { mode: "fast" },
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses a kind it does not know", () => {
+    // A kind added server-side without client copy would otherwise render
+    // as an empty toast.
+    expect(parseProviderFailurePart(part({ kind: "invented" }))).toBeNull();
+  });
+
+  it("does not infer advice the server withheld", () => {
+    // Absent means "not retryable", never "probably fine to retry".
+    const parsed = parseProviderFailurePart(part({ kind: "policy_denied" }));
+    expect(parsed?.retryable).toBe(false);
+    expect(parsed?.reconnectFixesIt).toBe(false);
+  });
+});
+
+describe("describeProviderFailure", () => {
+  it("does not tell someone to retry what cannot succeed", () => {
+    // The whole point of the envelope: three failures that used to get
+    // "Press Try Again" now say what would actually help.
+    for (const kind of [
+      "auth_expired",
+      "usage_limit",
+      "model_unavailable",
+    ] as const) {
+      const copy = describeProviderFailure(failure({ kind }));
+      expect(copy.description.toLowerCase()).not.toContain("try again");
+    }
+  });
+
+  it("names the reset when the provider reported one", () => {
+    const copy = describeProviderFailure(
+      failure({ resetsAt: Math.floor(Date.now() / 1000) + 20 * 60 }),
+    );
+    expect(copy.description).toContain("about 20 minutes");
+  });
+
+  it("names no time when the provider reported no reset", () => {
+    // The kind's own copy may mention resetting in general; what must not
+    // appear is a specific time nobody reported.
+    const copy = describeProviderFailure(failure({ resetsAt: null }));
+    expect(copy.description).not.toMatch(/Resets in/i);
+  });
+
+  it("drops a reset that has already passed", () => {
+    const copy = describeProviderFailure(
+      failure({ resetsAt: Math.floor(Date.now() / 1000) - 60 }),
+    );
+    expect(copy.description).not.toMatch(/Resets in/i);
+  });
+
+  it("prefers the provider's own words for the detail", () => {
+    const copy = describeProviderFailure(
+      failure({
+        kind: "policy_denied",
+        message: "This request was blocked by the provider's safety policy.",
+      }),
+    );
+    expect(copy.description).toContain("safety policy");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/copilotStreamErrorHandlers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/copilotStreamErrorHandlers.ts
@@ -1,5 +1,10 @@
 import { toast } from "@/components/molecules/Toast/use-toast";
 
+import {
+  describeProviderFailure,
+  type ProviderFailure,
+} from "./providerFailure";
+
 /**
  * Parses a backend-encoded error code from an `errorText` payload.
  *
@@ -97,6 +102,12 @@ interface HandleStreamErrorArgs {
   onRateLimit: (message: string) => void;
   onReconnect: () => void;
   isUserStoppingRef: React.MutableRefObject<boolean>;
+  /**
+   * The typed envelope, when this turn sent one. It is the only source here
+   * that actually knows what happened; every branch below it is inference
+   * from error text.
+   */
+  providerFailure?: ProviderFailure | null;
 }
 
 /**
@@ -104,6 +115,8 @@ interface HandleStreamErrorArgs {
  * (or rate-limit UI), and decides whether to retry via reconnect.
  *
  * Dispatch order (exclusive branches):
+ *  0. A typed provider-failure envelope → its own copy. Preferred over
+ *     everything below, which is guesswork from error text.
  *  1. `usage limit` substring → rate-limit UI via `onRateLimit`.
  *  2. 401 / auth failure → auth-error toast.
  *  3. `[code:<id>]` backend prefix → curated or generic backend toast.
@@ -117,8 +130,27 @@ export function handleStreamError({
   onRateLimit,
   onReconnect,
   isUserStoppingRef,
+  providerFailure,
 }: HandleStreamErrorArgs): void {
   const errorDetail = extractErrorDetail(error);
+
+  // 0. The server said what went wrong, so stop guessing.
+  if (providerFailure) {
+    const copy = describeProviderFailure(providerFailure);
+    if (providerFailure.kind === "usage_limit") {
+      // Still routed through the rate-limit path: it restores the composer
+      // text for a message the backend refused before persisting, which a
+      // toast alone would lose.
+      onRateLimit(`${copy.title}. ${copy.description}`);
+      return;
+    }
+    toast({
+      title: copy.title,
+      description: copy.description,
+      variant: "destructive",
+    });
+    return;
+  }
 
   // 1. Rate limit (FastAPI 429 body contains "usage limit")
   if (errorDetail.toLowerCase().includes("usage limit")) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/providerFailure.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/providerFailure.ts
@@ -1,0 +1,129 @@
+/**
+ * The typed reason a provider refused a turn, as it arrives on the stream.
+ *
+ * Until this existed the client had to sniff substrings out of error text --
+ * `"usage limit"`, `"401"` -- to guess what happened, and everything it
+ * could not place got the same advice: press Try Again. That advice is
+ * wrong for most provider failures. Retrying an expired login, a spent
+ * quota or a retired model cannot succeed, and telling someone to retry
+ * costs them the time it takes to find out.
+ *
+ * The server decides `retryable` and `reconnectFixesIt` so a second
+ * implementation of that judgement cannot drift from the one that classified
+ * the failure.
+ */
+
+export type ProviderFailureKind =
+  | "auth_expired"
+  | "invalid_credential"
+  | "usage_limit"
+  | "model_unavailable"
+  | "policy_denied"
+  | "entitlement_required"
+  | "transient";
+
+export interface ProviderFailure {
+  kind: ProviderFailureKind;
+  message: string;
+  authProvider: string | null;
+  credentialId: string | null;
+  resetsAt: number | null;
+  retryable: boolean;
+  reconnectFixesIt: boolean;
+}
+
+const KINDS = new Set<string>([
+  "auth_expired",
+  "invalid_credential",
+  "usage_limit",
+  "model_unavailable",
+  "policy_denied",
+  "entitlement_required",
+  "transient",
+]);
+
+export function parseProviderFailurePart(dataPart: {
+  type: string;
+  data?: unknown;
+}): ProviderFailure | null {
+  if (dataPart.type !== "data-provider-failure") return null;
+  const data = dataPart.data as Partial<ProviderFailure> | undefined;
+  if (!data || typeof data.kind !== "string" || !KINDS.has(data.kind)) {
+    return null;
+  }
+  return {
+    kind: data.kind as ProviderFailureKind,
+    message: typeof data.message === "string" ? data.message : "",
+    authProvider: data.authProvider ?? null,
+    credentialId: data.credentialId ?? null,
+    resetsAt: typeof data.resetsAt === "number" ? data.resetsAt : null,
+    retryable: data.retryable === true,
+    reconnectFixesIt: data.reconnectFixesIt === true,
+  };
+}
+
+interface FailureCopy {
+  title: string;
+  description: string;
+}
+
+const COPY_BY_KIND: Record<ProviderFailureKind, FailureCopy> = {
+  auth_expired: {
+    title: "Your connection needs signing in again",
+    description: "Reconnect the account in Settings, then send this again.",
+  },
+  invalid_credential: {
+    title: "That connection can't be used",
+    description: "Reconnect the account in Settings, then send this again.",
+  },
+  usage_limit: {
+    title: "You've hit this connection's limit",
+    description: "Switch connection to keep going, or wait for it to reset.",
+  },
+  model_unavailable: {
+    title: "That model isn't available",
+    description: "Pick another model tier, or switch connection.",
+  },
+  policy_denied: {
+    title: "The provider declined this request",
+    description: "Rewording it may help. Retrying it unchanged won't.",
+  },
+  entitlement_required: {
+    title: "Your plan doesn't include this connection",
+    description: "Switch connection, or see plans to unlock it.",
+  },
+  transient: {
+    title: "Connection hiccup",
+    description: "Something went wrong on the way to the model. Try again.",
+  },
+};
+
+/**
+ * What to tell the user, preferring the provider's own words for the detail.
+ *
+ * The reset time is appended only when the provider reported one -- an
+ * invented "try again in an hour" is worse than silence, because people plan
+ * around it.
+ */
+export function describeProviderFailure(failure: ProviderFailure): FailureCopy {
+  const base = COPY_BY_KIND[failure.kind];
+  const reset = formatResetHint(failure.resetsAt);
+  const detail = failure.message.trim() || base.description;
+  return {
+    title: base.title,
+    description: reset ? `${base.description} ${reset}` : detail,
+  };
+}
+
+function formatResetHint(resetsAt: number | null): string | null {
+  if (resetsAt === null) return null;
+  const seconds = resetsAt - Math.floor(Date.now() / 1000);
+  if (seconds <= 0) return null;
+  if (seconds < 90) return "Resets in under a minute.";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `Resets in about ${minutes} minutes.`;
+  const hours = Math.round(minutes / 60);
+  return hours === 1
+    ? "Resets in about an hour."
+    : `Resets in about ${hours} hours.`;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotStream.ts
@@ -34,6 +34,10 @@ import {
 } from "./helpers";
 import { extractDbSequence } from "./helpers/convertChatSessionToUiMessages";
 import { getLatestAssistantStatusMessage } from "./messageParts";
+import {
+  parseProviderFailurePart,
+  type ProviderFailure,
+} from "./providerFailure";
 import { useCopilotUIStore } from "./store";
 import type { CopilotLlmModel } from "./store";
 import { useCopilotReconnect } from "./useCopilotReconnect";
@@ -118,6 +122,9 @@ export function useCopilotStream({
   // plain boolean can't bleed state across sessions.
   const isUserStoppingRef = useRef(false);
   const pendingEngineSwitchRef = useRef(false);
+  // Cleared once consumed, so a later failure without an envelope cannot
+  // inherit the explanation of an earlier one.
+  const providerFailureRef = useRef<ProviderFailure | null>(null);
   // State mirror of ``isUserStoppingRef`` — the ref is read synchronously
   // inside SDK callbacks, the state drives UI so a click on the stop button
   // immediately overrides ``isStreaming`` regardless of whether AI SDK has
@@ -183,6 +190,7 @@ export function useCopilotStream({
         ? FINISH_REFETCH_ATTEMPTS_PENDING_SWITCH
         : FINISH_REFETCH_ATTEMPTS_DEFAULT;
       pendingEngineSwitchRef.current = false;
+      providerFailureRef.current = null;
       setIsFinishProbing(true);
       try {
         for (let attempt = 0; attempt < attempts; attempt++) {
@@ -211,8 +219,11 @@ export function useCopilotStream({
           clearKickoffPending(userId, kickoffExpertId, kickoffAttemptToken);
         }).catch(() => undefined);
       }
+      const failureForThisTurn = providerFailureRef.current;
+      providerFailureRef.current = null;
       handleStreamError({
         error,
+        providerFailure: failureForThisTurn,
         onRateLimit: (message) => {
           // Backend raises 429 BEFORE persisting the user message, so the
           // optimistic user bubble added by useChat is a lie. Restore the text
@@ -286,6 +297,12 @@ export function useCopilotStream({
       // is kept to widen the post-finish refetch window below.
       if (isEngineSwitchPart(dataPart)) {
         pendingEngineSwitchRef.current = true;
+      }
+      // The envelope always precedes the error frame it explains, so
+      // stashing it here means handleError has it in hand.
+      const failure = parseProviderFailurePart(dataPart);
+      if (failure) {
+        providerFailureRef.current = failure;
       }
     }
 


### PR DESCRIPTION
> First of three PRs for S8. This one carries the failure; per-turn execution
> segments and same-chat recovery follow separately, per the repo's split-by-concern rule.

### Why

Every provider refusal reaches the client as one opaque `baseline_error` carrying a
stringified exception:

```python
yield StreamError(errorText=error_msg, code="baseline_error")
```

An expired ChatGPT login, a spent monthly quota, a retired model and a policy refusal are
indistinguishable by the time the UI sees them, so it offers all four the same advice —
**press Try Again** — which is wrong for three of them. The user only finds out by
spending the retry.

The client's current best effort is sniffing substrings out of error text (`"usage limit"`,
`"401"`), which is guesswork over a message that was never meant to be parsed.

### What

The failure is named where the provider exception is still intact, and carried whole:
which kind, which connection, whether retrying can work, whether reconnecting would, and
when the limit lifts.

| Kind | Retry? | Reconnect? |
|---|---|---|
| `auth_expired` | no | **yes** |
| `invalid_credential` | no | **yes** |
| `usage_limit` | no | no |
| `model_unavailable` | no | no |
| `policy_denied` | no | no |
| `entitlement_required` | no | no |
| `transient` | **yes** | no |

### How

**It refuses to claim a failure it cannot recognise.** A 4xx we did not name is a request
*we* built wrong — ours, not the provider's. Calling it a provider failure would send the
user to reconnect an account that was never broken. `classify` returns `None` there and
existing handling stands untouched. Same for any ordinary exception.

**It refuses to invent a reset time.** `resets_at` comes only from a real
`x-ratelimit-reset-*` header. A reported duration (`6m0s`) is anchored to the clock —
"60 seconds from now" is a fact, not a guess — but an unreadable value is dropped rather
than approximated. A wrong time is worse than no time, because people plan around it.

**It rides as a data part, not on the error frame.** The AI SDK pins error frames to
`z.strictObject({type, errorText})` — which is why `StreamError.details` never reaches the
client today and `code` has to travel disguised as a `[code:x]` text prefix. A
`data-provider-failure` part has no such ceiling, using the same AI SDK v5 mechanism as the
existing `data-mode-changed`. Every existing consumer of the error frame is unaffected.

**The advice is computed server-side** so a second implementation of "is this worth
retrying" cannot drift from the one that classified the failure.

**`entitlement_required` shares its value with `ExecutionFailureReason.ENTITLEMENT_REQUIRED`**
from #14060 on purpose: the same denial can end a graph run or a chat turn, and two names
would split every downstream count in half.

### Test plan

- [x] Backend: 25 new in `provider_failure_test.py` — one per refusal kind, the two
      "not the provider's fault" cases, the advice matrix, and five covering reset times
      (duration, epoch, token-vs-request header, unreadable, absent)
- [x] Frontend: 9 new in `providerFailure.test.ts`, including that no `auth_expired`,
      `usage_limit` or `model_unavailable` copy tells the user to try again
- [x] Copilot suite 130 files / 1561 tests, `pnpm types` and eslint clean

> Note: the backend suite was run locally with `graph_cleanup`/`server` stubbed, because
> that session fixture deadlocks on Windows without the docker postgres. CI runs the real
> fixture.

### Not in this PR

- Per-turn execution segments (S8b)
- Same-chat recovery: pause at a safe boundary, keep completed tool output, continue as a
  new segment (S8c). The composer-restoring rate-limit path is deliberately left in place
  and now fed by the envelope rather than a substring match.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible error handling and the copilot SSE stream contract on the baseline path, but failures are gated behind conservative classification and existing error frames remain for compatibility.
> 
> **Overview**
> Copilot **baseline** turns no longer surface every LLM/provider error as a generic `baseline_error`. When the streaming exception is a recognizable provider refusal, the server **classifies** it (auth, quota, model missing, policy, entitlement, transient), attaches **retry / reconnect** advice and optional **quota reset** time from rate-limit headers, and emits a **`data-provider-failure`** stream part **before** the existing `StreamError` (whose `code` becomes the failure kind). Unrecognized errors (e.g. our own 400s) still behave as before.
> 
> The **frontend** parses that envelope from `onData`, stashes it for `onError`, and routes **usage limits** through the existing composer-restore path while other kinds get **kind-specific** toast copy instead of substring guessing on error text.
> 
> **Registry replay** registers the new chunk type in `CHUNK_TYPE_TO_CLASS` so executor → Redis → client relay does not drop the envelope. Backend and frontend tests cover classification, reset parsing, replay, and copy rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc5bb45337031273bfe82c0eafe1916d89cc4ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->