### PR TITLE
feat(platform): next-step suggestion chips after a completed task

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -78,6 +78,7 @@ from backend.copilot.prompting import (
     SHARED_TOOL_NOTES,
     get_delegation_supplement,
     get_graphiti_supplement,
+    get_next_step_chips_supplement,
 )
 from backend.copilot.rate_limit import build_budget_ctx
 from backend.copilot.response_model import (
@@ -1848,6 +1849,15 @@ async def stream_chat_completion_baseline(
         Flag.HIRE_EXPERTS, user_id, default=False
     )
     delegation_supplement = get_delegation_supplement() if experts_enabled else ""
+    # Next-step chips ride their own flag, failing closed for anonymous
+    # turns.  Same reasoning as the expert gate above: the prompt rule and
+    # the tool must be enabled or disabled together.
+    next_step_chips_enabled = bool(user_id) and await is_feature_enabled(
+        Flag.COPILOT_NEXT_STEP_CHIPS, user_id, default=False
+    )
+    next_step_chips_supplement = (
+        get_next_step_chips_supplement() if next_step_chips_enabled else ""
+    )
     # Append the builder-session block (graph id+name + full building guide)
     # AFTER the shared supplements so the system prompt is byte-identical
     # across turns of the same builder session — Claude's prompt cache keeps
@@ -1858,6 +1868,7 @@ async def stream_chat_completion_baseline(
         base_system_prompt
         + SHARED_TOOL_NOTES
         + delegation_supplement
+        + next_step_chips_supplement
         + graphiti_supplement
         + builder_session_suffix
         + expert_session_suffix
@@ -2130,6 +2141,8 @@ async def stream_chat_completion_baseline(
     disabled_tool_groups: list[ToolGroup] = []
     if not graphiti_enabled:
         disabled_tool_groups.append("graphiti")
+    if not next_step_chips_enabled:
+        disabled_tool_groups.append("next_step_chips")
     # ``experts_enabled`` was resolved with the system-prompt supplements
     # above; the role split lives in the shared helper.
     disabled_tool_groups.extend(

--- a/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service_unit_test.py
@@ -48,6 +48,7 @@ from backend.copilot.response_model import (
 )
 from backend.copilot.token_tracking import _extract_cache_creation_tokens
 from backend.copilot.transcript_builder import TranscriptBuilder
+from backend.util.feature_flag import Flag
 from backend.util.prompt import CompressResult
 from backend.util.tool_call_loop import LLMLoopResponse, LLMToolCall, ToolCallResult
 
@@ -2971,7 +2972,15 @@ class TestBaselineExpertsFlagGuard:
         is_feature_enabled_mock = await _run_baseline_until_experts_gate(
             user_id="user-1", hire_experts_enabled=True
         )
-        is_feature_enabled_mock.assert_awaited_once()
+        # Assert on the HIRE_EXPERTS lookup specifically: a turn legitimately
+        # resolves other per-turn flags too, so a bare await count would break
+        # every time an unrelated flag is added.
+        hire_experts_awaits = [
+            call
+            for call in is_feature_enabled_mock.await_args_list
+            if call.args and call.args[0] is Flag.HIRE_EXPERTS
+        ]
+        assert len(hire_experts_awaits) == 1
 
 
 class TestBaselineToolExecutorForwardsDisabledGroups:

--- a/autogpt_platform/backend/backend/copilot/permissions.py
+++ b/autogpt_platform/backend/backend/copilot/permissions.py
@@ -130,6 +130,7 @@ ToolName = Literal[
     "search_feature_requests",
     "setup_agent_webhook_trigger",
     "store_skill",
+    "suggest_next_steps",
     "update_expert",
     "update_expert_soul",
     "update_folder",

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -719,6 +719,22 @@ def get_delegation_supplement() -> str:
 """
 
 
+def get_next_step_chips_supplement() -> str:
+    """Next-step chip rules, appended only when the chips flag is on.
+
+    Deliberately two sentences: these tokens ship on every turn, and the
+    argument schema on ``suggest_next_steps`` already carries the shape.
+    """
+    return """
+
+### Next steps
+After finishing substantive work, call `suggest_next_steps` just before your
+closing summary with up to 3 short imperative follow-ups you could carry out
+yourself if tapped. Skip it entirely for chit-chat, clarifications, or any turn
+that produced no result worth building on.
+"""
+
+
 def get_graphiti_supplement() -> str:
     """Get the memory system instructions to append when Graphiti is enabled.
 

--- a/autogpt_platform/backend/backend/copilot/response_model.py
+++ b/autogpt_platform/backend/backend/copilot/response_model.py
@@ -10,7 +10,7 @@ import logging
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from backend.util.json import dumps as json_dumps
 from backend.util.truncate import truncate
@@ -62,6 +62,10 @@ class ResponseType(str, Enum):
     # bubbles immediately instead of waiting for its backstop poll.
     PENDING_DRAINED = "data-pending-drained"
     MODE_CHANGED = "data-mode-changed"
+    # Next-step chips proposed by the model at the end of a substantive
+    # turn.  Supplied via the ``suggest_next_steps`` tool and re-emitted
+    # here so the client gets a typed part instead of sniffing tool output.
+    SUGGESTIONS = "data-suggestions"
 
 
 class StreamBaseResponse(BaseModel):
@@ -408,5 +412,50 @@ class StreamPendingDrained(StreamBaseResponse):
         data = {
             "type": self.type.value,
             "data": {"drainedCount": self.drainedCount},
+        }
+        return f"data: {json.dumps(data)}\n\n"
+
+
+MAX_SUGGESTIONS = 3
+MAX_SUGGESTION_LENGTH = 60
+
+
+class StreamSuggestions(StreamBaseResponse):
+    """Up to three one-tap next actions offered after a substantive turn.
+
+    The model supplies these through the ``suggest_next_steps`` tool; this
+    event re-publishes them as an AI SDK v5 data part so the client renders
+    chips from a typed ``message.parts`` entry instead of parsing tool
+    output.  Labels are normalised here rather than at the call site so the
+    same guarantees hold for events replayed from Redis on stream resume.
+    """
+
+    type: ResponseType = ResponseType.SUGGESTIONS
+    suggestions: list[str] = Field(
+        default_factory=list,
+        description=f"Short imperative labels, at most {MAX_SUGGESTIONS}.",
+    )
+
+    @field_validator("suggestions", mode="after")
+    @classmethod
+    def _normalize(cls, value: list[str]) -> list[str]:
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for raw in value:
+            label = " ".join(raw.split())[:MAX_SUGGESTION_LENGTH].strip()
+            key = label.casefold()
+            if not label or key in seen:
+                continue
+            seen.add(key)
+            cleaned.append(label)
+            if len(cleaned) == MAX_SUGGESTIONS:
+                break
+        return cleaned
+
+    def to_sse(self) -> str:
+        """Emit as an AI SDK v5 data part (``type='data-suggestions'``)."""
+        data = {
+            "type": self.type.value,
+            "data": {"suggestions": self.suggestions},
         }
         return f"data: {json.dumps(data)}\n\n"

--- a/autogpt_platform/backend/backend/copilot/response_model_test.py
+++ b/autogpt_platform/backend/backend/copilot/response_model_test.py
@@ -84,9 +84,7 @@ def test_suggestions_drop_blanks_and_duplicates_and_clamp_length():
 def test_suggestions_survive_redis_round_trip():
     """Replayed chunks are rebuilt with ``model_validate`` on stream resume;
     normalisation must apply there too."""
-    raw = StreamSuggestions(
-        suggestions=["A", "B", "C", "D"]
-    ).model_dump_json()
+    raw = StreamSuggestions(suggestions=["A", "B", "C", "D"]).model_dump_json()
     restored = StreamSuggestions.model_validate_json(raw)
     assert restored.suggestions == ["A", "B", "C"]
     assert restored.type.value == "data-suggestions"

--- a/autogpt_platform/backend/backend/copilot/response_model_test.py
+++ b/autogpt_platform/backend/backend/copilot/response_model_test.py
@@ -2,7 +2,12 @@
 
 import json
 
-from backend.copilot.response_model import StreamModeChanged
+from backend.copilot.response_model import (
+    MAX_SUGGESTION_LENGTH,
+    MAX_SUGGESTIONS,
+    StreamModeChanged,
+    StreamSuggestions,
+)
 
 
 def test_mode_changed_serializes_as_ai_sdk_data_part():
@@ -15,3 +20,73 @@ def test_mode_changed_serializes_as_ai_sdk_data_part():
         "type": "data-mode-changed",
         "data": {"mode": "extended_thinking"},
     }
+
+
+def _payload(event: StreamSuggestions) -> dict:
+    sse = event.to_sse()
+    assert sse.startswith("data: ")
+    return json.loads(sse[len("data: ") :])
+
+
+def test_suggestions_serialize_as_ai_sdk_data_part():
+    """Chips must arrive nested under ``data`` so the AI SDK surfaces them
+    as a ``data-suggestions`` part on ``message.parts``."""
+    event = StreamSuggestions(
+        suggestions=["Email the report", "Post on r/SaaS", "Fix the criticals"]
+    )
+    assert _payload(event) == {
+        "type": "data-suggestions",
+        "data": {
+            "suggestions": [
+                "Email the report",
+                "Post on r/SaaS",
+                "Fix the criticals",
+            ]
+        },
+    }
+
+
+def test_suggestions_absent_serializes_as_empty_list():
+    """A turn with nothing worth suggesting still round-trips — the client
+    renders no chips rather than crashing on a missing key."""
+    assert _payload(StreamSuggestions()) == {
+        "type": "data-suggestions",
+        "data": {"suggestions": []},
+    }
+
+
+def test_suggestions_beyond_the_cap_are_truncated():
+    """The model is told "up to 3"; a fourth is dropped at the model layer so
+    the cap holds for replayed events too, not just freshly published ones."""
+    event = StreamSuggestions(
+        suggestions=["One", "Two", "Three", "Four", "Five"],
+    )
+    assert event.suggestions == ["One", "Two", "Three"]
+    assert len(_payload(event)["data"]["suggestions"]) == MAX_SUGGESTIONS
+
+
+def test_suggestions_drop_blanks_and_duplicates_and_clamp_length():
+    event = StreamSuggestions(
+        suggestions=[
+            "  Email   the report  ",
+            "",
+            "   ",
+            "email the report",
+            "x" * (MAX_SUGGESTION_LENGTH + 20),
+        ]
+    )
+    assert event.suggestions == [
+        "Email the report",
+        "x" * MAX_SUGGESTION_LENGTH,
+    ]
+
+
+def test_suggestions_survive_redis_round_trip():
+    """Replayed chunks are rebuilt with ``model_validate`` on stream resume;
+    normalisation must apply there too."""
+    raw = StreamSuggestions(
+        suggestions=["A", "B", "C", "D"]
+    ).model_dump_json()
+    restored = StreamSuggestions.model_validate_json(raw)
+    assert restored.suggestions == ["A", "B", "C"]
+    assert restored.type.value == "data-suggestions"

--- a/autogpt_platform/backend/backend/copilot/sdk/expert_tool_gate_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/expert_tool_gate_test.py
@@ -34,6 +34,7 @@ from claude_agent_sdk import ResultMessage
 
 from backend.copilot.model import ChatMessage, ChatSession
 from backend.copilot.response_model import StreamStart
+from backend.util.feature_flag import Flag
 
 _SVC = "backend.copilot.sdk.service"
 
@@ -160,6 +161,11 @@ def _make_patches(*, hire_experts_enabled: bool):
     return patches, mcp_server_mock, is_feature_enabled_mock
 
 
+def _await_count(mock, flag) -> int:
+    """How many times *flag* specifically was resolved."""
+    return sum(1 for call in mock.await_args_list if call.args and call.args[0] is flag)
+
+
 async def _run_sdk_turn(*, user_id: str | None, hire_experts_enabled: bool):
     from backend.copilot.sdk.service import stream_chat_completion_sdk
 
@@ -210,7 +216,10 @@ class TestSdkExpertsFlagGuard:
             user_id="test-user", hire_experts_enabled=True
         )
 
-        is_feature_enabled_mock.assert_awaited_once()
+        # Assert on the HIRE_EXPERTS lookup specifically: a turn legitimately
+        # resolves other per-turn flags too, so a bare await count would break
+        # every time an unrelated flag is added.
+        assert _await_count(is_feature_enabled_mock, Flag.HIRE_EXPERTS) == 1
         hidden = mcp_server_mock.call_args.kwargs["hidden_tool_names"]
         # Plain Autopilot session (no session.expert_id): loses the
         # expert-session tools, keeps the staffing ("expert_admin") tools.

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -107,6 +107,7 @@ from ..permissions import (
 from ..prompting import (
     get_delegation_supplement,
     get_graphiti_supplement,
+    get_next_step_chips_supplement,
     get_sdk_supplement,
 )
 from ..rate_limit import (
@@ -4337,6 +4338,15 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             Flag.HIRE_EXPERTS, user_id, default=False
         )
         delegation_supplement = get_delegation_supplement() if experts_enabled else ""
+        # Next-step chips ride their own flag, failing closed for anonymous
+        # turns.  Same reasoning as the expert gate above: the prompt rule
+        # and the MCP tool must be enabled or disabled together.
+        next_step_chips_enabled = bool(user_id) and await is_feature_enabled(
+            Flag.COPILOT_NEXT_STEP_CHIPS, user_id, default=False
+        )
+        next_step_chips_supplement = (
+            get_next_step_chips_supplement() if next_step_chips_enabled else ""
+        )
         # Append the builder-session block (graph id+name + full building
         # guide) AFTER the shared supplements so the system prompt is
         # byte-identical across turns of the same builder session — Claude's
@@ -4352,6 +4362,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             base_system_prompt
             + get_sdk_supplement(use_e2b=use_e2b)
             + delegation_supplement
+            + next_step_chips_supplement
             + graphiti_supplement
             + builder_session_suffix
             + expert_session_suffix
@@ -4396,6 +4407,8 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         disabled_tool_groups: list[ToolGroup] = []
         if not graphiti_enabled:
             disabled_tool_groups.append("graphiti")
+        if not next_step_chips_enabled:
+            disabled_tool_groups.append("next_step_chips")
         # ``experts_enabled`` was resolved with the system-prompt supplements
         # above; the role split lives in the shared helper.
         disabled_tool_groups.extend(

--- a/autogpt_platform/backend/backend/copilot/stream_registry.py
+++ b/autogpt_platform/backend/backend/copilot/stream_registry.py
@@ -55,6 +55,7 @@ from .response_model import (
     StreamStart,
     StreamStartStep,
     StreamStatus,
+    StreamSuggestions,
     StreamTextDelta,
     StreamTextEnd,
     StreamTextStart,
@@ -1179,6 +1180,7 @@ def _reconstruct_chunk(chunk_data: dict) -> StreamBaseResponse | None:
         ResponseType.DREAM_OPERATIONS.value: StreamDreamOperations,
         ResponseType.PENDING_DRAINED.value: StreamPendingDrained,
         ResponseType.MODE_CHANGED.value: StreamModeChanged,
+        ResponseType.SUGGESTIONS.value: StreamSuggestions,
     }
 
     chunk_type = chunk_data.get("type")

--- a/autogpt_platform/backend/backend/copilot/tools/__init__.py
+++ b/autogpt_platform/backend/backend/copilot/tools/__init__.py
@@ -61,6 +61,7 @@ from .schedule_followup import ScheduleFollowupTool
 from .search_docs import SearchDocsTool
 from .setup_agent_webhook_trigger import SetupAgentWebhookTriggerTool
 from .skills import DeleteSkillTool, ListSkillsTool, ReadSkillTool, StoreSkillTool
+from .suggest_next_steps import SuggestNextStepsTool
 from .todo_write import TodoWriteTool
 from .update_expert import UpdateExpertTool
 from .update_soul import ConfirmExpertSoulUpdateTool, UpdateExpertSoulTool
@@ -124,6 +125,7 @@ TOOL_REGISTRY: dict[str, BaseTool] = {
     "get_sub_session_result": GetSubSessionResultTool(),
     "delegate_to_expert": DelegateToExpertTool(),
     "TodoWrite": TodoWriteTool(),
+    "suggest_next_steps": SuggestNextStepsTool(),
     "run_mcp_tool": RunMCPToolTool(),
     "get_mcp_guide": GetMCPGuideTool(),
     "view_agent_output": AgentOutputTool(),
@@ -185,7 +187,9 @@ run_agent_tool = TOOL_REGISTRY["run_agent"]
 # for tools whose backend is off and then hit opaque runtime errors.  Add
 # a new group by extending ``ToolGroup`` and registering its members in
 # ``TOOL_GROUPS`` below.
-ToolGroup = Literal["graphiti", "experts", "expert_admin", "delegation"]
+ToolGroup = Literal[
+    "graphiti", "experts", "expert_admin", "delegation", "next_step_chips"
+]
 
 TOOL_GROUPS: dict[str, ToolGroup] = {
     "memory_store": "graphiti",
@@ -211,6 +215,10 @@ TOOL_GROUPS: dict[str, ToolGroup] = {
     # and expert sessions alike), so it has its own group: the engines
     # disable it only when the user's hire-experts flag is off.
     "delegate_to_expert": "delegation",
+    # Chips are gated on ``copilot-next-step-chips``; when the flag is off
+    # the engines disable this group so the model is never told to call a
+    # tool whose UI surface is hidden.
+    "suggest_next_steps": "next_step_chips",
 }
 
 

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -109,6 +109,7 @@ class ResponseType(str, Enum):
 
     # Planning
     TODO_WRITE = "todo_write"
+    NEXT_STEPS_SUGGESTED = "next_steps_suggested"
 
     # Platform info
     PLATFORM_INFO = "platform_info"
@@ -1293,6 +1294,18 @@ class TodoWriteResponse(ToolResponseBase):
 
     type: ResponseType = ResponseType.TODO_WRITE
     todos: list[TodoItem] = Field(default_factory=list)
+
+
+class SuggestNextStepsResponse(ToolResponseBase):
+    """Ack returned by ``suggest_next_steps``.
+
+    Echoes the normalised labels back so the model sees exactly what the
+    user was offered — the chips themselves reach the client through the
+    ``data-suggestions`` stream part emitted while the tool runs.
+    """
+
+    type: ResponseType = ResponseType.NEXT_STEPS_SUGGESTED
+    suggestions: list[str] = Field(default_factory=list)
 
 
 class PlatformInfoResponse(ToolResponseBase):

--- a/autogpt_platform/backend/backend/copilot/tools/suggest_next_steps.py
+++ b/autogpt_platform/backend/backend/copilot/tools/suggest_next_steps.py
@@ -1,0 +1,123 @@
+"""Next-step chips offered to the user after a substantive turn.
+
+The model supplies up to three short imperative labels; this tool
+normalises them and republishes them onto the live turn stream as a
+``data-suggestions`` part, so the client renders chips from a typed
+``message.parts`` entry instead of parsing tool output.
+
+Emitting from the tool (rather than from ``mark_session_completed``) keeps
+the chips authored by the model — the same way ``TodoWrite`` lets the model
+own the checklist — and reuses the mid-turn publish path already used by
+``pending_messages._notify_pending_drained``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from backend.copilot.model import ChatSession
+from backend.copilot.response_model import (
+    MAX_SUGGESTION_LENGTH,
+    MAX_SUGGESTIONS,
+    StreamSuggestions,
+)
+from backend.copilot.stream_registry import get_session, publish_chunk
+
+from .base import BaseTool
+from .models import ErrorResponse, SuggestNextStepsResponse, ToolResponseBase
+
+logger = logging.getLogger(__name__)
+
+
+class SuggestNextStepsTool(BaseTool):
+    """Offer the user up to three one-tap follow-up actions."""
+
+    @property
+    def name(self) -> str:
+        return "suggest_next_steps"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Offer the user up to 3 one-tap next actions as chips, right "
+            "before your closing summary. Only after substantive work, and "
+            "only for actions you can carry out yourself if tapped."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "suggestions": {
+                    "type": "array",
+                    "description": (
+                        "Short imperative labels, e.g. 'Email the report'. "
+                        f"At most {MAX_SUGGESTIONS}; extras are dropped."
+                    ),
+                    "maxItems": MAX_SUGGESTIONS,
+                    "items": {
+                        "type": "string",
+                        "maxLength": MAX_SUGGESTION_LENGTH,
+                    },
+                },
+            },
+            "required": ["suggestions"],
+        }
+
+    async def _execute(
+        self,
+        user_id: str | None,
+        session: ChatSession,
+        **kwargs: Any,
+    ) -> ToolResponseBase:
+        del user_id
+        raw = kwargs.get("suggestions")
+        if not isinstance(raw, list):
+            return ErrorResponse(
+                message="`suggestions` must be an array of strings.",
+                session_id=session.session_id,
+            )
+        if any(not isinstance(item, str) for item in raw):
+            return ErrorResponse(
+                message="`suggestions` entries must be strings.",
+                session_id=session.session_id,
+            )
+
+        event = StreamSuggestions(suggestions=raw)
+        if not event.suggestions:
+            return ErrorResponse(
+                message="`suggestions` contained no usable labels.",
+                session_id=session.session_id,
+            )
+
+        await _publish_suggestions(session.session_id, event)
+        return SuggestNextStepsResponse(
+            message="Next-step chips shown to the user.",
+            session_id=session.session_id,
+            suggestions=event.suggestions,
+        )
+
+
+async def _publish_suggestions(
+    session_id: str | None, event: StreamSuggestions
+) -> None:
+    """Push the chips onto the session's live turn stream.
+
+    Best-effort: chips are a convenience surface, so a failed publish must
+    never fail the turn the model just completed.
+    """
+    if not session_id:
+        return
+    try:
+        active = await get_session(session_id)
+        if active is None or not active.turn_id:
+            return
+        await publish_chunk(active.turn_id, event, session_id=session_id)
+    except Exception:
+        logger.debug(
+            "suggest_next_steps: chip emit failed for session=%s",
+            session_id,
+            exc_info=True,
+        )

--- a/autogpt_platform/backend/backend/copilot/tools/suggest_next_steps_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/suggest_next_steps_test.py
@@ -1,0 +1,134 @@
+"""Tests for SuggestNextStepsTool."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.copilot.model import ChatSession
+from backend.copilot.response_model import MAX_SUGGESTIONS, StreamSuggestions
+from backend.copilot.tools.models import ErrorResponse, SuggestNextStepsResponse
+from backend.copilot.tools.suggest_next_steps import SuggestNextStepsTool
+
+
+@pytest.fixture()
+def tool() -> SuggestNextStepsTool:
+    return SuggestNextStepsTool()
+
+
+@pytest.fixture()
+def session() -> ChatSession:
+    return ChatSession.new(user_id="test-user", dry_run=False)
+
+
+class _ActiveTurn:
+    def __init__(self, turn_id: str) -> None:
+        self.turn_id = turn_id
+
+
+@pytest.fixture()
+def publish():
+    with patch(
+        "backend.copilot.tools.suggest_next_steps.publish_chunk",
+        new=AsyncMock(),
+    ) as publish_chunk, patch(
+        "backend.copilot.tools.suggest_next_steps.get_session",
+        new=AsyncMock(return_value=_ActiveTurn("turn-1")),
+    ):
+        yield publish_chunk
+
+
+@pytest.mark.asyncio
+async def test_publishes_chips_onto_the_turn_stream(
+    tool: SuggestNextStepsTool, session: ChatSession, publish: AsyncMock
+):
+    result = await tool._execute(
+        user_id="test-user",
+        session=session,
+        suggestions=["Email the report", "Post on r/SaaS"],
+    )
+
+    assert isinstance(result, SuggestNextStepsResponse)
+    assert result.suggestions == ["Email the report", "Post on r/SaaS"]
+
+    publish.assert_awaited_once()
+    turn_id, event = publish.await_args.args
+    assert turn_id == "turn-1"
+    assert isinstance(event, StreamSuggestions)
+    assert event.suggestions == ["Email the report", "Post on r/SaaS"]
+
+
+@pytest.mark.asyncio
+async def test_extra_suggestions_are_dropped(
+    tool: SuggestNextStepsTool, session: ChatSession, publish: AsyncMock
+):
+    result = await tool._execute(
+        user_id="test-user",
+        session=session,
+        suggestions=["One", "Two", "Three", "Four"],
+    )
+
+    assert isinstance(result, SuggestNextStepsResponse)
+    assert result.suggestions == ["One", "Two", "Three"]
+    assert len(result.suggestions) == MAX_SUGGESTIONS
+
+
+@pytest.mark.asyncio
+async def test_non_list_returns_error_without_publishing(
+    tool: SuggestNextStepsTool, session: ChatSession, publish: AsyncMock
+):
+    result = await tool._execute(
+        user_id="test-user", session=session, suggestions="Email the report"
+    )
+
+    assert isinstance(result, ErrorResponse)
+    publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_string_entries_return_error(
+    tool: SuggestNextStepsTool, session: ChatSession, publish: AsyncMock
+):
+    result = await tool._execute(
+        user_id="test-user", session=session, suggestions=["Ok", 7]
+    )
+
+    assert isinstance(result, ErrorResponse)
+    publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_all_blank_suggestions_return_error(
+    tool: SuggestNextStepsTool, session: ChatSession, publish: AsyncMock
+):
+    result = await tool._execute(
+        user_id="test-user", session=session, suggestions=["", "   "]
+    )
+
+    assert isinstance(result, ErrorResponse)
+    publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_failure_does_not_fail_the_turn(
+    tool: SuggestNextStepsTool, session: ChatSession
+):
+    """Chips are a convenience surface — a Redis hiccup must not surface as
+    a tool error the model then has to apologise for."""
+    with patch(
+        "backend.copilot.tools.suggest_next_steps.get_session",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        result = await tool._execute(
+            user_id="test-user", session=session, suggestions=["Email the report"]
+        )
+
+    assert isinstance(result, SuggestNextStepsResponse)
+    assert result.suggestions == ["Email the report"]
+
+
+def test_openai_schema_shape(tool: SuggestNextStepsTool):
+    schema = tool.as_openai_tool()
+    assert schema["function"]["name"] == "suggest_next_steps"
+    params = schema["function"]["parameters"]
+    assert params["required"] == ["suggestions"]
+    assert params["properties"]["suggestions"]["maxItems"] == MAX_SUGGESTIONS

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -77,6 +77,11 @@ class Flag(str, Enum):
     # (default False) — these are unprompted messages, so a flag lookup
     # failure has to mean silence rather than a surprise post.
     COPILOT_PROACTIVE_WATCHERS = "copilot-proactive-watchers"
+    # Next-step chips after a completed task (suggest_next_steps tool +
+    # the prompt rule that asks for them + the chips under the final
+    # assistant message).  Fail-closed: when off the tool is not offered
+    # to the model and the prompt rule is omitted entirely.
+    COPILOT_NEXT_STEP_CHIPS = "copilot-next-step-chips"
     COPILOT_TIER_MULTIPLIERS = "copilot-tier-multipliers"
     COPILOT_TIER_WORKSPACE_STORAGE_LIMITS = "copilot-tier-workspace-storage-limits"
     COPILOT_TIER_STRIPE_PRICES = "copilot-tier-stripe-prices"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/next-step-chips.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/next-step-chips.test.tsx
@@ -52,11 +52,7 @@ vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
   };
 });
 
-const SUGGESTIONS = [
-  "Email the report",
-  "Post on r/SaaS",
-  "Fix the criticals",
-];
+const SUGGESTIONS = ["Email the report", "Post on r/SaaS", "Fix the criticals"];
 
 function turnWithSuggestions(
   text: string,
@@ -146,7 +142,9 @@ describe("next-step chips", () => {
 
     const chips = await screen.findByTestId("next-step-chips");
     const user = userEvent.setup();
-    await user.click(within(chips).getByRole("button", { name: SUGGESTIONS[0] }));
+    await user.click(
+      within(chips).getByRole("button", { name: SUGGESTIONS[0] }),
+    );
 
     await waitFor(
       () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/next-step-chips.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/next-step-chips.test.tsx
@@ -1,0 +1,210 @@
+import { server } from "@/mocks/mock-server";
+import { streamSseResponse } from "@/tests/integrations/copilot-sse";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UIMessageChunk } from "ai";
+import { http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetCopilotChatRegistry } from "../copilotChatRegistry";
+import {
+  renderHost,
+  TEST_BACKEND_BASE_URL,
+  TEST_SESSION_ID,
+  typeAndSend,
+} from "./sse-helpers";
+
+// Pin the backend host so the CoPilot transport's absolute URL is deterministic.
+vi.mock("@/services/environment", async (importActual) => {
+  const actual = await importActual<typeof import("@/services/environment")>();
+  return {
+    ...actual,
+    environment: {
+      ...actual.environment,
+      getAGPTServerBaseUrl: () => TEST_BACKEND_BASE_URL,
+    },
+  };
+});
+
+vi.mock("../helpers", async (importActual) => {
+  const actual = await importActual<typeof import("../helpers")>();
+  return { ...actual, getCopilotAuthHeaders: async () => ({}) };
+});
+
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => ({ isUserLoading: false, isLoggedIn: true }),
+}));
+
+// Only the chips flag is on: everything else off keeps the input rendering a
+// single Submit button, which ``typeAndSend`` relies on.
+const flagState = vi.hoisted(() => ({ nextStepChips: true }));
+
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    useGetFlag: (flag: string) =>
+      flag === actual.Flag.COPILOT_NEXT_STEP_CHIPS
+        ? flagState.nextStepChips
+        : false,
+  };
+});
+
+const SUGGESTIONS = [
+  "Email the report",
+  "Post on r/SaaS",
+  "Fix the criticals",
+];
+
+function turnWithSuggestions(
+  text: string,
+  suggestions: string[],
+  messageId: string,
+): UIMessageChunk[] {
+  const textPartId = `${messageId}-text`;
+  return [
+    { type: "start", messageId },
+    { type: "start-step" },
+    { type: "text-start", id: textPartId },
+    { type: "text-delta", id: textPartId, delta: text },
+    { type: "text-end", id: textPartId },
+    { type: "data-suggestions", data: { suggestions } },
+    { type: "finish-step" },
+    { type: "finish" },
+  ] as UIMessageChunk[];
+}
+
+/**
+ * Records the ``message`` field of every stream POST so a test can assert
+ * what the chip actually sent, not just what re-rendered.
+ */
+function recordingStreamHandler(chunksPerTurn: UIMessageChunk[][]) {
+  const sentMessages: string[] = [];
+  let turn = 0;
+  const handler = http.post(
+    `${TEST_BACKEND_BASE_URL}/api/chat/sessions/${TEST_SESSION_ID}/stream`,
+    async ({ request }) => {
+      const body = (await request.clone().json()) as { message?: string };
+      sentMessages.push(body.message ?? "");
+      const chunks =
+        chunksPerTurn[turn] ?? chunksPerTurn[chunksPerTurn.length - 1];
+      turn += 1;
+      return streamSseResponse(chunks, { abortSignal: request.signal });
+    },
+  );
+  return { handler, sentMessages };
+}
+
+beforeEach(() => {
+  flagState.nextStepChips = true;
+  resetCopilotChatRegistry();
+});
+
+afterEach(() => {
+  resetCopilotChatRegistry();
+});
+
+describe("next-step chips", () => {
+  it("renders the model's suggestions as chips under the final assistant message", async () => {
+    const { handler } = recordingStreamHandler([
+      turnWithSuggestions("Report is ready.", SUGGESTIONS, "assistant-1"),
+    ]);
+    server.use(handler);
+    renderHost();
+
+    await typeAndSend("build me a report");
+
+    expect(
+      await screen.findByText("Report is ready.", undefined, { timeout: 5000 }),
+    ).toBeDefined();
+
+    const chips = await screen.findByTestId("next-step-chips");
+    for (const label of SUGGESTIONS) {
+      expect(within(chips).getByRole("button", { name: label })).toBeDefined();
+    }
+
+    // The chips belong to the assistant message that produced them, not to
+    // the message list as a whole.
+    const assistantMessage = chips.closest("[data-message-id]");
+    expect(assistantMessage).not.toBeNull();
+    expect(
+      within(assistantMessage as HTMLElement).getByText("Report is ready."),
+    ).toBeDefined();
+  });
+
+  it("sends the chip's text as the next user message when clicked", async () => {
+    const { handler, sentMessages } = recordingStreamHandler([
+      turnWithSuggestions("Report is ready.", SUGGESTIONS, "assistant-1"),
+      turnWithSuggestions("Sent it over.", [], "assistant-2"),
+    ]);
+    server.use(handler);
+    renderHost();
+
+    await typeAndSend("build me a report");
+
+    const chips = await screen.findByTestId("next-step-chips");
+    const user = userEvent.setup();
+    await user.click(within(chips).getByRole("button", { name: SUGGESTIONS[0] }));
+
+    await waitFor(
+      () => {
+        expect(sentMessages).toEqual(["build me a report", "Email the report"]);
+      },
+      { timeout: 5000 },
+    );
+
+    expect(
+      await screen.findByText("Sent it over.", undefined, { timeout: 5000 }),
+    ).toBeDefined();
+  });
+
+  it("renders no chips when the model offered none", async () => {
+    const { handler } = recordingStreamHandler([
+      turnWithSuggestions("Yes, that's right.", [], "assistant-1"),
+    ]);
+    server.use(handler);
+    renderHost();
+
+    await typeAndSend("is 2 + 2 four?");
+
+    expect(
+      await screen.findByText("Yes, that's right.", undefined, {
+        timeout: 5000,
+      }),
+    ).toBeDefined();
+    expect(screen.queryByTestId("next-step-chips")).toBeNull();
+  });
+
+  it("renders no chips when the flag is off, even if the backend sent some", async () => {
+    flagState.nextStepChips = false;
+    const { handler } = recordingStreamHandler([
+      turnWithSuggestions("Report is ready.", SUGGESTIONS, "assistant-1"),
+    ]);
+    server.use(handler);
+    renderHost();
+
+    await typeAndSend("build me a report");
+
+    expect(
+      await screen.findByText("Report is ready.", undefined, { timeout: 5000 }),
+    ).toBeDefined();
+    expect(screen.queryByTestId("next-step-chips")).toBeNull();
+    expect(screen.queryByRole("button", { name: SUGGESTIONS[0] })).toBeNull();
+  });
+
+  it("never leaks the raw data-suggestions payload into the message body", async () => {
+    const { handler } = recordingStreamHandler([
+      turnWithSuggestions("Report is ready.", SUGGESTIONS, "assistant-1"),
+    ]);
+    server.use(handler);
+    renderHost();
+
+    await typeAndSend("build me a report");
+
+    const chips = await screen.findByTestId("next-step-chips");
+    const assistantMessage = chips.closest("[data-message-id]") as HTMLElement;
+    expect(assistantMessage.textContent).not.toContain("data-suggestions");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -31,6 +31,7 @@ import {
   shouldShowTaskListNotice,
   splitReasoningAndResponse,
 } from "./helpers";
+import { SUGGESTIONS_PART_TYPE } from "../../nextStepSuggestions";
 import { RESTORE_STALL_TIMEOUT_MS } from "../../restoreConstants";
 import type { ExpertIdentity } from "../../useExpertMap";
 import { useCopilotUIStore } from "../../store";
@@ -45,6 +46,7 @@ import { ExpertAvatar } from "./components/ExpertAvatar/ExpertAvatar";
 import { ExpertSchedulesButton } from "./components/ExpertSchedulesButton/ExpertSchedulesButton";
 import { MessageAttachments } from "./components/MessageAttachments";
 import { MessagePartRenderer } from "./components/MessagePartRenderer";
+import { NextStepChips } from "./components/NextStepChips/NextStepChips";
 import { QueueBadge } from "./components/QueueBadge";
 import { ReasoningGroup } from "./components/ReasoningGroup";
 import { StepsCollapse } from "./components/StepsCollapse";
@@ -467,6 +469,7 @@ export function ChatMessagesContainer({
       const part = lastMessage.parts[i];
       if (part.type === "data-cursor") continue;
       if (part.type === "data-dream-operations") continue;
+      if (part.type === SUGGESTIONS_PART_TYPE) continue;
       if (part.type === "data-status") {
         const data = (part as { data?: { message?: unknown } }).data;
         return typeof data?.message === "string" ? data.message : null;
@@ -673,11 +676,15 @@ export function ChatMessagesContainer({
               isAssistant &&
               messageIndex <= messages.length - 1 &&
               (!nextMessage || nextMessage.role === "user");
-            // data-cursor / data-status parts are internal bookkeeping —
-            // strip them before any render/split logic so they never reach
-            // the user UI. data-status surfaces via ThinkingIndicator.
+            // data-cursor / data-status / data-suggestions parts are
+            // internal bookkeeping — strip them before any render/split
+            // logic so they never reach the user UI. data-status surfaces
+            // via ThinkingIndicator, data-suggestions via NextStepChips.
             const renderableParts = message.parts.filter(
-              (p) => p.type !== "data-cursor" && p.type !== "data-status",
+              (p) =>
+                p.type !== "data-cursor" &&
+                p.type !== "data-status" &&
+                p.type !== SUGGESTIONS_PART_TYPE,
             );
             const textParts = renderableParts.filter(
               (p): p is Extract<typeof p, { type: "text" }> =>
@@ -860,10 +867,13 @@ export function ChatMessagesContainer({
                   />
                 )}
                 {!readOnly && showActions && (
-                  <AssistantMessageActions
-                    message={message}
-                    sessionID={sessionID ?? null}
-                  />
+                  <>
+                    <AssistantMessageActions
+                      message={message}
+                      sessionID={sessionID ?? null}
+                    />
+                    <NextStepChips parts={message.parts} />
+                  </>
                 )}
                 {readOnly && showActions && (
                   <MessageActions

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -420,14 +420,16 @@ export function ChatMessagesContainer({
 
   const hasInflight = (() => {
     if (lastMessage?.role !== "assistant") return false;
-    // Ignore bookkeeping parts. data-cursor is legacy resume metadata and
-    // data-status is transient copy for the Thinking indicator; neither
-    // counts as "real" content that hides the indicator.
+    // Ignore bookkeeping parts. data-cursor is legacy resume metadata,
+    // data-status is transient copy for the Thinking indicator, and
+    // data-suggestions arrives before the final summary finishes streaming;
+    // none counts as "real" content that hides the indicator.
     const parts = lastMessage.parts.filter(
       (p) =>
         p.type !== "data-cursor" &&
         p.type !== "data-status" &&
-        p.type !== "data-dream-operations",
+        p.type !== "data-dream-operations" &&
+        p.type !== SUGGESTIONS_PART_TYPE,
     );
     if (parts.length === 0) return false;
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/NextStepChips.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/NextStepChips.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { ArrowRight02Icon } from "@hugeicons/core-free-icons";
+import type { MessagePart } from "../../helpers";
+import { useNextStepChips } from "./useNextStepChips";
+
+interface Props {
+  parts: MessagePart[];
+}
+
+export function NextStepChips({ parts }: Props) {
+  const { suggestions, sentLabel, handleSelect } = useNextStepChips(parts);
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div
+      data-testid="next-step-chips"
+      className="mt-3 flex flex-wrap items-center gap-2"
+    >
+      {suggestions.map((label) => (
+        <button
+          key={label}
+          type="button"
+          disabled={sentLabel !== null}
+          onClick={() => handleSelect(label)}
+          className="group inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-700 transition-colors hover:border-zinc-300 hover:bg-zinc-50 hover:text-zinc-900 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {label}
+          <Icon
+            icon={ArrowRight02Icon}
+            size={14}
+            className="text-zinc-400 transition-colors group-hover:text-zinc-600"
+          />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/__tests__/helpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { MessagePart } from "../../../helpers";
+import { getNextStepSuggestions } from "../helpers";
+
+function suggestionsPart(suggestions: unknown): MessagePart {
+  return {
+    type: "data-suggestions",
+    data: { suggestions },
+  } as unknown as MessagePart;
+}
+
+const TEXT_PART = { type: "text", text: "Report is ready." } as MessagePart;
+
+describe("getNextStepSuggestions", () => {
+  it("returns the labels from a data-suggestions part", () => {
+    expect(
+      getNextStepSuggestions([
+        TEXT_PART,
+        suggestionsPart(["Email the report", "Post on r/SaaS"]),
+      ]),
+    ).toEqual(["Email the report", "Post on r/SaaS"]);
+  });
+
+  it("returns nothing when the message carries no suggestions part", () => {
+    expect(getNextStepSuggestions([TEXT_PART])).toEqual([]);
+  });
+
+  it("keeps only the last part so a replayed stream does not stack rows", () => {
+    expect(
+      getNextStepSuggestions([
+        suggestionsPart(["Stale suggestion"]),
+        suggestionsPart(["Email the report"]),
+      ]),
+    ).toEqual(["Email the report"]);
+  });
+
+  it("caps the row at three chips", () => {
+    expect(
+      getNextStepSuggestions([suggestionsPart(["a", "b", "c", "d", "e"])]),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops blanks and non-strings instead of rendering empty chips", () => {
+    expect(
+      getNextStepSuggestions([suggestionsPart(["  Email  ", "", 7, null])]),
+    ).toEqual(["Email"]);
+  });
+
+  it("ignores a malformed payload rather than throwing", () => {
+    expect(getNextStepSuggestions([suggestionsPart("not an array")])).toEqual(
+      [],
+    );
+    expect(
+      getNextStepSuggestions([
+        { type: "data-suggestions" } as unknown as MessagePart,
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/helpers.ts
@@ -1,0 +1,18 @@
+import { readSuggestionsPart } from "../../../../nextStepSuggestions";
+import type { MessagePart } from "../../helpers";
+
+/**
+ * Collect the chip labels carried by one assistant message.
+ *
+ * The backend publishes at most one ``data-suggestions`` part per turn,
+ * but a resumed stream replays it — the last part wins so a replay never
+ * doubles the chip row.
+ */
+export function getNextStepSuggestions(parts: MessagePart[]): string[] {
+  let latest: string[] = [];
+  for (const part of parts) {
+    const suggestions = readSuggestionsPart(part);
+    if (suggestions && suggestions.length > 0) latest = suggestions;
+  }
+  return latest;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/useNextStepChips.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/useNextStepChips.ts
@@ -1,23 +1,26 @@
 "use client";
 
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
-import { useState } from "react";
-import { useCopilotChatActions } from "../../../CopilotChatActionsProvider/useCopilotChatActions";
+import { useContext, useState } from "react";
+import { CopilotChatActionsContext } from "../../../CopilotChatActionsProvider/useCopilotChatActions";
 import type { MessagePart } from "../../helpers";
 import { getNextStepSuggestions } from "./helpers";
 
 export function useNextStepChips(parts: MessagePart[]) {
   const isEnabled = useGetFlag(Flag.COPILOT_NEXT_STEP_CHIPS);
-  const { onSend } = useCopilotChatActions();
+  // Read the context rather than the throwing hook: the message list also
+  // renders on surfaces that mount no provider, and a chip that cannot send
+  // should simply not appear there.
+  const actions = useContext(CopilotChatActionsContext);
   const [sentLabel, setSentLabel] = useState<string | null>(null);
 
-  const suggestions = isEnabled ? getNextStepSuggestions(parts) : [];
+  const suggestions = isEnabled && actions ? getNextStepSuggestions(parts) : [];
 
   async function handleSelect(label: string) {
-    if (sentLabel) return;
+    if (sentLabel || !actions) return;
     setSentLabel(label);
     try {
-      await onSend(label);
+      await actions.onSend(label);
     } catch {
       setSentLabel(null);
     }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/useNextStepChips.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/NextStepChips/useNextStepChips.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
+import { useState } from "react";
+import { useCopilotChatActions } from "../../../CopilotChatActionsProvider/useCopilotChatActions";
+import type { MessagePart } from "../../helpers";
+import { getNextStepSuggestions } from "./helpers";
+
+export function useNextStepChips(parts: MessagePart[]) {
+  const isEnabled = useGetFlag(Flag.COPILOT_NEXT_STEP_CHIPS);
+  const { onSend } = useCopilotChatActions();
+  const [sentLabel, setSentLabel] = useState<string | null>(null);
+
+  const suggestions = isEnabled ? getNextStepSuggestions(parts) : [];
+
+  async function handleSelect(label: string) {
+    if (sentLabel) return;
+    setSentLabel(label);
+    try {
+      await onSend(label);
+    } catch {
+      setSentLabel(null);
+    }
+  }
+
+  return {
+    suggestions,
+    sentLabel,
+    handleSelect,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/nextStepSuggestions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/nextStepSuggestions.ts
@@ -1,0 +1,33 @@
+import type { UIMessage } from "ai";
+
+/**
+ * AI SDK v5 wire type for the next-step chips the model offers at the end
+ * of a substantive turn. Matches ``ResponseType.SUGGESTIONS`` on the
+ * backend (``data-suggestions``), published by the ``suggest_next_steps``
+ * tool in ``copilot/tools/suggest_next_steps.py``.
+ */
+export const SUGGESTIONS_PART_TYPE = "data-suggestions" as const;
+
+/** Mirror of ``MAX_SUGGESTIONS`` in ``copilot/response_model.py``. */
+export const MAX_SUGGESTIONS = 3;
+
+/**
+ * Pull the chip labels out of a ``data-suggestions`` part, or ``null`` for
+ * any other part. Malformed payloads yield ``null`` rather than throwing —
+ * the AI SDK passes unknown data parts through verbatim and one bad event
+ * must not take down the message list.
+ */
+export function readSuggestionsPart(
+  part: UIMessage["parts"][number],
+): string[] | null {
+  if (part.type !== SUGGESTIONS_PART_TYPE) return null;
+  const data = (part as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return null;
+  const raw = (data as Record<string, unknown>).suggestions;
+  if (!Array.isArray(raw)) return null;
+  return raw
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .slice(0, MAX_SUGGESTIONS);
+}

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -24565,6 +24565,7 @@
           "memory_forget_candidates",
           "memory_forget_confirm",
           "todo_write",
+          "next_steps_suggested",
           "platform_info",
           "chat_platform_channel_list",
           "chat_platform_posted",

--- a/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
+++ b/autogpt_platform/frontend/src/services/feature-flags/use-get-flag.ts
@@ -38,6 +38,10 @@ export enum Flag {
   // both sides must agree. Off renders the pillbox flow untouched.
   ONBOARDING_BRAIN_DUMP = "onboarding-brain-dump",
   NEW_TOOL_UI = "new-tool-ui",
+  // One-tap next-step chips under the final assistant message. Mirror of
+  // the backend ``Flag`` enum — with the flag off the backend never offers
+  // the ``suggest_next_steps`` tool, so both sides must agree.
+  COPILOT_NEXT_STEP_CHIPS = "copilot-next-step-chips",
   // Graphiti memory + dream-system gates. Mirror of the backend
   // ``Flag`` enum in ``backend/util/feature_flag.py``. Frontend reads
   // them when memory/dream-related UI surfaces ship (P6+ on the
@@ -87,6 +91,7 @@ const defaultFlags = {
   // prevent. Use NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP locally.
   [Flag.ONBOARDING_BRAIN_DUMP]: false,
   [Flag.NEW_TOOL_UI]: false,
+  [Flag.COPILOT_NEXT_STEP_CHIPS]: false,
   [Flag.GRAPHITI_MEMORY]: false,
   [Flag.GRAPHITI_COMMUNITIES_ENABLED]: false,
   [Flag.DREAM_PASS_ENABLED]: false,
@@ -156,6 +161,8 @@ function readEnvOverride(flag: Flag): string | undefined {
       return process.env.NEXT_PUBLIC_FORCE_FLAG_ONBOARDING_BRAIN_DUMP;
     case Flag.NEW_TOOL_UI:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_NEW_TOOL_UI;
+    case Flag.COPILOT_NEXT_STEP_CHIPS:
+      return process.env.NEXT_PUBLIC_FORCE_FLAG_COPILOT_NEXT_STEP_CHIPS;
     case Flag.GRAPHITI_MEMORY:
       return process.env.NEXT_PUBLIC_FORCE_FLAG_GRAPHITI_MEMORY;
     case Flag.GRAPHITI_COMMUNITIES_ENABLED:


### PR DESCRIPTION
> **Stacked PR 10 of 10** — Autopilot proactivity & conversation quality.
> Base: `Abhi1992002/expert-learned-notes`. Review only this PR's diff.

### Why / What / How

**Why.** When a task finishes, the copilot leaves the user at a dead end: a wall of summary text and a blank input box. The obvious follow-ups — email the report, post it, fix the criticals it just found — are all things the assistant could do next, but the user has to know to ask, and has to type it out.

**What.** Behind the new `copilot-next-step-chips` flag (default off), the model can offer up to 3 one-tap next actions after substantive work. They render as chips under the final assistant message; tapping one sends that text as the next user message.

- New `suggest_next_steps` tool the model calls just before its closing summary.
- New `data-suggestions` SSE part carrying the labels to the client.
- New `NextStepChips` component under the final assistant message.
- One shared, flag-gated prompt rule so both engines behave identically.

**How.**

*How the model supplies them.* Via a tool call, following the `TodoWrite` precedent — a stateless tool whose only job is to push structured state to the UI, validated server-side, with the model's arguments as the source of truth. Registering it in `TOOL_REGISTRY` means both engines pick it up automatically (MCP-wrapped for the SDK path, OpenAI schema for baseline). The alternative — parsing a fenced block off the final message — would have needed a new chunk-boundary state machine in both engines' hot delta paths, and the only precedent there (`ThinkingStripper`) discards text rather than extracting data.

*How they reach the client.* The tool republishes the labels as a `data-suggestions` AI SDK v5 data part, modelled on `data-dream-operations`: payload nested under `data`, own `to_sse`, and registered in `_reconstruct_chunk` so resumed streams replay it. The publish itself mirrors `pending_messages._notify_pending_drained` (resolve `turn_id` from the active session, `publish_chunk`, swallow failures) — chips are a convenience surface and must never fail the turn the model just completed.

*Normalisation* lives on the `StreamSuggestions` model rather than the call site — trim, drop blanks and case-insensitive duplicates, clamp each label to 60 chars, cap at 3 — so the same guarantees hold for events rebuilt from Redis on resume, not just freshly published ones. Truncation rather than rejection, so a formatting slip doesn't burn a model retry; an all-blank list *is* rejected.

*Gating.* The prompt rule and the tool flip together on the same per-turn boolean in both engines: with the flag off, `next_step_chips` is added to `disabled_tool_groups` and the supplement is the empty string, so flag-off users pay zero prompt tokens and are never told to call a tool whose UI is hidden. The frontend defaults the flag to `false` to match the backend.

*Frontend.* `data-suggestions` is stripped from `renderableParts` (and from the `data-status` back-scan) so it never leaks into the message body, and the chips read it off `message.parts` in the existing `showActions` block next to `AssistantMessageActions`. Sending goes through the existing `useCopilotChatActions()` context rather than prop-drilling through the message list. No reusable chip existed — `ToggleChip` is a toggle, `ChipList` is display-only, and `PulseChips` / `SuggestionThemes` are empty-session surfaces — so `NextStepChips` is a new molecule (`rounded-full`, Hugeicons via the `Icon` atom).

**Reviewer notes:**
- The spec asked for `suggestions` on the stream finish event; that isn't possible — `StreamFinish()` takes zero args and the AI SDK parses `finish` with `z.strictObject()`, so the field could not reach the client. The `data-*` part is the working equivalent.
- **Chips are per-turn ephemeral and do not survive a page reload.** The tool's arguments *are* persisted in `ChatMessage.toolCalls`, so durability is a small follow-up (read the persisted tool call during `convertChatSessionToUiMessages`).
- `MAX_SUGGESTIONS` is duplicated backend/frontend, consistent with how `data-status` / `data-pending-drained` mirror their shapes by hand; there is no shared codegen for stream parts.
- Named `NextStepChips` because "chips" is already overloaded — `useCopilotPendingChips` means *queued user messages*.
- Flag-on and flag-off users now have different cacheable prompt prefixes — the same trade-off the existing delegation and Graphiti supplements already make.

### Changes 🏗️

- `copilot/response_model.py` — `ResponseType.SUGGESTIONS` + `StreamSuggestions` with normalisation in a field validator.
- `copilot/stream_registry.py` — registered in `_reconstruct_chunk` so a resumed stream doesn't drop the part.
- `copilot/tools/suggest_next_steps.py` **(new)**, `tools/models.py`, `tools/__init__.py` — the tool, its echo response, and a `next_step_chips` tool group.
- `copilot/prompting.py` — `get_next_step_chips_supplement()`, 3 lines, omitted entirely when off.
- `copilot/sdk/service.py`, `baseline/service.py` — resolve the flag once per turn; prompt rule and tool flip together.
- `util/feature_flag.py` — the flag.
- `frontend copilot/nextStepSuggestions.ts` **(new)** — wire contract, mirroring `dreamOperations.ts`.
- `frontend .../ChatMessagesContainer/components/NextStepChips/` **(new)** + `ChatMessagesContainer.tsx`.
- `frontend/src/services/feature-flags/use-get-flag.ts`.
- Tests: 2 new backend files, 2 new frontend files.

**Flag added:** `copilot-next-step-chips` (default off). No schema, config, or `openapi.json` changes (the chat stream does not go through orval).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/response_model_test.py backend/copilot/tools/suggest_next_steps_test.py` — serialization (present / absent / >3 truncated / blanks + dupes / Redis round-trip) and the tool (publishes onto the turn stream, rejects non-list / non-string args without publishing, survives a publish failure)
  - [x] `pnpm test:unit` — chips render under the final assistant message and belong to that message; clicking one POSTs that exact text as the next user message; no chips when the model offered none; no chips when the flag is off; the raw payload never reaches the message body
  - [ ] Manual: enable the flag (or `NEXT_PUBLIC_FORCE_FLAG_COPILOT_NEXT_STEP_CHIPS=true`); ask for something substantive; confirm chips appear after the summary and tapping one starts the follow-up turn
  - [ ] Manual: with the flag off, confirm no chips appear and `suggest_next_steps` is absent from the tool list
