### PR TITLE
feat(platform): name the models a connection runs, and gate Advanced

### DIFF
--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -16,13 +16,14 @@ from pydantic import BaseModel
 
 from backend.copilot.config import ChatConfig, CopilotLlmAuthProvider, CopilotLLMModel
 from backend.copilot.engine import resolve_use_sdk
-from backend.copilot.model_router import resolve_model_route
+from backend.copilot.model_router import ROUTE_SURFACE_CODEX, resolve_model_route
 from backend.copilot.transports import (
     ChatTransportResponse,
     get_chat_transports,
     is_deployment_chat_available,
     settings,
 )
+from backend.data import llm_registry
 from backend.integrations.codex.access import (
     CODEX_MINIMUM_PLAN_ERROR,
     has_codex_access_for_discovery,
@@ -47,10 +48,12 @@ class ConnectionTier(BaseModel):
     same router the turn will use — LaunchDarkly cell, then registry, then
     config — so it cannot drift from what actually answers.
 
-    It is ``None`` on a ChatGPT connection. Naming that model means asking
-    the account what it advertises, which takes a runtime lease against the
-    provider; doing that once per credential to render a list is the cost
-    this endpoint exists to avoid.
+    On a ChatGPT connection it is the model the catalog pins for that cell,
+    read straight from the registry -- no lease, no call to the account.
+    What a lease would add is confirmation that this particular account still
+    advertises it; the router checks that when the turn runs and falls back
+    if not, so the name here is the routed model rather than a guarantee.
+    ``None`` only when the catalog pins nothing for the cell.
     """
 
     tier: CopilotLLMModel
@@ -88,9 +91,20 @@ async def get_connection_offers(user_id: str) -> list[AIConnectionOffer]:
     pick.
     """
     config = ChatConfig()
-    models = await _platform_tier_models(user_id, config)
+    # One engine decision for the whole response: it is a property of the
+    # deployment and the user, not of which connection they pick.
+    use_sdk = await resolve_use_sdk(
+        user_id,
+        use_claude_code_subscription=config.use_claude_code_subscription,
+        config_default=config.use_claude_agent_sdk,
+        thinking_available=config.thinking_available,
+    )
+    mode = "thinking" if use_sdk else "fast"
+    models = await _platform_tier_models(mode, user_id, config)
+    codex_models = _codex_tier_models(mode)
     offers = [
-        _offer(transport, models) for transport in await get_chat_transports(user_id)
+        _offer(transport, models, codex_models)
+        for transport in await get_chat_transports(user_id)
     ]
     locked = await _locked_codex_offer(user_id, offers)
     return offers + ([locked] if locked else [])
@@ -144,7 +158,7 @@ async def _locked_codex_offer(
 
 
 async def _platform_tier_models(
-    user_id: str, config: ChatConfig
+    mode: str, user_id: str, config: ChatConfig
 ) -> dict[CopilotLLMModel, str | None]:
     """Resolve each tier against the engine this user's turns will run on.
 
@@ -152,13 +166,6 @@ async def _platform_tier_models(
     any more — the decision is the server's, so it can be made before a turn
     exists rather than during one.
     """
-    use_sdk = await resolve_use_sdk(
-        user_id,
-        use_claude_code_subscription=config.use_claude_code_subscription,
-        config_default=config.use_claude_agent_sdk,
-        thinking_available=config.thinking_available,
-    )
-    mode = "thinking" if use_sdk else "fast"
     resolved: dict[CopilotLLMModel, str | None] = {}
     for tier in TIER_LABELS:
         try:
@@ -185,9 +192,24 @@ def offer_id_for(transport: ChatTransportResponse) -> str:
     return f"{transport.auth_provider}:{transport.credential_id or 'deployment'}"
 
 
+def _codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:
+    """The models the catalog pins for the Codex cells of this engine.
+
+    A registry read, so it costs nothing and needs no credential. The router
+    validates the pinned slug against what the account actually advertises
+    when the turn runs, and falls back if it is gone -- so this names the
+    routed model, not a promise about the account.
+    """
+    return {
+        tier: llm_registry.get_route(ROUTE_SURFACE_CODEX, mode, tier)
+        for tier in TIER_LABELS
+    }
+
+
 def _offer(
     transport: ChatTransportResponse,
     platform_models: dict[CopilotLLMModel, str | None],
+    codex_models: dict[CopilotLLMModel, str | None],
 ) -> AIConnectionOffer:
     return AIConnectionOffer(
         offer_id=offer_id_for(transport),
@@ -208,7 +230,7 @@ def _offer(
                 display_model=(
                     platform_models.get(tier)
                     if transport.auth_provider == "platform"
-                    else None
+                    else codex_models.get(tier)
                 ),
             )
             for tier, label in TIER_LABELS.items()

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -28,6 +28,7 @@ from backend.integrations.codex.access import (
     CODEX_MINIMUM_PLAN_ERROR,
     has_codex_access_for_discovery,
 )
+from backend.util.entitlements import Entitlement, has_entitlement
 from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.settings import BehaveAs
 
@@ -60,6 +61,10 @@ class ConnectionTier(BaseModel):
     label: str
     selectable: bool
     display_model: str | None = None
+    # Why this tier cannot be picked, when it cannot. Advanced is a paid
+    # tier on hosted, so the row stays visible and says what unlocks it --
+    # hiding it would remove the upgrade reason it exists to create.
+    lock_reason: str | None = None
 
 
 class AIConnectionOffer(BaseModel):
@@ -102,8 +107,9 @@ async def get_connection_offers(user_id: str) -> list[AIConnectionOffer]:
     mode = "thinking" if use_sdk else "fast"
     models = await _platform_tier_models(mode, user_id, config)
     codex_models = _codex_tier_models(mode)
+    advanced_allowed = await _advanced_tier_allowed(user_id)
     offers = [
-        _offer(transport, models, codex_models)
+        _offer(transport, models, codex_models, advanced_allowed)
         for transport in await get_chat_transports(user_id)
     ]
     locked = await _locked_codex_offer(user_id, offers)
@@ -192,6 +198,25 @@ def offer_id_for(transport: ChatTransportResponse) -> str:
     return f"{transport.auth_provider}:{transport.credential_id or 'deployment'}"
 
 
+ADVANCED_TIER_LOCK_REASON = "A Max plan or higher is required for Advanced."
+
+
+async def _advanced_tier_allowed(user_id: str) -> bool:
+    """Whether this user may pick the Advanced tier.
+
+    A failure to resolve the entitlement leaves the tier open rather than
+    locked: a billing hiccup should not silently downgrade someone's model.
+    """
+    try:
+        return await has_entitlement(user_id, Entitlement.ADVANCED_MODEL_TIER)
+    except Exception:
+        logger.warning(
+            "Could not resolve the Advanced tier entitlement; leaving it open",
+            exc_info=True,
+        )
+        return True
+
+
 def _display_name(slug: str | None) -> str | None:
     """What the catalog calls this model, rather than its slug.
 
@@ -224,6 +249,7 @@ def _offer(
     transport: ChatTransportResponse,
     platform_models: dict[CopilotLLMModel, str | None],
     codex_models: dict[CopilotLLMModel, str | None],
+    advanced_allowed: bool,
 ) -> AIConnectionOffer:
     return AIConnectionOffer(
         offer_id=offer_id_for(transport),
@@ -240,11 +266,18 @@ def _offer(
             ConnectionTier(
                 tier=tier,
                 label=label,
-                selectable=transport.available,
+                selectable=(
+                    transport.available and (advanced_allowed or tier != "advanced")
+                ),
                 display_model=(
                     platform_models.get(tier)
                     if transport.auth_provider == "platform"
                     else codex_models.get(tier)
+                ),
+                lock_reason=(
+                    None
+                    if advanced_allowed or tier != "advanced"
+                    else ADVANCED_TIER_LOCK_REASON
                 ),
             )
             for tier, label in TIER_LABELS.items()

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -112,12 +112,14 @@ async def get_connection_offers(user_id: str) -> list[AIConnectionOffer]:
         _offer(transport, models, codex_models, advanced_allowed)
         for transport in await get_chat_transports(user_id)
     ]
-    locked = await _locked_codex_offer(user_id, offers)
+    locked = await _locked_codex_offer(user_id, offers, codex_models)
     return offers + ([locked] if locked else [])
 
 
 async def _locked_codex_offer(
-    user_id: str, offers: list[AIConnectionOffer]
+    user_id: str,
+    offers: list[AIConnectionOffer],
+    codex_models: dict[CopilotLLMModel, str | None],
 ) -> AIConnectionOffer | None:
     """The ChatGPT connection a plan does not include, shown rather than hidden.
 
@@ -156,7 +158,19 @@ async def _locked_codex_offer(
         state="locked",
         selectable=False,
         is_default=False,
-        tiers=[],
+        # Named even though nothing here can be picked: "what you get" is the
+        # whole argument for connecting, and a surface that cannot say which
+        # models is asking the user to take it on faith. Not selectable, so
+        # naming them cannot be mistaken for offering them.
+        tiers=[
+            ConnectionTier(
+                tier=tier,
+                label=label,
+                selectable=False,
+                display_model=codex_models.get(tier),
+            )
+            for tier, label in TIER_LABELS.items()
+        ],
         limitations=[],
         lock_reason=CODEX_MINIMUM_PLAN_ERROR,
         unlock_href="/settings/billing",

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -170,7 +170,7 @@ async def _platform_tier_models(
     for tier in TIER_LABELS:
         try:
             route = await resolve_model_route(mode, tier, user_id, config=config)
-            resolved[tier] = route.model
+            resolved[tier] = _display_name(route.model)
         except Exception:
             # A tier that cannot be resolved is described without a name
             # rather than failing the whole list.
@@ -192,6 +192,20 @@ def offer_id_for(transport: ChatTransportResponse) -> str:
     return f"{transport.auth_provider}:{transport.credential_id or 'deployment'}"
 
 
+def _display_name(slug: str | None) -> str | None:
+    """What the catalog calls this model, rather than its slug.
+
+    The PRD labels tiers "Balanced · 5.6 Terra", not
+    "Balanced · gpt-5.6-terra": the slug is a routing key and reads as one.
+    Falls back to the slug when the registry has no entry, which is better
+    than showing nothing.
+    """
+    if not slug:
+        return None
+    model = llm_registry.get_model(slug)
+    return model.display_name if model else slug
+
+
 def _codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:
     """The models the catalog pins for the Codex cells of this engine.
 
@@ -201,7 +215,7 @@ def _codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:
     routed model, not a promise about the account.
     """
     return {
-        tier: llm_registry.get_route(ROUTE_SURFACE_CODEX, mode, tier)
+        tier: _display_name(llm_registry.get_route(ROUTE_SURFACE_CODEX, mode, tier))
         for tier in TIER_LABELS
     }
 

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -411,3 +411,28 @@ async def test_an_unresolvable_entitlement_leaves_advanced_open(
 
     assert tiers["advanced"].selectable is True
     assert tiers["advanced"].lock_reason is None
+
+
+@pytest.mark.asyncio
+async def test_a_locked_chatgpt_offer_still_names_the_models(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    # "What you get" is the argument for connecting; a locked row that
+    # cannot name the models asks the user to take it on faith.
+    mocker.patch.object(
+        offers.llm_registry, "get_route", side_effect=lambda s, m, t: f"{m}-{t}"
+    )
+    mocker.patch.object(offers.llm_registry, "get_model", return_value=None)
+    _mock_transports(mocker, [_transport("platform", None)])
+    _upsell(mocker)
+
+    locked = _locked(await get_connection_offers("user"))[0]
+
+    # The fixture pins the engine to the baseline, so the cells are "fast".
+    assert [t.display_model for t in locked.tiers] == [
+        "fast-standard",
+        "fast-advanced",
+    ]
+    # Naming them must not read as offering them.
+    assert all(t.selectable is False for t in locked.tiers)
+    assert locked.selectable is False

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -31,6 +31,14 @@ def _transport(
 
 
 @pytest.fixture(autouse=True)
+def advanced_allowed(mocker: pytest_mock.MockerFixture):
+    """Advanced is open unless a test says otherwise."""
+    return mocker.patch.object(
+        offers, "has_entitlement", new=AsyncMock(return_value=True)
+    )
+
+
+@pytest.fixture(autouse=True)
 def hosted(mocker: pytest_mock.MockerFixture):
     mocker.patch.object(offers.settings.config, "behave_as", BehaveAs.CLOUD)
     mocker.patch.object(transports.settings.config, "behave_as", BehaveAs.CLOUD)
@@ -360,3 +368,46 @@ async def test_self_host_sells_nothing_because_it_grants_everything(
     _upsell(mocker)
 
     assert _locked(await get_connection_offers("user")) == []
+
+
+@pytest.mark.asyncio
+async def test_advanced_is_locked_for_a_plan_that_does_not_include_it(
+    mocker: pytest_mock.MockerFixture, advanced_allowed
+) -> None:
+    # Visible and locked, not hidden: the row is the upgrade reason.
+    advanced_allowed.return_value = False
+    _mock_transports(mocker, [_transport("platform", None)])
+
+    tiers = {t.tier: t for t in (await get_connection_offers("user"))[0].tiers}
+
+    assert tiers["standard"].selectable is True
+    assert tiers["advanced"].selectable is False
+    assert tiers["advanced"].lock_reason
+    # Still named, so the user can see what they would be getting.
+    assert "advanced" in tiers
+
+
+@pytest.mark.asyncio
+async def test_advanced_is_open_when_the_plan_includes_it(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    _mock_transports(mocker, [_transport("platform", None)])
+
+    tiers = {t.tier: t for t in (await get_connection_offers("user"))[0].tiers}
+
+    assert all(t.selectable for t in tiers.values())
+    assert all(t.lock_reason is None for t in tiers.values())
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_entitlement_leaves_advanced_open(
+    mocker: pytest_mock.MockerFixture, advanced_allowed
+) -> None:
+    # A billing hiccup must not silently downgrade someone's model.
+    advanced_allowed.side_effect = RuntimeError("billing down")
+    _mock_transports(mocker, [_transport("platform", None)])
+
+    tiers = {t.tier: t for t in (await get_connection_offers("user"))[0].tiers}
+
+    assert tiers["advanced"].selectable is True
+    assert tiers["advanced"].lock_reason is None

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -115,6 +115,51 @@ async def test_offer_ids_are_stable_and_per_account(
 
 
 @pytest.mark.asyncio
+async def test_a_chatgpt_tier_names_the_model_the_catalog_pins(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    # A registry read, not a call to the account: the router validates the
+    # pinned slug against what the account advertises when the turn runs.
+    mocker.patch.object(
+        offers.llm_registry,
+        "get_route",
+        side_effect=lambda surface, mode, tier: f"{surface}:{mode}:{tier}",
+    )
+    _mock_transports(
+        mocker, [_transport("platform", None), _transport("codex", "cred-1")]
+    )
+
+    codex = [
+        o
+        for o in await get_connection_offers("user")
+        if o.auth_method == "chatgpt_oauth"
+    ][0]
+
+    assert [t.display_model for t in codex.tiers] == [
+        "copilot_codex:fast:standard",
+        "copilot_codex:fast:advanced",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_chatgpt_tier_the_catalog_pins_nothing_for_stays_unnamed(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch.object(offers.llm_registry, "get_route", return_value=None)
+    _mock_transports(
+        mocker, [_transport("platform", None), _transport("codex", "cred-1")]
+    )
+
+    codex = [
+        o
+        for o in await get_connection_offers("user")
+        if o.auth_method == "chatgpt_oauth"
+    ][0]
+
+    assert all(t.display_model is None for t in codex.tiers)
+
+
+@pytest.mark.asyncio
 async def test_tiers_name_the_model_they_resolve_to(
     mocker: pytest_mock.MockerFixture,
 ) -> None:

--- a/autogpt_platform/backend/backend/util/entitlements.py
+++ b/autogpt_platform/backend/backend/util/entitlements.py
@@ -11,6 +11,10 @@ from backend.util.settings import BehaveAs, Settings
 
 class Entitlement(str, Enum):
     CODEX_SUBSCRIPTION_TRANSPORT = "codex_subscription_transport"
+    # The Advanced model tier. Gated on hosted so it is a reason to upgrade
+    # rather than a reason not to; granted outright on self-host, where
+    # there is no plan to sell and the operator pays for their own tokens.
+    ADVANCED_MODEL_TIER = "advanced_model_tier"
 
 
 class EntitlementPolicy(BaseModel):
@@ -23,6 +27,10 @@ class EntitlementPolicy(BaseModel):
 ENTITLEMENT_POLICIES: Mapping[Entitlement, EntitlementPolicy] = MappingProxyType(
     {
         Entitlement.CODEX_SUBSCRIPTION_TRANSPORT: EntitlementPolicy(
+            minimum_tier=SubscriptionTier.MAX,
+            allow_local=True,
+        ),
+        Entitlement.ADVANCED_MODEL_TIER: EntitlementPolicy(
             minimum_tier=SubscriptionTier.MAX,
             allow_local=True,
         ),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
@@ -16,6 +16,8 @@ interface Props {
    * its own line, so the name a screen reader announces stays complete.
    */
   label?: string;
+  /** Shown beside the title, e.g. "Connected". */
+  badge?: string;
   /** Why this cannot be chosen, and where to go to change that. */
   lock?: { reason: string; href: string | null };
 }
@@ -28,6 +30,7 @@ export function ChoiceRow({
   onSelect,
   label,
   lock,
+  badge,
 }: Props) {
   if (lock) {
     return <LockedRow title={title} subtitle={subtitle} lock={lock} />;
@@ -58,7 +61,14 @@ export function ChoiceRow({
         )}
       </span>
       <span className="flex min-w-0 flex-col">
-        <span className="text-xs font-medium text-foreground">{title}</span>
+        <span className="flex items-center gap-1.5">
+          <span className="text-xs font-medium text-foreground">{title}</span>
+          {badge && (
+            <span className="rounded-full bg-green-500/10 px-1.5 py-px text-[10px] font-medium text-green-700">
+              {badge}
+            </span>
+          )}
+        </span>
         {subtitle && (
           <span className="break-words text-[11px] leading-snug text-muted-foreground">
             {subtitle}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ConnectionPicker.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ConnectionPicker.tsx
@@ -13,7 +13,15 @@ import {
 } from "react-icons/pi";
 
 import { ChoiceRow } from "./ChoiceRow";
-import { offerSubtitle, tierLabel, tierModel, tierName } from "./helpers";
+import {
+  isLinkedAccount,
+  offerSubtitle,
+  tierLabel,
+  tierModel,
+  tierName,
+  tierLock,
+  tierSummary,
+} from "./helpers";
 import { useConnectionPicker } from "./useConnectionPicker";
 
 const TIERS = ["standard", "advanced"] as const;
@@ -111,7 +119,10 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
                   key={offer.offer_id}
                   title={offer.display_name}
                   subtitle={offerSubtitle(offer)}
-                  notes={offer.limitations}
+                  badge={isLinkedAccount(offer) ? "Connected" : undefined}
+                  notes={[tierSummary(offer), ...offer.limitations].filter(
+                    Boolean,
+                  )}
                   isSelected={offer.offer_id === active?.offer_id}
                   onSelect={() => chooseConnection(offer)}
                   lock={
@@ -140,6 +151,7 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
                   label={tierLabel(active, candidate)}
                   isSelected={tier === candidate}
                   onSelect={() => setTier(candidate)}
+                  lock={tierLock(active, candidate)}
                 />
               ))}
             </div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/helpers.ts
@@ -105,3 +105,45 @@ export function tierLabel(
 export function offerSubtitle(offer: AIConnectionOffer): string {
   return offer.lock_reason ? offer.description : offer.backed_by_label;
 }
+
+/**
+ * "Balanced: Sonnet 5 · Advanced: Opus 5" for a connection row.
+ *
+ * The PRD's mock puts both models under each route so the choice can be made
+ * before switching to it -- otherwise you have to select a connection to
+ * discover what it runs, which is the wrong order.
+ *
+ * Empty when the server named no models, so the row simply omits the line
+ * rather than rendering "Balanced: · Advanced:".
+ */
+export function tierSummary(offer: AIConnectionOffer): string {
+  const named = offer.tiers
+    .filter((tier) => tier.display_model)
+    .map((tier) => `${tier.label}: ${tier.display_model}`);
+  return named.join(" · ");
+}
+
+/**
+ * Whether this connection is one the user linked themselves.
+ *
+ * Drives the "Connected" badge: a deployment route is not something anyone
+ * connected, so badging it would be meaningless.
+ */
+export function isLinkedAccount(offer: AIConnectionOffer): boolean {
+  return offer.auth_method !== "deployment" && Boolean(offer.credential_id);
+}
+
+/**
+ * The lock on a tier, when the plan does not include it.
+ *
+ * Advanced stays visible and locked rather than hidden: the row is the
+ * upgrade reason, and hiding it would remove the thing it exists to create.
+ */
+export function tierLock(
+  offer: AIConnectionOffer | undefined,
+  tier: string,
+): { reason: string; href: string | null } | undefined {
+  const match = tierOf(offer, tier);
+  if (!match?.lock_reason) return undefined;
+  return { reason: match.lock_reason, href: "/settings/billing" };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
@@ -5,7 +5,12 @@ import {
 import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import type { ConnectionTier } from "@/app/api/__generated__/models/connectionTier";
 import { server } from "@/mocks/mock-server";
-import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import {
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -393,6 +398,69 @@ describe("ConnectionPicker", () => {
     // chip names. Nothing is written into the store either, because showing a
     // default is not the user choosing it.
     expect(useCopilotUIStore.getState().copilotLlmAuth).toBeNull();
+  });
+
+  it("names both models on a connection before you switch to it", async () => {
+    // Otherwise you have to select a connection to discover what it runs,
+    // which is the wrong order.
+    mockOffers([offer(), chatgpt()]);
+
+    render(<ConnectionPicker />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Runs on/ }),
+    );
+
+    expect(
+      await screen.findByText("Balanced: sonnet-5 · Advanced: opus-5"),
+    ).toBeDefined();
+  });
+
+  it("badges a connection the user linked themselves", async () => {
+    mockOffers([offer(), chatgpt()]);
+
+    render(<ConnectionPicker />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Runs on/ }),
+    );
+
+    expect(await screen.findByText("Connected")).toBeDefined();
+    // The deployment route is not something anyone connected.
+    expect(screen.getAllByText("Connected")).toHaveLength(1);
+  });
+
+  it("shows a tier the plan excludes as locked rather than hiding it", async () => {
+    // The row is the upgrade reason; hiding it removes what it exists for.
+    mockOffers([
+      offer({
+        tiers: [
+          tier("standard", "Balanced", "sonnet-5"),
+          {
+            ...tier("advanced", "Advanced", "opus-5"),
+            selectable: false,
+            lock_reason: "A Max plan or higher is required for Advanced.",
+          },
+        ],
+      }),
+      chatgpt(),
+    ]);
+
+    render(<ConnectionPicker />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Runs on/ }),
+    );
+
+    expect(
+      await screen.findByText("A Max plan or higher is required for Advanced."),
+    ).toBeDefined();
+    // Still named, so the user sees what they would get.
+    expect(screen.getByText("opus-5")).toBeDefined();
+    // Scoped to the tier group: the connection row's own name now contains
+    // "Advanced: opus-5" from its tier summary, so a page-wide query matches it.
+    const tierGroup = screen.getByRole("radiogroup", { name: "Model tier" });
+    expect(
+      within(tierGroup).queryByRole("radio", { name: /Advanced/ }),
+    ).toBeNull();
+    expect(within(tierGroup).getAllByRole("radio")).toHaveLength(1);
   });
 
   it("reports a failure rather than inventing a connection", async () => {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -17295,12 +17295,16 @@
           "display_model": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Display Model"
+          },
+          "lock_reason": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Lock Reason"
           }
         },
         "type": "object",
         "required": ["tier", "label", "selectable"],
         "title": "ConnectionTier",
-        "description": "One quality level on a connection.\n\n``display_model`` is the model this tier resolves to, run through the\nsame router the turn will use — LaunchDarkly cell, then registry, then\nconfig — so it cannot drift from what actually answers.\n\nIt is ``None`` on a ChatGPT connection. Naming that model means asking\nthe account what it advertises, which takes a runtime lease against the\nprovider; doing that once per credential to render a list is the cost\nthis endpoint exists to avoid."
+        "description": "One quality level on a connection.\n\n``display_model`` is the model this tier resolves to, run through the\nsame router the turn will use — LaunchDarkly cell, then registry, then\nconfig — so it cannot drift from what actually answers.\n\nOn a ChatGPT connection it is the model the catalog pins for that cell,\nread straight from the registry -- no lease, no call to the account.\nWhat a lease would add is confirmation that this particular account still\nadvertises it; the router checks that when the turn runs and falls back\nif not, so the name here is the routed model rather than a guarantee.\n``None`` only when the catalog pins nothing for the cell."
       },
       "ContentType": {
         "type": "string",


### PR DESCRIPTION
> Stacked on #14094. Brings the picker in line with Mock 3 of the BYO-Sub PRD.

### Why

Compared the built picker against the PRD's Mock 3. Four things it specifies were missing
or wrong.

### What

**Tiers name their model, and use its name.** ChatGPT tiers rendered as bare "Balanced" /
"Advanced" on the stated grounds that naming one "takes a runtime lease against the
provider". That was wrong — the catalog pins the Codex cells and `llm_registry.get_route`
is a dictionary lookup. And the labels showed slugs (`anthropic/claude-sonnet-5`) where the
mock shows names (`Sonnet 5`); the catalog already carries `display_name`.

**Both models on the connection row.** `Balanced: Sonnet 5 · Advanced: Opus 5`, so the
choice can be made before switching. Otherwise you must select a connection to discover
what it runs.

**Advanced is a paid tier, shown locked.** The PRD gates it to Max on hosted and grants it
on self-host — the shape of an entitlement, so it becomes one (`ADVANCED_MODEL_TIER`). The
row stays visible and names its model: it *is* the upgrade reason.

**`Connected` badges a linked account**, and only that — a deployment route is not
something anyone connected.

**A locked ChatGPT offer names what you'd get.** Before connecting there is no ChatGPT
offer to read tiers from, so the locked upsell is the only source those names can come
from — which the connect modal needs.

### How

Two deliberate calls:

- **The Advanced lock fails open.** An entitlement that cannot be resolved leaves the tier
  available. A billing hiccup silently downgrading someone's model is worse than briefly
  giving it away.
- **Naming ≠ offering.** Locked tiers are marked unselectable, so listing their models
  cannot be mistaken for granting them.

### Verified

Against a live single-container build with a real linked ChatGPT account:

```
Self-hosted chat   Balanced=anthropic/claude-sonnet-5, Advanced=anthropic/claude-opus-4-8
ChatGPT            Balanced=GPT-5.6 Terra,             Advanced=GPT-5.6 Sol
```

Matching the PRD's mapping table exactly.

### Test plan

- [x] 23 in `offers_test.py` — catalog naming, display-name fallback, the tier lock
      (locked / open / unresolvable), locked-offer tiers
- [x] 20 in `ConnectionPicker.test.tsx` — tier summary, badge, locked tier
- [x] Copilot suite 130 files / 1567 tests; `pnpm types`, eslint clean
- [x] Live check above

> Backend suite run locally with `graph_cleanup`/`server` stubbed — that fixture deadlocks
> on Windows without the docker postgres. CI runs the real one.

### Not included

The settings AI-Connections section still reads `/transports` and so cannot show models —
that migration is deliberately separate.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing-gated tier selectability and connection-offer payloads used by the copilot picker; entitlement checks fail open, which could briefly allow Advanced during billing outages.
> 
> **Overview**
> Aligns connection offers and the copilot **ConnectionPicker** with the BYO-sub PRD: users see **which models** each route runs **before** picking, and **Advanced** stays visible as a locked upsell when the plan does not include it.
> 
> **Backend** enriches `GET` connection offers: platform tiers expose **catalog `display_name`** instead of routing slugs; ChatGPT (Codex) tiers now name models via **`llm_registry`** (no provider lease). The **locked ChatGPT upsell** lists the same tier/model names while remaining unselectable. A new **`ADVANCED_MODEL_TIER`** entitlement (Max+ on hosted, granted on self-host) drives per-tier **`selectable`** / **`lock_reason`**; entitlement lookup **fails open** so billing outages do not silently lock Advanced. **`ConnectionTier.lock_reason`** is added to the API schema.
> 
> **Frontend** shows a **tier summary** on each connection row (`Balanced: … · Advanced: …`), a **Connected** badge for linked OAuth accounts, and renders plan-gated Advanced as a **locked tier row** with billing copy instead of hiding it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109812aa78ad9c3755d319c72ddeebbe24558e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->