### PR TITLE
feat(backend): add OrcaRouter as a named LLM provider

### DIFF
--- a/autogpt_platform/backend/backend/util/clients.py
+++ b/autogpt_platform/backend/backend/util/clients.py
@@ -9,6 +9,13 @@ from backend.util.settings import Settings
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
+# OrcaRouter — an OpenAI-compatible model routing gateway (meta-router).
+# Same wire protocol shape as OpenRouter: ``provider/model`` namespaces and
+# a ``/v1`` chat-completions endpoint. Unlike OpenRouter it rejects the
+# ``usage: {"include": True}`` extra_body, so the caller must not send it —
+# only the attribution headers apply.
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
 settings = Settings()
 
 if TYPE_CHECKING:

--- a/autogpt_platform/backend/backend/util/llm/providers.py
+++ b/autogpt_platform/backend/backend/util/llm/providers.py
@@ -49,7 +49,7 @@ from backend.data.llm_registry.llm_models import (
     CLAUDE_5_FAMILY_PREFIXES,
     strip_anthropic_vendor_prefix,
 )
-from backend.util.clients import OPENROUTER_BASE_URL
+from backend.util.clients import OPENROUTER_BASE_URL, ORCAROUTER_BASE_URL
 from backend.util.llm.conversions import (
     ToolCall,
     ToolContentBlock,
@@ -93,6 +93,7 @@ ProviderLiteral = Literal[
     "llama_api",
     "aiml_api",
     "v0",
+    "orcarouter",
 ]
 
 ExecutionMode = Literal["sync", "batch", "flex"]
@@ -364,6 +365,22 @@ async def _dispatch_sync(
             parallel_tool_calls=parallel_tool_calls,
             timeout_seconds=timeout_seconds,
             include_openrouter_extras=True,
+            service_tier=service_tier,
+        )
+    if provider == "orcarouter":
+        return await _call_openai_compat(
+            base_url=ORCAROUTER_BASE_URL,
+            model=model,
+            api_key=api_key,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            tools=tools,
+            force_json_output=force_json_output,
+            parallel_tool_calls=parallel_tool_calls,
+            timeout_seconds=timeout_seconds,
+            include_openrouter_extras=False,
+            extra_headers={"HTTP-Referer": "https://agpt.co", "X-Title": "AutoGPT"},
             service_tier=service_tier,
         )
     if provider == "llama_api":

--- a/autogpt_platform/backend/backend/util/llm/providers_test.py
+++ b/autogpt_platform/backend/backend/util/llm/providers_test.py
@@ -660,6 +660,52 @@ class TestOpenRouter:
         assert "HTTP-Referer" in kwargs["extra_headers"]
 
 
+class TestOrcaRouter:
+    @pytest.mark.asyncio
+    async def test_dispatches_with_attribution_headers(self):
+        fake_response = _fake_openai_chat_response(
+            "hello", prompt=10, completion=5, cost=None
+        )
+        async_create = AsyncMock(return_value=fake_response)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=async_create))
+        )
+        constructor = MagicMock(return_value=fake_client)
+        with (
+            patch(
+                "backend.util.llm.providers.openai.AsyncOpenAI",
+                constructor,
+            ),
+            patch(
+                "backend.util.llm.providers.extract_openai_reasoning",
+                return_value=None,
+            ),
+            patch(
+                "backend.util.llm.providers.extract_openai_tool_calls",
+                return_value=None,
+            ),
+        ):
+            result = await call_provider(
+                provider="orcarouter",
+                model="openai/gpt-4o-mini",
+                api_key="sk-orca-test",
+                messages=[_msg("user", "hi")],
+                max_tokens=100,
+            )
+
+        assert result.content == "hello"
+        kwargs = async_create.call_args.kwargs
+        # OrcaRouter does NOT accept OpenRouter's ``usage: {"include": True}``
+        # extra_body (it 400s on ``usage``) — only the attribution headers
+        # are sent.
+        assert "extra_body" not in kwargs
+        assert kwargs["extra_headers"]["HTTP-Referer"] == "https://agpt.co"
+        assert kwargs["extra_headers"]["X-Title"] == "AutoGPT"
+        # The client must be pointed at the OrcaRouter base URL.
+        ctor_kwargs = constructor.call_args.kwargs
+        assert ctor_kwargs["base_url"] == "https://api.orcarouter.ai/v1"
+
+
 class TestLlamaAPI:
     @pytest.mark.asyncio
     async def test_omits_openrouter_extras(self):


### PR DESCRIPTION
## Why / What / How

**Why:** AutoGPT's chat and block layers route LLM calls through a small set of named OpenAI-compatible providers in `backend.util.llm.providers` (OpenRouter, AI/ML API, Llama API, v0). [OrcaRouter](https://www.orcarouter.ai) is another OpenAI-compatible model routing gateway with the same `provider/model` namespace shape, so adding it as a named provider lets operators point AutoGPT at OrcaRouter the same way they already point it at OpenRouter - no generic passthrough or base-URL fiddling required.

**What:** Adds `orcarouter` as a first-class entry in the provider dispatch, mirroring how `open_router` is wired:

- `backend/util/clients.py` - new `ORCAROUTER_BASE_URL` constant (`https://api.orcarouter.ai/v1`), placed next to `OPENROUTER_BASE_URL`.
- `backend/util/llm/providers.py` - `orcarouter` added to the `ProviderLiteral` type and to `_dispatch_sync`, dispatching through the shared `_call_openai_compat` helper with the OrcaRouter base URL and the same attribution headers (`HTTP-Referer` / `X-Title`) the OpenRouter and AI/ML paths send.
- `backend/util/llm/providers_test.py` - new `TestOrcaRouter` mirroring `TestOpenRouter`, asserting the client points at the OrcaRouter base URL and that the OrcaRouter-specific wire difference is honored: it does **not** send OpenRouter's `usage: {"include": True}` extra_body (OrcaRouter rejects `usage` with HTTP 400, verified live), only the attribution headers.

**How:** One wire-protocol difference from OpenRouter surfaced during live testing: OrcaRouter returns `400 Unrecognized request argument supplied: usage` for OpenRouter's `usage.include` cost-request body. The dispatch therefore passes `include_openrouter_extras=False` and supplies the attribution headers via `extra_headers` instead - the same `_call_openai_compat` path the AI/ML and Llama API providers already use.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint - screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Changes 🏗️

- Add `ORCAROUTER_BASE_URL` constant in `backend/util/clients.py`
- Add `orcarouter` provider dispatch in `backend/util/llm/providers.py` (`ProviderLiteral` + `_dispatch_sync`)
- Add `TestOrcaRouter` unit test in `backend/util/llm/providers_test.py`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pytest backend/util/llm/providers_test.py` - 85 passed (incl. new `TestOrcaRouter`)
  - [x] `pytest backend/util/llm/ backend/util/clients_test.py` - 106 passed
  - [x] `black --check` + `isort --check` on all changed files - clean
  - [x] Live integration: `call_provider(provider="orcarouter", model="openai/gpt-4o-mini", ...)` against the OrcaRouter API returned a real completion (`orca-ok`), confirming the new dispatch path works end-to-end.

I'm an engineer on the OrcaRouter team.
