### PR TITLE
feat(platform): name a provider's models before the user has that provider

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -22,11 +22,7 @@ from backend.copilot.active_turns import (
     inflight_turn_limit_message,
 )
 from backend.copilot.builder_context import resolve_session_permissions
-from backend.copilot.config import (
-    ChatConfig,
-    CopilotLlmAuthProvider,
-    CopilotLLMModel,
-)
+from backend.copilot.config import ChatConfig, CopilotLlmAuthProvider, CopilotLLMModel
 from backend.copilot.db import (
     chat_message_has_assistant_reply,
     get_chat_messages_paginated,
@@ -61,6 +57,10 @@ from backend.copilot.pending_message_helpers import (
 from backend.copilot.pending_messages import (
     clear_pending_messages_unsafe,
     peek_pending_messages,
+)
+from backend.copilot.provider_tiers import (
+    ProviderTiersResponse,
+    describe_provider_tiers,
 )
 from backend.copilot.rate_limit import (
     CoPilotUsagePublic,
@@ -564,6 +564,28 @@ async def list_chat_connections(
     so product and billing statements come from the side that enforces them.
     """
     return AIConnectionOffersResponse(offers=await get_connection_offers(user_id))
+
+
+@router.get(
+    "/model-tiers",
+    dependencies=[Security(auth.requires_user)],
+)
+async def list_provider_model_tiers(
+    user_id: Annotated[str, Security(auth.get_user_id)],
+) -> ProviderTiersResponse:
+    """What each provider's quality tiers resolve to, whoever you are.
+
+    ``GET /connections`` answers "what can you pick", and deliberately omits
+    a connection nobody can select. That makes it the wrong source for the
+    surfaces that describe a provider *before* the user has one -- the
+    connect dialog, and the plan cards selling a plan they have not bought.
+    Those need "ChatGPT's Advanced tier is 5.6 Sol", which is a fact about
+    the catalog rather than about this user's entitlements.
+
+    User-scoped only because the engine is: which model a tier maps to
+    depends on the path a turn will run on. Says nothing about access.
+    """
+    return ProviderTiersResponse(providers=await describe_provider_tiers(user_id))
 
 
 class SetDefaultTransportRequest(BaseModel):

--- a/autogpt_platform/backend/backend/copilot/offers.py
+++ b/autogpt_platform/backend/backend/copilot/offers.py
@@ -15,11 +15,11 @@ import logging
 from pydantic import BaseModel
 
 from backend.copilot.config import ChatConfig, CopilotLlmAuthProvider, CopilotLLMModel
-from backend.copilot.engine import resolve_use_sdk
-from backend.copilot.model_router import (
-    ROUTE_SURFACE_CODEX,
-    catalog_lookup,
-    resolve_model_route,
+from backend.copilot.provider_tiers import (
+    TIER_LABELS,
+    codex_tier_models,
+    platform_tier_models,
+    resolve_engine_mode,
 )
 from backend.copilot.transports import (
     ChatTransportResponse,
@@ -27,7 +27,6 @@ from backend.copilot.transports import (
     is_deployment_chat_available,
     settings,
 )
-from backend.data import llm_registry
 from backend.integrations.codex.access import (
     CODEX_MINIMUM_PLAN_ERROR,
     has_codex_access_for_discovery,
@@ -37,13 +36,6 @@ from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.settings import BehaveAs
 
 logger = logging.getLogger(__name__)
-
-# Product vocabulary. "Fast" and "Thinking" are execution paths, not tiers a
-# user picks between; the two labels below are what the product exposes.
-TIER_LABELS: dict[CopilotLLMModel, str] = {
-    "standard": "Balanced",
-    "advanced": "Advanced",
-}
 
 
 class ConnectionTier(BaseModel):
@@ -100,17 +92,9 @@ async def get_connection_offers(user_id: str) -> list[AIConnectionOffer]:
     pick.
     """
     config = ChatConfig()
-    # One engine decision for the whole response: it is a property of the
-    # deployment and the user, not of which connection they pick.
-    use_sdk = await resolve_use_sdk(
-        user_id,
-        use_claude_code_subscription=config.use_claude_code_subscription,
-        config_default=config.use_claude_agent_sdk,
-        thinking_available=config.thinking_available,
-    )
-    mode = "thinking" if use_sdk else "fast"
-    models = await _platform_tier_models(mode, user_id, config)
-    codex_models = _codex_tier_models(mode)
+    mode = await resolve_engine_mode(user_id, config)
+    models = await platform_tier_models(mode, user_id, config)
+    codex_models = codex_tier_models(mode)
     advanced_allowed = await _advanced_tier_allowed(user_id)
     offers = [
         _offer(transport, models, codex_models, advanced_allowed)
@@ -181,32 +165,6 @@ async def _locked_codex_offer(
     )
 
 
-async def _platform_tier_models(
-    mode: str, user_id: str, config: ChatConfig
-) -> dict[CopilotLLMModel, str | None]:
-    """Resolve each tier against the engine this user's turns will run on.
-
-    Answerable at all only because nothing can name an engine per request
-    any more — the decision is the server's, so it can be made before a turn
-    exists rather than during one.
-    """
-    resolved: dict[CopilotLLMModel, str | None] = {}
-    for tier in TIER_LABELS:
-        try:
-            route = await resolve_model_route(mode, tier, user_id, config=config)
-            resolved[tier] = _display_name(route.model)
-        except Exception:
-            # A tier that cannot be resolved is described without a name
-            # rather than failing the whole list.
-            logger.warning(
-                "Could not resolve the %s model for the platform connection",
-                tier,
-                exc_info=True,
-            )
-            resolved[tier] = None
-    return resolved
-
-
 def offer_id_for(transport: ChatTransportResponse) -> str:
     """Stable across requests, and unique per account.
 
@@ -233,47 +191,6 @@ async def _advanced_tier_allowed(user_id: str) -> bool:
             exc_info=True,
         )
         return True
-
-
-def _display_name(slug: str | None) -> str | None:
-    """What the catalog calls this model, rather than its slug.
-
-    The PRD labels tiers "Balanced · 5.6 Terra", not
-    "Balanced · gpt-5.6-terra": the slug is a routing key and reads as one.
-
-    Goes through the router's lookup rather than the catalog directly,
-    because the slug arrives in whatever spelling configured it. The default
-    configuration routes through OpenRouter, whose provider-prefixed forms
-    (``anthropic/claude-sonnet-5``) the catalog does not use as keys -- so a
-    direct read misses on exactly the setup most deployments run.
-
-    Falls back to the slug when nothing resolves, which is better than
-    showing nothing for a model the catalog has never heard of -- minus the
-    vendor prefix, which is how the transport addresses the model and carries
-    nothing for the reader. Keeping it costs ten characters in a control that
-    has to fit two of these side by side, and spends them on the one part of
-    the string that cannot tell anyone anything.
-    """
-    if not slug:
-        return None
-    model = catalog_lookup(slug)
-    if model:
-        return model.display_name
-    return slug.split("/", 1)[1] if "/" in slug else slug
-
-
-def _codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:
-    """The models the catalog pins for the Codex cells of this engine.
-
-    A registry read, so it costs nothing and needs no credential. The router
-    validates the pinned slug against what the account actually advertises
-    when the turn runs, and falls back if it is gone -- so this names the
-    routed model, not a promise about the account.
-    """
-    return {
-        tier: _display_name(llm_registry.get_route(ROUTE_SURFACE_CODEX, mode, tier))
-        for tier in TIER_LABELS
-    }
 
 
 def _offer(

--- a/autogpt_platform/backend/backend/copilot/offers_test.py
+++ b/autogpt_platform/backend/backend/copilot/offers_test.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import pytest_mock
 
-from backend.copilot import offers, transports
+from backend.copilot import offers, provider_tiers, transports
 from backend.copilot.offers import get_connection_offers, offer_id_for
 from backend.copilot.transports import ChatTransportResponse
 from backend.data.llm_registry import registry
@@ -43,9 +43,11 @@ def advanced_allowed(mocker: pytest_mock.MockerFixture):
 def hosted(mocker: pytest_mock.MockerFixture):
     mocker.patch.object(offers.settings.config, "behave_as", BehaveAs.CLOUD)
     mocker.patch.object(transports.settings.config, "behave_as", BehaveAs.CLOUD)
-    mocker.patch.object(offers, "resolve_use_sdk", new=AsyncMock(return_value=False))
     mocker.patch.object(
-        offers,
+        provider_tiers, "resolve_use_sdk", new=AsyncMock(return_value=False)
+    )
+    mocker.patch.object(
+        provider_tiers,
         "resolve_model_route",
         new=AsyncMock(
             side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
@@ -130,7 +132,7 @@ async def test_a_chatgpt_tier_names_the_model_the_catalog_pins(
     # A registry read, not a call to the account: the router validates the
     # pinned slug against what the account advertises when the turn runs.
     mocker.patch.object(
-        offers.llm_registry,
+        provider_tiers.llm_registry,
         "get_route",
         side_effect=lambda surface, mode, tier: f"{surface}:{mode}:{tier}",
     )
@@ -154,7 +156,7 @@ async def test_a_chatgpt_tier_names_the_model_the_catalog_pins(
 async def test_a_chatgpt_tier_the_catalog_pins_nothing_for_stays_unnamed(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    mocker.patch.object(offers.llm_registry, "get_route", return_value=None)
+    mocker.patch.object(provider_tiers.llm_registry, "get_route", return_value=None)
     _mock_transports(
         mocker, [_transport("platform", None), _transport("codex", "cred-1")]
     )
@@ -188,7 +190,9 @@ async def test_tiers_follow_the_engine_the_user_will_actually_run_on(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """The engine is the server's decision, so it is knowable before a turn."""
-    mocker.patch.object(offers, "resolve_use_sdk", new=AsyncMock(return_value=True))
+    mocker.patch.object(
+        provider_tiers, "resolve_use_sdk", new=AsyncMock(return_value=True)
+    )
     _mock_transports(mocker, [_transport(default=True)])
 
     (offer,) = await get_connection_offers(USER_ID)
@@ -217,7 +221,7 @@ async def test_an_unresolvable_tier_is_described_without_a_name(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     mocker.patch.object(
-        offers,
+        provider_tiers,
         "resolve_model_route",
         new=AsyncMock(side_effect=RuntimeError("registry down")),
     )
@@ -421,9 +425,9 @@ async def test_a_locked_chatgpt_offer_still_names_the_models(
     # "What you get" is the argument for connecting; a locked row that
     # cannot name the models asks the user to take it on faith.
     mocker.patch.object(
-        offers.llm_registry, "get_route", side_effect=lambda s, m, t: f"{m}-{t}"
+        provider_tiers.llm_registry, "get_route", side_effect=lambda s, m, t: f"{m}-{t}"
     )
-    mocker.patch.object(offers.llm_registry, "get_model", return_value=None)
+    mocker.patch.object(provider_tiers.llm_registry, "get_model", return_value=None)
     _mock_transports(mocker, [_transport("platform", None)])
     _upsell(mocker)
 
@@ -471,7 +475,7 @@ async def test_a_platform_tier_names_a_model_configured_in_transport_spelling(
     default."""
     _mock_transports(mocker, [_transport(default=True)])
     mocker.patch.object(
-        offers,
+        provider_tiers,
         "resolve_model_route",
         new=AsyncMock(
             side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
@@ -498,7 +502,7 @@ async def test_a_model_the_catalog_does_not_know_is_named_by_its_slug(
     prefix, which is addressing rather than identity."""
     _mock_transports(mocker, [_transport(default=True)])
     mocker.patch.object(
-        offers,
+        provider_tiers,
         "resolve_model_route",
         new=AsyncMock(
             side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(

--- a/autogpt_platform/backend/backend/copilot/provider_tiers.py
+++ b/autogpt_platform/backend/backend/copilot/provider_tiers.py
@@ -1,0 +1,175 @@
+"""What each quality tier resolves to, per provider, independent of access.
+
+``offers`` answers "which connections can this user pick, and what are they".
+That is the right question for the composer and for settings, and the wrong
+one for every surface that has to *describe* a provider before the user has
+one: the connect dialog, and the plan cards that sell a plan the user has not
+bought yet.
+
+Those surfaces need "ChatGPT's Advanced tier is 5.6 Sol" — a statement about
+the catalog, not about the user's entitlements. Asking ``offers`` for it does
+not work, because a connection nobody can select is deliberately absent from
+that list, and hardcoding it in the client reintroduces exactly the drift the
+offers endpoint exists to remove.
+
+So this module owns tier resolution, and ``offers`` consumes it.
+"""
+
+import logging
+
+from pydantic import BaseModel
+
+from backend.copilot.config import ChatConfig, CopilotLLMModel
+from backend.copilot.engine import resolve_use_sdk
+from backend.copilot.model_router import (
+    ROUTE_SURFACE_CODEX,
+    catalog_lookup,
+    resolve_model_route,
+)
+from backend.data import llm_registry
+
+logger = logging.getLogger(__name__)
+
+# Product vocabulary. "Fast" and "Thinking" are execution paths, not tiers a
+# user picks between; the two labels below are what the product exposes.
+TIER_LABELS: dict[CopilotLLMModel, str] = {
+    "standard": "Balanced",
+    "advanced": "Advanced",
+}
+
+
+class ProviderTier(BaseModel):
+    """A tier and the model it resolves to, with no claim about access.
+
+    Deliberately not ``ConnectionTier``: that type carries ``selectable`` and
+    ``lock_reason``, which are answers about a user. This one is a statement
+    about the catalog and is true whether or not anyone can pick it.
+    """
+
+    tier: CopilotLLMModel
+    label: str
+    display_model: str | None = None
+
+
+class ProviderTiers(BaseModel):
+    provider_family: str
+    display_name: str
+    tiers: list[ProviderTier]
+
+
+class ProviderTiersResponse(BaseModel):
+    providers: list[ProviderTiers]
+
+
+async def describe_provider_tiers(user_id: str) -> list[ProviderTiers]:
+    """What every provider's tiers resolve to for this user's engine.
+
+    User-scoped only because the engine is: which models a tier maps to
+    depends on whether the turn will run on the SDK path. It says nothing
+    about whether the user may use either provider.
+    """
+    config = ChatConfig()
+    mode = await resolve_engine_mode(user_id, config)
+    platform = await platform_tier_models(mode, user_id, config)
+    codex = codex_tier_models(mode)
+    return [
+        ProviderTiers(
+            provider_family="autogpt",
+            display_name="AutoGPT Platform",
+            tiers=_as_tiers(platform),
+        ),
+        ProviderTiers(
+            provider_family="openai",
+            display_name="ChatGPT",
+            tiers=_as_tiers(codex),
+        ),
+    ]
+
+
+async def resolve_engine_mode(user_id: str, config: ChatConfig) -> str:
+    """One engine decision per response.
+
+    It is a property of the deployment and the user, not of which connection
+    they pick, so it is resolved once rather than per provider.
+    """
+    use_sdk = await resolve_use_sdk(
+        user_id,
+        use_claude_code_subscription=config.use_claude_code_subscription,
+        config_default=config.use_claude_agent_sdk,
+        thinking_available=config.thinking_available,
+    )
+    return "thinking" if use_sdk else "fast"
+
+
+async def platform_tier_models(
+    mode: str, user_id: str, config: ChatConfig
+) -> dict[CopilotLLMModel, str | None]:
+    """Resolve each tier against the engine this user's turns will run on.
+
+    Answerable at all only because nothing can name an engine per request
+    any more — the decision is the server's, so it can be made before a turn
+    exists rather than during one.
+    """
+    resolved: dict[CopilotLLMModel, str | None] = {}
+    for tier in TIER_LABELS:
+        try:
+            route = await resolve_model_route(mode, tier, user_id, config=config)
+            resolved[tier] = display_name(route.model)
+        except Exception:
+            # A tier that cannot be resolved is described without a name
+            # rather than failing the whole list.
+            logger.warning(
+                "Could not resolve the %s model for the platform connection",
+                tier,
+                exc_info=True,
+            )
+            resolved[tier] = None
+    return resolved
+
+
+def codex_tier_models(mode: str) -> dict[CopilotLLMModel, str | None]:
+    """The models the catalog pins for the Codex cells of this engine.
+
+    A registry read, so it costs nothing and needs no credential. The router
+    validates the pinned slug against what the account actually advertises
+    when the turn runs, and falls back if it is gone -- so this names the
+    routed model, not a promise about the account.
+    """
+    return {
+        tier: display_name(llm_registry.get_route(ROUTE_SURFACE_CODEX, mode, tier))
+        for tier in TIER_LABELS
+    }
+
+
+def display_name(slug: str | None) -> str | None:
+    """What the catalog calls this model, rather than its slug.
+
+    The PRD labels tiers "Balanced · 5.6 Terra", not
+    "Balanced · gpt-5.6-terra": the slug is a routing key and reads as one.
+
+    Goes through the router's lookup rather than the catalog directly,
+    because the slug arrives in whatever spelling configured it. The default
+    configuration routes through OpenRouter, whose provider-prefixed forms
+    (``anthropic/claude-sonnet-5``) the catalog does not use as keys -- so a
+    direct read misses on exactly the setup most deployments run.
+
+    Falls back to the slug when nothing resolves, which is better than
+    showing nothing for a model the catalog has never heard of -- minus the
+    vendor prefix, which is how the transport addresses the model and carries
+    nothing for the reader. Keeping it costs ten characters in a control that
+    has to fit two of these side by side, and spends them on the one part of
+    the string that cannot tell anyone anything.
+    """
+    if not slug:
+        return None
+    model = catalog_lookup(slug)
+    if model:
+        return model.display_name
+    return slug.split("/", 1)[1] if "/" in slug else slug
+
+
+def _as_tiers(models: dict[CopilotLLMModel, str | None]) -> list[ProviderTier]:
+    return [
+        ProviderTier(tier=tier, label=label, display_model=models.get(tier))
+        for tier, label in TIER_LABELS.items()
+    ]

--- a/autogpt_platform/backend/backend/copilot/provider_tiers_test.py
+++ b/autogpt_platform/backend/backend/copilot/provider_tiers_test.py
@@ -1,0 +1,110 @@
+"""Describing a provider's tiers without asking whether the user may use it."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_mock
+
+from backend.copilot import provider_tiers
+from backend.copilot.provider_tiers import describe_provider_tiers, display_name
+from backend.data.llm_registry import registry
+
+USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
+
+
+@pytest.fixture
+def real_catalog():
+    """Resolution is only observable with the catalog actually loaded, and it
+    is process state, so it is put back afterwards."""
+    old = (
+        registry._dynamic_models,
+        registry._date_stripped_models,
+        registry._routes,
+        registry._loaded,
+    )
+    registry.load_catalog()
+    yield
+    (
+        registry._dynamic_models,
+        registry._date_stripped_models,
+        registry._routes,
+        registry._loaded,
+    ) = old
+
+
+@pytest.fixture(autouse=True)
+def engine(mocker: pytest_mock.MockerFixture):
+    mocker.patch.object(
+        provider_tiers, "resolve_use_sdk", new=AsyncMock(return_value=False)
+    )
+    mocker.patch.object(
+        provider_tiers,
+        "resolve_model_route",
+        new=AsyncMock(
+            side_effect=lambda mode, tier, user_id, *, config: SimpleNamespace(
+                model=f"{mode}-{tier}-model", source="config"
+            )
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_describes_chatgpt_without_the_user_having_it(
+    real_catalog,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """The whole reason this exists: the connect dialog and the plan cards
+    describe ChatGPT to someone who has not connected it, and the offers list
+    deliberately omits a connection nobody can select."""
+    mocker.patch.object(
+        provider_tiers.llm_registry,
+        "get_route",
+        side_effect=lambda surface, mode, tier: {
+            "standard": "gpt-5.6-terra",
+            "advanced": "gpt-5.6-sol",
+        }[tier],
+    )
+
+    providers = await describe_provider_tiers(USER_ID)
+
+    chatgpt = next(p for p in providers if p.provider_family == "openai")
+    # Named, not slugged: the catalog knows both, which is the point.
+    assert [(t.label, t.display_model) for t in chatgpt.tiers] == [
+        ("Balanced", "GPT-5.6 Terra"),
+        ("Advanced", "GPT-5.6 Sol"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_describes_the_platform_too(real_catalog) -> None:
+    providers = await describe_provider_tiers(USER_ID)
+
+    platform = next(p for p in providers if p.provider_family == "autogpt")
+    assert [t.label for t in platform.tiers] == ["Balanced", "Advanced"]
+    assert [t.tier for t in platform.tiers] == ["standard", "advanced"]
+
+
+@pytest.mark.asyncio
+async def test_says_nothing_about_access(real_catalog) -> None:
+    """A tier here carries no ``selectable`` and no ``lock_reason`` -- those
+    are answers about a user, and this is a statement about the catalog."""
+    providers = await describe_provider_tiers(USER_ID)
+
+    tier = providers[0].tiers[0]
+    assert not hasattr(tier, "selectable")
+    assert not hasattr(tier, "lock_reason")
+
+
+def test_names_a_model_configured_in_transport_spelling(real_catalog) -> None:
+    assert display_name("anthropic/claude-sonnet-5") == "Claude Sonnet 5"
+
+
+def test_falls_back_to_the_slug_tail_for_an_unlisted_model(real_catalog) -> None:
+    assert display_name("acme/a-model-nobody-has-heard-of") == (
+        "a-model-nobody-has-heard-of"
+    )
+
+
+def test_has_no_name_for_no_model(real_catalog) -> None:
+    assert display_name(None) is None

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/__tests__/ConnectStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/__tests__/ConnectStep.test.tsx
@@ -1,5 +1,9 @@
-import { getGetV2ListChatConnectionsMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import {
+  getGetV2ListChatConnectionsMockHandler200,
+  getGetV2ListProviderModelTiersMockHandler200,
+} from "@/app/api/__generated__/endpoints/chat/chat.msw";
 import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
+import type { ProviderTiers } from "@/app/api/__generated__/models/providerTiers";
 import { server } from "@/mocks/mock-server";
 import { render, screen } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
@@ -63,8 +67,25 @@ function chatgpt(over: Partial<AIConnectionOffer> = {}): AIConnectionOffer {
   });
 }
 
-function mockOffers(offers: AIConnectionOffer[]) {
-  server.use(getGetV2ListChatConnectionsMockHandler200({ offers }));
+function chatgptTiers(): ProviderTiers {
+  return {
+    provider_family: "openai",
+    display_name: "ChatGPT",
+    tiers: [
+      { tier: "standard", label: "Balanced", display_model: "GPT-5.6 Terra" },
+      { tier: "advanced", label: "Advanced", display_model: "GPT-5.6 Sol" },
+    ],
+  } as ProviderTiers;
+}
+
+function mockOffers(
+  offers: AIConnectionOffer[],
+  providers: ProviderTiers[] = [],
+) {
+  server.use(
+    getGetV2ListChatConnectionsMockHandler200({ offers }),
+    getGetV2ListProviderModelTiersMockHandler200({ providers }),
+  );
 }
 
 describe("ConnectStep", () => {
@@ -122,6 +143,18 @@ describe("ConnectStep", () => {
       await screen.findByText(/Claude subscriptions can't be linked/),
     ).toBeDefined();
   });
+
+  it("names what you get, from the catalog", async () => {
+    mockOffers([offer()], [chatgptTiers()]);
+
+    render(<ConnectStep />);
+
+    expect(
+      await screen.findByText(
+        /GPT-5\.6 Terra \(Balanced\) and GPT-5\.6 Sol \(Advanced\)/,
+      ),
+    ).toBeDefined();
+  });
 });
 
 describe("ConnectStep helpers", () => {
@@ -133,13 +166,22 @@ describe("ConnectStep helpers", () => {
   });
 
   it("names the models from the catalog rather than hardcoding them", () => {
-    expect(linkedModelsSentence([offer(), chatgpt()])).toBe(
+    expect(linkedModelsSentence([chatgptTiers()])).toBe(
       "GPT-5.6 Terra (Balanced) and GPT-5.6 Sol (Advanced)",
     );
   });
 
+  it("reads them from provider tiers, not from the user's connections", () => {
+    // The whole point of this screen is that the user has not connected yet,
+    // so ChatGPT is absent from their offers and this sentence would always
+    // have come out empty if it read them.
+    expect(linkedModelsSentence([])).toBe("");
+  });
+
   it("says nothing when the server named no models", () => {
-    expect(linkedModelsSentence([offer(), chatgpt({ tiers: [] })])).toBe("");
+    expect(
+      linkedModelsSentence([{ ...chatgptTiers(), tiers: [] } as ProviderTiers]),
+    ).toBe("");
     expect(linkedModelsSentence(undefined)).toBe("");
   });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/helpers.ts
@@ -1,4 +1,5 @@
 import type { AIConnectionOffer } from "@/app/api/__generated__/models/aIConnectionOffer";
+import type { ProviderTiers } from "@/app/api/__generated__/models/providerTiers";
 
 /**
  * Whether the user has already linked a subscription of their own.
@@ -19,16 +20,21 @@ export function hasLinkedSubscription(
 /**
  * "5.6 Terra (Balanced) and 5.6 Sol (Advanced)", from the catalog.
  *
+ * Read from the provider-tiers endpoint rather than from the user's
+ * connections, because the whole point of this screen is that the user does
+ * not have this connection yet -- so it is absent from the offers list, and
+ * the sentence would always come out empty.
+ *
  * Empty when the server named nothing, so the sentence that would have
  * carried it is dropped rather than rendered half-written. Never hardcoded
  * here: which model a tier resolves to is the server's to say, and this
  * screen is the one making the promise.
  */
 export function linkedModelsSentence(
-  offers: AIConnectionOffer[] | undefined,
+  providers: ProviderTiers[] | undefined,
 ): string {
-  const chatgpt = (offers ?? []).find(
-    (offer) => offer.auth_method === "chatgpt_oauth",
+  const chatgpt = (providers ?? []).find(
+    (provider) => provider.provider_family === "openai",
   );
   const named = (chatgpt?.tiers ?? [])
     .filter((tier) => tier.display_model)

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/useConnectStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/ConnectStep/useConnectStep.ts
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   getGetV2ListChatConnectionsQueryKey,
   useGetV2ListChatConnections,
+  useGetV2ListProviderModelTiers,
 } from "@/app/api/__generated__/endpoints/chat/chat";
 import { useOAuthConnect } from "@/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect";
 
@@ -21,6 +22,16 @@ export function useConnectStep() {
   const offers =
     connectionsQuery.data?.status === 200
       ? connectionsQuery.data.data.offers
+      : undefined;
+
+  // What ChatGPT's tiers resolve to, which the connections list cannot answer
+  // for a connection the user has not made yet.
+  const tiersQuery = useGetV2ListProviderModelTiers({
+    query: { refetchOnWindowFocus: false },
+  });
+  const providers =
+    tiersQuery.data?.status === 200
+      ? tiersQuery.data.data.providers
       : undefined;
 
   const { connect, isPending } = useOAuthConnect({
@@ -40,6 +51,6 @@ export function useConnectStep() {
     isConnecting: isPending,
     skip: nextStep,
     isAlreadyLinked: hasLinkedSubscription(offers),
-    models: linkedModelsSentence(offers),
+    models: linkedModelsSentence(providers),
   };
 }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -3703,6 +3703,30 @@
         }
       }
     },
+    "/api/chat/model-tiers": {
+      "get": {
+        "tags": ["v2", "chat", "chat"],
+        "summary": "List Provider Model Tiers",
+        "description": "What each provider's quality tiers resolve to, whoever you are.\n\n``GET /connections`` answers \"what can you pick\", and deliberately omits\na connection nobody can select. That makes it the wrong source for the\nsurfaces that describe a provider *before* the user has one -- the\nconnect dialog, and the plan cards selling a plan they have not bought.\nThose need \"ChatGPT's Advanced tier is 5.6 Sol\", which is a fact about\nthe catalog rather than about this user's entitlements.\n\nUser-scoped only because the engine is: which model a tier maps to\ndepends on the path a turn will run on. Says nothing about access.",
+        "operationId": "getV2ListProviderModelTiers",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderTiersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
     "/api/chat/schema/tool-responses": {
       "get": {
         "tags": ["v2", "chat", "chat"],
@@ -24121,6 +24145,50 @@
         "type": "object",
         "required": ["providers", "pagination"],
         "title": "ProviderResponse"
+      },
+      "ProviderTier": {
+        "properties": {
+          "tier": {
+            "type": "string",
+            "enum": ["standard", "advanced"],
+            "title": "Tier"
+          },
+          "label": { "type": "string", "title": "Label" },
+          "display_model": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Display Model"
+          }
+        },
+        "type": "object",
+        "required": ["tier", "label"],
+        "title": "ProviderTier",
+        "description": "A tier and the model it resolves to, with no claim about access.\n\nDeliberately not ``ConnectionTier``: that type carries ``selectable`` and\n``lock_reason``, which are answers about a user. This one is a statement\nabout the catalog and is true whether or not anyone can pick it."
+      },
+      "ProviderTiers": {
+        "properties": {
+          "provider_family": { "type": "string", "title": "Provider Family" },
+          "display_name": { "type": "string", "title": "Display Name" },
+          "tiers": {
+            "items": { "$ref": "#/components/schemas/ProviderTier" },
+            "type": "array",
+            "title": "Tiers"
+          }
+        },
+        "type": "object",
+        "required": ["provider_family", "display_name", "tiers"],
+        "title": "ProviderTiers"
+      },
+      "ProviderTiersResponse": {
+        "properties": {
+          "providers": {
+            "items": { "$ref": "#/components/schemas/ProviderTiers" },
+            "type": "array",
+            "title": "Providers"
+          }
+        },
+        "type": "object",
+        "required": ["providers"],
+        "title": "ProviderTiersResponse"
       },
       "PushSubscribeRequest": {
         "properties": {

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/ChatGPTConnectExplainer.tsx
@@ -8,13 +8,17 @@ import {
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 
+import { useGetV2ListProviderModelTiers } from "@/app/api/__generated__/endpoints/chat/chat";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
+
+import { chatgptModelsSentence } from "./helpers";
 
 interface Point {
   icon: IconSvgElement;
   title: string;
   body: string;
+  withModels?: (models: string) => string;
 }
 
 /**
@@ -22,9 +26,13 @@ interface Point {
  * that implies get answered on screen before the OAuth window opens rather
  * than after the user has committed.
  *
- * Deliberately claims nothing about specific models or about pausing and
- * resuming a run at a provider limit: the model catalog is server-owned, and
- * same-chat recovery is not built yet. Both land with their own work.
+ * Says nothing about pausing and resuming a run at a provider limit, because
+ * same-chat recovery is not built yet.
+ *
+ * It does name the models, from the catalog rather than from a literal here.
+ * The connections list cannot answer that at this point -- the user has not
+ * made this connection, so it is absent from their offers -- which is what
+ * the provider-tiers endpoint exists for.
  */
 const POINTS: Point[] = [
   {
@@ -41,6 +49,8 @@ const POINTS: Point[] = [
     icon: SparklesIcon,
     title: "What you get.",
     body: "The models your ChatGPT plan already includes, at no extra cost from AutoGPT.",
+    /** Replaced with the named models when the catalog can supply them. */
+    withModels: (models: string) => `${models}, at no extra cost from AutoGPT.`,
   },
   {
     icon: ShieldKeyIcon,
@@ -50,6 +60,12 @@ const POINTS: Point[] = [
 ];
 
 export function ChatGPTConnectExplainer() {
+  const { data } = useGetV2ListProviderModelTiers({
+    query: { refetchOnWindowFocus: false },
+  });
+  const models =
+    data?.status === 200 ? chatgptModelsSentence(data.data.providers) : "";
+
   return (
     <div className="divide-y divide-[#DADADC] rounded-2xl border border-[#DADADC] bg-[#FBFBFC]">
       {POINTS.map((point) => (
@@ -62,7 +78,7 @@ export function ChatGPTConnectExplainer() {
           </span>
           <Text variant="small" className="text-[#505057]">
             <span className="font-medium text-black">{point.title}</span>{" "}
-            {point.body}
+            {models && point.withModels ? point.withModels(models) : point.body}
           </Text>
         </div>
       ))}

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/MethodPanel.test.tsx
@@ -1,3 +1,6 @@
+import { getGetV2ListProviderModelTiersMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
+import type { ProviderTiers } from "@/app/api/__generated__/models/providerTiers";
+import { server } from "@/mocks/mock-server";
 import { render, screen } from "@/tests/integrations/test-utils";
 import { describe, expect, test, vi } from "vitest";
 
@@ -17,7 +20,61 @@ const openaiProvider: ConnectableProvider = {
   authProviderByType: { [AuthType.oauth2]: "codex" },
 };
 
+function mockProviderTiers(providers: ProviderTiers[]) {
+  server.use(getGetV2ListProviderModelTiersMockHandler200({ providers }));
+}
+
 describe("MethodPanel", () => {
+  test("names the models the plan gets you, from the catalog", async () => {
+    // Mock 2 spells these out. They cannot come from the connections list --
+    // the user has not connected yet, so ChatGPT is absent from it -- and
+    // hardcoding them here would drift from the catalog that routes the turn.
+    mockProviderTiers([
+      {
+        provider_family: "openai",
+        display_name: "ChatGPT",
+        tiers: [
+          {
+            tier: "standard",
+            label: "Balanced",
+            display_model: "GPT-5.6 Terra",
+          },
+          { tier: "advanced", label: "Advanced", display_model: "GPT-5.6 Sol" },
+        ],
+      } as ProviderTiers,
+    ]);
+
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        /GPT-5\.6 Terra \(Balanced\) and GPT-5\.6 Sol \(Advanced\)/,
+      ),
+    ).toBeDefined();
+  });
+
+  test("falls back to the general promise when the catalog names nothing", async () => {
+    mockProviderTiers([]);
+
+    render(
+      <MethodPanel
+        method={AuthType.oauth2}
+        provider={openaiProvider}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/models your ChatGPT plan already includes/),
+    ).toBeDefined();
+  });
+
   test("uses ChatGPT branding while sending OAuth to the Codex backend provider", () => {
     render(
       <MethodPanel

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/helpers.ts
@@ -1,3 +1,5 @@
+import type { ProviderTiers } from "@/app/api/__generated__/models/providerTiers";
+
 type ValidationDetailItem = { msg?: unknown };
 
 function readDetail(value: unknown): string | null {
@@ -51,4 +53,24 @@ export function getOAuthErrorMessage(error: unknown): string {
   }
 
   return "Something went wrong. Please try again.";
+}
+
+/**
+ * "5.6 Terra (Balanced) and 5.6 Sol (Advanced)", from the catalog.
+ *
+ * Empty when the server named nothing, so the sentence falls back to the
+ * general one rather than rendering half of a promise.
+ */
+export function chatgptModelsSentence(
+  providers: ProviderTiers[] | undefined,
+): string {
+  const chatgpt = (providers ?? []).find(
+    (provider) => provider.provider_family === "openai",
+  );
+  const named = (chatgpt?.tiers ?? [])
+    .filter((tier) => tier.display_model)
+    .map((tier) => `${tier.display_model} (${tier.label})`);
+  if (named.length === 0) return "";
+  if (named.length === 1) return named[0];
+  return `${named.slice(0, -1).join(", ")} and ${named[named.length - 1]}`;
 }


### PR DESCRIPTION
> Stacked on #14126 — review that first; this PR's diff is the one commit on top.

Closes the gap #14120 documented and could not fix.

### Why

Mock 2 promises, in the connect dialog, *"5.6 Terra (Balanced) and 5.6 Sol
(Advanced)"*. We shipped *"the models your ChatGPT plan already includes"*, and
the component's comment blamed the model catalog being server-owned. That
stopped being true several PRs ago, so I went to fix it — and hit the real
blocker.

`GET /connections` answers **"what can this user pick"**, and it is correct for
it to omit a connection nobody can select. But both audiences who ever open
that dialog get no ChatGPT entry at all, via two separate early returns in
`_locked_codex_offer`:

```python
if not _is_hosted():
    # Self-host grants the entitlement outright; there is nothing to sell.
    return None
if await has_codex_access_for_discovery(user_id):
    # Entitled but unconnected: the settings page owns that invitation.
    return None
```

So the only list that knows the models is empty of the provider being
described, at exactly the moment it is being described. Hardcoding the names in
the client would reintroduce the duplication #14104 removed.

### What

Tier resolution moves out of `offers` into its own module, and gets an endpoint.

`GET /api/chat/model-tiers` → what each provider's Balanced and Advanced
resolve to. A fact about the catalog, not about the user.

| | `GET /connections` | `GET /model-tiers` |
|---|---|---|
| question | what can I pick | what does a tier mean |
| omits unpickable providers | yes, deliberately | no |
| carries `selectable` / `lock_reason` | yes | no |

`ProviderTier` has no `selectable` and no `lock_reason` on purpose — those are
answers about a person; this type is a statement about the catalog.

### How

It is user-scoped only because the *engine* is: which model a tier maps to
depends on whether the turn runs on the SDK path. It says nothing about access.

**It also fixes a latent bug in #14126.** The self-host connect step I added
there read its models from the same connections list, so that sentence would
have rendered for nobody, ever. It now reads the new endpoint.

`offers.py` drops from 365 to 287 lines as a side effect — the right side of
the file-length guidance rather than the wrong one.

**The `openapi.json` change is spliced, not regenerated.** Exporting the whole
spec locally produces a ~14k-line diff against a file generated from a
different backend build, and the committed file is not Prettier-clean, so
formatting it churns everything. This is 108 insertions and no deletions,
matching how #14082 added `/connections`. The generated client is gitignored,
so nothing else needs committing.

### Testing

```
pytest backend/copilot/provider_tiers_test.py offers_test.py  →  31 passed
vitest run onboarding IntegrationsPanel copilot  →  164 files, 1959 passed
tsc --noEmit / eslint --max-warnings 0 / ruff  →  clean
```

New tests worth naming:

- `test_describes_chatgpt_without_the_user_having_it` — the whole reason this exists
- `test_says_nothing_about_access` — pins that the type carries no entitlement answers
- `names the models the plan gets you, from the catalog` (dialog)
- `falls back to the general promise when the catalog names nothing`
- `reads them from provider tiers, not from the user's connections` (connect step)

The moved mocks are worth a reviewer's eye: `offers_test` patched
`offers.resolve_use_sdk` and `offers.llm_registry`, which now live in
`provider_tiers`. Mocked where used, per the backend guide.

### Still open after this

Mock 2's *"How your data is handled"* link still has nothing to point at — the
only ChatGPT doc in the repo is an internal preview guide and `docs.agpt.co` is
dead. That needs a writer.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API and UI copy; tier naming is refactored but reused by existing connection offers with dedicated tests.
> 
> **Overview**
> Adds **`GET /api/chat/model-tiers`**, a user-authenticated catalog endpoint that returns Balanced/Advanced tier labels and resolved **display model names** per provider (AutoGPT Platform and ChatGPT) **without** `selectable`, `lock_reason`, or other entitlement fields—so connect flows can describe ChatGPT before it appears on **`GET /connections`**.
> 
> Tier resolution moves from **`offers.py`** into new **`provider_tiers.py`** (`resolve_engine_mode`, `platform_tier_models`, `codex_tier_models`, `display_name`); **`get_connection_offers`** now imports that shared logic so connection rows and the new endpoint stay aligned.
> 
> On the frontend, onboarding **ConnectStep** and **ChatGPTConnectExplainer** fetch provider tiers and build the “what you get” copy from server data (with generic fallback when names are missing), fixing the case where self-host/onboarding users had no ChatGPT offer to read models from. OpenAPI is updated for codegen; backend and frontend tests cover the new module, route, and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8b1259a3a448f0f35bcf18c28aa6e2eb9fa9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->