### PR TITLE
feat(blocks): add safe TaskMarket requester workflow

### DIFF
--- a/autogpt_platform/backend/backend/blocks/taskmarket/README.md
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/README.md
@@ -1,0 +1,58 @@
+# TaskMarket requester blocks
+
+These blocks let an AutoGPT graph prepare, authorize, create, and monitor a
+TaskMarket requester task. Funding is restricted to canonical USDC on Base.
+
+## Prerequisites
+
+Install the first-party `taskmarket` CLI on the backend host and complete its
+wallet and legal setup outside AutoGPT. The executable must be directly
+available as `taskmarket` on `PATH`; shell wrapper files are intentionally
+rejected. Never place a private key, seed phrase, device token, or keystore
+contents in a block input.
+
+The backend process must have access to the existing CLI keystore. These blocks
+do not read, return, or log that keystore.
+
+## Workflow
+
+1. **Prepare TaskMarket Task** validates the reward, maximum spend, deadline,
+   deliverables, Base chain, and canonical Base USDC contract. It emits an
+   immutable preview and SHA-256 fingerprint without making a network write.
+2. Connect that preview to **Create TaskMarket Task**. The block always creates
+   a new, non-editable human review tied to the current node execution. Normal
+   sensitive-action settings and reusable auto-approvals cannot bypass it.
+3. Review the exact description, deliverables, reward, deadline, Base network,
+   USDC contract, and maximum spend in AutoGPT. Approve or reject it there.
+4. After approval, the block runs read-only CLI preflights for wallet address,
+   chain ID, USDC contract, current legal acceptance, and balance. It then makes
+   one `taskmarket task create` call and reads the new task back.
+5. Use **Inspect TaskMarket Task** to retrieve live status and submissions. Its
+   output always sets `human_review_required` to `true`; it exposes no accept,
+   reject, rate, or winner-selection operation.
+
+## Settlement safety
+
+A timeout, malformed response, non-zero exit, or missing task ID during task
+creation is classified as unknown settlement. The block never retries the
+funding call. Its approval is consumed before the write, so replaying the same
+node execution cannot fund a second task. If a task ID was returned but the
+status read fails, the block preserves the ID and link with an `unknown` status
+so an operator can inspect it manually.
+
+## Reproduction
+
+From `autogpt_platform/backend`:
+
+```text
+poetry run pytest backend/blocks/taskmarket/taskmarket_test.py -q
+poetry run pytest 'backend/blocks/test/test_block.py::test_available_blocks[PrepareTaskMarketTaskBlock]' -xvs
+poetry run pytest 'backend/blocks/test/test_block.py::test_available_blocks[CreateTaskMarketTaskBlock]' -xvs
+poetry run pytest 'backend/blocks/test/test_block.py::test_available_blocks[InspectTaskMarketTaskBlock]' -xvs
+poetry run format
+poetry run lint
+```
+
+All automated tests use injected command runners and make no network request or
+payment. A live demo must stop at the human review unless the operator explicitly
+chooses to fund the displayed task.

--- a/autogpt_platform/backend/backend/blocks/taskmarket/README.md
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/README.md
@@ -26,7 +26,8 @@ do not read, return, or log that keystore.
    USDC contract, and maximum spend in AutoGPT. Approve or reject it there.
 4. After approval, the block runs read-only CLI preflights for wallet address,
    chain ID, USDC contract, current legal acceptance, and balance. It then makes
-   one `taskmarket task create` call and reads the new task back.
+   one `taskmarket task create` call and reads the new task back. The reviewed
+   preview fingerprint is supplied as the write's deterministic idempotency key.
 5. Use **Inspect TaskMarket Task** to retrieve live status and submissions. Its
    output always sets `human_review_required` to `true`; it exposes no accept,
    reject, rate, or winner-selection operation.
@@ -35,10 +36,12 @@ do not read, return, or log that keystore.
 
 A timeout, malformed response, non-zero exit, or missing task ID during task
 creation is classified as unknown settlement. The block never retries the
-funding call. Its approval is consumed before the write, so replaying the same
-node execution cannot fund a second task. If a task ID was returned but the
-status read fails, the block preserves the ID and link with an `unknown` status
-so an operator can inspect it manually.
+funding call. Its approval is atomically consumed before the write, so concurrent
+or replayed executions cannot fund a second task. The first-party create command
+is a single write operation, and its deterministic idempotency key is derived
+from the exact reviewed preview. If a task ID was returned but the status read
+fails, the block preserves the ID and link with an `unknown` status so an
+operator can inspect it manually.
 
 ## Reproduction
 

--- a/autogpt_platform/backend/backend/blocks/taskmarket/__init__.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/__init__.py
@@ -1,0 +1,1 @@
+"""TaskMarket requester blocks."""

--- a/autogpt_platform/backend/backend/blocks/taskmarket/blocks.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/blocks.py
@@ -11,6 +11,7 @@ from backend.blocks.taskmarket.models import (
     TaskMarketMode,
     TaskMarketTaskPreview,
 )
+from backend.blocks.taskmarket.review import consume_approved_review
 from backend.data.execution import ExecutionContext, ExecutionStatus
 from backend.sdk import (
     Block,
@@ -22,6 +23,7 @@ from backend.sdk import (
 )
 from backend.util.exceptions import BlockExecutionError, BlockInputError
 
+
 class PrepareTaskMarketTaskBlock(Block):
     class Input(BlockSchemaInput):
         description: str = SchemaField(
@@ -31,14 +33,12 @@ class PrepareTaskMarketTaskBlock(Block):
             description="Exact files or outcomes the worker must deliver"
         )
         reward_usdc: Decimal = SchemaField(
-            description="USDC reward to escrow", gt=0
+            description="USDC reward to escrow", ge=0.000001
         )
         maximum_spend_usdc: Decimal = SchemaField(
-            description="Hard operator-approved USDC spend ceiling", gt=0
+            description="Hard operator-approved USDC spend ceiling", ge=0.000001
         )
-        deadline: datetime = SchemaField(
-            description="Timezone-aware task deadline"
-        )
+        deadline: datetime = SchemaField(description="Timezone-aware task deadline")
         mode: TaskMarketMode = SchemaField(
             description="Task selection mode", default=TaskMarketMode.BOUNTY
         )
@@ -109,8 +109,8 @@ class CreateTaskMarketTaskBlock(Block):
         test_preview = TaskMarketTaskPreview.build(
             description="Write an accessibility report",
             deliverables=["report.md"],
-            reward_usdc=Decimal("2"),
-            maximum_spend_usdc=Decimal("2"),
+            reward_usdc=Decimal(2),
+            maximum_spend_usdc=Decimal(2),
             deadline=datetime(2099, 1, 1, tzinfo=timezone.utc),
             mode="bounty",
             tags=["accessibility"],
@@ -191,27 +191,42 @@ class CreateTaskMarketTaskBlock(Block):
             user_id, node_id, node_exec_id, graph_exec_id, graph_id
         )
         payload = preview.model_dump(mode="json")
-        result = await HITLReviewHelper.get_or_create_human_review(
-            user_id=user_id,
+        result = await HITLReviewHelper.check_approval(
             node_exec_id=node_exec_id,
             graph_exec_id=graph_exec_id,
-            graph_id=graph_id,
-            graph_version=graph_version,
+            node_id=node_id,
+            user_id=user_id,
             input_data=payload,
-            message="Authorize this exact TaskMarket Base USDC funding request",
-            editable=False,
-            organization_id=execution_context.organization_id,
-            team_id=execution_context.team_id,
         )
         if result is None:
-            await HITLReviewHelper.update_node_execution_status(
-                exec_id=node_exec_id, status=ExecutionStatus.REVIEW
+            result = await HITLReviewHelper.get_or_create_human_review(
+                user_id=user_id,
+                node_exec_id=node_exec_id,
+                graph_exec_id=graph_exec_id,
+                graph_id=graph_id,
+                graph_version=graph_version,
+                input_data=payload,
+                message="Authorize this exact TaskMarket Base USDC funding request",
+                editable=False,
+                organization_id=execution_context.organization_id,
+                team_id=execution_context.team_id,
             )
-            return None
+            if result is None:
+                await HITLReviewHelper.update_node_execution_status(
+                    exec_id=node_exec_id, status=ExecutionStatus.REVIEW
+                )
+                return None
         if result.node_exec_id != node_exec_id or result.data != payload:
             raise self._execution_error("Review does not match this exact execution")
-        await HITLReviewHelper.update_review_processed_status(node_exec_id, True)
-        return result.status == ReviewStatus.APPROVED
+        if result.status != ReviewStatus.APPROVED:
+            await HITLReviewHelper.update_review_processed_status(node_exec_id, True)
+            return False
+        claimed = await consume_approved_review(node_exec_id, user_id)
+        if not claimed:
+            raise self._execution_error(
+                "Task funding approval was already consumed by another execution"
+            )
+        return True
 
     @staticmethod
     async def create_task(
@@ -225,6 +240,7 @@ class CreateTaskMarketTaskBlock(Block):
             duration_hours=duration,
             mode=preview.mode.value,
             tags=preview.tags,
+            idempotency_key=preview.fingerprint,
         )
 
     def _validate_preview(self, preview: TaskMarketTaskPreview) -> None:

--- a/autogpt_platform/backend/backend/blocks/taskmarket/blocks.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/blocks.py
@@ -1,0 +1,299 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from prisma.enums import ReviewStatus
+
+from backend.blocks.helpers.review import HITLReviewHelper
+from backend.blocks.taskmarket.cli import TaskMarketCLI
+from backend.blocks.taskmarket.models import (
+    TaskMarketCreationResult,
+    TaskMarketMode,
+    TaskMarketTaskPreview,
+)
+from backend.data.execution import ExecutionContext, ExecutionStatus
+from backend.sdk import (
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+    SchemaField,
+)
+from backend.util.exceptions import BlockExecutionError, BlockInputError
+
+class PrepareTaskMarketTaskBlock(Block):
+    class Input(BlockSchemaInput):
+        description: str = SchemaField(
+            description="Exact public task description", min_length=1
+        )
+        deliverables: list[str] = SchemaField(
+            description="Exact files or outcomes the worker must deliver"
+        )
+        reward_usdc: Decimal = SchemaField(
+            description="USDC reward to escrow", gt=0
+        )
+        maximum_spend_usdc: Decimal = SchemaField(
+            description="Hard operator-approved USDC spend ceiling", gt=0
+        )
+        deadline: datetime = SchemaField(
+            description="Timezone-aware task deadline"
+        )
+        mode: TaskMarketMode = SchemaField(
+            description="Task selection mode", default=TaskMarketMode.BOUNTY
+        )
+        tags: list[str] = SchemaField(
+            description="Optional discovery tags", default_factory=list
+        )
+
+    class Output(BlockSchemaOutput):
+        preview: TaskMarketTaskPreview = SchemaField(
+            description="Immutable Base task preview for human authorization"
+        )
+        fingerprint: str = SchemaField(
+            description="SHA-256 binding for every preview and spend field"
+        )
+
+    def __init__(self) -> None:
+        super().__init__(
+            id="11f5e907-e830-46f7-85c9-cad99fcafb15",
+            description=(
+                "Builds an immutable TaskMarket requester preview without moving funds"
+            ),
+            categories={BlockCategory.AGENT, BlockCategory.DEVELOPER_TOOLS},
+            input_schema=self.Input,
+            output_schema=self.Output,
+            test_input={
+                "description": "Write an accessibility report",
+                "deliverables": ["report.md"],
+                "reward_usdc": "2",
+                "maximum_spend_usdc": "2",
+                "deadline": "2099-01-01T00:00:00Z",
+                "mode": "bounty",
+                "tags": ["accessibility"],
+            },
+            test_output=[
+                ("preview", TaskMarketTaskPreview),
+                ("fingerprint", lambda value: len(value) == 64),
+            ],
+        )
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        preview = TaskMarketTaskPreview.build(
+            description=input_data.description,
+            deliverables=input_data.deliverables,
+            reward_usdc=input_data.reward_usdc,
+            maximum_spend_usdc=input_data.maximum_spend_usdc,
+            deadline=input_data.deadline,
+            mode=input_data.mode.value,
+            tags=input_data.tags,
+        )
+        yield "preview", preview
+        yield "fingerprint", preview.fingerprint
+
+
+class CreateTaskMarketTaskBlock(Block):
+    class Input(BlockSchemaInput):
+        preview: TaskMarketTaskPreview = SchemaField(
+            description="Exact preview produced by PrepareTaskMarketTaskBlock"
+        )
+
+    class Output(BlockSchemaOutput):
+        task_id: str = SchemaField(description="Created TaskMarket task ID")
+        task_url: str = SchemaField(description="Canonical TaskMarket task link")
+        live_status: dict[str, Any] = SchemaField(
+            description="Live task state read back after creation"
+        )
+
+    def __init__(self) -> None:
+        test_preview = TaskMarketTaskPreview.build(
+            description="Write an accessibility report",
+            deliverables=["report.md"],
+            reward_usdc=Decimal("2"),
+            maximum_spend_usdc=Decimal("2"),
+            deadline=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            mode="bounty",
+            tags=["accessibility"],
+        )
+        test_result = TaskMarketCreationResult(
+            task_id="0x" + "1" * 64,
+            task_url="https://taskmarket.dev/tasks/0x" + "1" * 64,
+            live_status={"status": "open"},
+        )
+        super().__init__(
+            id="84d76be7-c9f2-4481-9914-315c83347753",
+            description=(
+                "Creates one Base-funded TaskMarket task only after a fresh, exact "
+                "human review"
+            ),
+            categories={BlockCategory.AGENT, BlockCategory.DEVELOPER_TOOLS},
+            input_schema=self.Input,
+            output_schema=self.Output,
+            test_input={"preview": test_preview.model_dump(mode="json")},
+            test_output=[
+                ("task_id", test_result.task_id),
+                ("task_url", test_result.task_url),
+                ("live_status", test_result.live_status),
+            ],
+            test_mock={
+                "request_funding_approval": lambda **kwargs: True,
+                "create_task": lambda preview: test_result,
+            },
+        )
+
+    async def run(
+        self,
+        input_data: Input,
+        *,
+        user_id: str,
+        node_id: str,
+        node_exec_id: str,
+        graph_exec_id: str,
+        graph_id: str,
+        graph_version: int,
+        execution_context: ExecutionContext,
+        **kwargs,
+    ) -> BlockOutput:
+        preview = input_data.preview
+        self._validate_preview(preview)
+        approved = await self.request_funding_approval(
+            preview=preview,
+            user_id=user_id,
+            node_id=node_id,
+            node_exec_id=node_exec_id,
+            graph_exec_id=graph_exec_id,
+            graph_id=graph_id,
+            graph_version=graph_version,
+            execution_context=execution_context,
+        )
+        if approved is None:
+            return
+        if not approved:
+            raise self._execution_error("Task funding was rejected by the reviewer")
+        result = await self.create_task(preview)
+        yield "task_id", result.task_id
+        yield "task_url", result.task_url
+        yield "live_status", result.live_status
+
+    async def request_funding_approval(
+        self,
+        *,
+        preview: TaskMarketTaskPreview,
+        user_id: str,
+        node_id: str,
+        node_exec_id: str,
+        graph_exec_id: str,
+        graph_id: str,
+        graph_version: int,
+        execution_context: ExecutionContext,
+    ) -> bool | None:
+        self._validate_execution_ids(
+            user_id, node_id, node_exec_id, graph_exec_id, graph_id
+        )
+        payload = preview.model_dump(mode="json")
+        result = await HITLReviewHelper.get_or_create_human_review(
+            user_id=user_id,
+            node_exec_id=node_exec_id,
+            graph_exec_id=graph_exec_id,
+            graph_id=graph_id,
+            graph_version=graph_version,
+            input_data=payload,
+            message="Authorize this exact TaskMarket Base USDC funding request",
+            editable=False,
+            organization_id=execution_context.organization_id,
+            team_id=execution_context.team_id,
+        )
+        if result is None:
+            await HITLReviewHelper.update_node_execution_status(
+                exec_id=node_exec_id, status=ExecutionStatus.REVIEW
+            )
+            return None
+        if result.node_exec_id != node_exec_id or result.data != payload:
+            raise self._execution_error("Review does not match this exact execution")
+        await HITLReviewHelper.update_review_processed_status(node_exec_id, True)
+        return result.status == ReviewStatus.APPROVED
+
+    @staticmethod
+    async def create_task(
+        preview: TaskMarketTaskPreview,
+    ) -> TaskMarketCreationResult:
+        duration = preview.remaining_duration_hours(datetime.now(timezone.utc))
+        return await TaskMarketCLI().create_and_read(
+            description=preview.full_description(),
+            reward_usdc=preview.reward_usdc,
+            maximum_spend_usdc=preview.maximum_spend_usdc,
+            duration_hours=duration,
+            mode=preview.mode.value,
+            tags=preview.tags,
+        )
+
+    def _validate_preview(self, preview: TaskMarketTaskPreview) -> None:
+        try:
+            preview.verify_fingerprint()
+            preview.remaining_duration_hours(datetime.now(timezone.utc))
+        except ValueError as error:
+            raise BlockInputError(str(error), self.name, self.id) from error
+
+    def _validate_execution_ids(self, *values: str) -> None:
+        if any(not value for value in values):
+            raise BlockInputError(
+                "Task funding requires a persisted graph execution for fresh review",
+                self.name,
+                self.id,
+            )
+
+    def _execution_error(self, message: str) -> BlockExecutionError:
+        return BlockExecutionError(message, self.name, self.id)
+
+
+class InspectTaskMarketTaskBlock(Block):
+    class Input(BlockSchemaInput):
+        task_id: str = SchemaField(description="0x-prefixed TaskMarket task ID")
+
+    class Output(BlockSchemaOutput):
+        task: dict[str, Any] = SchemaField(description="Current live task state")
+        submissions: list[dict[str, Any]] = SchemaField(
+            description="Submissions presented for human review"
+        )
+        human_review_required: bool = SchemaField(
+            description="Always true; this block cannot accept or reject work"
+        )
+
+    def __init__(self) -> None:
+        task_id = "0x" + "1" * 64
+        super().__init__(
+            id="1f003c4e-21c7-4776-a467-2f52b23cc0a5",
+            description=(
+                "Reads a TaskMarket task and its submissions without deciding outcomes"
+            ),
+            categories={BlockCategory.AGENT, BlockCategory.DEVELOPER_TOOLS},
+            input_schema=self.Input,
+            output_schema=self.Output,
+            test_input={"task_id": task_id},
+            test_output=[
+                ("task", {"taskId": task_id, "status": "open"}),
+                ("submissions", []),
+                ("human_review_required", True),
+            ],
+            test_mock={
+                "inspect_task": lambda task_id: (
+                    {"taskId": task_id, "status": "open"},
+                    [],
+                )
+            },
+        )
+
+    async def run(self, input_data: Input, **kwargs) -> BlockOutput:
+        task, submissions = await self.inspect_task(input_data.task_id)
+        yield "task", task
+        yield "submissions", submissions
+        yield "human_review_required", True
+
+    @staticmethod
+    async def inspect_task(
+        task_id: str,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        cli = TaskMarketCLI()
+        task = await cli.get_task(task_id)
+        submissions = await cli.get_submissions(task_id)
+        return task, submissions

--- a/autogpt_platform/backend/backend/blocks/taskmarket/cli.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import re
 import shutil
 from collections.abc import Awaitable, Callable, Sequence
@@ -36,6 +37,7 @@ class TaskMarketCLI:
     ) -> None:
         self._runner = command_runner or self._run_command
         self._timeout_seconds = timeout_seconds
+        self._write_idempotency_key: str | None = None
 
     async def preflight(self, maximum_spend_usdc: Decimal) -> TaskMarketPreflight:
         deposit = self._expect_object(await self._runner(("deposit",)))
@@ -59,6 +61,7 @@ class TaskMarketCLI:
         duration_hours: Decimal,
         mode: str,
         tags: list[str],
+        idempotency_key: str,
     ) -> str:
         args = (
             "task",
@@ -74,12 +77,19 @@ class TaskMarketCLI:
             "--tags",
             ",".join(tags),
         )
+        self._write_idempotency_key = idempotency_key
         try:
             result = self._expect_object(await self._runner(args))
-        except Exception as error:
+        except asyncio.CancelledError as error:
             raise SettlementUnknownError(
                 "Task creation settlement is unknown and must not be retried"
             ) from error
+        except (OSError, TaskMarketCLIError, TimeoutError) as error:
+            raise SettlementUnknownError(
+                "Task creation settlement is unknown and must not be retried"
+            ) from error
+        finally:
+            self._write_idempotency_key = None
         task_id = str(result.get("taskId", ""))
         if not TASK_ID_PATTERN.fullmatch(task_id):
             raise SettlementUnknownError(
@@ -97,7 +107,10 @@ class TaskMarketCLI:
         duration_hours: Decimal,
         mode: str,
         tags: list[str],
+        idempotency_key: str,
     ) -> TaskMarketCreationResult:
+        if reward_usdc > maximum_spend_usdc:
+            raise TaskMarketCLIError("Reward exceeds the approved maximum spend")
         await self.preflight(maximum_spend_usdc)
         task_id = await self.create_task(
             description=description,
@@ -105,10 +118,11 @@ class TaskMarketCLI:
             duration_hours=duration_hours,
             mode=mode,
             tags=tags,
+            idempotency_key=idempotency_key,
         )
         try:
             status = await self.get_task(task_id)
-        except Exception:
+        except (asyncio.CancelledError, OSError, TaskMarketCLIError):
             status = {
                 "taskId": task_id,
                 "status": "unknown",
@@ -142,18 +156,26 @@ class TaskMarketCLI:
             *arguments,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=self._command_environment(),
         )
         try:
             stdout, _ = await asyncio.wait_for(
                 process.communicate(), timeout=self._timeout_seconds
             )
-        except TimeoutError:
-            process.kill()
-            await process.wait()
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
             raise
         if process.returncode != 0:
             raise TaskMarketCLIError("TaskMarket CLI command failed")
         return self._parse_output(stdout)
+
+    def _command_environment(self) -> dict[str, str]:
+        environment = os.environ.copy()
+        if self._write_idempotency_key:
+            environment["TASKMARKET_IDEMPOTENCY_KEY"] = self._write_idempotency_key
+        return environment
 
     @staticmethod
     def _resolve_executable() -> str:
@@ -199,12 +221,18 @@ class TaskMarketCLI:
         preflight: TaskMarketPreflight, maximum_spend_usdc: Decimal
     ) -> None:
         if not WALLET_PATTERN.fullmatch(preflight.wallet_address):
-            raise TaskMarketCLIError("TaskMarket CLI returned an invalid wallet address")
+            raise TaskMarketCLIError(
+                "TaskMarket CLI returned an invalid wallet address"
+            )
         if preflight.chain_id != BASE_CHAIN_ID:
             raise TaskMarketCLIError("Task creation is restricted to Base chain 8453")
         if preflight.usdc_contract.lower() != BASE_USDC_ADDRESS.lower():
             raise TaskMarketCLIError("Task creation requires canonical Base USDC")
         if not preflight.legal_accepted:
-            raise TaskMarketCLIError("Current TaskMarket terms require operator acceptance")
+            raise TaskMarketCLIError(
+                "Current TaskMarket terms require operator acceptance"
+            )
         if preflight.balance_usdc < maximum_spend_usdc:
-            raise TaskMarketCLIError("Wallet balance is below the approved maximum spend")
+            raise TaskMarketCLIError(
+                "Wallet balance is below the approved maximum spend"
+            )

--- a/autogpt_platform/backend/backend/blocks/taskmarket/cli.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/cli.py
@@ -1,0 +1,210 @@
+import asyncio
+import json
+import re
+import shutil
+from collections.abc import Awaitable, Callable, Sequence
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from backend.blocks.taskmarket.models import (
+    BASE_CHAIN_ID,
+    BASE_USDC_ADDRESS,
+    TaskMarketCreationResult,
+    TaskMarketPreflight,
+)
+
+JsonResult = dict[str, Any] | list[Any]
+CommandRunner = Callable[[Sequence[str]], Awaitable[JsonResult]]
+TASK_ID_PATTERN = re.compile(r"^0x[0-9a-fA-F]{64}$")
+WALLET_PATTERN = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+
+class TaskMarketCLIError(RuntimeError):
+    """The first-party TaskMarket CLI could not complete a safe operation."""
+
+
+class SettlementUnknownError(TaskMarketCLIError):
+    """A funding call ended without a trustworthy settlement result."""
+
+
+class TaskMarketCLI:
+    def __init__(
+        self,
+        command_runner: CommandRunner | None = None,
+        timeout_seconds: float = 60,
+    ) -> None:
+        self._runner = command_runner or self._run_command
+        self._timeout_seconds = timeout_seconds
+
+    async def preflight(self, maximum_spend_usdc: Decimal) -> TaskMarketPreflight:
+        deposit = self._expect_object(await self._runner(("deposit",)))
+        legal = self._expect_object(await self._runner(("legal", "status")))
+        balance = self._expect_object(await self._runner(("wallet", "balance")))
+        preflight = TaskMarketPreflight(
+            wallet_address=str(deposit.get("address", "")),
+            chain_id=int(deposit.get("chainId", 0)),
+            usdc_contract=str(deposit.get("usdcContract", "")),
+            balance_usdc=Decimal(str(balance.get("balanceUsdc", "0"))),
+            legal_accepted=legal.get("accepted") is True,
+        )
+        self._validate_preflight(preflight, maximum_spend_usdc)
+        return preflight
+
+    async def create_task(
+        self,
+        *,
+        description: str,
+        reward_usdc: Decimal,
+        duration_hours: Decimal,
+        mode: str,
+        tags: list[str],
+    ) -> str:
+        args = (
+            "task",
+            "create",
+            "--description",
+            description,
+            "--reward",
+            format(reward_usdc, "f"),
+            "--duration",
+            format(duration_hours, "f"),
+            "--mode",
+            mode,
+            "--tags",
+            ",".join(tags),
+        )
+        try:
+            result = self._expect_object(await self._runner(args))
+        except Exception as error:
+            raise SettlementUnknownError(
+                "Task creation settlement is unknown and must not be retried"
+            ) from error
+        task_id = str(result.get("taskId", ""))
+        if not TASK_ID_PATTERN.fullmatch(task_id):
+            raise SettlementUnknownError(
+                "Task creation returned no verifiable task ID; settlement is unknown "
+                "and must not be retried"
+            )
+        return task_id
+
+    async def create_and_read(
+        self,
+        *,
+        description: str,
+        reward_usdc: Decimal,
+        maximum_spend_usdc: Decimal,
+        duration_hours: Decimal,
+        mode: str,
+        tags: list[str],
+    ) -> TaskMarketCreationResult:
+        await self.preflight(maximum_spend_usdc)
+        task_id = await self.create_task(
+            description=description,
+            reward_usdc=reward_usdc,
+            duration_hours=duration_hours,
+            mode=mode,
+            tags=tags,
+        )
+        try:
+            status = await self.get_task(task_id)
+        except Exception:
+            status = {
+                "taskId": task_id,
+                "status": "unknown",
+                "humanAction": "Open the task link before attempting any new write",
+            }
+        return TaskMarketCreationResult(
+            task_id=task_id,
+            task_url=f"https://taskmarket.dev/tasks/{task_id}",
+            live_status=status,
+        )
+
+    async def get_task(self, task_id: str) -> dict[str, Any]:
+        self._validate_task_id(task_id)
+        result = await self._runner(("task", "get", task_id))
+        return self._expect_object(result)
+
+    async def get_submissions(self, task_id: str) -> list[dict[str, Any]]:
+        self._validate_task_id(task_id)
+        result = await self._runner(("task", "submissions", task_id))
+        if isinstance(result, list):
+            return [self._expect_object(item) for item in result]
+        submissions = self._expect_object(result).get("submissions", [])
+        if not isinstance(submissions, list):
+            raise TaskMarketCLIError("CLI returned invalid submission data")
+        return [self._expect_object(item) for item in submissions]
+
+    async def _run_command(self, arguments: Sequence[str]) -> JsonResult:
+        executable = self._resolve_executable()
+        process = await asyncio.create_subprocess_exec(
+            executable,
+            *arguments,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(
+                process.communicate(), timeout=self._timeout_seconds
+            )
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+            raise
+        if process.returncode != 0:
+            raise TaskMarketCLIError("TaskMarket CLI command failed")
+        return self._parse_output(stdout)
+
+    @staticmethod
+    def _resolve_executable() -> str:
+        executable = shutil.which("taskmarket")
+        if not executable:
+            raise TaskMarketCLIError(
+                "First-party TaskMarket CLI was not found on the server PATH"
+            )
+        if Path(executable).suffix.lower() in {".bat", ".cmd"}:
+            raise TaskMarketCLIError(
+                "TaskMarket CLI must be a direct executable, not a shell wrapper"
+            )
+        return executable
+
+    @staticmethod
+    def _parse_output(stdout: bytes) -> JsonResult:
+        if len(stdout) > 1_000_000:
+            raise TaskMarketCLIError("TaskMarket CLI output exceeded the safe limit")
+        try:
+            envelope = json.loads(stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise TaskMarketCLIError("TaskMarket CLI returned invalid JSON") from error
+        if not isinstance(envelope, dict) or envelope.get("ok") is not True:
+            raise TaskMarketCLIError("TaskMarket CLI returned an unsuccessful response")
+        data = envelope.get("data")
+        if not isinstance(data, (dict, list)):
+            raise TaskMarketCLIError("TaskMarket CLI returned invalid result data")
+        return data
+
+    @staticmethod
+    def _expect_object(result: Any) -> dict[str, Any]:
+        if not isinstance(result, dict):
+            raise TaskMarketCLIError("TaskMarket CLI returned an invalid object")
+        return result
+
+    @staticmethod
+    def _validate_task_id(task_id: str) -> None:
+        if not TASK_ID_PATTERN.fullmatch(task_id):
+            raise ValueError("Task ID must be a 0x-prefixed 32-byte hex value")
+
+    @staticmethod
+    def _validate_preflight(
+        preflight: TaskMarketPreflight, maximum_spend_usdc: Decimal
+    ) -> None:
+        if not WALLET_PATTERN.fullmatch(preflight.wallet_address):
+            raise TaskMarketCLIError("TaskMarket CLI returned an invalid wallet address")
+        if preflight.chain_id != BASE_CHAIN_ID:
+            raise TaskMarketCLIError("Task creation is restricted to Base chain 8453")
+        if preflight.usdc_contract.lower() != BASE_USDC_ADDRESS.lower():
+            raise TaskMarketCLIError("Task creation requires canonical Base USDC")
+        if not preflight.legal_accepted:
+            raise TaskMarketCLIError("Current TaskMarket terms require operator acceptance")
+        if preflight.balance_usdc < maximum_spend_usdc:
+            raise TaskMarketCLIError("Wallet balance is below the approved maximum spend")

--- a/autogpt_platform/backend/backend/blocks/taskmarket/models.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/models.py
@@ -1,0 +1,152 @@
+import hashlib
+import json
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from strenum import StrEnum
+
+BASE_CHAIN_ID = 8453
+BASE_USDC_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+USDC_QUANTUM = Decimal("0.000001")
+
+
+class TaskMarketMode(StrEnum):
+    BOUNTY = "bounty"
+    CLAIM = "claim"
+    PITCH = "pitch"
+    BENCHMARK = "benchmark"
+
+
+class TaskMarketNetwork(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str = "Base"
+    chain_id: int = BASE_CHAIN_ID
+    currency: str = "USDC"
+    usdc_contract: str = BASE_USDC_ADDRESS
+
+
+class TaskMarketTaskPreview(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    description: str = Field(min_length=1, max_length=10_000)
+    deliverables: list[str] = Field(min_length=1, max_length=20)
+    reward_usdc: Decimal
+    maximum_spend_usdc: Decimal
+    deadline: datetime
+    mode: TaskMarketMode
+    tags: list[str] = Field(default_factory=list, max_length=10)
+    network: TaskMarketNetwork = Field(default_factory=TaskMarketNetwork)
+    fingerprint: str = ""
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        description: str,
+        deliverables: list[str],
+        reward_usdc: Decimal,
+        maximum_spend_usdc: Decimal,
+        deadline: datetime,
+        mode: str,
+        tags: list[str],
+    ) -> "TaskMarketTaskPreview":
+        preview = cls(
+            description=description,
+            deliverables=deliverables,
+            reward_usdc=reward_usdc,
+            maximum_spend_usdc=maximum_spend_usdc,
+            deadline=deadline,
+            mode=TaskMarketMode(mode),
+            tags=tags,
+        )
+        return preview.model_copy(update={"fingerprint": preview.calculate_fingerprint()})
+
+    def calculate_fingerprint(self) -> str:
+        canonical = json.dumps(
+            self._canonical_payload(), sort_keys=True, separators=(",", ":")
+        ).encode()
+        return hashlib.sha256(canonical).hexdigest()
+
+    def verify_fingerprint(self) -> None:
+        if not self.fingerprint or self.fingerprint != self.calculate_fingerprint():
+            raise ValueError("Task preview fingerprint does not match its contents")
+
+    def full_description(self) -> str:
+        items = "\n".join(f"- {item}" for item in self.deliverables)
+        return f"{self.description.strip()}\n\nDeliverables:\n{items}"
+
+    def remaining_duration_hours(self, now: datetime) -> Decimal:
+        seconds = Decimal(str((self.deadline - now).total_seconds()))
+        if seconds <= 0:
+            raise ValueError("Task deadline must be in the future")
+        return (seconds / Decimal(3600)).quantize(Decimal("0.000001"))
+
+    @field_validator("reward_usdc", "maximum_spend_usdc", mode="before")
+    @classmethod
+    def validate_usdc(cls, value: Any) -> Decimal:
+        try:
+            raw_amount = Decimal(str(value))
+            amount = raw_amount.quantize(USDC_QUANTUM)
+        except (InvalidOperation, ValueError) as error:
+            raise ValueError("USDC amount must have at most six decimals") from error
+        if amount != raw_amount:
+            raise ValueError("USDC amount must have at most six decimals")
+        if not amount.is_finite() or amount <= 0:
+            raise ValueError("USDC amount must be greater than zero")
+        return amount
+
+    @field_validator("deadline")
+    @classmethod
+    def validate_deadline(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("Task deadline must include a timezone")
+        return value.astimezone(timezone.utc)
+
+    @field_validator("deliverables", "tags")
+    @classmethod
+    def validate_string_list(cls, values: list[str]) -> list[str]:
+        cleaned = [value.strip() for value in values]
+        if any(not value for value in cleaned):
+            raise ValueError("List entries must not be empty")
+        if len(set(cleaned)) != len(cleaned):
+            raise ValueError("List entries must be unique")
+        return cleaned
+
+    @model_validator(mode="after")
+    def validate_budget_and_network(self) -> "TaskMarketTaskPreview":
+        if self.reward_usdc > self.maximum_spend_usdc:
+            raise ValueError("Reward exceeds the declared maximum spend")
+        if self.network.chain_id != BASE_CHAIN_ID:
+            raise ValueError("TaskMarket funding is restricted to Base chain 8453")
+        if self.network.usdc_contract.lower() != BASE_USDC_ADDRESS.lower():
+            raise ValueError("TaskMarket funding requires canonical Base USDC")
+        return self
+
+    def _canonical_payload(self) -> dict[str, Any]:
+        return {
+            "deadline": self.deadline.isoformat(),
+            "deliverables": self.deliverables,
+            "description": self.description.strip(),
+            "maximum_spend_usdc": format(self.maximum_spend_usdc, "f"),
+            "mode": self.mode.value,
+            "network": self.network.model_dump(),
+            "reward_usdc": format(self.reward_usdc, "f"),
+            "tags": self.tags,
+        }
+
+
+class TaskMarketPreflight(BaseModel):
+    wallet_address: str
+    chain_id: int
+    usdc_contract: str
+    balance_usdc: Decimal
+    legal_accepted: bool
+
+
+class TaskMarketCreationResult(BaseModel):
+    task_id: str
+    task_url: str
+    live_status: dict[str, Any]

--- a/autogpt_platform/backend/backend/blocks/taskmarket/models.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/models.py
@@ -62,7 +62,9 @@ class TaskMarketTaskPreview(BaseModel):
             mode=TaskMarketMode(mode),
             tags=tags,
         )
-        return preview.model_copy(update={"fingerprint": preview.calculate_fingerprint()})
+        return preview.model_copy(
+            update={"fingerprint": preview.calculate_fingerprint()}
+        )
 
     def calculate_fingerprint(self) -> str:
         canonical = json.dumps(
@@ -111,6 +113,8 @@ class TaskMarketTaskPreview(BaseModel):
         cleaned = [value.strip() for value in values]
         if any(not value for value in cleaned):
             raise ValueError("List entries must not be empty")
+        if any("," in value for value in cleaned):
+            raise ValueError("List entries must not contain commas")
         if len(set(cleaned)) != len(cleaned):
             raise ValueError("List entries must be unique")
         return cleaned

--- a/autogpt_platform/backend/backend/blocks/taskmarket/review.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/review.py
@@ -1,0 +1,16 @@
+from prisma.enums import ReviewStatus
+from prisma.models import PendingHumanReview
+
+
+async def consume_approved_review(node_exec_id: str, user_id: str) -> bool:
+    """Atomically claim one approved review before funding a task."""
+    updated = await PendingHumanReview.prisma().update_many(
+        where={
+            "nodeExecId": node_exec_id,
+            "userId": user_id,
+            "status": ReviewStatus.APPROVED,
+            "processed": False,
+        },
+        data={"processed": True},
+    )
+    return updated == 1

--- a/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
@@ -68,6 +68,76 @@ async def test_create_preflight_enforces_base_usdc_and_balance():
 
 
 @pytest.mark.asyncio
+async def test_create_and_read_runs_one_complete_idempotent_write():
+    task_id = "0x" + "a" * 64
+    runner = AsyncMock(
+        side_effect=[
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 8453,
+                "usdcContract": BASE_USDC_ADDRESS,
+            },
+            {"accepted": True},
+            {"balanceUsdc": "3"},
+            {"taskId": task_id},
+            {"taskId": task_id, "status": "open"},
+        ]
+    )
+    cli = TaskMarketCLI(command_runner=runner)
+
+    result = await cli.create_and_read(
+        description="Write a report\n\nDeliverables:\n- report.md",
+        reward_usdc=Decimal(2),
+        maximum_spend_usdc=Decimal(3),
+        duration_hours=Decimal(4),
+        mode="bounty",
+        tags=["report"],
+        idempotency_key="b" * 64,
+    )
+
+    assert result.task_id == task_id
+    assert result.task_url.endswith(task_id)
+    assert result.live_status == {"taskId": task_id, "status": "open"}
+    assert runner.await_count == 5
+    assert runner.await_args_list[3].args[0][:2] == ("task", "create")
+    assert runner.await_args_list[4].args[0] == ("task", "get", task_id)
+    assert cli._write_idempotency_key is None
+
+
+@pytest.mark.asyncio
+async def test_create_and_read_preserves_task_id_when_status_read_fails():
+    task_id = "0x" + "c" * 64
+    runner = AsyncMock(
+        side_effect=[
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 8453,
+                "usdcContract": BASE_USDC_ADDRESS,
+            },
+            {"accepted": True},
+            {"balanceUsdc": "2"},
+            {"taskId": task_id},
+            OSError("status endpoint unavailable"),
+        ]
+    )
+    cli = TaskMarketCLI(command_runner=runner)
+
+    result = await cli.create_and_read(
+        description="Write a report\n\nDeliverables:\n- report.md",
+        reward_usdc=Decimal(2),
+        maximum_spend_usdc=Decimal(2),
+        duration_hours=Decimal(4),
+        mode="bounty",
+        tags=[],
+        idempotency_key="d" * 64,
+    )
+
+    assert result.task_id == task_id
+    assert result.live_status["taskId"] == task_id
+    assert result.live_status["status"] == "unknown"
+
+
+@pytest.mark.asyncio
 async def test_create_timeout_is_unknown_and_never_retried():
     runner = AsyncMock(side_effect=TimeoutError("relayer timed out"))
     cli = TaskMarketCLI(command_runner=runner)

--- a/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
@@ -1,18 +1,27 @@
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from prisma.enums import ReviewStatus
+
+from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
+from backend.blocks.taskmarket.cli import SettlementUnknownError, TaskMarketCLI
+from backend.blocks.taskmarket.models import (
+    BASE_USDC_ADDRESS,
+    TaskMarketTaskPreview,
+)
+from backend.blocks.taskmarket.review import consume_approved_review
+from backend.data.human_review import ReviewResult
+from backend.util.exceptions import BlockExecutionError
 
 
 def test_preview_binds_exact_spend_and_deliverables():
-    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
-
     preview = TaskMarketTaskPreview.build(
         description="Implement an accessibility audit",
         deliverables=["report.md", "screenshots.zip"],
         reward_usdc=Decimal("2.5"),
-        maximum_spend_usdc=Decimal("3"),
+        maximum_spend_usdc=Decimal(3),
         deadline=datetime.now(timezone.utc) + timedelta(hours=4),
         mode="bounty",
         tags=["audit", "accessibility"],
@@ -26,14 +35,12 @@ def test_preview_binds_exact_spend_and_deliverables():
 
 
 def test_preview_rejects_reward_above_maximum_spend():
-    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
-
     with pytest.raises(ValueError, match="maximum spend"):
         TaskMarketTaskPreview.build(
             description="Write a report",
             deliverables=["report.md"],
-            reward_usdc=Decimal("4"),
-            maximum_spend_usdc=Decimal("3"),
+            reward_usdc=Decimal(4),
+            maximum_spend_usdc=Decimal(3),
             deadline=datetime.now(timezone.utc) + timedelta(hours=4),
             mode="bounty",
             tags=[],
@@ -42,9 +49,6 @@ def test_preview_rejects_reward_above_maximum_spend():
 
 @pytest.mark.asyncio
 async def test_create_preflight_enforces_base_usdc_and_balance():
-    from backend.blocks.taskmarket.cli import TaskMarketCLI
-    from backend.blocks.taskmarket.models import BASE_USDC_ADDRESS
-
     runner = AsyncMock(
         side_effect=[
             {
@@ -59,7 +63,7 @@ async def test_create_preflight_enforces_base_usdc_and_balance():
     )
     cli = TaskMarketCLI(command_runner=runner)
 
-    preflight = await cli.preflight(Decimal("3"))
+    preflight = await cli.preflight(Decimal(3))
 
     assert preflight.chain_id == 8453
     assert preflight.balance_usdc == Decimal("5.000000")
@@ -68,18 +72,17 @@ async def test_create_preflight_enforces_base_usdc_and_balance():
 
 @pytest.mark.asyncio
 async def test_create_timeout_is_unknown_and_never_retried():
-    from backend.blocks.taskmarket.cli import SettlementUnknownError, TaskMarketCLI
-
     runner = AsyncMock(side_effect=TimeoutError("relayer timed out"))
     cli = TaskMarketCLI(command_runner=runner)
 
     with pytest.raises(SettlementUnknownError, match="must not be retried"):
         await cli.create_task(
             description="Write a report\n\nDeliverables:\n- report.md",
-            reward_usdc=Decimal("2"),
-            duration_hours=Decimal("4"),
+            reward_usdc=Decimal(2),
+            duration_hours=Decimal(4),
             mode="bounty",
             tags=["report"],
+            idempotency_key="a" * 64,
         )
 
     assert runner.await_count == 1
@@ -87,15 +90,11 @@ async def test_create_timeout_is_unknown_and_never_retried():
 
 @pytest.mark.asyncio
 async def test_create_requires_exact_fresh_review_before_cli_call():
-    from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
-    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
-    from backend.util.exceptions import BlockExecutionError
-
     preview = TaskMarketTaskPreview.build(
         description="Write a report",
         deliverables=["report.md"],
-        reward_usdc=Decimal("2"),
-        maximum_spend_usdc=Decimal("2"),
+        reward_usdc=Decimal(2),
+        maximum_spend_usdc=Decimal(2),
         deadline=datetime.now(timezone.utc) + timedelta(hours=4),
         mode="bounty",
         tags=["report"],
@@ -127,18 +126,11 @@ async def test_create_requires_exact_fresh_review_before_cli_call():
 
 @pytest.mark.asyncio
 async def test_create_rejects_review_bound_to_different_execution():
-    from prisma.enums import ReviewStatus
-
-    from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
-    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
-    from backend.data.human_review import ReviewResult
-    from backend.util.exceptions import BlockExecutionError
-
     preview = TaskMarketTaskPreview.build(
         description="Write a report",
         deliverables=["report.md"],
-        reward_usdc=Decimal("2"),
-        maximum_spend_usdc=Decimal("2"),
+        reward_usdc=Decimal(2),
+        maximum_spend_usdc=Decimal(2),
         deadline=datetime.now(timezone.utc) + timedelta(hours=4),
         mode="bounty",
         tags=[],
@@ -157,6 +149,11 @@ async def test_create_rejects_review_bound_to_different_execution():
         pytest.raises(BlockExecutionError, match="exact execution"),
     ):
         get_review = AsyncMock(return_value=wrong_review)
+        check_approval = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            "backend.blocks.taskmarket.blocks.HITLReviewHelper.check_approval",
+            check_approval,
+        )
         monkeypatch.setattr(
             "backend.blocks.taskmarket.blocks.HITLReviewHelper.get_or_create_human_review",
             get_review,
@@ -173,3 +170,86 @@ async def test_create_rejects_review_bound_to_different_execution():
                 "Context", (), {"organization_id": None, "team_id": None}
             )(),
         )
+
+
+def test_preview_rejects_comma_delimited_tag():
+    with pytest.raises(ValueError, match="commas"):
+        TaskMarketTaskPreview.build(
+            description="Write a report",
+            deliverables=["report.md"],
+            reward_usdc=Decimal(2),
+            maximum_spend_usdc=Decimal(2),
+            deadline=datetime.now(timezone.utc) + timedelta(hours=4),
+            mode="bounty",
+            tags=["audit,urgent"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_approved_review_must_be_claimed_atomically():
+    preview = TaskMarketTaskPreview.build(
+        description="Write a report",
+        deliverables=["report.md"],
+        reward_usdc=Decimal(2),
+        maximum_spend_usdc=Decimal(2),
+        deadline=datetime.now(timezone.utc) + timedelta(hours=4),
+        mode="bounty",
+        tags=[],
+    )
+    review = ReviewResult(
+        data=preview.model_dump(mode="json"),
+        status=ReviewStatus.APPROVED,
+        message="approved",
+        processed=False,
+        node_exec_id="node-exec",
+    )
+    block = CreateTaskMarketTaskBlock()
+
+    with (
+        pytest.MonkeyPatch.context() as monkeypatch,
+        pytest.raises(BlockExecutionError, match="already consumed"),
+    ):
+        monkeypatch.setattr(
+            "backend.blocks.taskmarket.blocks.HITLReviewHelper.check_approval",
+            AsyncMock(return_value=review),
+        )
+        monkeypatch.setattr(
+            "backend.blocks.taskmarket.blocks.consume_approved_review",
+            AsyncMock(return_value=False),
+        )
+        await block.request_funding_approval(
+            preview=preview,
+            user_id="user",
+            node_id="node",
+            node_exec_id="node-exec",
+            graph_exec_id="graph-exec",
+            graph_id="graph",
+            graph_version=1,
+            execution_context=type(
+                "Context", (), {"organization_id": None, "team_id": None}
+            )(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_consume_approved_review_uses_conditional_update():
+    model = Mock()
+    model.update_many = AsyncMock(return_value=1)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "backend.blocks.taskmarket.review.PendingHumanReview.prisma",
+            Mock(return_value=model),
+        )
+        claimed = await consume_approved_review("node-exec", "user")
+
+    assert claimed is True
+    model.update_many.assert_awaited_once_with(
+        where={
+            "nodeExecId": "node-exec",
+            "userId": "user",
+            "status": ReviewStatus.APPROVED,
+            "processed": False,
+        },
+        data={"processed": True},
+    )

--- a/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
@@ -1,0 +1,175 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def test_preview_binds_exact_spend_and_deliverables():
+    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
+
+    preview = TaskMarketTaskPreview.build(
+        description="Implement an accessibility audit",
+        deliverables=["report.md", "screenshots.zip"],
+        reward_usdc=Decimal("2.5"),
+        maximum_spend_usdc=Decimal("3"),
+        deadline=datetime.now(timezone.utc) + timedelta(hours=4),
+        mode="bounty",
+        tags=["audit", "accessibility"],
+    )
+
+    assert preview.network.chain_id == 8453
+    assert preview.reward_usdc == Decimal("2.500000")
+    assert preview.maximum_spend_usdc == Decimal("3.000000")
+    assert preview.deliverables == ["report.md", "screenshots.zip"]
+    assert preview.fingerprint == preview.calculate_fingerprint()
+
+
+def test_preview_rejects_reward_above_maximum_spend():
+    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
+
+    with pytest.raises(ValueError, match="maximum spend"):
+        TaskMarketTaskPreview.build(
+            description="Write a report",
+            deliverables=["report.md"],
+            reward_usdc=Decimal("4"),
+            maximum_spend_usdc=Decimal("3"),
+            deadline=datetime.now(timezone.utc) + timedelta(hours=4),
+            mode="bounty",
+            tags=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_preflight_enforces_base_usdc_and_balance():
+    from backend.blocks.taskmarket.cli import TaskMarketCLI
+    from backend.blocks.taskmarket.models import BASE_USDC_ADDRESS
+
+    runner = AsyncMock(
+        side_effect=[
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 8453,
+                "currency": "USDC",
+                "usdcContract": BASE_USDC_ADDRESS,
+            },
+            {"accepted": True, "enforcementEnabled": True},
+            {"balanceUsdc": "5.0", "balanceBaseUnits": "5000000"},
+        ]
+    )
+    cli = TaskMarketCLI(command_runner=runner)
+
+    preflight = await cli.preflight(Decimal("3"))
+
+    assert preflight.chain_id == 8453
+    assert preflight.balance_usdc == Decimal("5.000000")
+    assert runner.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_create_timeout_is_unknown_and_never_retried():
+    from backend.blocks.taskmarket.cli import SettlementUnknownError, TaskMarketCLI
+
+    runner = AsyncMock(side_effect=TimeoutError("relayer timed out"))
+    cli = TaskMarketCLI(command_runner=runner)
+
+    with pytest.raises(SettlementUnknownError, match="must not be retried"):
+        await cli.create_task(
+            description="Write a report\n\nDeliverables:\n- report.md",
+            reward_usdc=Decimal("2"),
+            duration_hours=Decimal("4"),
+            mode="bounty",
+            tags=["report"],
+        )
+
+    assert runner.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_requires_exact_fresh_review_before_cli_call():
+    from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
+    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
+    from backend.util.exceptions import BlockExecutionError
+
+    preview = TaskMarketTaskPreview.build(
+        description="Write a report",
+        deliverables=["report.md"],
+        reward_usdc=Decimal("2"),
+        maximum_spend_usdc=Decimal("2"),
+        deadline=datetime.now(timezone.utc) + timedelta(hours=4),
+        mode="bounty",
+        tags=["report"],
+    )
+    block = CreateTaskMarketTaskBlock()
+    block.request_funding_approval = AsyncMock(return_value=False)
+    block.create_task = AsyncMock()
+    input_data = block.Input(preview=preview)
+
+    with pytest.raises(BlockExecutionError, match="rejected"):
+        _ = [
+            item
+            async for item in block.run(
+                input_data,
+                user_id="user",
+                node_id="node",
+                node_exec_id="node-exec",
+                graph_exec_id="graph-exec",
+                graph_id="graph",
+                graph_version=1,
+                execution_context=type(
+                    "Context", (), {"organization_id": None, "team_id": None}
+                )(),
+            )
+        ]
+
+    block.create_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_review_bound_to_different_execution():
+    from prisma.enums import ReviewStatus
+
+    from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
+    from backend.blocks.taskmarket.models import TaskMarketTaskPreview
+    from backend.data.human_review import ReviewResult
+    from backend.util.exceptions import BlockExecutionError
+
+    preview = TaskMarketTaskPreview.build(
+        description="Write a report",
+        deliverables=["report.md"],
+        reward_usdc=Decimal("2"),
+        maximum_spend_usdc=Decimal("2"),
+        deadline=datetime.now(timezone.utc) + timedelta(hours=4),
+        mode="bounty",
+        tags=[],
+    )
+    block = CreateTaskMarketTaskBlock()
+    wrong_review = ReviewResult(
+        data=preview.model_dump(mode="json"),
+        status=ReviewStatus.APPROVED,
+        message="approved",
+        processed=False,
+        node_exec_id="old-execution",
+    )
+
+    with (
+        pytest.MonkeyPatch.context() as monkeypatch,
+        pytest.raises(BlockExecutionError, match="exact execution"),
+    ):
+        get_review = AsyncMock(return_value=wrong_review)
+        monkeypatch.setattr(
+            "backend.blocks.taskmarket.blocks.HITLReviewHelper.get_or_create_human_review",
+            get_review,
+        )
+        await block.request_funding_approval(
+            preview=preview,
+            user_id="user",
+            node_id="node",
+            node_exec_id="node-exec",
+            graph_exec_id="graph-exec",
+            graph_id="graph",
+            graph_version=1,
+            execution_context=type(
+                "Context", (), {"organization_id": None, "team_id": None}
+            )(),
+        )

--- a/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
@@ -7,10 +7,7 @@ from prisma.enums import ReviewStatus
 
 from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
 from backend.blocks.taskmarket.cli import SettlementUnknownError, TaskMarketCLI
-from backend.blocks.taskmarket.models import (
-    BASE_USDC_ADDRESS,
-    TaskMarketTaskPreview,
-)
+from backend.blocks.taskmarket.models import BASE_USDC_ADDRESS, TaskMarketTaskPreview
 from backend.blocks.taskmarket.review import consume_approved_review
 from backend.data.human_review import ReviewResult
 from backend.util.exceptions import BlockExecutionError

--- a/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
+++ b/autogpt_platform/backend/backend/blocks/taskmarket/taskmarket_test.py
@@ -6,7 +6,11 @@ import pytest
 from prisma.enums import ReviewStatus
 
 from backend.blocks.taskmarket.blocks import CreateTaskMarketTaskBlock
-from backend.blocks.taskmarket.cli import SettlementUnknownError, TaskMarketCLI
+from backend.blocks.taskmarket.cli import (
+    SettlementUnknownError,
+    TaskMarketCLI,
+    TaskMarketCLIError,
+)
 from backend.blocks.taskmarket.models import BASE_USDC_ADDRESS, TaskMarketTaskPreview
 from backend.blocks.taskmarket.review import consume_approved_review
 from backend.data.human_review import ReviewResult
@@ -65,6 +69,61 @@ async def test_create_preflight_enforces_base_usdc_and_balance():
     assert preflight.chain_id == 8453
     assert preflight.balance_usdc == Decimal("5.000000")
     assert runner.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("deposit", "legal", "balance", "message"),
+    [
+        (
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 1,
+                "usdcContract": BASE_USDC_ADDRESS,
+            },
+            {"accepted": True},
+            {"balanceUsdc": "3"},
+            "Base chain",
+        ),
+        (
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 8453,
+                "usdcContract": "0x" + "0" * 40,
+            },
+            {"accepted": True},
+            {"balanceUsdc": "3"},
+            "canonical Base USDC",
+        ),
+        (
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 8453,
+                "usdcContract": BASE_USDC_ADDRESS,
+            },
+            {"accepted": False},
+            {"balanceUsdc": "3"},
+            "operator acceptance",
+        ),
+        (
+            {
+                "address": "0x38fA0E8373649d90c34E7D4228254B4795a5a8b5",
+                "chainId": 8453,
+                "usdcContract": BASE_USDC_ADDRESS,
+            },
+            {"accepted": True},
+            {"balanceUsdc": "1"},
+            "below the approved maximum",
+        ),
+    ],
+)
+async def test_preflight_rejects_unsafe_configuration(
+    deposit: dict, legal: dict, balance: dict, message: str
+):
+    cli = TaskMarketCLI(command_runner=AsyncMock(side_effect=[deposit, legal, balance]))
+
+    with pytest.raises(TaskMarketCLIError, match=message):
+        await cli.preflight(Decimal(2))
 
 
 @pytest.mark.asyncio
@@ -135,6 +194,27 @@ async def test_create_and_read_preserves_task_id_when_status_read_fails():
     assert result.task_id == task_id
     assert result.live_status["taskId"] == task_id
     assert result.live_status["status"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_get_submissions_accepts_cli_envelope():
+    task_id = "0x" + "e" * 64
+    runner = AsyncMock(return_value={"submissions": [{"id": "sub-1"}]})
+    cli = TaskMarketCLI(command_runner=runner)
+
+    submissions = await cli.get_submissions(task_id)
+
+    assert submissions == [{"id": "sub-1"}]
+    runner.assert_awaited_once_with(("task", "submissions", task_id))
+
+
+def test_cli_output_parser_accepts_success_and_rejects_invalid_json():
+    assert TaskMarketCLI._parse_output(b'{"ok":true,"data":{"status":"open"}}') == {
+        "status": "open"
+    }
+
+    with pytest.raises(TaskMarketCLIError, match="invalid JSON"):
+        TaskMarketCLI._parse_output(b"not-json")
 
 
 @pytest.mark.asyncio

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -644,6 +644,9 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 |------------|-------------|
 | [Agent Executor](block-integrations/misc.md#agent-executor) | Executes an existing agent inside your agent |
 | [AutoPilot](block-integrations/misc.md#autopilot) | Execute tasks using AutoGPT AutoPilot with full access to platform tools (agent management, workspace files, web fetch, block execution, and more) |
+| [Create Task Market Task](block-integrations/taskmarket/blocks.md#create-task-market-task) | Creates one Base-funded TaskMarket task only after a fresh, exact human review |
+| [Inspect Task Market Task](block-integrations/taskmarket/blocks.md#inspect-task-market-task) | Reads a TaskMarket task and its submissions without deciding outcomes |
+| [Prepare Task Market Task](block-integrations/taskmarket/blocks.md#prepare-task-market-task) | Builds an immutable TaskMarket requester preview without moving funds |
 
 ## CRM Services
 

--- a/docs/integrations/SUMMARY.md
+++ b/docs/integrations/SUMMARY.md
@@ -127,6 +127,7 @@
 * [Stripe Link Spend Request](block-integrations/stripe_link/spend_request.md)
 * [System Library Operations](block-integrations/system/library_operations.md)
 * [System Store Operations](block-integrations/system/store_operations.md)
+* [Taskmarket Blocks](block-integrations/taskmarket/blocks.md)
 * [Tavily Crawl](block-integrations/tavily/crawl.md)
 * [Tavily Extract](block-integrations/tavily/extract.md)
 * [Tavily Map](block-integrations/tavily/map.md)

--- a/docs/integrations/block-integrations/taskmarket/blocks.md
+++ b/docs/integrations/block-integrations/taskmarket/blocks.md
@@ -1,0 +1,105 @@
+# Taskmarket Blocks
+<!-- MANUAL: file_description -->
+TaskMarket requester blocks for safely preparing, funding, and monitoring Base USDC tasks with explicit human review.
+<!-- END MANUAL -->
+
+## Create Task Market Task
+
+### What it is
+Creates one Base-funded TaskMarket task only after a fresh, exact human review
+
+### How it works
+<!-- MANUAL: how_it_works -->
+Consumes an approved review atomically, verifies the reviewed preview fingerprint and spend ceiling, checks the configured TaskMarket wallet on Base, and performs one idempotent task-creation operation. Ambiguous settlement is never retried automatically.
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| preview | Exact preview produced by PrepareTaskMarketTaskBlock | TaskMarketTaskPreview | Yes |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| task_id | Created TaskMarket task ID | str |
+| task_url | Canonical TaskMarket task link | str |
+| live_status | Live task state read back after creation | Dict[str, Any] |
+| error | Error message if the operation failed | str |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+Publish a reviewed bounty from an AutoGPT workflow while enforcing an exact maximum USDC spend and retaining the created task ID for audit and monitoring.
+<!-- END MANUAL -->
+
+---
+
+## Inspect Task Market Task
+
+### What it is
+Reads a TaskMarket task and its submissions without deciding outcomes
+
+### How it works
+<!-- MANUAL: how_it_works -->
+Uses read-only TaskMarket CLI operations to retrieve the current task state and its submissions. The block never accepts, rejects, rates, or selects a winner.
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| task_id | 0x-prefixed TaskMarket task ID | str | Yes |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| task | Current live task state | Dict[str, Any] |
+| submissions | Submissions presented for human review | List[Dict[str, Any]] |
+| human_review_required | Always true; this block cannot accept or reject work | bool |
+| error | Error message if the operation failed | str |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+Monitor a published TaskMarket bounty and surface worker submissions to a human reviewer without allowing the automation to make an irreversible winner decision.
+<!-- END MANUAL -->
+
+---
+
+## Prepare Task Market Task
+
+### What it is
+Builds an immutable TaskMarket requester preview without moving funds
+
+### How it works
+<!-- MANUAL: how_it_works -->
+Validates the description, deliverables, reward, hard spend ceiling, deadline, Base network, and canonical Base USDC contract. It emits a frozen preview and SHA-256 fingerprint without making a network write.
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| description | Exact public task description | str | Yes |
+| deliverables | Exact files or outcomes the worker must deliver | List[str] | Yes |
+| reward_usdc | USDC reward to escrow | float \| str | Yes |
+| maximum_spend_usdc | Hard operator-approved USDC spend ceiling | float \| str | Yes |
+| deadline | Timezone-aware task deadline | str (date-time) | Yes |
+| mode | Task selection mode | "bounty" \| "claim" \| "pitch" \| "benchmark" | No |
+| tags | Optional discovery tags | List[str] | No |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| preview | Immutable Base task preview for human authorization | TaskMarketTaskPreview |
+| fingerprint | SHA-256 binding for every preview and spend field | str |
+| error | Error message if the operation failed | str |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+Construct a deterministic bounty proposal for human approval before any USDC can be moved, with the exact terms cryptographically bound to the later creation step.
+<!-- END MANUAL -->
+
+---

--- a/docs/integrations/block-integrations/taskmarket/blocks.md
+++ b/docs/integrations/block-integrations/taskmarket/blocks.md
@@ -23,10 +23,10 @@ Consumes an approved review atomically, verifies the reviewed preview fingerprin
 
 | Output | Description | Type |
 |--------|-------------|------|
+| error | Error message if the operation failed | str |
 | task_id | Created TaskMarket task ID | str |
 | task_url | Canonical TaskMarket task link | str |
 | live_status | Live task state read back after creation | Dict[str, Any] |
-| error | Error message if the operation failed | str |
 
 ### Possible use case
 <!-- MANUAL: use_case -->
@@ -55,10 +55,10 @@ Uses read-only TaskMarket CLI operations to retrieve the current task state and 
 
 | Output | Description | Type |
 |--------|-------------|------|
+| error | Error message if the operation failed | str |
 | task | Current live task state | Dict[str, Any] |
 | submissions | Submissions presented for human review | List[Dict[str, Any]] |
 | human_review_required | Always true; this block cannot accept or reject work | bool |
-| error | Error message if the operation failed | str |
 
 ### Possible use case
 <!-- MANUAL: use_case -->
@@ -93,9 +93,9 @@ Validates the description, deliverables, reward, hard spend ceiling, deadline, B
 
 | Output | Description | Type |
 |--------|-------------|------|
+| error | Error message if the operation failed | str |
 | preview | Immutable Base task preview for human authorization | TaskMarketTaskPreview |
 | fingerprint | SHA-256 binding for every preview and spend field | str |
-| error | Error message if the operation failed | str |
 
 ### Possible use case
 <!-- MANUAL: use_case -->


### PR DESCRIPTION
### Why / What / How

**Why:** AutoGPT graphs currently cannot create and monitor TaskMarket requester tasks with a funding approval bound to the exact task terms. A requester integration needs an explicit spend and settlement boundary instead of treating task creation like an ordinary retryable API call.

**What:** This adds three backend blocks: one to prepare an immutable task preview, one to create the task after a fresh human review, and one read-only block to retrieve task status and submissions for human review. It also adds focused safety tests, generated integration documentation, and operator setup instructions.

**How:** The preview binds description, deliverables, reward, deadline, Base chain, canonical Base USDC, and maximum spend into a SHA-256 fingerprint. The create block atomically consumes the exact current execution's approval, performs wallet/network/legal/balance preflight checks through the first-party TaskMarket CLI, and makes exactly one idempotent funding call. Cancellation, timeouts, malformed results, and missing task IDs become unknown-settlement errors and are never blindly retried. Submission inspection exposes no accept or reject operation.

### Changes 🏗️

- Add `PrepareTaskMarketTaskBlock`, `CreateTaskMarketTaskBlock`, and `InspectTaskMarketTaskBlock`.
- Restrict funding to chain ID 8453 and canonical Base USDC.
- Bind approval and the deterministic idempotency key to immutable task terms and the current node execution.
- Atomically consume an approved review before dispatch so concurrent executions cannot double-fund.
- Validate maximum spend and available USDC before task creation.
- Terminate and reap cancelled subprocesses; preserve a returned task ID if the status read fails.
- Use direct subprocess arguments and the first-party `taskmarket` executable; never request or expose wallet secrets.
- Add fourteen focused safeguard test functions (seventeen cases) plus generated docs and reproduction instructions.

### Verification 📋

GitHub CI for commit `cad040ac4ce1ac9862f98d2e1f48ef4663565138` reports:

- [x] Backend lint and format checks
- [x] Python type checks on 3.11, 3.12, and 3.13
- [x] Classic lint and types
- [x] Block documentation sync
- [x] Full-stack end-to-end tests
- [x] API type check
- [x] CodeQL (Python and TypeScript), Snyk, and Codecov patch coverage at 81.35% (80% target)
- [x] CodeRabbit and Seer review checks
- [x] Backend test matrix on Python 3.11, 3.12, and 3.13
- [x] AMD64 and ARM64 image build, smoke, and scan

Local targeted verification:

```text
$ ruff check backend/blocks/taskmarket
All checks passed!
$ ruff format --check backend/blocks/taskmarket
7 files already formatted
```

The full Poetry environment was not installed on the authoring host, so the authoritative test results are the linked GitHub Actions checks. All TaskMarket tests inject the CLI boundary and make no network request or payment.

### Concise flow demo (no funds moved)

```text
Prepare TaskMarket Task
  -> validates description, deliverables, reward <= maximum_spend
  -> binds Base chain 8453 + canonical Base USDC
  -> emits immutable preview + SHA-256 fingerprint

Create Task Market Task
  -> pauses for fresh non-editable review of the exact preview
  -> atomically consumes the matching approved review
  -> checks wallet/network/legal/balance
  -> performs one idempotent `taskmarket task create`
  -> returns task ID, canonical link, and live status

Inspect Task Market Task
  -> reads task + submissions
  -> always reports human_review_required=true
  -> exposes no accept/reject/winner action
```

### Configuration

- [x] No `.env`, Docker, database, OAuth, or secret-storage changes are required.
- [x] The backend host must install the first-party TaskMarket CLI and complete its wallet/legal setup outside block inputs, as documented in the included README.

TaskMarket integration bounty context: `0xfb182f610d57a6c056a8cfd1c9b691a0869c1e0d67c041ac27ed9f42a9c732a1`.
