### PR TITLE
feat(backend): wake the parent chat when a delegated sub-session finishes

### DIFF
--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -689,9 +689,10 @@ def get_delegation_supplement() -> str:
 - **Waiting etiquette.** If a sub-session is still running when your turn
   ends: give ONE short status line (include the ETA when you know it), then
   call `schedule_followup` with this session's `session_id` and a sensible
-  delay (60s minimum) so you pick it back up yourself. Never ask the user
-  whether to keep polling, and never tell them to check back later — the
-  waiting is yours to manage.
+  delay (60s minimum) so you pick it back up yourself. If a finished
+  delegation wakes this chat sooner, report then and let the followup find
+  nothing new to add. Never ask the user whether to keep polling, and never
+  tell them to check back later — the waiting is yours to manage.
 - **One status line per wait cycle.** Live progress already renders on the
   sub-session card above, so skip repeated "still working…" filler. Post
   again only when the status actually changes.

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -188,17 +188,18 @@ class TestDelegationWaitingEtiquette:
         assert "`schedule_followup` with this session's `session_id`" in supplement
         assert "60s minimum" in flat(supplement)
 
-    def test_waiting_rule_promises_no_resume_mechanism_that_does_not_exist(self):
-        """Nothing enqueues a turn back onto the parent when a sub finishes —
-        a delegation that outlives its turn resumes only because the model
-        scheduled a followup. Promising an automatic wake-up here would let
-        the model end the turn with no resume at all, which is worse than the
-        babysitting these rules exist to remove. The PR that adds the wake
-        mechanism updates this assertion along with the wording."""
+    def test_the_wake_is_an_accelerator_not_the_resume_path(self):
+        """This commit adds the wake, so the rule may now mention it — but
+        ``copilot-subsession-wake`` is default-off, so a turn that *relied* on
+        being woken would still end with no resume for most users. The
+        scheduled followup stays the unconditional instruction; the wake only
+        lets the model report sooner."""
         supplement = flat(prompting.get_delegation_supplement())
 
-        assert "woken automatically" not in supplement
-        assert "wakes this chat" not in supplement
+        assert "`schedule_followup` with this session's `session_id`" in supplement
+        assert "wakes this chat sooner" in supplement
+        # Never phrased as something to lean on instead of scheduling.
+        assert "rely on being woken" not in supplement
 
     def test_waiting_rule_requires_status_line_with_eta(self):
         supplement = prompting.get_delegation_supplement()

--- a/autogpt_platform/backend/backend/copilot/sdk/session_waiter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_waiter.py
@@ -92,10 +92,20 @@ async def wait_for_session_result(
     """
     if timeout > 0:
         await mark_awaited_inline(session_id, timeout)
-    queue = await stream_registry.subscribe_to_session(
-        session_id=session_id,
-        user_id=user_id,
-    )
+    try:
+        queue = await stream_registry.subscribe_to_session(
+            session_id=session_id,
+            user_id=user_id,
+        )
+    except BaseException:
+        # The lease is taken before the subscribe, and the try/finally that
+        # normally clears it starts after. Without this, a failing subscribe
+        # strands the lease for its whole TTL — and a live lease suppresses
+        # the delegated-task wake, so the parent chat would silently never be
+        # told its sub finished.
+        if timeout > 0:
+            await clear_awaited_inline(session_id)
+        raise
     result = SessionResult()
     if queue is None:
         if timeout > 0:

--- a/autogpt_platform/backend/backend/copilot/sdk/session_waiter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_waiter.py
@@ -32,6 +32,7 @@ from backend.copilot.pending_message_helpers import (
     queue_user_message,
 )
 from backend.copilot.response_model import StreamError, StreamFinish
+from backend.copilot.subsession_wake import clear_awaited_inline, mark_awaited_inline
 
 from .stream_accumulator import EventAccumulator, ToolCallEntry, process_event
 
@@ -83,13 +84,22 @@ async def wait_for_session_result(
     result) or at the terminal event (``completed`` / ``failed`` + full
     result). Cleans up the subscriber listener on every exit path so
     long-running polls don't leak listeners (sentry r3105348640).
+
+    For the duration of a real wait this also leases "a turn is blocked on
+    this session" in Redis, which suppresses the delegated-task wake — the
+    caller is about to surface the same result through its own tool call
+    (see :mod:`backend.copilot.subsession_wake`).
     """
+    if timeout > 0:
+        await mark_awaited_inline(session_id, timeout)
     queue = await stream_registry.subscribe_to_session(
         session_id=session_id,
         user_id=user_id,
     )
     result = SessionResult()
     if queue is None:
+        if timeout > 0:
+            await clear_awaited_inline(session_id)
         # Session meta not in Redis yet, or the caller doesn't own it.
         # ``subscribe_to_session`` already retried with backoff before
         # returning None.
@@ -119,6 +129,8 @@ async def wait_for_session_result(
             session_id=session_id,
             subscriber_queue=queue,
         )
+        if timeout > 0:
+            await clear_awaited_inline(session_id)
 
     result.response_text = "".join(acc.response_parts)
     result.tool_calls = list(acc.tool_calls)

--- a/autogpt_platform/backend/backend/copilot/sdk/session_waiter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_waiter_test.py
@@ -295,3 +295,28 @@ async def test_zero_timeout_wait_takes_no_lease():
 
     mark.assert_not_awaited()
     clear.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failing_subscribe_does_not_strand_the_inline_lease(monkeypatch):
+    """A live lease suppresses the delegated-task wake, so leaking one on a
+    subscribe failure would silently cost the parent chat its report."""
+    cleared: list[str] = []
+
+    monkeypatch.setattr(
+        "backend.copilot.sdk.session_waiter.mark_awaited_inline",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "backend.copilot.sdk.session_waiter.clear_awaited_inline",
+        AsyncMock(side_effect=lambda sid: cleared.append(sid)),
+    )
+    monkeypatch.setattr(
+        "backend.copilot.sdk.session_waiter.stream_registry.subscribe_to_session",
+        AsyncMock(side_effect=RuntimeError("redis down")),
+    )
+
+    with pytest.raises(RuntimeError):
+        await wait_for_session_result(session_id="sess-1", user_id="user-1", timeout=30)
+
+    assert cleared == ["sess-1"]

--- a/autogpt_platform/backend/backend/copilot/sdk/session_waiter_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/session_waiter_test.py
@@ -16,7 +16,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.copilot import active_turns
-from backend.copilot.sdk.session_waiter import SessionResult, run_copilot_turn_via_queue
+from backend.copilot.sdk.session_waiter import (
+    SessionResult,
+    run_copilot_turn_via_queue,
+    wait_for_session_result,
+)
 
 _QR = type(
     "QR",
@@ -246,3 +250,48 @@ async def test_idle_session_concurrent_turn_cap_returns_rejected_outcome():
     create_session.assert_not_awaited()
     enqueue.assert_not_awaited()
     wait_result.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_leases_the_session_for_the_duration_of_the_wait():
+    """A real wait must advertise itself so the delegated-task wake stays
+    quiet — this caller is about to report the same result itself."""
+    mark = AsyncMock()
+    clear = AsyncMock()
+
+    with (
+        patch("backend.copilot.sdk.session_waiter.mark_awaited_inline", new=mark),
+        patch("backend.copilot.sdk.session_waiter.clear_awaited_inline", new=clear),
+        patch(
+            "backend.copilot.sdk.session_waiter.stream_registry.subscribe_to_session",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        outcome, _ = await wait_for_session_result(
+            session_id="sub-1", user_id="u1", timeout=5.0
+        )
+
+    assert outcome == "running"
+    mark.assert_awaited_once_with("sub-1", 5.0)
+    clear.assert_awaited_once_with("sub-1")
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_wait_takes_no_lease():
+    """``timeout=0`` isn't a wait — leasing there would let a fire-and-forget
+    dispatch suppress a wake nobody is waiting to deliver."""
+    mark = AsyncMock()
+    clear = AsyncMock()
+
+    with (
+        patch("backend.copilot.sdk.session_waiter.mark_awaited_inline", new=mark),
+        patch("backend.copilot.sdk.session_waiter.clear_awaited_inline", new=clear),
+        patch(
+            "backend.copilot.sdk.session_waiter.stream_registry.subscribe_to_session",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await wait_for_session_result(session_id="sub-1", user_id="u1", timeout=0)
+
+    mark.assert_not_awaited()
+    clear.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/stream_registry.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry.py
@@ -63,6 +63,7 @@ from .response_model import (
     StreamToolOutputAvailable,
     StreamUsage,
 )
+from .subsession_wake import schedule_parent_wake
 
 logger = logging.getLogger(__name__)
 config = ChatConfig()
@@ -1009,6 +1010,13 @@ async def mark_session_completed(
                     f"Failed to publish copilot completion notification "
                     f"for session {session_id}: {e}"
                 )
+
+    # If this session was work delegated by another chat, wake that chat so
+    # it reviews the result and reports back on its own. Detached and
+    # self-guarding: the completion path must never wait on it or fail with
+    # it. Reached only on the branch that actually swapped the status, so a
+    # repeat call cannot double-post.
+    schedule_parent_wake(session_id, status)
 
     return True
 

--- a/autogpt_platform/backend/backend/copilot/stream_registry_test.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry_test.py
@@ -18,6 +18,14 @@ def _clear_listener_sessions():
     stream_registry._listener_sessions.clear()
 
 
+@pytest.fixture(autouse=True)
+def _no_subsession_wake():
+    """``mark_session_completed`` spawns a detached delegated-task wake; stub
+    it so these tests don't leave a background task doing real I/O behind."""
+    with patch.object(stream_registry, "schedule_parent_wake"):
+        yield
+
+
 async def _sleep_forever():
     try:
         await asyncio.sleep(3600)

--- a/autogpt_platform/backend/backend/copilot/subsession_wake.py
+++ b/autogpt_platform/backend/backend/copilot/subsession_wake.py
@@ -1,0 +1,201 @@
+"""Wake the delegating chat when a delegated sub-session finishes.
+
+``delegate_to_expert`` records who asked for the work on the sub's session
+metadata (``delegated_by_session_id``). Until now nothing consumed that on
+the *completion* side: if the teammate finished after the delegating turn
+had already closed, the result sat in the sub's transcript until the user
+nudged the parent chat.
+
+:func:`schedule_parent_wake` closes that loop. When a sub reaches a terminal
+status it posts one system-framed message onto the delegating chat telling
+the model to read the result and report it to the user in its own voice.
+
+Three things keep this safe to run from the completion hot path:
+
+* **Detached** — :func:`spawn_background_task`, so a slow or failing wake
+  never delays or breaks the sub's own completion.
+* **At most once** — the enqueue is claimed with a ``SET NX`` marker keyed
+  on ``(parent, sub, terminal status)``. Unlike the briefing dedupe there is
+  no message row to hang a PK on (we enqueue a *turn*, not a message), so
+  the Redis claim is the atomic primitive. It is taken *before* the enqueue:
+  a dropped wake is recoverable by the model's own polling, a double-posted
+  one is not.
+* **Never double-reports** — a turn that is still blocked inside
+  ``wait_for_session_result`` for this sub will surface the result through
+  its own tool call. That wait registers an :func:`inline_wait_key` lease
+  for the duration, and a live lease suppresses the wake.
+"""
+
+import logging
+from typing import Literal
+
+from backend.copilot.model import get_chat_session_metadata
+from backend.data.redis_client import get_redis_async
+from backend.util.background import spawn_background_task
+from backend.util.feature_flag import Flag, is_feature_enabled
+
+logger = logging.getLogger(__name__)
+
+TerminalStatus = Literal["completed", "failed"]
+
+# Claim marker for "this (parent, sub, status) wake has been enqueued".
+# The TTL only has to outlive retries and pod restarts for the same
+# completion, not the session — a day is generous.
+_WAKE_CLAIM_PREFIX = "copilot:subsession_wake:"
+_WAKE_CLAIM_TTL_SECONDS = 24 * 60 * 60
+
+# Lease marking "some turn is currently blocked waiting on this session's
+# terminal event". Written by ``wait_for_session_result``.
+_INLINE_WAIT_PREFIX = "copilot:subsession_wait:"
+_INLINE_WAIT_SLACK_SECONDS = 15
+
+
+def inline_wait_key(session_id: str) -> str:
+    return f"{_INLINE_WAIT_PREFIX}{session_id}"
+
+
+def schedule_parent_wake(sub_session_id: str, status: TerminalStatus) -> None:
+    """Fire-and-forget the parent-chat wake for a just-finished session."""
+    spawn_background_task(
+        _wake_parent(sub_session_id, status),
+        name=f"subsession-wake-{sub_session_id[:12]}",
+    )
+
+
+async def _wake_parent(sub_session_id: str, status: TerminalStatus) -> None:
+    """Post the delegated-task-finished turn onto the delegating chat.
+
+    Every guard below is a silent no-op rather than an error: the sub has
+    already finished successfully by the time we run, and nothing here is
+    worth failing that.
+    """
+    try:
+        sub = await get_chat_session_metadata(sub_session_id)
+        if sub is None:
+            return
+
+        parent_session_id = sub.metadata.delegated_by_session_id
+        if not parent_session_id:
+            return
+
+        # A handoff writes the delegation fields too, but transfers
+        # *ownership*: the receiving expert reports to the user directly and
+        # the handing-off session cannot even poll the sub
+        # (``get_sub_session_result._in_caller_scope``). Waking it would
+        # report work that is no longer its own.
+        if sub.metadata.handed_off_from_expert_id is not None:
+            return
+
+        if not await is_feature_enabled(
+            Flag.COPILOT_SUBSESSION_WAKE, sub.user_id, default=False
+        ):
+            return
+
+        if await _is_awaited_inline(sub_session_id):
+            logger.debug(
+                "subsession wake skipped for sub=%s: a turn is still waiting "
+                "on it inline",
+                sub_session_id[:12],
+            )
+            return
+
+        parent = await get_chat_session_metadata(parent_session_id, sub.user_id)
+        if parent is None:
+            return
+
+        if not await _claim_wake(parent_session_id, sub_session_id, status):
+            return
+
+        # Local import: ``stream_registry`` imports this module for the
+        # completion hook, and ``session_waiter`` imports ``stream_registry``.
+        from backend.copilot.sdk.session_waiter import run_copilot_turn_via_queue
+
+        outcome, _ = await run_copilot_turn_via_queue(
+            session_id=parent_session_id,
+            user_id=parent.user_id,
+            message=wake_message(sub_session_id=sub_session_id, status=status),
+            # 0 = don't wait: an idle parent gets a fresh turn dispatched, a
+            # busy one gets the message on its pending buffer. Either way we
+            # return without occupying this worker.
+            timeout=0,
+            tool_call_id=f"subwake:{sub_session_id}",
+            tool_name="delegated_task_completed",
+        )
+        logger.info(
+            "subsession wake enqueued on parent=%s for sub=%s (status=%s, "
+            "outcome=%s)",
+            parent_session_id[:12],
+            sub_session_id[:12],
+            status,
+            outcome,
+        )
+    except Exception:
+        logger.warning(
+            "subsession wake failed for sub=%s; dropping",
+            sub_session_id[:12],
+            exc_info=True,
+        )
+
+
+def wake_message(*, sub_session_id: str, status: TerminalStatus) -> str:
+    """The system-framed prompt the delegating model wakes up to.
+
+    There is no author field on a pending message — everything buffered is
+    presented to the model as the user — so the framing is the only thing
+    that stops the model from answering this line as if the user typed it.
+    Same convention as ``delegate_to_expert._handoff_message``.
+    """
+    return (
+        "[System notice, not the user speaking: a task you delegated has "
+        "finished. Do not reply to this notice itself.]\n\n"
+        f'<delegated_task_completed sub_session_id="{sub_session_id}" '
+        f'status="{status}" />\n\n'
+        "Call `get_sub_session_result` with that sub_session_id to read what "
+        "came back, then report the outcome to the user in your own voice: "
+        "what you had asked for, what you got, and what happens next. If it "
+        "failed or came back short of the goal, say so plainly and take the "
+        "next step yourself rather than handing the chase back to the user."
+    )
+
+
+async def _claim_wake(
+    parent_session_id: str, sub_session_id: str, status: TerminalStatus
+) -> bool:
+    """Claim the right to enqueue this wake exactly once."""
+    redis = await get_redis_async()
+    key = f"{_WAKE_CLAIM_PREFIX}{parent_session_id}:{sub_session_id}:{status}"
+    return bool(await redis.set(key, "1", nx=True, ex=_WAKE_CLAIM_TTL_SECONDS))
+
+
+async def _is_awaited_inline(session_id: str) -> bool:
+    redis = await get_redis_async()
+    return bool(await redis.get(inline_wait_key(session_id)))
+
+
+async def mark_awaited_inline(session_id: str, timeout: float) -> None:
+    """Lease "a turn is blocked on this session" for the length of the wait."""
+    try:
+        redis = await get_redis_async()
+        await redis.setex(
+            inline_wait_key(session_id),
+            int(timeout) + _INLINE_WAIT_SLACK_SECONDS,
+            "1",
+        )
+    except Exception:
+        logger.debug(
+            "could not register inline-wait lease for session=%s",
+            session_id[:12],
+            exc_info=True,
+        )
+
+
+async def clear_awaited_inline(session_id: str) -> None:
+    try:
+        redis = await get_redis_async()
+        await redis.delete(inline_wait_key(session_id))
+    except Exception:
+        logger.debug(
+            "could not clear inline-wait lease for session=%s",
+            session_id[:12],
+            exc_info=True,
+        )

--- a/autogpt_platform/backend/backend/copilot/subsession_wake_test.py
+++ b/autogpt_platform/backend/backend/copilot/subsession_wake_test.py
@@ -1,0 +1,410 @@
+"""Tests for the delegated-task wake.
+
+Covers the trigger contract:
+
+* a terminal sub-session with parent linkage enqueues exactly one parent turn
+* a retry / restart of the same completion enqueues none (Redis claim)
+* a parent with a turn in flight receives the wake on its pending buffer
+* no linkage, a handoff, a missing parent, an inline waiter, or a flag-off
+  user are all silent no-ops
+* an enqueue that blows up is swallowed — the sub's completion still stands
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.copilot import stream_registry, subsession_wake
+from backend.copilot.subsession_wake import _wake_parent, schedule_parent_wake
+
+_SUB = "sub-session-1"
+_PARENT = "parent-session-1"
+_USER = "user-1"
+
+
+class _FakeRedis:
+    """Async-Redis fake covering only the calls the wake path makes."""
+
+    def __init__(self, store: dict[str, str] | None = None):
+        self.store: dict[str, str] = dict(store or {})
+
+    async def set(self, key: str, value: str, *, nx: bool = False, ex=None):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def setex(self, key: str, _ttl: int, value: str):
+        self.store[key] = value
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        for key in keys:
+            self.store.pop(key, None)
+        return len(keys)
+
+
+def _session_info(
+    *,
+    user_id: str = _USER,
+    delegated_by: str | None = None,
+    handed_off_from: str | None = None,
+) -> MagicMock:
+    info = MagicMock()
+    info.user_id = user_id
+    info.metadata.delegated_by_session_id = delegated_by
+    info.metadata.handed_off_from_expert_id = handed_off_from
+    return info
+
+
+def _lookup(sessions: dict[str, MagicMock] | None = None) -> AsyncMock:
+    """Fake ``get_chat_session_metadata`` keyed by session id."""
+    known = sessions or {}
+
+    async def _get(session_id: str, _user_id: str | None = None):
+        return known.get(session_id)
+
+    return AsyncMock(side_effect=_get)
+
+
+def _patched(
+    *,
+    lookup: AsyncMock,
+    redis: _FakeRedis,
+    enqueue: AsyncMock,
+    flag_enabled: bool = True,
+):
+    return (
+        patch.object(subsession_wake, "get_chat_session_metadata", new=lookup),
+        patch.object(
+            subsession_wake, "get_redis_async", new=AsyncMock(return_value=redis)
+        ),
+        patch.object(
+            subsession_wake,
+            "is_feature_enabled",
+            new=AsyncMock(return_value=flag_enabled),
+        ),
+        patch(
+            "backend.copilot.sdk.session_waiter.run_copilot_turn_via_queue",
+            new=enqueue,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_terminal_status_enqueues_exactly_one_parent_turn():
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_awaited_once()
+    kwargs = enqueue.await_args.kwargs
+    assert kwargs["session_id"] == _PARENT
+    assert kwargs["user_id"] == _USER
+    # timeout=0 hands the in-flight/idle decision to run_copilot_turn_via_queue
+    # instead of occupying the completion worker with a wait.
+    assert kwargs["timeout"] == 0
+    assert f'sub_session_id="{_SUB}"' in kwargs["message"]
+    assert 'status="completed"' in kwargs["message"]
+    assert "get_sub_session_result" in kwargs["message"]
+    # System-framed, because the pending buffer has no author field.
+    assert kwargs["message"].startswith("[System notice")
+
+
+@pytest.mark.asyncio
+async def test_failed_status_is_reported_too():
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "failed")
+
+    assert 'status="failed"' in enqueue.await_args.kwargs["message"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_completion_does_not_double_post():
+    """A retry or a pod restart replaying the same completion must not
+    produce a second parent turn — the Redis claim is the dedupe primitive."""
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+    redis = _FakeRedis()
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=redis, enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_parent_with_turn_in_flight_goes_to_pending_buffer():
+    """End-to-end through the real ``run_copilot_turn_via_queue``: a busy
+    parent must receive the wake on its pending buffer, never as a parallel
+    turn racing the in-flight one on the cluster lock."""
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    queue_message = AsyncMock(return_value=MagicMock(buffer_length=1))
+    schedule = AsyncMock()
+    parent_session = MagicMock()
+    parent_session.metadata.llm_auth_provider = "platform"
+    parent_session.metadata.llm_credential_id = None
+
+    with (
+        patch.object(subsession_wake, "get_chat_session_metadata", new=lookup),
+        patch.object(
+            subsession_wake,
+            "get_redis_async",
+            new=AsyncMock(return_value=_FakeRedis()),
+        ),
+        patch.object(
+            subsession_wake, "is_feature_enabled", new=AsyncMock(return_value=True)
+        ),
+        patch(
+            "backend.copilot.sdk.session_waiter.get_chat_session",
+            new=AsyncMock(return_value=parent_session),
+        ),
+        patch(
+            "backend.copilot.sdk.session_waiter.is_turn_in_flight",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "backend.copilot.sdk.session_waiter.queue_user_message",
+            new=queue_message,
+        ),
+        patch("backend.copilot.sdk.session_waiter.schedule_turn", new=schedule),
+    ):
+        await _wake_parent(_SUB, "completed")
+
+    queue_message.assert_awaited_once()
+    assert queue_message.await_args.kwargs["session_id"] == _PARENT
+    assert f'sub_session_id="{_SUB}"' in queue_message.await_args.kwargs["message"]
+    schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_parent_linkage_is_a_noop():
+    lookup = _lookup({_SUB: _session_info(delegated_by=None)})
+    enqueue = AsyncMock()
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handoff_is_a_noop():
+    """A handoff transfers ownership: the receiving expert reports to the
+    user directly, and the handing-off session cannot even poll the sub."""
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT, handed_off_from="expert-9"),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock()
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_is_a_noop():
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock()
+    flag = AsyncMock(return_value=False)
+
+    with (
+        patch.object(subsession_wake, "get_chat_session_metadata", new=lookup),
+        patch.object(
+            subsession_wake,
+            "get_redis_async",
+            new=AsyncMock(return_value=_FakeRedis()),
+        ),
+        patch.object(subsession_wake, "is_feature_enabled", new=flag),
+        patch(
+            "backend.copilot.sdk.session_waiter.run_copilot_turn_via_queue",
+            new=enqueue,
+        ),
+    ):
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+    assert flag.await_args.args[0].value == "copilot-subsession-wake"
+    assert flag.await_args.args[1] == _USER
+
+
+@pytest.mark.asyncio
+async def test_missing_parent_session_is_a_noop():
+    """Deleted parent (hard delete leaves no row) — nothing to wake."""
+    lookup = _lookup({_SUB: _session_info(delegated_by=_PARENT)})
+    enqueue = AsyncMock()
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_sub_session_is_a_noop():
+    lookup = _lookup()
+    enqueue = AsyncMock()
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inline_waiter_suppresses_the_wake():
+    """The spawning turn is still blocked in ``wait_for_session_result`` for
+    this sub, so it will surface the result through its own tool call —
+    waking as well would report the same outcome twice."""
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock()
+    redis = _FakeRedis({subsession_wake.inline_wait_key(_SUB): "1"})
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=redis, enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleared_inline_lease_no_longer_suppresses():
+    redis = _FakeRedis()
+    with patch.object(
+        subsession_wake, "get_redis_async", new=AsyncMock(return_value=redis)
+    ):
+        await subsession_wake.mark_awaited_inline(_SUB, 30)
+        assert await subsession_wake._is_awaited_inline(_SUB) is True
+        await subsession_wake.clear_awaited_inline(_SUB)
+        assert await subsession_wake._is_awaited_inline(_SUB) is False
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_is_swallowed():
+    """The sub-session's own completion must never break because the wake
+    could not be enqueued."""
+    lookup = _lookup(
+        {
+            _SUB: _session_info(delegated_by=_PARENT),
+            _PARENT: _session_info(),
+        }
+    )
+    enqueue = AsyncMock(side_effect=RuntimeError("rabbit down"))
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lookup_failure_is_swallowed():
+    lookup = AsyncMock(side_effect=RuntimeError("db down"))
+    enqueue = AsyncMock()
+    p1, p2, p3, p4 = _patched(lookup=lookup, redis=_FakeRedis(), enqueue=enqueue)
+
+    with p1, p2, p3, p4:
+        await _wake_parent(_SUB, "completed")
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_parent_wake_runs_detached():
+    wake = AsyncMock()
+    with patch.object(subsession_wake, "_wake_parent", new=wake):
+        schedule_parent_wake(_SUB, "completed")
+        await asyncio.sleep(0)
+
+    wake.assert_awaited_once_with(_SUB, "completed")
+
+
+class _CompletionRedis:
+    """Just enough of the Redis surface for ``mark_session_completed``."""
+
+    def __init__(self, meta: dict[str, str]):
+        self._meta = dict(meta)
+        self.delete = AsyncMock(return_value=1)
+
+    async def hgetall(self, _key: str):
+        return dict(self._meta)
+
+
+@pytest.mark.asyncio
+async def test_mark_session_completed_schedules_the_wake_once_per_swap():
+    """The wake hangs off the branch that actually swapped the status, so a
+    second (idempotent) completion call cannot schedule a second wake."""
+    redis = _CompletionRedis({"status": "running", "turn_id": "turn-1"})
+    swapped = AsyncMock(side_effect=[True, False])
+    schedule = MagicMock()
+
+    with (
+        patch.object(
+            stream_registry, "get_redis_async", new=AsyncMock(return_value=redis)
+        ),
+        patch.object(stream_registry, "hash_compare_and_set", new=swapped),
+        patch.object(stream_registry, "publish_chunk", new=AsyncMock()),
+        patch.object(stream_registry, "schedule_parent_wake", new=schedule),
+        patch.object(
+            stream_registry.chat_db(),
+            "set_turn_duration",
+            new=AsyncMock(),
+            create=True,
+        ),
+    ):
+        assert await stream_registry.mark_session_completed("sess-1") is True
+        assert await stream_registry.mark_session_completed("sess-1") is False
+
+    schedule.assert_called_once_with("sess-1", "completed")

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -60,6 +60,11 @@ class Flag(str, Enum):
     # current_session_id line stays regardless — only the followup
     # surface is gated.  Default-on.
     COPILOT_SCHEDULED_FOLLOWUPS = "copilot-scheduled-followups"
+    # Wakes the delegating chat when a task it handed to a teammate
+    # finishes: the parent gets one system-framed turn telling it to read
+    # the sub-session's result and report to the user.  Off by default —
+    # it posts into a chat the user is not necessarily looking at.
+    COPILOT_SUBSESSION_WAKE = "copilot-subsession-wake"
     COPILOT_TIER_MULTIPLIERS = "copilot-tier-multipliers"
     COPILOT_TIER_WORKSPACE_STORAGE_LIMITS = "copilot-tier-workspace-storage-limits"
     COPILOT_TIER_STRIPE_PRICES = "copilot-tier-stripe-prices"

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -418,12 +418,17 @@ async def is_feature_enabled(
     Returns:
         True if feature is enabled, False otherwise
     """
+    # Log the LaunchDarkly key, not the ``flag_key`` binding itself: CodeQL's
+    # py/clear-text-logging-sensitive-data treats any ``*key*`` name reaching a
+    # log sink as a credential, which this is not.
+    flag_name = flag_key.value
+
     override = _env_flag_override(flag_key)
     if override is not None:
-        logger.debug(f"Feature flag {flag_key} overridden by env: {override}")
+        logger.debug(f"Feature flag {flag_name} overridden by env: {override}")
         return override
 
-    result = await get_feature_flag_value(flag_key.value, user_id, default)
+    result = await get_feature_flag_value(flag_name, user_id, default)
 
     # If the result is already a boolean, return it
     if isinstance(result, bool):
@@ -431,7 +436,7 @@ async def is_feature_enabled(
 
     # Log a warning if the flag is not returning a boolean
     logger.warning(
-        f"Feature flag {flag_key} returned non-boolean value: {result} (type: {type(result).__name__}). "
+        f"Feature flag {flag_name} returned non-boolean value: {result} (type: {type(result).__name__}). "
         f"This flag should be configured as a boolean in LaunchDarkly. Using default={default}"
     )
 


### PR DESCRIPTION
> **Stacked PR 4 of 10** — Autopilot proactivity & conversation quality.
> Base: `Abhi1992002/copilot-team-preview-card`. Review only this PR's diff.

### Why / What / How

**Why.** A task handed to a teammate that outlives the delegating turn lands nowhere. `delegate_to_expert` records who asked on the sub's session metadata (`delegated_by_session_id`), but nothing consumed that on the *completion* side. If the teammate finished after the delegating turn had already closed, the result sat in the sub's transcript until the user thought to go nudge the parent chat — the exact "go check on it yourself" ending that PR 1 of this stack tells the model never to produce.

**What.** When a delegated sub-session reaches a terminal status, the delegating chat is woken with one system-framed turn that tells the model to read the result and report it to the user in its own voice. No user nudge, no model polling loop.

Behind a new LaunchDarkly flag **`copilot-subsession-wake`, off by default**. No frontend surface — the wake produces an ordinary assistant turn in the existing chat, and the existing `copilot_completion` notification already alerts an away user.

**How.** `mark_session_completed` gains one detached call, on the branch that actually won the status CAS:

- **Provenance** — the wake reads the finished session's metadata. No `delegated_by_session_id` → no-op. A **handoff** (`handed_off_from_expert_id` set) → no-op: a handoff transfers ownership, the receiver reports to the user directly, and the handing-off session can't even poll the sub. (`handoff_to_expert` writes the same field, so without this skip every handoff would have woken the session that gave the work away.)
- **Enqueue** — `run_copilot_turn_via_queue(..., timeout=0)`. An idle parent gets a fresh turn dispatched; a parent with a turn in flight gets the message on its **pending buffer** instead of a second turn racing the first on the cluster lock. That branch already existed; the wake just uses it.
- **At most once** — `SET NX` on `(parent, sub, terminal status)` with a 24h TTL, claimed *before* the enqueue. Retries and pod restarts replaying the same completion produce nothing. (The morning-briefing dedupe hangs off a message row's PK; we enqueue a *turn*, not a message, so Redis is the only atomic primitive available here.)
- **Never double-reports** — a turn still blocked inside `wait_for_session_result` for this sub will surface the same outcome through its own tool call. That wait now leases the session in Redis for its duration, and a live lease suppresses the wake. This covers both the spawning `delegate_to_expert` wait and a later `get_sub_session_result` poll, since both go through the same waiter.
- **Never breaks completion** — the existing `spawn_background_task` helper (keeps a strong ref, logs unobserved exceptions) plus a blanket try/except. Every guard is a silent no-op; any failure is logged and dropped.

Prompt: the delegation supplement's existing waiting-etiquette bullet (added in PR 1) gains **one sentence** making the promise explicit, rather than a new bullet — these tokens ship every turn.

**Scope call:** `run_sub_session` does **not** get parent linkage. `delegated_by_session_id` is not just provenance — it is the poll *capability* (`get_sub_session_result._in_caller_scope`). Same-expert subs are already pollable, so writing it buys nothing and widens an authz-adjacent field; it would also change which threads reach Home. This keeps the flagged blast radius to cross-expert delegation, the case that actually strands results.

**Known residual race:** if the waiter's `asyncio.wait_for` times out in the same instant the sub completes, the lease may still be live and the wake is skipped; the model then falls back to `get_sub_session_result` / `schedule_followup` per the prompt rules.

### Changes 🏗️

- `copilot/subsession_wake.py` **(new)** — `schedule_parent_wake`, `_wake_parent`, `wake_message`, the `SET NX` claim, the inline-wait lease helpers.
- `copilot/stream_registry.py` — one `schedule_parent_wake(...)` call at the end of `mark_session_completed`, after the CAS branch that swapped.
- `copilot/sdk/session_waiter.py` — `wait_for_session_result` leases "a turn is blocked on this session" for the length of a real wait (`timeout > 0`), cleared on every exit path.
- `util/feature_flag.py` — `COPILOT_SUBSESSION_WAKE = "copilot-subsession-wake"`, off by default.
- `copilot/prompting.py` — one sentence folded into the existing waiting-etiquette bullet.
- `copilot/subsession_wake_test.py` **(new)** — 14 tests. `sdk/session_waiter_test.py`, `stream_registry_test.py` — lease tests + an autouse fixture so existing tests don't leave a detached task doing real I/O.

**Flag added:** `copilot-subsession-wake` (default off). No schema or config changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `poetry run pytest backend/copilot/subsession_wake_test.py` — terminal status enqueues exactly one parent turn with `timeout=0` and a system-framed `<delegated_task_completed>` payload; failed status reports too; a replayed completion enqueues none; an in-flight parent lands on the pending buffer (driven through the real `run_copilot_turn_via_queue`, asserting `schedule_turn` is never called); no linkage / handoff / unknown sub / missing parent / flag-off are all no-ops; a live inline-wait lease suppresses the wake; enqueue and lookup failures are swallowed
  - [ ] `poetry run pytest backend/copilot/sdk/session_waiter_test.py backend/copilot/stream_registry_test.py`
  - [ ] Manual, flag on for one user: delegate with `wait_for_result` shorter than the task, let the turn close, confirm the parent chat posts a report on its own; then cancel→complete and confirm nothing further posts
  - [ ] Manual: delegate with a long `wait_for_result` and let it finish inside the window — confirm exactly one report, from the tool result
