### PR TITLE
feat(frontend/copilot): slim delegated-run cards to status and link

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/AgentCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/AgentCards.tsx
@@ -171,7 +171,10 @@ export function AgentPreviewCard({ output }: OutputCardProps) {
   );
 }
 
-export function SubSessionCard({ output }: OutputCardProps) {
+export function SubSessionCard({
+  output,
+  minimal = false,
+}: OutputCardProps & { minimal?: boolean }) {
   const frozenStatus = str(output, "status");
   const response = str(output, "response");
   const link = str(output, "sub_autopilot_session_link");
@@ -203,7 +206,7 @@ export function SubSessionCard({ output }: OutputCardProps) {
         {status && <StatusPill status={status} />}
         {link && <CardLink href={link} label="Open sub-session" />}
       </div>
-      {response && (
+      {!minimal && response && (
         <p className="mt-1.5 line-clamp-2 pl-9 text-xs text-zinc-500">
           {response}
         </p>
@@ -211,7 +214,7 @@ export function SubSessionCard({ output }: OutputCardProps) {
       {/* Keyed to the FROZEN status on purpose: once mounted for a running
           output, the live view stays up after completion showing the final
           steps + answer (it stops polling on its own). */}
-      {subSessionId && (
+      {!minimal && subSessionId && (
         <SubSessionLive
           subSessionId={subSessionId}
           active={["running", "queued"].includes(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/AgentCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/AgentCards.tsx
@@ -171,10 +171,14 @@ export function AgentPreviewCard({ output }: OutputCardProps) {
   );
 }
 
+interface SubSessionCardProps extends OutputCardProps {
+  minimal?: boolean;
+}
+
 export function SubSessionCard({
   output,
   minimal = false,
-}: OutputCardProps & { minimal?: boolean }) {
+}: SubSessionCardProps) {
   const frozenStatus = str(output, "status");
   const response = str(output, "response");
   const link = str(output, "sub_autopilot_session_link");

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
@@ -108,10 +108,16 @@ export function ChainRowView({ row, isLast }: Props) {
       : null,
     isSubTool && typeof output?.status === "string" ? output.status : null,
   );
+  // "unknown" means the poll died, not that the teammate finished — the row
+  // only has a running label and a done label, and claiming a result landed
+  // is the worse of the two guesses. It also keeps this row consistent with
+  // the card below it, whose poll caps on its own mount clock.
   const stillWorking =
     isSubTool &&
     row.state === "done" &&
-    ["running", "queued"].includes(effectiveStatus?.toLowerCase() ?? "");
+    ["running", "queued", "unknown"].includes(
+      effectiveStatus?.toLowerCase() ?? "",
+    );
   const liveReasoning =
     isReasoning && row.state === "running" && !!row.reasoningText;
   // An expert being hired/raised has no output until it lands — the skeleton

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/SubSessionLive.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/SubSessionLive.tsx
@@ -238,7 +238,13 @@ function toMiniRow(step: LiveStep, index: number, running: boolean): ChainRow {
  *  polling their session list; when only the session is known, the expert
  *  is read off the polled session itself. Swapped for the full
  *  SubSessionCard the moment the tool returns. */
-export function SubSessionPendingCard({ input }: { input: unknown }) {
+export function SubSessionPendingCard({
+  input,
+  minimal = false,
+}: {
+  input: unknown;
+  minimal?: boolean;
+}) {
   const { expertsById } = useExpertMap();
   const args = asObject(input) ?? {};
   const inputExpertId = str(args, "expert_id");
@@ -289,12 +295,14 @@ export function SubSessionPendingCard({ input }: { input: unknown }) {
           </Link>
         )}
       </div>
-      {prompt && (
+      {!minimal && prompt && (
         <p className="mt-1.5 line-clamp-2 pl-9 text-sm text-zinc-500">
           {prompt}
         </p>
       )}
-      {liveSessionId && <SubSessionLive subSessionId={liveSessionId} active />}
+      {!minimal && liveSessionId && (
+        <SubSessionLive subSessionId={liveSessionId} active />
+      )}
     </div>
   );
 }
@@ -346,9 +354,20 @@ export function useSubSessionEffectiveStatus(
   status: string | null,
 ) {
   const stale = ["running", "queued"].includes(status?.toLowerCase() ?? "");
+  // Own polling (capped) rather than piggybacking on SubSessionLive's
+  // cache-shared query — minimal delegate cards render no live view, so
+  // this hook is the only thing left that can flip running → completed.
+  const mountedAtRef = useRef(Date.now());
   const { data, isError } = useGetV2GetSession(subSessionId ?? "", undefined, {
     query: {
       enabled: stale && !!subSessionId,
+      refetchInterval: (query) => {
+        if (query.state.status === "error") return false;
+        if (Date.now() - mountedAtRef.current > POLL_CAP_MS) return false;
+        const raw = query.state.data;
+        const polled = raw && raw.status === 200 ? raw.data : null;
+        return !polled || isSessionLive(polled) ? POLL_MS : false;
+      },
       select: (res) => (res.status === 200 ? res.data : null),
     },
   });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/SubSessionLive.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/SubSessionLive.tsx
@@ -238,13 +238,15 @@ function toMiniRow(step: LiveStep, index: number, running: boolean): ChainRow {
  *  polling their session list; when only the session is known, the expert
  *  is read off the polled session itself. Swapped for the full
  *  SubSessionCard the moment the tool returns. */
+interface PendingCardProps {
+  input: unknown;
+  minimal?: boolean;
+}
+
 export function SubSessionPendingCard({
   input,
   minimal = false,
-}: {
-  input: unknown;
-  minimal?: boolean;
-}) {
+}: PendingCardProps) {
   const { expertsById } = useExpertMap();
   const args = asObject(input) ?? {};
   const inputExpertId = str(args, "expert_id");
@@ -254,7 +256,7 @@ export function SubSessionPendingCard({
     inputSessionId ? null : inputExpertId,
   );
   const liveSessionId = inputSessionId ?? discoveredId;
-  // Cache-shared with SubSessionLive's query below — no extra request.
+  // Same query key as the live view below, so a full card polls once.
   const {
     session: liveSession,
     isError,
@@ -347,35 +349,28 @@ function useDelegatedSessionId(expertId: string | null) {
 /** A sub-session tool output freezes the status it had when the tool
  *  returned — a "running" card would say running forever after the work
  *  lands. While the frozen status is running/queued, read the truth off the
- *  polled session (cache-shared with the live view) and flip to completed
- *  once it goes idle. */
+ *  polled session and flip to completed once it goes idle.
+ *
+ *  Owns the poll through `useLiveSubSession` rather than piggybacking on a
+ *  mounted live view: a minimal delegate card renders no live view, so this
+ *  is the only thing left that can flip running → completed. On a full card
+ *  it is the same query key, so the two share one poll. */
 export function useSubSessionEffectiveStatus(
   subSessionId: string | null,
   status: string | null,
 ) {
   const stale = ["running", "queued"].includes(status?.toLowerCase() ?? "");
-  // Own polling (capped) rather than piggybacking on SubSessionLive's
-  // cache-shared query — minimal delegate cards render no live view, so
-  // this hook is the only thing left that can flip running → completed.
-  const mountedAtRef = useRef(Date.now());
-  const { data, isError } = useGetV2GetSession(subSessionId ?? "", undefined, {
-    query: {
-      enabled: stale && !!subSessionId,
-      refetchInterval: (query) => {
-        if (query.state.status === "error") return false;
-        if (Date.now() - mountedAtRef.current > POLL_CAP_MS) return false;
-        const raw = query.state.data;
-        const polled = raw && raw.status === 200 ? raw.data : null;
-        return !polled || isSessionLive(polled) ? POLL_MS : false;
-      },
-      select: (res) => (res.status === 200 ? res.data : null),
-    },
-  });
+  const { session, isError, isPaused } = useLiveSubSession(
+    subSessionId ?? "",
+    stale && !!subSessionId,
+  );
   if (!stale) return status;
-  // The frozen status is only trustworthy while the poll can refute it.
-  if (isError) return "unknown";
-  if (!data) return status;
-  return isSessionLive(data) ? status : "completed";
+  // The frozen status is only trustworthy while the poll can refute it. A
+  // minimal card has no "Live updates paused" notice to fall back on, so a
+  // dead poll has to show up in the pill or it reads as fact.
+  if (isError || isPaused) return "unknown";
+  if (!session) return status;
+  return isSessionLive(session) ? status : "completed";
 }
 
 function isSessionLive(session: SessionDetailResponse): boolean {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
@@ -255,17 +255,25 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
     case "run_sub_session":
     case "get_sub_session_result":
     case "delegate_to_expert":
-    case "handoff_to_expert":
+    case "handoff_to_expert": {
+      // A teammate's thread is their own workspace: delegated cards stay
+      // minimal (who, status, elapsed, link) — no response preview, no live
+      // step feed. Only the model's own run_sub_session shows its work here.
+      const delegated =
+        row.tool === "delegate_to_expert" ||
+        row.tool === "handoff_to_expert" ||
+        !!(output && asObject(output.expert));
       if (output && str(output, "status"))
-        return <SubSessionCard output={output} />;
+        return <SubSessionCard output={output} minimal={delegated} />;
       // A blocking delegate has no output while the teammate works — show
       // who's on it and what they were asked from the tool input instead.
       // Not for result polls: the delegation card above is already showing
       // this sub-session live, a second identical card would stack under it.
       return row.state === "running" &&
         row.tool !== "get_sub_session_result" ? (
-        <SubSessionPendingCard input={row.input} />
+        <SubSessionPendingCard input={row.input} minimal={delegated} />
       ) : null;
+    }
     case "hire_expert":
     case "raise_expert":
     case "update_expert":

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
@@ -258,7 +258,10 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
     case "handoff_to_expert": {
       // A teammate's thread is their own workspace: delegated cards stay
       // minimal (who, status, elapsed, link) — no response preview, no live
-      // step feed. Only the model's own run_sub_session shows its work here.
+      // step feed. Only the model's own run_sub_session shows its work here,
+      // and it always will: `expert` is written solely by the backend's
+      // apply_delegated_expert, which run_sub_session never calls (its subs
+      // are same-scope by construction, so the identity is None anyway).
       const delegated =
         row.tool === "delegate_to_expert" ||
         row.tool === "handoff_to_expert" ||

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ChainRowView.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ChainRowView.test.tsx
@@ -1,6 +1,7 @@
 import { getGetV2GetSessionMockHandler200 } from "@/app/api/__generated__/endpoints/chat/chat.msw";
 import { server } from "@/mocks/mock-server";
 import { render, screen } from "@/tests/integrations/test-utils";
+import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ChainRow } from "../helpers";
 import { ChainRowView } from "../ChainRowView";
@@ -101,6 +102,36 @@ describe("ChainRowView - live sub-session rows", () => {
       await screen.findByText(
         'Handing off to a teammate: "Create a chat app"…',
       ),
+    ).toBeDefined();
+  });
+
+  it("does not claim the teammate finished when the poll dies", async () => {
+    server.use(
+      http.get("*/api/chat/sessions/:sessionId", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    render(
+      <ChainRowView
+        row={row({
+          tool: "delegate_to_expert",
+          state: "done",
+          text: 'Teammate handled: "Create a chat app"',
+          output: { status: "running", sub_session_id: "sub-1" },
+          input: { prompt: "Create a chat app" },
+        })}
+        isLast
+      />,
+    );
+
+    // A dead poll can't refute the frozen "running", so the done label must
+    // never land — the row keeps saying the teammate is on it.
+    await expect(
+      screen.findByText('Teammate handled: "Create a chat app"'),
+    ).rejects.toThrow();
+    expect(
+      screen.getByText('Handing off to a teammate: "Create a chat app"…'),
     ).toBeDefined();
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ChainRowView.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ChainRowView.test.tsx
@@ -45,7 +45,9 @@ describe("ChainRowView - live sub-session rows", () => {
     );
 
     expect(await screen.findByText("Sub-AutoPilot")).toBeDefined();
-    expect(screen.getByText("Create a chat app")).toBeDefined();
+    // Delegated cards are status-only — the prompt stays in the teammate's
+    // own thread, not in the parent chain.
+    expect(screen.queryByText("Create a chat app")).toBeNull();
   });
 
   it("does not auto-open a result-poll row with no output (nothing to show)", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/SubSessionLive.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/SubSessionLive.test.tsx
@@ -127,7 +127,7 @@ describe("SubSessionLive", () => {
     expect(screen.queryByText("Done. Discord clone is built.")).toBeNull();
   });
 
-  it("shows who is on it before a blocking delegate returns", () => {
+  it("shows who is on it — and nothing else — before a blocking delegate returns", () => {
     render(
       <ToolResult
         row={{
@@ -142,8 +142,46 @@ describe("SubSessionLive", () => {
     );
 
     expect(screen.getByText("Sub-AutoPilot")).toBeDefined();
-    expect(screen.getByText("Create a chat app")).toBeDefined();
     expect(screen.getByText("running")).toBeDefined();
+    // A teammate's thread is their own workspace: the delegated card is
+    // status-only, so the prompt preview stays out of the parent chain.
+    expect(screen.queryByText("Create a chat app")).toBeNull();
+  });
+
+  it("keeps a finished delegate card to name, role, status, time, and link", () => {
+    render(
+      <ToolResult
+        row={{
+          key: "delegate",
+          category: "agent",
+          text: "Teammate handled it",
+          state: "done",
+          tool: "delegate_to_expert",
+          input: {},
+          output: {
+            status: "completed",
+            response: "Here is the full brief the teammate wrote.",
+            sub_session_id: "sub-1",
+            sub_autopilot_session_link: "/copilot?sessionId=sub-1",
+            elapsed_seconds: 75,
+            expert: { name: "Vera", role: "Research" },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Vera/)).toBeDefined();
+    expect(screen.getByText("Research")).toBeDefined();
+    expect(screen.getByText("completed")).toBeDefined();
+    expect(screen.getByText("1m 15s")).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Open sub-session" })
+        .getAttribute("href"),
+    ).toBe("/copilot?sessionId=sub-1");
+    expect(
+      screen.queryByText("Here is the full brief the teammate wrote."),
+    ).toBeNull();
   });
 
   it("finds the delegate's running session behind a wall of pinned ones", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/SubSessionLive.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/SubSessionLive.test.tsx
@@ -3,9 +3,13 @@ import { server } from "@/mocks/mock-server";
 import { render, screen } from "@/tests/integrations/test-utils";
 import { cleanup } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SubSessionCard } from "../AgentCards";
 import { ToolResult } from "../ToolResult";
+
+/** Mirrors POLL_CAP_MS in SubSessionLive.tsx — the poll gives up after this.
+ *  Kept local so the test states the contract rather than importing it. */
+const POLL_CAP_MS = 5 * 60_000;
 
 const SESSION_ROUTE = "/api/proxy/api/chat/sessions/:sessionId";
 const SESSION_LIST_ROUTE = "/api/proxy/api/chat/sessions";
@@ -231,6 +235,70 @@ describe("SubSessionLive", () => {
     expect(await screen.findByText("completed")).toBeDefined();
     expect(screen.queryByText("Looking for the right agent now.")).toBeNull();
     expect(screen.queryByText("Half of the brief so far.")).toBeNull();
+  });
+
+  /** The pill is the only status surface a minimal card has — the full card's
+   *  "Live updates paused" notice is exactly what got removed — so a dead
+   *  poll has to reach it instead of leaving "running" standing as fact. */
+  it("stops asserting running on a minimal card once its poll dies", async () => {
+    server.use(failingSubSession());
+
+    render(
+      <ToolResult
+        row={{
+          key: "delegate",
+          category: "agent",
+          text: "Teammate is on it",
+          state: "done",
+          tool: "delegate_to_expert",
+          input: {},
+          output: {
+            status: "running",
+            sub_session_id: "sub-1",
+            expert: { name: "Vera", role: "Research" },
+          },
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("unknown")).toBeDefined();
+    expect(screen.queryByText("running")).toBeNull();
+  });
+
+  /** The other way a poll dies: it is capped after 5 minutes so a forgotten
+   *  tab stops hammering the API. A long delegation reaches that cap while
+   *  the teammate is genuinely still working, so the pill must stop claiming
+   *  to know — same contract as the failed-fetch case above. */
+  it("stops asserting running on a minimal card once the poll cap expires", async () => {
+    server.use(subSession([], { chat_status: "running", active_stream: null }));
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      render(
+        <ToolResult
+          row={{
+            key: "delegate",
+            category: "agent",
+            text: "Teammate is on it",
+            state: "done",
+            tool: "delegate_to_expert",
+            input: {},
+            output: {
+              status: "running",
+              sub_session_id: "sub-1",
+              expert: { name: "Vera", role: "Research" },
+            },
+          }}
+        />,
+      );
+
+      await vi.advanceTimersByTimeAsync(POLL_CAP_MS + 1);
+
+      expect(screen.getByText("unknown")).toBeDefined();
+      expect(screen.queryByText("running")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("finds the delegate's running session behind a wall of pinned ones", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/SubSessionLive.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/SubSessionLive.test.tsx
@@ -48,13 +48,17 @@ function expertSessions() {
   });
 }
 
-function subSession(messages: Record<string, unknown>[]) {
+function subSession(
+  messages: Record<string, unknown>[],
+  extra: Record<string, unknown> = {},
+) {
   return getGetV2GetSessionMockHandler200({
     id: "sub-1",
     created_at: "2026-08-21T00:00:00Z",
     updated_at: "2026-08-21T00:00:00Z",
     user_id: "u-1",
     messages,
+    ...extra,
   });
 }
 
@@ -182,6 +186,51 @@ describe("SubSessionLive", () => {
     expect(
       screen.queryByText("Here is the full brief the teammate wrote."),
     ).toBeNull();
+  });
+
+  /** The delegate/handoff tools name themselves, but a result poll is the
+   *  same tool for the model's own scratch sub and for a teammate's thread —
+   *  the `expert` on the output is the only thing telling them apart. */
+  it("keeps a delegated result poll minimal and still flips its pill when the teammate lands", async () => {
+    server.use(
+      subSession(
+        [
+          {
+            role: "assistant",
+            content: "Looking for the right agent now.",
+            tool_calls: null,
+          },
+        ],
+        { chat_status: "idle", active_stream: null },
+      ),
+    );
+
+    render(
+      <ToolResult
+        row={{
+          key: "poll",
+          category: "agent",
+          text: "Checking on the teammate",
+          state: "done",
+          tool: "get_sub_session_result",
+          input: {},
+          output: {
+            status: "running",
+            response: "Half of the brief so far.",
+            sub_session_id: "sub-1",
+            sub_autopilot_session_link: "/copilot?sessionId=sub-1",
+            expert: { name: "Vera", role: "Research" },
+          },
+        }}
+      />,
+    );
+
+    // The pill can only flip off the frozen "running" once the poll this hook
+    // owns has answered — so this also proves the card polls with no live
+    // view mounted to do it for them.
+    expect(await screen.findByText("completed")).toBeDefined();
+    expect(screen.queryByText("Looking for the right agent now.")).toBeNull();
+    expect(screen.queryByText("Half of the brief so far.")).toBeNull();
   });
 
   it("finds the delegate's running session behind a wall of pinned ones", async () => {


### PR DESCRIPTION
### Why / What / How

**Why** — A delegated teammate's card streamed their whole working session into the parent chain: a response preview plus a polled live step feed. That's noisy, duplicates the teammate's own thread, and leaks their intermediate work into a chat that only needs to know who's on it and whether it's done.

**What** — Delegated cards (`delegate_to_expert`, `handoff_to_expert`, and result polls of delegated sessions) now show only: avatar + name + role + running/completed pill + elapsed time + open-session link. The teammate's work lives behind the link. `run_sub_session` — the model's own scratch context, not a teammate's thread — keeps its full live view.

**How** — `ToolResult` decides whether a card is delegated (`minimal` = the delegate/handoff tool, or an `expert` object on the tool output) and passes it down; `SubSessionCard` and `SubSessionPendingCard` drop the response/prompt preview and the `SubSessionLive` step feed when minimal. Because the live view's cache-shared session query no longer mounts on those cards, status polling moves into `useSubSessionEffectiveStatus`, which now owns a capped `refetchInterval` (same `POLL_MS` / `POLL_CAP_MS` budget as the live view) so the frozen `running` pill still flips to `completed` when the teammate lands.

### Changes 🏗️

- `ToolResult.tsx` — delegated-vs-own-scratch decision for the sub-session tool group; threads `minimal` into both cards.
- `AgentCards.tsx` — `SubSessionCard` takes `minimal`; hides the response preview and the live step feed.
- `SubSessionLive.tsx` — `SubSessionPendingCard` takes `minimal`; hides the prompt preview and the live view. `useSubSessionEffectiveStatus` gets its own capped poll so the status pill stays correct without the live view mounted.
- Tests — new minimal pending-card and finished-card contract cases in `SubSessionLive.test.tsx`; `ChainRowView.test.tsx` now asserts the prompt stays out of the parent chain.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `SubSessionLive.test.tsx` — minimal pending card (name + status only, no prompt), finished-card contract (name / role / status / elapsed / link present, response absent), live-session discovery still works
  - [x] `ChainRowView.test.tsx` — delegate prompt no longer rendered in the parent chain
  - [x] Full ToolChain suite green locally — 19 files, 341 tests
  - [x] `pnpm types` clean, prettier clean
  - [ ] Manual: delegate to a teammate, confirm the parent card shows only status + link while the teammate's own thread still shows the full run, and the pill flips running → completed when they finish

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

---
**Stack (top → bottom):** #14158 (chain UI polish) ← #14159 (compaction progress) ← **this PR**. Review/merge in that order; this PR targets `feat/copilot-compaction-progress`.
