### PR TITLE
feat(frontend): name the tools section in Integrations

### DIFF
--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState } from "react";
+
+import { Text } from "@/components/atoms/Text/Text";
+
 import { AIConnectionsSection } from "./components/AIConnectionsSection/AIConnectionsSection";
 import { ConnectServiceDialog } from "./components/ConnectServiceDialog/ConnectServiceDialog";
 import { IntegrationsHeader } from "./components/IntegrationsHeader/IntegrationsHeader";
@@ -20,7 +23,17 @@ export function IntegrationsPanel({ withHeading = true }: Props) {
         withTitle={withHeading}
       />
       <AIConnectionsSection />
-      <IntegrationsList />
+      <section aria-labelledby="tool-connections-heading">
+        <Text
+          variant="small-medium"
+          as="h2"
+          id="tool-connections-heading"
+          className="pb-3 pl-4 uppercase tracking-[0.06em] text-[#505057]"
+        >
+          Tools your agents use
+        </Text>
+        <IntegrationsList />
+      </section>
       <ConnectServiceDialog
         open={isConnectOpen}
         onOpenChange={setIsConnectOpen}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/__tests__/IntegrationsPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/__tests__/IntegrationsPanel.test.tsx
@@ -1,0 +1,36 @@
+import { getGetV2ListChatConnectionsMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { IntegrationsPanel } from "../IntegrationsPanel";
+
+describe("IntegrationsPanel", () => {
+  it("separates the subscriptions that pay for a chat from the tools a chat uses", async () => {
+    server.use(
+      getGetV2ListChatConnectionsMockHandler200({ offers: [] }),
+      getGetV1ListCredentialsMockHandler200([]),
+    );
+
+    render(<IntegrationsPanel />);
+
+    const headings = await screen.findAllByRole("heading", { level: 2 });
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      "AI subscriptions",
+      "Tools your agents use",
+    ]);
+  });
+
+  it("keeps the tools heading while the list is still loading", async () => {
+    // The heading names what the region is, so it should not appear only once
+    // the region has content -- the AI section above it behaves the same way.
+    server.use(getGetV2ListChatConnectionsMockHandler200({ offers: [] }));
+
+    render(<IntegrationsPanel />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Tools your agents use" }),
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
> Stacked on #14104 — review that first; this PR's diff is the one commit on top.

### Why

Mock 1 of the PRD splits Integrations into two labelled regions: **AI
subscriptions** (what pays for a chat) above **Tools your agents use** (what a
chat can reach). We built the first heading and not the second, so the
separation exists on one side of the line only — a reader arriving at the
connector list has to infer that these are a different kind of thing from the
two rows above, which is exactly the inference the section was added to spare
them.

### What

The connector list gets a heading, matching the treatment of the one above it.

### How

It lives in `IntegrationsPanel` rather than inside `IntegrationsList`, for one
reason: the list renders three different trees (loading, error, content), and
a heading that names a region should not disappear when the region is empty or
failed. The AI section above behaves the same way. The `<section>` wrapper
carries `aria-labelledby`, so the region is named for screen readers too, not
just visually.

### Testing

Two tests at the panel level, which is where the relationship between the two
regions is actually observable:

- both headings render, in order — this is the separation the PRD asks for
- the tools heading survives the list's loading state

```
vitest run IntegrationsPanel  →  13 files, 84 passed
tsc --noEmit / eslint --max-warnings 0  →  clean
```

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational Integrations UI and accessibility labelling only, with no API or auth changes.
> 
> **Overview**
> Adds a labelled **Tools your agents use** region in `IntegrationsPanel`, parallel to the existing **AI subscriptions** block, so Integrations reads as two distinct areas instead of an unlabeled connector list.
> 
> The heading and a `<section aria-labelledby="…">` wrapper sit in the panel (not inside `IntegrationsList`) so the title stays visible while the list is loading, empty, or in error. Styling uses the shared `Text` atom as an `h2`, consistent with the section above.
> 
> New panel-level Vitest coverage asserts both `h2` headings render in order and that the tools heading is present during list loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f46d2890de3d3d4cabe58ea536e1c16f0b10a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->