### PR TITLE
fix(backend): Claude Sonnet 4.6 max_output_tokens 64K -> 128K in catalog.py

### DIFF
--- a/autogpt_platform/backend/backend/data/llm_registry/catalog.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/catalog.py
@@ -175,7 +175,7 @@ def _build_catalog() -> CatalogPayload:
                 provider="anthropic",
                 creator="anthropic",
                 context_window=200000,
-                max_output_tokens=64000,
+                max_output_tokens=128000,
                 price_tier=3,
                 cost=CatalogModelCost(
                     run_credits=9,


### PR DESCRIPTION
### Why / What / How

**Why:** Fixes #13582. Replaces #13583, which I accidentally closed by deleting its head branch while rebasing it onto the `catalog-as-code` refactor (model facts moved from `blocks/llm.py`'s `MODEL_METADATA` into `data/llm_registry/catalog.py` since that PR was opened) — apologies for the churn on the issue thread.

Re-investigating against current `master` also **narrowed the fix's scope**. The original PR claimed Opus 4.6/4.7 and Sonnet 4.6 should all have `context_window=1000000`. That's no longer accurate: the `claude-sonnet-5` entry (added in #13629) documents that `context_window` is *intentionally* capped at 200K platform-wide for the Claude 5-tokenizer generation, pending a correction-factor soak (the family tokenizes ~30% denser than 4.x, and `context_window` feeds estimate-based compaction). That's a deliberate, documented design choice — not a bug — so this PR does **not** touch `context_window` for any model.

What's left, and still a real bug: `max_output_tokens` is a separate, hard API-enforced cap with no estimation involved, so the tokenizer-margin rationale doesn't apply to it. Opus 4.6 and Opus 4.7 already carry the accurate `128000` in this same table. Sonnet 4.6 is the one entry still at a stale `64000` — its real cap, like its Opus siblings, is `128000` per Anthropic's model docs.

**What:** One field in `data/llm_registry/catalog.py`: the `claude-sonnet-4-6` entry's `max_output_tokens`, `64000` → `128000`.

**How:** `max_output_tokens` is assigned directly to `input_data.max_tokens` for the actual API call (`blocks/llm.py`), so Sonnet 4.6 completions were capped at half their real ceiling. No test changes needed: `prompt_test.py`'s `context_window` pins (`200_000`) are untouched by this change (verified — grepped for any test pinning `max_output_tokens` or `64000` for this model; found none), and `catalog_test.py`'s integrity/cost-drift guards don't reference this value either.

### Changes 🏗️

- `data/llm_registry/catalog.py`: `claude-sonnet-4-6` entry's `max_output_tokens` corrected from `64000` to `128000`. Single-line, single-file change.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified against Anthropic's model documentation (Claude Sonnet 4.6 max output: 128,000 tokens, same tier as Opus 4.6/4.7)
  - [x] Grepped `catalog_test.py`, `prompt_test.py`, `test_llm.py`, and `llm_models_test.py` for any assertion pinning `max_output_tokens=64000` or referencing Sonnet 4.6's output cap — none found, so this change needs no accompanying test update
  - [x] Confirmed the change is isolated: `claude-opus-4-6`/`claude-opus-4-7` entries (same table, same generation) are unaffected and already correctly at `128000`
  - [x] File parses cleanly (`ast.parse`)
