### PR TITLE
fix(forge): stop list_folders crashing on prefix-sibling keys in S3/GCS storage

### DIFF
--- a/classic/forge/forge/file_storage/gcs.py
+++ b/classic/forge/forge/file_storage/gcs.py
@@ -173,7 +173,9 @@ class GCSFileStorage(FileStorage):
         folder_names = set()
 
         # List objects with the specified prefix and delimiter
-        for blob in self._bucket.list_blobs(prefix=path):
+        for blob in self._bucket.list_blobs(
+            prefix=f"{path}/" if path != Path(".") else None
+        ):
             # Remove path prefix and the object name (last part)
             folder = Path(blob.name).relative_to(path).parent
             if not folder or folder == Path("."):

--- a/classic/forge/forge/file_storage/s3.py
+++ b/classic/forge/forge/file_storage/s3.py
@@ -177,7 +177,12 @@ class S3FileStorage(FileStorage):
         folder_names = set()
 
         # List objects with the specified prefix and delimiter
-        for obj_summary in self._bucket.objects.filter(Prefix=str(path)):
+        objects = (
+            self._bucket.objects.all()
+            if path == Path(".")
+            else self._bucket.objects.filter(Prefix=f"{path}/")
+        )
+        for obj_summary in objects:
             # Remove path prefix and the object name (last part)
             folder = Path(obj_summary.key).relative_to(path).parent
             if not folder or folder == Path("."):

--- a/classic/forge/forge/file_storage/test_gcs_file_storage.py
+++ b/classic/forge/forge/file_storage/test_gcs_file_storage.py
@@ -133,6 +133,16 @@ def test_list_folders(gcs_storage_with_files: GCSFileStorage):
     assert set(folders) == {Path("existing")}
 
 
+def test_list_folders_at_path_excludes_prefix_siblings(
+    gcs_storage_with_files: GCSFileStorage,
+):
+    # "existing_test_file_1" etc. are flat files at the bucket root that share a
+    # raw string prefix with the "existing/" folder without being nested under it.
+    # list_folders("existing") must not treat them as descendants of "existing".
+    folders = gcs_storage_with_files.list_folders("existing", recursive=True)
+    assert set(folders) == {Path("test"), Path("test/dir")}
+
+
 @pytest.mark.asyncio
 async def test_write_read_file(gcs_storage: GCSFileStorage):
     await gcs_storage.write_file("test_file", "test_content")

--- a/classic/forge/forge/file_storage/test_gcs_file_storage.py
+++ b/classic/forge/forge/file_storage/test_gcs_file_storage.py
@@ -135,7 +135,7 @@ def test_list_folders(gcs_storage_with_files: GCSFileStorage):
 
 def test_list_folders_at_path_excludes_prefix_siblings(
     gcs_storage_with_files: GCSFileStorage,
-):
+) -> None:
     # "existing_test_file_1" etc. are flat files at the bucket root that share a
     # raw string prefix with the "existing/" folder without being nested under it.
     # list_folders("existing") must not treat them as descendants of "existing".

--- a/classic/forge/forge/file_storage/test_s3_file_storage.py
+++ b/classic/forge/forge/file_storage/test_s3_file_storage.py
@@ -135,7 +135,7 @@ def test_list_folders(s3_storage_with_files: S3FileStorage):
 
 def test_list_folders_at_path_excludes_prefix_siblings(
     s3_storage_with_files: S3FileStorage,
-):
+) -> None:
     # "existing_test_file_1" etc. are flat files at the bucket root that share a
     # raw string prefix with the "existing/" folder without being nested under it.
     # list_folders("existing") must not treat them as descendants of "existing".

--- a/classic/forge/forge/file_storage/test_s3_file_storage.py
+++ b/classic/forge/forge/file_storage/test_s3_file_storage.py
@@ -133,6 +133,16 @@ def test_list_folders(s3_storage_with_files: S3FileStorage):
     assert set(folders) == {Path("existing")}
 
 
+def test_list_folders_at_path_excludes_prefix_siblings(
+    s3_storage_with_files: S3FileStorage,
+):
+    # "existing_test_file_1" etc. are flat files at the bucket root that share a
+    # raw string prefix with the "existing/" folder without being nested under it.
+    # list_folders("existing") must not treat them as descendants of "existing".
+    folders = s3_storage_with_files.list_folders("existing", recursive=True)
+    assert set(folders) == {Path("test"), Path("test/dir")}
+
+
 @pytest.mark.asyncio
 async def test_write_read_file(s3_storage: S3FileStorage):
     await s3_storage.write_file("test_file", "test_content")


### PR DESCRIPTION
### Why / What / How

**Why:** `S3FileStorage.list_folders()` and `GCSFileStorage.list_folders()` build their object-listing prefix from `str(path)` / `path` directly, without the trailing `"/"` that their own sibling method `list_files()` already adds for exactly this reason. Any object whose key shares a raw string prefix with the target path but isn't actually nested under it - e.g. `existing_test_file_1` sitting next to an `existing/` folder, which is exactly the layout already present in this file's own `TEST_FILES` fixture - gets matched by the over-broad listing, and then crashes with an uncaught `ValueError` in `Path.relative_to()` instead of being correctly excluded.

**What:** Apply the same `f"{path}/"` (or `None`/`.objects.all()` at true root) prefix pattern `list_files()` already uses correctly, to `list_folders()` in both backends.

**How:** Mirrors the exact conditional already used by each backend's own `list_files()` method - no new pattern introduced, just applying the existing correct one consistently to the sibling method that was missing it.

### Changes 🏗️

- `forge/forge/file_storage/gcs.py`: `list_folders()` now passes `prefix=f"{path}/" if path != Path(".") else None` to `list_blobs()`, matching `list_files()`.
- `forge/forge/file_storage/s3.py`: `list_folders()` now uses `.objects.all()` at true root and `Prefix=f"{path}/"` otherwise, matching `list_files()`.
- `forge/forge/file_storage/test_gcs_file_storage.py` / `test_s3_file_storage.py`: added `test_list_folders_at_path_excludes_prefix_siblings`, calling `list_folders("existing", recursive=True)` against the existing fixture (which already contains the prefix-sibling collision) and asserting the correct, non-crashing result.

### Test plan

- [x] Replicated both backends' prefix-selection + `relative_to()` logic against `PurePosixPath` objects built from this file's own `TEST_FILES` fixture data, to work around not having live S3/GCS credentials in my environment. Confirmed the **old** code raises `ValueError: '.../existing_test_file_1' is not in the subpath of '.../existing'` on this exact data, and the **fixed** code returns `{Path("test"), Path("test/dir")}` with no crash.
- [x] Ran `black --check`, `isort --check-only --profile black`, and `flake8` on all four changed files - all clean.
- [ ] Could not execute `test_s3_file_storage.py` / `test_gcs_file_storage.py` themselves - both require `S3_ENDPOINT_URL`/`AWS_ACCESS_KEY_ID` or Google Cloud Application Default Credentials respectively, which aren't available in my environment. The new regression tests follow the exact structure and assertion style of the existing tests in the same files, using the existing fixtures without any new setup, so they should run the same way the pre-existing tests do in CI. Flagging this honestly rather than claiming an execution I didn't do - would appreciate a CI run / maintainer check of the new tests specifically.

Assisted-by: AI