### PR TITLE
feat(backend/copilot): give delegated work an ETA, phases, and a done-condition

### DIFF
--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -140,6 +140,14 @@ class ChatSessionMetadata(BaseModel):
     delegated_by_expert_id: str | None = None
     delegated_by_session_id: str | None = None
 
+    # The delegating model's own up-front estimate and its definition of done,
+    # recorded when the sub is opened. Both are read back by
+    # ``get_sub_session_result`` so a poll (or a wake-up turn that never saw
+    # the original tool call) can state the ETA and verify the result against
+    # the criteria instead of taking "done" on faith.
+    estimated_minutes: int | None = None
+    success_criteria: list[str] | None = None
+
     # Set by ``handoff_to_expert`` alongside the delegation fields: a handoff
     # transfers ownership rather than borrowing a teammate, so the receiving
     # expert can tell "this is now mine" from "report back to whoever asked".
@@ -484,6 +492,8 @@ class ChatSession(ChatSessionInfo):
         delegated_by_expert_id: str | None = None,
         delegated_by_session_id: str | None = None,
         handed_off_from_expert_id: str | None = None,
+        estimated_minutes: int | None = None,
+        success_criteria: list[str] | None = None,
     ) -> Self:
         return cls(
             session_id=session_id or str(uuid.uuid4()),
@@ -504,6 +514,8 @@ class ChatSession(ChatSessionInfo):
                 delegated_by_expert_id=delegated_by_expert_id,
                 delegated_by_session_id=delegated_by_session_id,
                 handed_off_from_expert_id=handed_off_from_expert_id,
+                estimated_minutes=estimated_minutes,
+                success_criteria=success_criteria,
             ),
             organization_id=organization_id,
             team_id=team_id,
@@ -1302,6 +1314,8 @@ async def create_chat_session(
     delegated_by_expert_id: str | None = None,
     delegated_by_session_id: str | None = None,
     handed_off_from_expert_id: str | None = None,
+    estimated_minutes: int | None = None,
+    success_criteria: list[str] | None = None,
 ) -> ChatSession:
     """Create a new chat session and persist it.
 
@@ -1326,6 +1340,9 @@ async def create_chat_session(
             Doubles as the poll capability for cross-expert delegation.
         handed_off_from_expert_id: Expert that handed this work off for good,
             set only by ``handoff_to_expert``. Provenance only.
+        estimated_minutes: The delegating model's own estimate for this work.
+        success_criteria: Testable conditions the delegated work must meet,
+            read back on poll so completion can be verified rather than assumed.
 
     Raises:
         DatabaseError: If the database write fails. We fail fast to ensure
@@ -1352,6 +1369,8 @@ async def create_chat_session(
         delegated_by_expert_id=delegated_by_expert_id,
         delegated_by_session_id=delegated_by_session_id,
         handed_off_from_expert_id=handed_off_from_expert_id,
+        estimated_minutes=estimated_minutes,
+        success_criteria=success_criteria,
     )
 
     # Create in database first - fail fast if this fails

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -696,6 +696,18 @@ def get_delegation_supplement() -> str:
 - **One status line per wait cycle.** Live progress already renders on the
   sub-session card above, so skip repeated "still working…" filler. Post
   again only when the status actually changes.
+- **Give an ETA up front.** Always pass `estimated_minutes` on a build or
+  research delegation — your own honest guess. State it ONCE, in the line
+  where you first say you delegated. On later polls report the *phase* the
+  work has reached, not a fresh elapsed-time reading.
+- **Say what "done" means.** Pass 2-5 concrete, checkable `success_criteria`
+  for any build or research delegation. They are handed to the teammate up
+  front and returned to you alongside the result.
+- **Verify before declaring success.** When a delegation completes — including
+  when this chat is woken by a `<delegated_task_completed />` notice — check the
+  result against every criterion before telling the user it is done. If one is
+  unmet, name it and take the next step yourself; never report "done" on the
+  teammate's say-so alone.
 """
 
 

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -222,6 +222,51 @@ class TestDelegationWaitingEtiquette:
         )
 
 
+class TestDelegationEtaAndDoneCondition:
+    """Delegation is a tracked job: an estimate stated once up front, and a
+    definition of done that must be checked before success is reported.
+    """
+
+    def setup_method(self):
+        importlib.reload(prompting)
+
+    def test_supplement_requires_an_up_front_estimate(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "Give an ETA up front." in supplement
+        assert "`estimated_minutes`" in supplement
+
+    def test_estimate_is_stated_once_not_re_narrated(self):
+        """Repeating the clock on every poll is the dead-air problem the ETA
+        was meant to fix, so the rule names the phase as the thing to report
+        instead."""
+        supplement = prompting.get_delegation_supplement()
+        assert "State it ONCE" in supplement
+        assert "not a fresh elapsed-time reading" in supplement
+
+    def test_supplement_asks_for_concrete_success_criteria(self):
+        supplement = prompting.get_delegation_supplement()
+        assert 'Say what "done" means.' in supplement
+        assert "2-5 concrete, checkable `success_criteria`" in supplement
+
+    def test_completion_must_be_verified_against_the_criteria(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "Verify before declaring success." in supplement
+        assert "result against every criterion before telling the user" in supplement
+
+    def test_verification_rule_covers_the_wake_up_path(self):
+        """A chat woken by the delegated-task notice is a *fresh* turn — it is
+        exactly the one that would otherwise relay "done" unchecked."""
+        assert (
+            "when this chat is woken by a `<delegated_task_completed />` notice"
+            in prompting.get_delegation_supplement()
+        )
+
+    def test_unmet_criteria_must_be_named_rather_than_glossed(self):
+        supplement = prompting.get_delegation_supplement()
+        assert "unmet, name it and take the next step yourself" in supplement
+        assert 'never report "done" on the' in supplement
+
+
 class TestDurablePreferenceCapture:
     """A mid-task correction with lasting intent ("always use X") is a rule to
     persist immediately, not a one-off instruction to follow and forget.

--- a/autogpt_platform/backend/backend/copilot/subsession_wake.py
+++ b/autogpt_platform/backend/backend/copilot/subsession_wake.py
@@ -151,9 +151,11 @@ def wake_message(*, sub_session_id: str, status: TerminalStatus) -> str:
         f'<delegated_task_completed sub_session_id="{sub_session_id}" '
         f'status="{status}" />\n\n'
         "Call `get_sub_session_result` with that sub_session_id to read what "
-        "came back, then report the outcome to the user in your own voice: "
-        "what you had asked for, what you got, and what happens next. If it "
-        "failed or came back short of the goal, say so plainly and take the "
+        "came back. It returns the `success_criteria` this delegation was "
+        "given — check the result against every one of them before you call "
+        "it done. Then report the outcome to the user in your own voice: what "
+        "you had asked for, what you got, and what happens next. If it failed "
+        "or left any criterion unmet, name that criterion plainly and take the "
         "next step yourself rather than handing the chase back to the user."
     )
 

--- a/autogpt_platform/backend/backend/copilot/subsession_wake_test.py
+++ b/autogpt_platform/backend/backend/copilot/subsession_wake_test.py
@@ -428,7 +428,7 @@ def test_wake_prompt_sends_the_model_to_the_criteria_before_declaring_done():
 
 
 def test_wake_prompt_requires_naming_an_unmet_criterion():
-    """"Mostly done" reported as done is the exact failure this closes."""
+    """ "Mostly done" reported as done is the exact failure this closes."""
     message = wake_message(sub_session_id=_SUB, status="completed")
     assert "left any criterion unmet, name that criterion plainly" in message
 

--- a/autogpt_platform/backend/backend/copilot/subsession_wake_test.py
+++ b/autogpt_platform/backend/backend/copilot/subsession_wake_test.py
@@ -16,7 +16,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.copilot import stream_registry, subsession_wake
-from backend.copilot.subsession_wake import _wake_parent, schedule_parent_wake
+from backend.copilot.subsession_wake import (
+    _wake_parent,
+    schedule_parent_wake,
+    wake_message,
+)
 
 _SUB = "sub-session-1"
 _PARENT = "parent-session-1"
@@ -408,3 +412,34 @@ async def test_mark_session_completed_schedules_the_wake_once_per_swap():
         assert await stream_registry.mark_session_completed("sess-1") is False
 
     schedule.assert_called_once_with("sess-1", "completed")
+
+
+# ---------------------------------------------------------------------------
+# The wake prompt itself. A woken turn is a *fresh* turn: it never saw the
+# tool call that set the delegation's success criteria, so the prompt has to
+# point it at them rather than assume they are in context.
+# ---------------------------------------------------------------------------
+
+
+def test_wake_prompt_sends_the_model_to_the_criteria_before_declaring_done():
+    message = wake_message(sub_session_id=_SUB, status="completed")
+    assert "`success_criteria`" in message
+    assert "check the result against every one of them before you call" in message
+
+
+def test_wake_prompt_requires_naming_an_unmet_criterion():
+    """"Mostly done" reported as done is the exact failure this closes."""
+    message = wake_message(sub_session_id=_SUB, status="completed")
+    assert "left any criterion unmet, name that criterion plainly" in message
+
+
+def test_wake_prompt_keeps_its_original_reporting_contract():
+    """The criteria check is layered onto the existing instructions, not
+    swapped in for them."""
+    message = wake_message(sub_session_id=_SUB, status="failed")
+    assert message.startswith("[System notice")
+    assert f'sub_session_id="{_SUB}"' in message
+    assert 'status="failed"' in message
+    assert "get_sub_session_result" in message
+    assert "report the outcome to the user in your own voice" in message
+    assert "rather than handing the chase back to the user" in message

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
@@ -52,6 +52,14 @@ from .run_sub_session import (
     list_sub_workspace_files,
     response_from_outcome,
 )
+from .sub_session_context import (
+    ESTIMATED_MINUTES_PARAM,
+    SUCCESS_CRITERIA_PARAM,
+    criteria_preamble,
+    latest_sub_phases,
+    normalize_estimated_minutes,
+    normalize_success_criteria,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +128,8 @@ class DelegateToExpertTool(BaseTool):
                     ),
                     "default": 60,
                 },
+                "estimated_minutes": ESTIMATED_MINUTES_PARAM,
+                "success_criteria": SUCCESS_CRITERIA_PARAM,
             },
             "required": ["expert_id", "prompt"],
         }
@@ -134,6 +144,8 @@ class DelegateToExpertTool(BaseTool):
         system_context: str = "",
         delegated_session_id: str = "",
         wait_for_result: int = 60,
+        estimated_minutes: Any = None,
+        success_criteria: Any = None,
         **kwargs,
     ) -> ToolResponseBase:
         target_id = expert_id.strip()
@@ -158,11 +170,15 @@ class DelegateToExpertTool(BaseTool):
         if refusal is not None:
             return self._error(refusal, session)
 
+        estimate = normalize_estimated_minutes(estimated_minutes)
+        criteria = normalize_success_criteria(success_criteria)
         inner_session_id = await self._resolve_session(
             user_id=user_id,
             session=session,
             target=target,
             delegated_session_id=delegated_session_id.strip(),
+            estimated_minutes=estimate,
+            success_criteria=criteria,
         )
         if isinstance(inner_session_id, ErrorResponse):
             return inner_session_id
@@ -172,7 +188,7 @@ class DelegateToExpertTool(BaseTool):
         outcome, result = await run_copilot_turn_via_queue(
             session_id=inner_session_id,
             user_id=user_id,
-            message=_handoff_message(caller, system_context, prompt),
+            message=_handoff_message(caller, system_context, prompt, criteria),
             timeout=max(0, min(wait_for_result, MAX_SUB_SESSION_WAIT_SECONDS)),
             permissions=get_current_permissions(),
             tool_call_id=(
@@ -195,6 +211,13 @@ class DelegateToExpertTool(BaseTool):
                 elapsed=elapsed,
                 workspace_files=workspace_files,
                 actor=target.name,
+                estimated_minutes=estimate,
+                success_criteria=criteria,
+                phases=(
+                    await latest_sub_phases(inner_session_id)
+                    if outcome == "running"
+                    else None
+                ),
             ),
             DelegatedExpertInfo(
                 id=target.id,
@@ -242,12 +265,20 @@ class DelegateToExpertTool(BaseTool):
         session: ChatSession,
         target: Expert,
         delegated_session_id: str,
+        estimated_minutes: int | None = None,
+        success_criteria: list[str] | None = None,
     ) -> str | ErrorResponse:
         """Reuse a prior delegation thread with this teammate, or open one.
 
         Resuming is restricted to threads this session itself delegated, so a
         session can never read or steer another scope's conversation by
         guessing an id.
+
+        The estimate and criteria are recorded on a *new* thread's metadata.
+        A resumed thread keeps the ones it was opened with — a re-delegation
+        still carries its own criteria in the prompt, and rewriting the stored
+        pair would mean a full session upsert on the hot path to change what a
+        later poll reports about work already underway.
         """
         if not delegated_session_id:
             new_session = await create_chat_session(
@@ -259,6 +290,8 @@ class DelegateToExpertTool(BaseTool):
                 delegated_by_expert_id=session.expert_id,
                 delegated_by_session_id=session.session_id,
                 origin=child_session_origin(session.metadata),
+                estimated_minutes=estimated_minutes,
+                success_criteria=success_criteria,
             )
             return new_session.session_id
 
@@ -303,12 +336,21 @@ class DelegateToExpertTool(BaseTool):
         return caller.name if caller else "a teammate"
 
 
-def _handoff_message(caller: str, system_context: str, prompt: str) -> str:
+def _handoff_message(
+    caller: str,
+    system_context: str,
+    prompt: str,
+    success_criteria: list[str] | None = None,
+) -> str:
     """Frame the task so the teammate knows a colleague — not the user — asked.
 
     Without this the delegated prompt reads as the user speaking, and the
     teammate would address them directly and ask follow-up questions nobody
     is there to answer.
+
+    The criteria go last, immediately before the task itself, so "done means
+    X" is the final instruction the teammate reads rather than a header it
+    scrolls past.
     """
     name = safe_caller_name(caller)
     preamble = (
@@ -319,4 +361,7 @@ def _handoff_message(caller: str, system_context: str, prompt: str) -> str:
     )
     if system_context.strip():
         preamble += f"\n\n[Context: {system_context.strip()}]"
+    criteria_block = criteria_preamble(success_criteria)
+    if criteria_block:
+        preamble += f"\n\n{criteria_block}"
     return f"{preamble}\n\n{prompt}"

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
@@ -37,8 +37,12 @@ def _session(
     sess.metadata.llm_credential_id = None
     sess.metadata.delegated_by_session_id = None
     # Set explicitly: a bare MagicMock attribute is truthy, so an origin
-    # assertion would pass even if the kwarg were dropped.
+    # assertion would pass even if the kwarg were dropped. The delegation
+    # context below additionally has to hold a *real* value — it is read back
+    # onto a pydantic response, which would reject a MagicMock outright.
     sess.metadata.origin = origin
+    sess.metadata.estimated_minutes = None
+    sess.metadata.success_criteria = None
     sess.expert_id = expert_id
     return sess
 
@@ -107,6 +111,8 @@ def mock_sessions(monkeypatch):
         sess.metadata.handed_off_from_expert_id = kwargs.get(
             "handed_off_from_expert_id"
         )
+        sess.metadata.estimated_minutes = kwargs.get("estimated_minutes")
+        sess.metadata.success_criteria = kwargs.get("success_criteria")
         sess.messages = []
         created.append(sess)
         return sess
@@ -125,6 +131,10 @@ def mock_sessions(monkeypatch):
     )
     monkeypatch.setattr(
         "backend.copilot.tools.get_sub_session_result.get_chat_session", fake_get
+    )
+    # The phase-timeline lookup binds its own copy of the loader.
+    monkeypatch.setattr(
+        "backend.copilot.tools.sub_session_context.get_chat_session", fake_get
     )
     return created
 
@@ -711,3 +721,104 @@ class TestCallerNameFraming:
         )
 
         assert "from a teammate," in mock_turn.await_args.kwargs["message"]
+
+
+class TestDelegationTrackingContext:
+    """A delegation is a tracked job: it carries an up-front estimate and an
+    explicit definition of done, both recorded on the sub so a later poll can
+    state the ETA and verify the outcome."""
+
+    @pytest.mark.asyncio
+    async def test_criteria_are_prepended_to_the_handoff_prompt(
+        self, roster, mock_turn, mock_sessions
+    ):
+        await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id="expert-a"),
+            expert_id="expert-b",
+            prompt="draft the ops update",
+            system_context="Q3 numbers are final",
+            success_criteria=["covers every region", "under 400 words"],
+            wait_for_result=0,
+        )
+        message = mock_turn.await_args.kwargs["message"]
+        assert "Done means ALL of the following are true" in message
+        assert "- covers every region" in message
+        assert "- under 400 words" in message
+        # Order matters: teammate framing, then context, then the criteria
+        # immediately before the task itself.
+        assert message.index("Delegated task from") < message.index("[Context:")
+        assert message.index("[Context:") < message.index("Done means")
+        assert message.index("Done means") < message.index("draft the ops update")
+
+    @pytest.mark.asyncio
+    async def test_tracking_context_is_stored_on_the_delegated_session(
+        self, roster, mock_turn, mock_sessions
+    ):
+        await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id="expert-a"),
+            expert_id="expert-b",
+            prompt="draft the ops update",
+            estimated_minutes=25,
+            success_criteria=["covers every region"],
+            wait_for_result=0,
+        )
+        sub = mock_sessions[0]
+        assert sub.metadata.estimated_minutes == 25
+        assert sub.metadata.success_criteria == ["covers every region"]
+
+    @pytest.mark.asyncio
+    async def test_estimate_reaches_the_response_and_its_message(
+        self, roster, mock_turn, mock_sessions
+    ):
+        r = await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id="expert-a"),
+            expert_id="expert-b",
+            prompt="draft the ops update",
+            estimated_minutes=25,
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.estimated_minutes == 25
+        assert "Estimated ~25 min" in (r.message or "")
+
+    @pytest.mark.asyncio
+    async def test_no_criteria_leaves_the_handoff_prompt_untouched(
+        self, roster, mock_turn, mock_sessions
+    ):
+        r = await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id="expert-a"),
+            expert_id="expert-b",
+            prompt="draft the ops update",
+            wait_for_result=0,
+        )
+        assert "Done means" not in mock_turn.await_args.kwargs["message"]
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.success_criteria is None
+        assert r.estimated_minutes is None
+
+    @pytest.mark.asyncio
+    async def test_a_poll_of_the_delegation_reports_its_criteria_back(
+        self, roster, mock_turn, mock_sessions
+    ):
+        """The parent turn that reads the result may be a wake-up that never
+        saw the delegating call, so the criteria come off the sub itself."""
+        await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id="expert-a"),
+            expert_id="expert-b",
+            prompt="draft the ops update",
+            success_criteria=["covers every region"],
+            wait_for_result=0,
+        )
+        r = await GetSubSessionResultTool()._execute(
+            user_id="alice",
+            session=_session(expert_id="expert-a"),
+            sub_session_id="inner-1",
+            wait_if_running=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.success_criteria == ["covers every region"]

--- a/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
@@ -48,6 +48,7 @@ from .run_sub_session import (
     list_sub_workspace_files,
     response_from_outcome,
 )
+from .sub_session_context import phases_from_messages
 
 logger = logging.getLogger(__name__)
 
@@ -106,8 +107,9 @@ class GetSubSessionResultTool(BaseTool):
                 "include_progress": {
                     "type": "boolean",
                     "description": (
-                        "Populate progress.last_messages when status=running. "
-                        "Ignored for a teammate's delegated thread."
+                        "Populate progress.last_messages and progress.phases "
+                        "when status=running. Ignored for a teammate's "
+                        "delegated thread."
                     ),
                     "default": False,
                 },
@@ -155,6 +157,16 @@ class GetSubSessionResultTool(BaseTool):
         started_at = time.monotonic()
         delegate = await _delegated_expert_info(user_id, sub, session)
         borrowed = _is_borrowed_thread(sub, session)
+        # The delegation's own tracking context, read back off the sub instead
+        # of expected in the caller's context: a turn woken by
+        # ``subsession_wake`` never saw the tool call that set these, and it is
+        # exactly that turn which has to judge whether the work is really done.
+        estimate = sub.metadata.estimated_minutes
+        criteria = sub.metadata.success_criteria
+        # Phases follow the same rule as ``include_progress``: a borrowed
+        # thread is the teammate's own user-facing chat, so its live plan may
+        # describe something the user asked them directly, not this delegation.
+        phases = None if borrowed else phases_from_messages(sub.messages) or None
 
         if cancel:
             if borrowed:
@@ -182,6 +194,9 @@ class GetSubSessionResultTool(BaseTool):
                     sub_autopilot_session_id=inner_session_id,
                     sub_autopilot_session_link=_sub_session_link(inner_session_id),
                     elapsed_seconds=0.0,
+                    estimated_minutes=estimate,
+                    success_criteria=criteria,
+                    phases=phases,
                 ),
                 delegate,
             )
@@ -234,6 +249,9 @@ class GetSubSessionResultTool(BaseTool):
                     sub_autopilot_session_link=link,
                     elapsed_seconds=round(elapsed, 2),
                     progress=progress,
+                    estimated_minutes=estimate,
+                    success_criteria=criteria,
+                    phases=(progress.phases or None) if progress else phases,
                 ),
                 delegate,
             )
@@ -255,6 +273,9 @@ class GetSubSessionResultTool(BaseTool):
                 parent_session_id=session.session_id,
                 elapsed=elapsed,
                 workspace_files=workspace_files,
+                estimated_minutes=estimate,
+                success_criteria=criteria,
+                phases=phases,
             ),
             delegate,
         )
@@ -358,7 +379,8 @@ def _already_terminal_result(sub: ChatSession) -> SessionResult | None:
 async def _build_progress_snapshot(
     inner_session_id: str | None,
 ) -> SubSessionProgressSnapshot | None:
-    """Read the sub's ChatSession and return a preview of recent messages.
+    """Read the sub's ChatSession and return a preview of recent messages plus
+    the phase timeline mined from its latest ``TodoWrite``.
 
     Returns ``None`` silently on lookup failure — progress is best-effort;
     missing progress shouldn't abort the normal ``still running`` response.
@@ -398,4 +420,5 @@ async def _build_progress_snapshot(
     return SubSessionProgressSnapshot(
         message_count=len(messages),
         last_messages=previews,
+        phases=phases_from_messages(messages),
     )

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -331,6 +331,22 @@ class ErrorResponse(ToolResponseBase):
     details: dict[str, Any] | None = None
 
 
+class SubSessionPhase(BaseModel):
+    """One step of a sub-AutoPilot's plan, mined from its latest ``TodoWrite``.
+
+    ``TodoWrite`` is stateless — the model's most recent ``todos`` argument in
+    the transcript *is* the canonical list (see ``tools/todo_write.py``) — so a
+    phase timeline is read back from the sub's persisted tool calls rather than
+    from any separate store. ``activeForm`` is not mirrored: the parent renders
+    a static timeline, not the sub's own live label.
+    """
+
+    content: str = Field(description="Imperative description of the step.")
+    status: Literal["pending", "in_progress", "completed"] = Field(
+        default="pending",
+    )
+
+
 class SubSessionProgressSnapshot(BaseModel):
     """Mid-flight snapshot of a running sub-AutoPilot.
 
@@ -346,6 +362,14 @@ class SubSessionProgressSnapshot(BaseModel):
         description=(
             "Up to the last 5 messages (role + truncated content) from the "
             "sub's ChatSession — lets the agent report intermediate progress."
+        ),
+    )
+    phases: list[SubSessionPhase] = Field(
+        default_factory=list,
+        description=(
+            "The sub's latest task list (completed / in_progress / pending), "
+            "so progress can be reported as a named phase instead of a message "
+            "count. Empty when the sub has not planned with TodoWrite."
         ),
     )
 
@@ -458,6 +482,28 @@ class SubSessionStatusResponse(ToolResponseBase):
     elapsed_seconds: float | None = Field(
         default=None,
         description="How long the sub-AutoPilot has been running (or took).",
+    )
+    estimated_minutes: int | None = Field(
+        default=None,
+        description=(
+            "Up-front estimate supplied when the work was delegated. State it "
+            "to the user once; do not restate elapsed time on every poll."
+        ),
+    )
+    success_criteria: list[str] | None = Field(
+        default=None,
+        description=(
+            "The completion criteria this delegation was given. On completion "
+            "check the result against every one of them before reporting "
+            "success, and name any that is unmet."
+        ),
+    )
+    phases: list[SubSessionPhase] | None = Field(
+        default=None,
+        description=(
+            "The sub's latest task list, so the parent can report which phase "
+            "the work is in instead of only how long it has been running."
+        ),
     )
     progress: SubSessionProgressSnapshot | None = Field(
         default=None,

--- a/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
@@ -43,9 +43,19 @@ from .base import BaseTool
 from .models import (
     DelegatedExpertInfo,
     ErrorResponse,
+    SubSessionPhase,
     SubSessionStatusResponse,
     ToolResponseBase,
     WorkspaceFileInfoData,
+)
+from .sub_session_context import (
+    ESTIMATED_MINUTES_PARAM,
+    SUCCESS_CRITERIA_PARAM,
+    completion_criteria_reminder,
+    criteria_preamble,
+    latest_sub_phases,
+    normalize_estimated_minutes,
+    normalize_success_criteria,
 )
 
 logger = logging.getLogger(__name__)
@@ -109,6 +119,8 @@ class RunSubSessionTool(BaseTool):
                     ),
                     "default": 60,
                 },
+                "estimated_minutes": ESTIMATED_MINUTES_PARAM,
+                "success_criteria": SUCCESS_CRITERIA_PARAM,
             },
             "required": ["prompt"],
         }
@@ -122,6 +134,8 @@ class RunSubSessionTool(BaseTool):
         system_context: str = "",
         sub_autopilot_session_id: str = "",
         wait_for_result: int = 60,
+        estimated_minutes: Any = None,
+        success_criteria: Any = None,
         **kwargs,
     ) -> ToolResponseBase:
         if not prompt.strip():
@@ -134,6 +148,9 @@ class RunSubSessionTool(BaseTool):
                 message="Authentication required",
                 session_id=session.session_id,
             )
+
+        estimate = normalize_estimated_minutes(estimated_minutes)
+        criteria = normalize_success_criteria(success_criteria)
 
         # Resolve the sub's ChatSession id — either resume an owned one or
         # create a fresh session that inherits the parent's dry_run so a
@@ -207,12 +224,17 @@ class RunSubSessionTool(BaseTool):
                 # origin would put the staffing tools one hop away from the
                 # gate that refuses them directly.
                 origin="automation",
+                estimated_minutes=estimate,
+                success_criteria=criteria,
             )
             inner_session_id = new_session.session_id
 
         effective_prompt = prompt
         if system_context.strip():
             effective_prompt = f"[System Context: {system_context.strip()}]\n\n{prompt}"
+        preamble = criteria_preamble(criteria)
+        if preamble:
+            effective_prompt = f"{preamble}\n\n{effective_prompt}"
 
         cap = max(0, min(wait_for_result, MAX_SUB_SESSION_WAIT_SECONDS))
         started_at = time.monotonic()
@@ -238,6 +260,15 @@ class RunSubSessionTool(BaseTool):
             parent_session_id=session.session_id,
             elapsed=elapsed,
             workspace_files=workspace_files,
+            estimated_minutes=estimate,
+            success_criteria=criteria,
+            # Only worth a lookup while the work is unfinished: that is when a
+            # phase timeline is all the parent (and its card) has to show.
+            phases=(
+                await latest_sub_phases(inner_session_id)
+                if outcome == "running"
+                else None
+            ),
         )
 
 
@@ -395,6 +426,9 @@ def response_from_outcome(
     elapsed: float,
     workspace_files: list[WorkspaceFileInfoData] | None = None,
     actor: str = "Sub-AutoPilot",
+    estimated_minutes: int | None = None,
+    success_criteria: list[str] | None = None,
+    phases: list[SubSessionPhase] | None = None,
 ) -> SubSessionStatusResponse:
     """Translate a ``(SessionOutcome, SessionResult)`` tuple into the
     ``SubSessionStatusResponse`` contract the LLM sees.
@@ -404,6 +438,11 @@ def response_from_outcome(
     when the caller already knows it (e.g. ``delegate_to_expert``), so the
     message is built correctly once instead of via a post-hoc string
     substitution against this function's own wording.
+
+    ``estimated_minutes``, ``success_criteria`` and ``phases`` are the
+    delegation's tracking context. They ride *every* branch, not just the
+    happy one: a poll that lands on a failure or a queue-up still has to be
+    judged against the definition of done that was set for it.
 
     ``completed`` surfaces the aggregated response text + tool calls, plus a
     manifest of any workspace files the sub wrote (SECRT-2377). Pass
@@ -417,6 +456,11 @@ def response_from_outcome(
     the existing turn on its next drain.
     """
     link = _sub_session_link(inner_session_id)
+    context: dict[str, Any] = {
+        "estimated_minutes": estimated_minutes,
+        "success_criteria": success_criteria,
+        "phases": phases or None,
+    }
     if outcome == "queued":
         return SubSessionStatusResponse(
             message=(
@@ -432,12 +476,14 @@ def response_from_outcome(
             sub_autopilot_session_id=inner_session_id,
             sub_autopilot_session_link=link,
             elapsed_seconds=round(elapsed, 2),
+            **context,
         )
 
     if outcome == "running":
         return SubSessionStatusResponse(
             message=(
                 f"{actor} is still running after {elapsed:.0f}s."
+                f"{_estimate_note(estimated_minutes)}{_phase_note(phases)}"
                 f"{f' Watch live at {link}.' if link else ''} "
                 "Call get_sub_session_result (optionally with "
                 "include_progress=true) to wait, poll, or inspect progress."
@@ -448,6 +494,7 @@ def response_from_outcome(
             sub_autopilot_session_id=inner_session_id,
             sub_autopilot_session_link=link,
             elapsed_seconds=round(elapsed, 2),
+            **context,
         )
 
     if outcome == "rejected_concurrent_turn_cap":
@@ -463,6 +510,7 @@ def response_from_outcome(
             sub_autopilot_session_id=inner_session_id,
             sub_autopilot_session_link=link,
             elapsed_seconds=round(elapsed, 2),
+            **context,
         )
 
     if outcome == "failed":
@@ -474,6 +522,7 @@ def response_from_outcome(
             sub_autopilot_session_id=inner_session_id,
             sub_autopilot_session_link=link,
             elapsed_seconds=round(elapsed, 2),
+            **context,
         )
 
     # completed — prefer the authoritative listing supplied by the caller;
@@ -489,6 +538,7 @@ def response_from_outcome(
             f" It wrote {len(workspace_files)} workspace file(s); read them via "
             "read_workspace_file(path=<read_path>) — see sub_workspace_files."
         )
+    message += completion_criteria_reminder(success_criteria)
     return SubSessionStatusResponse(
         message=message,
         session_id=parent_session_id,
@@ -500,4 +550,24 @@ def response_from_outcome(
         tool_calls=[tc.model_dump() for tc in result.tool_calls],
         sub_workspace_files=workspace_files or None,
         elapsed_seconds=round(elapsed, 2),
+        **context,
     )
+
+
+def _estimate_note(estimated_minutes: int | None) -> str:
+    """The ETA, stated on the running message so the parent can promise a time
+    rather than an open-ended wait."""
+    if not estimated_minutes:
+        return ""
+    return f" Estimated ~{estimated_minutes} min in total."
+
+
+def _phase_note(phases: list[SubSessionPhase] | None) -> str:
+    """Where in its own plan the sub currently is — a more useful thing to
+    relay than another elapsed-seconds reading."""
+    if not phases:
+        return ""
+    done = sum(1 for p in phases if p.status == "completed")
+    current = next((p for p in phases if p.status == "in_progress"), None)
+    label = f": {current.content}" if current else ""
+    return f" Phase {min(done + 1, len(phases))}/{len(phases)}{label}."

--- a/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_sub_session.py
@@ -564,10 +564,18 @@ def _estimate_note(estimated_minutes: int | None) -> str:
 
 def _phase_note(phases: list[SubSessionPhase] | None) -> str:
     """Where in its own plan the sub currently is — a more useful thing to
-    relay than another elapsed-seconds reading."""
+    relay than another elapsed-seconds reading.
+
+    The position comes from the in-progress item's own index, not from a count
+    of completed items: nothing makes the model emit its todos in status order,
+    and counting completions can print a number that names a different phase
+    than the label beside it.
+    """
     if not phases:
         return ""
+    total = len(phases)
+    current = next((i for i, p in enumerate(phases) if p.status == "in_progress"), None)
+    if current is not None:
+        return f" Phase {current + 1}/{total}: {phases[current].content}."
     done = sum(1 for p in phases if p.status == "completed")
-    current = next((p for p in phases if p.status == "in_progress"), None)
-    label = f": {current.content}" if current else ""
-    return f" Phase {min(done + 1, len(phases))}/{len(phases)}{label}."
+    return f" Phase {min(done + 1, total)}/{total}."

--- a/autogpt_platform/backend/backend/copilot/tools/sub_session_context.py
+++ b/autogpt_platform/backend/backend/copilot/tools/sub_session_context.py
@@ -1,0 +1,250 @@
+"""ETA, definition-of-done, and phase timeline for delegated work.
+
+Three small concerns shared by ``run_sub_session``, ``delegate_to_expert``
+and ``get_sub_session_result``, kept together here rather than bolted onto
+any one of those already-long modules:
+
+* **Estimate** — the delegating model's own ``estimated_minutes`` guess. It
+  is recorded on the sub's session metadata so a later poll (or a wake-up
+  turn that never saw the original tool call) can still state it.
+* **Success criteria** — the caller's testable definition of done. It goes
+  two places: into the delegated prompt, so the sub knows what it is being
+  measured against, and onto the sub's metadata, so the parent can re-read
+  it on completion instead of taking "done" on faith.
+* **Phases** — a progress timeline for the parent's card. ``TodoWrite`` is
+  stateless: the model's most recent ``todos`` argument in the transcript
+  *is* the canonical list (see :mod:`todo_write`), and it is persisted like
+  any other tool call. So the latest snapshot is mined by walking the sub's
+  messages backwards — no new table, no new cache, and it works for both
+  the baseline MCP tool and the SDK's CLI-native one, which write the same
+  arguments under the same name.
+
+Every value here originates in model-authored JSON, so each one is
+normalised at this boundary rather than trusted.
+"""
+
+import json
+import logging
+from typing import Any
+
+from backend.copilot.model import ChatMessage, get_chat_session
+
+from .models import SubSessionPhase
+
+logger = logging.getLogger(__name__)
+
+# Enough for a real definition of done, short enough that the delegated
+# prompt stays readable and the criteria stay concrete.
+MAX_SUCCESS_CRITERIA = 8
+_MAX_CRITERION_CHARS = 300
+
+# A delegated turn that genuinely needs longer than a day is not something an
+# up-front estimate helps with; clamp rather than surface an absurd ETA.
+MAX_ESTIMATED_MINUTES = 24 * 60
+
+# Bounds how much of a long plan we echo back into the parent's context.
+_MAX_PHASES = 20
+
+_TODO_TOOL_NAME = "todowrite"
+
+
+ESTIMATED_MINUTES_PARAM: dict[str, Any] = {
+    "type": "integer",
+    "description": (
+        "Your honest estimate in minutes. Always give one for a build or "
+        "research task — the user sees it, so you can promise a time instead "
+        "of an open-ended wait."
+    ),
+}
+
+SUCCESS_CRITERIA_PARAM: dict[str, Any] = {
+    "type": "array",
+    "items": {"type": "string"},
+    "description": (
+        "2-5 concrete, checkable conditions that define 'done' (max "
+        f"{MAX_SUCCESS_CRITERIA}). Given to the worker up front and returned "
+        "to you with the result, so you verify it instead of assuming it."
+    ),
+}
+
+
+def normalize_estimated_minutes(raw: Any) -> int | None:
+    """Coerce a model-supplied estimate to a sane positive minute count."""
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        minutes = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if minutes <= 0:
+        return None
+    return min(minutes, MAX_ESTIMATED_MINUTES)
+
+
+def normalize_success_criteria(raw: Any) -> list[str] | None:
+    """Coerce model-supplied criteria to a bounded list of non-empty strings.
+
+    Returns ``None`` — not ``[]`` — when nothing usable was supplied, so the
+    "caller gave no definition of done" case stays distinguishable from
+    "caller gave an empty one" all the way down to the stored metadata.
+    """
+    if not isinstance(raw, list):
+        return None
+    criteria = [
+        item.strip()[:_MAX_CRITERION_CHARS]
+        for item in raw
+        if isinstance(item, str) and item.strip()
+    ]
+    return criteria[:MAX_SUCCESS_CRITERIA] or None
+
+
+def criteria_preamble(success_criteria: list[str] | None) -> str:
+    """The block prepended to a delegated prompt stating what 'done' means.
+
+    Empty string when no criteria were given, so callers can concatenate it
+    unconditionally.
+    """
+    if not success_criteria:
+        return ""
+    lines = "\n".join(f"- {c}" for c in success_criteria)
+    return (
+        "[Done means ALL of the following are true. Check each one before "
+        f"you report back, and say plainly which are unmet:\n{lines}]"
+    )
+
+
+def completion_criteria_reminder(success_criteria: list[str] | None) -> str:
+    """The sentence appended to a completed sub-session's tool message.
+
+    The parent may be a fresh turn woken by ``subsession_wake`` that never saw
+    the criteria it once set, so they are restated at the point of judgement
+    rather than assumed to be in context.
+    """
+    if not success_criteria:
+        return ""
+    lines = "; ".join(success_criteria)
+    return (
+        f" Before telling the user this is done, check the result against the "
+        f"{len(success_criteria)} success criteria you set ({lines}) and name "
+        "any that is not met instead of declaring success."
+    )
+
+
+async def latest_sub_phases(inner_session_id: str | None) -> list[SubSessionPhase]:
+    """The sub's latest plan, loaded by id. Best-effort: ``[]`` on any failure.
+
+    A phase timeline is a nicety on top of the status the caller actually
+    asked for, so a lookup problem must never turn a healthy "still running"
+    into an error.
+    """
+    if not inner_session_id:
+        return []
+    try:
+        sub = await get_chat_session(inner_session_id)
+    except Exception:
+        logger.debug(
+            "Phase snapshot unavailable for sub %s",
+            inner_session_id[:12],
+            exc_info=True,
+        )
+        return []
+    return phases_from_messages(sub.messages) if sub else []
+
+
+def phases_from_messages(messages: list[ChatMessage]) -> list[SubSessionPhase]:
+    """Mine the most recent ``TodoWrite`` task list out of a transcript.
+
+    Walks backwards and stops at the first entry that yields a usable list —
+    every ``TodoWrite`` call carries the *whole* plan, so the newest one is
+    the current state and everything before it is history.
+
+    Each message is checked two ways because the assistant row carrying the
+    ``todos`` argument is not always persisted: ``tool_calls_pending_save`` is
+    in-memory only, and the turn's final all-completed update is the one most
+    often lost. The baseline tool's *result* row echoes the same list, so it is
+    used as a fallback — the frontend history converter compensates for the
+    same gap (``orphanTodoWriteResultToPart``).
+    """
+    for message in reversed(messages):
+        for call in reversed(message.tool_calls or []):
+            phases = _phases_from_tool_call(call)
+            if phases:
+                return phases
+        phases = _phases_from_result_row(message)
+        if phases:
+            return phases
+    return []
+
+
+def _phases_from_tool_call(call: Any) -> list[SubSessionPhase]:
+    """Parse one persisted tool call into phases, or ``[]`` if it isn't a
+    ``TodoWrite`` (or is one we cannot read).
+
+    Tool calls reach us in more than one shape: the persisted OpenAI form
+    nests name/arguments under ``function`` with arguments as a JSON string,
+    while the live-drain form carries them flat with a dict payload. Both are
+    accepted, the same way ``_already_terminal_result`` does.
+    """
+    if not isinstance(call, dict):
+        return []
+    function = call.get("function")
+    function = function if isinstance(function, dict) else {}
+    name = function.get("name") or call.get("name") or ""
+    if not isinstance(name, str) or name.lower() != _TODO_TOOL_NAME:
+        return []
+
+    payload = _as_mapping(
+        function.get("arguments") or call.get("arguments") or call.get("input")
+    )
+    return _phases_from_todos(payload.get("todos") if payload else None)
+
+
+def _phases_from_result_row(message: ChatMessage) -> list[SubSessionPhase]:
+    """Recover the list from a ``TodoWrite`` result row whose assistant row
+    never made it to the database. Baseline serialises the full
+    ``TodoWriteResponse`` (including ``todos``) as the row's content; the SDK
+    path returns a plain ack, so this simply finds nothing there."""
+    if message.role != "tool":
+        return []
+    payload = _as_mapping(message.content)
+    if not payload or payload.get("type") != "todo_write":
+        return []
+    return _phases_from_todos(payload.get("todos"))
+
+
+def _phases_from_todos(raw_todos: Any) -> list[SubSessionPhase]:
+    if not isinstance(raw_todos, list):
+        return []
+    phases: list[SubSessionPhase] = []
+    for item in raw_todos[:_MAX_PHASES]:
+        if not isinstance(item, dict):
+            continue
+        content = item.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        status = item.get("status")
+        phases.append(
+            SubSessionPhase(
+                content=content.strip(),
+                status=(
+                    status
+                    if status in ("pending", "in_progress", "completed")
+                    else "pending"
+                ),
+            )
+        )
+    return phases
+
+
+def _as_mapping(raw: Any) -> dict[str, Any] | None:
+    """Coerce a JSON string or dict into a dict, or ``None`` when it is
+    neither — every payload here is untrusted transcript content."""
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None

--- a/autogpt_platform/backend/backend/copilot/tools/sub_session_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/sub_session_context_test.py
@@ -1,0 +1,189 @@
+"""Tests for the delegation tracking context: ETA, criteria, phase timeline.
+
+Every value these helpers handle originates in model-authored JSON or in an
+untrusted transcript, so the normalisation and parsing paths are the contract
+under test — a malformed ``todos`` payload must degrade to "no phases", never
+to an exception on the polling hot path.
+"""
+
+from __future__ import annotations
+
+import json
+
+from backend.copilot.model import ChatMessage
+
+from .sub_session_context import (
+    MAX_ESTIMATED_MINUTES,
+    MAX_SUCCESS_CRITERIA,
+    completion_criteria_reminder,
+    criteria_preamble,
+    normalize_estimated_minutes,
+    normalize_success_criteria,
+    phases_from_messages,
+)
+
+
+def _todo_call(todos: object, name: str = "TodoWrite") -> dict:
+    """An assistant tool call in the persisted OpenAI shape, where
+    ``arguments`` is a JSON *string* rather than an object."""
+    return {
+        "id": "call-1",
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps({"todos": todos})},
+    }
+
+
+def _assistant(tool_calls: list[dict] | None) -> ChatMessage:
+    return ChatMessage(role="assistant", content="", tool_calls=tool_calls)
+
+
+def _todo(content: str, status: str) -> dict:
+    return {"content": content, "activeForm": f"{content}ing", "status": status}
+
+
+class TestNormalizeEstimatedMinutes:
+    def test_accepts_a_positive_int(self):
+        assert normalize_estimated_minutes(15) == 15
+
+    def test_accepts_a_numeric_string(self):
+        assert normalize_estimated_minutes("15") == 15
+
+    def test_rejects_zero_and_negatives(self):
+        assert normalize_estimated_minutes(0) is None
+        assert normalize_estimated_minutes(-5) is None
+
+    def test_rejects_unparseable_values(self):
+        assert normalize_estimated_minutes("soon") is None
+        assert normalize_estimated_minutes(None) is None
+        assert normalize_estimated_minutes({"minutes": 5}) is None
+
+    def test_rejects_booleans(self):
+        """``True`` is an int in Python; surfacing it as a 1-minute ETA would
+        turn a type confusion into a promise made to the user."""
+        assert normalize_estimated_minutes(True) is None
+
+    def test_clamps_absurd_estimates(self):
+        assert normalize_estimated_minutes(10**9) == MAX_ESTIMATED_MINUTES
+
+
+class TestNormalizeSuccessCriteria:
+    def test_keeps_non_empty_strings_in_order(self):
+        assert normalize_success_criteria(["  runs clean  ", "has tests"]) == [
+            "runs clean",
+            "has tests",
+        ]
+
+    def test_absent_and_empty_both_collapse_to_none(self):
+        """``None`` rather than ``[]`` so "no definition of done was given"
+        stays distinguishable from "an empty one was"."""
+        assert normalize_success_criteria(None) is None
+        assert normalize_success_criteria([]) is None
+        assert normalize_success_criteria(["", "   "]) is None
+
+    def test_drops_non_string_entries(self):
+        assert normalize_success_criteria(["ok", 5, None, {"a": 1}]) == ["ok"]
+
+    def test_rejects_a_bare_string(self):
+        assert normalize_success_criteria("runs clean") is None
+
+    def test_caps_the_list(self):
+        criteria = normalize_success_criteria([f"c{i}" for i in range(50)])
+        assert criteria is not None
+        assert len(criteria) == MAX_SUCCESS_CRITERIA
+
+
+class TestCriteriaPrompting:
+    def test_preamble_lists_every_criterion(self):
+        block = criteria_preamble(["runs clean", "has tests"])
+        assert "Done means ALL of the following are true" in block
+        assert "- runs clean" in block
+        assert "- has tests" in block
+
+    def test_preamble_is_empty_without_criteria(self):
+        """Callers concatenate it unconditionally, so "none" must contribute
+        nothing rather than an empty bracketed block."""
+        assert criteria_preamble(None) == ""
+        assert criteria_preamble([]) == ""
+
+    def test_reminder_restates_the_criteria_at_the_point_of_judgement(self):
+        reminder = completion_criteria_reminder(["runs clean", "has tests"])
+        assert "2 success criteria" in reminder
+        assert "runs clean; has tests" in reminder
+        assert "name any that is not met" in reminder
+
+    def test_reminder_is_empty_without_criteria(self):
+        assert completion_criteria_reminder(None) == ""
+
+
+class TestPhasesFromMessages:
+    def test_mines_the_latest_todo_write(self):
+        phases = phases_from_messages(
+            [
+                _assistant([_todo_call([_todo("Plan", "in_progress")])]),
+                _assistant([_todo_call([_todo("Plan", "completed")])]),
+            ]
+        )
+        assert [(p.content, p.status) for p in phases] == [("Plan", "completed")]
+
+    def test_a_newer_list_wins_over_an_older_one(self):
+        """Every TodoWrite call carries the whole plan, so the newest call is
+        the current state — an older one must not leak back in."""
+        phases = phases_from_messages(
+            [
+                _assistant([_todo_call([_todo("Old", "pending")])]),
+                _assistant(
+                    [
+                        _todo_call(
+                            [_todo("New A", "completed"), _todo("New B", "pending")]
+                        )
+                    ]
+                ),
+            ]
+        )
+        assert [p.content for p in phases] == ["New A", "New B"]
+
+    def test_reads_a_dict_arguments_payload(self):
+        """The live-drain shape carries arguments as a dict, not a string."""
+        call = {"name": "TodoWrite", "input": {"todos": [_todo("Ship", "pending")]}}
+        assert [p.content for p in phases_from_messages([_assistant([call])])] == [
+            "Ship"
+        ]
+
+    def test_falls_back_to_an_orphaned_result_row(self):
+        """The assistant row carrying the arguments is not always persisted —
+        the turn's final all-completed update is the one most often lost — so
+        the baseline tool's result row is used instead."""
+        orphan = ChatMessage(
+            role="tool",
+            tool_call_id="call-1",
+            content=json.dumps(
+                {"type": "todo_write", "todos": [_todo("Ship", "completed")]}
+            ),
+        )
+        stale = _assistant([_todo_call([_todo("Ship", "pending")])])
+        phases = phases_from_messages([stale, orphan])
+        assert [(p.content, p.status) for p in phases] == [("Ship", "completed")]
+
+    def test_ignores_other_tools(self):
+        other = _assistant([_todo_call([_todo("X", "pending")], name="run_agent")])
+        assert phases_from_messages([other]) == []
+
+    def test_unknown_status_degrades_to_pending(self):
+        phases = phases_from_messages(
+            [_assistant([_todo_call([{"content": "Ship", "status": "wat"}])])]
+        )
+        assert phases[0].status == "pending"
+
+    def test_malformed_payloads_yield_no_phases(self):
+        malformed = [
+            _assistant([{"function": {"name": "TodoWrite", "arguments": "{not json"}}]),
+            _assistant([{"function": {"name": "TodoWrite", "arguments": "[]"}}]),
+            _assistant([_todo_call({"not": "a list"})]),
+            _assistant([_todo_call([{"activeForm": "no content"}, "junk"])]),
+            _assistant(None),
+        ]
+        for message in malformed:
+            assert phases_from_messages([message]) == []
+
+    def test_empty_transcript_yields_no_phases(self):
+        assert phases_from_messages([]) == []

--- a/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
@@ -49,8 +49,53 @@ def _session(
     sess.metadata.llm_auth_provider = "platform"
     sess.metadata.llm_credential_id = None
     sess.metadata.origin = origin
+    # Real values, not bare MagicMock attributes: the delegation context is
+    # read straight onto a pydantic response, which rejects a MagicMock.
+    sess.metadata.estimated_minutes = None
+    sess.metadata.success_criteria = None
     sess.expert_id = expert_id
     return sess
+
+
+def _sub(
+    *,
+    user_id: str = "alice",
+    expert_id: str | None = None,
+    messages: list | None = None,
+) -> MagicMock:
+    """A pollable sub-session.
+
+    ``metadata`` is populated with real values rather than left as bare
+    MagicMock attributes: ``get_sub_session_result`` reads the delegation
+    context straight onto a pydantic response, which a MagicMock would fail.
+    """
+    sub = MagicMock(user_id=user_id, expert_id=expert_id, messages=messages or [])
+    sub.metadata.estimated_minutes = None
+    sub.metadata.success_criteria = None
+    return sub
+
+
+def _todo(content: str, status: str) -> dict:
+    return {"content": content, "activeForm": f"{content}…", "status": status}
+
+
+def _todo_message(todos: list[dict]) -> MagicMock:
+    """An assistant message carrying a persisted ``TodoWrite`` call, in the
+    OpenAI shape the DB stores (``arguments`` is a JSON string)."""
+    message = MagicMock()
+    message.role = "assistant"
+    message.content = ""
+    message.tool_calls = [
+        {
+            "id": "call-todo",
+            "type": "function",
+            "function": {
+                "name": "TodoWrite",
+                "arguments": json.dumps({"todos": todos}),
+            },
+        }
+    ]
+    return message
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +199,8 @@ def mock_model(monkeypatch):
         llm_credential_id: str | None = None,
         expert_id: str | None = None,
         origin: str = "interactive",
+        estimated_minutes: int | None = None,
+        success_criteria: list[str] | None = None,
     ):
         sess = MagicMock()
         sess.session_id = f"inner-{len(created) + 1}"
@@ -164,6 +211,8 @@ def mock_model(monkeypatch):
         sess.team_id = team_id
         sess.metadata.llm_auth_provider = llm_auth_provider
         sess.metadata.llm_credential_id = llm_credential_id
+        sess.metadata.estimated_minutes = estimated_minutes
+        sess.metadata.success_criteria = success_criteria
         sess.expert_id = expert_id
         sess.messages = []
         created.append(sess)
@@ -185,6 +234,10 @@ def mock_model(monkeypatch):
     )
     monkeypatch.setattr(
         "backend.copilot.tools.get_sub_session_result.get_chat_session", fake_get
+    )
+    # The phase-timeline lookup binds its own copy of the loader.
+    monkeypatch.setattr(
+        "backend.copilot.tools.sub_session_context.get_chat_session", fake_get
     )
     return {"created": created, "get": fake_get}
 
@@ -587,7 +640,7 @@ class TestGetSubSessionResult:
 
     @pytest.mark.asyncio
     async def test_wait_returns_running(self, monkeypatch, mock_waiter):
-        sub = MagicMock(user_id="alice", expert_id=None, messages=[])
+        sub = _sub()
 
         async def fake_get(_sid):
             return sub
@@ -619,9 +672,7 @@ class TestGetSubSessionResult:
     async def test_wait_returns_completed_with_response(self, monkeypatch, mock_waiter):
         """'completed' outcome surfaces the SessionResult directly."""
 
-        sub = MagicMock(
-            user_id="alice", expert_id=None, messages=[]
-        )  # not terminal-looking
+        sub = _sub()  # not terminal-looking
 
         async def fake_get(_sid):
             return sub
@@ -658,7 +709,7 @@ class TestGetSubSessionResult:
         in flight, the tool returns 'completed' without ever calling
         wait_for_session_result — it rebuilds the response from the
         persisted message instead."""
-        sub = MagicMock(user_id="alice", expert_id=None)
+        sub = _sub()
         assistant = MagicMock()
         assistant.role = "assistant"
         assistant.content = "already done"
@@ -704,7 +755,7 @@ class TestGetSubSessionResult:
         prior.role = "assistant"
         prior.content = "OLD stale result"
         prior.tool_calls = None
-        sub = MagicMock(user_id="alice", expert_id=None, messages=[prior])
+        sub = _sub(messages=[prior])
 
         async def fake_get(_sid):
             return sub
@@ -743,7 +794,7 @@ class TestGetSubSessionResult:
     ):
         """cancel=true fans out a CancelCoPilotEvent and returns 'cancelled'
         without waiting for the sub to finish (the worker will finalise)."""
-        sub = MagicMock(user_id="alice", expert_id=None, messages=[])
+        sub = _sub()
 
         async def fake_get(_sid):
             return sub
@@ -773,7 +824,7 @@ class TestGetSubSessionResult:
         log only holds the last message — yet the file manifest is still
         populated from the authoritative workspace listing."""
 
-        sub = MagicMock(user_id="alice", expert_id=None)
+        sub = _sub()
         assistant = MagicMock()
         assistant.role = "assistant"
         assistant.content = "done — see the docs I wrote"
@@ -1009,3 +1060,338 @@ class TestActorParameter:
         result = apply_delegated_expert(response, expert)
         assert result.message == response.message
         assert "Sub-AutoPilot" not in (result.message or "")
+
+
+# ---------------------------------------------------------------------------
+# Delegation tracking — up-front ETA, definition of done, phase timeline.
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationEstimate:
+    """The estimate is the model's own guess, carried on the response so the
+    parent can promise a time instead of an open-ended wait."""
+
+    @pytest.mark.asyncio
+    async def test_estimate_rides_the_running_response(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            estimated_minutes=12,
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.status == "running"
+        assert r.estimated_minutes == 12
+        assert "Estimated ~12 min" in (r.message or "")
+
+    @pytest.mark.asyncio
+    async def test_estimate_is_stored_on_the_sub_session(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        """Persisted so a later poll — or a wake-up turn that never saw the
+        original tool call — can still state the ETA."""
+        await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            estimated_minutes=12,
+            wait_for_result=0,
+        )
+        assert mock_model["created"][0].metadata.estimated_minutes == 12
+
+    @pytest.mark.asyncio
+    async def test_no_estimate_means_no_invented_one(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.estimated_minutes is None
+        assert "Estimated" not in (r.message or "")
+
+    @pytest.mark.asyncio
+    async def test_unusable_estimate_is_dropped_not_surfaced(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        """A garbage value must not reach the user as a time promise."""
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            estimated_minutes="soon",
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.estimated_minutes is None
+
+
+class TestSuccessCriteria:
+    """Criteria go two places: into the delegated prompt so the worker knows
+    what it is measured against, and onto the response so the parent can
+    verify the outcome instead of relaying "done" on faith."""
+
+    @pytest.mark.asyncio
+    async def test_criteria_are_prepended_to_the_delegated_prompt(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            success_criteria=["runs clean", "has tests"],
+            wait_for_result=0,
+        )
+        sent = mock_waiter.await_args.kwargs["message"]
+        assert "Done means ALL of the following are true" in sent
+        assert "- runs clean" in sent
+        assert "- has tests" in sent
+        # The task itself still lands last, after the framing.
+        assert sent.rstrip().endswith("build it")
+
+    @pytest.mark.asyncio
+    async def test_criteria_are_stored_on_the_sub_session(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            success_criteria=["runs clean", "has tests"],
+            wait_for_result=0,
+        )
+        assert mock_model["created"][0].metadata.success_criteria == [
+            "runs clean",
+            "has tests",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_criteria_round_trip_onto_the_response(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            success_criteria=["runs clean"],
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.success_criteria == ["runs clean"]
+
+    @pytest.mark.asyncio
+    async def test_completion_demands_verification_against_the_criteria(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        done = SessionResult()
+        done.response_text = "all set"
+        mock_waiter.return_value = ("completed", done)
+
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            success_criteria=["runs clean", "has tests"],
+            wait_for_result=30,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.status == "completed"
+        message = r.message or ""
+        assert "check the result against the 2 success criteria" in message
+        assert "runs clean; has tests" in message
+
+    @pytest.mark.asyncio
+    async def test_completion_without_criteria_adds_no_reminder(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        done = SessionResult()
+        done.response_text = "all set"
+        mock_waiter.return_value = ("completed", done)
+
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            wait_for_result=30,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.success_criteria is None
+        assert "success criteria" not in (r.message or "")
+
+    @pytest.mark.asyncio
+    async def test_unusable_criteria_are_dropped(
+        self, mock_queue, mock_waiter, mock_model
+    ):
+        r = await RunSubSessionTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            prompt="build it",
+            success_criteria="runs clean",
+            wait_for_result=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.success_criteria is None
+        assert "Done means" not in mock_waiter.await_args.kwargs["message"]
+
+
+class TestPhaseTimeline:
+    """``TodoWrite`` is stateless — its latest arguments in the transcript are
+    the canonical plan — so a poll reports phases by mining the sub's own
+    messages rather than reading any separate progress store."""
+
+    @pytest.mark.asyncio
+    async def test_poll_reports_the_subs_phases(self, monkeypatch, mock_waiter):
+        sub = _sub(
+            messages=[
+                _todo_message(
+                    [
+                        _todo("Scaffold", "completed"),
+                        _todo("Wire it up", "in_progress"),
+                        _todo("Test", "pending"),
+                    ]
+                ),
+                # A trailing tool row keeps the last message non-terminal, so
+                # the poll takes the running path rather than short-circuiting.
+                MagicMock(role="tool", content="ok", tool_calls=None),
+            ]
+        )
+
+        async def fake_get(_sid):
+            return sub
+
+        async def no_active_session(_sid):
+            return None
+
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.get_chat_session", fake_get
+        )
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.stream_registry.get_session",
+            no_active_session,
+        )
+
+        r = await GetSubSessionResultTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            sub_session_id="inner-1",
+            wait_if_running=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.status == "running"
+        assert r.phases is not None
+        assert [(p.content, p.status) for p in r.phases] == [
+            ("Scaffold", "completed"),
+            ("Wire it up", "in_progress"),
+            ("Test", "pending"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_include_progress_carries_the_same_phases(
+        self, monkeypatch, mock_waiter
+    ):
+        sub = _sub(
+            messages=[
+                _todo_message([_todo("Scaffold", "in_progress")]),
+                MagicMock(role="tool", content="ok", tool_calls=None),
+            ]
+        )
+
+        async def fake_get(_sid):
+            return sub
+
+        async def no_active_session(_sid):
+            return None
+
+        for target in (
+            "backend.copilot.tools.get_sub_session_result.get_chat_session",
+            "backend.copilot.tools.sub_session_context.get_chat_session",
+        ):
+            monkeypatch.setattr(target, fake_get)
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.stream_registry.get_session",
+            no_active_session,
+        )
+
+        r = await GetSubSessionResultTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            sub_session_id="inner-1",
+            wait_if_running=0,
+            include_progress=True,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.progress is not None
+        assert [p.content for p in r.progress.phases] == ["Scaffold"]
+        assert r.phases is not None
+        assert [p.content for p in r.phases] == ["Scaffold"]
+
+    @pytest.mark.asyncio
+    async def test_a_sub_without_a_plan_reports_no_phases(
+        self, monkeypatch, mock_waiter
+    ):
+        """Absent is absent — an unplanned sub must not render an empty
+        timeline on the parent's card."""
+        sub = _sub(messages=[MagicMock(role="tool", content="ok", tool_calls=None)])
+
+        async def fake_get(_sid):
+            return sub
+
+        async def no_active_session(_sid):
+            return None
+
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.get_chat_session", fake_get
+        )
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.stream_registry.get_session",
+            no_active_session,
+        )
+
+        r = await GetSubSessionResultTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            sub_session_id="inner-1",
+            wait_if_running=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.phases is None
+
+    @pytest.mark.asyncio
+    async def test_stored_context_is_read_back_on_a_cold_poll(
+        self, monkeypatch, mock_waiter
+    ):
+        """The turn that polls may be a wake-up that never saw the delegating
+        tool call, so the ETA and criteria come off the sub itself."""
+        sub = _sub(messages=[MagicMock(role="tool", content="ok", tool_calls=None)])
+        sub.metadata.estimated_minutes = 20
+        sub.metadata.success_criteria = ["runs clean"]
+
+        async def fake_get(_sid):
+            return sub
+
+        async def no_active_session(_sid):
+            return None
+
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.get_chat_session", fake_get
+        )
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.stream_registry.get_session",
+            no_active_session,
+        )
+
+        r = await GetSubSessionResultTool()._execute(
+            user_id="alice",
+            session=_session("alice"),
+            sub_session_id="inner-1",
+            wait_if_running=0,
+        )
+        assert isinstance(r, SubSessionStatusResponse)
+        assert r.estimated_minutes == 20
+        assert r.success_criteria == ["runs clean"]

--- a/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/sub_session_test.py
@@ -23,12 +23,14 @@ from .get_sub_session_result import GetSubSessionResultTool
 from .models import (
     DelegatedExpertInfo,
     ErrorResponse,
+    SubSessionPhase,
     SubSessionStatusResponse,
     WorkspaceFileInfoData,
 )
 from .run_sub_session import (
     MAX_SUB_SESSION_WAIT_SECONDS,
     RunSubSessionTool,
+    _phase_note,
     apply_delegated_expert,
     response_from_outcome,
 )
@@ -1395,3 +1397,52 @@ class TestPhaseTimeline:
         assert isinstance(r, SubSessionStatusResponse)
         assert r.estimated_minutes == 20
         assert r.success_criteria == ["runs clean"]
+
+
+class TestPhaseNoteOrdering:
+    """The phase number and the phase label must always describe the SAME
+    item. Deriving the number from a count of completed todos assumed the
+    model emits them in status order, which nothing enforces."""
+
+    @staticmethod
+    def _phases(*pairs: tuple[str, str]) -> list[SubSessionPhase]:
+        return [SubSessionPhase(content=c, status=s) for c, s in pairs]  # type: ignore[arg-type]
+
+    def test_position_follows_the_in_progress_item_not_the_completed_count(self):
+        # Out-of-order plan: the in-progress item is last, but only one item
+        # is completed. Counting completions would say "Phase 2/3" while
+        # naming the third phase.
+        note = _phase_note(
+            self._phases(
+                ("Draft the outline", "completed"),
+                ("Collect sources", "pending"),
+                ("Write the report", "in_progress"),
+            )
+        )
+
+        assert note == " Phase 3/3: Write the report."
+
+    def test_in_order_plan_is_unchanged(self):
+        note = _phase_note(
+            self._phases(
+                ("Draft the outline", "completed"),
+                ("Collect sources", "in_progress"),
+                ("Write the report", "pending"),
+            )
+        )
+
+        assert note == " Phase 2/3: Collect sources."
+
+    def test_nothing_in_progress_falls_back_to_the_completed_count(self):
+        note = _phase_note(
+            self._phases(
+                ("Draft the outline", "completed"),
+                ("Collect sources", "pending"),
+            )
+        )
+
+        assert note == " Phase 2/2."
+
+    def test_no_phases_renders_nothing(self):
+        assert _phase_note(None) == ""
+        assert _phase_note([]) == ""

--- a/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
@@ -112,7 +112,12 @@ from backend.copilot.tools import TOOL_REGISTRY
 # Bumped 59_000 -> 61_000 for update_expert (the Autopilot-side soul edit,
 # same confirm gate) and raise_expert's color palette enum + persona-name
 # guidance. Merged registry measures 59625 chars; ~1.4k headroom.
-_CHAR_BUDGET = 61_000
+# Bumped 61_000 -> 62_000 for the shared estimated_minutes + success_criteria
+# params on run_sub_session and delegate_to_expert (~950 chars total). Both are
+# decision-critical: without the ETA the model reports open-ended waits, and
+# without the criteria it relays a teammate's "done" unverified. Descriptions
+# are already trimmed to the minimum viable copy; ~1.4k headroom retained.
+_CHAR_BUDGET = 62_000
 
 
 @pytest.fixture(scope="module")

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/AgentCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/AgentCards.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { CARD, HALF, RESULT_GRID, StatusPill } from "./ResultCards";
 import { asObject, inline, resultItemKey, str } from "./resultHelpers";
 import { SubSessionLive, useSubSessionEffectiveStatus } from "./SubSessionLive";
+import { SubSessionPhases, toPhases } from "./SubSessionPhases";
 
 function agentHref(agent: Record<string, unknown>): string | null {
   const id = str(agent, "id");
@@ -179,6 +180,11 @@ export function SubSessionCard({ output }: OutputCardProps) {
   const status = useSubSessionEffectiveStatus(subSessionId, frozenStatus);
   const elapsed =
     typeof output.elapsed_seconds === "number" ? output.elapsed_seconds : null;
+  const estimate =
+    typeof output.estimated_minutes === "number" && output.estimated_minutes > 0
+      ? output.estimated_minutes
+      : null;
+  const phases = toPhases(output.phases);
   const expert = asObject(output.expert);
   const avatarUrl = expert && str(expert, "avatar_url");
   const role = expert && str(expert, "role");
@@ -193,6 +199,11 @@ export function SubSessionCard({ output }: OutputCardProps) {
             <span className="ml-1.5 font-normal text-zinc-400">{role}</span>
           )}
         </p>
+        {estimate !== null && (
+          <span className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-500">
+            ~{estimate}m est
+          </span>
+        )}
         {elapsed !== null && (
           <span className="shrink-0 text-[11px] text-zinc-400">
             {elapsed >= 60
@@ -208,6 +219,7 @@ export function SubSessionCard({ output }: OutputCardProps) {
           {response}
         </p>
       )}
+      <SubSessionPhases phases={phases} />
       {/* Keyed to the FROZEN status on purpose: once mounted for a running
           output, the live view stays up after completion showing the final
           steps + answer (it stops polling on its own). */}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/SubSessionPhases.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/SubSessionPhases.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { StatusIcon } from "../TaskProgressBar/components/StatusIcon/StatusIcon";
+
+type PhaseStatus = "pending" | "in_progress" | "completed";
+
+interface Phase {
+  content: string;
+  status: PhaseStatus;
+}
+
+interface Props {
+  phases: Phase[];
+}
+
+const STATUSES: PhaseStatus[] = ["pending", "in_progress", "completed"];
+
+export function toPhases(value: unknown): Phase[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const { content, status } = entry as Record<string, unknown>;
+    if (typeof content !== "string" || !content.trim()) return [];
+    return [
+      {
+        content: content.trim(),
+        status: STATUSES.includes(status as PhaseStatus)
+          ? (status as PhaseStatus)
+          : "pending",
+      },
+    ];
+  });
+}
+
+/** The delegated run's plan as a timeline — what is done, what is happening
+ *  now, what is still queued. Elapsed seconds alone say a run is alive but
+ *  not what it is doing; this is the part the user can actually read. */
+export function SubSessionPhases({ phases }: Props) {
+  if (phases.length === 0) return null;
+  const completed = phases.filter((p) => p.status === "completed").length;
+
+  return (
+    <div className="mt-2 border-t border-zinc-100 pl-1 pt-2.5">
+      <p className="mb-1.5 text-[11px] uppercase tracking-wide text-zinc-400">
+        {completed} of {phases.length} steps done
+      </p>
+      <ul className="flex flex-col gap-1">
+        {phases.map((phase, i) => (
+          <li
+            key={`${i}-${phase.content}`}
+            className="flex items-center gap-2 text-xs"
+          >
+            <span className="flex size-4 shrink-0 items-center justify-center">
+              <StatusIcon status={phase.status} />
+            </span>
+            <span
+              className={cn(
+                "truncate",
+                phase.status === "completed" && "text-zinc-400 line-through",
+                phase.status === "in_progress" && "font-medium text-zinc-700",
+                phase.status === "pending" && "text-zinc-500",
+              )}
+            >
+              {phase.content}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/AgentCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/AgentCards.test.tsx
@@ -197,4 +197,92 @@ describe("SubSessionCard", () => {
     expect(screen.getByText("45s")).toBeDefined();
     expect(screen.queryByLabelText("Open sub-session")).toBeNull();
   });
+
+  // A running delegation used to show only a ticking clock. It now reads as a
+  // tracked job: an up-front estimate, the elapsed time, and which phase of
+  // the delegate's own plan the work has reached.
+  it("shows the estimate, the elapsed time and the phase timeline together", () => {
+    render(
+      <SubSessionCard
+        output={{
+          status: "RUNNING",
+          elapsed_seconds: 125,
+          estimated_minutes: 25,
+          sub_autopilot_session_link: "/copilot?sessionId=sub-1",
+          phases: [
+            { content: "Scaffold the agent", status: "completed" },
+            { content: "Wire the integrations", status: "in_progress" },
+            { content: "Run a smoke test", status: "pending" },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("~25m est")).toBeDefined();
+    expect(screen.getByText("2m 5s")).toBeDefined();
+    expect(screen.getByText("1 of 3 steps done")).toBeDefined();
+    expect(screen.getByText("Scaffold the agent")).toBeDefined();
+    expect(screen.getByText("Wire the integrations")).toBeDefined();
+    expect(screen.getByText("Run a smoke test")).toBeDefined();
+    expect(screen.getByLabelText("completed")).toBeDefined();
+    expect(screen.getByLabelText("in progress")).toBeDefined();
+    expect(screen.getByLabelText("pending")).toBeDefined();
+    // The deep link survives the extra chrome.
+    expect(screen.getByLabelText("Open sub-session").getAttribute("href")).toBe(
+      "/copilot?sessionId=sub-1",
+    );
+  });
+
+  it("renders no estimate chip and no timeline when the backend sent neither", () => {
+    render(
+      <SubSessionCard output={{ status: "RUNNING", elapsed_seconds: 45 }} />,
+    );
+
+    expect(screen.queryByText(/est$/)).toBeNull();
+    expect(screen.queryByText(/steps done$/)).toBeNull();
+  });
+
+  it("ignores a non-positive estimate instead of promising 0 minutes", () => {
+    render(
+      <SubSessionCard
+        output={{ status: "RUNNING", estimated_minutes: 0, elapsed_seconds: 5 }}
+      />,
+    );
+
+    expect(screen.queryByText(/est$/)).toBeNull();
+  });
+
+  it("drops malformed phase entries rather than rendering blank rows", () => {
+    render(
+      <SubSessionCard
+        output={{
+          status: "RUNNING",
+          phases: [
+            { content: "Real step", status: "completed" },
+            { content: "   ", status: "pending" },
+            { status: "pending" },
+            "junk",
+            null,
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("1 of 1 steps done")).toBeDefined();
+    expect(screen.getByText("Real step")).toBeDefined();
+  });
+
+  it("treats an unknown phase status as pending", () => {
+    render(
+      <SubSessionCard
+        output={{
+          status: "RUNNING",
+          phases: [{ content: "Mystery step", status: "wat" }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Mystery step")).toBeDefined();
+    expect(screen.getByLabelText("pending")).toBeDefined();
+  });
 });

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -16746,6 +16746,17 @@
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Delegated By Session Id"
           },
+          "estimated_minutes": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "title": "Estimated Minutes"
+          },
+          "success_criteria": {
+            "anyOf": [
+              { "items": { "type": "string" }, "type": "array" },
+              { "type": "null" }
+            ],
+            "title": "Success Criteria"
+          },
           "handed_off_from_expert_id": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Handed Off From Expert Id"


### PR DESCRIPTION
> **Stacked PR 6 of 10** — Autopilot proactivity & conversation quality.
> Base: `Abhi1992002/copilot-oauth-scope-verification`. Review only this PR's diff.

### Why / What / How

**Why.** Delegation was a black box with a clock on it. A parent could tell the user a teammate was "still running after 214s" and nothing more — no sense of how long the job should take, and no sense of what it was actually doing. Worse, when the work came back, the parent relayed "done" on the teammate's word alone. A delegation that came back 80% finished was reported as finished.

PR 4 of this stack made a finished delegation wake the parent chat. That made the second problem sharper, not softer: the woken turn is a *fresh* turn that never saw the tool call that started the work, so it had nothing at all to judge the result against.

**What.** Delegation now behaves like a tracked job.

- `delegate_to_expert` and `run_sub_session` take an optional `estimated_minutes` and `success_criteria` (2–5 testable conditions).
- The criteria are prepended to the delegated prompt, so the worker knows up front what it is measured against.
- Both are stored on the sub-session's metadata and read back on every poll — so a woken turn can state the ETA and verify the result against the definition of done.
- `get_sub_session_result` exposes a phase timeline (done / current / pending) alongside the existing message preview.
- The sub-session card renders the estimate, the elapsed time, and the phase list.
- Prompt rules: always estimate build/research work, state the ETA once, report the *phase* on later polls rather than a fresh clock reading, and never declare success without checking every criterion — including on the wake-up path.

**How.**

*Phases without a new store.* `TodoWrite` is stateless by design: the model's latest `todos` argument in the transcript *is* the canonical list, and it is persisted like any other tool call. So the snapshot is mined by walking the sub's messages backwards rather than by adding a table, a cache, or a write hook. This works for both engines — the baseline MCP tool and the SDK's CLI-native builtin write the same arguments under the same name — and it is free in `get_sub_session_result`, which already loads the sub for its ownership check. Two shapes are accepted (persisted JSON-string `arguments`, live-drain dict), and the tool *result* row is used as a fallback for the known case where the assistant row carrying the arguments was never persisted (`tool_calls_pending_save` is in-memory only; the turn's final all-completed update is the one most often lost — the frontend's `orphanTodoWriteResultToPart` compensates for the same gap).

*Verification is prompt + plumbing, no judge service.* The criteria travel storage → tool response → message text, and the wake prompt points the model at them. Nothing evaluates them automatically in v1.

*Metadata over a hot-path upsert.* A *new* sub records the estimate and criteria at creation. A resumed thread keeps the pair it was opened with — a re-delegation still carries its own criteria in the prompt, and rewriting the stored values would mean a full session upsert on the hot path just to change what a later poll reports about work already underway.

*Privacy.* Phases are withheld for a teammate's borrowed thread, matching the existing `include_progress` rule: that thread is the teammate's own user-facing chat, so its live plan may describe something the user asked them directly rather than this delegation.

*Untrusted input.* Every new value originates in model-authored JSON, so it is normalised at the boundary — booleans rejected as estimates (`True` is an `int` in Python and would surface as a 1-minute promise), absurd values clamped, criteria capped and stripped, and `None` kept distinct from `[]` so "no definition of done" stays distinguishable from "an empty one".

**Reviewer notes:**
- The tool-schema char budget moves 61k → 62k with the required rationale comment; the new params cost ~950 chars after one trim pass.
- `estimated_minutes` / `success_criteria` are typed `Any` in `_execute` because `BaseTool.execute` passes raw model JSON through with no coercion; they are narrowed immediately by the normalisers.
- Two pre-existing test fixtures left `metadata.*` as bare `MagicMock` attributes, which blew up once two new metadata fields were read onto a pydantic response. Six inline sub constructions were converted to an explicit `_sub()` factory — that is why the `sub_session_test.py` diff is larger than the new tests alone.

### Changes 🏗️

- `copilot/tools/sub_session_context.py` **(new)** — ETA normalisation, criteria prompt/reminder blocks, TodoWrite phase mining (kept out of the three already-long tool modules).
- `copilot/tools/models.py` — `SubSessionPhase`; `phases` on `SubSessionProgressSnapshot`; `estimated_minutes` / `success_criteria` / `phases` on `SubSessionStatusResponse`.
- `copilot/model.py` — the two new fields on `ChatSessionMetadata`, threaded through `ChatSession.new` and `create_chat_session`.
- `copilot/tools/run_sub_session.py`, `delegate_to_expert.py`, `get_sub_session_result.py` — params, prompt injection, storage, read-back.
- `copilot/prompting.py` — three terse delegation bullets.
- `copilot/subsession_wake.py` — the wake prompt routes the model through the criteria before it may say "done".
- `frontend .../ToolChain/SubSessionPhases.tsx` **(new)** + `AgentCards.tsx` — estimate chip and timeline; elapsed time and deep link untouched.
- Test files: 1 new backend, 4 extended, 1 frontend.

No flags added. No schema or config changes. No `openapi.json` change (`SubSessionStatusResponse` is a tool payload, not a REST shape).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/tools/sub_session_context_test.py` — normalisation, prompt blocks, transcript mining (newest list wins, both call shapes, orphan-result fallback, malformed payloads, unknown status)
  - [x] `poetry run pytest backend/copilot/tools/sub_session_test.py backend/copilot/tools/delegate_to_expert_test.py` — estimate/criteria present + absent + unusable, stored on the sub, round-tripped onto the response, prepended to the prompt, completion demands verification, phase timeline via poll and via `include_progress`, criteria ordering inside the handoff prompt
  - [x] `poetry run pytest backend/copilot/prompting_test.py backend/copilot/subsession_wake_test.py backend/copilot/tools/tool_schema_test.py`
  - [x] `pnpm test:unit` — `AgentCards.test.tsx`: estimate + elapsed + timeline together, deep link survives, absent/zero estimate, malformed phases, unknown status
  - [ ] Manual: delegate a build task with an estimate and 3 criteria; confirm the card shows `~Nm est` and the timeline advancing, and that the woken parent names an unmet criterion instead of reporting success
