### PR TITLE
fix(backend): name a tier's model when the slug carries a vendor prefix

### DIFF
--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -102,7 +102,7 @@ _CODEX_PREFERRED_EFFORTS: dict[tuple[ModelMode, ModelTier], CodexReasoningEffort
 }
 
 
-def _catalog_lookup(slug: str) -> llm_registry.RegistryModel | None:
+def catalog_lookup(slug: str) -> llm_registry.RegistryModel | None:
     """Look up *slug* in the catalog, tolerating transport spellings.
 
     The catalog registers Claude models under bare canonical enum slugs
@@ -161,7 +161,7 @@ async def _registry_refuses(slug: str, layer: RoutingSource) -> str | None:
                 "gating are inactive"
             )
         return None
-    model = _catalog_lookup(slug)
+    model = catalog_lookup(slug)
     if model is None:
         reason = "unknown to the model registry"
     elif not model.is_enabled:
@@ -434,7 +434,7 @@ def _resolved_codex_model(
 def _codex_catalog_allows(slug: str) -> bool:
     if not llm_registry.has_models():
         return True
-    model = _catalog_lookup(slug)
+    model = catalog_lookup(slug)
     return bool(
         model is not None and model.is_enabled and model.metadata.provider == "openai"
     )
@@ -443,7 +443,7 @@ def _codex_catalog_allows(slug: str) -> bool:
 def _codex_account_fallback_allowed(slug: str) -> bool:
     if not llm_registry.has_models():
         return True
-    model = _catalog_lookup(slug)
+    model = catalog_lookup(slug)
     if model is None:
         return True
     return model.is_enabled and model.metadata.provider == "openai"

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel
 
 from backend.copilot.config import ChatConfig, CopilotLlmAuthProvider, CopilotLLMModel
 from backend.copilot.engine import resolve_use_sdk
-from backend.copilot.model_router import ROUTE_SURFACE_CODEX, resolve_model_route
+from backend.copilot.model_router import (
+    ROUTE_SURFACE_CODEX,
+    catalog_lookup,
+    resolve_model_route,
+)
 from backend.copilot.transports import (
     ChatTransportResponse,
     get_chat_transports,
@@ -236,12 +240,19 @@ def _display_name(slug: str | None) -> str | None:
 
     The PRD labels tiers "Balanced · 5.6 Terra", not
     "Balanced · gpt-5.6-terra": the slug is a routing key and reads as one.
-    Falls back to the slug when the registry has no entry, which is better
-    than showing nothing.
+
+    Goes through the router's lookup rather than the catalog directly,
+    because the slug arrives in whatever spelling configured it. The default
+    configuration routes through OpenRouter, whose provider-prefixed forms
+    (``anthropic/claude-sonnet-5``) the catalog does not use as keys -- so a
+    direct read misses on exactly the setup most deployments run.
+
+    Falls back to the slug when nothing resolves, which is better than
+    showing nothing for a model the catalog has never heard of.
     """
     if not slug:
         return None
-    model = llm_registry.get_model(slug)
+    model = catalog_lookup(slug)
     return model.display_name if model else slug
 
 

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -9,6 +9,7 @@ import pytest_mock
 from backend.copilot import offers, transports
 from backend.copilot.offers import get_connection_offers, offer_id_for
 from backend.copilot.transports import ChatTransportResponse
+from backend.data.llm_registry import registry
 from backend.util.settings import BehaveAs
 
 USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
@@ -436,3 +437,75 @@ async def test_a_locked_chatgpt_offer_still_names_the_models(
     # Naming them must not read as offering them.
     assert all(t.selectable is False for t in locked.tiers)
     assert locked.selectable is False
+
+
+@pytest.fixture
+def real_catalog():
+    """The other tests here run against an empty registry and assert the
+    slug fallback. These two are about resolution, so they need the catalog
+    actually loaded -- and must put it back, since it is process state."""
+    old = (
+        registry._dynamic_models,
+        registry._date_stripped_models,
+        registry._routes,
+        registry._loaded,
+    )
+    registry.load_catalog()
+    yield
+    (
+        registry._dynamic_models,
+        registry._date_stripped_models,
+        registry._routes,
+        registry._loaded,
+    ) = old
+
+
+@pytest.mark.asyncio
+async def test_a_platform_tier_names_a_model_configured_in_transport_spelling(
+    real_catalog,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """The default configuration routes through OpenRouter, whose slugs carry a
+    provider prefix the catalog does not use. Naming the model has to survive
+    that, or the row reads as a routing key on every deployment that took the
+    default."""
+    _mock_transports(mocker, [_transport(default=True)])
+    mocker.patch.object(
+        offers,
+        "resolve_model_route",
+        new=AsyncMock(
+            side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
+                model="anthropic/claude-sonnet-5", source="config"
+            )
+        ),
+    )
+
+    offer = (await get_connection_offers(USER_ID))[0]
+
+    assert [tier.display_model for tier in offer.tiers] == [
+        "Claude Sonnet 5",
+        "Claude Sonnet 5",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_model_the_catalog_does_not_know_is_named_by_its_slug(
+    real_catalog,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """A deployment may point a tier at anything. Showing the slug is worse than
+    showing a name and better than showing nothing."""
+    _mock_transports(mocker, [_transport(default=True)])
+    mocker.patch.object(
+        offers,
+        "resolve_model_route",
+        new=AsyncMock(
+            side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
+                model="a-model-nobody-has-heard-of", source="config"
+            )
+        ),
+    )
+
+    offer = (await get_connection_offers(USER_ID))[0]
+
+    assert offer.tiers[0].display_model == "a-model-nobody-has-heard-of"


### PR DESCRIPTION
> Stacked on #14105 — review that first; this PR's diff is the one commit on top.

Found by looking at the screen, not by a failing test.

### Why

Settings renders the platform connection as:

> Balanced: **anthropic/claude-sonnet-5** · Advanced: **anthropic/claude-opus-4-8**

and the ChatGPT row directly above it as:

> Balanced: **GPT-5.6 Terra** · Advanced: **GPT-5.6 Sol**

Same line, same helper, one of them printing a routing key at the user. The
difference is how each row reaches the catalog. The codex row passes the
catalog's own routing-cell slug, which is bare and hits. The platform row
passes whatever resolved the route — and since `use_openrouter` defaults to
true, that is an OpenRouter slug carrying a vendor prefix the catalog does not
use as a key. `get_model()` misses, and `_display_name` falls back to the slug.

So this is not an edge case: it is what the **default** configuration shows.

### What

`_display_name` resolves through `catalog_lookup` instead of reading the
registry directly.

### How

`model_router` already had this problem and already solved it. `catalog_lookup`
tries the exact slug, then the vendor-stripped tail, then the dots→dashes form,
then the date-stripped index, then the enum's aliases. It was private, so
`offers` reached past it to the raw registry and reintroduced the spelling
problem the helper exists to absorb. This makes it public and uses it — one
resolver, so a spelling accepted when *routing* a turn cannot be refused when
*describing* it.

A model the catalog has never heard of still shows its slug. For a deployment
pointing a tier at something unlisted that is the honest answer, and the second
test pins it so a future change doesn't turn it into a blank.

### Testing

Both new tests load the real catalog and restore it afterwards. Worth knowing
for anyone extending this file: every other test here runs against an *empty*
registry and therefore asserts the fallback path — resolution is only
observable with the catalog actually loaded, which is why my first attempt at
these tests passed the fix and still failed.

```
pytest backend/copilot/offers_test.py  →  25 passed
```

**Pre-existing failures, not from this change.** `model_router_test.py` has 8
failures (`TestRegistryGating`, `TestEnvFloorIncidentPath`) about dot-vs-dash
slug spellings. They reproduce with this branch's changes stashed, and no
commit in this stack touches `model_router.py`, `model_router_test.py`, or
`data/llm_registry/` — verified with `git log origin/dev..HEAD -- <those
paths>`, which is empty. They arrive from `dev`. Flagging because this PR does
touch `model_router.py` and a reviewer running that file will see red.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in connection offers plus exposing an existing lookup helper; no routing or auth behavior changes.
> 
> **Overview**
> **Connection settings** were showing raw routing slugs (e.g. `anthropic/claude-sonnet-5`) on the platform row while ChatGPT tiers showed friendly catalog names, because tier labels used `llm_registry.get_model(slug)` on the resolved route slug.
> 
> **`_display_name` in `offers.py`** now resolves through **`catalog_lookup`** from `model_router`, which already normalizes transport spellings (vendor prefix, dots/dashes, aliases). **`_catalog_lookup` is renamed to public `catalog_lookup`** so naming and routing share one resolver.
> 
> **Tests** add a `real_catalog` fixture plus coverage for OpenRouter-style slugs mapping to display names and unknown models still falling back to the slug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e896b62195ddf9b007b3bfe47c5c11d3f8bd21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->