### PR TITLE
fix(backend): keep a failed baseline turn in the chat

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -52,6 +52,7 @@ from backend.copilot.local_context_probe import (
     compaction_target_for_window,
     probe_local_context_window,
 )
+from backend.copilot.markers import append_error_marker
 from backend.copilot.model import (
     ChatMessage,
     ChatSession,
@@ -2468,7 +2469,16 @@ async def stream_chat_completion_baseline(
             yield StreamError(errorText=error_msg, code=failure.kind.value)
         else:
             yield StreamError(errorText=error_msg, code="baseline_error")
-        # Still persist whatever we got
+        # The stream error dies with the SSE connection. Without a row in the
+        # chat, reloading shows the question and nothing after it -- no
+        # answer, no error, no sign the turn ever ran. Retry is offered only
+        # when the failure says trying again could work; an unclassified
+        # error keeps the existing benefit of the doubt.
+        append_error_marker(
+            session,
+            error_msg,
+            retryable=failure.retryable if failure is not None else True,
+        )
     finally:
         # Cancel the inner task if we're unwinding early (client disconnect,
         # unexpected error in the consumer) so it doesn't keep streaming

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -2462,6 +2462,27 @@ async def stream_chat_completion_baseline(
             credential_id=session.metadata.llm_credential_id if session else None,
             message=error_msg,
         )
+        # Written before the error is yielded, and deliberately not in
+        # ``finally``. The consumer breaks out of its loop the moment it sees
+        # a StreamError and closes this generator, so the tail of ``finally``
+        # -- including its session upsert -- is cut short at the first await.
+        # A marker appended there is built correctly and then thrown away.
+        #
+        # ``_session_holder[0]`` rather than ``session``: the inner task can
+        # replace the binding mid-turn, and the marker has to land on the
+        # object that is actually current.
+        _failed_session = _session_holder[0]
+        if append_error_marker(
+            _failed_session,
+            error_msg,
+            retryable=failure.retryable if failure is not None else True,
+        ):
+            try:
+                await upsert_chat_session(_failed_session)
+            except Exception as marker_err:
+                logger.error(
+                    "[Baseline] Failed to persist the error marker: %s", marker_err
+                )
         if failure is not None:
             # Before the error, so a client that acts on the envelope has it
             # in hand by the time the turn is reported failed.
@@ -2469,16 +2490,6 @@ async def stream_chat_completion_baseline(
             yield StreamError(errorText=error_msg, code=failure.kind.value)
         else:
             yield StreamError(errorText=error_msg, code="baseline_error")
-        # The stream error dies with the SSE connection. Without a row in the
-        # chat, reloading shows the question and nothing after it -- no
-        # answer, no error, no sign the turn ever ran. Retry is offered only
-        # when the failure says trying again could work; an unclassified
-        # error keeps the existing benefit of the doubt.
-        append_error_marker(
-            session,
-            error_msg,
-            retryable=failure.retryable if failure is not None else True,
-        )
     finally:
         # Cancel the inner task if we're unwinding early (client disconnect,
         # unexpected error in the consumer) so it doesn't keep streaming

--- a/autogpt_platform/backend/backend/copilot/markers.py
+++ b/autogpt_platform/backend/backend/copilot/markers.py
@@ -1,0 +1,70 @@
+"""Error markers persisted into a chat so a failure survives the stream.
+
+A stream error lives only on the wire. When the SSE connection ends the
+message is gone, and a reloaded chat shows the user's question followed by
+nothing at all -- no answer, no error, no sign anything happened. The SDK
+path solved this by appending a marker row; the baseline path never did.
+
+The prefixes are a frontend rendering contract, not decoration:
+``COPILOT_ERROR_PREFIX`` renders an error card, and
+``COPILOT_RETRYABLE_ERROR_PREFIX`` renders one that also offers Try Again.
+Choosing between them is a claim about whether trying again can work, so it
+is made from the typed failure rather than assumed.
+"""
+
+from backend.copilot.constants import (
+    COPILOT_ERROR_PREFIX,
+    COPILOT_RETRYABLE_ERROR_PREFIX,
+    COPILOT_SYSTEM_PREFIX,
+    STREAM_ERROR_MARKER,
+    STREAM_INCOMPLETE_MARKER,
+)
+from backend.copilot.model import ChatMessage, ChatSession
+
+
+def is_error_marker(message: ChatMessage) -> bool:
+    """True when this row is a marker rather than something the model said."""
+    if message.role != "assistant" or not message.content:
+        return False
+    return message.content.startswith(
+        (COPILOT_ERROR_PREFIX, COPILOT_RETRYABLE_ERROR_PREFIX)
+    )
+
+
+def has_trailing_marker(session: ChatSession | None) -> bool:
+    """True when the last row is already a marker.
+
+    Several guards can fire on one failed turn. Without this check a single
+    failure stacks two or three error cards on the same chat.
+    """
+    if session is None or not session.messages:
+        return False
+    last = session.messages[-1]
+    if last.role != "assistant" or not last.content:
+        return False
+    return (
+        is_error_marker(last)
+        or last.content.startswith(COPILOT_SYSTEM_PREFIX)
+        or last.content in (STREAM_ERROR_MARKER, STREAM_INCOMPLETE_MARKER)
+    )
+
+
+def append_error_marker(
+    session: ChatSession | None,
+    display_message: str,
+    *,
+    retryable: bool,
+) -> bool:
+    """Record a failure in the chat itself. Returns whether a row was added.
+
+    ``retryable`` decides which card the user sees, so it must come from
+    something that actually knows -- offering Try Again on an expired login
+    or a spent quota costs the user a retry to learn it cannot work.
+    """
+    if session is None or has_trailing_marker(session):
+        return False
+    prefix = COPILOT_RETRYABLE_ERROR_PREFIX if retryable else COPILOT_ERROR_PREFIX
+    session.messages.append(
+        ChatMessage(role="assistant", content=f"{prefix} {display_message}")
+    )
+    return True

--- a/autogpt_platform/backend/backend/copilot/markers_test.py
+++ b/autogpt_platform/backend/backend/copilot/markers_test.py
@@ -108,3 +108,61 @@ class TestRecognisingMarkers:
     def test_an_empty_session_has_no_trailing_marker(self) -> None:
         assert has_trailing_marker(_session()) is False
         assert has_trailing_marker(None) is False
+
+
+class TestTheMarkerReachesTheDatabase:
+    """Building the marker is not the same as saving it.
+
+    The baseline yields the error and its consumer immediately breaks and
+    closes the generator, so the tail of its ``finally`` -- including the
+    session upsert -- never runs. A marker appended there is constructed
+    correctly and then discarded, which is exactly what happened: the append
+    reported success while the row never appeared in Postgres.
+
+    The failure path therefore has to persist the marker itself, before it
+    yields the error that ends the stream.
+
+    These two are structural guards, not behavioural proof: they assert the
+    ordering in the source rather than driving a real turn, because standing
+    up that generator needs a provider, a session, tools and an execution
+    context. The behavioural evidence is a live run against a deployment --
+    a 404 leaves a non-retryable card and a dead endpoint leaves a retryable
+    one -- and these keep the ordering from silently regressing afterwards.
+    """
+
+    def test_the_error_path_persists_before_it_yields(self) -> None:
+        import inspect
+
+        from backend.copilot.baseline import service
+
+        source = inspect.getsource(service.stream_chat_completion_baseline)
+        marker_at = source.find("append_error_marker(")
+        assert marker_at != -1, "the failure path no longer records a marker"
+
+        upsert_at = source.find("upsert_chat_session", marker_at)
+        error_yield_at = source.find("yield StreamError(", marker_at)
+        assert upsert_at != -1, "the marker is appended but never persisted"
+        assert error_yield_at != -1
+
+        # Persisting after the error is yielded is the bug this guards:
+        # the consumer closes the generator on that yield.
+        assert upsert_at < error_yield_at, (
+            "the marker must be persisted before StreamError is yielded -- "
+            "the consumer closes the generator on it, so anything after is "
+            "not guaranteed to run"
+        )
+
+    def test_the_marker_is_not_left_to_the_finally_block(self) -> None:
+        import inspect
+
+        from backend.copilot.baseline import service
+
+        source = inspect.getsource(service.stream_chat_completion_baseline)
+        finally_at = source.rfind("\n    finally:")
+        marker_at = source.find("append_error_marker(")
+        assert marker_at != -1
+        assert finally_at != -1
+        assert marker_at < finally_at, (
+            "the marker moved into finally, where generator teardown cuts it "
+            "short at the first await"
+        )

--- a/autogpt_platform/backend/backend/copilot/markers_test.py
+++ b/autogpt_platform/backend/backend/copilot/markers_test.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from backend.copilot.constants import (
+    COPILOT_ERROR_PREFIX,
+    COPILOT_RETRYABLE_ERROR_PREFIX,
+    STREAM_ERROR_MARKER,
+)
+from backend.copilot.markers import (
+    append_error_marker,
+    has_trailing_marker,
+    is_error_marker,
+)
+from backend.copilot.model import ChatMessage, ChatSession
+
+
+def _session(messages: list[ChatMessage] | None = None) -> ChatSession:
+    now = datetime(2026, 8, 20, tzinfo=UTC)
+    return ChatSession(
+        session_id="s1",
+        user_id="u1",
+        usage=[],
+        started_at=now,
+        updated_at=now,
+        messages=messages or [],
+    )
+
+
+class TestAFailureSurvivesTheStream:
+    def test_a_failed_turn_leaves_something_behind(self) -> None:
+        # Without this the chat shows the question and nothing after it.
+        session = _session([ChatMessage(role="user", content="hi")])
+
+        assert append_error_marker(session, "boom", retryable=True) is True
+        assert len(session.messages) == 2
+        assert session.messages[-1].role == "assistant"
+        assert "boom" in (session.messages[-1].content or "")
+
+    def test_the_provider_s_own_words_are_kept(self) -> None:
+        session = _session()
+        append_error_marker(
+            session, "Can't reach the local LLM backend at :8099.", retryable=True
+        )
+        assert "8099" in (session.messages[-1].content or "")
+
+
+class TestRetryIsOnlyOfferedWhenItCanWork:
+    def test_a_transient_failure_offers_try_again(self) -> None:
+        session = _session()
+        append_error_marker(session, "hiccup", retryable=True)
+        assert (session.messages[-1].content or "").startswith(
+            COPILOT_RETRYABLE_ERROR_PREFIX
+        )
+
+    def test_a_failure_retrying_cannot_fix_does_not(self) -> None:
+        # An expired login or a spent quota costs the user a retry to learn
+        # the retry was never going to work.
+        session = _session()
+        append_error_marker(session, "Your plan does not include this", retryable=False)
+        content = session.messages[-1].content or ""
+        assert content.startswith(COPILOT_ERROR_PREFIX)
+        assert not content.startswith(COPILOT_RETRYABLE_ERROR_PREFIX)
+
+
+class TestOneFailureIsOneCard:
+    @pytest.mark.parametrize(
+        "existing",
+        [
+            f"{COPILOT_ERROR_PREFIX} already failed",
+            f"{COPILOT_RETRYABLE_ERROR_PREFIX} already failed",
+            STREAM_ERROR_MARKER,
+        ],
+    )
+    def test_a_second_guard_does_not_stack_another_card(self, existing: str) -> None:
+        # Several guards can fire on one failed turn.
+        session = _session([ChatMessage(role="assistant", content=existing)])
+
+        assert append_error_marker(session, "boom", retryable=True) is False
+        assert len(session.messages) == 1
+
+    def test_a_normal_reply_is_not_mistaken_for_a_marker(self) -> None:
+        session = _session([ChatMessage(role="assistant", content="Here you go.")])
+
+        assert has_trailing_marker(session) is False
+        assert append_error_marker(session, "boom", retryable=True) is True
+
+    def test_a_user_row_never_blocks_the_marker(self) -> None:
+        session = _session([ChatMessage(role="user", content="hi")])
+        assert has_trailing_marker(session) is False
+
+
+class TestRecognisingMarkers:
+    def test_both_error_prefixes_count(self) -> None:
+        for prefix in (COPILOT_ERROR_PREFIX, COPILOT_RETRYABLE_ERROR_PREFIX):
+            assert is_error_marker(ChatMessage(role="assistant", content=f"{prefix} x"))
+
+    def test_ordinary_content_does_not(self) -> None:
+        assert not is_error_marker(ChatMessage(role="assistant", content="hello"))
+
+    def test_a_user_row_carrying_the_text_does_not(self) -> None:
+        # Only the assistant writes markers; a user pasting the string in
+        # must not make their own message render as an error card.
+        assert not is_error_marker(
+            ChatMessage(role="user", content=f"{COPILOT_ERROR_PREFIX} spoof")
+        )
+
+    def test_an_empty_session_has_no_trailing_marker(self) -> None:
+        assert has_trailing_marker(_session()) is False
+        assert has_trailing_marker(None) is False


### PR DESCRIPTION
> Stacked on #14090. First slice of S8c: before a failed turn can pause and ask, it has to
> leave something behind to pause *at*.

### Why

A failed baseline turn persists **nothing**. The error is yielded onto the SSE stream and
dies with the connection, so reloading the chat shows the user's question followed by
silence — no answer, no error, no sign the turn ever ran.

Confirmed against a real failed session before the fix:

```
sequence  role   content
0         user   <available_skills>…
                 (nothing else)
```

The SDK path solved this with `STREAM_ERROR_MARKER`. The baseline never got the
equivalent, though the `# Still persist whatever we got` comment sitting directly above
the error yield shows it was meant to.

### What

The failure is recorded as a marker row in the chat, and **retry is only offered when
retrying could work**.

The two marker prefixes were already a choice the code had no way to make —
`COPILOT_ERROR_PREFIX` renders an error card, `COPILOT_RETRYABLE_ERROR_PREFIX` renders one
with Try Again. The typed failure from #14087 answers it:

| Failure | Kind | Card |
|---|---|---|
| dead endpoint | `transient` | Try Again |
| 404 model | `model_unavailable` | plain |
| expired login | `auth_expired` | plain |
| spent quota | `usage_limit` | plain |
| policy refusal | `policy_denied` | plain |
| unclassified | — | Try Again (keeps today's benefit of the doubt) |

Offering Try Again on an expired login costs the user a retry to learn it was never
going to work.

### How

**The marker is persisted in the `except` block, not in `finally`** — and that distinction
is the whole fix. `stream_chat_completion_baseline` is an async generator whose consumer
breaks the instant it sees a `StreamError` and calls `aclose()`. Teardown does not survive
its first await (`persist_and_record_usage`), so the session upsert forty lines below never
runs.

The first attempt appended in `finally` and silently persisted nothing. Instrumentation
showed `added=True`, the marker present in the session with the right prefix — and no row
in Postgres. Same shape as the two delivery bugs already fixed in this stack: correct at the
point of assignment, discarded on the way out.

It also uses `_session_holder[0]` rather than the local `session`, because the inner task
can replace that binding mid-turn.

Helpers live in a new `markers.py` rather than reaching into `sdk/service.py`'s privates.
The SDK keeps its own copies for now — consolidating means editing a six-thousand-line
file, which deserves its own change.

### Test plan

- [x] 15 in `markers_test.py`: retryable vs not, double-card guards, marker recognition
      (including that a user row carrying the string is not mistaken for one)
- [x] **Live, both directions** — 404 → `[__COPILOT_ERROR_f7a1__]`, dead endpoint →
      `[__COPILOT_RETRYABLE_ERROR_a9c2__]`, both read straight out of Postgres
- [x] `black` / `isort` / `ruff` clean

> The two ordering tests are structural guards: they assert the source order rather than
> driving a turn, because that generator needs a provider, session, tools and execution
> context to stand up. Stated plainly in the test. The behavioural evidence is the live run.

> Backend suite run locally with `graph_cleanup`/`server` stubbed — that session fixture
> deadlocks on Windows without the docker postgres. CI runs the real fixture.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes baseline failure handling and chat persistence timing on the hot error path; incorrect ordering would again drop errors from the DB, but scope is limited to the except branch with structural tests.
> 
> **Overview**
> **Failed baseline copilot turns now leave a persisted assistant row** so reloading the chat shows an error card instead of silence after the user’s message.
> 
> On the streaming `except` path, **`append_error_marker`** runs on **`_session_holder[0]`**, chooses retryable vs plain error prefixes from **`classify_provider_failure`**, and **`upsert_chat_session`** runs **before** **`StreamError`** is yielded—because the SSE consumer closes the async generator on that yield and **`finally`** session saves often never complete.
> 
> New **`markers.py`** centralizes marker append/dedup (no stacked cards when a trailing marker already exists). **`markers_test.py`** covers prefix choice, dedup, and source-order guards so persistence is not regressed into **`finally`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1bd096034a82e1742cd53ba78125698e2347bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->