### PR TITLE
feat(backend): record which connection failed, on the failure itself

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -2476,6 +2476,7 @@ async def stream_chat_completion_baseline(
             _failed_session,
             error_msg,
             retryable=failure.retryable if failure is not None else True,
+            failure=failure.as_part() if failure is not None else None,
         ):
             try:
                 await upsert_chat_session(_failed_session)

--- a/autogpt_platform/backend/backend/copilot/db.py
+++ b/autogpt_platform/backend/backend/copilot/db.py
@@ -660,6 +660,12 @@ async def add_chat_messages_batch(
                     if msg.get("llm_credential_id") is not None:
                         data["llmCredentialId"] = msg["llm_credential_id"]
 
+                    # Per-row bag. The single-message path already persisted
+                    # this; the batch path silently dropped it, so anything
+                    # written here by a turn never survived the insert.
+                    if msg.get("metadata") is not None:
+                        data["metadata"] = SafeJson(msg["metadata"])
+
                     messages_data.append(data)
 
                 # Run create_many and session update in parallel within transaction

--- a/autogpt_platform/backend/backend/copilot/markers.py
+++ b/autogpt_platform/backend/backend/copilot/markers.py
@@ -12,6 +12,8 @@ Choosing between them is a claim about whether trying again can work, so it
 is made from the typed failure rather than assumed.
 """
 
+from typing import Any
+
 from backend.copilot.constants import (
     COPILOT_ERROR_PREFIX,
     COPILOT_RETRYABLE_ERROR_PREFIX,
@@ -49,22 +51,52 @@ def has_trailing_marker(session: ChatSession | None) -> bool:
     )
 
 
+# Key under which the typed failure rides on the marker row's metadata bag.
+# Namespaced because the bag is shared with the dispatcher's submit-time
+# payload and anything else that lands there later.
+PROVIDER_FAILURE_KEY = "provider_failure"
+
+
 def append_error_marker(
     session: ChatSession | None,
     display_message: str,
     *,
     retryable: bool,
+    failure: dict[str, Any] | None = None,
 ) -> bool:
     """Record a failure in the chat itself. Returns whether a row was added.
 
     ``retryable`` decides which card the user sees, so it must come from
     something that actually knows -- offering Try Again on an expired login
     or a spent quota costs the user a retry to learn it cannot work.
+
+    ``failure`` is the typed envelope, stored on the row so a chat reopened
+    tomorrow can still say *which* connection failed and what would fix it.
+    Without it the prefix is all that survives, which distinguishes only
+    "retry" from "do not retry" -- enough for a button, not enough to offer
+    the switch-connection or reconnect the failure actually calls for.
     """
     if session is None or has_trailing_marker(session):
         return False
     prefix = COPILOT_RETRYABLE_ERROR_PREFIX if retryable else COPILOT_ERROR_PREFIX
     session.messages.append(
-        ChatMessage(role="assistant", content=f"{prefix} {display_message}")
+        ChatMessage(
+            role="assistant",
+            content=f"{prefix} {display_message}",
+            metadata={PROVIDER_FAILURE_KEY: failure} if failure else None,
+        )
     )
     return True
+
+
+def provider_failure_of(message: ChatMessage) -> dict[str, Any] | None:
+    """The typed failure recorded on a marker row, if it carries one.
+
+    ``None`` for every marker written before this existed, and for a failure
+    the classifier declined to name. Callers fall back to the prefix, which
+    is what they had before.
+    """
+    if not is_error_marker(message) or not message.metadata:
+        return None
+    failure = message.metadata.get(PROVIDER_FAILURE_KEY)
+    return failure if isinstance(failure, dict) else None

--- a/autogpt_platform/backend/backend/copilot/markers_test.py
+++ b/autogpt_platform/backend/backend/copilot/markers_test.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import pytest_mock
 
 from backend.copilot.constants import (
     COPILOT_ERROR_PREFIX,
@@ -11,6 +13,7 @@ from backend.copilot.markers import (
     append_error_marker,
     has_trailing_marker,
     is_error_marker,
+    provider_failure_of,
 )
 from backend.copilot.model import ChatMessage, ChatSession
 
@@ -166,3 +169,89 @@ class TestTheMarkerReachesTheDatabase:
             "the marker moved into finally, where generator teardown cuts it "
             "short at the first await"
         )
+
+
+class TestTheMarkerCarriesTheFailure:
+    """The prefix says retry-or-not. The envelope says what would fix it.
+
+    A chat reopened tomorrow has only the row: without the failure on it,
+    the most a card can offer is Try Again, which is the wrong advice for
+    an expired login, a spent quota or a plan that excludes the connection.
+    """
+
+    def test_the_failure_rides_on_the_row(self) -> None:
+        session = _session()
+        append_error_marker(
+            session,
+            "You've hit this connection's limit",
+            retryable=False,
+            failure={"kind": "usage_limit", "authProvider": "codex", "resetsAt": None},
+        )
+
+        recorded = provider_failure_of(session.messages[-1])
+        assert recorded is not None
+        assert recorded["kind"] == "usage_limit"
+        assert recorded["authProvider"] == "codex"
+
+    def test_a_marker_without_one_reads_as_none(self) -> None:
+        # Every marker written before this existed, and every failure the
+        # classifier declined to name. Callers fall back to the prefix.
+        session = _session()
+        append_error_marker(session, "boom", retryable=True)
+        assert provider_failure_of(session.messages[-1]) is None
+
+    def test_an_ordinary_reply_is_never_read_as_a_failure(self) -> None:
+        assert (
+            provider_failure_of(ChatMessage(role="assistant", content="Here you go."))
+            is None
+        )
+
+    def test_a_non_dict_payload_is_refused(self) -> None:
+        # The bag is shared; a collision on the key must not crash a render.
+        msg = ChatMessage(
+            role="assistant",
+            content=f"{COPILOT_ERROR_PREFIX} boom",
+            metadata={"provider_failure": "not-a-dict"},
+        )
+        assert provider_failure_of(msg) is None
+
+
+class TestTheFailureReachesTheDatabase:
+    """Setting metadata on the row is not the same as saving it.
+
+    ``_save_session_to_db`` builds each row field by field and
+    ``add_chat_messages_batch`` maps them one by one, so a field is only
+    persisted if it is named in both. ``metadata`` was named in neither --
+    the single-message path persisted it, the batch path silently dropped it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_marker_reaches_the_database_layer_with_its_failure(
+        self, mocker: pytest_mock.MockerFixture
+    ) -> None:
+        from backend.copilot import model as model_module
+
+        captured: dict[str, object] = {}
+
+        async def _capture(session_id: str, messages: list, start_sequence: int) -> int:
+            captured["messages"] = messages
+            return start_sequence
+
+        fake_db = MagicMock()
+        fake_db.add_chat_messages_batch = AsyncMock(side_effect=_capture)
+        fake_db.get_chat_session_metadata = AsyncMock(return_value=None)
+        fake_db.create_chat_session = AsyncMock(return_value=None)
+        fake_db.update_chat_session = AsyncMock(return_value=None)
+        mocker.patch.object(model_module, "chat_db", return_value=fake_db)
+
+        session = _session()
+        append_error_marker(
+            session, "boom", retryable=False, failure={"kind": "auth_expired"}
+        )
+        await model_module._save_session_to_db(
+            session, existing_message_count=0, skip_existence_check=True
+        )
+
+        rows = captured.get("messages")
+        assert rows, "no rows reached the database layer"
+        assert rows[0]["metadata"] == {"provider_failure": {"kind": "auth_expired"}}

--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -1116,6 +1116,7 @@ async def _save_session_to_db(
                     "routing_source": msg.routing_source,
                     "llm_auth_provider": msg.llm_auth_provider,
                     "llm_credential_id": msg.llm_credential_id,
+                    "metadata": msg.metadata,
                 }
             )
         logger.info(


### PR DESCRIPTION
> Stacked on #14092. Second slice of S8c: the marker records *what* failed, not just
> whether to offer a retry button.

### Why

The marker prefix distinguishes exactly two things — retry, or don't. That's enough to
decide whether a button appears and nothing more.

A chat reopened tomorrow has only the row. It can't say which connection failed, whether
reconnecting would clear it, or when a spent quota lifts — so the only recovery it can
offer is **Try Again**, which is the wrong advice for an expired login, a usage limit, a
retired model or a plan that excludes the connection.

### What

The typed envelope from #14087 is stored on the marker row, so the failure outlives the
stream that reported it.

Verified in Postgres against a real 401:

```
[__COPILOT_ERROR_f7a1__] Error code: 401 …
meta={"provider_failure": {"kind": "auth_expired", "retryable": false,
      "authProvider": "platform", "resetsAt": null, "message": "…"}}
```

### How

**Carrying it meant fixing the same gap the route had.** A message is persisted through two
hand-maintained mappings — the row dict in `_save_session_to_db` and the field-by-field
insert in `add_chat_messages_batch` — and `metadata` was named in **neither**. The
single-message path persisted it, so the column looked functional; anything a *turn* wrote
there was dropped at the batch insert. Both halves now carry it.

The round-trip test follows a marker to the database layer and asserts the failure is in
what reaches `add_chat_messages_batch`. Confirmed it fails without the fix.

**`provider_failure_of` reads defensively** — `None` for markers written before this
existed, for failures the classifier declined to name, and for a non-dict payload. The bag
is shared with the dispatcher's submit-time state, so a key collision must not break a
render. Callers fall back to the prefix, which is what they had.

### Scope: this is baseline-only

`resolve_use_sdk` picks the engine, and on a normal Anthropic configuration it picks the
**SDK**. This work — and #14092 — only covers the baseline:

| Engine | Failure persisted | Carries the envelope |
|---|---|---|
| Baseline | yes (#14092) | **yes** (this PR) |
| SDK | yes, via its own `_append_error_marker` | no |

The SDK path persists an error row with no prefix and no metadata, so it renders as an
ordinary assistant message. Bringing it onto the same footing is the marker consolidation
deferred in #14092 — which is more than tidying duplicate helpers, since that duplication
is exactly why the two engines behave differently.

### Test plan

- [x] 20 in `markers_test.py` — 5 new covering the envelope on the row, absence, a
      non-marker row, a non-dict payload, and the database round-trip
- [x] Round-trip test verified to fail without the save-path fix
- [x] **Live**: real 401 → `auth_expired`, non-retryable prefix, envelope in `metadata`
- [x] `black` / `isort` / `ruff` clean

> Backend suite run locally with `graph_cleanup`/`server` stubbed — that session fixture
> deadlocks on Windows without the docker postgres. CI runs the real fixture.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan
- [x] Touches `data`-adjacent code: `add_chat_messages_batch` keeps its existing
      session-scoped insert, so the authorization reasoning is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the chat message batch save path and stores provider/auth-adjacent failure metadata on rows; scope is limited to baseline error markers with defensive reads and tests, but a regression could drop metadata or mis-render recovery UI.
> 
> **Overview**
> Baseline stream failures now attach the **typed provider-failure envelope** (not just retry vs non-retry prefix) to the persisted error-marker row, so a chat reopened later can still know which connection failed and what recovery fits (reconnect, switch connection, etc.).
> 
> **`append_error_marker`** accepts optional structured `failure` and stores it under `metadata.provider_failure`; **`provider_failure_of`** reads it defensively for legacy markers and bad payloads. On baseline errors, **`stream_chat_completion_baseline`** passes `failure.as_part()` when classification succeeds.
> 
> **Persistence fix:** turn saves went through `_save_session_to_db` and **`add_chat_messages_batch`**, but `metadata` was omitted from both hand-maintained field maps while the single-message insert path already saved it—marker metadata never reached Postgres. Both paths now carry `metadata` through to the batch insert.
> 
> Tests cover envelope on the row, absent failure, non-marker rows, non-dict metadata, and a round-trip to the database layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54197ce9871cf4060a64b11f31220c37caf82305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->