### PR TITLE
feat(platform): make the route picker the design Mock 3 asks for

### DIFF
--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -248,12 +248,18 @@ def _display_name(slug: str | None) -> str | None:
     direct read misses on exactly the setup most deployments run.
 
     Falls back to the slug when nothing resolves, which is better than
-    showing nothing for a model the catalog has never heard of.
+    showing nothing for a model the catalog has never heard of -- minus the
+    vendor prefix, which is how the transport addresses the model and carries
+    nothing for the reader. Keeping it costs ten characters in a control that
+    has to fit two of these side by side, and spends them on the one part of
+    the string that cannot tell anyone anything.
     """
     if not slug:
         return None
     model = catalog_lookup(slug)
-    return model.display_name if model else slug
+    if model:
+        return model.display_name
+    return slug.split("/", 1)[1] if "/" in slug else slug
 
 
 def _codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -494,14 +494,15 @@ async def test_a_model_the_catalog_does_not_know_is_named_by_its_slug(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """A deployment may point a tier at anything. Showing the slug is worse than
-    showing a name and better than showing nothing."""
+    showing a name and better than showing nothing -- without the vendor
+    prefix, which is addressing rather than identity."""
     _mock_transports(mocker, [_transport(default=True)])
     mocker.patch.object(
         offers,
         "resolve_model_route",
         new=AsyncMock(
             side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
-                model="a-model-nobody-has-heard-of", source="config"
+                model="acme/a-model-nobody-has-heard-of", source="config"
             )
         ),
     )

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
@@ -64,7 +64,9 @@ export function ChoiceRow({
       </span>
       <span className="flex min-w-0 flex-col">
         <span className="flex items-center gap-1.5">
-          <span className="text-xs font-medium text-foreground">{title}</span>
+          <span className="text-[13px] font-semibold text-foreground">
+            {title}
+          </span>
           {badge && (
             <span className="rounded-full bg-green-500/10 px-1.5 py-px text-[10px] font-medium text-green-700">
               {badge}
@@ -110,7 +112,7 @@ function LockedRow({ title, subtitle, lock }: LockedProps) {
         className="mt-[3px] flex-none text-muted-foreground/70"
       />
       <span className="flex min-w-0 flex-col">
-        <span className="text-xs font-medium text-muted-foreground">
+        <span className="text-[13px] font-semibold text-muted-foreground">
           {title}
         </span>
         {subtitle && (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
@@ -2,7 +2,9 @@
 
 import { cn } from "@/lib/utils";
 import Link from "next/link";
-import { PiLockSimple as LockIcon } from "react-icons/pi";
+import { LockIcon } from "@hugeicons/core-free-icons";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
 
 interface Props {
   title: string;
@@ -101,7 +103,8 @@ interface LockedProps {
 function LockedRow({ title, subtitle, lock }: LockedProps) {
   return (
     <div className="flex items-start gap-2.5 px-3 py-2">
-      <LockIcon
+      <Icon
+        icon={LockIcon}
         size={14}
         aria-hidden
         className="mt-[3px] flex-none text-muted-foreground/70"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ConnectionPicker.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ConnectionPicker.tsx
@@ -5,23 +5,26 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
-import Link from "next/link";
 import {
-  PiCaretDown as CaretDownIcon,
-  PiKey as KeyIcon,
-  PiWarningCircle as WarningCircleIcon,
-} from "react-icons/pi";
+  AlertCircleIcon,
+  ArrowDown01Icon,
+  KeyIcon,
+} from "@hugeicons/core-free-icons";
+import Link from "next/link";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { cn } from "@/lib/utils";
 
 import { ChoiceRow } from "./ChoiceRow";
 import {
   isLinkedAccount,
   offerSubtitle,
   tierLabel,
-  tierModel,
   tierName,
   tierLock,
   tierSummary,
 } from "./helpers";
+import { TierToggle } from "./TierToggle";
 import { useConnectionPicker } from "./useConnectionPicker";
 
 const TIERS = ["standard", "advanced"] as const;
@@ -63,7 +66,7 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
         aria-label="AI connections unavailable"
         className="ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border border-destructive/20 bg-destructive/10 px-2.5 text-xs font-medium text-destructive"
       >
-        <WarningCircleIcon size={14} />
+        <Icon icon={AlertCircleIcon} size={14} />
         <span className="hidden sm:inline">Connections unavailable</span>
       </span>
     );
@@ -76,7 +79,7 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
         aria-label="Set up an AI connection"
         className="ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/80"
       >
-        <WarningCircleIcon size={14} />
+        <Icon icon={AlertCircleIcon} size={14} />
         <span className="hidden sm:inline">Set up AI connection</span>
       </Link>
     );
@@ -87,9 +90,15 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
   // the same model.
   if (!showTiers && (connectionLocked || offers.length === 1)) return null;
 
+  const runsOnOwnPlan = active ? isLinkedAccount(active) : false;
   const label = connectionLocked
     ? tierName(active, tier)
     : (active?.display_name ?? "Choose connection");
+  // "ChatGPT · your plan". Spending your own subscription rather than the
+  // platform's is the thing worth noticing before sending, so the chip says
+  // so and carries the accent that goes with it.
+  const triggerLabel =
+    runsOnOwnPlan && !connectionLocked ? `${label} · your plan` : label;
 
   return (
     <DropdownMenu>
@@ -99,17 +108,29 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
           aria-label={
             connectionLocked
               ? `Model tier ${label} — change`
-              : `Runs on ${label} — change`
+              : `Runs on ${triggerLabel} — change`
           }
-          className="ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border border-border bg-background px-2.5 text-xs font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+          className={cn(
+            "ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium shadow-sm transition-colors",
+            runsOnOwnPlan && !connectionLocked
+              ? "border-accent/40 bg-accent/5 text-accent hover:bg-accent/10"
+              : "border-border bg-background text-foreground hover:bg-muted",
+          )}
         >
-          <KeyIcon size={14} />
-          <span className="hidden sm:inline">{label}</span>
-          <CaretDownIcon size={12} className="text-muted-foreground" />
+          <Icon icon={KeyIcon} size={14} />
+          <span className="hidden sm:inline">{triggerLabel}</span>
+          <Icon
+            icon={ArrowDown01Icon}
+            size={12}
+            className="text-muted-foreground"
+          />
         </button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start" className="w-80 p-0">
+      <DropdownMenuContent
+        align="start"
+        className="w-[26rem] max-w-[calc(100vw-2rem)] p-0"
+      >
         {!connectionLocked && (
           <>
             <SectionLabel>Runs on</SectionLabel>
@@ -142,19 +163,15 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
         {showTiers && (
           <>
             <SectionLabel>Model tier</SectionLabel>
-            <div role="radiogroup" aria-label="Model tier">
-              {TIERS.map((candidate) => (
-                <ChoiceRow
-                  key={candidate}
-                  title={tierName(active, candidate)}
-                  subtitle={tierModel(active, candidate) ?? undefined}
-                  label={tierLabel(active, candidate)}
-                  isSelected={tier === candidate}
-                  onSelect={() => setTier(candidate)}
-                  lock={tierLock(active, candidate)}
-                />
-              ))}
-            </div>
+            <TierToggle
+              value={tier}
+              onSelect={setTier}
+              segments={TIERS.map((candidate) => ({
+                tier: candidate,
+                label: tierLabel(active, candidate),
+                lock: tierLock(active, candidate),
+              }))}
+            />
           </>
         )}
       </DropdownMenuContent>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/TierToggle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/TierToggle.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { LockIcon } from "@hugeicons/core-free-icons";
+import Link from "next/link";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { cn } from "@/lib/utils";
+
+import type { CopilotLlmModel } from "../../../../store";
+
+interface Segment {
+  tier: CopilotLlmModel;
+  /** "Balanced · Claude Sonnet 5" — the tier and the model it resolves to. */
+  label: string;
+  lock?: { reason: string; href: string | null };
+}
+
+interface Props {
+  segments: Segment[];
+  value: CopilotLlmModel;
+  onSelect: (tier: CopilotLlmModel) => void;
+}
+
+/**
+ * The two tiers side by side, as one control rather than a list of choices.
+ *
+ * A list reads as "here are some options"; a segmented control reads as "it is
+ * one of these two", which is the shape of the decision — there is no third
+ * tier, because absorbing that complexity is what having tiers is for.
+ *
+ * Each segment names its model inline. That only fits because the model now
+ * arrives as a display name rather than a routing slug; while a tier read
+ * "anthropic/claude-sonnet-5" the label had to wrap onto a second line.
+ */
+export function TierToggle({ segments, value, onSelect }: Props) {
+  const locked = segments.filter((segment) => segment.lock);
+
+  return (
+    <div className="mb-3 mt-1 flex flex-col gap-1.5 px-3">
+      <div
+        role="radiogroup"
+        aria-label="Model tier"
+        className="flex items-stretch gap-1 rounded-full bg-muted/70 p-1"
+      >
+        {segments.map((segment) =>
+          segment.lock ? (
+            <LockedSegment key={segment.tier} segment={segment} />
+          ) : (
+            <button
+              key={segment.tier}
+              type="button"
+              role="radio"
+              aria-checked={segment.tier === value}
+              onClick={() => onSelect(segment.tier)}
+              className={cn(
+                "min-w-0 flex-1 truncate rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                segment.tier === value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {segment.label}
+            </button>
+          ),
+        )}
+      </div>
+
+      {/* A segment has room for the lock but not for why. Saying only "locked"
+          would leave the user to guess at a barrier they can actually clear. */}
+      {locked.map((segment) => (
+        <p
+          key={segment.tier}
+          className="px-1 text-[11px] leading-snug text-muted-foreground/80"
+        >
+          {segment.lock?.reason}{" "}
+          {segment.lock?.href && (
+            <Link
+              href={segment.lock.href}
+              className="font-medium text-accent underline-offset-2 hover:underline"
+            >
+              See plans
+            </Link>
+          )}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A tier the plan excludes. Not a radio: choosing it is not among the things
+ * that can happen, so it shows the barrier and leaves the action to the line
+ * below, which has room to say what the barrier is.
+ */
+function LockedSegment({ segment }: { segment: Segment }) {
+  return (
+    <span
+      aria-disabled
+      aria-label={`${segment.label} — ${segment.lock?.reason ?? "unavailable"}`}
+      className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-full px-3 py-1.5 text-[11px] font-medium text-muted-foreground/70"
+    >
+      <Icon icon={LockIcon} size={11} aria-hidden className="flex-none" />
+      <span className="truncate">{segment.label}</span>
+    </span>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
@@ -133,9 +133,11 @@ describe("ConnectionPicker", () => {
     ).toBeDefined();
   });
 
-  it("gives the model its own line so a long name stays readable", async () => {
-    // The model is the reason the tier row exists; sharing one line with the
-    // label truncates it away on any realistic model id.
+  it("names the model inside each tier segment", async () => {
+    // The model is the reason the tier control exists, so it is on the control
+    // rather than a line under it. This fits only because the model arrives as
+    // a display name; while it arrived as "anthropic/claude-sonnet-5" the label
+    // had to wrap, which is why this once asserted a separate line.
     mockOffers([offer(), chatgpt()]);
 
     render(<ConnectionPicker />);
@@ -143,8 +145,13 @@ describe("ConnectionPicker", () => {
       await screen.findByRole("button", { name: /Runs on/ }),
     );
 
-    expect(await screen.findByText("sonnet-5")).toBeDefined();
-    expect(screen.getByText("opus-5")).toBeDefined();
+    const tiers = await screen.findByRole("radiogroup", { name: "Model tier" });
+    expect(
+      within(tiers).getByRole("radio", { name: "Balanced · sonnet-5" }),
+    ).toBeDefined();
+    expect(
+      within(tiers).getByRole("radio", { name: "Advanced · opus-5" }),
+    ).toBeDefined();
   });
 
   it("puts the chosen tier in the store", async () => {
@@ -450,13 +457,13 @@ describe("ConnectionPicker", () => {
     );
 
     expect(
-      await screen.findByText("A Max plan or higher is required for Advanced."),
+      await screen.findByText(/A Max plan or higher is required for Advanced/),
     ).toBeDefined();
-    // Still named, so the user sees what they would get.
-    expect(screen.getByText("opus-5")).toBeDefined();
-    // Scoped to the tier group: the connection row's own name now contains
-    // "Advanced: opus-5" from its tier summary, so a page-wide query matches it.
+    // Still named, so the user sees what they would get. Scoped to the tier
+    // control: the connection row's own summary also mentions Advanced.
     const tierGroup = screen.getByRole("radiogroup", { name: "Model tier" });
+    expect(within(tierGroup).getByText(/opus-5/)).toBeDefined();
+    // Named, but not offered as a choice that cannot happen.
     expect(
       within(tierGroup).queryByRole("radio", { name: /Advanced/ }),
     ).toBeNull();
@@ -471,5 +478,28 @@ describe("ConnectionPicker", () => {
     expect(
       await screen.findByLabelText("AI connections unavailable"),
     ).toBeDefined();
+  });
+
+  it("says whose plan pays when the answer is the user's own", async () => {
+    // The point of labelling by payer is that spending your own subscription
+    // is worth noticing before you send, not after.
+    mockOffers([offer({ is_default: false }), chatgpt({ is_default: true })]);
+
+    render(<ConnectionPicker />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: /Runs on ChatGPT . your plan/,
+      }),
+    ).toBeDefined();
+  });
+
+  it("does not claim a platform connection is the user's own plan", async () => {
+    mockOffers([offer({ is_default: true }), chatgpt({ is_default: false })]);
+
+    render(<ConnectionPicker />);
+
+    const trigger = await screen.findByRole("button", { name: /Runs on/ });
+    expect(trigger.getAttribute("aria-label")).not.toMatch(/your plan/);
   });
 });


### PR DESCRIPTION
> Stacked on #14106 — review that first; this PR's diff is the three commits on top.

Opened because Nick spotted that the picker we shipped and Mock 3 in the PRD
are different designs. They are, and the reason turned out to be a bug.

### Why

Mock 3 puts the two tiers **side by side in one segmented control**, each
segment reading `Balanced · 5.6 Terra`. We shipped a vertical list of radios
with the model on a second line underneath.

That divergence was mine, and I introduced it for a reason that was itself a
defect. The model went onto its own line after side-by-side labels truncated on
a real deployment — but what was truncating was `anthropic/claude-sonnet-5`, a
routing slug being displayed because `offers` read the registry directly
instead of through the router's spelling-tolerant lookup. #14106 fixed that.
With the label now reading `Claude Sonnet 5`, the mock's layout fits.

So the "design decision" was a bug wearing a design decision's clothes, and it
stayed in the codebase as a test asserting the wrong thing:

```
it("gives the model its own line so a long name stays readable")
```

### What

| | before | after (Mock 3) |
|---|---|---|
| tier control | vertical radio list, model on line 2 | one segmented control, `Balanced · Claude Sonnet 5` inline |
| panel width | `w-80` (320px) | `w-[26rem]`, capped at the viewport |
| trigger, on your own subscription | `Self-hosted chat` in neutral grey | `ChatGPT · your plan` in the accent |
| unresolvable model | `anthropic/claude-opus-4-8` | `claude-opus-4-8` |
| row title | `text-xs` medium, near the weight of the two muted lines under it | `13px` semibold, so the row reads as a name with detail beneath |

### How

**Where I did not follow the mock.** It compresses a locked tier to a padlock
and a `Max` chip, which tells the user they are blocked but not what would
unblock them. The segment shows the lock; the line beneath it says why and
links to plans. A barrier the user can actually clear is worth a sentence.

**The second commit came straight out of looking at it.** Building the
segmented control gave the label a width budget, and the unresolved fallback
blew it immediately — `Advanced · anthropic/claude-…`, the exact failure the
vertical layout had been working around. Ten of those characters are
`anthropic/`, which is how the transport addresses the model and tells the
reader nothing; the part that carries information is what got truncated. An
unresolved slug now shows its tail. It only arises when the catalog has never
heard of the model, which is how this deployment surfaced it — a tier pointed
at `claude-opus-4-8` while the catalog stops at `4-7`.

**Icons.** This folder is now Hugeicons through the `Icon` atom, matching the
rest of `ChatInput` and the frontend guide. The `react-icons` imports were
mine, from earlier in this stack.

**Accent, not primary.** The first cut used `text-primary` for the chip.
`--primary` is `240 5.9% 10%` — near-black — so the emphasis would have been
invisible and the chip would have looked exactly like its own unemphasized
state. `--accent` (`262 83% 58%`) is the violet the mock uses.

### Testing

Verified on a single-container build, which is where both the truncation and
the near-black chip would have shown up and no test would have.

- 22 tests in `ConnectionPicker.test.tsx`, including two rewritten ones
- the model-on-its-own-line test is replaced by one pinning the invariant it
  was really about: **the model is named on the tier control**
- the locked-tier test still pins that the reason stays visible and that a
  locked tier is not offered as a radio
- 2 new tests for the trigger: it says `· your plan` on a linked account and
  does not claim it for a platform connection

```
vitest run ConnectionPicker  →  22 passed
vitest run copilot           →  130 files, 1569 passed
pytest backend/copilot/offers_test.py  →  25 passed
tsc --noEmit / eslint --max-warnings 0 →  clean
```

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copilot UI and display-string formatting only; no routing, auth, or billing enforcement changes.
> 
> **Overview**
> Aligns the copilot **connection picker** with Mock 3: model tiers are a **horizontal segmented control** (`Balanced · {display model}`) instead of a vertical radio list with the model on a second line. The dropdown is wider; row titles use **13px semibold**; icons move to **Hugeicons** via the shared `Icon` atom.
> 
> When the active connection is a **linked ChatGPT account**, the trigger shows **`{name} · your plan`** with accent styling so users see they are spending their own subscription before sending.
> 
> On the backend, **`_display_name`** still prefers catalog names but, for unknown slugs, **drops the vendor prefix** (e.g. `acme/foo` → `foo`) so inline tier labels fit the segmented control without truncating routing noise.
> 
> Locked tiers stay visible: the segment shows a lock; a line below explains why and links to plans. Tests cover the new layout, slug fallback, and trigger copy for linked vs platform connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9414fa653657be4534d01ea1c1dc3abc58ad5ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->