### PR TITLE
feat(backend): confirm several approved expert previews in one call

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
+++ b/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
@@ -12,11 +12,10 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationError
 
 from backend.copilot.model import ChatSession
-from backend.data.redis_client import get_redis_async
+from backend.data.redis_client import AsyncRedisClient, get_redis_async
 
 from .base import BaseTool
 from .expert_proposal import (
-    ExpertChangeProposal,
     apply_proposal,
     autopilot_session_guard,
     load_bound_proposal,
@@ -215,24 +214,10 @@ async def _confirm_batch(
             session_id=session_id,
         )
 
-    # Every id is resolved and bound-checked before a single write happens,
-    # so a stale or foreign id in the batch is reported instead of deciding
-    # what the ids beside it are allowed to do.
-    #
-    # ``load_bound_proposal`` consumes as it checks, so this pass burns the
-    # ids it accepts. That is deliberate: it makes one batch behave exactly
-    # like N sequential single-id confirms, where a proposal that fails at
-    # apply time is likewise discarded and re-previewed. Splitting the check
-    # from the consume would give the batch path its own, weaker single-use
-    # guarantee than the single-id path it has to match.
     redis = await get_redis_async()
-    loaded = [
-        await load_bound_proposal(redis, candidate, user_id, session)
-        for candidate in ids
-    ]
     results = [
-        await _apply_one(user_id, session_id, candidate, proposal)
-        for candidate, proposal in zip(ids, loaded)
+        await _confirm_and_apply(redis, user_id, session, candidate)
+        for candidate in ids
     ]
     experts = _created_experts(results)
     return ExpertChangeBatchAppliedResponse(
@@ -244,15 +229,25 @@ async def _confirm_batch(
     )
 
 
-async def _apply_one(
+async def _confirm_and_apply(
+    redis: AsyncRedisClient,
     user_id: str,
-    session_id: str,
+    session: ChatSession,
     confirmation_id: str,
-    proposal: ExpertChangeProposal | ExpertChangeError,
 ) -> ExpertChangeResult:
+    """Consume one id and apply it before the next id is touched.
+
+    ``load_bound_proposal`` tombstones as it checks, so consuming all N up
+    front and applying afterwards means an interrupted call — a Stop or a
+    disconnect, both of which cancel the turn mid-tool — permanently burns
+    every approval it never got to, with nothing created. Because no apply
+    reads the ids beside it, interleaving costs nothing and leaves the ids
+    past the interruption still valid and re-confirmable.
+    """
+    proposal = await load_bound_proposal(redis, confirmation_id, user_id, session)
     if isinstance(proposal, ExpertChangeError):
         return _unapplied_result(confirmation_id, proposal)
-    applied = await apply_proposal(user_id, session_id, proposal)
+    applied = await apply_proposal(user_id, session.session_id, proposal)
     if isinstance(applied, ExpertChangeAppliedResponse):
         return ExpertChangeResult(
             confirmation_id=confirmation_id,

--- a/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
+++ b/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
@@ -43,11 +43,28 @@ _PROPOSAL_FIELDS = (
 MAX_BATCH_CONFIRMATIONS = 20
 
 
-class _BatchParams(BaseModel):
-    """Bounds on the batch itself, checked before anything is consumed."""
+_MALFORMED_IDS_MESSAGE = (
+    "confirm_expert_change takes confirmation_id as a single id string or "
+    f"confirmation_ids as a list of 1 to {MAX_BATCH_CONFIRMATIONS} id "
+    "strings, and nothing else. No confirmation was used up."
+)
 
-    confirmation_ids: list[str] = Field(
-        min_length=1, max_length=MAX_BATCH_CONFIRMATIONS
+
+class _ConfirmParams(BaseModel):
+    """Both ids as a model may actually send them, checked before anything
+    is consumed.
+
+    Filling both keys and nulling the unused one is a routine tool-call
+    shape, so ``None`` is a value here rather than a crash. Anything else
+    that is not a string or a list of strings is answered with the guidance
+    below instead of escaping as a traceback, which ``BaseTool.execute``
+    would flatten into "an error occurred" — leaving the model unable to
+    tell whether the ids were consumed.
+    """
+
+    confirmation_id: str | None = None
+    confirmation_ids: list[str] | None = Field(
+        default=None, max_length=MAX_BATCH_CONFIRMATIONS
     )
 
 
@@ -102,8 +119,8 @@ class ConfirmExpertChangeTool(BaseTool):
         user_id: str | None,
         session: ChatSession,
         *,
-        confirmation_id: str = "",
-        confirmation_ids: list[str] | None = None,
+        confirmation_id: object = None,
+        confirmation_ids: object = None,
         **kwargs,
     ) -> ToolResponseBase:
         session_id = session.session_id
@@ -121,10 +138,23 @@ class ConfirmExpertChangeTool(BaseTool):
                 session_id=session_id,
             )
 
-        single = confirmation_id.strip()
+        try:
+            params = _ConfirmParams.model_validate(
+                {
+                    "confirmation_id": confirmation_id,
+                    "confirmation_ids": confirmation_ids,
+                }
+            )
+        except ValidationError:
+            return ErrorResponse(
+                message=_MALFORMED_IDS_MESSAGE,
+                session_id=session_id,
+            )
+
+        single = (params.confirmation_id or "").strip()
         # An empty list is "no batch", not "a batch of nothing", so a model
         # that fills both keys but only means one of them still works.
-        batch = confirmation_ids or None
+        batch = params.confirmation_ids or None
         if single and batch:
             return ErrorResponse(
                 message=(
@@ -176,17 +206,7 @@ async def _confirm_batch(
     per-id limit errors and the team can never actually exceed the cap.
     """
     session_id = session.session_id
-    try:
-        params = _BatchParams(confirmation_ids=confirmation_ids)
-    except ValidationError:
-        return ErrorResponse(
-            message=(
-                "confirmation_ids must be a list of 1 to "
-                f"{MAX_BATCH_CONFIRMATIONS} confirmation ids."
-            ),
-            session_id=session_id,
-        )
-    ids = [candidate.strip() for candidate in params.confirmation_ids]
+    ids = [candidate.strip() for candidate in confirmation_ids]
     if not all(ids):
         return ErrorResponse(
             message="confirmation_ids must not contain a blank id.",

--- a/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
+++ b/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
@@ -1,23 +1,34 @@
-"""Apply a previewed hire or raise by its one-time confirmation_id.
+"""Apply previewed hires or raises by their one-time confirmation ids.
 
-Step 2 of the confirm-gated team-change flow. One confirm tool serves both
-kinds: it takes nothing but the id, so the applied change is exactly what the
-user saw. The id is single-use and bound to the Autopilot session that
-produced it.
+Step 2 of the confirm-gated team-change flow. One confirm tool serves every
+kind: it takes nothing but the ids, so the applied change is exactly what the
+user saw. Each id is single-use and bound to the Autopilot session that
+produced it. A user who approves several previews in one breath is one call,
+not one round-trip each — pass ``confirmation_ids``.
 """
 
 from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
 
 from backend.copilot.model import ChatSession
 from backend.data.redis_client import get_redis_async
 
 from .base import BaseTool
 from .expert_proposal import (
+    ExpertChangeProposal,
     apply_proposal,
     autopilot_session_guard,
     load_bound_proposal,
 )
-from .models import ErrorResponse, ToolResponseBase
+from .models import (
+    ErrorResponse,
+    ExpertChangeAppliedResponse,
+    ExpertChangeBatchAppliedResponse,
+    ExpertChangeResult,
+    ExpertSummary,
+    ToolResponseBase,
+)
 
 _PROPOSAL_FIELDS = (
     "template_id",
@@ -29,9 +40,19 @@ _PROPOSAL_FIELDS = (
     "weekly_budget",
 )
 
+MAX_BATCH_CONFIRMATIONS = 20
+
+
+class _BatchParams(BaseModel):
+    """Bounds on the batch itself, checked before anything is consumed."""
+
+    confirmation_ids: list[str] = Field(
+        min_length=1, max_length=MAX_BATCH_CONFIRMATIONS
+    )
+
 
 class ConfirmExpertChangeTool(BaseTool):
-    """Create the expert previewed by hire_expert or raise_expert."""
+    """Create the experts previewed by hire_expert or raise_expert."""
 
     @property
     def name(self) -> str:
@@ -45,8 +66,10 @@ class ConfirmExpertChangeTool(BaseTool):
     def description(self) -> str:
         return (
             "Apply a hire_expert or raise_expert proposal after the user has "
-            "approved it. Takes only the confirmation_id and creates exactly "
-            "the previewed expert; the id is single-use."
+            "approved it. Takes only confirmation ids and creates exactly the "
+            "previewed experts; each id is single-use. When the user approves "
+            "several previews at once, confirm them in a single call by "
+            "passing confirmation_ids."
         )
 
     @property
@@ -56,10 +79,22 @@ class ConfirmExpertChangeTool(BaseTool):
             "properties": {
                 "confirmation_id": {
                     "type": "string",
-                    "description": "The id returned by hire_expert/raise_expert.",
+                    "description": (
+                        "One id returned by hire_expert/raise_expert. Use "
+                        "this or confirmation_ids, never both."
+                    ),
+                },
+                "confirmation_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": MAX_BATCH_CONFIRMATIONS,
+                    "description": (
+                        "Every id the user approved together, applied in one "
+                        f"call (max {MAX_BATCH_CONFIRMATIONS})."
+                    ),
                 },
             },
-            "required": ["confirmation_id"],
         }
 
     async def _execute(
@@ -68,6 +103,7 @@ class ConfirmExpertChangeTool(BaseTool):
         session: ChatSession,
         *,
         confirmation_id: str = "",
+        confirmation_ids: list[str] | None = None,
         **kwargs,
     ) -> ToolResponseBase:
         session_id = session.session_id
@@ -84,20 +120,170 @@ class ConfirmExpertChangeTool(BaseTool):
                 ),
                 session_id=session_id,
             )
-        if not confirmation_id:
+
+        single = confirmation_id.strip()
+        # An empty list is "no batch", not "a batch of nothing", so a model
+        # that fills both keys but only means one of them still works.
+        batch = confirmation_ids or None
+        if single and batch:
             return ErrorResponse(
                 message=(
-                    "A confirmation_id from hire_expert or raise_expert is required."
+                    "Pass confirmation_id for one approved preview or "
+                    "confirmation_ids for several, never both."
                 ),
                 session_id=session_id,
             )
+        if batch:
+            return await _confirm_batch(user_id, session, batch)
+        if not single:
+            return ErrorResponse(
+                message=(
+                    "A confirmation_id from hire_expert or raise_expert is "
+                    "required, or confirmation_ids to apply several at once."
+                ),
+                session_id=session_id,
+            )
+        return await _confirm_one(user_id, session, single)
 
-        proposal = await load_bound_proposal(
-            await get_redis_async(),
-            confirmation_id,
-            user_id,
-            session,
+
+async def _confirm_one(
+    user_id: str,
+    session: ChatSession,
+    confirmation_id: str,
+) -> ToolResponseBase:
+    proposal = await load_bound_proposal(
+        await get_redis_async(),
+        confirmation_id,
+        user_id,
+        session,
+    )
+    if isinstance(proposal, ErrorResponse):
+        return proposal
+    return await apply_proposal(user_id, session.session_id, proposal)
+
+
+async def _confirm_batch(
+    user_id: str,
+    session: ChatSession,
+    confirmation_ids: list[str],
+) -> ToolResponseBase:
+    """Apply every approved id, reporting each one's outcome separately.
+
+    ``capacity_error`` only runs at preview time, so N previews that were
+    each under the active-expert cap can exceed it together. Nothing is
+    pre-computed here to stop that: the creation transaction is the cap's
+    real enforcement point, so the overflowing hires come back as ordinary
+    per-id limit errors and the team can never actually exceed the cap.
+    """
+    session_id = session.session_id
+    try:
+        params = _BatchParams(confirmation_ids=confirmation_ids)
+    except ValidationError:
+        return ErrorResponse(
+            message=(
+                "confirmation_ids must be a list of 1 to "
+                f"{MAX_BATCH_CONFIRMATIONS} confirmation ids."
+            ),
+            session_id=session_id,
         )
-        if isinstance(proposal, ErrorResponse):
-            return proposal
-        return await apply_proposal(user_id, session_id, proposal)
+    ids = [candidate.strip() for candidate in params.confirmation_ids]
+    if not all(ids):
+        return ErrorResponse(
+            message="confirmation_ids must not contain a blank id.",
+            session_id=session_id,
+        )
+
+    # Every id is resolved and bound-checked before a single write happens,
+    # so a stale or foreign id in the batch is reported instead of deciding
+    # what the ids beside it are allowed to do.
+    #
+    # ``load_bound_proposal`` consumes as it checks, so this pass burns the
+    # ids it accepts. That is deliberate: it makes one batch behave exactly
+    # like N sequential single-id confirms, where a proposal that fails at
+    # apply time is likewise discarded and re-previewed. Splitting the check
+    # from the consume would give the batch path its own, weaker single-use
+    # guarantee than the single-id path it has to match.
+    redis = await get_redis_async()
+    loaded = [
+        await load_bound_proposal(redis, candidate, user_id, session)
+        for candidate in ids
+    ]
+    results = [
+        await _apply_one(user_id, session_id, candidate, proposal)
+        for candidate, proposal in zip(ids, loaded)
+    ]
+    experts = [
+        result.expert
+        for result in results
+        if result.applied and result.expert is not None
+    ]
+    return ExpertChangeBatchAppliedResponse(
+        message=_batch_message(results),
+        session_id=session_id,
+        applied=bool(experts),
+        results=results,
+        experts=experts,
+    )
+
+
+async def _apply_one(
+    user_id: str,
+    session_id: str,
+    confirmation_id: str,
+    proposal: ExpertChangeProposal | ErrorResponse,
+) -> ExpertChangeResult:
+    if isinstance(proposal, ErrorResponse):
+        return ExpertChangeResult(
+            confirmation_id=confirmation_id,
+            applied=False,
+            error=proposal.message,
+        )
+    applied = await apply_proposal(user_id, session_id, proposal)
+    if isinstance(applied, ExpertChangeAppliedResponse):
+        return ExpertChangeResult(
+            confirmation_id=confirmation_id,
+            applied=True,
+            kind=applied.kind,
+            expert=applied.expert,
+            failed_workflows=applied.failed_workflows,
+        )
+    return ExpertChangeResult(
+        confirmation_id=confirmation_id,
+        applied=False,
+        error=applied.message,
+    )
+
+
+def _batch_message(results: list[ExpertChangeResult]) -> str:
+    """Read the batch back the way the user has to hear it.
+
+    A partial batch is the dangerous case: without naming both halves the
+    model announces the whole approval as done, so every failure and every
+    half-installed hire gets its own sentence.
+    """
+    created: list[ExpertSummary] = [
+        result.expert
+        for result in results
+        if result.applied and result.expert is not None
+    ]
+    failures = [result for result in results if not result.applied]
+    names = ", ".join(expert.name for expert in created)
+
+    if not created:
+        parts = [f"Nothing was applied — all {len(results)} confirmations failed."]
+    elif failures:
+        parts = [f"{len(created)} of {len(results)} applied: {names}."]
+    else:
+        parts = [f"All {len(results)} approved changes applied: {names}."]
+
+    parts.extend(
+        f"{result.confirmation_id} failed: {result.error}" for result in failures
+    )
+    parts.extend(
+        f"{result.expert.name} joined without these workflows: "
+        f"{', '.join(result.failed_workflows)}."
+        for result in results
+        if result.expert is not None and result.failed_workflows
+    )
+    parts.append("Tell the user exactly who is on the team now and what did not land.")
+    return " ".join(parts)

--- a/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
+++ b/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
@@ -22,9 +22,11 @@ from .expert_proposal import (
     load_bound_proposal,
 )
 from .models import (
+    EXPERT_CHANGE_LANDED_REASONS,
     ErrorResponse,
     ExpertChangeAppliedResponse,
     ExpertChangeBatchAppliedResponse,
+    ExpertChangeError,
     ExpertChangeResult,
     ExpertSummary,
     ToolResponseBase,
@@ -187,7 +189,7 @@ async def _confirm_one(
         user_id,
         session,
     )
-    if isinstance(proposal, ErrorResponse):
+    if isinstance(proposal, ExpertChangeError):
         return proposal
     return await apply_proposal(user_id, session.session_id, proposal)
 
@@ -232,15 +234,11 @@ async def _confirm_batch(
         await _apply_one(user_id, session_id, candidate, proposal)
         for candidate, proposal in zip(ids, loaded)
     ]
-    experts = [
-        result.expert
-        for result in results
-        if result.applied and result.expert is not None
-    ]
+    experts = _created_experts(results)
     return ExpertChangeBatchAppliedResponse(
         message=_batch_message(results),
         session_id=session_id,
-        applied=bool(experts),
+        applied=any(result.outcome != "failed" for result in results),
         results=results,
         experts=experts,
     )
@@ -250,28 +248,47 @@ async def _apply_one(
     user_id: str,
     session_id: str,
     confirmation_id: str,
-    proposal: ExpertChangeProposal | ErrorResponse,
+    proposal: ExpertChangeProposal | ExpertChangeError,
 ) -> ExpertChangeResult:
-    if isinstance(proposal, ErrorResponse):
-        return ExpertChangeResult(
-            confirmation_id=confirmation_id,
-            applied=False,
-            error=proposal.message,
-        )
+    if isinstance(proposal, ExpertChangeError):
+        return _unapplied_result(confirmation_id, proposal)
     applied = await apply_proposal(user_id, session_id, proposal)
     if isinstance(applied, ExpertChangeAppliedResponse):
         return ExpertChangeResult(
             confirmation_id=confirmation_id,
-            applied=True,
+            outcome="applied",
             kind=applied.kind,
             expert=applied.expert,
             failed_workflows=applied.failed_workflows,
         )
+    return _unapplied_result(confirmation_id, applied)
+
+
+def _unapplied_result(
+    confirmation_id: str, error: ExpertChangeError
+) -> ExpertChangeResult:
+    """Not every refusal is a failure.
+
+    ``already_applied`` and ``applied_but_expert_gone`` both mean the change
+    is on the team — the first from an earlier confirm, the second from this
+    one — so folding them in with the genuine failures makes the batch tell
+    the user a teammate they have was never added.
+    """
+    landed = error.reason in EXPERT_CHANGE_LANDED_REASONS
     return ExpertChangeResult(
         confirmation_id=confirmation_id,
-        applied=False,
-        error=applied.message,
+        outcome="already_applied" if landed else "failed",
+        reason=error.reason,
+        error=error.message,
     )
+
+
+def _created_experts(results: list[ExpertChangeResult]) -> list[ExpertSummary]:
+    return [
+        result.expert
+        for result in results
+        if result.outcome == "applied" and result.expert is not None
+    ]
 
 
 def _batch_message(results: list[ExpertChangeResult]) -> str:
@@ -281,21 +298,25 @@ def _batch_message(results: list[ExpertChangeResult]) -> str:
     model announces the whole approval as done, so every failure and every
     half-installed hire gets its own sentence.
     """
-    created: list[ExpertSummary] = [
-        result.expert
-        for result in results
-        if result.applied and result.expert is not None
-    ]
-    failures = [result for result in results if not result.applied]
+    created = _created_experts(results)
+    already = [result for result in results if result.outcome == "already_applied"]
+    failures = [result for result in results if result.outcome == "failed"]
+    landed = len(results) - len(failures)
     names = ", ".join(expert.name for expert in created)
+    named = f": {names}" if names else ""
 
-    if not created:
+    if not landed:
         parts = [f"Nothing was applied — all {len(results)} confirmations failed."]
     elif failures:
-        parts = [f"{len(created)} of {len(results)} applied: {names}."]
+        parts = [f"{landed} of {len(results)} approved changes are done{named}."]
     else:
-        parts = [f"All {len(results)} approved changes applied: {names}."]
+        parts = [f"All {len(results)} approved changes are done{named}."]
 
+    if already:
+        parts.append(
+            f"{len(already)} of them were already applied before this call — "
+            "they are done, do not re-preview or retry them."
+        )
     parts.extend(
         f"{result.confirmation_id} failed: {result.error}" for result in failures
     )

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -927,7 +927,7 @@ class TestBatchConfirm:
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
         assert resp.applied is True
         assert [result.confirmation_id for result in resp.results] == [first, second]
-        assert all(result.applied for result in resp.results)
+        assert all(result.outcome == "applied" for result in resp.results)
         assert [expert.name for expert in resp.experts] == ["Scout", "Otto"]
         assert "Scout" in resp.message and "Otto" in resp.message
         db.hire_expert.assert_awaited_once()
@@ -946,9 +946,14 @@ class TestBatchConfirm:
             )
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
         assert resp.applied is True
-        assert [result.applied for result in resp.results] == [True, False, True]
+        assert [result.outcome for result in resp.results] == [
+            "applied",
+            "failed",
+            "applied",
+        ]
         failed = resp.results[1]
         assert failed.confirmation_id == "nope"
+        assert failed.reason == "expired"
         assert failed.error is not None
         assert "expired" in failed.error
         assert failed.expert is None
@@ -965,12 +970,71 @@ class TestBatchConfirm:
             resp = await _confirm(_approve(session), confirmation_ids=[first, second])
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
         replayed = resp.results[0]
-        assert replayed.applied is False
+        assert replayed.outcome == "already_applied"
+        assert replayed.reason == "already_applied"
         assert replayed.error is not None
         assert "already confirmed" in replayed.error
-        assert resp.results[1].applied is True
+        assert resp.results[1].outcome == "applied"
         # The replay must not hire a second Scout.
         assert db.hire_expert.await_count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_batch_of_replays_reads_as_done_not_as_a_total_failure(self):
+        """ "Nothing was applied" about changes that are all on the team is the
+        worst thing this tool can say: the model repeats it, and the user is
+        told their team is empty while looking at it."""
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            await _confirm(_approve(session), confirmation_ids=[first, second])
+            resp = await _confirm(_approve(session), confirmation_ids=[first, second])
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.applied is True
+        assert [result.outcome for result in resp.results] == [
+            "already_applied",
+            "already_applied",
+        ]
+        assert "Nothing was applied" not in resp.message
+        assert "already applied" in resp.message
+        # The replay must not hire a second Scout or raise a second Otto.
+        assert db.hire_expert.await_count == 1
+        assert db.create_raised_expert.await_count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_saved_but_unreadable_edit_is_not_reported_as_not_added(self):
+        """``_applied_but_unreadable_error`` says the edit "was saved". The
+        batch must agree with it instead of rendering the same change as a
+        failure."""
+        with _env() as db:
+            db.update_soul_if_current.side_effect = ExpertWriteNotReadableError("exp-2")
+            session = make_session(_USER)
+            preview = await _update(session, expert_id="exp-2", name="Nick")
+            assert isinstance(preview, ExpertChangeProposedResponse)
+            resp = await _confirm(
+                _approve(session), confirmation_ids=[preview.confirmation_id]
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.applied is True
+        assert resp.results[0].outcome == "already_applied"
+        assert resp.results[0].reason == "applied_but_expert_gone"
+        assert "Nothing was applied" not in resp.message
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_replay_beside_a_failure_still_counts_as_landed(self):
+        with _env():
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            await _confirm(_approve(session), confirmation_id=first)
+            resp = await _confirm(
+                _approve(session), confirmation_ids=[first, second, "nope"]
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert [result.outcome for result in resp.results] == [
+            "already_applied",
+            "applied",
+            "failed",
+        ]
+        assert "2 of 3" in resp.message
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_an_id_from_another_chat_is_refused_inside_a_batch(self):
@@ -986,10 +1050,11 @@ class TestBatchConfirm:
                 confirmation_ids=[stranger.confirmation_id, mine.confirmation_id],
             )
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
-        assert resp.results[0].applied is False
+        assert resp.results[0].outcome == "failed"
+        assert resp.results[0].reason == "wrong_chat"
         assert resp.results[0].error is not None
         assert "different chat" in resp.results[0].error
-        assert resp.results[1].applied is True
+        assert resp.results[1].outcome == "applied"
         db.hire_expert.assert_not_called()
 
     @pytest.mark.asyncio(loop_scope="session")
@@ -1025,8 +1090,9 @@ class TestBatchConfirm:
                 confirmation_ids=[first.confirmation_id, second.confirmation_id],
             )
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
-        assert resp.results[0].applied is True
-        assert resp.results[1].applied is False
+        assert resp.results[0].outcome == "applied"
+        assert resp.results[1].outcome == "failed"
+        assert resp.results[1].reason == "limit_reached"
         assert resp.results[1].error is not None
         assert str(ACTIVE_EXPERT_LIMIT) in resp.results[1].error
         assert len(resp.experts) == 1
@@ -1231,7 +1297,7 @@ class TestBatchParameterValidation:
             resp = await _confirm(session, confirmation_ids=[first, second])
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
         assert resp.applied is False
-        assert all(not result.applied for result in resp.results)
+        assert all(result.outcome == "failed" for result in resp.results)
         assert all(
             result.error is not None and "not answered" in result.error
             for result in resp.results

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -6,6 +6,7 @@ produced it, confirm must apply exactly what was previewed, and only a
 session a human is actually driving may reach any of it.
 """
 
+import asyncio
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1112,6 +1113,36 @@ class TestBatchConfirm:
         assert isinstance(resp, ExpertChangeBatchAppliedResponse)
         assert resp.results[0].failed_workflows == ["Inbox triage"]
         assert "Inbox triage" in resp.message
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_an_interrupted_batch_leaves_the_ids_it_never_reached(self):
+        """A Stop or a disconnect cancels the turn mid-tool, and a 20-hire
+        batch is a long call. Consuming every id up front would tombstone
+        approvals the call never acted on: the user loses them all, and the
+        replay tells the model to say a team that does not exist is done."""
+        redis = _FakeRedis()
+        with _env(redis=redis) as db:
+            db.hire_expert.side_effect = [
+                SimpleNamespace(expert=_created(), failed_preloads=[]),
+                asyncio.CancelledError(),
+            ]
+            session = make_session(_USER)
+            previews = [await _hire(session, template_id="tpl-scout") for _ in range(3)]
+            ids = [
+                preview.confirmation_id
+                for preview in previews
+                if isinstance(preview, ExpertChangeProposedResponse)
+            ]
+            assert len(ids) == 3
+            with pytest.raises(asyncio.CancelledError):
+                await _confirm(_approve(session), confirmation_ids=ids)
+
+        assert proposal_key(ids[0]) not in redis.store
+        assert proposal_key(ids[1]) not in redis.store
+        # The one the cancelled call never reached is still the user's to
+        # confirm — it was neither applied nor burned.
+        assert proposal_key(ids[2]) in redis.store
+        assert db.hire_expert.await_count == 2
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_a_batch_of_one_is_still_a_batch(self):

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -24,12 +24,13 @@ from backend.copilot.model import ChatMessage, ChatSessionMetadata
 from backend.util.exceptions import ExpertNotFoundError, ExpertWriteNotReadableError
 
 from ._test_data import make_session
-from .confirm_expert_change import ConfirmExpertChangeTool
+from .confirm_expert_change import MAX_BATCH_CONFIRMATIONS, ConfirmExpertChangeTool
 from .expert_proposal import ExpertChangeProposal, apply_proposal, proposal_key
 from .hire_expert import HireExpertTool
 from .models import (
     ErrorResponse,
     ExpertChangeAppliedResponse,
+    ExpertChangeBatchAppliedResponse,
     ExpertChangePreview,
     ExpertChangeProposedResponse,
 )
@@ -900,3 +901,287 @@ class TestProposalsInFlightAcrossTheDeploy:
             )
             await _confirm(session, confirmation_id="pre-deploy-id")
         assert proposal_key("pre-deploy-id") in redis.store
+
+
+async def _two_previews(session) -> tuple[str, str]:
+    """A hire and a raise the user is about to approve in one breath."""
+    hire = await _hire(session, template_id="tpl-scout")
+    raised = await _raise(session, **_CHARTER)
+    assert isinstance(hire, ExpertChangeProposedResponse)
+    assert isinstance(raised, ExpertChangeProposedResponse)
+    return hire.confirmation_id, raised.confirmation_id
+
+
+class TestBatchConfirm:
+    """A user who approves three previews at once should cost one call, not
+    three round-trips. Every id is still checked against the same gate, and
+    each one reports its own outcome so a single bad id cannot silently void
+    the changes beside it."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_an_all_valid_batch_applies_every_id(self):
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            resp = await _confirm(_approve(session), confirmation_ids=[first, second])
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.applied is True
+        assert [result.confirmation_id for result in resp.results] == [first, second]
+        assert all(result.applied for result in resp.results)
+        assert [expert.name for expert in resp.experts] == ["Scout", "Otto"]
+        assert "Scout" in resp.message and "Otto" in resp.message
+        db.hire_expert.assert_awaited_once()
+        db.create_raised_expert.assert_awaited_once()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_one_bad_id_does_not_void_the_rest(self):
+        """The whole point of the batch: an id that went stale between the
+        preview and the "yes" must be reported, not turned into a refusal
+        that drops the experts the user actually approved."""
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            resp = await _confirm(
+                _approve(session), confirmation_ids=[first, "nope", second]
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.applied is True
+        assert [result.applied for result in resp.results] == [True, False, True]
+        failed = resp.results[1]
+        assert failed.confirmation_id == "nope"
+        assert failed.error is not None
+        assert "expired" in failed.error
+        assert failed.expert is None
+        assert [expert.name for expert in resp.experts] == ["Scout", "Otto"]
+        assert db.hire_expert.await_count == 1
+        assert db.create_raised_expert.await_count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_replayed_id_reads_as_already_done_beside_a_fresh_one(self):
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            await _confirm(_approve(session), confirmation_id=first)
+            resp = await _confirm(_approve(session), confirmation_ids=[first, second])
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        replayed = resp.results[0]
+        assert replayed.applied is False
+        assert replayed.error is not None
+        assert "already confirmed" in replayed.error
+        assert resp.results[1].applied is True
+        # The replay must not hire a second Scout.
+        assert db.hire_expert.await_count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_an_id_from_another_chat_is_refused_inside_a_batch(self):
+        with _env() as db:
+            other = make_session(_USER)
+            stranger = await _hire(other, template_id="tpl-scout")
+            assert isinstance(stranger, ExpertChangeProposedResponse)
+            session = make_session(_USER)
+            mine = await _raise(session, **_CHARTER)
+            assert isinstance(mine, ExpertChangeProposedResponse)
+            resp = await _confirm(
+                _approve(session),
+                confirmation_ids=[stranger.confirmation_id, mine.confirmation_id],
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.results[0].applied is False
+        assert resp.results[0].error is not None
+        assert "different chat" in resp.results[0].error
+        assert resp.results[1].applied is True
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_batch_where_nothing_lands_says_so(self):
+        with _env() as db:
+            resp = await _confirm(
+                _approve(make_session(_USER)), confirmation_ids=["nope", "also-nope"]
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.applied is False
+        assert resp.experts == []
+        assert "Nothing was applied" in resp.message
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_cap_reached_mid_batch_is_reported_per_id(self):
+        """``capacity_error`` only runs at preview time, so N previews that
+        each fit can exceed the cap together. The creation transaction is the
+        real enforcement point — the overflow must surface as that id's error
+        rather than as an over-hired team."""
+        with _env() as db:
+            db.hire_expert.side_effect = [
+                SimpleNamespace(expert=_created(), failed_preloads=[]),
+                ExpertLimitExceededError(ACTIVE_EXPERT_LIMIT),
+            ]
+            session = make_session(_USER)
+            first = await _hire(session, template_id="tpl-scout")
+            second = await _hire(session, template_id="tpl-scout")
+            assert isinstance(first, ExpertChangeProposedResponse)
+            assert isinstance(second, ExpertChangeProposedResponse)
+            resp = await _confirm(
+                _approve(session),
+                confirmation_ids=[first.confirmation_id, second.confirmation_id],
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.results[0].applied is True
+        assert resp.results[1].applied is False
+        assert resp.results[1].error is not None
+        assert str(ACTIVE_EXPERT_LIMIT) in resp.results[1].error
+        assert len(resp.experts) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_partial_hire_inside_a_batch_still_names_its_workflows(self):
+        """The single-id path spells the failed workflows out in its message;
+        folding N applies into one message must not drop that warning."""
+        partial = SimpleNamespace(
+            expert=_created(),
+            failed_preloads=["Inbox triage"],
+        )
+        with _env(hire_result=partial):
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            resp = await _confirm(_approve(session), confirmation_ids=[first, second])
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.results[0].failed_workflows == ["Inbox triage"]
+        assert "Inbox triage" in resp.message
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_batch_of_one_is_still_a_batch(self):
+        """The response shape follows the parameter the model used, so a card
+        built for confirmation_ids never has to handle two payload shapes."""
+        with _env():
+            session = make_session(_USER)
+            preview = await _hire(session, template_id="tpl-scout")
+            assert isinstance(preview, ExpertChangeProposedResponse)
+            resp = await _confirm(
+                _approve(session), confirmation_ids=[preview.confirmation_id]
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert len(resp.results) == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_single_confirmation_id_keeps_the_old_response_shape(self):
+        """Backward compatibility: the single param must still return the
+        applied response the existing card and prompts were written for."""
+        with _env() as db:
+            session = make_session(_USER)
+            preview = await _hire(session, template_id="tpl-scout")
+            assert isinstance(preview, ExpertChangeProposedResponse)
+            resp = await _confirm(
+                _approve(session), confirmation_id=preview.confirmation_id
+            )
+        assert isinstance(resp, ExpertChangeAppliedResponse)
+        assert resp.kind == "hire"
+        assert resp.expert.name == "Scout"
+        db.hire_expert.assert_awaited_once()
+
+
+class TestBatchParameterValidation:
+    """Both parameters mean the model is guessing about what the user
+    approved, and neither means it has nothing to apply — either way the
+    right answer is to refuse before any proposal is consumed."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_supplying_both_parameters_is_refused(self):
+        redis = _FakeRedis()
+        with _env(redis=redis) as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            resp = await _confirm(
+                _approve(session),
+                confirmation_id=first,
+                confirmation_ids=[second],
+            )
+        assert isinstance(resp, ErrorResponse)
+        assert "never both" in resp.message
+        assert proposal_key(first) in redis.store
+        assert proposal_key(second) in redis.store
+        db.hire_expert.assert_not_called()
+        db.create_raised_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_supplying_neither_parameter_is_refused(self):
+        with _env() as db:
+            resp = await _confirm(_approve(make_session(_USER)))
+        assert isinstance(resp, ErrorResponse)
+        assert "confirmation_ids" in resp.message
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_an_empty_id_list_reads_as_no_id_at_all(self):
+        with _env() as db:
+            resp = await _confirm(_approve(make_session(_USER)), confirmation_ids=[])
+        assert isinstance(resp, ErrorResponse)
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_an_oversized_batch_is_refused_before_anything_is_consumed(self):
+        redis = _FakeRedis()
+        with _env(redis=redis) as db:
+            session = make_session(_USER)
+            first, _ = await _two_previews(session)
+            resp = await _confirm(
+                _approve(session),
+                confirmation_ids=[first]
+                + [f"filler-{i}" for i in range(MAX_BATCH_CONFIRMATIONS)],
+            )
+        assert isinstance(resp, ErrorResponse)
+        assert str(MAX_BATCH_CONFIRMATIONS) in resp.message
+        assert proposal_key(first) in redis.store
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_blank_id_in_the_batch_is_refused(self):
+        redis = _FakeRedis()
+        with _env(redis=redis) as db:
+            session = make_session(_USER)
+            first, _ = await _two_previews(session)
+            resp = await _confirm(_approve(session), confirmation_ids=[first, "   "])
+        assert isinstance(resp, ErrorResponse)
+        assert proposal_key(first) in redis.store
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_batch_still_refuses_inline_field_values(self):
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            resp = await _confirm(
+                _approve(session),
+                confirmation_ids=[first, second],
+                name="Someone else",
+            )
+        assert isinstance(resp, ErrorResponse)
+        db.hire_expert.assert_not_called()
+        db.create_raised_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_batch_is_refused_in_a_block_origin_session(self):
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            block_session = _automation_session()
+            block_session.session_id = session.session_id
+            resp = await _confirm(block_session, confirmation_ids=[first, second])
+        assert isinstance(resp, ErrorResponse)
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_batch_confirmed_in_the_same_turn_as_its_previews_is_refused(self):
+        """The watermark gate is per id, so batching must not become the way
+        the model previews and confirms inside one uninterrupted turn."""
+        with _env() as db:
+            session = _approve(make_session(_USER))
+            first, second = await _two_previews(session)
+            resp = await _confirm(session, confirmation_ids=[first, second])
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert resp.applied is False
+        assert all(not result.applied for result in resp.results)
+        assert all(
+            result.error is not None and "not answered" in result.error
+            for result in resp.results
+        )
+        db.hire_expert.assert_not_called()
+        db.create_raised_expert.assert_not_called()

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -1102,6 +1102,59 @@ class TestBatchParameterValidation:
         db.create_raised_expert.assert_not_called()
 
     @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_null_confirmation_id_beside_a_batch_still_applies_it(self):
+        """Filling both keys and nulling the unused one is a routine tool-call
+        shape. It must read as "no single id", not crash out of the tool and
+        leave the model unable to tell whether the ids were consumed."""
+        with _env() as db:
+            session = make_session(_USER)
+            first, second = await _two_previews(session)
+            resp = await _confirm(
+                _approve(session),
+                confirmation_id=None,
+                confirmation_ids=[first, second],
+            )
+        assert isinstance(resp, ExpertChangeBatchAppliedResponse)
+        assert len(resp.results) == 2
+        db.hire_expert.assert_awaited_once()
+        db.create_raised_expert.assert_awaited_once()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_a_null_confirmation_id_on_its_own_is_refused(self):
+        with _env() as db:
+            resp = await _confirm(_approve(make_session(_USER)), confirmation_id=None)
+        assert isinstance(resp, ErrorResponse)
+        assert "confirmation_ids" in resp.message
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"confirmation_id": 7},
+            {"confirmation_id": ["c-1"]},
+            {"confirmation_ids": "c-1"},
+            {"confirmation_ids": {"id": "c-1"}},
+            {"confirmation_ids": ["c-1", None]},
+            {"confirmation_ids": ["c-1", 7]},
+        ],
+    )
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_an_id_of_the_wrong_shape_is_refused_not_raised(self, params):
+        """Every malformed shape has to come back as the actionable refusal;
+        a traceback becomes "an error occurred" and tells the model nothing
+        about whether its approvals survived."""
+        redis = _FakeRedis()
+        with _env(redis=redis) as db:
+            session = make_session(_USER)
+            first, _ = await _two_previews(session)
+            resp = await _confirm(_approve(session), **params)
+        assert isinstance(resp, ErrorResponse)
+        assert str(MAX_BATCH_CONFIRMATIONS) in resp.message
+        assert proposal_key(first) in redis.store
+        db.hire_expert.assert_not_called()
+        db.create_raised_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
     async def test_supplying_neither_parameter_is_refused(self):
         with _env() as db:
             resp = await _confirm(_approve(make_session(_USER)))

--- a/autogpt_platform/backend/backend/copilot/tools/expert_proposal.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_proposal.py
@@ -37,10 +37,11 @@ from backend.util.exceptions import (
 from .models import (
     ErrorResponse,
     ExpertChangeAppliedResponse,
+    ExpertChangeError,
     ExpertChangeKind,
     ExpertChangePreview,
+    ExpertChangeReason,
     ExpertSummary,
-    ToolResponseBase,
 )
 
 logger = logging.getLogger(__name__)
@@ -97,8 +98,9 @@ def _consumed_key(confirmation_id: str) -> str:
     return f"{_CONSUMED_KEY_PREFIX}{confirmation_id}"
 
 
-def _stale_preview_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _stale_preview_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="expired",
         message=(
             "This confirmation_id is unknown or has expired — previews last "
             f"{PROPOSAL_TTL_MINUTES} minutes. Call {_PREVIEW_TOOLS} again for "
@@ -108,8 +110,9 @@ def _stale_preview_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _unapproved_preview_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _unapproved_preview_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="not_approved",
         message=(
             "The user has not answered this preview yet, so there is nothing "
             "to confirm. Read the change back to them and call "
@@ -119,8 +122,9 @@ def _unapproved_preview_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _unwatermarked_preview_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _unwatermarked_preview_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="unwatermarked",
         message=(
             "This preview was created before the approval check and carries "
             "no record of the turn it answered, so it cannot be confirmed. "
@@ -131,8 +135,9 @@ def _unwatermarked_preview_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _already_confirmed_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _already_confirmed_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="already_applied",
         message=(
             "You already confirmed this change, so there is nothing left to "
             "apply — tell the user it is done. Call "
@@ -229,7 +234,7 @@ async def capacity_error(
     user_id: str,
     session_id: str,
     kind: ExpertChangeKind,
-) -> ErrorResponse | None:
+) -> ExpertChangeError | None:
     """Refuse at preview time when the team is already full.
 
     Advisory only — the creation transaction re-enforces both caps. Checking
@@ -240,6 +245,7 @@ async def capacity_error(
             f"The team is already at its limit of {ACTIVE_EXPERT_LIMIT} active "
             "experts. Ask the user to archive someone first.",
             session_id,
+            "limit_reached",
         )
     if kind == "raise":
         raised = await experts_db().count_raised_experts(user_id)
@@ -249,6 +255,7 @@ async def capacity_error(
                 f"{LIFETIME_RAISED_EXPERT_LIMIT} experts. Hiring from the "
                 "roster still works.",
                 session_id,
+                "lifetime_limit_reached",
             )
     return None
 
@@ -258,7 +265,7 @@ async def load_bound_proposal(
     confirmation_id: str,
     user_id: str,
     session: ChatSession,
-) -> ExpertChangeProposal | ErrorResponse:
+) -> ExpertChangeProposal | ExpertChangeError:
     key = proposal_key(confirmation_id)
     raw = await redis.get(key)
     if raw is None:
@@ -277,7 +284,8 @@ async def load_bound_proposal(
         return _stale_preview_error(session.session_id)
 
     if proposal.user_id != user_id or proposal.session_id != session.session_id:
-        return ErrorResponse(
+        return ExpertChangeError(
+            reason="wrong_chat",
             message="This confirmation_id belongs to a different chat.",
             session_id=session.session_id,
         )
@@ -302,7 +310,7 @@ async def apply_proposal(
     user_id: str,
     session_id: str,
     proposal: ExpertChangeProposal,
-) -> ToolResponseBase:
+) -> ExpertChangeAppliedResponse | ExpertChangeError:
     preview = proposal.preview
     if preview.kind == "hire":
         return await _apply_hire(user_id, session_id, preview)
@@ -315,7 +323,8 @@ async def apply_proposal(
         preview.kind,
         user_id[:_LOG_ID_PREFIX_LENGTH],
     )
-    return ErrorResponse(
+    return ExpertChangeError(
+        reason="unsupported_kind",
         message=(
             "This proposal kind is not supported by confirm_expert_change. "
             f"Call {_PREVIEW_TOOLS} again for a fresh preview."
@@ -328,7 +337,7 @@ async def _apply_hire(
     user_id: str,
     session_id: str,
     preview: ExpertChangePreview,
-) -> ToolResponseBase:
+) -> ExpertChangeAppliedResponse | ExpertChangeError:
     if preview.template_id is None:
         return _discarded_proposal_error(session_id, "template", "hire_expert")
     try:
@@ -370,7 +379,7 @@ async def _apply_raise(
     user_id: str,
     session_id: str,
     preview: ExpertChangePreview,
-) -> ToolResponseBase:
+) -> ExpertChangeAppliedResponse | ExpertChangeError:
     try:
         result: RaiseResult = await experts_db().create_raised_expert(
             user_id,
@@ -399,7 +408,7 @@ async def _apply_update(
     user_id: str,
     session_id: str,
     proposal: ExpertChangeProposal,
-) -> ToolResponseBase:
+) -> ExpertChangeAppliedResponse | ExpertChangeError:
     """Write the soul edit previewed by ``update_expert``.
 
     The preview merged the requested fields over the stored soul, so this
@@ -445,8 +454,9 @@ async def _apply_update(
     )
 
 
-def _stale_expert_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _stale_expert_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="expert_moved",
         message=(
             "That expert is gone or was edited somewhere else since this "
             "preview, so nothing was changed. Call update_expert again to "
@@ -456,14 +466,15 @@ def _stale_expert_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _applied_but_unreadable_error(session_id: str, name: str) -> ErrorResponse:
+def _applied_but_unreadable_error(session_id: str, name: str) -> ExpertChangeError:
     """The edit committed, then the teammate disappeared before the read-back.
 
     Never route this to :func:`_stale_expert_error`: the change did land, so
     telling the model to re-preview would have it re-apply an edit that is
     already saved, or announce it was dropped when it was not.
     """
-    return ErrorResponse(
+    return ExpertChangeError(
+        reason="applied_but_expert_gone",
         message=(
             f"The edit to {name} was saved, but they were removed from the "
             "team before it could be read back. Do not re-preview or retry: "
@@ -474,10 +485,11 @@ def _applied_but_unreadable_error(session_id: str, name: str) -> ErrorResponse:
     )
 
 
-def _hire_failure_response(error: Exception, session_id: str) -> ErrorResponse:
+def _hire_failure_response(error: Exception, session_id: str) -> ExpertChangeError:
     """Map the hire path's typed failures to something the user can act on."""
     if isinstance(error, ExpertTemplateNotFoundError):
-        return ErrorResponse(
+        return ExpertChangeError(
+            reason="template_gone",
             message=(
                 "That expert template no longer exists. List the roster again "
                 "and pick a current one."
@@ -489,6 +501,7 @@ def _hire_failure_response(error: Exception, session_id: str) -> ErrorResponse:
             f"The team is already at its limit of {error.limit} active "
             "experts. Archive someone before hiring.",
             session_id,
+            "limit_reached",
         )
     if isinstance(
         error,
@@ -498,7 +511,8 @@ def _hire_failure_response(error: Exception, session_id: str) -> ErrorResponse:
             ExpertNotFoundError,
         ),
     ):
-        return ErrorResponse(
+        return ExpertChangeError(
+            reason="workspace_unavailable",
             message=(
                 "The expert workspace is temporarily unavailable, so nothing "
                 "was hired. Try again shortly."
@@ -508,31 +522,36 @@ def _hire_failure_response(error: Exception, session_id: str) -> ErrorResponse:
     return _unexpected_failure(error, session_id, "hire_expert")
 
 
-def _raise_failure_response(error: Exception, session_id: str) -> ErrorResponse:
+def _raise_failure_response(error: Exception, session_id: str) -> ExpertChangeError:
     if isinstance(error, ExpertLimitExceededError):
         return _limit_error(
             f"The team is already at its limit of {error.limit} active "
             "experts. Archive someone before raising a new one.",
             session_id,
+            "limit_reached",
         )
     if isinstance(error, RaisedExpertLifetimeLimitExceededError):
         return _limit_error(
             f"This account has raised its lifetime maximum of {error.limit} "
             "experts.",
             session_id,
+            "lifetime_limit_reached",
         )
     return _unexpected_failure(error, session_id, "raise_expert")
 
 
-def _limit_error(message: str, session_id: str) -> ErrorResponse:
-    return ErrorResponse(message=message, session_id=session_id)
+def _limit_error(
+    message: str, session_id: str, reason: ExpertChangeReason
+) -> ExpertChangeError:
+    return ExpertChangeError(reason=reason, message=message, session_id=session_id)
 
 
 def _unexpected_failure(
     error: Exception, session_id: str, tool_name: str
-) -> ErrorResponse:
+) -> ExpertChangeError:
     logger.warning("%s apply failed: %s", tool_name, error, exc_info=True)
-    return ErrorResponse(
+    return ExpertChangeError(
+        reason="unexpected_failure",
         message=(
             "Couldn't complete that change, and the proposal has been "
             f"discarded. Call {tool_name} again to re-preview and retry."
@@ -553,8 +572,9 @@ def _summary(expert: Expert) -> ExpertSummary:
 
 def _discarded_proposal_error(
     session_id: str, missing: str, tool_name: str
-) -> ErrorResponse:
-    return ErrorResponse(
+) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="proposal_incomplete",
         message=(
             f"That proposal is missing the {missing} it referred to and has "
             f"been discarded. Call {tool_name} again to re-preview."

--- a/autogpt_platform/backend/backend/copilot/tools/hire_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/hire_expert.py
@@ -141,7 +141,9 @@ class HireExpertTool(BaseTool):
                 "Nothing hired yet. Show the user who would join, what they "
                 "own, and that the hire draws on the shared weekly budget. "
                 "Only after they explicitly approve, call "
-                "confirm_expert_change with this confirmation_id."
+                "confirm_expert_change with this confirmation_id. If they "
+                "approve several previews at once, confirm them in a single "
+                "call by passing confirmation_ids."
             ),
             session_id=session_id,
             preview=preview,

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -127,6 +127,7 @@ class ResponseType(str, Enum):
     EXPERT_SOUL_UPDATED = "expert_soul_updated"
     EXPERT_CHANGE_PROPOSED = "expert_change_proposed"
     EXPERT_CHANGE_APPLIED = "expert_change_applied"
+    EXPERT_CHANGE_BATCH_APPLIED = "expert_change_batch_applied"
 
 
 # Base response model
@@ -597,6 +598,37 @@ class ExpertChangeAppliedResponse(ToolResponseBase):
     kind: ExpertChangeKind
     expert: ExpertSummary
     failed_workflows: list[str] = Field(default_factory=list)
+
+
+class ExpertChangeResult(BaseModel):
+    """What one confirmation_id in a batched confirm did.
+
+    Either the teammate it created (``applied``, with ``expert`` set) or the
+    reason it did not, so one bad id in a batch is reported rather than
+    voiding the ids the user approved alongside it.
+    """
+
+    confirmation_id: str
+    applied: bool
+    kind: ExpertChangeKind | None = None
+    expert: ExpertSummary | None = None
+    failed_workflows: list[str] = Field(default_factory=list)
+    error: str | None = None
+
+
+class ExpertChangeBatchAppliedResponse(ToolResponseBase):
+    """Outcome of a ``confirm_expert_change`` call given several ids.
+
+    ``results`` keeps the requested order and holds one entry per id;
+    ``experts`` is the flat list of teammates that actually landed, which is
+    what the roster card renders. ``applied`` is True when at least one id
+    landed — read ``results`` for the rest.
+    """
+
+    type: ResponseType = ResponseType.EXPERT_CHANGE_BATCH_APPLIED
+    applied: bool
+    results: list[ExpertChangeResult]
+    experts: list[ExpertSummary] = Field(default_factory=list)
 
 
 # Agent generation models

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -600,16 +600,57 @@ class ExpertChangeAppliedResponse(ToolResponseBase):
     failed_workflows: list[str] = Field(default_factory=list)
 
 
+ExpertChangeOutcome = Literal["applied", "already_applied", "failed"]
+
+ExpertChangeReason = Literal[
+    "already_applied",
+    "applied_but_expert_gone",
+    "expired",
+    "not_approved",
+    "unwatermarked",
+    "wrong_chat",
+    "expert_moved",
+    "template_gone",
+    "limit_reached",
+    "lifetime_limit_reached",
+    "workspace_unavailable",
+    "proposal_incomplete",
+    "unsupported_kind",
+    "unexpected_failure",
+]
+
+# Reasons that mean the change is on the team, just not because of this
+# call. Counting them as failures tells the user a teammate they have is
+# missing, so the batch treats them as landed.
+EXPERT_CHANGE_LANDED_REASONS: frozenset[str] = frozenset(
+    {"already_applied", "applied_but_expert_gone"}
+)
+
+
+class ExpertChangeError(ErrorResponse):
+    """An expert-change refusal, tagged with a stable reason code.
+
+    ``message`` is written for the model — second person, tool names, what to
+    call next — so it must never reach the chat UI. ``reason`` is the card's
+    vocabulary instead: a stable code it maps to its own copy.
+    """
+
+    reason: ExpertChangeReason
+
+
 class ExpertChangeResult(BaseModel):
     """What one confirmation_id in a batched confirm did.
 
-    Either the teammate it created (``applied``, with ``expert`` set) or the
-    reason it did not, so one bad id in a batch is reported rather than
-    voiding the ids the user approved alongside it.
+    ``outcome`` is three-valued on purpose. An id whose change landed in an
+    earlier confirm did not fail, and reporting it as one makes the batch
+    announce a teammate the user has as missing. ``reason`` is the stable
+    code the card renders from; ``error`` is the model-facing instruction
+    and is not for display.
     """
 
     confirmation_id: str
-    applied: bool
+    outcome: ExpertChangeOutcome
+    reason: ExpertChangeReason | None = None
     kind: ExpertChangeKind | None = None
     expert: ExpertSummary | None = None
     failed_workflows: list[str] = Field(default_factory=list)

--- a/autogpt_platform/backend/backend/copilot/tools/raise_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/raise_expert.py
@@ -230,7 +230,8 @@ class RaiseExpertTool(BaseTool):
                 "user — name, role, color, what this expert owns, where "
                 "they stop, voice and weekly budget — and only after they "
                 "explicitly approve, call confirm_expert_change with this "
-                "confirmation_id."
+                "confirmation_id. If they approve several previews at once, "
+                "confirm them in a single call by passing confirmation_ids."
             ),
             session_id=session_id,
             preview=preview,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -84,11 +84,42 @@ function ExpertNoticeRow({ result, done }: NoticeProps) {
         )}
         {done ? "Already done" : "Not added"}
       </p>
-      <p className="mt-1 text-xs text-zinc-500">
-        {str(result, "error") ?? "This approval could no longer be applied."}
-      </p>
+      <p className="mt-1 text-xs text-zinc-500">{noticeCopy(result, done)}</p>
     </div>
   );
+}
+
+/** The card has its own vocabulary on purpose. ``result.error`` is written
+ *  for the model — second person, tool names, "tell the user it is done" —
+ *  so it is never shown; the stable ``reason`` code is mapped here instead
+ *  and the model-facing text stays model-facing. */
+const REASON_COPY: Record<string, string> = {
+  already_applied: "This was already added earlier — nothing to redo.",
+  applied_but_expert_gone:
+    "The change was saved, but this teammate is no longer on the team.",
+  expired: "This preview expired before it was confirmed. Ask for a fresh one.",
+  not_approved: "This one wasn't confirmed. Ask again and it'll go through.",
+  unwatermarked: "This preview is too old to apply. Ask for a fresh one.",
+  wrong_chat: "This one belongs to a different chat.",
+  expert_moved: "This teammate changed somewhere else, so nothing was updated.",
+  template_gone: "That expert is no longer available.",
+  limit_reached: "Your team is already at its limit — archive someone first.",
+  lifetime_limit_reached:
+    "You've reached the maximum number of experts you can raise.",
+  workspace_unavailable:
+    "The expert workspace was busy, so nothing was created. Try again shortly.",
+  proposal_incomplete: "Some details were missing, so nothing was applied.",
+  unsupported_kind: "This kind of change can't be applied here.",
+  unexpected_failure: "Something went wrong, so nothing was applied.",
+};
+
+function noticeCopy(result: Record<string, unknown>, done: boolean): string {
+  const reason = str(result, "reason");
+  const copy = reason ? REASON_COPY[reason] : undefined;
+  if (copy) return copy;
+  return done
+    ? "This change was already applied."
+    : "This approval could no longer be applied.";
 }
 
 /** An expert inside the chain — either a hire/raise preview awaiting the

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
 import { CARD, HALF } from "./ResultCards";
-import { asObject, str } from "./resultHelpers";
+import { asItems, asObject, str } from "./resultHelpers";
 
 interface Props {
   output: Record<string, unknown>;
@@ -29,11 +29,51 @@ function failedWorkflows(output: Record<string, unknown>): string[] {
   );
 }
 
+/** One or several experts inside the chain. A batched confirm carries a
+ *  ``results`` list — one entry per approved preview, each either the
+ *  teammate it created or why it didn't — so a single bad id in the batch
+ *  never hides the ones that landed. */
+export function ExpertChangeCard({ output }: Props) {
+  const results = asItems(output.results);
+  if (!results) return <ExpertRow output={output} />;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {results.map((result, index) =>
+        result.applied === true ? (
+          <ExpertRow key={resultKey(result, index)} output={result} />
+        ) : (
+          <ExpertFailureRow key={resultKey(result, index)} result={result} />
+        ),
+      )}
+    </div>
+  );
+}
+
+function resultKey(result: Record<string, unknown>, index: number): string {
+  return str(result, "confirmation_id") ?? `result-${index}`;
+}
+
+interface FailureProps {
+  result: Record<string, unknown>;
+}
+
+function ExpertFailureRow({ result }: FailureProps) {
+  return (
+    <div className={`${CARD} ${HALF} p-2.5`}>
+      <p className="text-[13px] font-medium text-zinc-800">Not added</p>
+      <p className="mt-1 text-xs text-zinc-500">
+        {str(result, "error") ?? "This approval could no longer be applied."}
+      </p>
+    </div>
+  );
+}
+
 /** An expert inside the chain — either a hire/raise preview awaiting the
  *  user's OK (given in chat, nothing created yet) or the teammate
  *  ``confirm_expert_change`` actually created. Once they exist, the card
  *  offers the two things the user does next: adjust them or talk to them. */
-export function ExpertChangeCard({ output }: Props) {
+function ExpertRow({ output }: Props) {
   const applied = output.applied === true;
   const expert = asObject(output.expert) ?? asObject(output.preview);
   if (!expert) return null;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -13,6 +13,7 @@ import { asItems, asObject, str } from "./resultHelpers";
 
 interface Props {
   output: Record<string, unknown>;
+  applied?: boolean;
 }
 
 const APPLIED_LABELS: Record<string, string> = {
@@ -39,13 +40,9 @@ export function ExpertChangeCard({ output }: Props) {
 
   return (
     <div className="flex flex-col gap-1.5">
-      {results.map((result, index) =>
-        result.applied === true ? (
-          <ExpertRow key={resultKey(result, index)} output={result} />
-        ) : (
-          <ExpertFailureRow key={resultKey(result, index)} result={result} />
-        ),
-      )}
+      {results.map((result, index) => (
+        <ResultRow key={resultKey(result, index)} result={result} />
+      ))}
     </div>
   );
 }
@@ -54,14 +51,39 @@ function resultKey(result: Record<string, unknown>, index: number): string {
   return str(result, "confirmation_id") ?? `result-${index}`;
 }
 
-interface FailureProps {
+interface ResultProps {
   result: Record<string, unknown>;
 }
 
-function ExpertFailureRow({ result }: FailureProps) {
+/** ``outcome`` is three-valued: an approval that landed in an earlier
+ *  confirm is done, not a failure, and drawing it as "Not added" tells the
+ *  user a teammate they have was never created. */
+function ResultRow({ result }: ResultProps) {
+  const outcome = str(result, "outcome");
+  if (outcome === "applied") return <ExpertRow output={result} applied />;
+  return (
+    <ExpertNoticeRow result={result} done={outcome === "already_applied"} />
+  );
+}
+
+interface NoticeProps {
+  result: Record<string, unknown>;
+  done: boolean;
+}
+
+function ExpertNoticeRow({ result, done }: NoticeProps) {
   return (
     <div className={`${CARD} ${HALF} p-2.5`}>
-      <p className="text-[13px] font-medium text-zinc-800">Not added</p>
+      <p className="flex items-center gap-1.5 text-[13px] font-medium text-zinc-800">
+        {done && (
+          <Icon
+            icon={CheckmarkCircle02Icon}
+            size={13}
+            className="text-emerald-600"
+          />
+        )}
+        {done ? "Already done" : "Not added"}
+      </p>
       <p className="mt-1 text-xs text-zinc-500">
         {str(result, "error") ?? "This approval could no longer be applied."}
       </p>
@@ -73,8 +95,8 @@ function ExpertFailureRow({ result }: FailureProps) {
  *  user's OK (given in chat, nothing created yet) or the teammate
  *  ``confirm_expert_change`` actually created. Once they exist, the card
  *  offers the two things the user does next: adjust them or talk to them. */
-function ExpertRow({ output }: Props) {
-  const applied = output.applied === true;
+function ExpertRow({ output, applied }: Props) {
+  const isApplied = applied ?? output.applied === true;
   const expert = asObject(output.expert) ?? asObject(output.preview);
   if (!expert) return null;
 
@@ -86,7 +108,7 @@ function ExpertRow({ output }: Props) {
   const budget =
     typeof expert.weekly_budget === "number" ? expert.weekly_budget : null;
   const appliedLabel = APPLIED_LABELS[str(output, "kind") ?? ""] ?? "Done";
-  const failed = applied ? failedWorkflows(output) : [];
+  const failed = isApplied ? failedWorkflows(output) : [];
 
   return (
     <div className={`${CARD} ${HALF} p-2.5`}>
@@ -102,7 +124,7 @@ function ExpertRow({ output }: Props) {
             <span className="ml-1.5 font-normal text-zinc-400">{role}</span>
           )}
         </p>
-        {applied ? (
+        {isApplied ? (
           <span className="inline-flex shrink-0 items-center gap-1 rounded-md bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
             <Icon icon={CheckmarkCircle02Icon} size={11} />
             {appliedLabel}
@@ -134,7 +156,7 @@ function ExpertRow({ output }: Props) {
           add {failed.length > 1 ? "them" : "it"} from the expert&apos;s page.
         </p>
       )}
-      {applied && id && (
+      {isApplied && id && (
         <div className="mt-2.5 flex items-center gap-1.5 pl-9">
           <Link
             href={`/team/${id}`}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -114,6 +114,78 @@ describe("expert change cards", () => {
     expect(screen.queryByText(/Couldn't set up/)).toBeNull();
   });
 
+  it("renders one card per expert when several are confirmed at once", () => {
+    render(
+      <ToolResult
+        row={row("confirm_expert_change", {
+          type: "expert_change_batch_applied",
+          message: "All 2 approved changes applied: Otto, Scout.",
+          applied: true,
+          results: [
+            {
+              confirmation_id: "c-1",
+              applied: true,
+              kind: "raise",
+              expert: { id: "exp-otto", name: "Otto", role: "Inbox triage" },
+            },
+            {
+              confirmation_id: "c-2",
+              applied: true,
+              kind: "hire",
+              expert: { id: "exp-scout", name: "Scout", role: "Research" },
+            },
+          ],
+          experts: [
+            { id: "exp-otto", name: "Otto", role: "Inbox triage" },
+            { id: "exp-scout", name: "Scout", role: "Research" },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Otto")).toBeDefined();
+    expect(screen.getByText("Scout")).toBeDefined();
+    expect(screen.getByText("Raised")).toBeDefined();
+    expect(screen.getByText("Hired")).toBeDefined();
+    expect(
+      screen
+        .getAllByRole("link", { name: /Chat/ })
+        .map((link) => link.getAttribute("href")),
+    ).toEqual(["/copilot?expertId=exp-otto", "/copilot?expertId=exp-scout"]);
+  });
+
+  it("says which approval did not land in a partly applied batch", () => {
+    render(
+      <ToolResult
+        row={row("confirm_expert_change", {
+          type: "expert_change_batch_applied",
+          message: "1 of 2 applied: Otto.",
+          applied: true,
+          results: [
+            {
+              confirmation_id: "c-1",
+              applied: true,
+              kind: "raise",
+              expert: { id: "exp-otto", name: "Otto", role: "Inbox triage" },
+            },
+            {
+              confirmation_id: "c-2",
+              applied: false,
+              error: "This confirmation_id is unknown or has expired.",
+            },
+          ],
+          experts: [{ id: "exp-otto", name: "Otto", role: "Inbox triage" }],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Otto")).toBeDefined();
+    expect(screen.getByText("Not added")).toBeDefined();
+    expect(
+      screen.getByText("This confirmation_id is unknown or has expired."),
+    ).toBeDefined();
+  });
+
   it("renders a handoff as the receiving teammate's sub-session", () => {
     render(
       <ToolResult

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -172,7 +172,8 @@ describe("expert change cards", () => {
               confirmation_id: "c-2",
               outcome: "failed",
               reason: "expired",
-              error: "This confirmation_id is unknown or has expired.",
+              error:
+                "This confirmation_id is unknown or has expired - previews last 15 minutes. Call hire_expert, raise_expert or update_expert again for a fresh preview.",
             },
           ],
           experts: [{ id: "exp-otto", name: "Otto", role: "Inbox triage" }],
@@ -183,8 +184,13 @@ describe("expert change cards", () => {
     expect(screen.getByText("Otto")).toBeDefined();
     expect(screen.getByText("Not added")).toBeDefined();
     expect(
-      screen.getByText("This confirmation_id is unknown or has expired."),
+      screen.getByText(
+        "This preview expired before it was confirmed. Ask for a fresh one.",
+      ),
     ).toBeDefined();
+    // result.error is written for the model; it must never reach the chat.
+    expect(screen.queryByText(/confirmation_id/)).toBeNull();
+    expect(screen.queryByText(/hire_expert/)).toBeNull();
   });
 
   it("shows an already-applied approval as done, not as a failure", () => {
@@ -210,6 +216,36 @@ describe("expert change cards", () => {
 
     expect(screen.getByText("Already done")).toBeDefined();
     expect(screen.queryByText("Not added")).toBeNull();
+    expect(
+      screen.getByText("This was already added earlier — nothing to redo."),
+    ).toBeDefined();
+    expect(screen.queryByText(/tell the user it is done/)).toBeNull();
+  });
+
+  it("falls back to neutral copy for a reason it does not know", () => {
+    render(
+      <ToolResult
+        row={row("confirm_expert_change", {
+          type: "expert_change_batch_applied",
+          message: "Nothing was applied.",
+          applied: false,
+          results: [
+            {
+              confirmation_id: "c-1",
+              outcome: "failed",
+              reason: "some_future_reason",
+              error: "Call hire_expert again for a fresh preview.",
+            },
+          ],
+          experts: [],
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText("This approval could no longer be applied."),
+    ).toBeDefined();
+    expect(screen.queryByText(/hire_expert/)).toBeNull();
   });
 
   it("renders a handoff as the receiving teammate's sub-session", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -124,13 +124,13 @@ describe("expert change cards", () => {
           results: [
             {
               confirmation_id: "c-1",
-              applied: true,
+              outcome: "applied",
               kind: "raise",
               expert: { id: "exp-otto", name: "Otto", role: "Inbox triage" },
             },
             {
               confirmation_id: "c-2",
-              applied: true,
+              outcome: "applied",
               kind: "hire",
               expert: { id: "exp-scout", name: "Scout", role: "Research" },
             },
@@ -164,13 +164,14 @@ describe("expert change cards", () => {
           results: [
             {
               confirmation_id: "c-1",
-              applied: true,
+              outcome: "applied",
               kind: "raise",
               expert: { id: "exp-otto", name: "Otto", role: "Inbox triage" },
             },
             {
               confirmation_id: "c-2",
-              applied: false,
+              outcome: "failed",
+              reason: "expired",
               error: "This confirmation_id is unknown or has expired.",
             },
           ],
@@ -184,6 +185,31 @@ describe("expert change cards", () => {
     expect(
       screen.getByText("This confirmation_id is unknown or has expired."),
     ).toBeDefined();
+  });
+
+  it("shows an already-applied approval as done, not as a failure", () => {
+    render(
+      <ToolResult
+        row={row("confirm_expert_change", {
+          type: "expert_change_batch_applied",
+          message: "All 1 approved changes are done.",
+          applied: true,
+          results: [
+            {
+              confirmation_id: "c-1",
+              outcome: "already_applied",
+              reason: "already_applied",
+              error:
+                "You already confirmed this change, so there is nothing left to apply — tell the user it is done.",
+            },
+          ],
+          experts: [],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Already done")).toBeDefined();
+    expect(screen.queryByText("Not added")).toBeNull();
   });
 
   it("renders a handoff as the receiving teammate's sub-session", () => {

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -24430,7 +24430,8 @@
           "skill_list",
           "expert_soul_updated",
           "expert_change_proposed",
-          "expert_change_applied"
+          "expert_change_applied",
+          "expert_change_batch_applied"
         ],
         "title": "ResponseType",
         "description": "Types of tool responses."


### PR DESCRIPTION
> **Stacked PR 2 of 10** — Autopilot proactivity & conversation quality.
> Base: `Abhi1992002/copilot-drive-to-completion-prompts`. Review only this PR's diff.

### Why / What / How

**Why.** "Confirm all" was N round-trips. Every approved preview needed its own `confirm_expert_change` call, so a user staffing a three-person team paid three full model turns for one "yes" — and each turn is another chance for the model to drift, re-preview, or drop one.

**What.**

- `confirm_expert_change` accepts `confirmation_ids: list[str]` (1–20) alongside the existing `confirmation_id`. Either one, never both; neither is refused.
- Every id goes through the existing `load_bound_proposal` gate (bound to this session, single-use, user-turn watermark strictly newer than the preview) before anything is written, and each id reports its own outcome — a stale or foreign id no longer voids the changes approved beside it.
- No new field values are accepted, exactly as before.
- New `expert_change_batch_applied` response: `results` (per-id) + `experts` (flat). The single-id path returns the unchanged `expert_change_applied`.
- `hire_expert` / `raise_expert` return copy tells the model it can batch.
- The chat card renders one row per result and names the approvals that didn't land.

**How.** Shape follows the parameter used, so the card never has to handle two payloads for one call — a batch of one is still a batch.

`load_bound_proposal` **consumes as it checks** (`DEL` + tombstone), so the "validate everything first" pass burns the ids it accepts. That is deliberate: it makes one batch behave exactly like N sequential single-id confirms, where a proposal that fails at apply time is likewise discarded and re-previewed. Splitting validate from consume would give the batch path a *weaker* single-use guarantee than the single-id path it has to match.

`capacity_error` only runs at preview time, so N previews that each fit under the active-expert cap can exceed it together. Nothing is pre-computed to stop that: the creation transaction is the cap's real enforcement point, so the overflow surfaces as that id's own limit error and the team can never actually exceed the cap. Covered by a test.

Frontend is the minimum needed for correctness — the roster card is PR 3.

### Changes 🏗️

- `copilot/tools/confirm_expert_change.py` — accepts `confirmation_ids` (1–20); validate-then-apply loop; per-id results.
- `copilot/tools/models.py` — `ExpertChangeResult`, `ExpertChangeBatchAppliedResponse`, `ResponseType.EXPERT_CHANGE_BATCH_APPLIED`.
- `copilot/tools/hire_expert.py`, `raise_expert.py` — return copy tells the model to batch (tool *descriptions* untouched; those ship every turn).
- `copilot/tools/expert_change_test.py` — 16 new tests across `TestBatchConfirm` + `TestBatchParameterValidation`.
- `frontend .../ToolChain/ExpertCards.tsx` — renders a `results` list, one row per outcome; single-result path extracted to `ExpertRow`, behaviour unchanged.
- `frontend .../ToolChain/__tests__/ExpertCards.test.tsx` — all-applied and partly-applied batches.
- `frontend/src/app/api/openapi.json` — one new `ResponseType` enum value, hand-spliced (no full regen).

No flags added. No schema or config changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `poetry run pytest backend/copilot/tools/expert_change_test.py` — all-valid batch; mixed valid/invalid (valid ones still applied, per-id errors reported); replayed id reads "already confirmed" beside a fresh one; cross-session id refused inside a batch; both params supplied; neither supplied; empty list; oversized batch; blank id; inline field values still refused; automation-origin session refused; same-turn preview+confirm refused per id; cap reached mid-batch; partial hire still names its workflows; single `confirmation_id` returns the old shape
  - [ ] `pnpm test:unit` — `ExpertCards.test.tsx`, incl. existing single-result cases unchanged
  - [ ] Manual: approve two previews in one message, confirm the model makes one call
