### PR TITLE
feat(backend): record which connection each turn actually ran on

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -42,7 +42,7 @@ from backend.copilot.builder_context import (
     build_builder_context_turn_prefix,
     build_builder_system_prompt_suffix,
 )
-from backend.copilot.config import CopilotLLMModel
+from backend.copilot.config import CopilotLlmAuthProvider, CopilotLLMModel
 from backend.copilot.context import get_workspace_manager, set_execution_context
 from backend.copilot.expert_context import build_expert_identity_suffix
 from backend.copilot.graphiti.config import is_enabled_for_user
@@ -447,6 +447,11 @@ class _BaselineStreamState:
     # ever produces "ld" | "catalog" | "env" ("fallback" is SDK-only, marking
     # a CLI 529-overload swap); typed as the shared RoutingSource superset.
     routing_source: RoutingSource = "env"
+    # The connection this turn runs on, stamped onto each assistant row as
+    # it is built. Recorded per turn so a later route change cannot rewrite
+    # what already ran; see backend/copilot/segments.py.
+    llm_auth_provider: CopilotLlmAuthProvider | None = None
+    llm_credential_id: str | None = None
     # Live delivery channel drained concurrently by ``stream_chat_completion_baseline``
     # so reasoning / text / tool events reach the SSE wire **during** the upstream
     # LLM stream, not after ``_baseline_llm_caller`` returns.  Before this was a
@@ -1266,6 +1271,8 @@ def _baseline_conversation_updater(
             role="assistant",
             model=state.model,
             routing_source=state.routing_source,
+            llm_auth_provider=state.llm_auth_provider,
+            llm_credential_id=state.llm_credential_id,
             content=response.response_text or "",
             tool_calls=[
                 {
@@ -2153,7 +2160,16 @@ async def stream_chat_completion_baseline(
         logger.warning("[Baseline] Langfuse trace context setup failed")
 
     _stream_error = False  # Track whether an error occurred during streaming
-    state = _BaselineStreamState(model=active_model, routing_source=routing_source)
+    state = _BaselineStreamState(
+        model=active_model,
+        routing_source=routing_source,
+        llm_auth_provider=(
+            session.metadata.llm_auth_provider if session is not None else None
+        ),
+        llm_credential_id=(
+            session.metadata.llm_credential_id if session is not None else None
+        ),
+    )
 
     # Bind extracted module-level callbacks to this request's state/session
     # using functools.partial so they satisfy the Protocol signatures.
@@ -2311,6 +2327,8 @@ async def stream_chat_completion_baseline(
                                 content=text_only_text,
                                 model=state.model,
                                 routing_source=state.routing_source,
+                                llm_auth_provider=state.llm_auth_provider,
+                                llm_credential_id=state.llm_credential_id,
                             )
                         )
                     for _buffered in state.session_messages:
@@ -2599,6 +2617,8 @@ async def stream_chat_completion_baseline(
                     content=final_text,
                     model=state.model,
                     routing_source=state.routing_source,
+                    llm_auth_provider=state.llm_auth_provider,
+                    llm_credential_id=state.llm_credential_id,
                 )
             )
         try:

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -12,6 +12,7 @@ from prisma.models import ChatMessage as PrismaChatMessage
 from prisma.models import ChatSession as PrismaChatSession
 from prisma.types import (
     ChatMessageCreateInput,
+    ChatMessageUpdateInput,
     ChatMessageWhereInput,
     ChatSessionCreateInput,
     ChatSessionUpdateInput,
@@ -654,6 +655,11 @@ async def add_chat_messages_batch(
                     if msg.get("routing_source") is not None:
                         data["routingSource"] = msg["routing_source"]
 
+                    if msg.get("llm_auth_provider") is not None:
+                        data["llmAuthProvider"] = msg["llm_auth_provider"]
+                    if msg.get("llm_credential_id") is not None:
+                        data["llmCredentialId"] = msg["llm_credential_id"]
+
                     messages_data.append(data)
 
                 # Run create_many and session update in parallel within transaction
@@ -1156,17 +1162,31 @@ async def update_chat_message_stamps(
     sequence: int,
     model: str | None,
     routing_source: str | None,
+    llm_auth_provider: str | None = None,
+    llm_credential_id: str | None = None,
 ) -> bool:
-    """Back-fill model/routingSource on an already-persisted message row.
+    """Back-fill the execution stamps on an already-persisted message row.
 
     Mid-turn flushes persist assistant rows (assigning sequences) BEFORE
     the end-of-turn stamping runs; this repairs those rows so the
     analytics columns survive in the DB. Same mechanism and authorization
     reasoning as ``update_chat_message_tool_calls``.
+
+    The route is written only when known. Passing None for it would blank a
+    row that a previous stamp already got right, which is precisely the
+    rewriting of history per-turn segments exist to prevent.
     """
+    data: ChatMessageUpdateInput = {
+        "model": model,
+        "routingSource": routing_source,
+    }
+    if llm_auth_provider is not None:
+        data["llmAuthProvider"] = llm_auth_provider
+    if llm_credential_id is not None:
+        data["llmCredentialId"] = llm_credential_id
     result = await PrismaChatMessage.prisma().update(
         where={"sessionId_sequence": {"sessionId": session_id, "sequence": sequence}},
-        data={"model": model, "routingSource": routing_source},
+        data=data,
     )
     if not result:
         logger.warning(

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -198,6 +198,14 @@ class ChatMessage(BaseModel):
     model: str | None = None
     routing_source: RoutingSource | None = Field(default=None, exclude=True)
 
+    # Which connection served this turn. Unlike routing_source this is the
+    # user's own choice, not an internal cohort, so it is safe to serialize
+    # and is what lets a chat show what each turn actually ran on.
+    # None on user/tool rows and on rows written before this existed --
+    # ``segment_of`` resolves those against the session's own route.
+    llm_auth_provider: CopilotLlmAuthProvider | None = None
+    llm_credential_id: str | None = None
+
     stamps_pending_save: bool = Field(default=False, exclude=True)
     """True when model/routing_source were stamped after this row was already
     persisted (mid-turn flush assigned its sequence before end-of-turn
@@ -261,6 +269,10 @@ class ChatMessage(BaseModel):
             # DB column is a plain string; the values are always ones we wrote
             # (this PR owns the column) and Pydantic re-validates on construct.
             routing_source=cast("RoutingSource | None", prisma_message.routingSource),
+            llm_auth_provider=cast(
+                "CopilotLlmAuthProvider | None", prisma_message.llmAuthProvider
+            ),
+            llm_credential_id=prisma_message.llmCredentialId,
         )
 
 
@@ -1152,6 +1164,8 @@ async def _save_session_to_db(
                 sequence=msg.sequence,
                 model=msg.model,
                 routing_source=msg.routing_source,
+                llm_auth_provider=msg.llm_auth_provider,
+                llm_credential_id=msg.llm_credential_id,
             )
         except Exception as e:
             logger.error(

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -1114,6 +1114,8 @@ async def _save_session_to_db(
                     "function_call": msg.function_call,
                     "model": msg.model,
                     "routing_source": msg.routing_source,
+                    "llm_auth_provider": msg.llm_auth_provider,
+                    "llm_credential_id": msg.llm_credential_id,
                 }
             )
         logger.info(

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -48,6 +48,7 @@ from backend.copilot.model_router import (
     resolve_model_route,
 )
 from backend.copilot.graphiti.context import fetch_warm_context
+from backend.copilot.segments import session_segment, stamp_segment
 from backend.copilot.graphiti.ingest import enqueue_conversation_turn
 from backend.copilot.sdk.codex_compat_gateway import CodexAnthropicGateway
 from backend.data.db_accessors import chat_db
@@ -5965,6 +5966,13 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 requested_model=sdk_model,
                 actual_model=state.observed_model if state is not None else None,
                 routing_source=routing_source,
+            )
+            # What this turn ran on, recorded on the turn rather than read
+            # back off the session later, so a route change cannot rewrite it.
+            stamp_segment(
+                session.messages,
+                pre_turn_message_count,
+                session_segment(session),
             )
             try:
                 await asyncio.shield(upsert_chat_session(session))

--- a/autogpt_platform/backend/backend/copilot/segments.py
+++ b/autogpt_platform/backend/backend/copilot/segments.py
@@ -1,0 +1,118 @@
+"""Which connection a given turn actually ran on.
+
+A session's metadata says where a chat *starts*. For most of this codebase's
+life that was the same thing as where every turn in it ran, because the
+connection was chosen at creation and could never change. Once it can --
+after a usage limit, on a user's switch -- the two stop being the same, and
+a session-level answer starts lying about history: every past turn would
+appear to have run on whatever the connection happens to be now.
+
+So each assistant turn records its own route, and the session's metadata
+becomes the answer for turns that have none -- segment zero. That covers
+every row written before the columns existed, without a backfill that would
+have to invent what it could not know.
+
+Nothing here rewrites a stamped turn. A route change applies forward.
+"""
+
+from backend.copilot.config import CopilotLlmAuthProvider
+from backend.copilot.model import ChatMessage, ChatSession
+
+
+class Segment:
+    """The connection one turn ran on, and where that answer came from."""
+
+    __slots__ = ("auth_provider", "credential_id", "is_segment_zero")
+
+    def __init__(
+        self,
+        auth_provider: CopilotLlmAuthProvider,
+        credential_id: str | None,
+        *,
+        is_segment_zero: bool,
+    ) -> None:
+        self.auth_provider = auth_provider
+        self.credential_id = credential_id
+        # True when this came from the session rather than the turn itself:
+        # the turn predates per-turn stamping, or is the first of the chat.
+        self.is_segment_zero = is_segment_zero
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Segment):
+            return NotImplemented
+        return (
+            self.auth_provider == other.auth_provider
+            and self.credential_id == other.credential_id
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Segment({self.auth_provider!r}, {self.credential_id!r}, "
+            f"is_segment_zero={self.is_segment_zero})"
+        )
+
+
+def segment_of(message: ChatMessage, session: ChatSession) -> Segment:
+    """The route this turn ran on, falling back to the session's own.
+
+    A stamp is only trusted when the turn carries an auth provider. A
+    credential id without one cannot be interpreted -- it names an account
+    without saying whose -- so it is ignored rather than guessed at.
+    """
+    if message.llm_auth_provider is None:
+        return session_segment(session)
+    return Segment(
+        message.llm_auth_provider,
+        message.llm_credential_id,
+        is_segment_zero=False,
+    )
+
+
+def session_segment(session: ChatSession) -> Segment:
+    """Segment zero: where this chat started."""
+    return Segment(
+        session.metadata.llm_auth_provider,
+        session.metadata.llm_credential_id,
+        is_segment_zero=True,
+    )
+
+
+def segment_boundaries(messages: list[ChatMessage], session: ChatSession) -> list[int]:
+    """Indexes where the connection changed, in order.
+
+    Only assistant turns carry a route, so user and tool rows are skipped
+    rather than treated as a change back to segment zero. The first assistant
+    turn is a boundary only when it ran somewhere other than where the chat
+    started.
+    """
+    boundaries: list[int] = []
+    current = session_segment(session)
+    for index, message in enumerate(messages):
+        if message.role != "assistant" or message.llm_auth_provider is None:
+            continue
+        segment = segment_of(message, session)
+        if segment != current:
+            boundaries.append(index)
+            current = segment
+    return boundaries
+
+
+def stamp_segment(
+    messages: list[ChatMessage],
+    start_index: int,
+    segment: Segment,
+) -> None:
+    """Record the connection on the assistant turns this run produced.
+
+    Mirrors how ``model`` / ``routing_source`` are stamped: only rows that
+    have none are written, so a re-stamp cannot overwrite what an earlier
+    run recorded. Rows already flushed to the database mid-turn are flagged
+    for back-fill by the save path.
+    """
+    for message in messages[start_index:]:
+        if message.role != "assistant" or message.llm_auth_provider is not None:
+            continue
+        message.llm_auth_provider = segment.auth_provider
+        message.llm_credential_id = segment.credential_id
+        if message.sequence is not None:
+            message.stamps_pending_save = True

--- a/autogpt_platform/backend/backend/copilot/segments_test.py
+++ b/autogpt_platform/backend/backend/copilot/segments_test.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import pytest_mock
 
 from backend.copilot.config import CopilotLlmAuthProvider
 from backend.copilot.model import ChatMessage, ChatSession, ChatSessionMetadata
@@ -192,3 +194,46 @@ def test_two_segments_match_on_the_route_not_on_where_it_was_read(
     # not identity -- otherwise the first stamped turn of an unchanged chat
     # would read as a boundary.
     assert (a == b) is equal
+
+
+class TestTheRouteSurvivesTheSavePath:
+    """The stamp is worthless if it is dropped on the way to the database.
+
+    ``_save_session_to_db`` builds each row's dict field by field rather than
+    dumping the model, so a new field on ``ChatMessage`` reaches Postgres only
+    if it is named there too. Stamping worked and the column existed, and the
+    route still landed as NULL because that one list had not been updated.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_stamped_turn_reaches_the_database_layer_with_its_route(
+        self, mocker: pytest_mock.MockerFixture
+    ) -> None:
+        from backend.copilot import model as model_module
+
+        captured: dict[str, object] = {}
+
+        async def _capture(
+            session_id: str, messages: list, start_sequence: int
+        ) -> int:
+            captured["messages"] = messages
+            return start_sequence
+
+        fake_db = MagicMock()
+        fake_db.add_chat_messages_batch = AsyncMock(side_effect=_capture)
+        fake_db.get_chat_session_metadata = AsyncMock(return_value=None)
+        fake_db.create_chat_session = AsyncMock(return_value=None)
+        fake_db.update_chat_session = AsyncMock(return_value=None)
+        mocker.patch.object(model_module, "chat_db", return_value=fake_db)
+
+        session = _session("codex", "cred-1", [_assistant("codex", "cred-1")])
+        await model_module._save_session_to_db(
+            session, existing_message_count=0, skip_existence_check=True
+        )
+
+        rows = captured.get("messages")
+        assert rows, "no rows reached the database layer"
+        assistant_rows = [r for r in rows if r["role"] == "assistant"]
+        assert assistant_rows, "the assistant row never reached the database layer"
+        assert assistant_rows[0]["llm_auth_provider"] == "codex"
+        assert assistant_rows[0]["llm_credential_id"] == "cred-1"

--- a/autogpt_platform/backend/backend/copilot/segments_test.py
+++ b/autogpt_platform/backend/backend/copilot/segments_test.py
@@ -1,0 +1,194 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from backend.copilot.config import CopilotLlmAuthProvider
+from backend.copilot.model import ChatMessage, ChatSession, ChatSessionMetadata
+from backend.copilot.segments import (
+    Segment,
+    segment_boundaries,
+    segment_of,
+    session_segment,
+    stamp_segment,
+)
+
+
+def _session(
+    auth_provider: CopilotLlmAuthProvider = "platform",
+    credential_id: str | None = None,
+    messages: list[ChatMessage] | None = None,
+) -> ChatSession:
+    now = datetime(2026, 8, 20, tzinfo=UTC)
+    return ChatSession(
+        session_id="s1",
+        user_id="u1",
+        usage=[],
+        started_at=now,
+        updated_at=now,
+        messages=messages or [],
+        metadata=ChatSessionMetadata(
+            llm_auth_provider=auth_provider,
+            llm_credential_id=credential_id,
+        ),
+    )
+
+
+def _assistant(
+    auth_provider: CopilotLlmAuthProvider | None = None,
+    credential_id: str | None = None,
+    sequence: int | None = None,
+) -> ChatMessage:
+    return ChatMessage(
+        role="assistant",
+        content="hi",
+        llm_auth_provider=auth_provider,
+        llm_credential_id=credential_id,
+        sequence=sequence,
+    )
+
+
+class TestSegmentZero:
+    def test_a_turn_that_recorded_nothing_reads_as_the_session_route(self) -> None:
+        # Every row written before these columns existed. A backfill would
+        # have had to invent what it could not know.
+        session = _session("codex", "cred-1")
+        segment = segment_of(_assistant(), session)
+        assert segment == Segment("codex", "cred-1", is_segment_zero=True)
+        assert segment.is_segment_zero is True
+
+    def test_a_turn_that_recorded_its_route_is_believed(self) -> None:
+        session = _session("platform", None)
+        segment = segment_of(_assistant("codex", "cred-9"), session)
+        assert segment == Segment("codex", "cred-9", is_segment_zero=False)
+        assert segment.is_segment_zero is False
+
+    def test_a_credential_without_a_provider_is_not_guessed_at(self) -> None:
+        # It names an account without saying whose. Falling back is honest;
+        # pairing it with the session's provider would fabricate a route.
+        session = _session("platform", None)
+        segment = segment_of(_assistant(None, "cred-9"), session)
+        assert segment == Segment("platform", None, is_segment_zero=True)
+
+
+class TestHistoryIsNotRewritten:
+    def test_a_route_change_leaves_earlier_turns_alone(self) -> None:
+        earlier = _assistant("codex", "cred-1")
+        session = _session("platform", None, [earlier])
+
+        # The session now points somewhere else entirely.
+        assert segment_of(earlier, session) == Segment(
+            "codex", "cred-1", is_segment_zero=False
+        )
+
+    def test_stamping_never_overwrites_a_turn_that_already_has_a_route(self) -> None:
+        already = _assistant("codex", "cred-1")
+        stamp_segment([already], 0, Segment("platform", None, is_segment_zero=True))
+        assert already.llm_auth_provider == "codex"
+        assert already.llm_credential_id == "cred-1"
+
+    def test_only_this_run_s_turns_are_stamped(self) -> None:
+        history = _assistant()
+        fresh = _assistant()
+        stamp_segment(
+            [history, fresh], 1, Segment("codex", "cred-1", is_segment_zero=False)
+        )
+        assert history.llm_auth_provider is None
+        assert fresh.llm_auth_provider == "codex"
+
+
+class TestStamping:
+    def test_a_user_row_is_never_given_a_route(self) -> None:
+        user = ChatMessage(role="user", content="hi")
+        stamp_segment([user], 0, Segment("codex", "cred-1", is_segment_zero=False))
+        assert user.llm_auth_provider is None
+
+    def test_a_row_already_flushed_is_flagged_for_backfill(self) -> None:
+        # Mid-turn flush assigned a sequence before end-of-turn stamping.
+        flushed = _assistant(sequence=4)
+        stamp_segment([flushed], 0, Segment("codex", "cred-1", is_segment_zero=False))
+        assert flushed.stamps_pending_save is True
+
+    def test_an_unflushed_row_needs_no_backfill(self) -> None:
+        fresh = _assistant()
+        stamp_segment([fresh], 0, Segment("codex", "cred-1", is_segment_zero=False))
+        assert fresh.stamps_pending_save is False
+
+
+class TestBoundaries:
+    def test_a_chat_that_never_moved_has_none(self) -> None:
+        session = _session("platform", None)
+        messages = [_assistant("platform"), _assistant("platform")]
+        assert segment_boundaries(messages, session) == []
+
+    def test_the_turn_the_route_changed_on_is_a_boundary(self) -> None:
+        session = _session("platform", None)
+        messages = [
+            _assistant("platform"),
+            _assistant("codex", "cred-1"),
+            _assistant("codex", "cred-1"),
+        ]
+        assert segment_boundaries(messages, session) == [1]
+
+    def test_moving_back_is_a_boundary_too(self) -> None:
+        session = _session("platform", None)
+        messages = [
+            _assistant("codex", "cred-1"),
+            _assistant("platform"),
+        ]
+        assert segment_boundaries(messages, session) == [0, 1]
+
+    def test_switching_between_two_accounts_of_one_provider_counts(self) -> None:
+        # Same provider, different subscription -- a real change of who pays.
+        session = _session("codex", "cred-1")
+        messages = [_assistant("codex", "cred-1"), _assistant("codex", "cred-2")]
+        assert segment_boundaries(messages, session) == [1]
+
+    def test_unstamped_rows_do_not_read_as_a_change(self) -> None:
+        # User and tool rows carry no route, and neither do turns written
+        # before the columns existed. Treating either as "back to segment
+        # zero" would invent boundaries that never happened.
+        session = _session("codex", "cred-1")
+        messages = [
+            _assistant("codex", "cred-1"),
+            ChatMessage(role="user", content="next"),
+            ChatMessage(role="tool", content="{}", tool_call_id="t1"),
+            _assistant("codex", "cred-1"),
+        ]
+        assert segment_boundaries(messages, session) == []
+
+
+class TestSessionSegment:
+    def test_it_reports_where_the_chat_started(self) -> None:
+        segment = session_segment(_session("codex", "cred-1"))
+        assert segment.auth_provider == "codex"
+        assert segment.credential_id == "cred-1"
+        assert segment.is_segment_zero is True
+
+
+@pytest.mark.parametrize(
+    "a, b, equal",
+    [
+        (
+            Segment("platform", None, is_segment_zero=True),
+            Segment("platform", None, is_segment_zero=False),
+            True,
+        ),
+        (
+            Segment("codex", "c1", is_segment_zero=False),
+            Segment("codex", "c2", is_segment_zero=False),
+            False,
+        ),
+        (
+            Segment("platform", None, is_segment_zero=False),
+            Segment("codex", None, is_segment_zero=False),
+            False,
+        ),
+    ],
+)
+def test_two_segments_match_on_the_route_not_on_where_it_was_read(
+    a: Segment, b: Segment, equal: bool
+) -> None:
+    # Whether the answer came from the turn or the session is provenance,
+    # not identity -- otherwise the first stamped turn of an unchanged chat
+    # would read as a boundary.
+    assert (a == b) is equal

--- a/autogpt_platform/backend/migrations/20260820030000_add_chat_message_llm_route/migration.sql
+++ b/autogpt_platform/backend/migrations/20260820030000_add_chat_message_llm_route/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- Nullable with no default: Postgres records this in the catalog only, so
+-- it does not rewrite the table. Existing rows read as NULL and fall back
+-- to the session's own route.
+ALTER TABLE "ChatMessage" ADD COLUMN     "llmAuthProvider" TEXT,
+ADD COLUMN     "llmCredentialId" TEXT;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -590,6 +590,14 @@ model ChatMessage {
   model         String?
   routingSource String?
 
+  // Which connection served this assistant turn. The session's metadata is
+  // the route a chat STARTS on; these record the route a turn actually RAN
+  // on, so a later route change cannot rewrite what already happened.
+  // Null on user/tool rows and on rows predating this column, where the
+  // session's own route is the answer (see `segment_of`).
+  llmAuthProvider String?
+  llmCredentialId String?
+
   // Per-row JSONB metadata bag.  Currently holds the dispatcher's
   // submit-time payload (file_ids, mode, model, permissions, context,
   // request_arrival_at) on the user row that triggered a queued turn,


### PR DESCRIPTION
> Second of three PRs for S8. #14087 carried the failure; this records what each turn
> ran on; same-chat recovery follows.

### Why

A session's metadata says where a chat *starts*. For as long as the connection was chosen
at creation and could never change, that was also where every turn in it ran — one value
answered both questions.

Once the connection can change (after a usage limit, on a user's switch), it stops being
one question, and the session-level answer starts lying about the past: **every earlier
turn would appear to have run on whatever the connection happens to be now.** Billing
attribution, debugging "why did this turn fail", and any UI showing what a turn ran on
would all read the wrong value.

### What

Each assistant turn records its own route. The session's metadata answers for turns that
have none — **segment zero** — which covers every row written before these columns existed,
without a backfill that would have had to invent what it could not know.

`backend/copilot/segments.py`: `segment_of`, `session_segment`, `segment_boundaries`,
`stamp_segment`.

### How

Three things it deliberately refuses to do:

**It never rewrites a stamped turn.** Stamping only fills rows that have no route, and the
back-fill writes the route only when one is known — so a `None` can never blank a row an
earlier run got right.

**It never guesses a route from half a stamp.** A `credential_id` without an
`auth_provider` names an account without saying whose. Pairing it with the session's
provider would fabricate a route that was never used, so such a row falls back instead.

**It never invents a boundary.** Only assistant rows carry a route, so user and tool rows
are skipped rather than read as a change back to segment zero. And two segments compare on
the route alone, not on whether the answer came from the turn or the session — otherwise
the first stamped turn of an unchanged chat would read as a boundary.

**Migration cost is nil.** Both columns are nullable with no default, so Postgres records
this in the catalog and does not rewrite `ChatMessage`.

**Nothing is exposed on the wire.** `ChatMessage` is not part of any API response schema —
regenerating `openapi.json` produced no diff.

### Scope

No route change exists to record yet — the connection is still fixed for a session's
lifetime. This is the substrate that makes introducing one safe, and is why it ships
separately from the recovery flow that will use it.

### Test plan

- [x] 18 new in `segments_test.py`: segment-zero fallback, the half-stamp case,
      history-not-rewritten (3), stamping rules (3), boundary detection (5) including
      two accounts of one provider and the unstamped-rows case, and segment equality
- [x] 60 passing across `segments_test.py`, `provider_failure_test.py`, `offers_test.py`
- [x] `black` / `isort` / `ruff` clean; no `# type: ignore` added

> Note: the backend suite was run locally with `graph_cleanup`/`server` stubbed, because
> that session fixture deadlocks on Windows without the docker postgres. CI runs the real
> fixture.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan
- [x] Touches `data`-adjacent code: `update_chat_message_stamps` keeps its existing
      `sessionId_sequence` scoping, so the authorization reasoning is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat message persistence and back-fill logic across baseline/SDK save paths; migration is additive/nullable, but incorrect stamping would misattribute billing/debug UI later when route switching lands.
> 
> **Overview**
> Adds **per-assistant-turn** recording of which LLM connection (`llm_auth_provider` + `llm_credential_id`) served the turn, so a later session-level route change cannot make past turns look like they ran on the current connection.
> 
> **Schema & model:** Nullable `llmAuthProvider` / `llmCredentialId` columns on `ChatMessage`, mirrored on `ChatMessage` (safe to serialize to clients, unlike `routing_source`). Save, batch insert, and `update_chat_message_stamps` back-fill paths all map the new fields; route stamps are only written when known so `None` cannot erase an earlier stamp.
> 
> **`segments.py`:** `segment_of` / `session_segment` (segment zero fallback for legacy rows), `stamp_segment` (fill only unstamped assistant rows), and `segment_boundaries` for detecting connection changes across history.
> 
> **Execution paths:** Baseline streaming copies the session route into `_BaselineStreamState` and stamps every persisted assistant row; SDK end-of-turn persistence calls `stamp_segment` with `session_segment(session)` after model stamping.
> 
> **Tests:** `segments_test.py` covers fallback, no history rewrite, stamping rules, boundaries, and save-path field mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa250e19522f3a7f64969d022056e194186a3669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->