### PR TITLE
feat(frontend): lead a self-host install with the connection, not the questions

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/brain-dump.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/brain-dump.test.tsx
@@ -85,6 +85,19 @@ vi.mock("../steps/BrainDumpStep/recordingStore", () => ({
   },
 }));
 
+// These tests navigate by NO_PAYWALL_STEPS, which is the layout for a
+// deployment with neither a paywall nor a self-host connect step. isLocal()
+// is true for anything not explicitly CLOUD, including the test environment,
+// so it is pinned here rather than left to the default.
+vi.mock("@/services/environment", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/environment")>();
+  return {
+    ...actual,
+    environment: { ...actual.environment, isLocal: () => false },
+  };
+});
+
 vi.mock("posthog-js", () => ({
   default: { capture: vi.fn() },
 }));

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -20,6 +20,10 @@ vi.mock("../steps/RoleStep", () => ({
 vi.mock("../steps/PainPointsStep", () => ({
   PainPointsStep: () => <div data-testid="step-painpoints" />,
 }));
+vi.mock("../steps/ConnectStep/ConnectStep", () => ({
+  ConnectStep: () => <div data-testid="step-connect" />,
+}));
+
 vi.mock("../steps/SubscriptionStep/SubscriptionStep", () => ({
   SubscriptionStep: () => <div data-testid="step-subscription" />,
 }));
@@ -112,6 +116,15 @@ vi.mock("@/services/feature-flags/use-get-flag", () => ({
     flag === "ENABLE_PLATFORM_PAYMENT" ? mockFlagValue : false,
 }));
 
+vi.mock("@/services/environment", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/environment")>();
+  return {
+    ...actual,
+    environment: { ...actual.environment, isLocal: () => mockIsLocal },
+  };
+});
+
 vi.mock("launchdarkly-react-client-sdk", () => ({
   useLDClient: () => ({
     waitForInitialization: () => Promise.resolve(),
@@ -119,10 +132,12 @@ vi.mock("launchdarkly-react-client-sdk", () => ({
 }));
 
 const STEP_STORAGE_KEY = "autogpt:onboarding-highest-step";
+let mockIsLocal = false;
 
 beforeEach(() => {
   currentSearchParams = new URLSearchParams();
   mockFlagValue = false;
+  mockIsLocal = false;
   mockSubscriptionTier = "NO_TIER";
   mockAuthState = { isLoggedIn: true, isUserLoading: false };
   authUserPutBodies.length = 0;
@@ -382,5 +397,45 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     expect(state.name).toBe("Alice");
     expect(state.role).toBe("Engineering");
     expect(state.painPoints).toEqual(["slow builds"]);
+  });
+});
+
+describe("OnboardingPage — self-host leads with the connection", () => {
+  it("renders ConnectStep first on a self-host install", async () => {
+    // A fresh self-host install cannot answer a single message until it has
+    // a model, so asking for one comes before personalising the chat.
+    mockIsLocal = true;
+    currentSearchParams = new URLSearchParams("step=1");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-connect")).toBeDefined();
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
+  });
+
+  it("puts Welcome after it, the way the paywall does on cloud", async () => {
+    mockIsLocal = true;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "2");
+    currentSearchParams = new URLSearchParams("step=2");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-connect")).toBeNull();
+  });
+
+  it("does not insert it on cloud", async () => {
+    mockIsLocal = false;
+    currentSearchParams = new URLSearchParams("step=1");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-welcome")).toBeDefined();
+    expect(screen.queryByTestId("step-connect")).toBeNull();
+  });
+
+  it("yields to the paywall rather than showing both first steps", async () => {
+    // Payments and self-host are mutually exclusive in practice; if a
+    // deployment ever had both, only one step can be first.
+    mockIsLocal = true;
+    mockFlagValue = true;
+    currentSearchParams = new URLSearchParams("step=1");
+    render(<OnboardingPage />);
+    expect(await screen.findByTestId("step-subscription")).toBeDefined();
+    expect(screen.queryByTestId("step-connect")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/page.tsx
@@ -6,9 +6,14 @@ import { BrainDumpStep } from "./steps/BrainDumpStep/BrainDumpStep";
 import { PainPointsStep } from "./steps/PainPointsStep";
 import { PreparingStep } from "./steps/PreparingStep";
 import { RoleStep } from "./steps/RoleStep";
+import { ConnectStep } from "./steps/ConnectStep/ConnectStep";
 import { SubscriptionStep } from "./steps/SubscriptionStep/SubscriptionStep";
 import { WelcomeStep } from "./steps/WelcomeStep";
-import { PAYWALL_FIRST_STEPS, useOnboardingWizardStore } from "./store";
+import {
+  PAYWALL_FIRST_STEPS,
+  SELF_HOST_STEPS,
+  useOnboardingWizardStore,
+} from "./store";
 import { useOnboardingPage } from "./useOnboardingPage";
 import { ArrowLeft01Icon, Logout03Icon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
@@ -19,6 +24,7 @@ export default function OnboardingPage() {
     isLoading,
     handlePreparingComplete,
     isPaymentEnabled,
+    isSelfHostConnectEnabled,
     isBrainDumpEnabled,
     steps,
     preparingStep,
@@ -64,6 +70,8 @@ export default function OnboardingPage() {
           currentStep === PAYWALL_FIRST_STEPS.subscription && (
             <SubscriptionStep />
           )}
+        {isSelfHostConnectEnabled &&
+          currentStep === SELF_HOST_STEPS.connect && <ConnectStep />}
         {currentStep === steps.welcome && <WelcomeStep />}
         {currentStep === steps.role && <RoleStep />}
         {currentStep === steps.painPoints &&

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/ConnectStep.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/ConnectStep.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { LinkSquare01Icon } from "@hugeicons/core-free-icons";
+import Link from "next/link";
+
+import { AutoGPTLogo } from "@/components/atoms/AutoGPTLogo/AutoGPTLogo";
+import { Button } from "@/components/atoms/Button/Button";
+import { FadeIn } from "@/components/atoms/FadeIn/FadeIn";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+
+import { useConnectStep } from "./useConnectStep";
+
+/**
+ * The first thing a self-host install asks for: a model to run on.
+ *
+ * A fresh install has no way to answer a single message until someone
+ * configures a provider, and the honest shape of that ask is not "paste an
+ * API key" — most people setting this up already pay for a subscription that
+ * can do the work. So the zero-config path leads and API keys become the
+ * advanced one.
+ *
+ * Deliberately skippable. A user who wants API keys, or who has already
+ * configured them, should not have to link an account to get past a wizard.
+ */
+export function ConnectStep() {
+  const { connect, isConnecting, skip, isAlreadyLinked, models } =
+    useConnectStep();
+
+  return (
+    <FadeIn>
+      <div className="flex w-full max-w-lg flex-col items-center gap-8 px-4">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <AutoGPTLogo
+            className="relative right-[3rem] h-24 w-[12rem]"
+            hideText
+          />
+          <Text variant="h3">Power your agents in one sign-in</Text>
+          <Text variant="lead" as="span" className="!text-zinc-500">
+            {isAlreadyLinked
+              ? "Your ChatGPT plan is connected. Agents will run on it instead of spending AutoGPT credits."
+              : "Connect the ChatGPT plan you already have and AutoGPT runs with no API keys and no billing setup."}
+            {models && !isAlreadyLinked ? ` You get ${models}.` : ""}
+          </Text>
+        </div>
+
+        <div className="flex w-full flex-col items-center gap-4">
+          {isAlreadyLinked ? (
+            <Button variant="primary" size="large" onClick={skip}>
+              Continue
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="large"
+              onClick={connect}
+              loading={isConnecting}
+              rightIcon={<Icon icon={LinkSquare01Icon} size={18} />}
+            >
+              Sign in with ChatGPT
+            </Button>
+          )}
+
+          {!isAlreadyLinked && (
+            <>
+              <Text
+                variant="small"
+                as="span"
+                className="uppercase tracking-[0.08em] !text-zinc-400"
+              >
+                or configure manually
+              </Text>
+              <Button variant="secondary" size="large" onClick={skip}>
+                Add API keys instead
+              </Button>
+            </>
+          )}
+        </div>
+
+        {/* Named here rather than discovered later: someone arriving with a
+            Claude subscription will look for it, and the answer is a policy
+            they cannot change, not a missing feature. */}
+        <Text variant="small" as="span" className="text-center !text-zinc-400">
+          Claude subscriptions can&apos;t be linked — Anthropic blocks
+          third-party subscription access. Anthropic models work via{" "}
+          <Link
+            href="/settings/integrations"
+            className="underline underline-offset-2"
+          >
+            API key
+          </Link>
+          .
+        </Text>
+      </div>
+    </FadeIn>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/__tests__/ConnectStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/__tests__/ConnectStep.test.tsx
@@ -1,0 +1,145 @@
+import { getGetV2ListChatConnectionsMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOnboardingWizardStore } from "../../../store";
+import { ConnectStep } from "../ConnectStep";
+import { hasLinkedSubscription, linkedModelsSentence } from "../helpers";
+
+const connect = vi.fn();
+vi.mock(
+  "@/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect",
+  () => ({
+    useOAuthConnect: () => ({ connect, isPending: false }),
+  }),
+);
+
+function offer(over: Partial<AIConnectionOffer> = {}): AIConnectionOffer {
+  return {
+    offer_id: "platform:deployment",
+    provider_family: "autogpt",
+    display_name: "Self-hosted chat",
+    auth_method: "deployment",
+    credential_id: null,
+    backed_by_label: "This server's chat provider",
+    description: "New chats are backed by the chat provider on this server.",
+    state: "ready",
+    selectable: true,
+    is_default: true,
+    tiers: [],
+    limitations: [],
+    lock_reason: null,
+    unlock_href: null,
+    ...over,
+  } as AIConnectionOffer;
+}
+
+function chatgpt(over: Partial<AIConnectionOffer> = {}): AIConnectionOffer {
+  return offer({
+    offer_id: "codex:cred-1",
+    provider_family: "openai",
+    display_name: "ChatGPT",
+    auth_method: "chatgpt_oauth",
+    credential_id: "cred-1",
+    is_default: false,
+    tiers: [
+      {
+        tier: "standard",
+        label: "Balanced",
+        selectable: true,
+        display_model: "GPT-5.6 Terra",
+      },
+      {
+        tier: "advanced",
+        label: "Advanced",
+        selectable: true,
+        display_model: "GPT-5.6 Sol",
+      },
+    ],
+    ...over,
+  });
+}
+
+function mockOffers(offers: AIConnectionOffer[]) {
+  server.use(getGetV2ListChatConnectionsMockHandler200({ offers }));
+}
+
+describe("ConnectStep", () => {
+  beforeEach(() => {
+    connect.mockClear();
+    useOnboardingWizardStore.setState({ currentStep: 1 });
+  });
+
+  it("leads with the zero-config path", async () => {
+    mockOffers([offer()]);
+
+    render(<ConnectStep />);
+
+    expect(
+      await screen.findByRole("button", { name: /Sign in with ChatGPT/ }),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /Add API keys instead/ }),
+    ).toBeDefined();
+  });
+
+  it("can be skipped, because API keys are a legitimate answer", async () => {
+    // A wizard that cannot be passed without linking an account would make
+    // the advanced path a dead end rather than an alternative.
+    mockOffers([offer()]);
+
+    render(<ConnectStep />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Add API keys instead/ }),
+    );
+
+    expect(useOnboardingWizardStore.getState().currentStep).toBe(2);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("stops asking once a subscription is linked", async () => {
+    mockOffers([offer(), chatgpt()]);
+
+    render(<ConnectStep />);
+
+    expect(
+      await screen.findByText(/Your ChatGPT plan is connected/),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Sign in with ChatGPT/ })).toBe(
+      null,
+    );
+  });
+
+  it("says a Claude subscription cannot be linked, rather than leaving it to be discovered", async () => {
+    mockOffers([offer()]);
+
+    render(<ConnectStep />);
+
+    expect(
+      await screen.findByText(/Claude subscriptions can't be linked/),
+    ).toBeDefined();
+  });
+});
+
+describe("ConnectStep helpers", () => {
+  it("does not count the deployment's own provider as a linked subscription", () => {
+    // It is a connection, but it is the one that exists because someone put
+    // an API key in a file -- which is what this step offers a way around.
+    expect(hasLinkedSubscription([offer()])).toBe(false);
+    expect(hasLinkedSubscription([offer(), chatgpt()])).toBe(true);
+  });
+
+  it("names the models from the catalog rather than hardcoding them", () => {
+    expect(linkedModelsSentence([offer(), chatgpt()])).toBe(
+      "GPT-5.6 Terra (Balanced) and GPT-5.6 Sol (Advanced)",
+    );
+  });
+
+  it("says nothing when the server named no models", () => {
+    expect(linkedModelsSentence([offer(), chatgpt({ tiers: [] })])).toBe("");
+    expect(linkedModelsSentence(undefined)).toBe("");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/helpers.ts
@@ -1,0 +1,39 @@
+import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
+
+/**
+ * Whether the user has already linked a subscription of their own.
+ *
+ * The deployment's own chat provider does not count. It is a connection, but
+ * it is the one that exists because someone put an API key in a file — which
+ * is the thing this step offers a way around.
+ */
+export function hasLinkedSubscription(
+  offers: AIConnectionOffer[] | undefined,
+): boolean {
+  return (offers ?? []).some(
+    (offer) =>
+      offer.auth_method !== "deployment" && Boolean(offer.credential_id),
+  );
+}
+
+/**
+ * "5.6 Terra (Balanced) and 5.6 Sol (Advanced)", from the catalog.
+ *
+ * Empty when the server named nothing, so the sentence that would have
+ * carried it is dropped rather than rendered half-written. Never hardcoded
+ * here: which model a tier resolves to is the server's to say, and this
+ * screen is the one making the promise.
+ */
+export function linkedModelsSentence(
+  offers: AIConnectionOffer[] | undefined,
+): string {
+  const chatgpt = (offers ?? []).find(
+    (offer) => offer.auth_method === "chatgpt_oauth",
+  );
+  const named = (chatgpt?.tiers ?? [])
+    .filter((tier) => tier.display_model)
+    .map((tier) => `${tier.display_model} (${tier.label})`);
+  if (named.length === 0) return "";
+  if (named.length === 1) return named[0];
+  return `${named.slice(0, -1).join(", ")} and ${named[named.length - 1]}`;
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/useConnectStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/useConnectStep.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGetV2ListChatConnectionsQueryKey,
+  useGetV2ListChatConnections,
+} from "@/app/api/__generated__/endpoints/chat/chat";
+import { useOAuthConnect } from "@/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect";
+
+import { useOnboardingWizardStore } from "../../store";
+import { hasLinkedSubscription, linkedModelsSentence } from "./helpers";
+
+export function useConnectStep() {
+  const queryClient = useQueryClient();
+  const nextStep = useOnboardingWizardStore((s) => s.nextStep);
+
+  const connectionsQuery = useGetV2ListChatConnections({
+    query: { refetchOnWindowFocus: false },
+  });
+  const offers =
+    connectionsQuery.data?.status === 200
+      ? connectionsQuery.data.data.offers
+      : undefined;
+
+  const { connect, isPending } = useOAuthConnect({
+    provider: "codex",
+    onSuccess: () => {
+      // The next step's copy depends on what is connected, and so does the
+      // decision to show this step at all on a later visit.
+      queryClient.invalidateQueries({
+        queryKey: getGetV2ListChatConnectionsQueryKey(),
+      });
+      nextStep();
+    },
+  });
+
+  return {
+    connect,
+    isConnecting: isPending,
+    skip: nextStep,
+    isAlreadyLinked: hasLinkedSubscription(offers),
+    models: linkedModelsSentence(offers),
+  };
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/store.ts
@@ -23,6 +23,18 @@ export const NO_PAYWALL_STEPS = {
   preparing: 4,
 } as const;
 
+// Self-host has no paywall, but it has the same question in a different
+// currency: a chat needs a model behind it before personalising the chat is
+// worth anything. On cloud the user pays us first; on self-host they connect
+// a plan they already pay for. Same slot, same reason.
+export const SELF_HOST_STEPS = {
+  connect: 1,
+  welcome: 2,
+  role: 3,
+  painPoints: 4,
+  preparing: 5,
+} as const;
+
 interface OnboardingWizardState {
   currentStep: Step;
   name: string;

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -16,6 +16,7 @@ import { normalizeOnboardingProfile } from "./helpers";
 import {
   NO_PAYWALL_STEPS,
   PAYWALL_FIRST_STEPS,
+  SELF_HOST_STEPS,
   Step,
   useOnboardingWizardStore,
 } from "./store";
@@ -118,9 +119,18 @@ export function useOnboardingPage() {
 
   const isPaymentEnabled =
     (paymentEnabledSnapshot.current ?? false) && !userHasActivePlan;
-  const steps = isPaymentEnabled ? PAYWALL_FIRST_STEPS : NO_PAYWALL_STEPS;
+  // A self-host install has no paywall and no model until someone gives it
+  // one, so it leads with the connection instead. Payments and self-host are
+  // mutually exclusive in practice; the check is ordered anyway so a
+  // deployment that somehow had both still only inserts one first step.
+  const isSelfHostConnectEnabled = !isPaymentEnabled && environment.isLocal();
+  const steps = isPaymentEnabled
+    ? PAYWALL_FIRST_STEPS
+    : isSelfHostConnectEnabled
+      ? SELF_HOST_STEPS
+      : NO_PAYWALL_STEPS;
   const preparingStep: Step = steps.preparing;
-  const totalSteps = isPaymentEnabled ? 4 : 3;
+  const totalSteps = isPaymentEnabled || isSelfHostConnectEnabled ? 4 : 3;
 
   // Wait for auth too — without !isUserLoading, LD can resolve while
   // isLoggedIn is transiently false, the tier query stays disabled
@@ -260,6 +270,7 @@ export function useOnboardingPage() {
     isLoading: isOnboardingStateLoading || !isReady,
     handlePreparingComplete,
     isPaymentEnabled,
+    isSelfHostConnectEnabled,
     isBrainDumpEnabled,
     steps,
     preparingStep,

--- a/autogpt_platform/frontend/src/playwright/auth-happy-path.spec.ts
+++ b/autogpt_platform/frontend/src/playwright/auth-happy-path.spec.ts
@@ -4,6 +4,7 @@ import { BuildPage } from "./pages/build.page";
 import { LoginPage } from "./pages/login.page";
 import {
   completeOnboardingWizard,
+  dismissConnectStepIfPresent,
   skipOnboardingIfPresent,
 } from "./utils/onboarding";
 import { signupTestUser } from "./utils/signup";
@@ -15,6 +16,8 @@ test("auth happy path: user can sign up with a fresh account", async ({
 
   await signupTestUser(page, undefined, undefined, false);
   await expect(page).toHaveURL(/\/onboarding/);
+  // A self-host build opens on the connect step; Welcome is behind it.
+  await dismissConnectStepIfPresent(page);
   await expect(page.getByText("Welcome to AutoGPT")).toBeVisible();
 });
 
@@ -25,6 +28,8 @@ test("auth happy path: user can sign up, enter the app, and log out", async ({
 
   await signupTestUser(page, undefined, undefined, false);
   await expect(page).toHaveURL(/\/onboarding/);
+  // A self-host build opens on the connect step; Welcome is behind it.
+  await dismissConnectStepIfPresent(page);
   await expect(page.getByText("Welcome to AutoGPT")).toBeVisible();
 
   await skipOnboardingIfPresent(page, "/marketplace");

--- a/autogpt_platform/frontend/src/playwright/utils/onboarding.ts
+++ b/autogpt_platform/frontend/src/playwright/utils/onboarding.ts
@@ -45,6 +45,48 @@ export async function skipOnboardingIfPresent(
 }
 
 /**
+ * Dismiss the self-host connect step if this build shows it.
+ *
+ * It is the first onboarding screen when payment is off and the deployment is
+ * local -- which is exactly how the e2e stack is built -- so on those runs it
+ * sits in front of the Welcome step every other assertion starts from. It is
+ * genuinely optional: skipping leaves the account on the platform connection,
+ * which is what the rest of the wizard expects.
+ *
+ * Races the two headers rather than waiting on a timeout, so the helper works
+ * in both configurations without flaking on a slow render.
+ */
+export async function dismissConnectStepIfPresent(page: Page) {
+  const connectHeader = page.getByText("Power your agents in one sign-in");
+  const welcomeHeader = page.getByText("Welcome to AutoGPT");
+
+  const shown = await Promise.race([
+    connectHeader
+      .waitFor({ state: "visible", timeout: 10000 })
+      .then(() => "connect" as const),
+    welcomeHeader
+      .waitFor({ state: "visible", timeout: 10000 })
+      .then(() => "welcome" as const),
+  ]);
+
+  if (shown !== "connect") return;
+
+  // Several different buttons advance past this step. Which one renders
+  // depends on whether the account already has a linked plan ("Continue" when
+  // it does), and on where in this stack the suite is running -- a later PR
+  // renames the opt-out from "Add API keys instead" to "Skip for now". Match
+  // by what the button does rather than what this commit happens to call it,
+  // so the helper holds at every point in the stack instead of only at the
+  // tip.
+  const skipButton = page.getByRole("button", {
+    name: /^(Skip for now|Add API keys instead|Continue)$/,
+  });
+  await skipButton.first().waitFor({ state: "visible", timeout: 15000 });
+  await skipButton.first().click();
+  await expect(welcomeHeader).toBeVisible({ timeout: 10000 });
+}
+
+/**
  * Walk through the onboarding wizard in the browser. The Subscription step
  * is gated behind ENABLE_PLATFORM_PAYMENT and only walked when present.
  * Returns the data that was entered so tests can verify it was submitted.
@@ -62,6 +104,9 @@ export async function completeOnboardingWizard(
   const role = options?.role ?? "Engineering";
   const painPoints = options?.painPoints ?? ["Research", "Reports & data"];
   const plan = options?.plan ?? "pro";
+
+  // Step 0: the self-host connect step, when this build shows it.
+  await dismissConnectStepIfPresent(page);
 
   // Step 1: Welcome — enter name
   await expect(page.getByText("Welcome to AutoGPT")).toBeVisible({


### PR DESCRIPTION
> Stacked on #14120 — review that first; this PR's diff is the one commit on top.

This is **F3**, and Mock 5. The PRD resequenced F3 to ship *before* F1:

> **Resequenced Aug 11 (Nick's proposal, accepted by John).** F3 now ships first, before F1. Reason: merge logistics.

We then built all of F1's surfaces and never built F3.

### Why

A fresh self-host install cannot answer a single message until someone gives
it a model. Asking three personalisation questions first is asking someone to
furnish a house with no electricity — and the PRD's stated goal for this
feature is *"single-container install + one OAuth = working platform. No
feature flag, no gating, on by default."*

### What

A `ConnectStep` at the front of the onboarding wizard on self-host installs.

| | cloud, payments on | cloud, payments off | self-host |
|---|---|---|---|
| step 1 | Subscription | Welcome | **Connect** |
| step 2 | Welcome | Role | Welcome |

### How

The wizard already knows how to put a prerequisite in front. With payments on,
the paywall is step one *"so the user pays before personalising"*. Self-host
has the same question in a different currency, so it takes the same slot —
on cloud you pay us first; on self-host you connect a plan you already pay for.
That is one more entry in the existing step-layout table, not a new mechanism:

```ts
const steps = isPaymentEnabled
  ? PAYWALL_FIRST_STEPS
  : isSelfHostConnectEnabled
    ? SELF_HOST_STEPS
    : NO_PAYWALL_STEPS;
```

**It is skippable.** Mock 5 puts "or configure manually → Add API keys" on the
same screen, and that is right: API keys are a real answer, and a wizard you
cannot pass without linking an account turns the advanced path into a dead end.

**It does not hardcode the models.** Mock 5 names 5.6 Terra and 5.6 Sol
literally. This builds that sentence from the catalog via the offers endpoint
and omits it when the server names nothing — which model a tier resolves to is
the server's to say, and this screen is the one making the promise. Same
reasoning as #14104.

**It names the Claude exclusion up front.** Someone arriving with a Claude
subscription will look for it, and the answer is a policy they cannot change
rather than a feature we forgot.

### Fallout worth knowing

`environment.isLocal()` is true for anything not explicitly `CLOUD`, so
inserting a step for local shifts every later step by one *there* — including
the test environment. That is the intended change, and it is why
`brain-dump.test.tsx` now pins the environment it was already assuming by
navigating with `NO_PAYWALL_STEPS`. Sixteen tests failed on the first run for
exactly this reason; the fix is one mock at the top of that file, not sixteen
edits.

### Testing

```
vitest run onboarding  →  28 files, 376 passed
tsc --noEmit / eslint --max-warnings 0  →  clean
```

Eleven new tests. The ones that matter:

- `renders ConnectStep first on a self-host install`
- `does not insert it on cloud`
- `yields to the paywall rather than showing both first steps`
- `can be skipped, because API keys are a legitimate answer`
- `stops asking once a subscription is linked`
- `does not count the deployment's own provider as a linked subscription` —
  it is a connection, but it is the one that exists because someone put an API
  key in a file, which is what this step offers a way around

**Verified on a fresh install.** Built the branch, ran the single container
against a brand-new volume with no accounts and nothing connected, signed up,
and landed on `/onboarding?step=1`:

- the connect screen renders with Mock 5's copy and the Claude-exclusion note
- "Add API keys instead" advances to `?step=2`, Welcome, as designed
- the step indicator shows four steps, first active

It also renders the models line — "You get GPT-5.6 Terra (Balanced) and
GPT-5.6 Sol (Advanced)" — which only works because of the follow-up PR that
adds the provider-tiers endpoint. On this branch alone that sentence is empty,
since the connections list has no ChatGPT entry on a self-host install.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run onboarding routing and OAuth connection flow for self-host; paywall precedence is tested, but wrong `isLocal` detection could show or hide Connect on the wrong deployments.
> 
> **Overview**
> Self-host installs now open onboarding with a new **Connect** step so users can link ChatGPT (OAuth) or skip to API keys before Welcome/role/pain points. Cloud keeps the existing layouts; when payments are on, the subscription step still wins over connect.
> 
> The wizard picks `SELF_HOST_STEPS` when `environment.isLocal()` is true and the paywall is off (`useOnboardingPage`), and `OnboardingPage` renders `ConnectStep` at that slot. The step loads chat connection offers, drives sign-in via existing `useOAuthConnect`, builds model copy from the catalog, treats deployment-only connections as “not linked,” and advances on success or skip.
> 
> Tests pin `isLocal` where step indices assumed `NO_PAYWALL_STEPS`, add page-level self-host vs cloud vs paywall precedence cases, unit-test `ConnectStep`, and extend Playwright helpers to dismiss the connect screen when the e2e stack shows it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115d90ffe40688def210942294efba611bbf8bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

