### PR TITLE
fix(keysmith): handle None and non-string inputs safely in verify_key

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/api_key/keysmith.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/api_key/keysmith.py
@@ -40,7 +40,11 @@ class APIKeySmith:
         Verify an API key against a known hash (+ salt).
         Supports verifying both legacy SHA256 and secure Scrypt hashes.
         """
-        if not provided_key or not isinstance(provided_key, str) or not provided_key.startswith(self.PREFIX):
+        if (
+            not provided_key
+            or not isinstance(provided_key, str)
+            or not provided_key.startswith(self.PREFIX)
+        ):
             return False
 
         if not known_hash or not isinstance(known_hash, str):

--- a/autogpt_platform/autogpt_libs/autogpt_libs/api_key/keysmith.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/api_key/keysmith.py
@@ -40,7 +40,10 @@ class APIKeySmith:
         Verify an API key against a known hash (+ salt).
         Supports verifying both legacy SHA256 and secure Scrypt hashes.
         """
-        if not provided_key.startswith(self.PREFIX):
+        if not provided_key or not isinstance(provided_key, str) or not provided_key.startswith(self.PREFIX):
+            return False
+
+        if not known_hash or not isinstance(known_hash, str):
             return False
 
         # Handle legacy SHA256 hashes (migration support)

--- a/autogpt_platform/autogpt_libs/autogpt_libs/api_key/test_keysmith.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/api_key/test_keysmith.py
@@ -77,3 +77,15 @@ def test_invalid_salt_format():
 
     # Invalid salt format should fail gracefully
     assert keysmith.verify_key(key.key, key.hash, "invalid_hex") is False
+
+
+def test_verify_key_none_and_type_safety():
+    keysmith = APIKeySmith()
+    key = keysmith.generate_key()
+
+    # Test None and non-string inputs fail gracefully without raising AttributeError
+    assert keysmith.verify_key(None, key.hash, key.salt) is False
+    assert keysmith.verify_key(12345, key.hash, key.salt) is False
+    assert keysmith.verify_key(key.key, None, key.salt) is False
+    assert keysmith.verify_key(key.key, None) is False
+

--- a/autogpt_platform/autogpt_libs/autogpt_libs/api_key/test_keysmith.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/api_key/test_keysmith.py
@@ -83,9 +83,12 @@ def test_verify_key_none_and_type_safety():
     keysmith = APIKeySmith()
     key = keysmith.generate_key()
 
-    # Test None and non-string inputs fail gracefully without raising AttributeError
+    # Test None and non-string inputs fail gracefully without raising AttributeError or TypeError
     assert keysmith.verify_key(None, key.hash, key.salt) is False
     assert keysmith.verify_key(12345, key.hash, key.salt) is False
     assert keysmith.verify_key(key.key, None, key.salt) is False
     assert keysmith.verify_key(key.key, None) is False
+    assert keysmith.verify_key(key.key, 12345, key.salt) is False
+    assert keysmith.verify_key(key.key, 12345) is False
+
 


### PR DESCRIPTION
## Summary

Improves input validation and type safety in `APIKeySmith.verify_key()`:
- Gracefully handles `None` and non-string types for `provided_key` and `known_hash`, returning `False` instead of raising unhandled `AttributeError` or `TypeError`.
- Added unit test `test_verify_key_none_and_type_safety` in `test_keysmith.py`.

## Motivation

When incoming API requests contain missing or invalid authorization headers (such as `None` or non-string values passed to authentication dependencies), `verify_key()` previously called `.startswith()` on `provided_key` directly, causing an unhandled `AttributeError` server error rather than returning a clean `401 Unauthorized`.

## Changes

- `autogpt_platform/autogpt_libs/autogpt_libs/api_key/keysmith.py`: Added checks for `provided_key` and `known_hash` validity before prefix matching and hash comparison.
- `autogpt_platform/autogpt_libs/autogpt_libs/api_key/test_keysmith.py`: Added unit test asserting graceful failure on `None` and integer inputs.

## Tests

- Added `test_verify_key_none_and_type_safety`.
