### PR TITLE
feat(frontend): raise a whole team from one card

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -645,7 +645,8 @@ def get_sdk_supplement(use_e2b: bool) -> str:
 
 
 def get_delegation_supplement() -> str:
-    """Delegation rules, appended only when the expert-team tools are enabled.
+    """Team rules — proposing a roster and delegating — appended only when
+    the expert-team tools are enabled.
 
     Kept out of ``SHARED_TOOL_NOTES`` — that constant is concatenated
     unconditionally by both engines, so leaving these rules there told
@@ -655,6 +656,14 @@ def get_delegation_supplement() -> str:
     is gated on its own tool group.
     """
     return """
+
+### Proposing a whole team
+- When the user needs several experts, propose all of them in ONE turn
+  (one `raise_expert`/`hire_expert` call each) — chat renders them as a
+  single roster card the user confirms once.
+- Read that roster back as one compact table (name, role, what they own,
+  where they stop, weekly budget) and point at the card — never a
+  paragraph of prose or a list of confirmation ids per expert.
 
 ### Delegating to a teammate
 - When a subtask needs a *teammate's* skills, workflows, or integrations

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -22,6 +22,7 @@ from backend.api.features.experts.errors import (
 )
 from backend.api.features.experts.models import EXPERT_NAME_MAX_LENGTH, ExpertSoulUpdate
 from backend.copilot.model import ChatMessage, ChatSessionMetadata
+from backend.copilot.prompting import get_delegation_supplement
 from backend.util.exceptions import ExpertNotFoundError, ExpertWriteNotReadableError
 
 from ._test_data import make_session
@@ -1335,3 +1336,15 @@ class TestBatchParameterValidation:
         )
         db.hire_expert.assert_not_called()
         db.create_raised_expert.assert_not_called()
+
+
+class TestTeamProposalPrompt:
+    """The roster card groups the previews of a single assistant turn, so a
+    model that drips one expert per turn never produces one."""
+
+    def test_the_supplement_asks_for_the_whole_roster_in_one_turn(self):
+        supplement = get_delegation_supplement()
+
+        assert "Proposing a whole team" in supplement
+        assert "ONE turn" in supplement
+        assert "compact table" in supplement

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
@@ -111,6 +111,7 @@ export function ChainRowView({ row, isLast }: Props) {
   const hasContent = isReasoning
     ? !!row.reasoningText
     : !row.supersededSubSession &&
+      !row.groupedProposal &&
       ((row.output !== undefined && row.output !== "") || liveSubSession);
   // Action-required cards (credential setup, review, login) must stay on
   // screen until resolved — the row cannot be collapsed.

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import type { TeamProposal } from "../helpers";
+import { ProposedExpertRow } from "./components/ProposedExpertRow";
+import { useTeamPreviewCard } from "./useTeamPreviewCard";
+
+interface Props {
+  proposals: TeamProposal[];
+}
+
+/** A whole team proposed in one turn, as one roster the user confirms once.
+ *  Each teammate opens to their full charter and can be dropped before
+ *  confirming; changing a charter stays conversational — the user says what
+ *  to change and the model re-proposes. */
+export function TeamPreviewCard({ proposals }: Props) {
+  const {
+    canConfirm,
+    kept,
+    openId,
+    removedIds,
+    hireAll,
+    toggleOpen,
+    toggleRemoved,
+  } = useTeamPreviewCard(proposals);
+
+  return (
+    <div className="rounded-2xl bg-white p-4 ring-1 ring-zinc-200/70">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-medium text-zinc-800">
+          {proposals.length} experts for your team
+        </p>
+        <p className="shrink-0 text-xs text-zinc-400">
+          {kept.length === proposals.length
+            ? "Nothing created yet"
+            : `${kept.length} of ${proposals.length} selected`}
+        </p>
+      </div>
+      <div className="mt-1.5 flex flex-col divide-y divide-zinc-100">
+        {proposals.map((proposal) => (
+          <ProposedExpertRow
+            key={proposal.confirmationId}
+            proposal={proposal}
+            removed={removedIds.includes(proposal.confirmationId)}
+            open={openId === proposal.confirmationId}
+            onToggleRemoved={() => toggleRemoved(proposal.confirmationId)}
+            onToggleOpen={() => toggleOpen(proposal.confirmationId)}
+          />
+        ))}
+      </div>
+      {canConfirm && (
+        <div className="mt-3 flex flex-wrap items-center gap-2.5">
+          <Button
+            variant="primary"
+            size="small"
+            disabled={kept.length === 0}
+            onClick={hireAll}
+          >
+            Hire all
+          </Button>
+          <span className="text-xs text-zinc-400">
+            {kept.length === 0
+              ? "Put someone back, or tell me who to draft instead."
+              : "To change a charter, just say what should be different."}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  ArrowDown01Icon,
+  ArrowTurnBackwardIcon,
+  Cancel01Icon,
+} from "@hugeicons/core-free-icons";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import { ACCORDION_PANEL, accordionState } from "../../accordion";
+import type { TeamProposal } from "../../helpers";
+import { str } from "../../resultHelpers";
+import { proposalName } from "../helpers";
+
+interface Props {
+  proposal: TeamProposal;
+  removed: boolean;
+  open: boolean;
+  onToggleRemoved: () => void;
+  onToggleOpen: () => void;
+}
+
+export function ProposedExpertRow({
+  proposal,
+  removed,
+  open,
+  onToggleRemoved,
+  onToggleOpen,
+}: Props) {
+  const { preview } = proposal;
+  const name = proposalName(proposal);
+  const role = str(preview, "role");
+  const about = str(preview, "about");
+  const boundaries = str(preview, "boundaries");
+  const voice = str(preview, "voice_preferences");
+  const budget =
+    typeof preview.weekly_budget === "number" ? preview.weekly_budget : null;
+  const hasCharter = !!(about || boundaries || voice) || budget !== null;
+
+  return (
+    <div className={"py-2.5 " + (removed ? "opacity-40" : "")}>
+      <div className="flex items-center gap-2.5">
+        <ExpertAvatar
+          name={name}
+          avatarUrl={str(preview, "avatar_url")}
+          size={28}
+        />
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          disabled={!hasCharter}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        >
+          <span
+            className={
+              "shrink-0 text-[13px] font-medium text-zinc-800 " +
+              (removed ? "line-through" : "")
+            }
+          >
+            {name}
+          </span>
+          {role && (
+            <span className="min-w-0 truncate text-xs text-zinc-400">
+              {role}
+            </span>
+          )}
+          {hasCharter && (
+            <Icon
+              icon={ArrowDown01Icon}
+              size={12}
+              className={
+                "shrink-0 text-zinc-400 transition-transform duration-300 ease-out-quint " +
+                (open ? "rotate-180" : "")
+              }
+            />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={onToggleRemoved}
+          aria-label={removed ? `Put ${name} back` : `Remove ${name}`}
+          className="flex size-7 shrink-0 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+        >
+          <Icon
+            icon={removed ? ArrowTurnBackwardIcon : Cancel01Icon}
+            size={14}
+          />
+        </button>
+      </div>
+      {hasCharter && (
+        <div className={ACCORDION_PANEL + " " + accordionState(open)}>
+          <div aria-hidden={!open} className="min-h-0 overflow-hidden">
+            <div className="flex flex-col gap-1 pl-[38px] pt-1.5 text-xs text-zinc-500">
+              {about && <p>{about}</p>}
+              {boundaries && (
+                <p className="text-zinc-400">Stops at: {boundaries}</p>
+              )}
+              {voice && <p className="text-zinc-400">Sounds like: {voice}</p>}
+              {budget !== null && (
+                <p className="text-zinc-400">
+                  Weekly budget: {budget} credits
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
@@ -98,9 +98,7 @@ export function ProposedExpertRow({
               )}
               {voice && <p className="text-zinc-400">Sounds like: {voice}</p>}
               {budget !== null && (
-                <p className="text-zinc-400">
-                  Weekly budget: {budget} credits
-                </p>
+                <p className="text-zinc-400">Weekly budget: {budget} credits</p>
               )}
             </div>
           </div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/helpers.ts
@@ -1,0 +1,25 @@
+import type { TeamProposal } from "../helpers";
+import { str } from "../resultHelpers";
+
+export function proposalName(proposal: TeamProposal): string {
+  return str(proposal.preview, "name") ?? "New expert";
+}
+
+export function joinNames(names: string[]): string {
+  if (names.length < 2) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+/** Cards cannot call tools, so confirming is a message that asks the model
+ *  to make the call. One id uses the single-id parameter and several use the
+ *  batch one — the tool rejects both at once. */
+export function buildConfirmMessage(proposals: TeamProposal[]): string {
+  const names = joinNames(proposals.map(proposalName));
+  if (proposals.length === 1) {
+    return `I approve ${names}. Call confirm_expert_change with confirmation_id "${proposals[0].confirmationId}".`;
+  }
+  const ids = proposals
+    .map((proposal) => `"${proposal.confirmationId}"`)
+    .join(", ");
+  return `I approve ${names}. Call confirm_expert_change once with confirmation_ids [${ids}].`;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useContext, useState } from "react";
+import { CopilotChatActionsContext } from "../../CopilotChatActionsProvider/useCopilotChatActions";
+import type { TeamProposal } from "../helpers";
+import { buildConfirmMessage } from "./helpers";
+
+export function useTeamPreviewCard(proposals: TeamProposal[]) {
+  const actions = useContext(CopilotChatActionsContext);
+  const [removedIds, setRemovedIds] = useState<readonly string[]>([]);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const kept = proposals.filter(
+    (proposal) => !removedIds.includes(proposal.confirmationId),
+  );
+
+  function toggleRemoved(confirmationId: string) {
+    setRemovedIds((previous) =>
+      previous.includes(confirmationId)
+        ? previous.filter((id) => id !== confirmationId)
+        : [...previous, confirmationId],
+    );
+  }
+
+  function toggleOpen(confirmationId: string) {
+    setOpenId((previous) =>
+      previous === confirmationId ? null : confirmationId,
+    );
+  }
+
+  function hireAll() {
+    if (!actions || kept.length === 0) return;
+    actions.onSend(buildConfirmMessage(kept));
+  }
+
+  return {
+    canConfirm: actions !== null,
+    kept,
+    openId,
+    removedIds,
+    hireAll,
+    toggleOpen,
+    toggleRemoved,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -33,6 +33,7 @@ import { ChainRowView } from "./ChainRowView";
 import {
   type ChainRow,
   getChainHeading,
+  groupTeamProposalRows,
   isLiftedSetupRow,
   markSupersededSubSessionRows,
   toChainRow,
@@ -97,19 +98,22 @@ export function ToolChain({ parts, isStreaming }: Props) {
 
   const rows = useMemo(
     () =>
-      markSupersededSubSessionRows(
-        parts
-          .map((part, i) => toChainRow(part, i))
-          .filter((row): row is ChainRow => row !== null)
-          // Unanswered clarifying questions and setup cards render their work
-          // in the card below the chain — their rows are lifted out of view.
-          .map((row) =>
-            pendingQuestions?.callIds.includes(row.key)
-              ? { ...row, requiresAction: true, lifted: true }
-              : isLiftedSetupRow(row)
-                ? { ...row, lifted: true }
-                : row,
-          ),
+      groupTeamProposalRows(
+        markSupersededSubSessionRows(
+          parts
+            .map((part, i) => toChainRow(part, i))
+            .filter((row): row is ChainRow => row !== null)
+            // Unanswered clarifying questions and setup cards render their
+            // work in the card below the chain — their rows are lifted out
+            // of view.
+            .map((row) =>
+              pendingQuestions?.callIds.includes(row.key)
+                ? { ...row, requiresAction: true, lifted: true }
+                : isLiftedSetupRow(row)
+                  ? { ...row, lifted: true }
+                  : row,
+            ),
+        ),
       ),
     [parts, pendingQuestions],
   );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
@@ -54,6 +54,7 @@ import {
   stripBaseFields,
 } from "./resultHelpers";
 import { SubSessionPendingCard } from "./SubSessionLive";
+import { TeamPreviewCard } from "./TeamPreviewCard/TeamPreviewCard";
 import {
   FileCard,
   KeyValueList,
@@ -266,8 +267,14 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
         row.tool !== "get_sub_session_result" ? (
         <SubSessionPendingCard input={row.input} />
       ) : null;
+    // Several previews in one turn are one roster card on the last row —
+    // see groupTeamProposalRows.
     case "hire_expert":
     case "raise_expert":
+      if (row.groupedProposal) return null;
+      if (row.teamProposals)
+        return <TeamPreviewCard proposals={row.teamProposals} />;
+      return output ? <ExpertChangeCard output={output} /> : null;
     case "update_expert":
     case "confirm_expert_change":
       return output ? <ExpertChangeCard output={output} /> : null;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
@@ -161,9 +161,39 @@ describe("TeamPreviewCard", () => {
       screen.getByRole("button", { name: /review the new team/i }),
     );
 
-    expect(screen.getAllByText("Drafted Otto").length).toBeGreaterThan(0);
+    // Otto's row is the carrier — it holds the roster and reads "Review the
+    // new team"; every other draft keeps its own name in the chain.
     expect(screen.getAllByText("Drafted Scout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Drafted Bea").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Drafted Otto")).toBeNull();
     expect(screen.getAllByRole("button", { name: "Hire all" })).toHaveLength(1);
+  });
+
+  it("keeps a removal when a later proposal streams in", async () => {
+    // Regression: the roster used to hang off the LAST proposal row, so each
+    // new proposal moved the card to a different row, remounting it and
+    // silently restoring experts the user had already removed.
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    const { rerender } = render(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ToolChain parts={TEAM.slice(0, 2).map(raisePart)} isStreaming />
+      </CopilotChatActionsProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove Scout" }));
+
+    rerender(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ToolChain parts={TEAM.map(raisePart)} isStreaming={false} />
+      </CopilotChatActionsProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Hire all" }));
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend.mock.calls[0][0]).not.toContain("c-2");
+    expect(onSend.mock.calls[0][0]).toContain("c-3");
   });
 
   it("keeps the single-expert card when only one is proposed", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
@@ -1,0 +1,175 @@
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/tests/integrations/test-utils";
+import type { MessagePart } from "../../ChatMessagesContainer/helpers";
+import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
+import { ToolChain } from "../ToolChain";
+
+interface Charter {
+  id: string;
+  name: string;
+  role: string;
+}
+
+function raisePart({ id, name, role }: Charter): MessagePart {
+  return {
+    type: "tool-raise_expert",
+    state: "output-available",
+    toolCallId: `call-${id}`,
+    input: { name },
+    output: {
+      type: "expert_change_proposed",
+      message: "Nothing created yet.",
+      applied: false,
+      confirmation_id: id,
+      preview: {
+        kind: "raise",
+        name,
+        role,
+        about: `You own ${role.toLowerCase()}.`,
+        boundaries: "You never send a reply yourself.",
+        weekly_budget: 2000,
+      },
+    },
+  } as MessagePart;
+}
+
+const TEAM: Charter[] = [
+  { id: "c-1", name: "Otto", role: "Inbox triage" },
+  { id: "c-2", name: "Scout", role: "Research" },
+  { id: "c-3", name: "Bea", role: "Ops" },
+];
+
+function renderTeam(onSend: (message: string) => void, team: Charter[] = TEAM) {
+  return render(
+    <CopilotChatActionsProvider onSend={onSend}>
+      <ToolChain parts={team.map(raisePart)} isStreaming={false} />
+    </CopilotChatActionsProvider>,
+  );
+}
+
+describe("TeamPreviewCard", () => {
+  afterEach(cleanup);
+
+  it("gathers a turn's proposals into one roster with a single confirm", () => {
+    renderTeam(vi.fn());
+
+    expect(screen.getByText("3 experts for your team")).toBeDefined();
+    expect(screen.getByText("Otto")).toBeDefined();
+    expect(screen.getByText("Scout")).toBeDefined();
+    expect(screen.getByText("Bea")).toBeDefined();
+    expect(screen.getByText("Inbox triage")).toBeDefined();
+    expect(screen.getAllByRole("button", { name: "Hire all" })).toHaveLength(1);
+    // The per-expert approval card is replaced, not stacked underneath.
+    expect(screen.queryByText("Needs your OK")).toBeNull();
+  });
+
+  it("confirms every proposal in one batched call", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend);
+
+    await user.click(screen.getByRole("button", { name: "Hire all" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      'I approve Otto, Scout and Bea. Call confirm_expert_change once with confirmation_ids ["c-1", "c-2", "c-3"].',
+    );
+  });
+
+  it("leaves a removed expert out of the confirm", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend);
+
+    await user.click(screen.getByRole("button", { name: "Remove Scout" }));
+
+    expect(screen.getByText("2 of 3 selected")).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Hire all" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      'I approve Otto and Bea. Call confirm_expert_change once with confirmation_ids ["c-1", "c-3"].',
+    );
+  });
+
+  it("puts a removed expert back", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend);
+
+    await user.click(screen.getByRole("button", { name: "Remove Bea" }));
+    await user.click(screen.getByRole("button", { name: "Put Bea back" }));
+    await user.click(screen.getByRole("button", { name: "Hire all" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      'I approve Otto, Scout and Bea. Call confirm_expert_change once with confirmation_ids ["c-1", "c-2", "c-3"].',
+    );
+  });
+
+  it("falls back to the single-id parameter when one expert is left", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend);
+
+    await user.click(screen.getByRole("button", { name: "Remove Scout" }));
+    await user.click(screen.getByRole("button", { name: "Remove Bea" }));
+    await user.click(screen.getByRole("button", { name: "Hire all" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      'I approve Otto. Call confirm_expert_change with confirmation_id "c-1".',
+    );
+  });
+
+  it("cannot confirm an empty roster", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend);
+
+    for (const member of TEAM) {
+      await user.click(
+        screen.getByRole("button", { name: `Remove ${member.name}` }),
+      );
+    }
+
+    expect(
+      screen.getByRole("button", { name: "Hire all" }).hasAttribute("disabled"),
+    ).toBe(true);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("opens one charter at a time", async () => {
+    const user = userEvent.setup();
+    renderTeam(vi.fn());
+
+    const otto = screen.getByRole("button", { name: "Otto Inbox triage" });
+    const scout = screen.getByRole("button", { name: "Scout Research" });
+    expect(otto.getAttribute("aria-expanded")).toBe("false");
+
+    await user.click(otto);
+    expect(otto.getAttribute("aria-expanded")).toBe("true");
+
+    await user.click(scout);
+    expect(otto.getAttribute("aria-expanded")).toBe("false");
+    expect(scout.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("names each draft in the chain without repeating the roster", async () => {
+    const user = userEvent.setup();
+    renderTeam(vi.fn());
+
+    await user.click(
+      screen.getByRole("button", { name: /review the new team/i }),
+    );
+
+    expect(screen.getAllByText("Drafted Otto").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Drafted Scout").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Hire all" })).toHaveLength(1);
+  });
+
+  it("keeps the single-expert card when only one is proposed", () => {
+    renderTeam(vi.fn(), [TEAM[0]]);
+
+    expect(screen.getByText("Needs your OK")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Hire all" })).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
@@ -6,7 +6,7 @@ import {
   getToolCategory,
 } from "../../tools/GenericTool/helpers";
 import { type ChainCategory, getCatalogLabel } from "./toolCatalog";
-import { asObject, integrationIconSrc } from "./resultHelpers";
+import { asObject, integrationIconSrc, str } from "./resultHelpers";
 
 export type ChainRowState = "running" | "done" | "error";
 
@@ -30,6 +30,19 @@ export interface ChainRow {
    *  row line but renders no card, so one delegation never stacks
    *  duplicate cards down the chain. */
   supersededSubSession?: boolean;
+  /** Every hire/raise preview proposed in this turn, attached to the last
+   *  of them so the whole roster renders as one card. */
+  teamProposals?: TeamProposal[];
+  /** An earlier proposal in a multi-expert turn — the roster card on the
+   *  last row already lists this expert. */
+  groupedProposal?: boolean;
+}
+
+/** One expert a turn proposed: the charter as previewed plus the id that
+ *  confirms it. */
+export interface TeamProposal {
+  confirmationId: string;
+  preview: Record<string, unknown>;
 }
 
 const SUB_SESSION_CARD_TOOLS = new Set([
@@ -75,6 +88,47 @@ export function markSupersededSubSessionRows(rows: ChainRow[]): ChainRow[] {
   return rows.map((row) =>
     supersededKeys.has(row.key) ? { ...row, supersededSubSession: true } : row,
   );
+}
+
+const TEAM_PROPOSAL_TOOLS = new Set(["hire_expert", "raise_expert"]);
+
+function teamProposalOf(row: ChainRow): TeamProposal | null {
+  if (!row.tool || !TEAM_PROPOSAL_TOOLS.has(row.tool)) return null;
+  const output = asObject(row.output);
+  if (!output || output.type !== "expert_change_proposed") return null;
+  const confirmationId = str(output, "confirmation_id");
+  const preview = asObject(output.preview);
+  return confirmationId && preview ? { confirmationId, preview } : null;
+}
+
+/** Raising a team is several independent ``raise_expert`` calls in one turn,
+ *  each with its own preview and confirmation id. The last of them carries
+ *  the whole roster so it renders as a single card with one confirm; the
+ *  earlier rows keep their line in the chain but drop their own card and
+ *  their "approve this" claim, which the roster card now owns. */
+export function groupTeamProposalRows(rows: ChainRow[]): ChainRow[] {
+  const proposed = new Map<string, TeamProposal>();
+  for (const row of rows) {
+    const proposal = teamProposalOf(row);
+    if (proposal) proposed.set(row.key, proposal);
+  }
+  if (proposed.size < 2) return rows;
+
+  const proposals = [...proposed.values()];
+  const lastKey = [...proposed.keys()].pop();
+  return rows.map((row) => {
+    const proposal = proposed.get(row.key);
+    if (!proposal) return row;
+    if (row.key === lastKey) {
+      return { ...row, teamProposals: proposals, text: "Review the new team" };
+    }
+    return {
+      ...row,
+      groupedProposal: true,
+      requiresAction: false,
+      text: `Drafted ${str(proposal.preview, "name") ?? "a new expert"}`,
+    };
+  });
 }
 
 const ACTION_RESPONSE_TYPES = new Set([

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
@@ -115,11 +115,16 @@ export function groupTeamProposalRows(rows: ChainRow[]): ChainRow[] {
   if (proposed.size < 2) return rows;
 
   const proposals = [...proposed.values()];
-  const lastKey = [...proposed.keys()].pop();
+  // The card hangs off the FIRST proposal row, not the last. Proposals stream
+  // in one at a time, so a last-row carrier moves on every new proposal —
+  // React then unmounts and remounts the card, silently resetting which
+  // experts the user had removed. The first row's key is stable as the rest
+  // append.
+  const carrierKey = [...proposed.keys()][0];
   return rows.map((row) => {
     const proposal = proposed.get(row.key);
     if (!proposal) return row;
-    if (row.key === lastKey) {
+    if (row.key === carrierKey) {
       return { ...row, teamProposals: proposals, text: "Review the new team" };
     }
     return {


### PR DESCRIPTION
> **Stacked PR 3 of 10** — Autopilot proactivity & conversation quality.
> Base: `Abhi1992002/copilot-batch-expert-confirm`. Review only this PR's diff.

### Why / What / How

**Why.** Raising a team was one approval card per expert and one "yes" per card. Staffing three roles meant three near-identical exchanges — read the charter back, wait, approve, repeat — before anything was created. The PR below this one lets the backend apply several approved previews in a single call; nothing on the surface let a user say yes to a team.

**What.** The hire/raise previews of a single assistant turn now render as **one roster card**: every proposed teammate with their role, each opening to their full charter (what they own, where they stop, voice, weekly budget), a per-expert **remove** that leaves that id out of the confirm, and a single **Hire all**.

Editing beyond remove stays conversational — the user says what should be different and the model re-issues a preview. There is no inline text editing in v1.

A lone preview is untouched: it still renders the existing single-expert card.

**How.** The grouping happens **on the client**, where the turn already exists. The tool chain attaches the turn's proposals to the last proposal row (`groupTeamProposalRows`, mirroring the existing `markSupersededSubSessionRows`); earlier rows keep their line in the chain — now reading "Drafted Otto" rather than N copies of "Approve the new expert" — but drop their own card.

Server-side aggregation was rejected: proposals are parked under opaque confirmation ids with no session index, so collecting a turn's pending previews means a keyspace scan plus a deserialize per key on *every* `raise_expert` call, to rebuild something the client already has.

"Hire all" cannot call a tool directly, so it sends a message through `CopilotChatActionsContext.onSend` — the same mechanism `SuggestedGoalCard` uses. It emits `confirmation_ids` for several and `confirmation_id` for one, because the tool refuses both at once.

The only backend change is the prompt rule that makes the turn-grouping assumption hold: `get_delegation_supplement` (expert-gated, shared by both engines) now asks for the whole roster in one turn and a compact table readback pointing at the card. `_CACHEABLE_SYSTEM_PROMPT` is untouched.

**Known scope calls:**
- `update_expert` is excluded from grouping — folding an edit-an-existing-teammate proposal into a "new team" roster would misdescribe it. It keeps the single card.
- Proposals TTL at 900s, so an old transcript renders the roster with expired ids; "Hire all" then produces per-id "expired" rows in the batch result card. Same property the existing single card already has.

### Changes 🏗️

- `copilot/prompting.py` — "Proposing a whole team" section in `get_delegation_supplement()`.
- `copilot/tools/expert_change_test.py` — `TestTeamProposalPrompt` pins the one-turn rule the card depends on.
- `frontend .../ToolChain/helpers.ts` — `TeamProposal` type + `groupTeamProposalRows()`; new `ChainRow` fields.
- `frontend .../ToolChain/ToolChain.tsx` — runs the grouping in the `rows` memo.
- `frontend .../ToolChain/ToolResult.tsx` — `hire_expert`/`raise_expert` split out of the shared expert case.
- `frontend .../ToolChain/ChainRowView.tsx` — grouped rows get no expander onto an empty panel.
- `frontend .../ToolChain/TeamPreviewCard/` — the roster card, its remove/expand hook, the confirm-message builder, and `ProposedExpertRow`.
- `frontend .../ToolChain/__tests__/TeamPreviewCard.test.tsx` — 8 tests driven **through `ToolChain`**, so the aggregation is exercised, not just the card.

No flags added. No schema, config, or `openapi.json` changes (copilot tool outputs are untyped).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `pnpm test:unit` — three proposals render as one roster; "Hire all" sends the batched confirm with all three ids; removing one drops that id; restoring it re-adds; one remaining falls back to the single-id parameter; an empty roster cannot confirm; charters open one at a time; a single proposal keeps the old card
  - [ ] `poetry run pytest backend/copilot/tools/expert_change_test.py -k TeamProposalPrompt`
  - [ ] `pnpm format` — new components have hand-written className literals and `prettier-plugin-tailwindcss` will reorder them
  - [ ] Manual: ask AutoPilot to staff three roles; confirm one roster card, remove one, hire the rest, check the batch result card
