### PR TITLE
refactor(frontend): read settings connections from the offers endpoint

### DIFF
--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -6,7 +6,7 @@ import {
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
@@ -14,7 +14,7 @@ import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
 
 import { ManageConnectionDialog } from "./ManageConnectionDialog";
-import { describeTransport, transportKey } from "./helpers";
+import { tierSummary } from "./helpers";
 import { useAIConnectionsSection } from "./useAIConnectionsSection";
 
 export function AIConnectionsSection() {
@@ -27,7 +27,7 @@ export function AIConnectionsSection() {
     isLoading,
     isError,
   } = useAIConnectionsSection();
-  const [managing, setManaging] = useState<ChatTransportResponse | null>(null);
+  const [managing, setManaging] = useState<AIConnectionOffer | null>(null);
 
   // A failure here must not take the tool integrations below it down with it.
   if (isError) return null;
@@ -65,15 +65,15 @@ export function AIConnectionsSection() {
         >
           {connections.map((connection) => (
             <ConnectionRow
-              key={transportKey(connection)}
+              key={connection.offer_id}
               connection={connection}
               account={accountFor(connection)}
               selectable={hasChoice}
-              isSelected={transportKey(connection) === selectedKey}
+              isSelected={connection.offer_id === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
               onManage={
-                connection.auth_provider === "codex"
+                connection.auth_method === "chatgpt_oauth"
                   ? () => setManaging(connection)
                   : undefined
               }
@@ -96,7 +96,7 @@ export function AIConnectionsSection() {
 }
 
 interface RowProps {
-  connection: ChatTransportResponse;
+  connection: AIConnectionOffer;
   account?: string;
   selectable: boolean;
   isSelected: boolean;
@@ -133,9 +133,9 @@ function ConnectionRow({
       <span className="flex min-w-0 flex-col gap-1">
         <span className="flex flex-wrap items-center gap-2">
           <Text variant="body-medium" as="span" className="text-black">
-            {connection.label}
+            {connection.display_name}
           </Text>
-          {connection.auth_provider === "codex" && (
+          {connection.auth_method === "chatgpt_oauth" && (
             <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#E8F8F0] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#157E58]">
               <Icon icon={CheckmarkCircle02Icon} size={13} />
               Connected
@@ -154,8 +154,18 @@ function ConnectionRow({
           )}
         </span>
         <Text variant="small" as="span" className="text-[#505057]">
-          {describeTransport(connection)}
+          {connection.description}
         </Text>
+        {tierSummary(connection) && (
+          <Text variant="small" as="span" className="text-[#7A7A80]">
+            {tierSummary(connection)}
+          </Text>
+        )}
+        {connection.lock_reason && (
+          <Text variant="small" as="span" className="text-[#7A7A80]">
+            {connection.lock_reason}
+          </Text>
+        )}
       </span>
     </>
   );

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 import { getGetV2ListChatTransportsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useGetV1CodexAccount } from "@/app/api/__generated__/endpoints/integrations/integrations";
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
@@ -13,7 +13,7 @@ import { useOAuthConnect } from "../ConnectServiceDialog/components/DetailView/u
 import { useDeleteIntegration } from "../hooks/useDeleteIntegration";
 
 interface Props {
-  connection: ChatTransportResponse | null;
+  connection: AIConnectionOffer | null;
   account?: string;
   onOpenChange: (open: boolean) => void;
 }
@@ -105,7 +105,7 @@ export function ManageConnectionDialog({
           </Text>
 
           <Text variant="small" className="text-[#505057]">
-            {connection?.default
+            {connection?.is_default
               ? "New chats start on this connection and run on your ChatGPT plan."
               : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
           </Text>

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -1,9 +1,9 @@
 import {
-  getGetV2ListChatTransportsMockHandler200,
+  getGetV2ListChatConnectionsMockHandler200,
   getPutV2SetDefaultChatTransportMockHandler200,
 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
 import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
@@ -11,33 +11,75 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AIConnectionsSection } from "../AIConnectionsSection";
 
-function platform(isDefault: boolean): ChatTransportResponse {
+function platform(isDefault: boolean): AIConnectionOffer {
   return {
-    auth_provider: "platform",
+    offer_id: "platform:deployment",
+    provider_family: "autogpt",
+    display_name: "Self-hosted chat",
+    auth_method: "deployment",
     credential_id: null,
-    label: "Self-hosted chat",
-    available: true,
-    default: isDefault,
-  };
+    backed_by_label: "This server's chat provider",
+    description:
+      "New chats are backed by the chat provider configured on this server.",
+    state: "ready",
+    selectable: true,
+    is_default: isDefault,
+    tiers: [
+      {
+        tier: "standard",
+        label: "Balanced",
+        selectable: true,
+        display_model: "Sonnet 5",
+      },
+      {
+        tier: "advanced",
+        label: "Advanced",
+        selectable: true,
+        display_model: "Opus 5",
+      },
+    ],
+    limitations: [],
+  } as AIConnectionOffer;
 }
 
-function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
+function chatgpt(isDefault: boolean, id = "cred-1"): AIConnectionOffer {
   return {
-    auth_provider: "codex",
+    offer_id: `codex:${id}`,
+    provider_family: "openai",
+    display_name: "ChatGPT",
+    auth_method: "chatgpt_oauth",
     credential_id: id,
-    label: "ChatGPT",
-    available: true,
-    default: isDefault,
-  };
+    backed_by_label: "Your ChatGPT plan",
+    description:
+      "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.",
+    state: "ready",
+    selectable: true,
+    is_default: isDefault,
+    tiers: [
+      {
+        tier: "standard",
+        label: "Balanced",
+        selectable: true,
+        display_model: "GPT-5.6 Terra",
+      },
+      {
+        tier: "advanced",
+        label: "Advanced",
+        selectable: true,
+        display_model: "GPT-5.6 Sol",
+      },
+    ],
+    limitations: [],
+  } as AIConnectionOffer;
 }
 
 function mockTransports(
-  transports: ChatTransportResponse[],
+  offers: AIConnectionOffer[],
   credentials: { id: string; username: string }[] = [],
 ) {
   server.use(
-    getGetV2ListChatTransportsMockHandler200({ transports }),
-    getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+    getGetV2ListChatConnectionsMockHandler200({ offers }),
+    getPutV2SetDefaultChatTransportMockHandler200({ transports: [] }),
     getGetV1ListCredentialsMockHandler200(
       credentials.map((credential) => ({
         id: credential.id,
@@ -145,5 +187,52 @@ describe("AIConnectionsSection", () => {
 
     expect(await screen.findByText("GitHub Copilot and Grok")).toBeDefined();
     expect(screen.getByText("Coming soon")).toBeDefined();
+  });
+
+  it("names the models each connection runs", async () => {
+    // The reason for reading /connections rather than /transports: transports
+    // carries no tiers, so this line could not exist before.
+    mockTransports([platform(true), chatgpt(false)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(
+      await screen.findByText(
+        "Balanced: GPT-5.6 Terra · Advanced: GPT-5.6 Sol",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText("Balanced: Sonnet 5 · Advanced: Opus 5"),
+    ).toBeDefined();
+  });
+
+  it("takes its copy from the server rather than deciding it here", async () => {
+    // describeTransport used to compose this sentence client-side, which
+    // drifts from the server that enforces the billing it describes.
+    mockTransports([{ ...chatgpt(true), description: "Server said this." }]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("Server said this.")).toBeDefined();
+  });
+
+  it("shows a connection the plan excludes, with what unlocks it", async () => {
+    mockTransports([
+      platform(true),
+      {
+        ...chatgpt(false),
+        state: "locked",
+        selectable: false,
+        lock_reason: "A Max plan or higher is required to use ChatGPT.",
+      } as AIConnectionOffer,
+    ]);
+
+    render(<AIConnectionsSection />);
+
+    expect(
+      await screen.findByText(
+        "A Max plan or higher is required to use ChatGPT.",
+      ),
+    ).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -1,40 +1,60 @@
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
+import type { SetDefaultTransportRequest } from "@/app/api/__generated__/models/setDefaultTransportRequest";
+import type { SetDefaultTransportRequestAuthProvider } from "@/app/api/__generated__/models/setDefaultTransportRequestAuthProvider";
 
 /**
- * The label the server sends for the platform transport on a self-hosted
- * install. It sends "AutoGPT Platform" on the hosted product instead.
+ * The route to send when making a connection the default.
+ *
+ * The offer describes a connection; the default is set on the transport that
+ * runs it, which is keyed by provider and credential. ``offer_id`` is built
+ * server-side as ``{auth_provider}:{credential_id or "deployment"}``, so the
+ * provider is recoverable from it without the client deciding anything.
  */
-export const SELF_HOSTED_LABEL = "Self-hosted chat";
-
-/**
- * Says what backs a run, which is the thing that actually differs between
- * connections. Copy lives here only until the server-owned connection offer
- * carries it — the client should not be deciding how a provider describes
- * its own billing.
- */
-export function describeTransport(transport: ChatTransportResponse): string {
-  if (transport.auth_provider === "codex") {
-    return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
-  }
-  // The ChatGPT line promises "no AutoGPT credits", which only means anything
-  // if the row it contrasts with says credits are spent. Self-host has no
-  // credits at all, so it says what it actually has instead.
-  return transport.label === SELF_HOSTED_LABEL
-    ? "New chats are backed by the chat provider configured on this server."
-    : "New chats are backed by your AutoGPT plan, and spend AutoGPT credits.";
+export function routeOf(offer: AIConnectionOffer): SetDefaultTransportRequest {
+  return {
+    auth_provider: offer.offer_id.split(
+      ":",
+    )[0] as SetDefaultTransportRequestAuthProvider,
+    credential_id: offer.credential_id ?? null,
+  };
 }
 
-export function isSelectable(transport: ChatTransportResponse): boolean {
+/**
+ * Whether this connection can be chosen as the default.
+ *
+ * A locked offer is listed so the user can see it exists and what unlocks it,
+ * but it cannot be routed to, so it cannot be a default either.
+ */
+export function isSelectable(offer: AIConnectionOffer): boolean {
   return (
-    transport.available &&
-    (transport.auth_provider === "platform" || transport.credential_id !== null)
+    offer.selectable &&
+    (offer.auth_method === "deployment" || offer.credential_id !== null)
   );
 }
 
 /**
- * A stable key. The platform transport carries no credential id, and a user
- * can hold several ChatGPT accounts, so neither half identifies a row alone.
+ * Every connection worth showing, selectable or not.
+ *
+ * A locked one earns its place by explaining an absence the user would
+ * otherwise have to guess at.
  */
-export function transportKey(transport: ChatTransportResponse): string {
-  return `${transport.auth_provider}:${transport.credential_id ?? "deployment"}`;
+export function visibleOffers(
+  offers: AIConnectionOffer[] | undefined,
+): AIConnectionOffer[] {
+  return (offers ?? []).filter(
+    (offer) => isSelectable(offer) || Boolean(offer.lock_reason),
+  );
+}
+
+/**
+ * "Balanced: Sonnet 5 · Advanced: Opus 5".
+ *
+ * Empty when the server named no models, so the row omits the line rather
+ * than rendering half of one.
+ */
+export function tierSummary(offer: AIConnectionOffer): string {
+  const named = offer.tiers
+    .filter((tier) => tier.display_model)
+    .map((tier) => `${tier.label}: ${tier.display_model}`);
+  return named.join(" · ");
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -3,27 +3,34 @@
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
+  getGetV2ListChatConnectionsQueryKey,
   getGetV2ListChatTransportsQueryKey,
-  useGetV2ListChatTransports,
+  useGetV2ListChatConnections,
   usePutV2SetDefaultChatTransport,
 } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useGetV1ListCredentials } from "@/app/api/__generated__/endpoints/integrations/integrations";
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { toast } from "@/components/molecules/Toast/use-toast";
 
-import { isSelectable, transportKey } from "./helpers";
+import { routeOf, visibleOffers } from "./helpers";
 
 export function useAIConnectionsSection() {
   const queryClient = useQueryClient();
-  const transportsQuery = useGetV2ListChatTransports({
+
+  // The offers endpoint rather than transports: transports answers "what may
+  // run", which is enough to route a turn and not enough to render one. What
+  // a connection is called, what backs it, and which models each tier uses
+  // are product statements, and a client that derives them drifts from the
+  // server that enforces them.
+  const connectionsQuery = useGetV2ListChatConnections({
     query: { refetchOnWindowFocus: true },
   });
 
-  const transports: ChatTransportResponse[] =
-    transportsQuery.data?.status === 200
-      ? transportsQuery.data.data.transports
-      : [];
-  const connections = transports.filter(isSelectable);
+  const offers: AIConnectionOffer[] = visibleOffers(
+    connectionsQuery.data?.status === 200
+      ? connectionsQuery.data.data.offers
+      : undefined,
+  );
 
   // The account a connection runs as. Read from the stored credential rather
   // than asked of the provider: this is the identity the user linked, so it is
@@ -40,15 +47,21 @@ export function useAIConnectionsSection() {
       .map((credential) => [credential.id, credential.username as string]),
   );
 
-  function accountFor(transport: ChatTransportResponse): string | undefined {
-    if (!transport.credential_id) return undefined;
-    return accountByCredentialId.get(transport.credential_id);
+  function accountFor(offer: AIConnectionOffer): string | undefined {
+    if (!offer.credential_id) return undefined;
+    return accountByCredentialId.get(offer.credential_id);
   }
 
   const { mutateAsync: setDefault, isPending: isSaving } =
     usePutV2SetDefaultChatTransport({
       mutation: {
         onSuccess: () => {
+          // Both lists carry the default: offers renders it, transports
+          // routes it. Refreshing one and not the other leaves the screen
+          // disagreeing with what a new chat will actually do.
+          queryClient.invalidateQueries({
+            queryKey: getGetV2ListChatConnectionsQueryKey(),
+          });
           queryClient.invalidateQueries({
             queryKey: getGetV2ListChatTransportsQueryKey(),
           });
@@ -66,28 +79,22 @@ export function useAIConnectionsSection() {
 
   // Tracked separately from the query so the row the user clicked shows the
   // pending state, rather than every row going busy at once.
-  const selectedKey = connections.find((t) => t.default)
-    ? transportKey(connections.find((t) => t.default)!)
-    : null;
+  const selectedKey =
+    offers.find((offer) => offer.is_default)?.offer_id ?? null;
 
-  async function chooseDefault(transport: ChatTransportResponse) {
-    if (transport.default) return;
-    await setDefault({
-      data: {
-        auth_provider: transport.auth_provider,
-        credential_id: transport.credential_id,
-      },
-    });
+  async function chooseDefault(offer: AIConnectionOffer) {
+    if (offer.is_default) return;
+    await setDefault({ data: routeOf(offer) });
   }
 
   return {
-    connections,
+    connections: offers,
     accountFor,
     selectedKey,
     chooseDefault,
     isSaving,
-    isLoading: transportsQuery.isLoading,
-    isError: transportsQuery.isError,
-    refetch: transportsQuery.refetch,
+    isLoading: connectionsQuery.isLoading,
+    isError: connectionsQuery.isError,
+    refetch: connectionsQuery.refetch,
   };
 }


### PR DESCRIPTION
> Stacked on #14103 — review that first; this PR's diff is the frontend commit on top.

### Why

The AI Connections section in settings shipped in #14079, before the offers
endpoint existed (#14082). So it reads `/api/chat/transports`, which answers
*what may run* — enough to route a turn, not enough to render one — and then
composes its own product copy client-side. Its own helper said so:

```ts
// Copy lives here only until the server-owned connection offer carries it —
// the client should not be deciding how a provider describes its own billing.
function describeTransport(...)
```

Two consequences:

1. **The section can't show models.** A transport has no tiers, so there is
   nowhere to read "Balanced: Sonnet 5 · Advanced: Opus 5" from. That line is
   in Mock 1 of the PRD and is the visible gap between the design and settings.
2. **Two places describe the same product.** The composer picker already reads
   `/connections`; settings paraphrases the same connections from a different
   endpoint. Any pricing or naming change has to land in both, and the one in
   the client can't be enforced.

### What

The section reads `/api/chat/connections`. `describeTransport`, `transportKey`
and `SELF_HOSTED_LABEL` are deleted. Each row now renders the server's
`display_name` and `description`, the models behind each tier, and — when the
connection is locked — the reason.

| | before | after |
|---|---|---|
| source | `GET /chat/transports` | `GET /chat/connections` |
| name + description | composed in `describeTransport` | `offer.display_name` / `offer.description` |
| models | *not available* | `offer.tiers[].display_model` |
| locked connections | not listed | listed, unselectable, with `lock_reason` |

### How

Writes are unchanged: `PUT /chat/transports/default` still sets the default,
because offers *describes* a connection and transports *routes* it. The route
is recovered from `offer_id`, whose `{auth_provider}:{credential_id}` format
the server owns:

```ts
export function routeOf(offer: AIConnectionOffer): SetDefaultTransportRequest {
  return {
    auth_provider: offer.offer_id.split(":")[0] as SetDefaultTransportRequestAuthProvider,
    credential_id: offer.credential_id ?? null,
  };
}
```

Both query keys are invalidated after a write — offers renders the default,
transports routes it, and refreshing one without the other leaves the screen
disagreeing with what the next chat will actually do.

**One deliberate behaviour change.** A plan-locked ChatGPT connection now
appears in settings, because offers includes the upsell that transports never
carried. It renders unselectable with its `lock_reason`. This is the
"visible but locked" state the entitlement work exists to produce, but it is a
change to a shipped screen rather than a pure refactor — worth a look in
review rather than assuming it's incidental.

### Testing

The seven existing tests pass with their **assertions unchanged** — the useful
signal here, since the section is meant to behave exactly as it did. Three
added for what the migration unlocks:

- models named per tier on each row
- the description comes from the server, not from the client
- a locked connection is listed with what unlocks it

```
vitest run AIConnectionsSection  →  10 passed (10)
vitest run copilot IntegrationsPanel  →  142 files, 1649 passed
tsc --noEmit  →  clean
eslint --max-warnings 0  →  clean
```

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which API drives settings copy and default-selection UX, including newly visible locked connections; routing still depends on parsing `offer_id` for the unchanged PUT default endpoint.
> 
> **Overview**
> The Integrations **AI subscriptions** section now loads **`GET /chat/connections`** and types rows as **`AIConnectionOffer`**, aligning settings with the composer picker instead of **`GET /chat/transports`** and client-composed copy.
> 
> Rows show server-owned **`display_name`**, **`description`**, per-tier model lines via **`tierSummary`**, and **`lock_reason`** when a connection is plan-locked but listed for upsell. Selection keys and default state use **`offer_id`** and **`is_default`**; ChatGPT manage flows key off **`auth_method === "chatgpt_oauth`**. **`describeTransport`**, **`transportKey`**, and **`SELF_HOSTED_LABEL`** are removed.
> 
> Default writes stay on **`PUT /chat/transports/default`**, with **`routeOf`** deriving the transport from **`offer_id`**. After a successful default change, both connections and transports query keys are invalidated so the UI matches routing.
> 
> Tests mock the connections endpoint and add coverage for tier models, server descriptions, and locked connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9327684ce2e13d7ecd050625bc502563e0e0465f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->