### PR TITLE
feat(frontend): describe the Integrations page as what it now holds

### DIFF
--- a/autogpt_platform/backend/backend/copilot/model_router.py
+++ b/autogpt_platform/backend/backend/copilot/model_router.py
@@ -102,7 +102,7 @@ _CODEX_PREFERRED_EFFORTS: dict[tuple[ModelMode, ModelTier], CodexReasoningEffort
 }
 
 
-def _catalog_lookup(slug: str) -> llm_registry.RegistryModel | None:
+def catalog_lookup(slug: str) -> llm_registry.RegistryModel | None:
     """Look up *slug* in the catalog, tolerating transport spellings.
 
     The catalog registers Claude models under bare canonical enum slugs
@@ -161,7 +161,7 @@ async def _registry_refuses(slug: str, layer: RoutingSource) -> str | None:
                 "gating are inactive"
             )
         return None
-    model = _catalog_lookup(slug)
+    model = catalog_lookup(slug)
     if model is None:
         reason = "unknown to the model registry"
     elif not model.is_enabled:
@@ -434,7 +434,7 @@ def _resolved_codex_model(
 def _codex_catalog_allows(slug: str) -> bool:
     if not llm_registry.has_models():
         return True
-    model = _catalog_lookup(slug)
+    model = catalog_lookup(slug)
     return bool(
         model is not None and model.is_enabled and model.metadata.provider == "openai"
     )
@@ -443,7 +443,7 @@ def _codex_catalog_allows(slug: str) -> bool:
 def _codex_account_fallback_allowed(slug: str) -> bool:
     if not llm_registry.has_models():
         return True
-    model = _catalog_lookup(slug)
+    model = catalog_lookup(slug)
     if model is None:
         return True
     return model.is_enabled and model.metadata.provider == "openai"

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -257,12 +257,18 @@ def _display_name(slug: str | None) -> str | None:
     direct read misses on exactly the setup most deployments run.
 
     Falls back to the slug when nothing resolves, which is better than
-    showing nothing for a model the catalog has never heard of.
+    showing nothing for a model the catalog has never heard of -- minus the
+    vendor prefix, which is how the transport addresses the model and carries
+    nothing for the reader. Keeping it costs ten characters in a control that
+    has to fit two of these side by side, and spends them on the one part of
+    the string that cannot tell anyone anything.
     """
     if not slug:
         return None
     model = catalog_lookup(slug)
-    return model.display_name if model else slug
+    if model:
+        return model.display_name
+    return slug.split("/", 1)[1] if "/" in slug else slug
 
 
 def _codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -19,6 +19,7 @@ from backend.copilot.engine import resolve_use_sdk
 from backend.copilot.model_router import (
     ROUTE_SURFACE_CODEX,
     ModelMode,
+    catalog_lookup,
     resolve_model_route,
 )
 from backend.copilot.transports import (
@@ -248,12 +249,19 @@ def _display_name(slug: str | None) -> str | None:
 
     The PRD labels tiers "Balanced · 5.6 Terra", not
     "Balanced · gpt-5.6-terra": the slug is a routing key and reads as one.
-    Falls back to the slug when the registry has no entry, which is better
-    than showing nothing.
+
+    Goes through the router's lookup rather than the catalog directly,
+    because the slug arrives in whatever spelling configured it. The default
+    configuration routes through OpenRouter, whose provider-prefixed forms
+    (``anthropic/claude-sonnet-5``) the catalog does not use as keys -- so a
+    direct read misses on exactly the setup most deployments run.
+
+    Falls back to the slug when nothing resolves, which is better than
+    showing nothing for a model the catalog has never heard of.
     """
     if not slug:
         return None
-    model = llm_registry.get_model(slug)
+    model = catalog_lookup(slug)
     return model.display_name if model else slug
 
 

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -508,14 +508,15 @@ async def test_a_model_the_catalog_does_not_know_is_named_by_its_slug(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """A deployment may point a tier at anything. Showing the slug is worse than
-    showing a name and better than showing nothing."""
+    showing a name and better than showing nothing -- without the vendor
+    prefix, which is addressing rather than identity."""
     _mock_transports(mocker, [_transport(default=True)])
     mocker.patch.object(
         offers,
         "resolve_model_route",
         new=AsyncMock(
             side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
-                model="a-model-nobody-has-heard-of", source="config"
+                model="acme/a-model-nobody-has-heard-of", source="config"
             )
         ),
     )

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -9,6 +9,7 @@ import pytest_mock
 from backend.copilot import offers, transports
 from backend.copilot.offers import get_connection_offers, offer_id_for
 from backend.copilot.transports import ChatTransportResponse
+from backend.data.llm_registry import registry
 from backend.util.settings import BehaveAs
 
 USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
@@ -450,3 +451,75 @@ async def test_a_locked_chatgpt_offer_still_names_the_models(
     # Naming them must not read as offering them.
     assert all(t.selectable is False for t in locked.tiers)
     assert locked.selectable is False
+
+
+@pytest.fixture
+def real_catalog():
+    """The other tests here run against an empty registry and assert the
+    slug fallback. These two are about resolution, so they need the catalog
+    actually loaded -- and must put it back, since it is process state."""
+    old = (
+        registry._dynamic_models,
+        registry._date_stripped_models,
+        registry._routes,
+        registry._loaded,
+    )
+    registry.load_catalog()
+    yield
+    (
+        registry._dynamic_models,
+        registry._date_stripped_models,
+        registry._routes,
+        registry._loaded,
+    ) = old
+
+
+@pytest.mark.asyncio
+async def test_a_platform_tier_names_a_model_configured_in_transport_spelling(
+    real_catalog,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """The default configuration routes through OpenRouter, whose slugs carry a
+    provider prefix the catalog does not use. Naming the model has to survive
+    that, or the row reads as a routing key on every deployment that took the
+    default."""
+    _mock_transports(mocker, [_transport(default=True)])
+    mocker.patch.object(
+        offers,
+        "resolve_model_route",
+        new=AsyncMock(
+            side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
+                model="anthropic/claude-sonnet-5", source="config"
+            )
+        ),
+    )
+
+    offer = (await get_connection_offers(USER_ID))[0]
+
+    assert [tier.display_model for tier in offer.tiers] == [
+        "Claude Sonnet 5",
+        "Claude Sonnet 5",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_model_the_catalog_does_not_know_is_named_by_its_slug(
+    real_catalog,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """A deployment may point a tier at anything. Showing the slug is worse than
+    showing a name and better than showing nothing."""
+    _mock_transports(mocker, [_transport(default=True)])
+    mocker.patch.object(
+        offers,
+        "resolve_model_route",
+        new=AsyncMock(
+            side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
+                model="a-model-nobody-has-heard-of", source="config"
+            )
+        ),
+    )
+
+    offer = (await get_connection_offers(USER_ID))[0]
+
+    assert offer.tiers[0].display_model == "a-model-nobody-has-heard-of"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
@@ -2,7 +2,9 @@
 
 import { cn } from "@/lib/utils";
 import Link from "next/link";
-import { PiLockSimple as LockIcon } from "react-icons/pi";
+import { LockIcon } from "@hugeicons/core-free-icons";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
 
 interface Props {
   title: string;
@@ -104,7 +106,8 @@ interface LockedProps {
 function LockedRow({ title, subtitle, notes, lock }: LockedProps) {
   return (
     <div className="flex items-start gap-2.5 px-3 py-2">
-      <LockIcon
+      <Icon
+        icon={LockIcon}
         size={14}
         aria-hidden
         className="mt-[3px] flex-none text-muted-foreground/70"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ChoiceRow.tsx
@@ -66,7 +66,9 @@ export function ChoiceRow({
       </span>
       <span className="flex min-w-0 flex-col">
         <span className="flex items-center gap-1.5">
-          <span className="text-xs font-medium text-foreground">{title}</span>
+          <span className="text-[13px] font-semibold text-foreground">
+            {title}
+          </span>
           {badge && (
             <span className="rounded-full bg-green-500/10 px-1.5 py-px text-[10px] font-medium text-green-700">
               {badge}
@@ -113,7 +115,7 @@ function LockedRow({ title, subtitle, notes, lock }: LockedProps) {
         className="mt-[3px] flex-none text-muted-foreground/70"
       />
       <span className="flex min-w-0 flex-col">
-        <span className="text-xs font-medium text-muted-foreground">
+        <span className="text-[13px] font-semibold text-muted-foreground">
           {title}
         </span>
         {subtitle && (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ConnectionPicker.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/ConnectionPicker.tsx
@@ -5,23 +5,26 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/molecules/DropdownMenu/DropdownMenu";
-import Link from "next/link";
 import {
-  PiCaretDown as CaretDownIcon,
-  PiKey as KeyIcon,
-  PiWarningCircle as WarningCircleIcon,
-} from "react-icons/pi";
+  AlertCircleIcon,
+  ArrowDown01Icon,
+  KeyIcon,
+} from "@hugeicons/core-free-icons";
+import Link from "next/link";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { cn } from "@/lib/utils";
 
 import { ChoiceRow } from "./ChoiceRow";
 import {
   isLinkedAccount,
   offerSubtitle,
   tierLabel,
-  tierModel,
   tierName,
   tierLock,
   tierSummary,
 } from "./helpers";
+import { TierToggle } from "./TierToggle";
 import { useConnectionPicker } from "./useConnectionPicker";
 
 const TIERS = ["standard", "advanced"] as const;
@@ -63,7 +66,7 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
         aria-label="AI connections unavailable"
         className="ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border border-destructive/20 bg-destructive/10 px-2.5 text-xs font-medium text-destructive"
       >
-        <WarningCircleIcon size={14} />
+        <Icon icon={AlertCircleIcon} size={14} />
         <span className="hidden sm:inline">Connections unavailable</span>
       </span>
     );
@@ -76,7 +79,7 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
         aria-label="Set up an AI connection"
         className="ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border border-border bg-muted px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/80"
       >
-        <WarningCircleIcon size={14} />
+        <Icon icon={AlertCircleIcon} size={14} />
         <span className="hidden sm:inline">Set up AI connection</span>
       </Link>
     );
@@ -95,10 +98,16 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
     return null;
   }
 
+  const runsOnOwnPlan = active ? isLinkedAccount(active) : false;
   const showsTier = connectionLocked && Boolean(active);
   const label = showsTier
     ? tierName(active, tier)
     : (active?.display_name ?? "Choose connection");
+  // "ChatGPT · your plan". Spending your own subscription rather than the
+  // platform's is the thing worth noticing before sending, so the chip says
+  // so and carries the accent that goes with it.
+  const triggerLabel =
+    runsOnOwnPlan && !showsTier ? `${label} · your plan` : label;
 
   return (
     <DropdownMenu>
@@ -108,17 +117,29 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
           aria-label={
             showsTier
               ? `Model tier ${label} — change`
-              : `Runs on ${label} — change`
+              : `Runs on ${triggerLabel} — change`
           }
-          className="ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border border-border bg-background px-2.5 text-xs font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
+          className={cn(
+            "ml-2 inline-flex h-9 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium shadow-sm transition-colors",
+            runsOnOwnPlan && !showsTier
+              ? "border-accent/40 bg-accent/5 text-accent hover:bg-accent/10"
+              : "border-border bg-background text-foreground hover:bg-muted",
+          )}
         >
-          <KeyIcon size={14} />
-          <span className="hidden sm:inline">{label}</span>
-          <CaretDownIcon size={12} className="text-muted-foreground" />
+          <Icon icon={KeyIcon} size={14} />
+          <span className="hidden sm:inline">{triggerLabel}</span>
+          <Icon
+            icon={ArrowDown01Icon}
+            size={12}
+            className="text-muted-foreground"
+          />
         </button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start" className="w-80 p-0">
+      <DropdownMenuContent
+        align="start"
+        className="w-[26rem] max-w-[calc(100vw-2rem)] p-0"
+      >
         {(!connectionLocked || onlyOfferIsLocked) && (
           <>
             <SectionLabel>Runs on</SectionLabel>
@@ -151,19 +172,15 @@ export function ConnectionPicker({ connectionLocked = false }: Props) {
         {showTiers && (
           <>
             <SectionLabel>Model tier</SectionLabel>
-            <div role="radiogroup" aria-label="Model tier">
-              {TIERS.map((candidate) => (
-                <ChoiceRow
-                  key={candidate}
-                  title={tierName(active, candidate)}
-                  subtitle={tierModel(active, candidate) ?? undefined}
-                  label={tierLabel(active, candidate)}
-                  isSelected={tier === candidate}
-                  onSelect={() => setTier(candidate)}
-                  lock={tierLock(active, candidate)}
-                />
-              ))}
-            </div>
+            <TierToggle
+              value={tier}
+              onSelect={setTier}
+              segments={TIERS.map((candidate) => ({
+                tier: candidate,
+                label: tierLabel(active, candidate),
+                lock: tierLock(active, candidate),
+              }))}
+            />
           </>
         )}
       </DropdownMenuContent>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/TierToggle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/TierToggle.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { LockIcon } from "@hugeicons/core-free-icons";
+import Link from "next/link";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { cn } from "@/lib/utils";
+
+import type { CopilotLlmModel } from "../../../../store";
+
+interface Segment {
+  tier: CopilotLlmModel;
+  /** "Balanced · Claude Sonnet 5" — the tier and the model it resolves to. */
+  label: string;
+  lock?: { reason: string; href: string | null };
+}
+
+interface Props {
+  segments: Segment[];
+  value: CopilotLlmModel;
+  onSelect: (tier: CopilotLlmModel) => void;
+}
+
+/**
+ * The two tiers side by side, as one control rather than a list of choices.
+ *
+ * A list reads as "here are some options"; a segmented control reads as "it is
+ * one of these two", which is the shape of the decision — there is no third
+ * tier, because absorbing that complexity is what having tiers is for.
+ *
+ * Each segment names its model inline. That only fits because the model now
+ * arrives as a display name rather than a routing slug; while a tier read
+ * "anthropic/claude-sonnet-5" the label had to wrap onto a second line.
+ */
+export function TierToggle({ segments, value, onSelect }: Props) {
+  const locked = segments.filter((segment) => segment.lock);
+
+  return (
+    <div className="mb-3 mt-1 flex flex-col gap-1.5 px-3">
+      <div
+        role="radiogroup"
+        aria-label="Model tier"
+        className="flex items-stretch gap-1 rounded-full bg-muted/70 p-1"
+      >
+        {segments.map((segment) =>
+          segment.lock ? (
+            <LockedSegment key={segment.tier} segment={segment} />
+          ) : (
+            <button
+              key={segment.tier}
+              type="button"
+              role="radio"
+              aria-checked={segment.tier === value}
+              onClick={() => onSelect(segment.tier)}
+              className={cn(
+                "min-w-0 flex-1 truncate rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                segment.tier === value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {segment.label}
+            </button>
+          ),
+        )}
+      </div>
+
+      {/* A segment has room for the lock but not for why. Saying only "locked"
+          would leave the user to guess at a barrier they can actually clear. */}
+      {locked.map((segment) => (
+        <p
+          key={segment.tier}
+          className="px-1 text-[11px] leading-snug text-muted-foreground/80"
+        >
+          {segment.lock?.reason}{" "}
+          {segment.lock?.href && (
+            <Link
+              href={segment.lock.href}
+              className="font-medium text-accent underline-offset-2 hover:underline"
+            >
+              See plans
+            </Link>
+          )}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A tier the plan excludes. Not a radio: choosing it is not among the things
+ * that can happen, so it shows the barrier and leaves the action to the line
+ * below, which has room to say what the barrier is.
+ */
+function LockedSegment({ segment }: { segment: Segment }) {
+  return (
+    <span
+      aria-disabled
+      aria-label={`${segment.label} — ${segment.lock?.reason ?? "unavailable"}`}
+      className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-full px-3 py-1.5 text-[11px] font-medium text-muted-foreground/70"
+    >
+      <Icon icon={LockIcon} size={11} aria-hidden className="flex-none" />
+      <span className="truncate">{segment.label}</span>
+    </span>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/TierToggle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/ConnectionPicker/TierToggle.tsx
@@ -89,15 +89,18 @@ export function TierToggle({ segments, value, onSelect }: Props) {
 }
 
 /**
- * A tier the plan excludes. Not a radio: choosing it is not among the things
- * that can happen, so it shows the barrier and leaves the action to the line
- * below, which has room to say what the barrier is.
+ * A tier the plan excludes. It remains a disabled radio so assistive
+ * technology receives a complete account of the radiogroup, while the line
+ * below has room to explain the barrier.
  */
 function LockedSegment({ segment }: { segment: Segment }) {
   return (
     <span
-      aria-disabled
+      role="radio"
+      aria-checked={false}
+      aria-disabled="true"
       aria-label={`${segment.label} — ${segment.lock?.reason ?? "unavailable"}`}
+      tabIndex={-1}
       className="flex min-w-0 flex-1 items-center justify-center gap-1 rounded-full px-3 py-1.5 text-[11px] font-medium text-muted-foreground/70"
     >
       <Icon icon={LockIcon} size={11} aria-hidden className="flex-none" />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
@@ -133,9 +133,11 @@ describe("ConnectionPicker", () => {
     ).toBeDefined();
   });
 
-  it("gives the model its own line so a long name stays readable", async () => {
-    // The model is the reason the tier row exists; sharing one line with the
-    // label truncates it away on any realistic model id.
+  it("names the model inside each tier segment", async () => {
+    // The model is the reason the tier control exists, so it is on the control
+    // rather than a line under it. This fits only because the model arrives as
+    // a display name; while it arrived as "anthropic/claude-sonnet-5" the label
+    // had to wrap, which is why this once asserted a separate line.
     mockOffers([offer(), chatgpt()]);
 
     render(<ConnectionPicker />);
@@ -143,8 +145,13 @@ describe("ConnectionPicker", () => {
       await screen.findByRole("button", { name: /Runs on/ }),
     );
 
-    expect(await screen.findByText("sonnet-5")).toBeDefined();
-    expect(screen.getByText("opus-5")).toBeDefined();
+    const tiers = await screen.findByRole("radiogroup", { name: "Model tier" });
+    expect(
+      within(tiers).getByRole("radio", { name: "Balanced · sonnet-5" }),
+    ).toBeDefined();
+    expect(
+      within(tiers).getByRole("radio", { name: "Advanced · opus-5" }),
+    ).toBeDefined();
   });
 
   it("puts the chosen tier in the store", async () => {
@@ -505,13 +512,13 @@ describe("ConnectionPicker", () => {
     );
 
     expect(
-      await screen.findByText("A Max plan or higher is required for Advanced."),
+      await screen.findByText(/A Max plan or higher is required for Advanced/),
     ).toBeDefined();
-    // Still named, so the user sees what they would get.
-    expect(screen.getByText("opus-5")).toBeDefined();
-    // Scoped to the tier group: the connection row's own name now contains
-    // "Advanced: opus-5" from its tier summary, so a page-wide query matches it.
+    // Still named, so the user sees what they would get. Scoped to the tier
+    // control: the connection row's own summary also mentions Advanced.
     const tierGroup = screen.getByRole("radiogroup", { name: "Model tier" });
+    expect(within(tierGroup).getByText(/opus-5/)).toBeDefined();
+    // Named, but not offered as a choice that cannot happen.
     expect(
       within(tierGroup).queryByRole("radio", { name: /Advanced/ }),
     ).toBeNull();
@@ -526,5 +533,28 @@ describe("ConnectionPicker", () => {
     expect(
       await screen.findByLabelText("AI connections unavailable"),
     ).toBeDefined();
+  });
+
+  it("says whose plan pays when the answer is the user's own", async () => {
+    // The point of labelling by payer is that spending your own subscription
+    // is worth noticing before you send, not after.
+    mockOffers([offer({ is_default: false }), chatgpt({ is_default: true })]);
+
+    render(<ConnectionPicker />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: /Runs on ChatGPT . your plan/,
+      }),
+    ).toBeDefined();
+  });
+
+  it("does not claim a platform connection is the user's own plan", async () => {
+    mockOffers([offer({ is_default: true }), chatgpt({ is_default: false })]);
+
+    render(<ConnectionPicker />);
+
+    const trigger = await screen.findByRole("button", { name: /Runs on/ });
+    expect(trigger.getAttribute("aria-label")).not.toMatch(/your plan/);
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/ConnectionPicker.test.tsx
@@ -518,11 +518,14 @@ describe("ConnectionPicker", () => {
     // control: the connection row's own summary also mentions Advanced.
     const tierGroup = screen.getByRole("radiogroup", { name: "Model tier" });
     expect(within(tierGroup).getByText(/opus-5/)).toBeDefined();
-    // Named, but not offered as a choice that cannot happen.
-    expect(
-      within(tierGroup).queryByRole("radio", { name: /Advanced/ }),
-    ).toBeNull();
-    expect(within(tierGroup).getAllByRole("radio")).toHaveLength(1);
+    // It remains a member of the radiogroup for assistive technology, but is
+    // exposed as disabled rather than offered as a choice that can happen.
+    const lockedTier = within(tierGroup).getByRole("radio", {
+      name: /Advanced/,
+    });
+    expect(lockedTier.getAttribute("aria-disabled")).toBe("true");
+    expect(lockedTier.getAttribute("aria-checked")).toBe("false");
+    expect(within(tierGroup).getAllByRole("radio")).toHaveLength(2);
   });
 
   it("reports a failure rather than inventing a connection", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/TierToggle.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/components/__tests__/TierToggle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, within } from "@/tests/integrations/test-utils";
+import { expect, it, vi } from "vitest";
+
+import { TierToggle } from "../ConnectionPicker/TierToggle";
+
+it("exposes a locked tier as a disabled member of the radio group", () => {
+  render(
+    <TierToggle
+      segments={[
+        { tier: "standard", label: "Balanced · Sonnet" },
+        {
+          tier: "advanced",
+          label: "Advanced · Opus",
+          lock: { reason: "Upgrade required", href: "/profile" },
+        },
+      ]}
+      value="standard"
+      onSelect={vi.fn()}
+    />,
+  );
+
+  const group = screen.getByRole("radiogroup", { name: "Model tier" });
+  expect(within(group).getAllByRole("radio")).toHaveLength(2);
+
+  const locked = within(group).getByRole("radio", { name: /Advanced · Opus/ });
+  expect(locked.getAttribute("aria-disabled")).toBe("true");
+  expect(locked.getAttribute("aria-checked")).toBe("false");
+  expect(locked.getAttribute("tabindex")).toBe("-1");
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/CopilotModals.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/CopilotModals.tsx
@@ -52,7 +52,7 @@ export function CopilotModals() {
       <Dialog
         controlled={{ isOpen: modal === "integrations", set: handleOpenChange }}
         styling={{ maxWidth: "56rem" }}
-        title="Third Party Integrations"
+        title="Integrations"
       >
         <Dialog.Content>
           <IntegrationsPanel withHeading={false} />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/__tests__/CopilotModals.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotModals/__tests__/CopilotModals.test.tsx
@@ -69,7 +69,7 @@ describe("CopilotModals", () => {
     render(<Harness />);
     expect(screen.queryByText("AutoPilot skills")).toBeNull();
     expect(screen.queryByText("Scheduled")).toBeNull();
-    expect(screen.queryByText("Third Party Integrations")).toBeNull();
+    expect(screen.queryByText("Integrations")).toBeNull();
   });
 
   test("opens the skills modal with header actions and empty state", async () => {
@@ -116,7 +116,7 @@ describe("CopilotModals", () => {
     render(<Harness />);
     fireEvent.click(screen.getByText("open-integrations"));
 
-    expect(await screen.findByText("Third Party Integrations")).toBeDefined();
+    expect(await screen.findByText("Integrations")).toBeDefined();
     expect(
       (await screen.findAllByText("Connect Service")).length,
     ).toBeGreaterThan(0);

--- a/autogpt_platform/frontend/src/components/contextual/DeviceAuth/useDeviceAuthConnect.ts
+++ b/autogpt_platform/frontend/src/components/contextual/DeviceAuth/useDeviceAuthConnect.ts
@@ -4,12 +4,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
-  getGetV1ListCredentialsQueryKey,
   postV1InitiateDeviceCodeOauthFlow,
   postV1PollDeviceCodeOauthFlowForCompletion,
 } from "@/app/api/__generated__/endpoints/integrations/integrations";
-import { toast } from "@/components/molecules/Toast/use-toast";
 import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/credentialsMetaResponse";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
 
 interface Args {
   provider: string;
@@ -82,9 +82,7 @@ export function useDeviceAuthConnect({ provider, onSuccess }: Args) {
           setPhase("done");
           stopPolling();
           toast({ title: "Connected via device auth", variant: "success" });
-          await queryClient.invalidateQueries({
-            queryKey: getGetV1ListCredentialsQueryKey(),
-          });
+          await invalidateConnectionQueries(queryClient);
           onSuccess(credentials ?? undefined);
           return;
         }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/IntegrationsPanel.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState } from "react";
+
+import { Text } from "@/components/atoms/Text/Text";
+
 import { AIConnectionsSection } from "./components/AIConnectionsSection/AIConnectionsSection";
 import { ConnectServiceDialog } from "./components/ConnectServiceDialog/ConnectServiceDialog";
 import { IntegrationsHeader } from "./components/IntegrationsHeader/IntegrationsHeader";
@@ -20,7 +23,17 @@ export function IntegrationsPanel({ withHeading = true }: Props) {
         withTitle={withHeading}
       />
       <AIConnectionsSection />
-      <IntegrationsList />
+      <section aria-labelledby="tool-connections-heading">
+        <Text
+          variant="small-medium"
+          as="h2"
+          id="tool-connections-heading"
+          className="pb-3 pl-4 uppercase tracking-[0.06em] text-[#505057]"
+        >
+          Tools your agents use
+        </Text>
+        <IntegrationsList />
+      </section>
       <ConnectServiceDialog
         open={isConnectOpen}
         onOpenChange={setIsConnectOpen}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/__tests__/IntegrationsPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/__tests__/IntegrationsPanel.test.tsx
@@ -1,0 +1,36 @@
+import { getGetV2ListChatConnectionsMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import { getGetV1ListCredentialsMockHandler200 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { IntegrationsPanel } from "../IntegrationsPanel";
+
+describe("IntegrationsPanel", () => {
+  it("separates the subscriptions that pay for a chat from the tools a chat uses", async () => {
+    server.use(
+      getGetV2ListChatConnectionsMockHandler200({ offers: [] }),
+      getGetV1ListCredentialsMockHandler200([]),
+    );
+
+    render(<IntegrationsPanel />);
+
+    const headings = await screen.findAllByRole("heading", { level: 2 });
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      "AI subscriptions",
+      "Tools your agents use",
+    ]);
+  });
+
+  it("keeps the tools heading while the list is still loading", async () => {
+    // The heading names what the region is, so it should not appear only once
+    // the region has content -- the AI section above it behaves the same way.
+    server.use(getGetV2ListChatConnectionsMockHandler200({ offers: [] }));
+
+    render(<IntegrationsPanel />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Tools your agents use" }),
+    ).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -6,7 +6,7 @@ import {
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
@@ -14,7 +14,7 @@ import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
 
 import { ManageConnectionDialog } from "./ManageConnectionDialog";
-import { describeTransport, transportKey } from "./helpers";
+import { isSelectable, tierSummary } from "./helpers";
 import { useAIConnectionsSection } from "./useAIConnectionsSection";
 
 export function AIConnectionsSection() {
@@ -27,7 +27,7 @@ export function AIConnectionsSection() {
     isLoading,
     isError,
   } = useAIConnectionsSection();
-  const [managing, setManaging] = useState<ChatTransportResponse | null>(null);
+  const [managing, setManaging] = useState<AIConnectionOffer | null>(null);
 
   // A failure here must not take the tool integrations below it down with it.
   if (isError) return null;
@@ -65,15 +65,15 @@ export function AIConnectionsSection() {
         >
           {connections.map((connection) => (
             <ConnectionRow
-              key={transportKey(connection)}
+              key={connection.offer_id}
               connection={connection}
               account={accountFor(connection)}
               selectable={hasChoice}
-              isSelected={transportKey(connection) === selectedKey}
+              isSelected={connection.offer_id === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
               onManage={
-                connection.auth_provider === "codex"
+                connection.auth_method === "chatgpt_oauth"
                   ? () => setManaging(connection)
                   : undefined
               }
@@ -96,7 +96,7 @@ export function AIConnectionsSection() {
 }
 
 interface RowProps {
-  connection: ChatTransportResponse;
+  connection: AIConnectionOffer;
   account?: string;
   selectable: boolean;
   isSelected: boolean;
@@ -133,14 +133,15 @@ function ConnectionRow({
       <span className="flex min-w-0 flex-col gap-1">
         <span className="flex flex-wrap items-center gap-2">
           <Text variant="body-medium" as="span" className="text-black">
-            {connection.label}
+            {connection.display_name}
           </Text>
-          {connection.auth_provider === "codex" && (
-            <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#E8F8F0] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#157E58]">
-              <Icon icon={CheckmarkCircle02Icon} size={13} />
-              Connected
-            </span>
-          )}
+          {connection.auth_method === "chatgpt_oauth" &&
+            isSelectable(connection) && (
+              <span className="inline-flex items-center gap-1 rounded-[10px] bg-[#E8F8F0] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#157E58]">
+                <Icon icon={CheckmarkCircle02Icon} size={13} />
+                Connected
+              </span>
+            )}
           {account && (
             <span className="max-w-full truncate rounded-[10px] bg-[#EFF1F4] px-2 py-[2px] text-[13px] font-medium leading-[20px] text-[#505057]">
               {account}
@@ -154,8 +155,18 @@ function ConnectionRow({
           )}
         </span>
         <Text variant="small" as="span" className="text-[#505057]">
-          {describeTransport(connection)}
+          {connection.description}
         </Text>
+        {tierSummary(connection) && (
+          <Text variant="small" as="span" className="text-[#7A7A80]">
+            {tierSummary(connection)}
+          </Text>
+        )}
+        {connection.lock_reason && (
+          <Text variant="small" as="span" className="text-[#7A7A80]">
+            {connection.lock_reason}
+          </Text>
+        )}
       </span>
     </>
   );

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -33,8 +33,9 @@ export function AIConnectionsSection() {
   if (isError) return null;
 
   // One connection is not a choice. The rows still say what powers a chat,
-  // they just stop presenting a decision that doesn't exist.
-  const hasChoice = connections.length > 1;
+  // they just stop presenting a decision that doesn't exist. A locked upsell
+  // row is visible context, not a route the user can select.
+  const hasChoice = connections.filter(isSelectable).length > 1;
 
   return (
     <section aria-labelledby="ai-connections-heading" className="pb-8 pl-4">
@@ -68,7 +69,7 @@ export function AIConnectionsSection() {
               key={connection.offer_id}
               connection={connection}
               account={accountFor(connection)}
-              selectable={hasChoice}
+              selectable={hasChoice && isSelectable(connection)}
               isSelected={connection.offer_id === selectedKey}
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/AIConnectionsSection.tsx
@@ -73,6 +73,7 @@ export function AIConnectionsSection() {
               isSaving={isSaving}
               onSelect={() => chooseDefault(connection)}
               onManage={
+                connection.credential_id &&
                 connection.auth_method === "chatgpt_oauth"
                   ? () => setManaging(connection)
                   : undefined

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 
-import { getGetV2ListChatConnectionsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useGetV1CodexAccount } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { Button } from "@/components/atoms/Button/Button";
@@ -31,7 +29,6 @@ export function ManageConnectionDialog({
   account,
   onOpenChange,
 }: Props) {
-  const queryClient = useQueryClient();
   const credentialId = connection?.credential_id ?? null;
   const [forceMessage, setForceMessage] = useState<string | null>(null);
 
@@ -63,12 +60,7 @@ export function ManageConnectionDialog({
 
   const { connect, isPending: isReconnecting } = useOAuthConnect({
     provider: "codex",
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: getGetV2ListChatConnectionsQueryKey(),
-      });
-      setManageOpen(false);
-    },
+    onSuccess: () => setManageOpen(false),
   });
 
   const { remove, isPending: isDisconnecting } = useDeleteIntegration();
@@ -89,9 +81,6 @@ export function ManageConnectionDialog({
     if (result.succeeded.length === 0) return;
 
     setForceMessage(null);
-    await queryClient.invalidateQueries({
-      queryKey: getGetV2ListChatConnectionsQueryKey(),
-    });
     setManageOpen(false);
   }
 

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/ManageConnectionDialog.tsx
@@ -3,9 +3,9 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { getGetV2ListChatTransportsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
+import { getGetV2ListChatConnectionsQueryKey } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useGetV1CodexAccount } from "@/app/api/__generated__/endpoints/integrations/integrations";
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
 import { Dialog } from "@/components/molecules/Dialog/Dialog";
@@ -15,7 +15,7 @@ import { DeleteConfirmDialog } from "../DeleteConfirmDialog/DeleteConfirmDialog"
 import { useDeleteIntegration } from "../hooks/useDeleteIntegration";
 
 interface Props {
-  connection: ChatTransportResponse | null;
+  connection: AIConnectionOffer | null;
   account?: string;
   onOpenChange: (open: boolean) => void;
 }
@@ -65,7 +65,7 @@ export function ManageConnectionDialog({
     provider: "codex",
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: getGetV2ListChatTransportsQueryKey(),
+        queryKey: getGetV2ListChatConnectionsQueryKey(),
       });
       setManageOpen(false);
     },
@@ -90,7 +90,7 @@ export function ManageConnectionDialog({
 
     setForceMessage(null);
     await queryClient.invalidateQueries({
-      queryKey: getGetV2ListChatTransportsQueryKey(),
+      queryKey: getGetV2ListChatConnectionsQueryKey(),
     });
     setManageOpen(false);
   }
@@ -149,7 +149,7 @@ export function ManageConnectionDialog({
             </Text>
 
             <Text variant="small" className="text-[#505057]">
-              {connection?.default
+              {connection?.is_default
                 ? "New chats start on this connection and run on your ChatGPT plan."
                 : "Chats you route here run on your ChatGPT plan instead of AutoGPT credits."}
             </Text>

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -1,5 +1,5 @@
 import {
-  getGetV2ListChatTransportsMockHandler200,
+  getGetV2ListChatConnectionsMockHandler200,
   getPutV2SetDefaultChatTransportMockHandler200,
 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
 import {
@@ -8,7 +8,7 @@ import {
   getGetV1CodexAccountMockHandler200,
   getGetV1ListCredentialsMockHandler200,
 } from "@/app/api/__generated__/endpoints/integrations/integrations.msw";
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
@@ -16,33 +16,86 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AIConnectionsSection } from "../AIConnectionsSection";
 
-function platform(isDefault: boolean): ChatTransportResponse {
+function platform(isDefault: boolean): AIConnectionOffer {
   return {
-    auth_provider: "platform",
+    offer_id: "platform:deployment",
+    provider_family: "autogpt",
+    display_name: "Self-hosted chat",
+    auth_method: "deployment",
     credential_id: null,
-    label: "Self-hosted chat",
-    available: true,
-    default: isDefault,
-  };
+    backed_by_label: "This server's chat provider",
+    description:
+      "New chats are backed by the chat provider configured on this server.",
+    state: "ready",
+    selectable: true,
+    is_default: isDefault,
+    tiers: [
+      {
+        tier: "standard",
+        label: "Balanced",
+        selectable: true,
+        display_model: "Sonnet 5",
+      },
+      {
+        tier: "advanced",
+        label: "Advanced",
+        selectable: true,
+        display_model: "Opus 5",
+      },
+    ],
+    limitations: [],
+  } as AIConnectionOffer;
 }
 
-function chatgpt(isDefault: boolean, id = "cred-1"): ChatTransportResponse {
+function chatgpt(isDefault: boolean, id = "cred-1"): AIConnectionOffer {
   return {
-    auth_provider: "codex",
+    offer_id: `codex:${id}`,
+    provider_family: "openai",
+    display_name: "ChatGPT",
+    auth_method: "chatgpt_oauth",
     credential_id: id,
-    label: "ChatGPT",
-    available: true,
-    default: isDefault,
+    backed_by_label: "Your ChatGPT plan",
+    description:
+      "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.",
+    state: "ready",
+    selectable: true,
+    is_default: isDefault,
+    tiers: [
+      {
+        tier: "standard",
+        label: "Balanced",
+        selectable: true,
+        display_model: "GPT-5.6 Terra",
+      },
+      {
+        tier: "advanced",
+        label: "Advanced",
+        selectable: true,
+        display_model: "GPT-5.6 Sol",
+      },
+    ],
+    limitations: [],
+  } as AIConnectionOffer;
+}
+
+function lockedChatgpt(): AIConnectionOffer {
+  return {
+    ...chatgpt(false),
+    offer_id: "codex:locked",
+    credential_id: null,
+    state: "locked",
+    selectable: false,
+    lock_reason: "Connect ChatGPT to use this subscription",
   };
 }
 
 function mockTransports(
-  transports: ChatTransportResponse[],
+  offers: AIConnectionOffer[],
   credentials: { id: string; username: string }[] = [],
 ) {
   server.use(
-    getGetV2ListChatTransportsMockHandler200({ transports }),
-    getPutV2SetDefaultChatTransportMockHandler200({ transports }),
+    getGetV2ListChatConnectionsMockHandler200({ offers }),
+    getPutV2SetDefaultChatTransportMockHandler200({ transports: [] }),
     getGetV1ListCredentialsMockHandler200(
       credentials.map((credential) => ({
         id: credential.id,
@@ -78,6 +131,15 @@ describe("AIConnectionsSection", () => {
     render(<AIConnectionsSection />);
 
     expect(await screen.findByText("nick@example.com")).toBeDefined();
+  });
+
+  it("does not call an unlinked ChatGPT offer connected", async () => {
+    mockTransports([platform(true), lockedChatgpt()]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("ChatGPT")).toBeDefined();
+    expect(screen.queryByText("Connected")).toBeNull();
   });
 
   it("treats a disconnected account snapshot as requiring reconnect", async () => {
@@ -233,5 +295,52 @@ describe("AIConnectionsSection", () => {
 
     expect(await screen.findByText("GitHub Copilot and Grok")).toBeDefined();
     expect(screen.getByText("Coming soon")).toBeDefined();
+  });
+
+  it("names the models each connection runs", async () => {
+    // The reason for reading /connections rather than /transports: transports
+    // carries no tiers, so this line could not exist before.
+    mockTransports([platform(true), chatgpt(false)]);
+
+    render(<AIConnectionsSection />);
+
+    expect(
+      await screen.findByText(
+        "Balanced: GPT-5.6 Terra · Advanced: GPT-5.6 Sol",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText("Balanced: Sonnet 5 · Advanced: Opus 5"),
+    ).toBeDefined();
+  });
+
+  it("takes its copy from the server rather than deciding it here", async () => {
+    // describeTransport used to compose this sentence client-side, which
+    // drifts from the server that enforces the billing it describes.
+    mockTransports([{ ...chatgpt(true), description: "Server said this." }]);
+
+    render(<AIConnectionsSection />);
+
+    expect(await screen.findByText("Server said this.")).toBeDefined();
+  });
+
+  it("shows a connection the plan excludes, with what unlocks it", async () => {
+    mockTransports([
+      platform(true),
+      {
+        ...chatgpt(false),
+        state: "locked",
+        selectable: false,
+        lock_reason: "A Max plan or higher is required to use ChatGPT.",
+      } as AIConnectionOffer,
+    ]);
+
+    render(<AIConnectionsSection />);
+
+    expect(
+      await screen.findByText(
+        "A Max plan or higher is required to use ChatGPT.",
+      ),
+    ).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -345,5 +345,7 @@ describe("AIConnectionsSection", () => {
         "A Max plan or higher is required to use ChatGPT.",
       ),
     ).toBeDefined();
+    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(screen.queryByRole("radio")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -142,6 +142,7 @@ describe("AIConnectionsSection", () => {
 
     expect(await screen.findByText("ChatGPT")).toBeDefined();
     expect(screen.queryByText("Connected")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Manage" })).toBeNull();
   });
 
   it("treats a disconnected account snapshot as requiring reconnect", async () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/__tests__/AIConnectionsSection.test.tsx
@@ -19,6 +19,7 @@ import { AIConnectionsSection } from "../AIConnectionsSection";
 function platform(isDefault: boolean): AIConnectionOffer {
   return {
     offer_id: "platform:deployment",
+    auth_provider: "platform",
     provider_family: "autogpt",
     display_name: "Self-hosted chat",
     auth_method: "deployment",
@@ -50,6 +51,7 @@ function platform(isDefault: boolean): AIConnectionOffer {
 function chatgpt(isDefault: boolean, id = "cred-1"): AIConnectionOffer {
   return {
     offer_id: `codex:${id}`,
+    auth_provider: "codex",
     provider_family: "openai",
     display_name: "ChatGPT",
     auth_method: "chatgpt_oauth",

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/helpers.ts
@@ -1,40 +1,60 @@
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
+import type { SetDefaultTransportRequest } from "@/app/api/__generated__/models/setDefaultTransportRequest";
+import type { SetDefaultTransportRequestAuthProvider } from "@/app/api/__generated__/models/setDefaultTransportRequestAuthProvider";
 
 /**
- * The label the server sends for the platform transport on a self-hosted
- * install. It sends "AutoGPT Platform" on the hosted product instead.
+ * The route to send when making a connection the default.
+ *
+ * The offer describes a connection; the default is set on the transport that
+ * runs it, which is keyed by provider and credential. ``offer_id`` is built
+ * server-side as ``{auth_provider}:{credential_id or "deployment"}``, so the
+ * provider is recoverable from it without the client deciding anything.
  */
-export const SELF_HOSTED_LABEL = "Self-hosted chat";
-
-/**
- * Says what backs a run, which is the thing that actually differs between
- * connections. Copy lives here only until the server-owned connection offer
- * carries it — the client should not be deciding how a provider describes
- * its own billing.
- */
-export function describeTransport(transport: ChatTransportResponse): string {
-  if (transport.auth_provider === "codex") {
-    return "New chats are backed by your ChatGPT plan, and spend no AutoGPT credits.";
-  }
-  // The ChatGPT line promises "no AutoGPT credits", which only means anything
-  // if the row it contrasts with says credits are spent. Self-host has no
-  // credits at all, so it says what it actually has instead.
-  return transport.label === SELF_HOSTED_LABEL
-    ? "New chats are backed by the chat provider configured on this server."
-    : "New chats are backed by your AutoGPT plan, and spend AutoGPT credits.";
+export function routeOf(offer: AIConnectionOffer): SetDefaultTransportRequest {
+  return {
+    auth_provider: offer.offer_id.split(
+      ":",
+    )[0] as SetDefaultTransportRequestAuthProvider,
+    credential_id: offer.credential_id ?? null,
+  };
 }
 
-export function isSelectable(transport: ChatTransportResponse): boolean {
+/**
+ * Whether this connection can be chosen as the default.
+ *
+ * A locked offer is listed so the user can see it exists and what unlocks it,
+ * but it cannot be routed to, so it cannot be a default either.
+ */
+export function isSelectable(offer: AIConnectionOffer): boolean {
   return (
-    transport.available &&
-    (transport.auth_provider === "platform" || transport.credential_id !== null)
+    offer.selectable &&
+    (offer.auth_method === "deployment" || offer.credential_id !== null)
   );
 }
 
 /**
- * A stable key. The platform transport carries no credential id, and a user
- * can hold several ChatGPT accounts, so neither half identifies a row alone.
+ * Every connection worth showing, selectable or not.
+ *
+ * A locked one earns its place by explaining an absence the user would
+ * otherwise have to guess at.
  */
-export function transportKey(transport: ChatTransportResponse): string {
-  return `${transport.auth_provider}:${transport.credential_id ?? "deployment"}`;
+export function visibleOffers(
+  offers: AIConnectionOffer[] | undefined,
+): AIConnectionOffer[] {
+  return (offers ?? []).filter(
+    (offer) => isSelectable(offer) || Boolean(offer.lock_reason),
+  );
+}
+
+/**
+ * "Balanced: Sonnet 5 · Advanced: Opus 5".
+ *
+ * Empty when the server named no models, so the row omits the line rather
+ * than rendering half of one.
+ */
+export function tierSummary(offer: AIConnectionOffer): string {
+  const named = offer.tiers
+    .filter((tier) => tier.display_model)
+    .map((tier) => `${tier.label}: ${tier.display_model}`);
+  return named.join(" · ");
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/AIConnectionsSection/useAIConnectionsSection.ts
@@ -3,27 +3,34 @@
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
+  getGetV2ListChatConnectionsQueryKey,
   getGetV2ListChatTransportsQueryKey,
-  useGetV2ListChatTransports,
+  useGetV2ListChatConnections,
   usePutV2SetDefaultChatTransport,
 } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useGetV1ListCredentials } from "@/app/api/__generated__/endpoints/integrations/integrations";
-import type { ChatTransportResponse } from "@/app/api/__generated__/models/chatTransportResponse";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
 import { toast } from "@/components/molecules/Toast/use-toast";
 
-import { isSelectable, transportKey } from "./helpers";
+import { routeOf, visibleOffers } from "./helpers";
 
 export function useAIConnectionsSection() {
   const queryClient = useQueryClient();
-  const transportsQuery = useGetV2ListChatTransports({
+
+  // The offers endpoint rather than transports: transports answers "what may
+  // run", which is enough to route a turn and not enough to render one. What
+  // a connection is called, what backs it, and which models each tier uses
+  // are product statements, and a client that derives them drifts from the
+  // server that enforces them.
+  const connectionsQuery = useGetV2ListChatConnections({
     query: { refetchOnWindowFocus: true },
   });
 
-  const transports: ChatTransportResponse[] =
-    transportsQuery.data?.status === 200
-      ? transportsQuery.data.data.transports
-      : [];
-  const connections = transports.filter(isSelectable);
+  const offers: AIConnectionOffer[] = visibleOffers(
+    connectionsQuery.data?.status === 200
+      ? connectionsQuery.data.data.offers
+      : undefined,
+  );
 
   // The account a connection runs as. Read from the stored credential rather
   // than asked of the provider: this is the identity the user linked, so it is
@@ -40,15 +47,21 @@ export function useAIConnectionsSection() {
       .map((credential) => [credential.id, credential.username as string]),
   );
 
-  function accountFor(transport: ChatTransportResponse): string | undefined {
-    if (!transport.credential_id) return undefined;
-    return accountByCredentialId.get(transport.credential_id);
+  function accountFor(offer: AIConnectionOffer): string | undefined {
+    if (!offer.credential_id) return undefined;
+    return accountByCredentialId.get(offer.credential_id);
   }
 
   const { mutate: setDefault, isPending: isSaving } =
     usePutV2SetDefaultChatTransport({
       mutation: {
         onSuccess: () => {
+          // Both lists carry the default: offers renders it, transports
+          // routes it. Refreshing one and not the other leaves the screen
+          // disagreeing with what a new chat will actually do.
+          queryClient.invalidateQueries({
+            queryKey: getGetV2ListChatConnectionsQueryKey(),
+          });
           queryClient.invalidateQueries({
             queryKey: getGetV2ListChatTransportsQueryKey(),
           });
@@ -66,28 +79,22 @@ export function useAIConnectionsSection() {
 
   // Tracked separately from the query so the row the user clicked shows the
   // pending state, rather than every row going busy at once.
-  const selectedKey = connections.find((t) => t.default)
-    ? transportKey(connections.find((t) => t.default)!)
-    : null;
+  const selectedKey =
+    offers.find((offer) => offer.is_default)?.offer_id ?? null;
 
-  function chooseDefault(transport: ChatTransportResponse) {
-    if (transport.default) return;
-    setDefault({
-      data: {
-        auth_provider: transport.auth_provider,
-        credential_id: transport.credential_id,
-      },
-    });
+  function chooseDefault(offer: AIConnectionOffer) {
+    if (offer.is_default) return;
+    setDefault({ data: routeOf(offer) });
   }
 
   return {
-    connections,
+    connections: offers,
     accountFor,
     selectedKey,
     chooseDefault,
     isSaving,
-    isLoading: transportsQuery.isLoading,
-    isError: transportsQuery.isError,
-    refetch: transportsQuery.refetch,
+    isLoading: connectionsQuery.isLoading,
+    isError: connectionsQuery.isError,
+    refetch: connectionsQuery.refetch,
   };
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/McpConnectPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/McpConnectPanel.tsx
@@ -8,13 +8,13 @@ import {
   postV2InitiateOauthLoginForAnMcpServer,
   postV2StoreABearerTokenForAnMcpServer,
 } from "@/app/api/__generated__/endpoints/mcp/mcp";
-import { getGetV1ListCredentialsQueryKey } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/credentialsMetaResponse";
 import type { MCPOAuthLoginResponse } from "@/app/api/__generated__/models/mCPOAuthLoginResponse";
 import { Button } from "@/components/atoms/Button/Button";
 import { Input } from "@/components/atoms/Input/Input";
 import { Text } from "@/components/atoms/Text/Text";
 import { openOAuthPopup } from "@/lib/oauth-popup";
+import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
 
 interface Props {
   onSuccess: (credential?: CredentialsMetaResponse) => void;
@@ -40,9 +40,7 @@ export function McpConnectPanel({ onSuccess }: Props) {
   const canSubmitToken = isUrlValid && trimmedToken.length > 0 && !isSubmitting;
 
   async function invalidateCredentials() {
-    await queryClient.invalidateQueries({
-      queryKey: getGetV1ListCredentialsQueryKey(),
-    });
+    await invalidateConnectionQueries(queryClient);
   }
 
   async function handleConnect() {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/MethodPanel.tsx
@@ -38,7 +38,7 @@ export function MethodPanel({ method, provider, onSuccess }: Props) {
           provider={authProvider}
           providerName={isChatGPT ? "ChatGPT" : provider.name}
           buttonLabel={isChatGPT ? "Sign in with ChatGPT" : undefined}
-          termsNotice={isChatGPT}
+          termsNotice={isChatGPT ? "OpenAI" : undefined}
           onSuccess={onSuccess}
         />
       </div>

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/OAuthConnectButton.tsx
@@ -12,9 +12,11 @@ interface Props {
   provider: string;
   providerName: string;
   buttonLabel?: string;
-  /** Say whose terms a linked run falls under. Only true where runs execute
-   *  on the provider's own account rather than on AutoGPT's. */
-  termsNotice?: boolean;
+  /** Whose terms a linked run falls under, where that is not AutoGPT's. The
+   *  sign-in window is a product ("ChatGPT") and the terms are a company's
+   *  ("OpenAI"), so this is named separately rather than reusing the label
+   *  on the button. */
+  termsNotice?: string;
   onSuccess: (credential?: CredentialsMetaResponse) => void;
 }
 
@@ -22,7 +24,7 @@ export function OAuthConnectButton({
   provider,
   providerName,
   buttonLabel,
-  termsNotice = false,
+  termsNotice,
   onSuccess,
 }: Props) {
   const { connect, isPending } = useOAuthConnect({ provider, onSuccess });
@@ -45,8 +47,8 @@ export function OAuthConnectButton({
       </Button>
       {termsNotice && (
         <Text variant="small" className="text-[#8A8A90]">
-          Linked runs are sent to {providerName} under your own account and
-          follow {providerName}&apos;s terms.
+          Linked runs are sent to {termsNotice} under your own account and
+          follow {termsNotice}&apos;s terms.
         </Text>
       )}
     </div>

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
@@ -50,7 +50,7 @@ describe("MethodPanel", () => {
     expect(screen.getByText("What you get.")).toBeDefined();
     expect(screen.getByText("Stay in control.")).toBeDefined();
     expect(screen.getByText(/spend zero AutoGPT credits/i)).toBeDefined();
-    expect(screen.getByText(/follow ChatGPT's terms/i)).toBeDefined();
+    expect(screen.getByText(/follow OpenAI's terms/i)).toBeDefined();
   });
 
   test("claims nothing it cannot back up", () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useApiKeyConnectForm.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useApiKeyConnectForm.ts
@@ -5,12 +5,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useQueryClient } from "@tanstack/react-query";
 
-import {
-  getGetV1ListCredentialsQueryKey,
-  postV1CreateCredentials,
-} from "@/app/api/__generated__/endpoints/integrations/integrations";
+import { postV1CreateCredentials } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/credentialsMetaResponse";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
 
 import { apiKeyConnectSchema, type ApiKeyConnectFormValues } from "./schema";
 
@@ -52,9 +50,7 @@ export function useApiKeyConnectForm({ provider, onSuccess }: Args) {
       });
 
       toast({ title: "API key saved", variant: "success" });
-      await queryClient.invalidateQueries({
-        queryKey: getGetV1ListCredentialsQueryKey(),
-      });
+      await invalidateConnectionQueries(queryClient);
       // Narrow by shape rather than by status code: the comment above keeps
       // this flow indifferent to a 201 ↔ 200 swap, and only the success
       // payload carries an id.

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect.ts
@@ -4,7 +4,6 @@ import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
-  getGetV1ListCredentialsQueryKey,
   getV1InitiateOauthFlow,
   postV1ExchangeOauthCodeForTokens,
 } from "@/app/api/__generated__/endpoints/integrations/integrations";
@@ -15,6 +14,7 @@ import {
   openOAuthPopup,
   preOpenOAuthPopup,
 } from "@/lib/oauth-popup";
+import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
 
 import { getOAuthErrorMessage } from "./helpers";
 
@@ -115,9 +115,7 @@ export function useOAuthConnect({ provider, onSuccess }: Args) {
       });
 
       toast({ title: "Connected via OAuth", variant: "success" });
-      await queryClient.invalidateQueries({
-        queryKey: getGetV1ListCredentialsQueryKey(),
-      });
+      await invalidateConnectionQueries(queryClient);
       // customMutator rejects non-2xx, so a 200 is the only way to get here;
       // the check narrows the union rather than guarding a real branch.
       onSuccess(exchanged.status === 200 ? exchanged.data : undefined);

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsHeader/IntegrationsHeader.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsHeader/IntegrationsHeader.tsx
@@ -15,13 +15,12 @@ export function IntegrationsHeader({ onConnect, withTitle = true }: Props) {
       <div className="flex min-w-0 flex-col">
         {withTitle && (
           <Text variant="h4" as="h1" className="leading-[28px] text-[#1F1F20]">
-            Third Party Integrations
+            Integrations
           </Text>
         )}
         <Text variant="body" className="mt-4 max-w-[600px] text-[#505057]">
-          Manage the 3rd party accounts you&apos;ve connected to AutoGPT. These
-          are services that can be used by your agents — like Gmail for sending
-          emails, GitHub for code, or Notion for documents.
+          Connect AI subscriptions to power your agents, and third-party tools
+          for them to use.
         </Text>
       </div>
 

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsHeader/__tests__/IntegrationsHeader.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/IntegrationsHeader/__tests__/IntegrationsHeader.test.tsx
@@ -5,12 +5,19 @@ import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
 import { IntegrationsHeader } from "../IntegrationsHeader";
 
 describe("IntegrationsHeader", () => {
-  test("renders the title and intro copy", () => {
+  test("names both kinds of thing the page now holds", () => {
+    // The page led with third-party tool connectors, which stopped being the
+    // whole story once AI subscriptions got their own section above them --
+    // and reads as wrong for a self-hosted connection, which is not a third
+    // party at all.
     render(<IntegrationsHeader onConnect={() => {}} />);
     expect(
-      screen.getByRole("heading", { name: /third party integrations/i }),
+      screen.getByRole("heading", { name: /^integrations$/i }),
     ).toBeDefined();
-    expect(screen.getByText(/Manage the 3rd party accounts/i)).toBeDefined();
+    expect(screen.getByText(/Connect AI subscriptions/i)).toBeDefined();
+    expect(
+      screen.getByText(/third-party tools for them to use/i),
+    ).toBeDefined();
   });
 
   test("invokes onConnect when any 'Connect Service' button is clicked", () => {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/hooks/useDeleteIntegration.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/hooks/useDeleteIntegration.ts
@@ -3,11 +3,9 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import {
-  deleteV1DeleteCredentials,
-  getGetV1ListCredentialsQueryKey,
-} from "@/app/api/__generated__/endpoints/integrations/integrations";
+import { deleteV1DeleteCredentials } from "@/app/api/__generated__/endpoints/integrations/integrations";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
 
 export interface DeleteIntegrationTarget {
   id: string;
@@ -123,9 +121,7 @@ export function useDeleteIntegration() {
         });
       }
 
-      await queryClient.invalidateQueries({
-        queryKey: getGetV1ListCredentialsQueryKey(),
-      });
+      await invalidateConnectionQueries(queryClient);
 
       return out;
     } finally {

--- a/autogpt_platform/frontend/src/lib/react-query/__tests__/invalidateConnections.test.ts
+++ b/autogpt_platform/frontend/src/lib/react-query/__tests__/invalidateConnections.test.ts
@@ -1,0 +1,49 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getGetV2ListChatConnectionsQueryKey,
+  getGetV2ListChatTransportsQueryKey,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import { getGetV1ListCredentialsQueryKey } from "@/app/api/__generated__/endpoints/integrations/integrations";
+
+import { invalidateConnectionQueries } from "../invalidateConnections";
+
+function hash(key: readonly unknown[]) {
+  return JSON.stringify(key);
+}
+
+describe("invalidateConnectionQueries", () => {
+  it("refreshes credentials, chat connections and transports", async () => {
+    const client = new QueryClient();
+    const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+    client.invalidateQueries = invalidateQueries;
+
+    await invalidateConnectionQueries(client);
+
+    const invalidated = invalidateQueries.mock.calls.map(([args]) =>
+      hash(args.queryKey),
+    );
+    expect(invalidated).toContain(hash(getGetV1ListCredentialsQueryKey()));
+    expect(invalidated).toContain(hash(getGetV2ListChatConnectionsQueryKey()));
+    expect(invalidated).toContain(hash(getGetV2ListChatTransportsQueryKey()));
+  });
+
+  it("waits for every invalidation before resolving", async () => {
+    const client = new QueryClient();
+    let settled = 0;
+    client.invalidateQueries = vi.fn(
+      () =>
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            settled += 1;
+            resolve();
+          }, 0),
+        ),
+    );
+
+    await invalidateConnectionQueries(client);
+
+    expect(settled).toBe(3);
+  });
+});

--- a/autogpt_platform/frontend/src/lib/react-query/invalidateConnections.ts
+++ b/autogpt_platform/frontend/src/lib/react-query/invalidateConnections.ts
@@ -1,0 +1,24 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import {
+  getGetV2ListChatConnectionsQueryKey,
+  getGetV2ListChatTransportsQueryKey,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import { getGetV1ListCredentialsQueryKey } from "@/app/api/__generated__/endpoints/integrations/integrations";
+
+/** Refresh every client-side view derived from a credential change. */
+export async function invalidateConnectionQueries(
+  queryClient: QueryClient,
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: getGetV1ListCredentialsQueryKey(),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: getGetV2ListChatConnectionsQueryKey(),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: getGetV2ListChatTransportsQueryKey(),
+    }),
+  ]);
+}


### PR DESCRIPTION
> Stacked on #14107 — review that first; this PR's diff is the one commit on top.

From checking what we built against Mock 2 and Mock 1 in the PRD.

### Why

**The page describes half of itself.** It is titled "Third Party Integrations"
and described as *"3rd party accounts … like Gmail for sending emails, GitHub
for code, or Notion for documents."* That was accurate when the page held tool
connectors. It now leads with an AI Subscriptions section, and one of the rows
in that section is the deployment's own chat provider — not a third party by
any reading. Mock 1 titles it **Integrations** and says what both sections are
for.

**The connect dialog names the wrong entity.** It told the user their linked
runs *"follow ChatGPT's terms"*. ChatGPT is a product; the terms are OpenAI's.
That is the one sentence on the screen asking the user to accept something, so
it should name the party they are accepting terms from. Mock 2 says OpenAI.

### What

| | before | after |
|---|---|---|
| page title | Third Party Integrations | Integrations |
| page description | 3rd-party accounts, Gmail/GitHub/Notion | Connect AI subscriptions to power your agents, and third-party tools for them to use |
| terms notice | follow **ChatGPT's** terms | follow **OpenAI's** terms |

The sign-in sentence still says ChatGPT, because the window genuinely is
ChatGPT's. `termsNotice` changed from `boolean` to the entity's name so the two
can differ, rather than both reusing the button's label.

The copilot modal that embeds the same panel is retitled to match — it shows
the same two sections, so leaving it on the old title would have split the
name across two surfaces.

### How

Nothing but copy and one prop type. Three tests changed to match; the header
test is rewritten to pin the reason rather than the string:

```
test("names both kinds of thing the page now holds")
```

### Not in this PR, and worth an owner

Two Mock 2 items I could not close honestly:

1. **"What you get" cannot name the models yet.** Mock 2 says *"5.6 Terra
   (Balanced) and 5.6 Sol (Advanced)"*; ours says "the models your ChatGPT plan
   already includes". The component's comment blames the catalog being
   server-owned — but the catalog is wired up now, so I went to fix it and
   found the real blocker: `_locked_codex_offer` returns `None` for **both**
   audiences who open this dialog — self-host (`_is_hosted()` is false) and
   hosted-but-already-entitled ("the settings page owns that invitation"). So
   there is no ChatGPT offer in the response to read tier models from at the
   moment the dialog is shown. Hardcoding them client-side would reintroduce
   exactly the duplication #14104 removed. This wants a small server-owned
   "what this provider's tiers resolve to" that describe-surfaces can read
   without a connectable offer — which F4's plan cards will need too.

2. **"How your data is handled" has nothing to link to.** Mock 2 and F1's P0
   list both call for a docs link. The only ChatGPT doc in the repo is
   `docs/platform/codex-subscription-preview.md`, an internal preview/testing
   guide, and `docs.agpt.co` is dead (live pattern is `agpt.co/docs/…` via
   `toDocsUrl`). Someone has to write the user-facing page before the link can
   exist.

### Testing

```
vitest run copilot IntegrationsPanel  →  143 files, 1653 passed
tsc --noEmit / eslint --max-warnings 0  →  clean
```

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how default connections and tier labels are sourced across copilot and settings, with backend display-name logic on live routing slugs; regressions would show wrong models or stale defaults after credential changes.
> 
> **Overview**
> **Backend** exposes `catalog_lookup` from the model router and uses it in connection offers so tier **display names** resolve OpenRouter-style slugs (e.g. `anthropic/claude-sonnet-5` → catalog display name) instead of showing raw routing keys; unknown models fall back to the slug without the vendor prefix.
> 
> **Integrations and copilot connection UI** switch from `GET /transports` + client-composed copy to **`GET /connections` offers** (`AIConnectionOffer`): server descriptions, tier model summaries, locked upsell rows, and `offer_id`-based default selection. The Integrations page is retitled **Integrations**, splits **AI subscriptions** from **Tools your agents use**, and ChatGPT OAuth copy names **OpenAI** for terms (not ChatGPT).
> 
> **Copilot ConnectionPicker** adds a **TierToggle** segmented control (models inline in tier labels), highlights linked ChatGPT with **· your plan** on the trigger, and refreshes icons/styling. **`invalidateConnectionQueries`** centralizes React Query invalidation (credentials, connections, transports) after connect/disconnect flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e3fa337fcf64515d022b3fa012d00f28fab0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->