### PR TITLE
fix(backend): route read-only Cypher through GRAPH.RO_QUERY

### DIFF
--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -49,6 +49,25 @@ _EMPTY_KEY_ERROR = "invalid graph operation on empty key"
 _RO_VIOLATION = "read-only"
 
 
+# Quoted string literals, and // or /* */ comments. Stripped before clause
+# detection so a value like ``{kind: 'CREATE'}`` in an otherwise read-only
+# query is not mistaken for a write clause — that misread would send the query
+# down the graph-materializing path and reintroduce the very bug this fixes.
+_CYPHER_NOISE_RE = re.compile(
+    r"'(?:[^'\\]|\\.)*'"  # single-quoted literal
+    r"|\"(?:[^\"\\]|\\.)*\""  # double-quoted literal
+    r"|`(?:[^`]|``)*`"  # back-quoted identifier
+    r"|//[^\n]*"  # line comment
+    r"|/\*.*?\*/",  # block comment
+    re.DOTALL,
+)
+
+
+def _strip_cypher_noise(cypher_query_: str) -> str:
+    """Blank out literals/comments so only real clause keywords remain."""
+    return _CYPHER_NOISE_RE.sub(" ", cypher_query_ or "")
+
+
 def _is_read_only_cypher(cypher_query_: str) -> bool:
     """True when the query contains no mutating clause.
 
@@ -60,7 +79,7 @@ def _is_read_only_cypher(cypher_query_: str) -> bool:
     the latter in a single weekly community-rebuild sweep: 91 -> 19,033
     graphs, 100% of sampled ones empty).
     """
-    return not _WRITE_CLAUSE_RE.search(cypher_query_ or "")
+    return not _WRITE_CLAUSE_RE.search(_strip_cypher_noise(cypher_query_))
 
 
 def _is_pending_queue_overflow(exc: Exception) -> bool:
@@ -150,17 +169,12 @@ class AutoGPTFalkorDriver(FalkorDriver):
         attempts = max(1, graphiti_config.falkordb_query_max_attempts)
         read_only = _is_read_only_cypher(cypher_query_)
 
-        for attempt in range(attempts):
+        attempt = 0
+        while attempt < attempts:
             try:
-                if read_only:
-                    result = await cast(
-                        Awaitable[Any], graph.ro_query(cypher_query_, params)
-                    )
-                else:
-                    result = await cast(
-                        Awaitable[Any], graph.query(cypher_query_, params)
-                    )
-                return self._to_records(result)
+                return self._to_records(
+                    await self._dispatch(graph, cypher_query_, params, read_only)
+                )
             except Exception as e:
                 message = str(e).lower()
                 if read_only and _EMPTY_KEY_ERROR in message:
@@ -172,8 +186,11 @@ class AutoGPTFalkorDriver(FalkorDriver):
                     return [], [], None
                 if read_only and _RO_VIOLATION in message:
                     # The classifier called a write read-only. Degrade to the
-                    # write path rather than failing the caller, and log it so
-                    # the missing clause can be added to _WRITE_CLAUSE_RE.
+                    # write path and log it so the missing clause can be added
+                    # to _WRITE_CLAUSE_RE. Deliberately does NOT consume an
+                    # attempt: on the final attempt (or with max_attempts=1)
+                    # that would exit the loop having never run the write,
+                    # falling through to the "unreachable" assertion.
                     logger.warning(
                         "Query classified read-only but rejected by RO_QUERY; "
                         "retrying as a write. Query: %s",
@@ -193,6 +210,7 @@ class AutoGPTFalkorDriver(FalkorDriver):
                         delay,
                     )
                     await asyncio.sleep(delay)
+                    attempt += 1
                     continue
                 # ``params`` hold user memory content (names, facts) — omit them
                 # from this Sentry-routed log to avoid leaking PII. The exception
@@ -202,6 +220,18 @@ class AutoGPTFalkorDriver(FalkorDriver):
                 )
                 raise
         raise AssertionError("unreachable: loop returns or raises on every path")
+
+    @staticmethod
+    async def _dispatch(graph, cypher_query_, params, read_only: bool) -> Any:
+        """Issue one attempt on the read-only or writing transport.
+
+        ``GRAPH.RO_QUERY`` cannot materialize a graph; ``GRAPH.QUERY`` does,
+        even for a bare MATCH. Keeping the choice here means every caller goes
+        through one place.
+        """
+        if read_only:
+            return await cast(Awaitable[Any], graph.ro_query(cypher_query_, params))
+        return await cast(Awaitable[Any], graph.query(cypher_query_, params))
 
     @staticmethod
     def _pending_queue_retry_delay(attempt: int) -> float:

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -46,8 +46,14 @@ _WRITE_CLAUSE_RE = re.compile(
 # FalkorDB's error when the graph key does not exist yet.
 _EMPTY_KEY_ERROR = "invalid graph operation on empty key"
 
-# FalkorDB's error when a write is attempted through GRAPH.RO_QUERY.
-_RO_VIOLATION = "read-only"
+# FalkorDB's error when a write is attempted through GRAPH.RO_QUERY:
+# "graph.RO_QUERY is to be executed only on read-only queries".
+#
+# Match the full phrase, not a bare "read-only" substring. A spurious match
+# would send a genuine READ down the write path and materialize the graph —
+# the exact bug this routing exists to prevent. Redis's own replica error says
+# "read only" with no hyphen, so it cannot collide with this.
+_RO_VIOLATION = "read-only quer"
 
 
 # Quoted string literals, and // or /* */ comments. Stripped before clause

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -173,6 +173,12 @@ class AutoGPTFalkorDriver(FalkorDriver):
         """
         if database == self._database:
             return self
+        # Upstream also special-cases ``default_group_id`` ('\\_') and maps it to
+        # a 'default_db' database. That branch is unreachable here: both
+        # graphiti.py clone sites call validate_group_id() first, whose
+        # ^[a-zA-Z0-9_-]+$ pattern rejects the backslash, and the group_id=None
+        # path never clones. Noted rather than mirrored — if it ever did become
+        # reachable, this would create a graph literally named '\\_'.
         return AutoGPTFalkorDriver(
             falkor_db=self.client, database=database, build_indices=False
         )

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import random
+import re
 from collections.abc import Awaitable
 from typing import Any, cast
 
@@ -31,6 +32,35 @@ _PENDING_QUEUE_OVERFLOW = "max pending queries exceeded"
 # one wait into minutes. At default settings total backoff stays well within the
 # warm-context timeout budget.
 _MAX_RETRY_DELAY_SECONDS = 2.0
+
+
+# Cypher clauses that mutate the graph. Deliberately CONSERVATIVE: anything
+# matching takes the write path, so a false positive merely preserves today's
+# behaviour, while a false negative would send a real write to RO_QUERY and
+# fail it. The runtime fallback below covers that case anyway.
+_WRITE_CLAUSE_RE = re.compile(
+    r"\b(CREATE|MERGE|SET|DELETE|DETACH|REMOVE|DROP|FOREACH)\b", re.IGNORECASE
+)
+
+# FalkorDB's error when the graph key does not exist yet.
+_EMPTY_KEY_ERROR = "invalid graph operation on empty key"
+
+# FalkorDB's error when a write is attempted through GRAPH.RO_QUERY.
+_RO_VIOLATION = "read-only"
+
+
+def _is_read_only_cypher(cypher_query_: str) -> bool:
+    """True when the query contains no mutating clause.
+
+    Read-only queries go to ``GRAPH.RO_QUERY``. This matters far more than
+    performance: ``GRAPH.QUERY`` MATERIALIZES THE GRAPH even for a pure MATCH,
+    so routing reads through it silently creates an empty, permanently
+    resident graph for every user merely looked at. That is what filled
+    FalkorDB to its maxmemory ceiling twice (2026-08-16 and again 2026-08-23,
+    the latter in a single weekly community-rebuild sweep: 91 -> 19,033
+    graphs, 100% of sampled ones empty).
+    """
+    return not _WRITE_CLAUSE_RE.search(cypher_query_ or "")
 
 
 def _is_pending_queue_overflow(exc: Exception) -> bool:
@@ -118,12 +148,39 @@ class AutoGPTFalkorDriver(FalkorDriver):
         # runtime call upstream ``FalkorDriver.execute_query`` makes.
         params = cast(dict[str, object], convert_datetimes_to_strings(dict(kwargs)))
         attempts = max(1, graphiti_config.falkordb_query_max_attempts)
+        read_only = _is_read_only_cypher(cypher_query_)
 
         for attempt in range(attempts):
             try:
-                result = await cast(Awaitable[Any], graph.query(cypher_query_, params))
+                if read_only:
+                    result = await cast(
+                        Awaitable[Any], graph.ro_query(cypher_query_, params)
+                    )
+                else:
+                    result = await cast(
+                        Awaitable[Any], graph.query(cypher_query_, params)
+                    )
                 return self._to_records(result)
             except Exception as e:
+                message = str(e).lower()
+                if read_only and _EMPTY_KEY_ERROR in message:
+                    # No graph for this group yet, which simply means no
+                    # memories. Return an empty result rather than raising —
+                    # and deliberately do NOT retry via ``graph.query``, since
+                    # that would materialize the graph and reintroduce the bug
+                    # this routing exists to prevent.
+                    return [], [], None
+                if read_only and _RO_VIOLATION in message:
+                    # The classifier called a write read-only. Degrade to the
+                    # write path rather than failing the caller, and log it so
+                    # the missing clause can be added to _WRITE_CLAUSE_RE.
+                    logger.warning(
+                        "Query classified read-only but rejected by RO_QUERY; "
+                        "retrying as a write. Query: %s",
+                        cypher_query_,
+                    )
+                    read_only = False
+                    continue
                 if "already indexed" in str(e):
                     _UPSTREAM_QUERY_LOGGER.info(f"Index already exists: {e}")
                     return None

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -5,6 +5,7 @@ import re
 from collections.abc import Awaitable
 from typing import Any, cast
 
+from graphiti_core.driver.driver import GraphDriver
 from graphiti_core.driver.falkordb import STOPWORDS
 from graphiti_core.driver.falkordb_driver import FalkorDriver
 from graphiti_core.helpers import validate_group_ids
@@ -63,6 +64,19 @@ _CYPHER_NOISE_RE = re.compile(
 )
 
 
+# Procedure calls that WRITE but contain no standalone clause keyword, so
+# _WRITE_CLAUSE_RE alone misses them: `\bCREATE\b` does not match
+# `createNodeIndex` — there is no word boundary between "create" and "Node".
+# graphiti-core builds its three fulltext indices this way
+# (graphiti_core/graph_queries.py), so every one of them was classified
+# read-only and bounced off RO_QUERY on the first write for every new group.
+_WRITE_PROCEDURE_RE = re.compile(
+    r"\bdb\.idx\.fulltext\.(createNodeIndex|createRelationshipIndex|drop)\b"
+    r"|\bdb\.create\.",
+    re.IGNORECASE,
+)
+
+
 def _strip_cypher_noise(cypher_query_: str) -> str:
     """Blank out literals/comments so only real clause keywords remain."""
     return _CYPHER_NOISE_RE.sub(" ", cypher_query_ or "")
@@ -79,7 +93,8 @@ def _is_read_only_cypher(cypher_query_: str) -> bool:
     the latter in a single weekly community-rebuild sweep: 91 -> 19,033
     graphs, 100% of sampled ones empty).
     """
-    return not _WRITE_CLAUSE_RE.search(_strip_cypher_noise(cypher_query_))
+    text = _strip_cypher_noise(cypher_query_)
+    return not (_WRITE_CLAUSE_RE.search(text) or _WRITE_PROCEDURE_RE.search(text))
 
 
 def _is_pending_queue_overflow(exc: Exception) -> bool:
@@ -143,6 +158,25 @@ class AutoGPTFalkorDriver(FalkorDriver):
         """
         await super().build_indices_and_constraints()
 
+    def clone(self, database: str) -> "GraphDriver":
+        """Clone onto the SUBCLASS, never a plain upstream ``FalkorDriver``.
+
+        Upstream's ``clone()`` constructs a bare ``FalkorDriver``, which would
+        re-enable the init-time ``build_indices`` task (#14052) *and* route
+        every read back through ``graph.query`` — resurrecting both mass
+        graph-materialization bugs with no test covering it.
+
+        Not exercised today: every AutoGPT call site passes a single group_id.
+        graphiti-core clones only when ``group_id != driver._database`` or when
+        a search spans 2+ groups, so this is one line of insurance against a
+        future multi-group read.
+        """
+        if database == self._database:
+            return self
+        return AutoGPTFalkorDriver(
+            falkor_db=self.client, database=database, build_indices=False
+        )
+
     async def execute_query(
         self, cypher_query_, **kwargs
     ) -> tuple[list[dict[str, Any]], list[str], None] | None:
@@ -183,6 +217,21 @@ class AutoGPTFalkorDriver(FalkorDriver):
                     # and deliberately do NOT retry via ``graph.query``, since
                     # that would materialize the graph and reintroduce the bug
                     # this routing exists to prevent.
+                    #
+                    # CAVEAT: FalkorDB checks key existence BEFORE
+                    # read-only-ness, so a MISCLASSIFIED WRITE against a
+                    # missing graph lands here rather than in the RO-violation
+                    # branch below, and is silently dropped. The classifier
+                    # covers every write in graphiti-core and this repo today
+                    # (clause keywords + write procedures), but log the query
+                    # so a future novel write clause is traceable rather than
+                    # invisible. Debug level because a genuine read against a
+                    # group with no memories yet is entirely normal and common.
+                    logger.debug(
+                        "Read on a group with no graph yet; returning empty. "
+                        "Query: %s",
+                        cypher_query_,
+                    )
                     return [], [], None
                 if read_only and _RO_VIOLATION in message:
                     # The classifier called a write read-only. Degrade to the

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -247,11 +247,15 @@ class AutoGPTFalkorDriver(FalkorDriver):
                     return [], [], None
                 if read_only and _RO_VIOLATION in message:
                     # The classifier called a write read-only. Degrade to the
-                    # write path and log it so the missing clause can be added
-                    # to _WRITE_CLAUSE_RE. Deliberately does NOT consume an
-                    # attempt: on the final attempt (or with max_attempts=1)
-                    # that would exit the loop having never run the write,
-                    # falling through to the "unreachable" assertion.
+                    # write path and log the query so the missing clause or
+                    # procedure can be added to _WRITE_CLAUSE_RE /
+                    # _WRITE_PROCEDURE_RE.
+                    #
+                    # `read_only = False` + `continue` retries on the SAME
+                    # attempt: the counter is not advanced here, so the write
+                    # actually runs. Consuming an attempt instead would, on the
+                    # final attempt or with max_attempts=1, skip the write
+                    # entirely and fall through to the "unreachable" assertion.
                     logger.warning(
                         "Query classified read-only but rejected by RO_QUERY; "
                         "retrying as a write. Query: %s",

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
@@ -374,7 +374,9 @@ async def test_missing_graph_returns_empty_without_creating(
 @pytest.mark.asyncio
 async def test_ro_violation_falls_back_to_write(driver: AutoGPTFalkorDriver) -> None:
     """If the classifier is wrong, degrade to the write path rather than fail."""
-    ro = _set_ro_query(driver, Exception("ERR graph is read-only for this command"))
+    ro = _set_ro_query(
+        driver, Exception("graph.RO_QUERY is to be executed only on read-only queries")
+    )
     write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
     await driver.execute_query("MATCH (n) RETURN count(n)")
     ro.assert_awaited_once()
@@ -409,7 +411,9 @@ async def test_ro_violation_on_final_attempt_still_writes(
     attempt would exit the loop having never issued the write, hitting the
     "unreachable" AssertionError.
     """
-    ro = _set_ro_query(driver, Exception("ERR graph is read-only for this command"))
+    ro = _set_ro_query(
+        driver, Exception("graph.RO_QUERY is to be executed only on read-only queries")
+    )
     write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
     with patch(
         "backend.copilot.graphiti.config.graphiti_config.falkordb_query_max_attempts",
@@ -430,8 +434,10 @@ async def test_ro_violation_on_final_attempt_still_writes(
         # graphiti-core builds all three fulltext indices this way. `\bCREATE\b`
         # does NOT match `createNodeIndex`, so these were classified read-only
         # and bounced off RO_QUERY on every new group's first write.
-        "CALL db.idx.fulltext.createNodeIndex({label: 'Episodic', stopwords: []},"
-        " 'content', 'source', 'source_description', 'group_id')",
+        (
+            "CALL db.idx.fulltext.createNodeIndex({label: 'Episodic', stopwords: []},"
+            " 'content', 'source', 'source_description', 'group_id')"
+        ),
         "CALL db.idx.fulltext.createNodeIndex({label: 'Entity'}, 'name')",
         "CALL db.idx.fulltext.createNodeIndex({label: 'Community'}, 'name')",
         "CALL db.idx.fulltext.drop('Entity')",
@@ -460,3 +466,20 @@ def test_clone_returns_subclass_with_indices_disabled() -> None:
     assert isinstance(cloned, AutoGPTFalkorDriver)
     assert cloned._build_indices_at_init is False
     assert driver.clone("user_a") is driver
+
+
+@pytest.mark.asyncio
+async def test_unrelated_readonly_wording_does_not_trigger_write_fallback(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """A spurious RO-violation match would send a genuine READ down the write
+    path and materialize the graph. Redis's replica error ("read only", no
+    hyphen) must not be mistaken for FalkorDB's RO_QUERY rejection."""
+    ro = _set_ro_query(
+        driver, Exception("READONLY You can't write against a read only replica.")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    with pytest.raises(Exception, match="read only replica"):
+        await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited()
+    write.assert_not_called()

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
@@ -419,3 +419,44 @@ async def test_ro_violation_on_final_attempt_still_writes(
     assert records == [{"n": 1}]
     ro.assert_awaited_once()
     write.assert_awaited_once()
+
+
+# --- guards for the fulltext index-creation writes -------------------------
+
+
+@pytest.mark.parametrize(
+    "cypher",
+    [
+        # graphiti-core builds all three fulltext indices this way. `\bCREATE\b`
+        # does NOT match `createNodeIndex`, so these were classified read-only
+        # and bounced off RO_QUERY on every new group's first write.
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Episodic', stopwords: []},"
+        " 'content', 'source', 'source_description', 'group_id')",
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Entity'}, 'name')",
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Community'}, 'name')",
+        "CALL db.idx.fulltext.drop('Entity')",
+    ],
+)
+def test_write_procedures_are_not_read_only(cypher) -> None:
+    assert fdb._is_read_only_cypher(cypher) is False
+
+
+def test_fulltext_query_procedure_stays_read_only() -> None:
+    """The search path must keep using RO_QUERY."""
+    assert (
+        fdb._is_read_only_cypher(
+            "CALL db.idx.fulltext.queryNodes('Entity', $query) YIELD node RETURN node"
+        )
+        is True
+    )
+
+
+def test_clone_returns_subclass_with_indices_disabled() -> None:
+    """Upstream clone() builds a plain FalkorDriver, which would re-enable the
+    init-time index task and route reads back through the creating path."""
+    driver = AutoGPTFalkorDriver(falkor_db=MagicMock())
+    driver._database = "user_a"
+    cloned = driver.clone("user_b")
+    assert isinstance(cloned, AutoGPTFalkorDriver)
+    assert cloned._build_indices_at_init is False
+    assert driver.clone("user_a") is driver

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
@@ -379,3 +379,43 @@ async def test_ro_violation_falls_back_to_write(driver: AutoGPTFalkorDriver) -> 
     await driver.execute_query("MATCH (n) RETURN count(n)")
     ro.assert_awaited_once()
     write.assert_awaited_once()
+
+
+# --- regression guards for the review findings on the read-only routing ----
+
+
+@pytest.mark.parametrize(
+    "cypher",
+    [
+        "MATCH (n {kind: 'CREATE'}) RETURN n",
+        'MATCH (n) WHERE n.name = "DELETE" RETURN n',
+        "MATCH (n) RETURN n // SET is only mentioned in this comment",
+        "/* MERGE */ MATCH (n) RETURN n",
+    ],
+)
+def test_write_keywords_inside_literals_stay_read_only(cypher) -> None:
+    """A write keyword inside a string literal or comment must not flip the
+    query onto the graph-materializing path."""
+    assert fdb._is_read_only_cypher(cypher) is True
+
+
+@pytest.mark.asyncio
+async def test_ro_violation_on_final_attempt_still_writes(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """The RO fallback must not consume a retry.
+
+    With max_attempts=1 (or on the last attempt) a fallback that burned an
+    attempt would exit the loop having never issued the write, hitting the
+    "unreachable" AssertionError.
+    """
+    ro = _set_ro_query(driver, Exception("ERR graph is read-only for this command"))
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    with patch(
+        "backend.copilot.graphiti.config.graphiti_config.falkordb_query_max_attempts",
+        1,
+    ):
+        records, _, _ = await driver.execute_query("MATCH (n) RETURN count(n)")
+    assert records == [{"n": 1}]
+    ro.assert_awaited_once()
+    write.assert_awaited_once()

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
@@ -21,6 +21,13 @@ def _set_query(driver: AutoGPTFalkorDriver, side_effect) -> AsyncMock:
     return query
 
 
+def _set_ro_query(driver: AutoGPTFalkorDriver, side_effect) -> AsyncMock:
+    """Wire ``graph.ro_query`` (reached via ``_get_graph``) to ``side_effect``."""
+    ro_query = AsyncMock(side_effect=side_effect)
+    driver.client.select_graph.return_value.ro_query = ro_query
+    return ro_query
+
+
 def _overflow() -> Exception:
     return Exception("Max pending queries exceeded")
 
@@ -187,7 +194,7 @@ async def test_execute_query_success_returns_upstream_shaped_records(
 ) -> None:
     """Happy path: no retry, and results are shaped like upstream
     (list-of-dicts, header, None)."""
-    _set_query(driver, [_FakeResult([("n.count", "count")], [[5]])])
+    _set_ro_query(driver, [_FakeResult([("n.count", "count")], [[5]])])
 
     records, header, meta = await driver.execute_query("MATCH (n) RETURN count(n)")
 
@@ -202,7 +209,7 @@ async def test_execute_query_retries_pending_queue_overflow_then_succeeds(
 ) -> None:
     """Two transient overflows are retried; the third attempt succeeds and its
     result is returned (memory op recovers instead of being dropped)."""
-    query = _set_query(
+    query = _set_ro_query(
         driver,
         [_overflow(), _overflow(), _FakeResult([("x", "count")], [[1]])],
     )
@@ -226,7 +233,7 @@ async def test_execute_query_raises_after_exhausting_retries(
 ) -> None:
     """A sustained overflow exhausts the budget, then raises AND logs exactly
     one terminal error under the upstream logger (so Sentry sees one event)."""
-    query = _set_query(driver, _overflow())
+    query = _set_ro_query(driver, _overflow())
 
     # max_attempts=4 (non-default) proves the knob controls the attempt count.
     with patch.object(fdb.asyncio, "sleep", new=AsyncMock()) as sleep, patch.object(
@@ -266,7 +273,7 @@ async def test_execute_query_non_overflow_error_fails_fast(
 ) -> None:
     """A genuine query error (Cypher typo, missing graph, teardown) is not
     retried — it raises on the first attempt and logs once."""
-    query = _set_query(driver, ValueError("syntax error near RETRN"))
+    query = _set_ro_query(driver, ValueError("syntax error near RETRN"))
 
     with patch.object(fdb.asyncio, "sleep", new=AsyncMock()) as sleep, patch.object(
         fdb, "_UPSTREAM_QUERY_LOGGER"
@@ -296,3 +303,79 @@ async def test_execute_query_already_indexed_returns_none_without_retry(
     assert query.await_count == 1
     sleep.assert_not_awaited()
     upstream_logger.error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Read-only query routing.
+#
+# GRAPH.QUERY materializes the graph even for a pure MATCH, so routing reads
+# through it silently creates an empty, permanently resident graph for every
+# user merely looked at. That filled FalkorDB to maxmemory twice — most
+# recently a single weekly community-rebuild sweep took prod from 91 to 19,033
+# graphs, 100% of sampled ones empty. Reads must use GRAPH.RO_QUERY.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cypher,expected_read_only",
+    [
+        ("MATCH (n) RETURN count(n)", True),
+        ("MATCH (n:Entity) WHERE n.group_id = $g RETURN n.name", True),
+        ("CALL db.idx.fulltext.queryNodes('Entity', $q) YIELD node RETURN node", True),
+        ("CREATE INDEX FOR (n:Entity) ON (n.uuid)", False),
+        ("MERGE (n:Entity {uuid: $u})", False),
+        ("MATCH (n) SET n.x = 1", False),
+        ("MATCH (n) DETACH DELETE n", False),
+        ("MATCH (n) REMOVE n.x", False),
+    ],
+)
+def test_read_only_cypher_classification(cypher, expected_read_only) -> None:
+    assert fdb._is_read_only_cypher(cypher) is expected_read_only
+
+
+@pytest.mark.asyncio
+async def test_read_only_query_uses_ro_query(driver: AutoGPTFalkorDriver) -> None:
+    """A MATCH must go to ro_query and must never touch the creating path."""
+    ro = _set_ro_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited_once()
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_query_uses_query(driver: AutoGPTFalkorDriver) -> None:
+    ro = _set_ro_query(driver, [_FakeResult([], [])])
+    write = _set_query(driver, [_FakeResult([], [])])
+    await driver.execute_query("MERGE (n:Entity {uuid: $u})", u="x")
+    write.assert_awaited_once()
+    ro.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_graph_returns_empty_without_creating(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """The regression guard.
+
+    A read against a group with no graph yet must yield an empty result, NOT
+    an error and NOT a fallback to ``graph.query`` — that fallback would
+    materialize the graph, which is the entire bug.
+    """
+    ro = _set_ro_query(driver, Exception("ERR Invalid graph operation on empty key"))
+    write = _set_query(driver, [_FakeResult([], [])])
+    records, header, _ = await driver.execute_query("MATCH (n) RETURN count(n)")
+    assert records == []
+    assert header == []
+    ro.assert_awaited_once()
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ro_violation_falls_back_to_write(driver: AutoGPTFalkorDriver) -> None:
+    """If the classifier is wrong, degrade to the write path rather than fail."""
+    ro = _set_ro_query(driver, Exception("ERR graph is read-only for this command"))
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited_once()
+    write.assert_awaited_once()


### PR DESCRIPTION
### Why / What / How

**Why.** `GRAPH.QUERY` **materializes the graph even for a pure `MATCH`** — only `GRAPH.RO_QUERY` does not. `AutoGPTFalkorDriver.execute_query` sent *every* query through `graph.query()`, which the falkordb client issues as `read_only=False`. So **every read silently created an empty, permanently resident graph** for any user merely looked at.

This is the actual root cause of the FalkorDB `maxmemory` wedge. #14052 (`build_indices=False`) only stopped the init-time `CREATE INDEX` — it never touched the read path, so the leak continued through a different door.

The weekly Graphiti community rebuild sweeps **every** user and runs a `MATCH` per user via `_activity_since_last_rebuild`. The **2026-08-23 sweep took prod from 91 to 19,033 graphs in a single pass** (100% of sampled ones empty) and wedged FalkorDB a second time, 7 days after the first cleanup.

**What.**
- `_is_read_only_cypher()` — clause keywords (`CREATE`/`MERGE`/`SET`/`DELETE`/`DETACH`/`REMOVE`/`DROP`/`FOREACH`) **plus write procedures**, evaluated after quoted literals and comments are stripped.
- Reads → `graph.ro_query()`; writes keep `graph.query()`, via a `_dispatch` helper.
- `RO_QUERY` against a group with **no graph yet** errors with `Invalid graph operation on empty key`. That is translated to an **empty result** (no graph == no memories) and deliberately does **not** fall back to `graph.query()`, which would materialize the graph and reintroduce the bug.
- `clone()` overridden so multi-group searches cannot drop back to the upstream driver.

**How.** FalkorDB's behaviour was verified directly, not assumed: `GRAPH.RO_QUERY` on a nonexistent graph returns `ERR Invalid graph operation on empty key` and **does not create it** (`GRAPH.LIST` count stayed 0).

### Changes 🏗️

- `falkordb_driver.py` — read/write classification and routing, literal/comment stripping, write-procedure detection, empty-key → empty result, RO-violation fallback, `clone()` override.
- `falkordb_driver_test.py` — classification (incl. keywords inside literals and comments), read→`ro_query`, write→`query`, the **missing-graph guard** (asserts `graph.query` is *never* called), the RO fallback on a final attempt, the three real `createNodeIndex` strings, and `clone()`.

### Checklist 📋

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/copilot/graphiti/` → **239 passed, 27 skipped, 1 xfailed**
  - [x] ruff / black / isort clean; pyright **0 errors** on the changed files
  - [x] Confirmed against prod that `RO_QUERY` on a missing graph errors *and does not create it*
  - [x] Adversarial review ran the classifier over **all 710** Cypher strings in graphiti-core 0.28.2 + this repo, and exercised the real driver against a live FalkorDB container: no read is misrouted onto the materializing path
  - [x] Prod cleaned up in parallel: 19,033 → 93 graphs, 9.39 GB freed, **zero data loss** (93/93 intact; nodes 29,981 → 29,993, i.e. growth from writes resuming)
  - [ ] Post-deploy: confirm graph count stays flat through the **next weekly community rebuild** — the sweep that caused this

### Limitations — read this before approving

**The classifier is textual.** It covers every write in graphiti-core 0.28.2 and this repo today, verified by sweeping all 710 query strings. A future novel write clause would not be covered.

**A misclassified write against a graph that does not exist yet is silently dropped.** FalkorDB checks key existence *before* read-only-ness, so such a write raises the empty-key error rather than a read-only violation, lands in the empty-result branch, and vanishes without an error. The RO-violation fallback therefore only protects writes against **graphs that already exist** — an earlier version of this description claimed otherwise, which was wrong. The branch logs the query at **debug** level. Be precise about what that buys: prod does not run at debug, so in practice this means *traceable once someone enables debug logging while already chasing the symptom* — not proactively detected. Debug rather than warn because a genuine read against a group with no memories yet is completely normal and would flood the logs.

**The hole is narrowed, not closed.** The clause half of the classifier (`CREATE`/`MERGE`/`SET`/`DELETE`/`DETACH`/`REMOVE`/`DROP`/`FOREACH`) is a closed grammar set — FalkorDB adding a mutating clause would be a headline language change. The open-ended half was always procedures, and the real fix for that is to read the server's own truth via `CALL dbms.procedures() YIELD name, mode` (verified to run under RO_QUERY and to report `createNodeIndex -> WRITE`), cache the write-set per process, and classify `CALL` sites against it. That is a follow-up ticket, not this hotfix.

### Review history

Three rounds of findings, all on my own code:
- Write keywords inside string literals/comments took the materializing path (`MATCH (n {kind: 'CREATE'})`).
- The RO fallback consumed a retry attempt, so a misclassification on the final attempt hit an `AssertionError` claiming that path was unreachable.
- `createNodeIndex` is a write that `\bCREATE\b` does not match, so all three of graphiti-core's fulltext index builders were classified read-only — bouncing off `RO_QUERY` on every new group's first write, and making the silent-drop case above reachable today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Graphiti/FalkorDB query routing for all memory reads and writes; a classifier miss could drop writes on nonexistent graphs or misroute queries, though RO-violation fallback and conservative write detection mitigate most cases.
> 
> **Overview**
> Fixes FalkorDB **maxmemory** blowups caused by sending every Cypher call through `graph.query`, which **materializes an empty graph** even for pure `MATCH` reads.
> 
> `AutoGPTFalkorDriver.execute_query` now classifies queries (mutating clauses and write procedures, after stripping string literals and comments) and routes **reads** to `graph.ro_query` and **writes** to `graph.query` via `_dispatch`. Reads against a group with no graph yet map the empty-key error to an **empty result** with no fallback to the write path. Misclassified writes that RO_QUERY rejects are retried on the write path **without burning a retry attempt**. **`clone()`** is overridden so clones stay `AutoGPTFalkorDriver` with `build_indices=False`.
> 
> Tests cover classification edge cases (keywords in literals/comments, fulltext index procedures), routing, the missing-graph guard, RO fallback on the final attempt, and clone behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1c686e21e26961cff460ad2279c1e9c75fd68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->