### PR TITLE
feat(backend): drive copilot turns to completion instead of asking the user to babysit

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -270,7 +270,10 @@ Once the user has approved a plan ("confirm all", "go with option 1", "yes,
 do it"), carry out the whole approved scope without a fresh "shall I
 start?" gate. Re-confirm only for **irreversible or external actions** —
 sending, publishing, deploying, spending, or anything that leaves the
-platform. External actions require approval. Reversible ones do not.
+platform. External actions require approval. So does destroying or
+overwriting state you cannot restore — deleting a file, schedule, preset,
+skill, folder or memory, or overwriting an existing file — even though it
+never leaves the platform. Reversible steps do not.
 
 ### Self-learning via skills — load existing, distill new
 

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -676,10 +676,10 @@ def get_delegation_supplement() -> str:
     job.
 - **Waiting etiquette.** If a sub-session is still running when your turn
   ends: give ONE short status line (include the ETA when you know it), then
-  either rely on being woken automatically with the result, or call
-  `schedule_followup` with this session's `session_id` and a sensible delay
-  to check again yourself. Never ask the user whether to keep polling, and
-  never tell them to check back later — the waiting is yours to manage.
+  call `schedule_followup` with this session's `session_id` and a sensible
+  delay (60s minimum) so you pick it back up yourself. Never ask the user
+  whether to keep polling, and never tell them to check back later — the
+  waiting is yours to manage.
 - **One status line per wait cycle.** Live progress already renders on the
   sub-session card above, so skip repeated "still working…" filler. Post
   again only when the status actually changes.

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -250,6 +250,28 @@ This applies whether the turn ends successfully, with a question for the
 user, or with a graceful stop — always reconcile the list with reality
 before signing off.
 
+### Finishing the job — never hand back half-done work
+
+Applies to EVERY turn, not just delegated or multi-step work.
+
+- Take the reversible next step instead of asking whether to take it. Do
+  not end a turn with "shall I start?", "let me know if you'd like me to
+  continue", or "check back later" when you could simply continue.
+- If a turn ends with work still pending, say in one line **what happens
+  next and who acts next**: you (and when/how you resume), a background
+  run (and how its result reaches the user), or the user (and exactly what
+  you need from them). "Still working on it" with no named owner is not an
+  acceptable ending.
+- Stop early only when you are blocked on information only the user holds,
+  or the next step is irreversible.
+
+#### Permission already granted — do not re-ask
+Once the user has approved a plan ("confirm all", "go with option 1", "yes,
+do it"), carry out the whole approved scope without a fresh "shall I
+start?" gate. Re-confirm only for **irreversible or external actions** —
+sending, publishing, deploying, spending, or anything that leaves the
+platform. External actions require approval. Reversible ones do not.
+
 ### Self-learning via skills — load existing, distill new
 
 The `<available_skills>` block injected at the start of the first user
@@ -652,6 +674,15 @@ def get_delegation_supplement() -> str:
     only the user holds, or you are relaying a hard failure. Never close
     a turn by telling the user to go nudge the expert — nudging is your
     job.
+- **Waiting etiquette.** If a sub-session is still running when your turn
+  ends: give ONE short status line (include the ETA when you know it), then
+  either rely on being woken automatically with the result, or call
+  `schedule_followup` with this session's `session_id` and a sensible delay
+  to check again yourself. Never ask the user whether to keep polling, and
+  never tell them to check back later — the waiting is yours to manage.
+- **One status line per wait cycle.** Live progress already renders on the
+  sub-session card above, so skip repeated "still working…" filler. Post
+  again only when the status actually changes.
 """
 
 
@@ -675,6 +706,7 @@ You have access to persistent temporal memory tools scoped to the assistant runn
 - Relationships between people, organizations, events
 - Operational rules (e.g. "invoices go out on the 1st", "CC Sarah on client stuff")
 - When you learn something new about the user
+- **Mid-task corrections — store immediately, do not batch to the end.** When the user corrects a tool, provider, model, or style choice with lasting intent ("always use X", "never do Y", "from now on…"), call `memory_store` in that same turn with `memory_kind="rule"` and a structured `rule` object (`instruction`, plus `actor`/`trigger`/`negation` where they apply), then acknowledge in ONE line — e.g. "Noted — Codex for all code tasks from now on."
 
 ### When to RECALL (memory_search):
 - **BEFORE answering any factual or context-dependent question — ALWAYS**

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -5,6 +5,11 @@ import importlib
 from backend.copilot import prompting
 
 
+def flat(text: str) -> str:
+    """Collapse wrapped prose so assertions survive re-flowed paragraphs."""
+    return " ".join(text.split())
+
+
 class TestGetSdkSupplementStaticPlaceholder:
     """get_sdk_supplement must return a static string so the system prompt is
     identical for all users and sessions, enabling cross-user prompt-cache hits.
@@ -79,6 +84,155 @@ class TestToolDiscoveryPriorityAntiPattern:
         # has a concrete template to follow, not just a prohibition.
         assert "Correct flow" in result
         assert 'find_block(query="<service> <action>")' in result
+
+
+class TestDriveToCompletionIsAlwaysOn:
+    """The general "never hand back half-done work" rules must live in
+    ``SHARED_TOOL_NOTES`` so they reach BOTH engines on every turn — the
+    baseline path concatenates the constant directly and the SDK path
+    embeds it via ``get_sdk_supplement``. Keeping them in the delegation
+    supplement would gate them behind ``Flag.HIRE_EXPERTS``.
+    """
+
+    def setup_method(self):
+        importlib.reload(prompting)
+
+    def test_shared_notes_contain_finishing_the_job_section(self):
+        assert (
+            "Finishing the job — never hand back half-done work"
+            in prompting.SHARED_TOOL_NOTES
+        )
+
+    def test_shared_notes_name_next_actor_for_pending_work(self):
+        assert "what happens next and who acts next" in flat(
+            prompting.SHARED_TOOL_NOTES
+        )
+
+    def test_shared_notes_forbid_check_back_later_endings(self):
+        assert '"check back later"' in prompting.SHARED_TOOL_NOTES
+
+    def test_local_sdk_supplement_includes_finishing_the_job(self):
+        result = prompting.get_sdk_supplement(use_e2b=False)
+        assert "Finishing the job — never hand back half-done work" in result
+
+    def test_e2b_sdk_supplement_includes_finishing_the_job(self):
+        result = prompting.get_sdk_supplement(use_e2b=True)
+        assert "Finishing the job — never hand back half-done work" in result
+
+    def test_drive_to_completion_is_not_gated_behind_delegation(self):
+        # The general rule must NOT be confined to the flagged supplement.
+        assert (
+            "Finishing the job — never hand back half-done work"
+            not in prompting.get_delegation_supplement()
+        )
+
+
+class TestGrantedPermissionIsNotReAsked:
+    """After the user approves a plan, reversible next steps proceed without a
+    fresh confirmation gate; only irreversible/external actions re-gate. The
+    wording tracks ``PROTECTED_SOUL_RULES.EXTERNAL_ACTION_APPROVAL_RULE``.
+    """
+
+    def setup_method(self):
+        importlib.reload(prompting)
+
+    def test_shared_notes_contain_no_re_ask_section(self):
+        assert (
+            "Permission already granted — do not re-ask" in prompting.SHARED_TOOL_NOTES
+        )
+
+    def test_shared_notes_list_approval_phrases(self):
+        assert '"confirm all"' in prompting.SHARED_TOOL_NOTES
+        assert '"go with option 1"' in prompting.SHARED_TOOL_NOTES
+
+    def test_shared_notes_keep_gate_for_irreversible_actions(self):
+        notes = prompting.SHARED_TOOL_NOTES
+        assert "irreversible or external actions" in notes
+        assert "sending, publishing, deploying, spending" in notes
+
+    def test_wording_stays_consistent_with_protected_soul_rules(self):
+        from backend.api.features.experts.models import EXTERNAL_ACTION_APPROVAL_RULE
+
+        # "External actions require approval." — restated verbatim so the
+        # copilot prompt and the expert soul rules cannot drift apart.
+        assert EXTERNAL_ACTION_APPROVAL_RULE in prompting.SHARED_TOOL_NOTES
+
+    def test_rule_reaches_the_sdk_supplement(self):
+        result = prompting.get_sdk_supplement(use_e2b=False)
+        assert "Permission already granted — do not re-ask" in result
+
+
+class TestDelegationWaitingEtiquette:
+    """While a sub-session is still running the model owns the wait: one short
+    status line, then either an automatic wake-up or a self-scheduled
+    ``schedule_followup`` — never a question to the user about polling.
+    """
+
+    def setup_method(self):
+        importlib.reload(prompting)
+
+    def test_supplement_contains_waiting_etiquette_rule(self):
+        assert "Waiting etiquette." in prompting.get_delegation_supplement()
+
+    def test_waiting_rule_offers_both_resume_paths(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "woken automatically with the result" in supplement
+        assert "`schedule_followup` with this session's `session_id`" in supplement
+
+    def test_waiting_rule_requires_status_line_with_eta(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "ONE short status line" in supplement
+        assert "include the ETA when you know it" in supplement
+
+    def test_waiting_rule_forbids_asking_the_user_to_wait(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "Never ask the user whether to keep polling" in flat(supplement)
+        assert "never tell them to check back later" in flat(supplement)
+
+    def test_supplement_caps_poll_narration(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "One status line per wait cycle." in supplement
+        assert 'skip repeated "still working…" filler' in supplement
+
+    def test_poll_cap_points_at_the_sub_session_card(self):
+        assert "Live progress already renders on the sub-session card above" in flat(
+            prompting.get_delegation_supplement()
+        )
+
+
+class TestDurablePreferenceCapture:
+    """A mid-task correction with lasting intent ("always use X") is a rule to
+    persist immediately, not a one-off instruction to follow and forget.
+    """
+
+    def setup_method(self):
+        importlib.reload(prompting)
+
+    def test_store_triggers_include_mid_task_corrections(self):
+        assert "Mid-task corrections" in prompting.get_graphiti_supplement()
+
+    def test_trigger_lists_the_durable_intent_phrases(self):
+        supplement = prompting.get_graphiti_supplement()
+        assert '"always use X"' in supplement
+        assert '"never do Y"' in supplement
+        assert '"from now on…"' in supplement
+
+    def test_trigger_specifies_the_real_memory_store_schema(self):
+        supplement = prompting.get_graphiti_supplement()
+        assert '`memory_kind="rule"`' in supplement
+        assert "`instruction`" in supplement
+        assert "`actor`/`trigger`/`negation`" in supplement
+
+    def test_trigger_requires_a_one_line_acknowledgement(self):
+        supplement = prompting.get_graphiti_supplement()
+        assert "acknowledge in ONE line" in supplement
+        assert "Noted — Codex for all code tasks from now on." in supplement
+
+    def test_trigger_forbids_deferring_the_write(self):
+        assert (
+            "store immediately, do not batch to the end"
+            in prompting.get_graphiti_supplement()
+        )
 
 
 class TestGraphitiMemoryScope:

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -173,10 +173,22 @@ class TestDelegationWaitingEtiquette:
     def test_supplement_contains_waiting_etiquette_rule(self):
         assert "Waiting etiquette." in prompting.get_delegation_supplement()
 
-    def test_waiting_rule_offers_both_resume_paths(self):
+    def test_waiting_rule_names_schedule_followup_as_the_resume_path(self):
         supplement = prompting.get_delegation_supplement()
-        assert "woken automatically with the result" in supplement
         assert "`schedule_followup` with this session's `session_id`" in supplement
+        assert "60s minimum" in flat(supplement)
+
+    def test_waiting_rule_promises_no_resume_mechanism_that_does_not_exist(self):
+        """Nothing enqueues a turn back onto the parent when a sub finishes —
+        a delegation that outlives its turn resumes only because the model
+        scheduled a followup. Promising an automatic wake-up here would let
+        the model end the turn with no resume at all, which is worse than the
+        babysitting these rules exist to remove. The PR that adds the wake
+        mechanism updates this assertion along with the wording."""
+        supplement = flat(prompting.get_delegation_supplement())
+
+        assert "woken automatically" not in supplement
+        assert "wakes this chat" not in supplement
 
     def test_waiting_rule_requires_status_line_with_eta(self):
         supplement = prompting.get_delegation_supplement()

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -2,6 +2,7 @@
 
 import importlib
 
+from backend.api.features.experts.models import EXTERNAL_ACTION_APPROVAL_RULE
 from backend.copilot import prompting
 
 
@@ -151,8 +152,6 @@ class TestGrantedPermissionIsNotReAsked:
         assert "sending, publishing, deploying, spending" in notes
 
     def test_wording_stays_consistent_with_protected_soul_rules(self):
-        from backend.api.features.experts.models import EXTERNAL_ACTION_APPROVAL_RULE
-
         # "External actions require approval." — restated verbatim so the
         # copilot prompt and the expert soul rules cannot drift apart.
         assert EXTERNAL_ACTION_APPROVAL_RULE in prompting.SHARED_TOOL_NOTES

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -151,6 +151,16 @@ class TestGrantedPermissionIsNotReAsked:
         assert "irreversible or external actions" in notes
         assert "sending, publishing, deploying, spending" in notes
 
+    def test_gate_covers_irreversible_actions_that_never_leave_the_platform(self):
+        """These tools have no code-level confirmation flow (`permissions.py`),
+        so this prose IS the gate. Closing on "external actions require
+        approval" alone reads as not-external ⇒ proceed, which would leave
+        every in-platform delete ungated."""
+        notes = flat(prompting.SHARED_TOOL_NOTES)
+
+        assert "destroying or overwriting state you cannot restore" in notes
+        assert "even though it never leaves the platform" in notes
+
     def test_wording_stays_consistent_with_protected_soul_rules(self):
         # "External actions require approval." — restated verbatim so the
         # copilot prompt and the expert soul rules cannot drift apart.


### PR DESCRIPTION
> **Stacked PR 1 of 10** — Autopilot proactivity & conversation quality. Base: `dev`.
> The stack is linear because these workstreams share `prompting.py`, `feature_flag.py`,
> `db.py` and `tools/models.py`; stacking removes the conflicts by construction.

### Why / What / How

**Why.** Copilot turns too often hand work back to the user half-done. Three shapes seen in real sessions:

1. **Babysitting a delegation.** A sub-session is still running at end of turn, so the model asks "want me to keep checking?" or says "check back in a few minutes" — making the user the scheduler for work the model owns.
2. **Re-asking for granted permission.** The user says "confirm all" or "go with option 1", and the next turn opens with "shall I start?" — a second gate on an approval already given.
3. **Losing durable corrections.** The user says "always use Codex for code tasks"; the model complies for one turn and forgets by the next session.

The strong "keep polling until it resolves / nudging is your job" language already existed, but only inside `get_delegation_supplement()`, which is gated behind `Flag.HIRE_EXPERTS`. Flag-off users got none of it, and even flag-on users only got it for delegated work.

**What.** Prompt-only, no new infra:

- **Waiting etiquette** (delegation supplement): if a sub-session is still running at end of turn — one short status line with the ETA when known, then either rely on being woken with the result or self-schedule a `schedule_followup` on the current `session_id`. Never ask the user whether to keep polling; never tell them to check back later.
- **Poll narration cap** (delegation supplement): at most one status message per wait cycle, since live progress already renders on the sub-session card.
- **Drive to completion, generalized** (shared notes, every turn): never hand back half-done work; if a turn ends with work pending, state what happens next *and who acts next*.
- **No re-asking for granted permission** (shared notes): after an approval, carry out the whole approved scope. Confirmation gates remain for irreversible/external actions only.
- **Durable-preference capture** (Graphiti supplement): a mid-task correction with lasting intent triggers an immediate `memory_store(memory_kind="rule", rule={...})` plus a one-line ack.

**How.** Everything lands inside existing shared constants/functions, so **no assembly-site changes** were needed — both engines pick the text up automatically:

- `SHARED_TOOL_NOTES` is concatenated inline by `baseline/service.py`, and reaches the SDK engine via `get_sdk_supplement`.
- Rules 3 and 4 deliberately live in `SHARED_TOOL_NOTES`, **not** the delegation supplement, because they must apply on every turn regardless of `Flag.HIRE_EXPERTS`. A negative test pins this.
- `get_sdk_supplement`'s `@cache` / byte-identical-across-users property is preserved: all added text is static, no per-user interpolation.
- The permission wording restates `EXTERNAL_ACTION_APPROVAL_RULE` verbatim, and a test asserts the constant is a literal substring, so copilot rules and expert soul rules cannot drift apart.
- These tokens ship on every turn, so wording is kept to the minimum that is unambiguous (+32 lines across three sections).

**No Langfuse update required.** `_CACHEABLE_SYSTEM_PROMPT` is untouched — it is hash-locked by `expert_context_test.py`'s SHA-256 prompt-cache contract. All added text lives in the supplements, which are assembled in-repo and appended after the (possibly hosted) system prompt, so the rules ship even when Langfuse serves the base prompt.

### Changes 🏗️

- `copilot/prompting.py` — new `### Finishing the job` section + `#### Permission already granted` subsection in `SHARED_TOOL_NOTES`; waiting-etiquette and poll-cap bullets in `get_delegation_supplement()`; mid-task-correction bullet in `get_graphiti_supplement()`.
- `copilot/prompting_test.py` — 4 new test classes, incl. a negative test that the general rule is not confined to the flagged delegation supplement.

No flags added. No schema or config changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `poetry run pytest backend/copilot/prompting_test.py -v`
  - [ ] `poetry run pytest backend/copilot/sdk/service_test.py backend/copilot/expert_context_test.py backend/copilot/prompt_cache_test.py` — confirms no prompt-content or prompt-cache contract broke
  - [ ] Manual, `HIRE_EXPERTS` off: ask for a multi-step build, approve with "confirm all", verify no second "shall I start?" gate
  - [ ] Manual, `HIRE_EXPERTS` on: delegate to an expert, confirm the turn ends with one status line and no "still working…" filler
  - [ ] Manual, Graphiti on: say "always use Codex for code tasks" mid-task; verify a `memory_store` call with `memory_kind="rule"` and recall in a fresh session
