### PR TITLE
feat(frontend/copilot): asymptotic progress bar for context compaction

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/components/atoms/Icon/Icon";
 import { cn } from "@/lib/utils";
 import { useCopilotUIStore } from "../../store";
 import { ACCORDION_PANEL, accordionState, PANEL_REVEAL } from "./accordion";
+import { CompactionProgress } from "./CompactionProgress";
 import { EXPERT_CHANGE_TOOLS } from "./ExpertCards";
 import type { ChainRow } from "./helpers";
 import { ProviderIcon, RowIcon } from "./RowIcon";
@@ -195,10 +196,13 @@ export function ChainRowView({ row, isLast }: Props) {
             {row.detail}
           </p>
         )}
+        {row.category === "compaction" && row.state !== "error" && (
+          <CompactionProgress done={row.state === "done"} />
+        )}
         <div className={ACCORDION_PANEL + " " + accordionState(showContent)}>
           <div
             aria-hidden={!showContent}
-            inert={!showContent ? ("" as unknown as boolean) : undefined}
+            inert={!showContent}
             className="min-h-0 overflow-hidden"
           >
             <div

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/CompactionProgress.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/CompactionProgress.tsx
@@ -9,7 +9,8 @@ interface Props {
 
 /** Progress bar for a running context-compaction row. Rows that mount
  *  already done (history replay) never show it; a live row fills to 100%
- *  on completion and fades out shortly after. */
+ *  on completion and fades out shortly after. Deliberately indeterminate to
+ *  assistive tech — the width is a time-based guess, not a real fraction. */
 export function CompactionProgress({ done }: Props) {
   const progress = useCompactionProgress(done);
   const [hidden, setHidden] = useState(done);
@@ -26,9 +27,7 @@ export function CompactionProgress({ done }: Props) {
     <div
       role="progressbar"
       aria-label="Summarizing earlier messages"
-      aria-valuenow={Math.round(progress * 100)}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      aria-hidden={progress >= 1}
       className={
         "mt-1.5 h-1 w-44 overflow-hidden rounded-full bg-zinc-100 transition-opacity duration-500 " +
         (progress >= 1 ? "opacity-0" : "opacity-100")

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/CompactionProgress.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/CompactionProgress.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useCompactionProgress } from "./useCompactionProgress";
+
+interface Props {
+  done: boolean;
+}
+
+/** Progress bar for a running context-compaction row. Rows that mount
+ *  already done (history replay) never show it; a live row fills to 100%
+ *  on completion and fades out shortly after. */
+export function CompactionProgress({ done }: Props) {
+  const progress = useCompactionProgress(done);
+  const [hidden, setHidden] = useState(done);
+
+  useEffect(() => {
+    if (!done || progress < 1 || hidden) return;
+    const timer = setTimeout(() => setHidden(true), 900);
+    return () => clearTimeout(timer);
+  }, [done, progress, hidden]);
+
+  if (hidden) return null;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Summarizing earlier messages"
+      aria-valuenow={Math.round(progress * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className={
+        "mt-1.5 h-1 w-44 overflow-hidden rounded-full bg-zinc-100 transition-opacity duration-500 " +
+        (progress >= 1 ? "opacity-0" : "opacity-100")
+      }
+    >
+      <div
+        className="h-full rounded-full bg-amber-400"
+        style={{ width: `${progress * 100}%` }}
+      />
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -220,7 +220,7 @@ export function ToolChain({ parts, isStreaming }: Props) {
               <div
                 id={panelId}
                 aria-hidden={!panelOpen}
-                inert={!panelOpen ? ("" as unknown as boolean) : undefined}
+                inert={!panelOpen}
                 className="min-h-0 overflow-hidden"
               >
                 <div

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/CompactionProgress.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/CompactionProgress.test.tsx
@@ -1,0 +1,55 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompactionProgress } from "../CompactionProgress";
+
+function fillWidth(container: HTMLElement) {
+  const bar = container.querySelector("[role=progressbar] > div");
+  if (!bar) return null;
+  return parseFloat((bar as HTMLElement).style.width);
+}
+
+function tick(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe("CompactionProgress", () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("stays hidden for a row replayed from history", () => {
+    const { container } = render(<CompactionProgress done />);
+
+    expect(fillWidth(container)).toBeNull();
+  });
+
+  it("advances while running but never reaches the end", () => {
+    const { container } = render(<CompactionProgress done={false} />);
+    expect(screen.getByRole("progressbar")).toBeDefined();
+
+    tick(5_000);
+    const early = fillWidth(container)!;
+    expect(early).toBeGreaterThan(0);
+
+    tick(120_000);
+    expect(fillWidth(container)!).toBeGreaterThan(early);
+    expect(fillWidth(container)!).toBeLessThan(100);
+  });
+
+  it("sprints to the end when compaction finishes, then unmounts", () => {
+    const { container, rerender } = render(<CompactionProgress done={false} />);
+    tick(5_000);
+
+    rerender(<CompactionProgress done />);
+    tick(700);
+    expect(fillWidth(container)).toBe(100);
+
+    tick(1_000);
+    expect(fillWidth(container)).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/useCompactionProgress.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/useCompactionProgress.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  asymptoticProgress,
+  finishProgress,
+} from "../useCompactionProgress";
+
+describe("asymptoticProgress", () => {
+  it("starts at zero and rises quickly at first", () => {
+    expect(asymptoticProgress(0)).toBe(0);
+    expect(asymptoticProgress(5_000)).toBeGreaterThan(0.2);
+  });
+
+  it("keeps slowing and never exceeds its cap", () => {
+    const atOneMinute = asymptoticProgress(60_000);
+    expect(atOneMinute).toBeLessThan(0.92);
+    // Float saturation: far out the curve rounds to the cap, never past it.
+    expect(asymptoticProgress(600_000)).toBeLessThanOrEqual(0.92);
+  });
+
+  it("is monotonic", () => {
+    let prev = -1;
+    for (let ms = 0; ms <= 120_000; ms += 1_000) {
+      const value = asymptoticProgress(ms);
+      expect(value).toBeGreaterThan(prev);
+      prev = value;
+    }
+  });
+});
+
+describe("finishProgress", () => {
+  it("sprints from the current value to exactly 1", () => {
+    expect(finishProgress(0.5, 0)).toBeCloseTo(0.5, 5);
+    expect(finishProgress(0.5, 200)).toBeGreaterThan(0.9);
+    expect(finishProgress(0.5, 1_000)).toBe(1);
+  });
+
+  it("snaps to 1 near the end instead of crawling forever", () => {
+    expect(finishProgress(0.99, 100)).toBe(1);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/useCompactionProgress.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/useCompactionProgress.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  asymptoticProgress,
-  finishProgress,
-} from "../useCompactionProgress";
+import { asymptoticProgress, finishProgress } from "../useCompactionProgress";
 
 describe("asymptoticProgress", () => {
   it("starts at zero and rises quickly at first", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/useCompactionProgress.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/useCompactionProgress.ts
@@ -17,7 +17,8 @@ export function asymptoticProgress(elapsedMs: number): number {
 }
 
 export function finishProgress(from: number, sinceDoneMs: number): number {
-  const next = 1 - (1 - from) * Math.exp(-Math.max(0, sinceDoneMs) / FINISH_TAU_MS);
+  const next =
+    1 - (1 - from) * Math.exp(-Math.max(0, sinceDoneMs) / FINISH_TAU_MS);
   return next >= FINISH_SNAP ? 1 : next;
 }
 
@@ -37,7 +38,10 @@ export function useCompactionProgress(done: boolean): number {
       let next: number;
       if (done) {
         finishRef.current ??= { at: now, from: progressRef.current };
-        next = finishProgress(finishRef.current.from, now - finishRef.current.at);
+        next = finishProgress(
+          finishRef.current.from,
+          now - finishRef.current.at,
+        );
       } else {
         startRef.current ??= now;
         next = asymptoticProgress(now - startRef.current);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/useCompactionProgress.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/useCompactionProgress.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from "react";
+
+/** Compaction duration is unknown (LLM summarization, often 20-90s), so the
+ *  bar saturates toward a cap it never reaches: every moment it covers a
+ *  fixed fraction of the REMAINING distance. Fast early movement, slows
+ *  forever, can't finish before the work does. */
+const CAP = 0.92;
+const TAU_MS = 15_000;
+
+/** When the real completion lands, sprint the remaining distance with the
+ *  same exponential shape, just much faster. */
+const FINISH_TAU_MS = 120;
+const FINISH_SNAP = 0.995;
+
+export function asymptoticProgress(elapsedMs: number): number {
+  return CAP * (1 - Math.exp(-Math.max(0, elapsedMs) / TAU_MS));
+}
+
+export function finishProgress(from: number, sinceDoneMs: number): number {
+  const next = 1 - (1 - from) * Math.exp(-Math.max(0, sinceDoneMs) / FINISH_TAU_MS);
+  return next >= FINISH_SNAP ? 1 : next;
+}
+
+/** 0..1 progress for a compaction row. While running it follows the
+ *  asymptotic curve; when `done` flips it interpolates to 100% from
+ *  wherever it was. Mounted already-done (history replay) → 1 instantly. */
+export function useCompactionProgress(done: boolean): number {
+  const [progress, setProgress] = useState(done ? 1 : 0);
+  const progressRef = useRef(progress);
+  const startRef = useRef<number | null>(null);
+  const finishRef = useRef<{ at: number; from: number } | null>(null);
+
+  useEffect(() => {
+    if (progressRef.current >= 1) return;
+    let raf = 0;
+    const tick = (now: number) => {
+      let next: number;
+      if (done) {
+        finishRef.current ??= { at: now, from: progressRef.current };
+        next = finishProgress(finishRef.current.from, now - finishRef.current.at);
+      } else {
+        startRef.current ??= now;
+        next = asymptoticProgress(now - startRef.current);
+      }
+      progressRef.current = next;
+      setProgress(next);
+      if (next < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [done]);
+
+  return progress;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/useCompactionProgress.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/useCompactionProgress.ts
@@ -7,6 +7,10 @@ import { useEffect, useRef, useState } from "react";
 const CAP = 0.92;
 const TAU_MS = 15_000;
 
+/** Once the curve is within a sub-pixel of the cap it is visually frozen, so
+ *  stop burning frames — the effect restarts the loop when `done` flips. */
+const SETTLED = CAP - 0.003;
+
 /** When the real completion lands, sprint the remaining distance with the
  *  same exponential shape, just much faster. */
 const FINISH_TAU_MS = 120;
@@ -48,7 +52,7 @@ export function useCompactionProgress(done: boolean): number {
       }
       progressRef.current = next;
       setProgress(next);
-      if (next < 1) raf = requestAnimationFrame(tick);
+      if (done ? next < 1 : next < SETTLED) raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);


### PR DESCRIPTION
## Why
When the context gets compacted the row showed a static label for the whole summarization (often 20–90s) — it read as instantly done followed by dead air. (Toran's ask.)

## What
The compaction row gets a progress bar that can never finish early: `progress = cap × (1 − e^(−t/τ))` (cap 92%, τ 15s) — it always covers a fixed fraction of the *remaining* distance, so it slows forever until the real end event lands, then sprints to 100% (τ 120ms) and fades out. Rows replayed from history never show the bar.

Also fixes `inert`: the `("" as unknown as boolean)` hack is treated as **false** by the bundled React (with a console warning), so hidden accordion panels stayed focusable. Both sites now pass the boolean directly.

## How
Pure math in `useCompactionProgress` (rAF-driven, tested), render in `CompactionProgress`, mounted by `ChainRowView` for `category === "compaction"`.

The rAF loop stops scheduling once the curve is within a sub-pixel of the cap (~87s), so a compaction that never resolves can't re-render at 60fps forever; the effect restarts the loop when `done` flips, so the finish sprint is unaffected. The bar is deliberately **indeterminate** to assistive tech — the width is a time-based guess, not a real fraction, so there's no `aria-valuenow` to announce ~60×/sec.

## Test plan
- [x] `useCompactionProgress.test.ts` — monotonic, capped, finish-sprint, snap-to-1
- [x] `CompactionProgress.test.tsx` — history replay stays hidden, running growth never reaches the end, finish sprint then unmount
- [x] ToolChain suites green (345 tests)

---
**Stack:** #14158 (chain UI polish) ← **this PR** ← #14160 (minimal delegate cards)
