### PR TITLE
fix(backend): tell the chat when an OAuth connect granted too little

### DIFF
--- a/autogpt_platform/backend/backend/api/features/integrations/incremental_oauth_test.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/incremental_oauth_test.py
@@ -65,6 +65,17 @@ def setup_auth(mock_jwt_user):
     app.dependency_overrides.clear()
 
 
+@pytest.fixture(autouse=True)
+def stub_scope_check():
+    """Keep the detached post-connect scope check out of these tests.
+
+    It is fire-and-forget and reaches Redis; the tests that care about it
+    take the mock and assert on it (see ``TestPostConnectScopeCheck``).
+    """
+    with patch("backend.api.features.integrations.router.schedule_scope_check") as stub:
+        yield stub
+
+
 # ==================== OAuthState model tests ==================== #
 
 
@@ -1289,3 +1300,118 @@ class TestExplicitUpgradeScopeGuard:
         assert resp.status_code == 200
         mock_mgr.update.assert_called_once()
         mock_mgr.create.assert_not_called()
+
+
+# ============ Post-connect scope verification (callback) ============ #
+
+
+class TestPostConnectScopeCheck:
+    """The callback must normalize the grant it stores and hand the
+    granted-vs-requested verdict to the copilot-side check."""
+
+    def _state(self, scopes: list[str], provider: str = "github") -> OAuthState:
+        return OAuthState(
+            token="state-token",
+            provider=provider,
+            expires_at=9999999999,
+            scopes=scopes,
+        )
+
+    def _callback(
+        self,
+        *,
+        state: OAuthState,
+        new_cred: OAuth2Credentials,
+        reports_granted_scopes: bool = True,
+        provider: str = "github",
+    ):
+        handler = MagicMock()
+        handler.REPORTS_GRANTED_SCOPES = reports_granted_scopes
+        handler.exchange_code_for_tokens = AsyncMock(return_value=new_cred)
+        handler.handle_default_scopes.return_value = state.scopes
+
+        with (
+            patch(
+                "backend.api.features.integrations.router._get_provider_oauth_handler",
+                return_value=handler,
+            ),
+            patch("backend.api.features.integrations.router.creds_manager") as mock_mgr,
+        ):
+            mock_mgr.store.verify_state_token = AsyncMock(return_value=state)
+            mock_mgr.store.get_creds_by_provider = AsyncMock(return_value=[])
+            mock_mgr.create = AsyncMock()
+            mock_mgr.update = AsyncMock()
+
+            return client.post(
+                f"/{provider}/callback",
+                json={"code": "auth-code", "state_token": "state-token"},
+            )
+
+    def test_empty_github_scope_is_stored_as_no_scopes(self):
+        """``"".split(",") == [""]`` used to persist a credential claiming one
+        nameless scope; normalization stores the honest empty grant."""
+        new_cred = _make_github_oauth2_cred(scopes=[""])
+        resp = self._callback(state=self._state(["repo"]), new_cred=new_cred)
+
+        assert resp.status_code == 200
+        assert resp.json()["scopes"] == []
+
+    def test_comma_separated_grant_is_split(self):
+        new_cred = _make_github_oauth2_cred(scopes=["repo,workflow"])
+        resp = self._callback(
+            state=self._state(["repo", "workflow"]), new_cred=new_cred
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["scopes"] == ["repo", "workflow"]
+
+    def test_space_separated_grant_is_split(self):
+        """Generalises the old Linear-only fixup to every provider."""
+        new_cred = _make_google_oauth2_cred(scopes=["openid email profile"])
+        resp = self._callback(
+            state=self._state(["openid"], provider="google"),
+            new_cred=new_cred,
+            provider="google",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["scopes"] == ["openid", "email", "profile"]
+
+    def test_zero_scope_grant_hands_the_shortfall_to_the_copilot_check(
+        self, stub_scope_check
+    ):
+        new_cred = _make_github_oauth2_cred(scopes=[""])
+        resp = self._callback(state=self._state(["repo"]), new_cred=new_cred)
+
+        assert resp.status_code == 200
+        stub_scope_check.assert_called_once()
+        kwargs = stub_scope_check.call_args.kwargs
+        assert kwargs["provider"] == "github"
+        assert kwargs["granted_scopes"] == []
+        assert kwargs["provider_reports_scopes"] is True
+        assert kwargs["username"] == "alice"
+
+    def test_full_grant_still_reports_so_a_stale_warning_can_be_cleared(
+        self, stub_scope_check
+    ):
+        new_cred = _make_github_oauth2_cred(scopes=["repo", "workflow"])
+        resp = self._callback(state=self._state(["repo"]), new_cred=new_cred)
+
+        assert resp.status_code == 200
+        assert stub_scope_check.call_args.kwargs["granted_scopes"] == [
+            "repo",
+            "workflow",
+        ]
+
+    def test_non_reporting_provider_is_passed_through_as_such(self, stub_scope_check):
+        """Notion hardcodes ``scopes=[]``; the callback must forward "this
+        provider does not report" rather than "nothing was granted"."""
+        new_cred = _make_github_oauth2_cred(scopes=[])
+        resp = self._callback(
+            state=self._state(["repo"]),
+            new_cred=new_cred,
+            reports_granted_scopes=False,
+        )
+
+        assert resp.status_code == 200
+        assert stub_scope_check.call_args.kwargs["provider_reports_scopes"] is False

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -21,6 +21,7 @@ from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR, HTTP_502_BAD_GATEWA
 
 from backend.api.features.library.db import set_preset_webhook, update_preset
 from backend.api.features.library.model import LibraryAgentPreset
+from backend.copilot.oauth_scope_check import schedule_scope_check
 from backend.data.db_accessors import experts_db
 from backend.data.graph import NodeModel, get_graph, set_node_webhook
 from backend.data.integrations import (
@@ -73,6 +74,11 @@ from backend.integrations.oauth import (
     HANDLERS_BY_NAME,
 )
 from backend.integrations.oauth.device_base import BaseDeviceAuthHandler
+from backend.integrations.oauth.scopes import (
+    ScopeCoverage,
+    evaluate_scope_coverage,
+    normalize_scopes,
+)
 from backend.integrations.providers import ProviderName, provider_key
 from backend.integrations.webhooks import get_webhook_manager
 from backend.util.exceptions import (
@@ -348,17 +354,27 @@ async def callback(
 
         logger.debug(f"Received credentials with final scopes: {credentials.scopes}")
 
-        # Linear returns scopes as a single string with spaces, so we need to split them
-        # TODO: make a bypass of this part of the OAuth handler
-        if len(credentials.scopes) == 1 and " " in credentials.scopes[0]:
-            credentials.scopes = credentials.scopes[0].split(" ")
+        # Providers disagree on the `scope` separator — comma (GitHub),
+        # space (Linear, Discord) or an already-split list (Google). Flatten
+        # them all here rather than adding a fourth per-provider fixup, and
+        # drop the empty fragments that made `"".split(...)` look like a
+        # credential holding one nameless scope.
+        credentials.scopes = normalize_scopes(credentials.scopes)
 
-        # Check if the granted scopes are sufficient for the requested scopes
-        if not set(scopes).issubset(set(credentials.scopes)):
-            # For now, we'll just log the warning and continue
+        coverage = evaluate_scope_coverage(
+            scopes,
+            credentials.scopes,
+            provider_reports_scopes=handler.REPORTS_GRANTED_SCOPES,
+        )
+        if coverage.is_shortfall:
             logger.warning(
                 f"Granted scopes {credentials.scopes} for provider {provider.value} "
                 f"do not include all requested scopes {scopes}"
+            )
+        elif coverage.coverage is ScopeCoverage.UNKNOWN:
+            logger.debug(
+                "Provider %s does not report granted scopes; skipping coverage check",
+                provider.value,
             )
 
     except Exception as e:
@@ -373,6 +389,17 @@ async def callback(
     # TODO: Allow specifying `title` to set on `credentials`
     credentials = await _merge_or_create_credential(
         user_id, provider, credentials, valid_state.credential_id
+    )
+
+    # Detached: reconciles this grant against whatever a copilot setup card
+    # asked for, and surfaces a shortfall in the chat that asked. Never
+    # blocks or fails the callback — the credential is already stored.
+    schedule_scope_check(
+        user_id=user_id,
+        provider=provider.value,
+        granted_scopes=credentials.scopes,
+        provider_reports_scopes=handler.REPORTS_GRANTED_SCOPES,
+        username=credentials.username,
     )
 
     logger.debug(

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -699,8 +699,7 @@ async def device_auth_poll(
     if result.status == "approved" and result.credentials:
         credentials = result.credentials
 
-        if len(credentials.scopes) == 1 and " " in credentials.scopes[0]:
-            credentials.scopes = credentials.scopes[0].split(" ")
+        credentials.scopes = normalize_scopes(credentials.scopes)
 
         try:
             credentials = await _merge_or_create_credential(

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
@@ -25,9 +25,16 @@ the key holds a bounded **list** of pending connects, and the callback drains
 all of them and judges each *chat* against the union of everything its own
 cards asked for. Both chats learn the truth about the connection they were
 both waiting on; neither is told about scopes it never asked for.
+
+A warning must also be retirable by the fix it prescribes. The setup card's
+Connect button calls ``/login`` directly, so the natural remedy — revoke at
+the provider, press Connect again on the card already on screen — never
+re-runs ``connect_integration`` and leaves nothing to drain. Every callback
+therefore also re-judges the sessions listed in a small per-provider reverse
+index against the new grant, so a fix in one chat retires the warning in all
+of them.
 """
 
-import json
 import logging
 import time
 from typing import Any, Awaitable, cast
@@ -55,6 +62,13 @@ _MAX_PENDING_PER_PROVIDER = 5
 # provider. Read once per turn by ``build_session_context``.
 _STATUS_PREFIX = "copilot:oauth_scope_status:"
 _STATUS_TTL_SECONDS = 24 * 60 * 60
+
+# Reverse index: which sessions currently warn about (user, provider). A
+# sorted set scored by write time so it self-bounds to the newest N. It exists
+# only so a later callback can find the warnings it should retire, and is never
+# touched by the per-turn read path — that stays one HGETALL.
+_STATUS_SESSIONS_PREFIX = "copilot:oauth_scope_sessions:"
+_MAX_STATUS_SESSIONS_PER_PROVIDER = 20
 
 # Claim marker so a replayed callback cannot post the same notice twice.
 _NOTICE_CLAIM_PREFIX = "copilot:oauth_scope_notice:"
@@ -92,7 +106,15 @@ def _pending_key(user_id: str, provider: str) -> str:
 
 
 def status_key(user_id: str, session_id: str) -> str:
-    return f"{_STATUS_PREFIX}{user_id}:{session_id}"
+    # Hash-tagged on the user so every one of that user's status keys and the
+    # per-provider reverse index land on one Redis Cluster slot and can share
+    # a transaction; without the braces the multi-key writes below would
+    # CROSSSLOT in production.
+    return f"{_STATUS_PREFIX}{{{user_id}}}:{session_id}"
+
+
+def _status_sessions_key(user_id: str, provider: str) -> str:
+    return f"{_STATUS_SESSIONS_PREFIX}{{{user_id}}}:{provider.lower()}"
 
 
 async def record_pending_connect(
@@ -189,7 +211,8 @@ async def _run_scope_check(
         )
         return
 
-    for session_id, requested_scopes in _requested_scopes_by_session(pending).items():
+    requested_by_session = _requested_scopes_by_session(pending)
+    for session_id, requested_scopes in requested_by_session.items():
         # Contained per session, not around the loop: the drain has already
         # deleted the records, so a chat we cannot reach is not retried. If
         # its failure aborted the loop, every later chat would lose its
@@ -211,6 +234,59 @@ async def _run_scope_check(
                 session_id[:12],
                 exc_info=True,
             )
+
+    if not provider_reports_scopes:
+        return
+    try:
+        await _retire_stale_statuses(
+            user_id=user_id,
+            provider=provider,
+            granted_scopes=granted_scopes,
+            already_judged=set(requested_by_session),
+        )
+    except Exception:
+        logger.warning(
+            "could not retire stale %s scope statuses", provider, exc_info=True
+        )
+
+
+async def _retire_stale_statuses(
+    *,
+    user_id: str,
+    provider: str,
+    granted_scopes: list[str],
+    already_judged: set[str],
+) -> None:
+    """Re-judge every chat still warning about this provider but holding no card.
+
+    The remediation the notice prescribes — revoke at the provider, then press
+    Connect on the setup card already on screen — goes straight to
+    ``/login`` and never re-runs ``connect_integration``, so it produces a
+    callback with no pending record at all. Same for a reconnect from
+    Settings → Integrations. Without this pass the user does exactly what
+    they were told and the warning they just fixed keeps telling the model
+    the credential is broken for the rest of the day, here and in every other
+    chat that asked.
+
+    Each stale status is re-diffed against the *new* grant rather than
+    cleared outright, so a reconnect that is still short stays flagged — with
+    a refreshed diff — instead of being silently forgiven.
+    """
+    for session_id in await _status_sessions(user_id, provider):
+        if session_id in already_judged:
+            continue
+        stored = await _read_status(user_id, session_id, provider)
+        if stored is None:
+            await _forget_status_session(user_id, provider, session_id)
+            continue
+
+        result = evaluate_scope_coverage(
+            stored.requested, granted_scopes, provider_reports_scopes=True
+        )
+        if result.is_shortfall:
+            await _write_status(user_id, session_id, provider, result)
+        else:
+            await _clear_status(user_id, session_id, provider)
 
 
 async def _judge_session(
@@ -270,26 +346,56 @@ def _requested_scopes_by_session(
 async def _write_status(
     user_id: str, session_id: str, provider: str, result: ScopeCoverageResult
 ) -> None:
-    payload = json.dumps(
-        {
-            "coverage": result.coverage.value,
-            "requested": result.requested,
-            "granted": result.granted,
-            "missing": result.missing,
-        }
-    )
     key = status_key(user_id, session_id)
+    sessions = _status_sessions_key(user_id, provider)
     redis = await get_redis_async()
     async with redis.pipeline(transaction=True) as pipe:
-        pipe.hset(key, provider.lower(), payload)
+        pipe.hset(key, provider.lower(), result.model_dump_json())
         pipe.expire(key, _STATUS_TTL_SECONDS)
+        pipe.zadd(sessions, {session_id: time.time()})
+        pipe.zremrangebyrank(sessions, 0, -_MAX_STATUS_SESSIONS_PER_PROVIDER - 1)
+        pipe.expire(sessions, _STATUS_TTL_SECONDS)
         await cast(Awaitable[list[Any]], pipe.execute())
 
 
 async def _clear_status(user_id: str, session_id: str, provider: str) -> None:
     redis = await get_redis_async()
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.hdel(status_key(user_id, session_id), provider.lower())
+        pipe.zrem(_status_sessions_key(user_id, provider), session_id)
+        await cast(Awaitable[list[Any]], pipe.execute())
+
+
+async def _read_status(
+    user_id: str, session_id: str, provider: str
+) -> ScopeCoverageResult | None:
+    redis = await get_redis_async()
+    raw = await cast(
+        Awaitable[Any], redis.hget(status_key(user_id, session_id), provider.lower())
+    )
+    if not raw:
+        return None
+    try:
+        return ScopeCoverageResult.model_validate_json(raw)
+    except Exception:
+        logger.warning("discarding unreadable %s scope status", provider)
+        return None
+
+
+async def _status_sessions(user_id: str, provider: str) -> list[str]:
+    redis = await get_redis_async()
+    members = await cast(
+        Awaitable[list[Any]],
+        redis.zrange(_status_sessions_key(user_id, provider), 0, -1),
+    )
+    return [str(member) for member in members]
+
+
+async def _forget_status_session(user_id: str, provider: str, session_id: str) -> None:
+    redis = await get_redis_async()
     await cast(
-        Awaitable[int], redis.hdel(status_key(user_id, session_id), provider.lower())
+        Awaitable[int],
+        redis.zrem(_status_sessions_key(user_id, provider), session_id),
     )
 
 
@@ -319,11 +425,11 @@ async def scope_status_lines(user_id: str, session_id: str) -> list[str]:
     lines: list[str] = []
     for provider, raw in sorted(entries.items()):
         try:
-            data = json.loads(raw)
+            status = ScopeCoverageResult.model_validate_json(raw)
         except Exception:
             continue
-        missing = ", ".join(data.get("missing") or []) or "(all requested)"
-        granted = ", ".join(data.get("granted") or []) or "none"
+        missing = ", ".join(status.missing) or "(all requested)"
+        granted = ", ".join(status.granted) or "none"
         lines.append(
             f"credential_scope_shortfall: {provider} is connected but the "
             f"granted token is missing {missing} (granted: {granted}). "

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
@@ -243,7 +243,9 @@ async def _write_status(
 
 async def _clear_status(user_id: str, session_id: str, provider: str) -> None:
     redis = await get_redis_async()
-    await redis.hdel(status_key(user_id, session_id), provider.lower())
+    await cast(
+        Awaitable[int], redis.hdel(status_key(user_id, session_id), provider.lower())
+    )
 
 
 async def scope_status_lines(user_id: str, session_id: str) -> list[str]:
@@ -259,7 +261,11 @@ async def scope_status_lines(user_id: str, session_id: str) -> list[str]:
     try:
         redis = await get_redis_async()
         entries = cast(
-            dict[str, str], await redis.hgetall(status_key(user_id, session_id))
+            dict[str, str],
+            await cast(
+                Awaitable[dict[Any, Any]],
+                redis.hgetall(status_key(user_id, session_id)),
+            ),
         )
     except Exception:
         logger.debug("could not read oauth scope status", exc_info=True)

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
@@ -22,9 +22,9 @@ frontend and OpenAPI change; a server-written record keyed by
 The obvious hole in a ``(user, provider)`` key is a user with two connect cards
 open for the same provider. Rather than guess which one a callback belongs to,
 the key holds a bounded **list** of pending connects, and the callback drains
-all of them and evaluates each against *its own* requested scopes. Both chats
-learn the truth about the connection they were both waiting on; neither is
-told about scopes it never asked for.
+all of them and judges each *chat* against the union of everything its own
+cards asked for. Both chats learn the truth about the connection they were
+both waiting on; neither is told about scopes it never asked for.
 """
 
 import json
@@ -184,27 +184,24 @@ async def _run_scope_check(
         if not pending:
             return
 
-        handled: set[str] = set()
-        for record in pending:
-            if record.session_id in handled:
-                continue
-            handled.add(record.session_id)
-
+        for session_id, requested_scopes in _requested_scopes_by_session(
+            pending
+        ).items():
             result = evaluate_scope_coverage(
-                record.requested_scopes,
+                requested_scopes,
                 granted_scopes,
                 provider_reports_scopes=provider_reports_scopes,
             )
             if not result.is_shortfall:
                 # A good reconnect clears whatever the last bad one left
                 # behind, so the model stops warning about a fixed problem.
-                await _clear_status(user_id, record.session_id, provider)
+                await _clear_status(user_id, session_id, provider)
                 continue
 
-            await _write_status(user_id, record.session_id, provider, result)
+            await _write_status(user_id, session_id, provider, result)
             await _post_chat_notice(
                 user_id=user_id,
-                session_id=record.session_id,
+                session_id=session_id,
                 provider=provider,
                 result=result,
                 username=username,
@@ -215,6 +212,24 @@ async def _run_scope_check(
             provider,
             exc_info=True,
         )
+
+
+def _requested_scopes_by_session(
+    pending: list[PendingConnect],
+) -> dict[str, list[str]]:
+    """Collapse one session's cards into the union of what they asked for.
+
+    ``record_pending_connect`` runs on every ``connect_integration`` call, so
+    a model that re-renders a widened card leaves a second record for the same
+    session. The user saw both cards and both asked for something, so the
+    honest thing to judge the grant against is everything that was on screen —
+    not whichever card happened to be recorded first, which would let a grant
+    that satisfies the narrow card bury the wider card's shortfall.
+    """
+    grouped: dict[str, list[str]] = {}
+    for record in pending:
+        grouped.setdefault(record.session_id, []).extend(record.requested_scopes)
+    return grouped
 
 
 # --------------------------------------------------------------------------- #

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
@@ -181,37 +181,67 @@ async def _run_scope_check(
 ) -> None:
     try:
         pending = await _drain_pending_connects(user_id, provider)
-        if not pending:
-            return
-
-        for session_id, requested_scopes in _requested_scopes_by_session(
-            pending
-        ).items():
-            result = evaluate_scope_coverage(
-                requested_scopes,
-                granted_scopes,
-                provider_reports_scopes=provider_reports_scopes,
-            )
-            if not result.is_shortfall:
-                # A good reconnect clears whatever the last bad one left
-                # behind, so the model stops warning about a fixed problem.
-                await _clear_status(user_id, session_id, provider)
-                continue
-
-            await _write_status(user_id, session_id, provider, result)
-            await _post_chat_notice(
-                user_id=user_id,
-                session_id=session_id,
-                provider=provider,
-                result=result,
-                username=username,
-            )
     except Exception:
         logger.warning(
-            "post-connect scope check failed for provider=%s; dropping",
+            "could not drain pending %s connects; dropping",
             provider,
             exc_info=True,
         )
+        return
+
+    for session_id, requested_scopes in _requested_scopes_by_session(pending).items():
+        # Contained per session, not around the loop: the drain has already
+        # deleted the records, so a chat we cannot reach is not retried. If
+        # its failure aborted the loop, every later chat would lose its
+        # notice *and* its model-facing status, permanently.
+        try:
+            await _judge_session(
+                user_id=user_id,
+                provider=provider,
+                session_id=session_id,
+                requested_scopes=requested_scopes,
+                granted_scopes=granted_scopes,
+                provider_reports_scopes=provider_reports_scopes,
+                username=username,
+            )
+        except Exception:
+            logger.warning(
+                "post-connect scope check failed for provider=%s session=%s",
+                provider,
+                session_id[:12],
+                exc_info=True,
+            )
+
+
+async def _judge_session(
+    *,
+    user_id: str,
+    provider: str,
+    session_id: str,
+    requested_scopes: list[str],
+    granted_scopes: list[str],
+    provider_reports_scopes: bool,
+    username: str | None,
+) -> None:
+    result = evaluate_scope_coverage(
+        requested_scopes,
+        granted_scopes,
+        provider_reports_scopes=provider_reports_scopes,
+    )
+    if not result.is_shortfall:
+        # A good reconnect clears whatever the last bad one left behind, so
+        # the model stops warning about a fixed problem.
+        await _clear_status(user_id, session_id, provider)
+        return
+
+    await _write_status(user_id, session_id, provider, result)
+    await _post_chat_notice(
+        user_id=user_id,
+        session_id=session_id,
+        provider=provider,
+        result=result,
+        username=username,
+    )
 
 
 def _requested_scopes_by_session(

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check.py
@@ -1,0 +1,381 @@
+"""Tell the chat — and the model — when an OAuth connect granted too little.
+
+A user connected GitHub from a copilot setup card, the OAuth round-trip
+succeeded, and the token that came back carried **zero** scopes. Nothing
+complained. The failure surfaced much later, at call time, as an opaque 403,
+and cost three rounds of "try connecting again" before anyone worked out that
+GitHub had silently reused a prior authorization and granted nothing new.
+
+The requested-vs-granted diff already existed in the OAuth callback; it just
+logged a warning nobody reads. This module is the missing half: it carries the
+*provenance* of a copilot-initiated connect from the setup card to the
+callback, and turns a shortfall into something both the user and the model
+can act on.
+
+Provenance is a short-TTL Redis record rather than a field on the OAuth state
+token, because the copilot never mints the state token — ``connect_integration``
+renders a card, the *frontend* calls ``/login``. Threading a session id through
+would mean a new user-supplied query parameter on an auth endpoint plus a
+frontend and OpenAPI change; a server-written record keyed by
+``(user_id, provider)`` needs neither and cannot be influenced by the client.
+
+The obvious hole in a ``(user, provider)`` key is a user with two connect cards
+open for the same provider. Rather than guess which one a callback belongs to,
+the key holds a bounded **list** of pending connects, and the callback drains
+all of them and evaluates each against *its own* requested scopes. Both chats
+learn the truth about the connection they were both waiting on; neither is
+told about scopes it never asked for.
+"""
+
+import json
+import logging
+import time
+from typing import Any, Awaitable, cast
+
+from pydantic import BaseModel, Field
+
+from backend.data.redis_client import get_redis_async
+from backend.integrations.oauth.scopes import (
+    ScopeCoverageResult,
+    evaluate_scope_coverage,
+)
+from backend.util.background import spawn_background_task
+from backend.util.feature_flag import Flag, is_feature_enabled
+
+logger = logging.getLogger(__name__)
+
+# Pending copilot-initiated connects, keyed by (user, provider). The TTL only
+# has to cover "card rendered → user finishes the OAuth popup"; a connect the
+# user comes back to an hour later simply isn't attributed to a chat.
+_PENDING_PREFIX = "copilot:oauth_pending_connect:"
+_PENDING_TTL_SECONDS = 30 * 60
+_MAX_PENDING_PER_PROVIDER = 5
+
+# Model-facing shortfall status, keyed by (user, session), one hash field per
+# provider. Read once per turn by ``build_session_context``.
+_STATUS_PREFIX = "copilot:oauth_scope_status:"
+_STATUS_TTL_SECONDS = 24 * 60 * 60
+
+# Claim marker so a replayed callback cannot post the same notice twice.
+_NOTICE_CLAIM_PREFIX = "copilot:oauth_scope_notice:"
+_NOTICE_CLAIM_TTL_SECONDS = 60 * 60
+
+_GENERIC_REMEDIATION = (
+    "Disconnect the app in the provider's account settings so it has to ask "
+    "again, then reconnect and leave every permission on the consent screen "
+    "checked."
+)
+_REMEDIATION_BY_PROVIDER: dict[str, str] = {
+    "github": (
+        "GitHub silently reuses a previous authorization instead of showing "
+        "the consent screen again, so reconnecting on its own changes "
+        "nothing. Revoke the app first at GitHub Settings → Applications → "
+        "Authorized OAuth Apps, then reconnect."
+    ),
+}
+
+
+def remediation_for(provider: str) -> str:
+    return _REMEDIATION_BY_PROVIDER.get(provider.lower(), _GENERIC_REMEDIATION)
+
+
+class PendingConnect(BaseModel):
+    """One copilot setup card awaiting an OAuth round-trip."""
+
+    session_id: str
+    requested_scopes: list[str] = Field(default_factory=list)
+    created_at: int
+
+
+def _pending_key(user_id: str, provider: str) -> str:
+    return f"{_PENDING_PREFIX}{user_id}:{provider.lower()}"
+
+
+def status_key(user_id: str, session_id: str) -> str:
+    return f"{_STATUS_PREFIX}{user_id}:{session_id}"
+
+
+async def record_pending_connect(
+    user_id: str, provider: str, session_id: str, requested_scopes: list[str]
+) -> None:
+    """Remember that *session_id* asked *user_id* to connect *provider*.
+
+    Best-effort: a Redis hiccup here must not stop the setup card from
+    rendering, it only means a later shortfall goes unattributed.
+    """
+    try:
+        record = PendingConnect(
+            session_id=session_id,
+            requested_scopes=requested_scopes,
+            created_at=int(time.time()),
+        )
+        key = _pending_key(user_id, provider)
+        redis = await get_redis_async()
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.rpush(key, record.model_dump_json())
+            # Keep the newest N: a user who keeps re-opening cards should not
+            # be able to grow this unboundedly.
+            pipe.ltrim(key, -_MAX_PENDING_PER_PROVIDER, -1)
+            pipe.expire(key, _PENDING_TTL_SECONDS)
+            await cast(Awaitable[list[Any]], pipe.execute())
+    except Exception:
+        logger.warning(
+            "could not record pending %s connect for session=%s",
+            provider,
+            session_id[:12],
+            exc_info=True,
+        )
+
+
+async def _drain_pending_connects(user_id: str, provider: str) -> list[PendingConnect]:
+    """Atomically read and clear every pending connect for (user, provider)."""
+    key = _pending_key(user_id, provider)
+    redis = await get_redis_async()
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.lrange(key, 0, -1)
+        pipe.delete(key)
+        results = await cast(Awaitable[list[Any]], pipe.execute())
+
+    records: list[PendingConnect] = []
+    for raw in cast(list[str], results[0] or []):
+        try:
+            records.append(PendingConnect.model_validate_json(raw))
+        except Exception:
+            logger.warning("discarding unparseable pending connect record")
+    return records
+
+
+def schedule_scope_check(
+    *,
+    user_id: str,
+    provider: str,
+    granted_scopes: list[str],
+    provider_reports_scopes: bool,
+    username: str | None,
+) -> None:
+    """Fire-and-forget the post-connect scope reconciliation.
+
+    Detached on purpose: the OAuth callback has already stored a working
+    credential by the time this runs, and nothing here is worth failing that
+    for.
+    """
+    spawn_background_task(
+        _run_scope_check(
+            user_id=user_id,
+            provider=provider,
+            granted_scopes=granted_scopes,
+            provider_reports_scopes=provider_reports_scopes,
+            username=username,
+        ),
+        name=f"oauth-scope-check-{provider}",
+    )
+
+
+async def _run_scope_check(
+    *,
+    user_id: str,
+    provider: str,
+    granted_scopes: list[str],
+    provider_reports_scopes: bool,
+    username: str | None,
+) -> None:
+    try:
+        pending = await _drain_pending_connects(user_id, provider)
+        if not pending:
+            return
+
+        handled: set[str] = set()
+        for record in pending:
+            if record.session_id in handled:
+                continue
+            handled.add(record.session_id)
+
+            result = evaluate_scope_coverage(
+                record.requested_scopes,
+                granted_scopes,
+                provider_reports_scopes=provider_reports_scopes,
+            )
+            if not result.is_shortfall:
+                # A good reconnect clears whatever the last bad one left
+                # behind, so the model stops warning about a fixed problem.
+                await _clear_status(user_id, record.session_id, provider)
+                continue
+
+            await _write_status(user_id, record.session_id, provider, result)
+            await _post_chat_notice(
+                user_id=user_id,
+                session_id=record.session_id,
+                provider=provider,
+                result=result,
+                username=username,
+            )
+    except Exception:
+        logger.warning(
+            "post-connect scope check failed for provider=%s; dropping",
+            provider,
+            exc_info=True,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Model-facing status (read per turn by ``build_session_context``)
+# --------------------------------------------------------------------------- #
+
+
+async def _write_status(
+    user_id: str, session_id: str, provider: str, result: ScopeCoverageResult
+) -> None:
+    payload = json.dumps(
+        {
+            "coverage": result.coverage.value,
+            "requested": result.requested,
+            "granted": result.granted,
+            "missing": result.missing,
+        }
+    )
+    key = status_key(user_id, session_id)
+    redis = await get_redis_async()
+    async with redis.pipeline(transaction=True) as pipe:
+        pipe.hset(key, provider.lower(), payload)
+        pipe.expire(key, _STATUS_TTL_SECONDS)
+        await cast(Awaitable[list[Any]], pipe.execute())
+
+
+async def _clear_status(user_id: str, session_id: str, provider: str) -> None:
+    redis = await get_redis_async()
+    await redis.hdel(status_key(user_id, session_id), provider.lower())
+
+
+async def scope_status_lines(user_id: str, session_id: str) -> list[str]:
+    """Render any outstanding scope shortfalls for this session.
+
+    Returned unconditionally — not behind the notice feature flag. The flag
+    gates whether we *interrupt the user*; the model should always know that
+    a connection it can see is narrower than it asked for, so it explains the
+    gap instead of re-firing ``connect_integration`` into the same wall.
+
+    Any failure yields no lines: this runs on the per-turn hot path.
+    """
+    try:
+        redis = await get_redis_async()
+        entries = cast(
+            dict[str, str], await redis.hgetall(status_key(user_id, session_id))
+        )
+    except Exception:
+        logger.debug("could not read oauth scope status", exc_info=True)
+        return []
+
+    lines: list[str] = []
+    for provider, raw in sorted(entries.items()):
+        try:
+            data = json.loads(raw)
+        except Exception:
+            continue
+        missing = ", ".join(data.get("missing") or []) or "(all requested)"
+        granted = ", ".join(data.get("granted") or []) or "none"
+        lines.append(
+            f"credential_scope_shortfall: {provider} is connected but the "
+            f"granted token is missing {missing} (granted: {granted}). "
+            f"Do not silently retry connect_integration for {provider} — tell "
+            f"the user what is missing and how to fix it: "
+            f"{remediation_for(provider)}"
+        )
+    return lines
+
+
+# --------------------------------------------------------------------------- #
+# User-facing chat notice (feature-flagged, default off)
+# --------------------------------------------------------------------------- #
+
+
+async def _post_chat_notice(
+    *,
+    user_id: str,
+    session_id: str,
+    provider: str,
+    result: ScopeCoverageResult,
+    username: str | None,
+) -> None:
+    if not await is_feature_enabled(
+        Flag.COPILOT_OAUTH_SCOPE_CHECK, user_id, default=False
+    ):
+        return
+
+    # Local imports: ``model`` and ``session_waiter`` pull in the copilot
+    # runtime, which this module is imported *by* (session context) and
+    # *into* (the integrations router).
+    from backend.copilot.model import get_chat_session_metadata
+    from backend.copilot.sdk.session_waiter import run_copilot_turn_via_queue
+
+    # Ownership re-check. The pending record is already namespaced by user id,
+    # so this cannot normally fail — but a wake posts into a chat transcript,
+    # and that is not a place to rely on "cannot normally".
+    session = await get_chat_session_metadata(session_id, user_id)
+    if session is None:
+        return
+
+    if not await _claim_notice(session_id, provider, result):
+        return
+
+    outcome, _ = await run_copilot_turn_via_queue(
+        session_id=session_id,
+        user_id=user_id,
+        message=shortfall_message(provider=provider, result=result, username=username),
+        # 0 = don't wait: an idle chat gets a fresh turn, a busy one gets the
+        # message on its pending buffer.
+        timeout=0,
+        tool_call_id=f"oauthscope:{provider}",
+        tool_name="oauth_scope_shortfall",
+    )
+    logger.info(
+        "oauth scope shortfall notice enqueued on session=%s for provider=%s "
+        "(missing=%s, outcome=%s)",
+        session_id[:12],
+        provider,
+        result.missing,
+        outcome,
+    )
+
+
+def shortfall_message(
+    *, provider: str, result: ScopeCoverageResult, username: str | None
+) -> str:
+    """The system-framed prompt the chat wakes up to.
+
+    Buffered messages carry no author field — everything on the pending
+    buffer is presented to the model as the user — so the framing is the only
+    thing stopping the model from answering this line as if the user typed
+    it. Same convention as ``subsession_wake.wake_message``.
+    """
+    connected_as = f" as `{username}`" if username else ""
+    missing = ", ".join(result.missing) or "the requested permissions"
+    granted = ", ".join(result.granted) or "nothing"
+    return (
+        "[System notice, not the user speaking: an OAuth connection the user "
+        "just completed came back with fewer permissions than were "
+        "requested. Do not reply to this notice itself.]\n\n"
+        f'<oauth_scope_shortfall provider="{provider}" '
+        f'coverage="{result.coverage.value}" missing="{missing}" />\n\n'
+        f"The {provider} account is connected{connected_as}, but the token "
+        f"only carries {granted}, so {missing} was not granted. Tell the user "
+        "this now, in your own voice and in one short paragraph: what "
+        "connected, exactly which permission is missing, and this fix — "
+        f"{remediation_for(provider)} Do not re-run the connect step for them "
+        "until they have done that; it would hand back the same token."
+    )
+
+
+async def _claim_notice(
+    session_id: str, provider: str, result: ScopeCoverageResult
+) -> bool:
+    """Claim the right to post this exact shortfall once.
+
+    Keyed on the missing set as well as the session, so a *different*
+    shortfall after a partial re-auth is still reported.
+    """
+    redis = await get_redis_async()
+    key = (
+        f"{_NOTICE_CLAIM_PREFIX}{session_id}:{provider.lower()}:"
+        f"{','.join(sorted(result.missing))}"
+    )
+    return bool(await redis.set(key, "1", nx=True, ex=_NOTICE_CLAIM_TTL_SECONDS))

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
@@ -1,0 +1,606 @@
+"""Tests for the post-OAuth scope check.
+
+Covers the contract:
+
+* a shortfall reaches the chat that asked for the connection, and nothing else
+* a clean connect produces no chat noise and clears any stale warning
+* two cards open for one provider are each judged against their own request
+* the model-facing status is emitted regardless of the notice feature flag
+* a failure anywhere is swallowed — the credential is already stored
+"""
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.copilot import oauth_scope_check
+from backend.copilot.oauth_scope_check import (
+    PendingConnect,
+    _run_scope_check,
+    record_pending_connect,
+    schedule_scope_check,
+    scope_status_lines,
+    status_key,
+)
+
+_USER = "user-1"
+_SESSION = "session-1"
+_OTHER_SESSION = "session-2"
+
+
+class _FakeRedis:
+    """Async-Redis fake covering only the calls this module makes."""
+
+    def __init__(self) -> None:
+        self.lists: dict[str, list[str]] = {}
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.strings: dict[str, str] = {}
+
+    async def rpush(self, key: str, *values: str) -> int:
+        self.lists.setdefault(key, []).extend(values)
+        return len(self.lists[key])
+
+    async def ltrim(self, key: str, start: int, stop: int) -> None:
+        values = self.lists.get(key, [])
+        self.lists[key] = values[start:] if stop == -1 else values[start : stop + 1]
+
+    async def lrange(self, key: str, start: int, stop: int) -> list[str]:
+        values = self.lists.get(key, [])
+        return list(values[start:] if stop == -1 else values[start : stop + 1])
+
+    async def expire(self, key: str, seconds: int) -> int:
+        return 1
+
+    async def delete(self, *keys: str) -> int:
+        for key in keys:
+            self.lists.pop(key, None)
+            self.hashes.pop(key, None)
+            self.strings.pop(key, None)
+        return len(keys)
+
+    async def hset(self, key: str, field: str, value: str) -> int:
+        self.hashes.setdefault(key, {})[field] = value
+        return 1
+
+    async def hdel(self, key: str, *fields: str) -> int:
+        entries = self.hashes.get(key, {})
+        return sum(1 for field in fields if entries.pop(field, None) is not None)
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        return dict(self.hashes.get(key, {}))
+
+    async def set(self, key: str, value: str, *, nx: bool = False, ex: Any = None):
+        if nx and key in self.strings:
+            return None
+        self.strings[key] = value
+        return True
+
+    def pipeline(self, transaction: bool = True) -> "_FakePipeline":
+        return _FakePipeline(self)
+
+
+class _FakePipeline:
+    def __init__(self, parent: _FakeRedis) -> None:
+        self._parent = parent
+        self._ops: list[tuple[str, tuple[Any, ...]]] = []
+
+    def __getattr__(self, name: str):
+        def _record(*args: Any) -> "_FakePipeline":
+            self._ops.append((name, args))
+            return self
+
+        return _record
+
+    async def execute(self) -> list[Any]:
+        return [await getattr(self._parent, name)(*args) for name, args in self._ops]
+
+    async def __aenter__(self) -> "_FakePipeline":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _session(user_id: str = _USER) -> MagicMock:
+    info = MagicMock()
+    info.user_id = user_id
+    return info
+
+
+def _patched(
+    redis: _FakeRedis,
+    *,
+    enqueue: AsyncMock,
+    flag_enabled: bool = True,
+    session: MagicMock | None = _session(),
+):
+    return (
+        patch.object(
+            oauth_scope_check, "get_redis_async", new=AsyncMock(return_value=redis)
+        ),
+        patch.object(
+            oauth_scope_check,
+            "is_feature_enabled",
+            new=AsyncMock(return_value=flag_enabled),
+        ),
+        patch(
+            "backend.copilot.model.get_chat_session_metadata",
+            new=AsyncMock(return_value=session),
+        ),
+        patch(
+            "backend.copilot.sdk.session_waiter.run_copilot_turn_via_queue",
+            new=enqueue,
+        ),
+    )
+
+
+async def _seed(redis: _FakeRedis, session_id: str, scopes: list[str]) -> None:
+    with patch.object(
+        oauth_scope_check, "get_redis_async", new=AsyncMock(return_value=redis)
+    ):
+        await record_pending_connect(
+            user_id=_USER,
+            provider="github",
+            session_id=session_id,
+            requested_scopes=scopes,
+        )
+
+
+# ── Shortfall reaches the originating chat ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_zero_scope_grant_notifies_the_originating_session():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_awaited_once()
+    kwargs = enqueue.await_args.kwargs
+    assert kwargs["session_id"] == _SESSION
+    assert kwargs["user_id"] == _USER
+    assert kwargs["timeout"] == 0
+    message = kwargs["message"]
+    # System-framed: the pending buffer has no author field.
+    assert message.startswith("[System notice")
+    assert 'provider="github"' in message
+    assert "repo" in message
+    assert "`alice`" in message
+    # Provider-specific remediation, not the generic one.
+    assert "Authorized OAuth Apps" in message
+
+
+@pytest.mark.asyncio
+async def test_partial_grant_names_only_the_missing_scope():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    assert 'missing="workflow"' in enqueue.await_args.kwargs["message"]
+
+
+# ── Silence on success ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_full_grant_produces_no_chat_noise():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    enqueue = AsyncMock()
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo", "workflow"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_reporting_provider_does_not_false_alarm():
+    """Notion hardcodes ``scopes=[]``; that is silence, not refusal."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["read_content"])
+    enqueue = AsyncMock()
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="notion",
+            granted_scopes=[],
+            provider_reports_scopes=False,
+            username="alice",
+        )
+
+        enqueue.assert_not_awaited()
+        assert await scope_status_lines(_USER, _SESSION) == []
+
+
+@pytest.mark.asyncio
+async def test_no_pending_connect_means_no_notice():
+    """A connect made from the Integrations panel was never attributed to a
+    chat; there is nobody to tell."""
+    redis = _FakeRedis()
+    enqueue = AsyncMock()
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_not_awaited()
+
+
+# ── Two cards open for the same provider ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_each_open_card_is_judged_against_its_own_request():
+    """One chat asked for `repo`, another for `repo`+`workflow`. A grant of
+    `repo` satisfies the first and shortchanges the second — and only the
+    second is told."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    await _seed(redis, _OTHER_SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_awaited_once()
+    assert enqueue.await_args.kwargs["session_id"] == _OTHER_SESSION
+
+
+@pytest.mark.asyncio
+async def test_pending_records_are_drained_so_a_replay_stays_quiet():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pending_list_is_bounded():
+    redis = _FakeRedis()
+    for index in range(oauth_scope_check._MAX_PENDING_PER_PROVIDER + 3):
+        await _seed(redis, f"session-{index}", ["repo"])
+
+    key = oauth_scope_check._pending_key(_USER, "github")
+    assert len(redis.lists[key]) == oauth_scope_check._MAX_PENDING_PER_PROVIDER
+    newest = PendingConnect.model_validate_json(redis.lists[key][-1])
+    assert newest.session_id == "session-7"
+
+
+# ── Model-facing status ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_model_status_is_written_even_when_the_notice_flag_is_off():
+    """The flag gates interrupting the user, not the model's awareness — the
+    model must still know not to re-fire connect_integration."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock()
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue, flag_enabled=False)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+        enqueue.assert_not_awaited()
+        lines = await scope_status_lines(_USER, _SESSION)
+
+    assert len(lines) == 1
+    assert "credential_scope_shortfall: github" in lines[0]
+    assert "workflow" in lines[0]
+    assert "Do not silently retry connect_integration" in lines[0]
+    assert "Authorized OAuth Apps" in lines[0]
+
+
+@pytest.mark.asyncio
+async def test_a_clean_reconnect_clears_a_stale_shortfall():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        assert len(await scope_status_lines(_USER, _SESSION)) == 1
+
+        await _seed(redis, _SESSION, ["repo", "workflow"])
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo", "workflow"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        assert await scope_status_lines(_USER, _SESSION) == []
+
+
+@pytest.mark.asyncio
+async def test_status_lines_are_scoped_to_one_session():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        assert await scope_status_lines(_USER, _OTHER_SESSION) == []
+        assert await scope_status_lines("other-user", _SESSION) == []
+
+
+def test_status_key_is_namespaced_by_user():
+    """Two users cannot read each other's shortfalls even on a shared
+    session id."""
+    assert status_key("u1", "s") != status_key("u2", "s")
+
+
+def test_pending_key_is_namespaced_by_user():
+    pending_key = oauth_scope_check._pending_key
+    assert pending_key("u1", "github") != pending_key("u2", "github")
+
+
+@pytest.mark.asyncio
+async def test_unreadable_status_entry_is_skipped_not_raised():
+    redis = _FakeRedis()
+    redis.hashes[status_key(_USER, _SESSION)] = {"github": "not json"}
+
+    with patch.object(
+        oauth_scope_check, "get_redis_async", new=AsyncMock(return_value=redis)
+    ):
+        assert await scope_status_lines(_USER, _SESSION) == []
+
+
+@pytest.mark.asyncio
+async def test_status_read_failure_degrades_to_no_lines():
+    """This runs on the per-turn hot path; a Redis blip must not break turns."""
+    with patch.object(
+        oauth_scope_check,
+        "get_redis_async",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        assert await scope_status_lines(_USER, _SESSION) == []
+
+
+# ── Ownership and failure handling ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_session_owned_by_another_user_is_never_posted_into():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    enqueue = AsyncMock()
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue, session=None)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_is_swallowed():
+    """The OAuth callback has already stored the credential; nothing here is
+    worth failing that for."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    enqueue = AsyncMock(side_effect=RuntimeError("rabbit down"))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_redis_failure_is_swallowed():
+    with patch.object(
+        oauth_scope_check,
+        "get_redis_async",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+
+@pytest.mark.asyncio
+async def test_recording_a_pending_connect_never_raises():
+    """A Redis hiccup must not stop the setup card from rendering."""
+    with patch.object(
+        oauth_scope_check,
+        "get_redis_async",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        await record_pending_connect(
+            user_id=_USER,
+            provider="github",
+            session_id=_SESSION,
+            requested_scopes=["repo"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_unparseable_pending_record_is_discarded():
+    redis = _FakeRedis()
+    redis.lists[oauth_scope_check._pending_key(_USER, "github")] = ["garbage"]
+    enqueue = AsyncMock()
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_scope_check_runs_detached():
+    run = AsyncMock()
+    with patch.object(oauth_scope_check, "_run_scope_check", new=run):
+        schedule_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        await asyncio.sleep(0)
+
+    run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_notice_flag_key():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    flag = AsyncMock(return_value=False)
+
+    with (
+        patch.object(
+            oauth_scope_check, "get_redis_async", new=AsyncMock(return_value=redis)
+        ),
+        patch.object(oauth_scope_check, "is_feature_enabled", new=flag),
+    ):
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    assert flag.await_args.args[0].value == "copilot-oauth-scope-check"
+    assert flag.await_args.args[1] == _USER
+
+
+@pytest.mark.asyncio
+async def test_status_payload_records_the_full_diff():
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+    payload = json.loads(redis.hashes[status_key(_USER, _SESSION)]["github"])
+    assert payload == {
+        "coverage": "partial",
+        "requested": ["repo", "workflow"],
+        "granted": ["repo"],
+        "missing": ["workflow"],
+    }
+
+
+def test_generic_remediation_for_unknown_provider():
+    text = oauth_scope_check.remediation_for("some-provider")
+    assert "consent screen" in text
+    assert "GitHub" not in text

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
@@ -293,6 +293,36 @@ async def test_each_open_card_is_judged_against_its_own_request():
 
 
 @pytest.mark.asyncio
+async def test_two_cards_in_one_session_are_judged_against_their_union():
+    """The model re-rendered a widened card into the *same* chat, so that chat
+    has two pending records. The grant satisfies the first card and
+    shortchanges the second — and the second is the one the user clicked.
+    Judging only the older, narrower record would call this a clean connect,
+    erase the warning, and never mention `workflow` again."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo"])
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        lines = await scope_status_lines(_USER, _SESSION)
+
+    enqueue.assert_awaited_once()
+    assert enqueue.await_args.kwargs["session_id"] == _SESSION
+    assert 'missing="workflow"' in enqueue.await_args.kwargs["message"]
+    assert len(lines) == 1
+    assert "workflow" in lines[0]
+
+
+@pytest.mark.asyncio
 async def test_pending_records_are_drained_so_a_replay_stays_quiet():
     redis = _FakeRedis()
     await _seed(redis, _SESSION, ["repo"])

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
@@ -494,11 +494,14 @@ async def test_session_owned_by_another_user_is_never_posted_into():
 
 
 @pytest.mark.asyncio
-async def test_enqueue_failure_is_swallowed():
+async def test_enqueue_failure_is_swallowed_per_session():
     """The OAuth callback has already stored the credential; nothing here is
-    worth failing that for."""
+    worth failing that for — and a chat we cannot reach must not cost the
+    *next* chat its notice and its model-facing status. The drain has already
+    deleted both records, so whatever this pass drops is dropped for good."""
     redis = _FakeRedis()
     await _seed(redis, _SESSION, ["repo"])
+    await _seed(redis, _OTHER_SESSION, ["repo"])
     enqueue = AsyncMock(side_effect=RuntimeError("rabbit down"))
 
     p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
@@ -510,8 +513,9 @@ async def test_enqueue_failure_is_swallowed():
             provider_reports_scopes=True,
             username="alice",
         )
+        assert len(await scope_status_lines(_USER, _OTHER_SESSION)) == 1
 
-    enqueue.assert_awaited_once()
+    assert enqueue.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
+++ b/autogpt_platform/backend/backend/copilot/oauth_scope_check_test.py
@@ -5,8 +5,10 @@ Covers the contract:
 * a shortfall reaches the chat that asked for the connection, and nothing else
 * a clean connect produces no chat noise and clears any stale warning
 * two cards open for one provider are each judged against their own request
+* the fix the notice prescribes can actually retire the warning it produced
 * the model-facing status is emitted regardless of the notice feature flag
-* a failure anywhere is swallowed — the credential is already stored
+* a failure anywhere is swallowed, and contained to the session it hit —
+  the credential is already stored
 """
 
 import asyncio
@@ -38,18 +40,21 @@ class _FakeRedis:
         self.lists: dict[str, list[str]] = {}
         self.hashes: dict[str, dict[str, str]] = {}
         self.strings: dict[str, str] = {}
+        self.zsets: dict[str, dict[str, float]] = {}
+
+    @staticmethod
+    def _rank_slice(members: list[str], start: int, stop: int) -> list[str]:
+        return members[start:] if stop == -1 else members[start : stop + 1]
 
     async def rpush(self, key: str, *values: str) -> int:
         self.lists.setdefault(key, []).extend(values)
         return len(self.lists[key])
 
     async def ltrim(self, key: str, start: int, stop: int) -> None:
-        values = self.lists.get(key, [])
-        self.lists[key] = values[start:] if stop == -1 else values[start : stop + 1]
+        self.lists[key] = self._rank_slice(self.lists.get(key, []), start, stop)
 
     async def lrange(self, key: str, start: int, stop: int) -> list[str]:
-        values = self.lists.get(key, [])
-        return list(values[start:] if stop == -1 else values[start : stop + 1])
+        return list(self._rank_slice(self.lists.get(key, []), start, stop))
 
     async def expire(self, key: str, seconds: int) -> int:
         return 1
@@ -59,6 +64,7 @@ class _FakeRedis:
             self.lists.pop(key, None)
             self.hashes.pop(key, None)
             self.strings.pop(key, None)
+            self.zsets.pop(key, None)
         return len(keys)
 
     async def hset(self, key: str, field: str, value: str) -> int:
@@ -69,8 +75,35 @@ class _FakeRedis:
         entries = self.hashes.get(key, {})
         return sum(1 for field in fields if entries.pop(field, None) is not None)
 
+    async def hget(self, key: str, field: str) -> str | None:
+        return self.hashes.get(key, {}).get(field)
+
     async def hgetall(self, key: str) -> dict[str, str]:
         return dict(self.hashes.get(key, {}))
+
+    def _ordered(self, key: str) -> list[str]:
+        entries = self.zsets.get(key, {})
+        return [member for member, _ in sorted(entries.items(), key=lambda i: i[1])]
+
+    async def zadd(self, key: str, mapping: dict[str, float]) -> int:
+        entries = self.zsets.setdefault(key, {})
+        added = sum(1 for member in mapping if member not in entries)
+        entries.update(mapping)
+        return added
+
+    async def zrem(self, key: str, *members: str) -> int:
+        entries = self.zsets.get(key, {})
+        return sum(1 for member in members if entries.pop(member, None) is not None)
+
+    async def zrange(self, key: str, start: int, stop: int) -> list[str]:
+        return self._rank_slice(self._ordered(key), start, stop)
+
+    async def zremrangebyrank(self, key: str, start: int, stop: int) -> int:
+        doomed = self._rank_slice(self._ordered(key), start, stop)
+        entries = self.zsets.get(key, {})
+        for member in doomed:
+            entries.pop(member, None)
+        return len(doomed)
 
     async def set(self, key: str, value: str, *, nx: bool = False, ex: Any = None):
         if nx and key in self.strings:
@@ -417,6 +450,101 @@ async def test_a_clean_reconnect_clears_a_stale_shortfall():
             username="alice",
         )
         assert await scope_status_lines(_USER, _SESSION) == []
+
+
+@pytest.mark.asyncio
+async def test_the_prescribed_fix_clears_the_warning_it_produced():
+    """The notice tells the user to revoke at GitHub and press Connect again.
+    That button calls ``/login`` straight from the setup card already on
+    screen — no ``connect_integration``, so the callback has nothing to
+    drain. The warning it was meant to retire must go anyway, or the copilot
+    keeps insisting a now-fully-granted credential is broken."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        assert len(await scope_status_lines(_USER, _SESSION)) == 1
+
+        # No _seed: the user pressed Connect on the card that was already there.
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo", "workflow"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        assert await scope_status_lines(_USER, _SESSION) == []
+
+
+@pytest.mark.asyncio
+async def test_a_fix_from_one_chat_retires_the_warning_in_every_chat():
+    """Two chats asked for github and both were shortchanged. The user fixes
+    it once; neither chat may be left telling the model it is still broken."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    await _seed(redis, _OTHER_SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo", "workflow"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+
+        assert await scope_status_lines(_USER, _SESSION) == []
+        assert await scope_status_lines(_USER, _OTHER_SESSION) == []
+
+
+@pytest.mark.asyncio
+async def test_a_cardless_reconnect_that_is_still_short_stays_flagged():
+    """Clearing on *any* cardless callback would forgive a reconnect that is
+    still narrow. The stored request is re-diffed against the new grant, so
+    the warning survives — with a refreshed diff."""
+    redis = _FakeRedis()
+    await _seed(redis, _SESSION, ["repo", "workflow"])
+    enqueue = AsyncMock(return_value=("running", MagicMock()))
+
+    p1, p2, p3, p4 = _patched(redis, enqueue=enqueue)
+    with p1, p2, p3, p4:
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=[],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        await _run_scope_check(
+            user_id=_USER,
+            provider="github",
+            granted_scopes=["repo"],
+            provider_reports_scopes=True,
+            username="alice",
+        )
+        lines = await scope_status_lines(_USER, _SESSION)
+
+    assert len(lines) == 1
+    assert "missing workflow" in lines[0]
+    assert "granted: repo" in lines[0]
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/tools/connect_integration.py
+++ b/autogpt_platform/backend/backend/copilot/tools/connect_integration.py
@@ -9,6 +9,7 @@ without configured credentials.
 from typing import Any, cast
 
 from backend.copilot.model import ChatSession
+from backend.copilot.oauth_scope_check import record_pending_connect
 from backend.copilot.providers import SUPPORTED_PROVIDERS, get_provider_auth_types
 from backend.copilot.tools.models import (
     ErrorResponse,
@@ -97,8 +98,8 @@ class ConnectIntegrationTool(BaseTool):
     @property
     def requires_auth(self) -> bool:
         # Require auth so only authenticated users can trigger the setup card.
-        # The card itself is user-agnostic (no per-user data needed), so
-        # user_id is intentionally unused in _execute.
+        # The card contents are user-agnostic, but the pending-connect record
+        # written alongside it is keyed by user.
         return True
 
     async def _execute(
@@ -119,7 +120,6 @@ class ConnectIntegrationTool(BaseTool):
 
         Returns an :class:`ErrorResponse` if *provider* is unknown.
         """
-        _ = user_id  # setup card is user-agnostic; auth is enforced via requires_auth
         session_id = session.session_id if session else None
         provider = (provider or "").strip().lower()
         reason = (reason or "").strip()[:500]  # cap LLM-controlled text
@@ -180,6 +180,17 @@ class ConnectIntegrationTool(BaseTool):
         # generic serializer produces from `field_key`.
         missing_credentials[field_key]["title"] = f"{display_name} Credentials"
         missing_credentials[field_key]["provider_name"] = display_name
+
+        # Remember what this card asked for, so the OAuth callback can tell
+        # whether the grant that comes back actually covers it and report
+        # back into *this* chat. See ``copilot.oauth_scope_check``.
+        if user_id and session_id:
+            await record_pending_connect(
+                user_id=user_id,
+                provider=provider,
+                session_id=session_id,
+                requested_scopes=merged_scopes,
+            )
 
         return SetupRequirementsResponse(
             type=ResponseType.SETUP_REQUIREMENTS,

--- a/autogpt_platform/backend/backend/copilot/tools/connect_integration_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/connect_integration_test.py
@@ -1,12 +1,24 @@
 """Tests for ConnectIntegrationTool."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
+from . import connect_integration as connect_integration_module
 from ._test_data import make_session
 from .connect_integration import ConnectIntegrationTool
 from .models import ErrorResponse, SetupRequirementsResponse
 
 _TEST_USER_ID = "test-user-connect-integration"
+
+
+@pytest.fixture(autouse=True)
+def stub_pending_connect():
+    """The card write-through to Redis is asserted in its own tests below."""
+    with patch.object(
+        connect_integration_module, "record_pending_connect", new=AsyncMock()
+    ) as stub:
+        yield stub
 
 
 class TestConnectIntegrationTool:
@@ -133,3 +145,90 @@ class TestConnectIntegrationTool:
         output = json.loads(raw) if isinstance(raw, str) else raw
         assert output.get("type") == "need_login"
         assert result.success is False
+
+
+class TestScopeMerge:
+    """The card carries the scopes the OAuth flow will actually request, so
+    what lands here is what the post-connect check diffs the grant against."""
+
+    def _scopes(self, response: SetupRequirementsResponse) -> list[str]:
+        return response.setup_info.requirements["credentials"][0]["scopes"]
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_defaults_used_when_the_model_asks_for_nothing(self):
+        result = await ConnectIntegrationTool()._execute(
+            user_id=_TEST_USER_ID,
+            session=make_session(user_id=_TEST_USER_ID),
+            provider="github",
+        )
+        assert isinstance(result, SetupRequirementsResponse)
+        assert self._scopes(result) == ["repo"]
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_requested_scopes_are_merged_on_top_of_the_defaults(self):
+        result = await ConnectIntegrationTool()._execute(
+            user_id=_TEST_USER_ID,
+            session=make_session(user_id=_TEST_USER_ID),
+            provider="github",
+            scopes=["workflow", "read:org"],
+        )
+        assert isinstance(result, SetupRequirementsResponse)
+        assert set(self._scopes(result)) == {"repo", "workflow", "read:org"}
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_duplicate_and_blank_scopes_are_dropped(self, stub_pending_connect):
+        result = await ConnectIntegrationTool()._execute(
+            user_id=_TEST_USER_ID,
+            session=make_session(user_id=_TEST_USER_ID),
+            provider="github",
+            scopes=["repo", "  ", "workflow", "workflow"],
+        )
+        assert isinstance(result, SetupRequirementsResponse)
+        assert set(self._scopes(result)) == {"repo", "workflow"}
+        # Order-preserving dedupe, defaults first.
+        recorded = stub_pending_connect.await_args.kwargs["requested_scopes"]
+        assert recorded == ["repo", "workflow"]
+
+
+class TestPendingConnectRecord:
+    """Rendering the card records what it asked for, so the OAuth callback
+    can report a shortfall back into this chat."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_card_records_the_merged_scopes_against_the_session(
+        self, stub_pending_connect
+    ):
+        session = make_session(user_id=_TEST_USER_ID)
+        await ConnectIntegrationTool()._execute(
+            user_id=_TEST_USER_ID,
+            session=session,
+            provider="github",
+            scopes=["workflow"],
+        )
+
+        stub_pending_connect.assert_awaited_once()
+        kwargs = stub_pending_connect.await_args.kwargs
+        assert kwargs["user_id"] == _TEST_USER_ID
+        assert kwargs["provider"] == "github"
+        assert kwargs["session_id"] == session.session_id
+        assert kwargs["requested_scopes"] == ["repo", "workflow"]
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_provider_slug_is_normalized_before_recording(
+        self, stub_pending_connect
+    ):
+        await ConnectIntegrationTool()._execute(
+            user_id=_TEST_USER_ID,
+            session=make_session(user_id=_TEST_USER_ID),
+            provider="GitHub",
+        )
+        assert stub_pending_connect.await_args.kwargs["provider"] == "github"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_unknown_provider_records_nothing(self, stub_pending_connect):
+        await ConnectIntegrationTool()._execute(
+            user_id=_TEST_USER_ID,
+            session=make_session(user_id=_TEST_USER_ID),
+            provider="nonexistent",
+        )
+        stub_pending_connect.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/tools/session_context.py
+++ b/autogpt_platform/backend/backend/copilot/tools/session_context.py
@@ -12,6 +12,10 @@ It carries:
 * ``pending_followups`` — count and a compact list (max 5; older ones
   collapsed into ``... +K more``) of the follow-ups currently queued
   against this session.
+* ``credential_scope_shortfall`` — one line per provider this session
+  asked the user to connect where the OAuth grant that came back was
+  narrower than requested, so the model explains the gap instead of
+  re-firing ``connect_integration`` into the same wall.
 
 When there are zero pending follow-ups the block is rendered as a
 single-line summary to save tokens — the model only needs the count
@@ -25,6 +29,7 @@ cache.  The system prompt itself is unchanged across sessions.
 
 import logging
 
+from backend.copilot.oauth_scope_check import scope_status_lines
 from backend.executor.scheduler import CopilotTurnJobInfo
 from backend.util.clients import get_scheduler_client
 from backend.util.feature_flag import Flag, is_feature_enabled
@@ -87,6 +92,19 @@ async def is_followups_feature_enabled(user_id: str | None) -> bool:
 async def build_session_context(session_id: str, user_id: str) -> str:
     """Return the body of the ``<session_context>`` block for this turn.
 
+    Followup awareness plus any outstanding OAuth scope shortfall for this
+    session (see ``copilot.oauth_scope_check``) — the latter is what stops
+    the model re-firing ``connect_integration`` against a provider that
+    already handed back a token too narrow to use.
+    """
+    lines = await _followup_lines(session_id, user_id)
+    lines.extend(await scope_status_lines(user_id, session_id))
+    return "\n".join(lines)
+
+
+async def _followup_lines(session_id: str, user_id: str) -> list[str]:
+    """Render the session id and any follow-ups queued against this session.
+
     Calls the polymorphic ``get_execution_schedules`` endpoint with
     ``kind="copilot_turn"`` + ``session_id`` so only follow-ups bound
     to *this* session are returned (other-session followups for the
@@ -98,16 +116,14 @@ async def build_session_context(session_id: str, user_id: str) -> str:
     session it is in, and the turn never fails because of a transient
     scheduler RPC issue.
 
-    The return value is the **body** of the block (no surrounding
-    ``<session_context>`` tags); the caller wraps it.
-
     When the ``COPILOT_SCHEDULED_FOLLOWUPS`` LD flag is off for this
     user, the followup awareness collapses to just ``pending_followups:
     0`` — we keep the ``session_id`` line so the model still knows
     which session it is in, and we skip the scheduler RPC entirely.
     """
+    collapsed = [f"session_id: {session_id}; pending_followups: 0"]
     if not await is_followups_feature_enabled(user_id):
-        return f"session_id: {session_id}; pending_followups: 0"
+        return collapsed
     try:
         raw_jobs = await get_scheduler_client().get_execution_schedules(
             user_id=user_id,
@@ -124,7 +140,7 @@ async def build_session_context(session_id: str, user_id: str) -> str:
             session_id,
             e,
         )
-        return f"session_id: {session_id}; pending_followups: 0"
+        return collapsed
 
     # The endpoint already narrows by ``kind`` server-side; the isinstance
     # filter is a belt-and-braces guard against a legacy untyped row that
@@ -134,11 +150,11 @@ async def build_session_context(session_id: str, user_id: str) -> str:
     if not jobs:
         # Zero-follow-up sessions are the common case — collapse to one
         # line to keep the per-turn prefix small.
-        return f"session_id: {session_id}; pending_followups: 0"
+        return collapsed
 
     lines = [
         f"session_id: {session_id}",
         f"pending_followups: {len(jobs)}",
     ]
     lines.extend(_format_followup_list(jobs))
-    return "\n".join(lines)
+    return lines

--- a/autogpt_platform/backend/backend/integrations/oauth/base.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/base.py
@@ -15,6 +15,18 @@ class BaseOAuthHandler(ABC):
     DEFAULT_SCOPES: ClassVar[list[str]] = []
     # --8<-- [end:BaseOAuthHandler1]
 
+    REPORTS_GRANTED_SCOPES: ClassVar[bool] = False
+    """Whether ``exchange_code_for_tokens`` populates ``scopes`` from the
+    provider's own report of what it granted.
+
+    Set this True only when the provider is contractually required to return
+    a ``scope`` field on the authorization-code exchange. It licenses the
+    post-connect check to read an *empty* scope list as "the provider granted
+    nothing" rather than "the provider told us nothing" — the difference
+    between catching a silently zero-scope token and false-alarming on every
+    handler that simply echoes back the requested scopes or hardcodes ``[]``.
+    """
+
     @abstractmethod
     # --8<-- [start:BaseOAuthHandler2]
     def __init__(self, client_id: str, client_secret: str, redirect_uri: str): ...

--- a/autogpt_platform/backend/backend/integrations/oauth/discord.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/discord.py
@@ -20,6 +20,7 @@ class DiscordOAuthHandler(BaseOAuthHandler):
     """
 
     PROVIDER_NAME = ProviderName.DISCORD
+    REPORTS_GRANTED_SCOPES = True
     DEFAULT_SCOPES = ["identify"]  # Basic user information
 
     def __init__(self, client_id: str, client_secret: str, redirect_uri: str):

--- a/autogpt_platform/backend/backend/integrations/oauth/github.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/github.py
@@ -7,6 +7,7 @@ from backend.integrations.providers import ProviderName
 from backend.util.request import Requests
 
 from .base import BaseOAuthHandler
+from .scopes import normalize_scopes
 
 
 # --8<-- [start:GithubOAuthHandlerExample]
@@ -25,6 +26,7 @@ class GitHubOAuthHandler(BaseOAuthHandler):
     """  # noqa
 
     PROVIDER_NAME = ProviderName.GITHUB
+    REPORTS_GRANTED_SCOPES = True
 
     def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
         self.client_id = client_id
@@ -106,12 +108,7 @@ class GitHubOAuthHandler(BaseOAuthHandler):
             title=current_credentials.title if current_credentials else None,
             username=username,
             access_token=token_data["access_token"],
-            # Token refresh responses have an empty `scope` property (see docs),
-            # so we have to get the scope from the existing credentials object.
-            scopes=(
-                token_data.get("scope", "").split(",")
-                or (current_credentials.scopes if current_credentials else [])
-            ),
+            scopes=self._resolve_scopes(token_data, current_credentials),
             # Refresh token and expiration intervals are only given if token expiration
             # is enabled in the GitHub App's settings.
             refresh_token=token_data.get("refresh_token"),
@@ -129,6 +126,31 @@ class GitHubOAuthHandler(BaseOAuthHandler):
         if current_credentials:
             new_credentials.id = current_credentials.id
         return new_credentials
+
+    @staticmethod
+    def _resolve_scopes(
+        token_data: dict, current_credentials: Optional[OAuth2Credentials]
+    ) -> list[str]:
+        """Read the granted scopes out of a GitHub token response.
+
+        GitHub delimits `scope` with commas on the authorization-code
+        exchange and with spaces on some app flows, so both are normalized.
+
+        The previous form — ``token_data.get("scope", "").split(",") or
+        (current_credentials.scopes if ... else [])`` — never reached its
+        fallback: ``"".split(",")`` is ``[""]``, which is truthy. A refresh
+        (whose `scope` is documented as empty) therefore dropped the
+        credential's real scopes, and a zero-scope authorization stored the
+        bogus scope ``""`` instead of an honest empty grant. Both are fixed
+        by splitting first and only then deciding the list is empty.
+        """
+        granted = normalize_scopes([str(token_data.get("scope") or "")])
+        if granted:
+            return granted
+        # Empty grant on a *refresh* means "unchanged" (see class docstring);
+        # empty on a first exchange really is a zero-scope token and must be
+        # recorded as such so the post-connect check can flag it.
+        return list(current_credentials.scopes) if current_credentials else []
 
     async def _request_username(self, access_token: str) -> str | None:
         url = "https://api.github.com/user"

--- a/autogpt_platform/backend/backend/integrations/oauth/github_test.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/github_test.py
@@ -1,0 +1,85 @@
+"""Regression tests for GitHub's granted-scope parsing.
+
+The original expression was::
+
+    scopes=(
+        token_data.get("scope", "").split(",")
+        or (current_credentials.scopes if current_credentials else [])
+    )
+
+``"".split(",")`` is ``[""]``, which is truthy, so the ``or`` fallback was
+dead code. Two real failures came out of that:
+
+* a **refresh** (whose ``scope`` is documented as empty) silently replaced the
+  credential's real scopes with ``[""]``;
+* a **zero-scope authorization** — GitHub reusing a prior grant and handing
+  back nothing — stored a credential claiming one nameless scope instead of
+  an honest empty grant, so no coverage check could ever notice.
+"""
+
+from pydantic import SecretStr
+
+from backend.data.model import OAuth2Credentials
+from backend.integrations.oauth.github import GitHubOAuthHandler
+
+
+def _existing(scopes: list[str]) -> OAuth2Credentials:
+    return OAuth2Credentials(
+        id="github-cred-1",
+        provider="github",
+        title="My GitHub",
+        access_token=SecretStr("ghp_old"),
+        refresh_token=SecretStr("ghr_old"),
+        scopes=scopes,
+        username="alice",
+    )
+
+
+class TestGitHubResolveScopes:
+    def test_empty_scope_on_first_exchange_is_no_scopes_not_one_empty_scope(self):
+        """The incident. A zero-scope token must be recorded as zero scopes so
+        the post-connect check can flag it."""
+        assert GitHubOAuthHandler._resolve_scopes({"scope": ""}, None) == []
+
+    def test_missing_scope_key_on_first_exchange_is_no_scopes(self):
+        assert GitHubOAuthHandler._resolve_scopes({}, None) == []
+
+    def test_empty_scope_on_refresh_keeps_the_existing_scopes(self):
+        """GitHub documents refresh responses as carrying an empty `scope`;
+        the credential's real grant must survive it."""
+        current = _existing(["repo", "workflow"])
+        assert GitHubOAuthHandler._resolve_scopes({"scope": ""}, current) == [
+            "repo",
+            "workflow",
+        ]
+
+    def test_missing_scope_key_on_refresh_keeps_the_existing_scopes(self):
+        current = _existing(["repo"])
+        assert GitHubOAuthHandler._resolve_scopes({}, current) == ["repo"]
+
+    def test_comma_separated_scopes_are_split(self):
+        assert GitHubOAuthHandler._resolve_scopes(
+            {"scope": "repo,read:org,workflow"}, None
+        ) == ["repo", "read:org", "workflow"]
+
+    def test_space_separated_scopes_are_split(self):
+        """Some GitHub flows space-delimit; the old code only split on comma,
+        so the whole string read as one exotic scope."""
+        assert GitHubOAuthHandler._resolve_scopes({"scope": "repo read:org"}, None) == [
+            "repo",
+            "read:org",
+        ]
+
+    def test_granted_scopes_win_over_existing_on_refresh(self):
+        current = _existing(["repo"])
+        assert GitHubOAuthHandler._resolve_scopes(
+            {"scope": "repo,workflow"}, current
+        ) == ["repo", "workflow"]
+
+    def test_null_scope_value_is_tolerated(self):
+        assert GitHubOAuthHandler._resolve_scopes({"scope": None}, None) == []
+
+    def test_handler_declares_that_it_reports_granted_scopes(self):
+        """Licenses the callback to read an empty grant as "nothing granted"
+        rather than "the provider said nothing"."""
+        assert GitHubOAuthHandler.REPORTS_GRANTED_SCOPES is True

--- a/autogpt_platform/backend/backend/integrations/oauth/google.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/google.py
@@ -25,6 +25,7 @@ class GoogleOAuthHandler(BaseOAuthHandler):
     """  # noqa
 
     PROVIDER_NAME = ProviderName.GOOGLE
+    REPORTS_GRANTED_SCOPES = True
     EMAIL_ENDPOINT = "https://www.googleapis.com/oauth2/v2/userinfo"
     DEFAULT_SCOPES = [
         "https://www.googleapis.com/auth/userinfo.email",

--- a/autogpt_platform/backend/backend/integrations/oauth/scopes.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/scopes.py
@@ -1,0 +1,119 @@
+"""Reconcile the scopes an OAuth provider *granted* with the ones we *asked for*.
+
+Two provider quirks make this less trivial than a set difference:
+
+* **Separators.** RFC 6749 says the ``scope`` response field is
+  space-delimited, but real providers ship comma-delimited (GitHub, in some
+  flows), space-delimited (GitHub in others, Linear, Discord, Stripe Link) or
+  already-split lists (Google via oauthlib).  A single scope string that was
+  never split looks like one exotic scope and makes every real scope read as
+  missing.  :func:`normalize_scopes` flattens all of those shapes.
+
+* **Silence vs. refusal.** A provider that omits ``scope`` from its token
+  response has told us *nothing* — alarming on that would false-alarm on
+  every Notion connect (its handler hardcodes ``scopes=[]``).  A provider
+  that is contractually required to report the grant and returns an empty
+  one has told us *nothing was granted* — which is exactly the failure we
+  need to shout about.  The two are indistinguishable from the credential
+  object alone, so the distinction is declared per handler via
+  ``BaseOAuthHandler.REPORTS_GRANTED_SCOPES``.
+"""
+
+import re
+from enum import Enum
+from typing import Iterable
+
+from pydantic import BaseModel
+
+# Split on any run of commas and/or whitespace, so one helper covers every
+# separator convention we have seen in the wild.
+_SCOPE_SPLIT_PATTERN = re.compile(r"[,\s]+")
+
+
+class ScopeCoverage(str, Enum):
+    """How well the granted grant covers what was requested."""
+
+    UNKNOWN = "unknown"
+    """The provider does not report its grant; we cannot tell. Not a failure."""
+
+    COVERED = "covered"
+    """Every requested scope is present in the grant."""
+
+    PARTIAL = "partial"
+    """Some scopes were granted, but not all of the requested ones."""
+
+    NONE_GRANTED = "none_granted"
+    """The provider reported a grant and it was empty."""
+
+
+class ScopeCoverageResult(BaseModel):
+    coverage: ScopeCoverage
+    requested: list[str]
+    granted: list[str]
+    missing: list[str]
+
+    @property
+    def is_shortfall(self) -> bool:
+        """True when the user must re-authorize for the connection to work."""
+        return self.coverage in (ScopeCoverage.PARTIAL, ScopeCoverage.NONE_GRANTED)
+
+
+def normalize_scopes(raw: Iterable[str]) -> list[str]:
+    """Flatten a provider's scope field into individual, deduplicated scopes.
+
+    Handles ``["repo,workflow"]``, ``["repo workflow"]``, ``["repo",
+    "workflow"]`` and mixtures of them identically.  Empty fragments are
+    dropped, which is what turns GitHub's ``"".split(",") == [""]`` into the
+    empty list it always meant.  Order is preserved so the stored scope list
+    still reads the way the provider sent it.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in raw:
+        for scope in _SCOPE_SPLIT_PATTERN.split(entry or ""):
+            if scope and scope not in seen:
+                seen.add(scope)
+                result.append(scope)
+    return result
+
+
+def evaluate_scope_coverage(
+    requested: Iterable[str],
+    granted: Iterable[str],
+    *,
+    provider_reports_scopes: bool,
+) -> ScopeCoverageResult:
+    """Diff *requested* against *granted*, honouring the silence/refusal split.
+
+    ``provider_reports_scopes`` mirrors the handler's
+    ``REPORTS_GRANTED_SCOPES``: when False the result is always
+    :attr:`ScopeCoverage.UNKNOWN` and ``missing`` is empty, because an absent
+    grant report is not evidence of a narrow grant.
+    """
+    requested_scopes = normalize_scopes(requested)
+    granted_scopes = normalize_scopes(granted)
+
+    if not provider_reports_scopes:
+        return ScopeCoverageResult(
+            coverage=ScopeCoverage.UNKNOWN,
+            requested=requested_scopes,
+            granted=granted_scopes,
+            missing=[],
+        )
+
+    granted_set = set(granted_scopes)
+    missing = [scope for scope in requested_scopes if scope not in granted_set]
+
+    if not missing:
+        coverage = ScopeCoverage.COVERED
+    elif granted_scopes:
+        coverage = ScopeCoverage.PARTIAL
+    else:
+        coverage = ScopeCoverage.NONE_GRANTED
+
+    return ScopeCoverageResult(
+        coverage=coverage,
+        requested=requested_scopes,
+        granted=granted_scopes,
+        missing=missing,
+    )

--- a/autogpt_platform/backend/backend/integrations/oauth/scopes_test.py
+++ b/autogpt_platform/backend/backend/integrations/oauth/scopes_test.py
@@ -1,0 +1,130 @@
+"""Tests for granted-vs-requested OAuth scope reconciliation."""
+
+import pytest
+
+from backend.integrations.oauth.scopes import (
+    ScopeCoverage,
+    evaluate_scope_coverage,
+    normalize_scopes,
+)
+
+
+class TestNormalizeScopes:
+    def test_comma_separated_single_string_is_split(self):
+        """GitHub's authorization-code exchange comma-delimits `scope`."""
+        assert normalize_scopes(["repo,read:org,workflow"]) == [
+            "repo",
+            "read:org",
+            "workflow",
+        ]
+
+    def test_space_separated_single_string_is_split(self):
+        """RFC 6749 / Linear / Discord space-delimit `scope`."""
+        assert normalize_scopes(["repo read:org"]) == ["repo", "read:org"]
+
+    def test_mixed_comma_and_space_separators(self):
+        assert normalize_scopes(["repo, read:org  workflow"]) == [
+            "repo",
+            "read:org",
+            "workflow",
+        ]
+
+    def test_already_split_list_passes_through(self):
+        """Google (via oauthlib) hands us a real list."""
+        assert normalize_scopes(["openid", "email"]) == ["openid", "email"]
+
+    def test_empty_string_yields_no_scopes(self):
+        """`"".split(",") == [""]` is the bug this exists to kill: an empty
+        scope field means zero scopes, not one scope named ``""``."""
+        assert normalize_scopes([""]) == []
+
+    def test_empty_input_yields_empty_list(self):
+        assert normalize_scopes([]) == []
+
+    def test_duplicates_are_dropped_and_order_preserved(self):
+        assert normalize_scopes(["repo", "repo,workflow", "repo"]) == [
+            "repo",
+            "workflow",
+        ]
+
+    def test_stray_separators_do_not_produce_empty_scopes(self):
+        assert normalize_scopes([" , repo , "]) == ["repo"]
+
+
+class TestEvaluateScopeCoverage:
+    def test_exact_match_is_covered(self):
+        result = evaluate_scope_coverage(
+            ["repo"], ["repo"], provider_reports_scopes=True
+        )
+        assert result.coverage is ScopeCoverage.COVERED
+        assert result.missing == []
+        assert result.is_shortfall is False
+
+    def test_superset_grant_is_covered(self):
+        """A provider that grants more than we asked for is not a problem."""
+        result = evaluate_scope_coverage(
+            ["repo"], ["repo", "workflow"], provider_reports_scopes=True
+        )
+        assert result.coverage is ScopeCoverage.COVERED
+        assert result.missing == []
+
+    def test_partial_grant_lists_only_the_missing_scopes(self):
+        result = evaluate_scope_coverage(
+            ["repo", "workflow", "read:org"],
+            ["repo"],
+            provider_reports_scopes=True,
+        )
+        assert result.coverage is ScopeCoverage.PARTIAL
+        assert result.missing == ["workflow", "read:org"]
+        assert result.is_shortfall is True
+
+    def test_empty_grant_from_a_reporting_provider_is_none_granted(self):
+        """The reported incident: OAuth succeeded, token carried nothing."""
+        result = evaluate_scope_coverage(["repo"], [], provider_reports_scopes=True)
+        assert result.coverage is ScopeCoverage.NONE_GRANTED
+        assert result.missing == ["repo"]
+        assert result.is_shortfall is True
+
+    def test_github_empty_scope_string_is_none_granted_not_one_scope(self):
+        result = evaluate_scope_coverage(["repo"], [""], provider_reports_scopes=True)
+        assert result.coverage is ScopeCoverage.NONE_GRANTED
+        assert result.granted == []
+        assert result.missing == ["repo"]
+
+    def test_non_reporting_provider_is_unknown_not_a_failure(self):
+        """Notion hardcodes ``scopes=[]``; alarming on it would false-alarm
+        on every successful Notion connect."""
+        result = evaluate_scope_coverage(["repo"], [], provider_reports_scopes=False)
+        assert result.coverage is ScopeCoverage.UNKNOWN
+        assert result.missing == []
+        assert result.is_shortfall is False
+
+    def test_non_reporting_provider_stays_unknown_even_with_a_real_shortfall(self):
+        result = evaluate_scope_coverage(
+            ["repo", "workflow"], ["repo"], provider_reports_scopes=False
+        )
+        assert result.coverage is ScopeCoverage.UNKNOWN
+        assert result.missing == []
+
+    def test_no_requested_scopes_is_covered(self):
+        result = evaluate_scope_coverage([], [], provider_reports_scopes=True)
+        assert result.coverage is ScopeCoverage.COVERED
+
+    @pytest.mark.parametrize(
+        "granted",
+        [["repo,workflow"], ["repo workflow"], ["repo", "workflow"]],
+    )
+    def test_separator_style_does_not_change_the_verdict(self, granted):
+        result = evaluate_scope_coverage(
+            ["repo", "workflow"], granted, provider_reports_scopes=True
+        )
+        assert result.coverage is ScopeCoverage.COVERED
+
+    def test_requested_side_is_normalized_too(self):
+        """`/login?scopes=` arrives comma-joined and round-trips through the
+        state token, so the requested side needs the same flattening."""
+        result = evaluate_scope_coverage(
+            ["repo,workflow"], ["repo", "workflow"], provider_reports_scopes=True
+        )
+        assert result.coverage is ScopeCoverage.COVERED
+        assert result.requested == ["repo", "workflow"]

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -65,6 +65,13 @@ class Flag(str, Enum):
     # the sub-session's result and report to the user.  Off by default —
     # it posts into a chat the user is not necessarily looking at.
     COPILOT_SUBSESSION_WAKE = "copilot-subsession-wake"
+    # Gates only the *user-visible* half of the post-OAuth scope check: the
+    # notice posted into the chat that asked for the connection.  The
+    # model-facing status in <session_context> is unconditional — knowing a
+    # token is narrower than requested stops a blind connect_integration
+    # retry, and costs the user nothing.  Off by default because the notice
+    # posts into a chat the user may have navigated away from.
+    COPILOT_OAUTH_SCOPE_CHECK = "copilot-oauth-scope-check"
     COPILOT_TIER_MULTIPLIERS = "copilot-tier-multipliers"
     COPILOT_TIER_WORKSPACE_STORAGE_LIMITS = "copilot-tier-workspace-storage-limits"
     COPILOT_TIER_STRIPE_PRICES = "copilot-tier-stripe-prices"


### PR DESCRIPTION
> **Stacked PR 5 of 10** — Autopilot proactivity & conversation quality.
> Base: `Abhi1992002/copilot-subsession-wake`. Review only this PR's diff.

### Why / What / How

**Why.** A user connected GitHub from a copilot setup card. The OAuth round-trip succeeded. The token that came back carried **zero scopes**. Nothing complained — the setup card went green, the model moved on, and the failure surfaced much later at call time as an opaque 403. It cost three rounds of "try connecting again" before anyone worked out what had happened: GitHub silently reuses a prior authorization instead of re-showing the consent screen, so reconnecting granted nothing, over and over.

Two things made this invisible:

1. **A latent bug in the GitHub handler.** Scopes were parsed as `token_data.get("scope", "").split(",") or (current_credentials.scopes ...)`. `"".split(",")` is `[""]` — truthy — so the `or` fallback was dead code. A zero-scope grant was stored as a credential claiming one nameless scope `""` rather than an honest empty grant, so no check could ever notice. The same dead branch also meant a *refresh* (whose `scope` GitHub documents as empty) silently dropped the credential's real scopes.
2. **The requested-vs-granted diff already existed and was silent.** The OAuth callback has always compared the two — and then written a `logger.warning` nobody reads.

**What.**

- Fixes the GitHub `[""]` bug, with a regression test.
- Generalises scope parsing: one helper handles comma, space, mixed and already-split shapes, replacing a Linear-specific fixup in the callback.
- After any OAuth connect, reconciles granted vs requested and surfaces a shortfall **to the user in the chat that asked for the connection** (behind `copilot-oauth-scope-check`, default off) and **to the model in `<session_context>`** (always), so it explains precisely what is missing instead of blindly re-firing `connect_integration` into the same wall.
- Distinguishes "the provider told us nothing" (unknown — no alarm) from "the provider granted nothing" (the incident).

**How.**

*Silence vs. refusal.* `BaseOAuthHandler.REPORTS_GRANTED_SCOPES` (default `False`) declares whether a handler populates `scopes` from the provider's own grant report. `True` for GitHub, Google, Discord. Notion hardcodes `scopes=[]`, and reddit/twitter/todoist echo back what was requested — all stay `False`, so an empty list from them reads as `unknown`, not as a failure. Only a provider contractually required to return `scope` can produce `none_granted`.

*Provenance without touching the auth surface.* The copilot never mints the OAuth state token — `connect_integration` renders a card and the *frontend* calls `/login` — so threading a session id through the state would mean a new user-supplied query parameter on an auth endpoint plus frontend and OpenAPI changes. Instead `connect_integration` writes a short-TTL, server-side Redis record keyed by `(user_id, provider)` when it renders the card. It cannot be influenced by the client, and the user-namespaced key plus a `get_chat_session_metadata(session_id, user_id)` ownership re-check mean a notice can never land in another user's chat.

*The two-cards race is resolved, not guessed.* The key holds a bounded list of pending connects. The callback drains it atomically and judges each record against *its own* requested scopes, so a chat that asked for `repo` stays quiet while a chat that asked for `repo`+`workflow` is told about `workflow`. Draining also makes a replayed callback silent.

*Delivery.* The user-facing notice reuses the subsession-wake machinery from PR 4 (`run_copilot_turn_via_queue(..., timeout=0)`, `SET NX` dedupe, system-framed message) rather than duplicating it. The whole check is detached via `spawn_background_task` and swallows every failure — by the time it runs the credential is already stored, and nothing here is worth failing that for. The model-facing status rides the **per-turn** user message; the prompt-cache-locked system prompt is untouched.

**Known follow-ups (deliberately out of scope):**
- The frontend already does its own client-side scope check (`useCredentialsInput.ts`) showing *"Connection failed: the granted permissions don't match what's required. Please contact the application administrator."* — no missing scope named, no remediation. It should be replaced by this PR's remediation text; that needs a frontend + `openapi.json` change.
- Stripe Link is a device-auth handler, not a `BaseOAuthHandler`, so it doesn't get the post-connect check. Fine today (the copilot connect card only supports GitHub).
- `build_session_context` now does one extra Redis `HGETALL` per turn. It fails closed to zero lines.

### Changes 🏗️

- `integrations/oauth/scopes.py` **(new)** — `normalize_scopes` (all separator conventions) + `evaluate_scope_coverage` → `covered` / `partial` / `none_granted` / `unknown`.
- `integrations/oauth/base.py` — `REPORTS_GRANTED_SCOPES: ClassVar[bool] = False`.
- `integrations/oauth/github.py` — `REPORTS_GRANTED_SCOPES = True` + the `[""]` fix in `_resolve_scopes`.
- `integrations/oauth/google.py`, `discord.py` — `REPORTS_GRANTED_SCOPES = True`.
- `api/features/integrations/router.py` — generic normalization (replaces the Linear-only space hack), coverage evaluation, detached copilot check after `_merge_or_create_credential`.
- `copilot/oauth_scope_check.py` **(new)** — provenance record + atomic drain, per-card shortfall diff, model-facing status store, flag-gated chat notice.
- `copilot/tools/connect_integration.py` — records merged scopes + session id when the card renders.
- `copilot/tools/session_context.py` — appends `credential_scope_shortfall` lines.
- `util/feature_flag.py` — `COPILOT_OAUTH_SCOPE_CHECK`.
- 4 test files (2 new, 2 extended).

**Flag added:** `copilot-oauth-scope-check` (default off) — gates only the user-visible chat notice. No schema or config changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/integrations/oauth/scopes_test.py` — separators (comma / space / mixed / pre-split), `[""]` → `[]`, dedupe, and the full coverage matrix
  - [x] `poetry run pytest backend/integrations/oauth/github_test.py` — the `[""]` regression: empty and absent `scope` on first exchange vs. on refresh, comma vs. space
  - [x] `poetry run pytest backend/copilot/oauth_scope_check_test.py` — message reaches the right session and no other; no message on a full grant; no false alarm from a non-reporting provider; two open cards judged independently; model status written even with the flag off and cleared by a clean reconnect; a cross-user session is never posted into; every failure swallowed
  - [x] `poetry run pytest backend/api/features/integrations/incremental_oauth_test.py backend/copilot/tools/connect_integration_test.py`
  - [ ] Manual: connect GitHub from a copilot card with the app already authorized at a narrower scope; confirm the chat names what is missing and that revoking + reconnecting clears it
