### PR TITLE
feat(frontend): fire Google Ads conversions across the signup-to-paid journey

### DIFF
--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -1184,7 +1184,10 @@ class UserCredit(UserCreditBase):
             ui_mode="hosted",
             payment_intent_data={"setup_future_usage": "off_session"},
             saved_payment_method_options={"payment_method_save": "enabled"},
-            success_url=base_url + "/settings/billing?topup=success",
+            # {CHECKOUT_SESSION_ID} is filled by Stripe; the return page uses
+            # it as the Google Ads dedup key so a refresh can't count twice.
+            success_url=base_url
+            + "/settings/billing?topup=success&session_id={CHECKOUT_SESSION_ID}",
             cancel_url=base_url + "/settings/billing?topup=cancel",
             allow_promotion_codes=True,
             automatic_tax={"enabled": True},

--- a/autogpt_platform/frontend/.env.default
+++ b/autogpt_platform/frontend/.env.default
@@ -57,6 +57,12 @@ NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_ID=687ab1372f497809b131e06e
 NEXT_PUBLIC_REACT_QUERY_DEVTOOL=true
 NEXT_PUBLIC_GA_MEASUREMENT_ID=G-FH2XK2W4GN
 
+# Google Ads conversion tracking (production only). The account's tag ID and
+# one label per conversion action, e.g.
+# "sign_up=AbCdEf,begin_checkout=GhIjKl,subscribe=MnOpQr,onboarding_complete=StUvWx,top_up=YzAbCd"
+NEXT_PUBLIC_GOOGLE_ADS_ID=
+NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS=
+
 # Google Drive Picker
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=
 NEXT_PUBLIC_GOOGLE_API_KEY=

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -134,7 +134,8 @@ beforeEach(() => {
   mockRefreshSession.mockClear();
   mockCompletedSteps = [];
   routerReplace.mockClear();
-  completeOnboardingStep.mockClear();
+  completeOnboardingStep.mockReset();
+  completeOnboardingStep.mockResolvedValue({ status: 200 });
   useOnboardingWizardStore.getState().reset();
   window.sessionStorage.removeItem(STEP_STORAGE_KEY);
 });
@@ -392,6 +393,34 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
     removeGtagShim();
     vi.unstubAllEnvs();
   });
+
+  it("reports no onboarding_complete when the API never confirms", async () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv(
+      "NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS",
+      "onboarding_complete=OC",
+    );
+    const gtagCalls = installGtagShim();
+    // All three attempts fail: the user still lands on the copilot, but the
+    // backend never recorded the milestone, so nothing converted.
+    completeOnboardingStep.mockRejectedValue(new Error("500"));
+    mockFlagValue = false;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    fireEvent.click(await screen.findByTestId("step-preparing"));
+    await waitFor(
+      () => {
+        expect(routerReplace).toHaveBeenCalledWith("/copilot");
+      },
+      { timeout: 5000 },
+    );
+
+    expect(completeOnboardingStep).toHaveBeenCalledTimes(3);
+    expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
+    removeGtagShim();
+    vi.unstubAllEnvs();
+  }, 10000);
 
   it("preserves form data on mount (zustand persist; no reset-on-init)", async () => {
     // Regression test for the 422 caused by init's old `reset()` wiping

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -142,6 +142,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  // Not at the end of each test body: an assertion that throws above would
+  // leak the shim and NEXT_PUBLIC_GOOGLE_ADS_ID into every later test here.
+  removeGtagShim();
+  vi.unstubAllEnvs();
 });
 
 describe("OnboardingPage — flag-gated SubscriptionStep", () => {
@@ -390,8 +394,6 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
       "conversion",
       { send_to: "AW-123/OC" },
     ]);
-    removeGtagShim();
-    vi.unstubAllEnvs();
   });
 
   it("reports no onboarding_complete when the API never confirms", async () => {
@@ -418,8 +420,6 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
 
     expect(completeOnboardingStep).toHaveBeenCalledTimes(3);
     expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
-    removeGtagShim();
-    vi.unstubAllEnvs();
   }, 10000);
 
   it("preserves form data on mount (zustand persist; no reset-on-init)", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/page.test.tsx
@@ -7,6 +7,10 @@ import {
   waitFor,
 } from "@/tests/integrations/test-utils";
 import { server } from "@/mocks/mock-server";
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
 import { http, HttpResponse } from "msw";
 import OnboardingPage from "../page";
 import { useOnboardingWizardStore } from "../store";
@@ -362,6 +366,31 @@ describe("OnboardingPage — flag-gated SubscriptionStep", () => {
       step: "ONBOARDING_COMPLETE",
     });
     expect(window.sessionStorage.getItem(STEP_STORAGE_KEY)).toBeNull();
+  });
+
+  it("reports onboarding_complete to Google Ads when Preparing finishes", async () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv(
+      "NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS",
+      "onboarding_complete=OC",
+    );
+    const gtagCalls = installGtagShim();
+    mockFlagValue = false;
+    window.sessionStorage.setItem(STEP_STORAGE_KEY, "4");
+    currentSearchParams = new URLSearchParams("step=4");
+    render(<OnboardingPage />);
+    fireEvent.click(await screen.findByTestId("step-preparing"));
+    await waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith("/copilot");
+    });
+
+    expect(gtagCalls).toContainEqual([
+      "event",
+      "conversion",
+      { send_to: "AW-123/OC" },
+    ]);
+    removeGtagShim();
+    vi.unstubAllEnvs();
   });
 
   it("preserves form data on mount (zustand persist; no reset-on-init)", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -1,6 +1,10 @@
 import { useUpdateSubscriptionTier } from "@/app/api/__generated__/endpoints/credits/credits";
 import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models/subscriptionTierRequestTier";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import {
+  getSubscriptionValue,
+  trackAdsConversion,
+} from "@/services/analytics/google-ads";
 import { environment } from "@/services/environment";
 import { useState } from "react";
 import { PAYWALL_FIRST_STEPS, useOnboardingWizardStore } from "../../store";
@@ -71,19 +75,24 @@ export function useSubscriptionStep() {
 
     setSelectedPlan(planKey);
     const tier = PLAN_TO_TIER[planKey];
+    const cycle = isYearly ? "yearly" : "monthly";
+    trackAdsConversion("begin_checkout", {
+      value: getSubscriptionValue(planKey, cycle),
+    });
 
     try {
       // The paywall is the first step, so there's no profile to submit yet —
       // name / role / pain points are collected after payment. On a successful
       // checkout Stripe returns the user to Welcome to begin onboarding; on
-      // cancel, back to this paywall.
+      // cancel, back to this paywall. Stripe fills {CHECKOUT_SESSION_ID}; plan
+      // and cycle let the return page report the subscription to Google Ads.
       const baseUrl = `${window.location.origin}/onboarding`;
       const result = await updateTier({
         data: {
           tier,
-          success_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.welcome}&subscription=success`,
+          success_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.welcome}&subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=${planKey}&cycle=${cycle}`,
           cancel_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.subscription}&subscription=cancelled`,
-          billing_cycle: isYearly ? "yearly" : "monthly",
+          billing_cycle: cycle,
         },
       });
       const url = (result?.data as CheckoutResponse | undefined)?.url;

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -76,9 +76,6 @@ export function useSubscriptionStep() {
     setSelectedPlan(planKey);
     const tier = PLAN_TO_TIER[planKey];
     const cycle = isYearly ? "yearly" : "monthly";
-    trackAdsConversion("begin_checkout", {
-      value: getSubscriptionValue(planKey, cycle),
-    });
 
     try {
       // The paywall is the first step, so there's no profile to submit yet —
@@ -97,6 +94,12 @@ export function useSubscriptionStep() {
       });
       const url = (result?.data as CheckoutResponse | undefined)?.url;
       if (url) {
+        // A Checkout URL is the only proof that Stripe Checkout actually
+        // starts — reporting earlier would count the in-place and failed
+        // paths as conversions.
+        trackAdsConversion("begin_checkout", {
+          value: getSubscriptionValue(planKey, cycle),
+        });
         // Navigating away — don't refetch (would set state on an
         // unmounting component while Stripe Checkout takes over).
         window.location.href = url;

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
 import {
-  cleanup,
   fireEvent,
   render,
   screen,
@@ -39,7 +38,6 @@ vi.mock("@/components/atoms/AutoGPTLogo/AutoGPTLogo", () => ({
 }));
 
 afterEach(() => {
-  cleanup();
   // Not at the end of each test body: an assertion that throws above would
   // leak the shim, the location stub and NEXT_PUBLIC_GOOGLE_ADS_ID into every
   // later test here.

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -50,6 +50,28 @@ beforeEach(() => {
   vi.spyOn(environment, "isLocal").mockReturnValue(false);
 });
 
+const originalLocation = window.location;
+
+// The success path hands off to Stripe via window.location.href; jsdom tears
+// the environment down on a real navigation, so swap in a plain object.
+function stubLocation() {
+  const location = { origin: "http://localhost", href: "http://localhost/" };
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: location,
+  });
+  return location;
+}
+
+function restoreLocation() {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  });
+}
+
 describe("subscription pricing experiment helpers", () => {
   test("defaults to monthly billing with no highlighted plan (matches the paywall)", () => {
     expect(getSubscriptionPricingExperimentConfig(undefined)).toMatchObject({
@@ -221,9 +243,10 @@ describe("SubscriptionStep", () => {
     vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
     vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
     const gtagCalls = installGtagShim();
+    const location = stubLocation();
     server.use(
       http.post("*/api/credits/subscription", () =>
-        HttpResponse.json({ url: null }),
+        HttpResponse.json({ url: "https://checkout.stripe.com/pay/cs_test" }),
       ),
     );
 
@@ -237,6 +260,33 @@ describe("SubscriptionStep", () => {
         { send_to: "AW-123/BC", value: 50, currency: "USD" },
       ]);
     });
+    expect(location.href).toBe("https://checkout.stripe.com/pay/cs_test");
+    restoreLocation();
+    removeGtagShim();
+    vi.unstubAllEnvs();
+  });
+
+  test("reports no begin_checkout when Stripe returns no Checkout URL", async () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
+    const gtagCalls = installGtagShim();
+    // The backend modified the subscription in place — no Checkout ever
+    // started, so counting it would inflate the funnel.
+    server.use(
+      http.post("*/api/credits/subscription", () =>
+        HttpResponse.json({ url: null }),
+      ),
+    );
+
+    render(<SubscriptionStep />);
+    fireEvent.click(screen.getByRole("button", { name: /Get Pro/i }));
+
+    await waitFor(() => {
+      expect(useOnboardingWizardStore.getState().currentStep).toBeGreaterThan(
+        1,
+      );
+    });
+    expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
     removeGtagShim();
     vi.unstubAllEnvs();
   });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -9,6 +9,10 @@ import {
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { server } from "@/mocks/mock-server";
 import { environment } from "@/services/environment";
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
 import { useOnboardingWizardStore } from "../../store";
 import {
   getSubscriptionPricingExperimentConfig,
@@ -203,9 +207,38 @@ describe("SubscriptionStep", () => {
     expect(capturedTierBody!.cancel_url).toContain(
       "/onboarding?step=1&subscription=cancelled",
     );
+    // Stripe fills {CHECKOUT_SESSION_ID}; plan and cycle let the return page
+    // report the subscription value to Google Ads.
+    expect(capturedTierBody!.success_url).toContain(
+      "&session_id={CHECKOUT_SESSION_ID}&plan=PRO&cycle=monthly",
+    );
     // Paywall-first: no profile data exists yet, so nothing is POSTed here —
     // the Preparing step submits the profile at the end of onboarding.
     expect(profileCalled).toBe(false);
+  });
+
+  test("reports begin_checkout with the plan price to Google Ads before redirecting", async () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
+    const gtagCalls = installGtagShim();
+    server.use(
+      http.post("*/api/credits/subscription", () =>
+        HttpResponse.json({ url: null }),
+      ),
+    );
+
+    render(<SubscriptionStep />);
+    fireEvent.click(screen.getByRole("button", { name: /Get Pro/i }));
+
+    await waitFor(() => {
+      expect(gtagCalls).toContainEqual([
+        "event",
+        "conversion",
+        { send_to: "AW-123/BC", value: 50, currency: "USD" },
+      ]);
+    });
+    removeGtagShim();
+    vi.unstubAllEnvs();
   });
 
   test("switching to yearly + selecting Pro forwards billing_cycle=yearly", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/__tests__/SubscriptionStep.test.tsx
@@ -38,7 +38,15 @@ vi.mock("@/components/atoms/AutoGPTLogo/AutoGPTLogo", () => ({
   AutoGPTLogo: () => <span>AutoGPTLogo</span>,
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  // Not at the end of each test body: an assertion that throws above would
+  // leak the shim, the location stub and NEXT_PUBLIC_GOOGLE_ADS_ID into every
+  // later test here.
+  restoreLocation();
+  removeGtagShim();
+  vi.unstubAllEnvs();
+});
 
 beforeEach(() => {
   postHog.variant = undefined;
@@ -261,9 +269,6 @@ describe("SubscriptionStep", () => {
       ]);
     });
     expect(location.href).toBe("https://checkout.stripe.com/pay/cs_test");
-    restoreLocation();
-    removeGtagShim();
-    vi.unstubAllEnvs();
   });
 
   test("reports no begin_checkout when Stripe returns no Checkout URL", async () => {
@@ -287,8 +292,6 @@ describe("SubscriptionStep", () => {
       );
     });
     expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
-    removeGtagShim();
-    vi.unstubAllEnvs();
   });
 
   test("switching to yearly + selecting Pro forwards billing_cycle=yearly", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -240,13 +240,16 @@ export function useOnboardingPage() {
   }, [currentStep, preparingStep, refreshSession]);
 
   async function handlePreparingComplete() {
-    trackAdsConversion("onboarding_complete", {
-      transactionID: user?.id,
-      email: user?.email,
-    });
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         await postV1CompleteOnboardingStep({ step: "ONBOARDING_COMPLETE" });
+        // Only a confirmed completion counts: the fall-through below still
+        // sends the user to the copilot after three failures, but the backend
+        // never recorded the milestone.
+        trackAdsConversion("onboarding_complete", {
+          transactionID: user?.id,
+          email: user?.email,
+        });
         clearHighestStep();
         useOnboardingWizardStore.persist.clearStorage();
         router.replace("/copilot");

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -7,6 +7,7 @@ import {
 import type { SubscriptionStatusResponse } from "@/app/api/__generated__/models/subscriptionStatusResponse";
 import { resolveResponse } from "@/app/api/helpers";
 import { useAuth } from "@/lib/auth/hooks/useAuth";
+import { trackAdsConversion } from "@/services/analytics/google-ads";
 import { environment } from "@/services/environment";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { useLDClient } from "launchdarkly-react-client-sdk";
@@ -55,7 +56,7 @@ function clearHighestStep() {
 export function useOnboardingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn, isUserLoading, refreshSession } = useAuth();
+  const { isLoggedIn, isUserLoading, refreshSession, user } = useAuth();
   const currentStep = useOnboardingWizardStore((s) => s.currentStep);
   const goToStep = useOnboardingWizardStore((s) => s.goToStep);
 
@@ -239,6 +240,10 @@ export function useOnboardingPage() {
   }, [currentStep, preparingStep, refreshSession]);
 
   async function handlePreparingComplete() {
+    trackAdsConversion("onboarding_complete", {
+      transactionID: user?.id,
+      email: user?.email,
+    });
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         await postV1CompleteOnboardingStep({ step: "ONBOARDING_COMPLETE" });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/signup/__tests__/actions.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/signup/__tests__/actions.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   rollbackSession: vi.fn(),
   postV1GetOrCreateUser: vi.fn(),
   scheduleAccountCreatedGoal: vi.fn(),
+  cookieSet: vi.fn(),
 }));
 
 vi.mock("@/app/api/__generated__/endpoints/auth/auth", () => ({
@@ -24,6 +25,7 @@ vi.mock("@/lib/auth/server/rollbackSession", () => ({
 }));
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
+  cookies: vi.fn().mockResolvedValue({ set: mocks.cookieSet }),
 }));
 vi.mock("@/services/analytics/datafast-server", async (importOriginal) => {
   const actual =
@@ -67,6 +69,13 @@ describe("email signup account creation tracking", () => {
     expect(result.success).toBe(true);
     expect(mocks.scheduleAccountCreatedGoal).toHaveBeenCalledOnce();
     expect(mocks.scheduleAccountCreatedGoal).toHaveBeenCalledWith("email");
+    // The browser reports the Google Ads sign-up conversion from this flag on
+    // the next page it renders.
+    expect(mocks.cookieSet).toHaveBeenCalledWith(
+      "agpt_account_created",
+      "email",
+      expect.objectContaining({ maxAge: 600, path: "/" }),
+    );
   });
 
   it("does not track an account that already existed", async () => {
@@ -85,6 +94,7 @@ describe("email signup account creation tracking", () => {
 
     expect(result.success).toBe(true);
     expect(mocks.scheduleAccountCreatedGoal).not.toHaveBeenCalled();
+    expect(mocks.cookieSet).not.toHaveBeenCalled();
   });
 
   it("reports a thrown backend error instead of completing signup", async () => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/signup/actions.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/signup/actions.ts
@@ -4,6 +4,7 @@ import { postV1GetOrCreateUser } from "@/app/api/__generated__/endpoints/auth/au
 import { getOnboardingStatus } from "@/app/api/helpers";
 import { auth } from "@/lib/auth/auth";
 import { rollbackSession } from "@/lib/auth/server/rollbackSession";
+import { markAccountCreated } from "@/services/analytics/account-created-server";
 import {
   scheduleAccountCreatedGoal,
   wasAccountCreated,
@@ -77,6 +78,7 @@ export async function signup(
       const createUserResponse = await postV1GetOrCreateUser();
       if (wasAccountCreated(createUserResponse)) {
         await scheduleAccountCreatedGoal("email");
+        await markAccountCreated("email");
       }
     } catch (createUserError) {
       console.error("Error creating user during signup:", createUserError);

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/__tests__/PaywallModal.test.tsx
@@ -1,3 +1,7 @@
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   render,
@@ -377,9 +381,49 @@ describe("PaywallModal — upgrade mutation", () => {
     });
     const [args] = mutateFn.mock.calls[0];
     expect(args.data.cancel_url).toBe("https://app.test/copilot");
+    // Stripe fills {CHECKOUT_SESSION_ID}; plan and cycle let the return page
+    // report the subscription to Google Ads.
     expect(args.data.success_url).toBe(
-      "https://app.test/profile/credits?subscription=success",
+      "https://app.test/profile/credits?subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=PRO&cycle=monthly",
     );
+  });
+
+  it("reports begin_checkout only once Stripe returns a Checkout URL", async () => {
+    stubLocation();
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
+    const gtagCalls = installGtagShim();
+    const mutateFn = vi
+      .fn()
+      .mockResolvedValue({ status: 200, data: { url: null } });
+    setupMocks({
+      mutateFn,
+      subscription: { tier: "NO_TIER", tier_costs: { PRO: 5000 } },
+    });
+
+    render(<PaywallModal />);
+    fireEvent.click(screen.getByRole("button", { name: /upgrade to pro/i }));
+
+    await waitFor(() => {
+      expect(mutateFn).toHaveBeenCalledTimes(1);
+    });
+    expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
+
+    mutateFn.mockResolvedValue({
+      status: 200,
+      data: { url: "https://checkout.stripe.com/pay/cs_test" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /upgrade to pro/i }));
+
+    await waitFor(() => {
+      expect(gtagCalls).toContainEqual([
+        "event",
+        "conversion",
+        { send_to: "AW-123/BC", value: 50, currency: "USD" },
+      ]);
+    });
+    removeGtagShim();
+    vi.unstubAllEnvs();
   });
 
   it("401 from updateTier routes to /login instead of toasting a dead-end error", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
@@ -18,6 +18,10 @@ import {
   type PlanDef,
   TEAM_INTAKE_FORM_URL,
 } from "@/components/molecules/PlanCard/plans";
+import {
+  getSubscriptionValue,
+  trackAdsConversion,
+} from "@/services/analytics/google-ads";
 
 interface CheckoutResponse {
   url?: string;
@@ -99,21 +103,27 @@ export function usePaywallModal() {
 
   async function fireUpdate(tier: string) {
     setSelectedTier(tier);
+    const cycle = isYearly ? "yearly" : "monthly";
     try {
       const result = await updateTier({
         data: {
           tier: tier as SubscriptionTierRequestTier,
-          success_url: `${window.location.origin}/profile/credits?subscription=success`,
+          // Stripe fills {CHECKOUT_SESSION_ID}; plan and cycle let the return
+          // page report the subscription to Google Ads.
+          success_url: `${window.location.origin}/profile/credits?subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=${tier}&cycle=${cycle}`,
           // Backing out of Stripe Checkout must return to the page the user
           // was on so the paywall re-gates immediately. /profile/* is
           // paywall-exempt — landing there let users wander an app that
           // looks unlocked until the next non-exempt navigation.
           cancel_url: window.location.href,
-          billing_cycle: isYearly ? "yearly" : "monthly",
+          billing_cycle: cycle,
         },
       });
       const url = (result?.data as CheckoutResponse | undefined)?.url;
       if (url) {
+        trackAdsConversion("begin_checkout", {
+          value: getSubscriptionValue(tier, cycle),
+        });
         window.location.href = url;
       }
     } catch (error) {

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/usePaywallModal.ts
@@ -121,8 +121,13 @@ export function usePaywallModal() {
       });
       const url = (result?.data as CheckoutResponse | undefined)?.url;
       if (url) {
+        // `plans` carries tier_costs / tier_costs_yearly straight from
+        // /credits/subscription — what Stripe actually charges. The static
+        // plan definition is only the fallback for a tier priced nowhere else.
+        const plan = plans.find((candidate) => candidate.key === tier);
+        const apiValue = isYearly ? plan?.usdYearly : plan?.usdMonthly;
         trackAdsConversion("begin_checkout", {
-          value: getSubscriptionValue(tier, cycle),
+          value: apiValue ?? getSubscriptionValue(tier, cycle),
         });
         window.location.href = url;
       }

--- a/autogpt_platform/frontend/src/app/(platform)/auth/callback/__tests__/route.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/auth/callback/__tests__/route.test.ts
@@ -5,6 +5,7 @@ const postV1GetOrCreateUserMock = vi.fn();
 const getOnboardingStatusMock = vi.fn();
 const revalidatePathMock = vi.fn();
 const scheduleAccountCreatedGoalMock = vi.fn();
+const cookieSetMock = vi.fn();
 
 vi.mock("@/lib/auth/server/getServerSession", () => ({
   getServerSession: () => getServerSessionMock(),
@@ -27,6 +28,11 @@ vi.mock("@/services/analytics/datafast-server", async (importOriginal) => ({
 
 vi.mock("@/app/api/helpers", () => ({
   getOnboardingStatus: () => getOnboardingStatusMock(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ set: cookieSetMock }),
+  headers: () => new Headers(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -77,6 +83,7 @@ beforeEach(() => {
   getOnboardingStatusMock.mockReset();
   revalidatePathMock.mockReset();
   scheduleAccountCreatedGoalMock.mockReset();
+  cookieSetMock.mockReset();
   vi.spyOn(console, "error").mockImplementation(() => undefined);
 });
 
@@ -137,6 +144,13 @@ describe("auth callback GET — account creation tracking", () => {
     expect(response.headers.get("location")).toBe(`${origin}/copilot`);
     expect(scheduleAccountCreatedGoalMock).toHaveBeenCalledOnce();
     expect(scheduleAccountCreatedGoalMock).toHaveBeenCalledWith("google");
+    // The browser reports the Google Ads sign-up conversion from this flag on
+    // the page it lands on.
+    expect(cookieSetMock).toHaveBeenCalledWith(
+      "agpt_account_created",
+      "google",
+      expect.objectContaining({ maxAge: 600, path: "/" }),
+    );
   });
 
   it("does not track a returning Google user", async () => {
@@ -145,6 +159,7 @@ describe("auth callback GET — account creation tracking", () => {
     await GET(makeCallbackRequest());
 
     expect(scheduleAccountCreatedGoalMock).not.toHaveBeenCalled();
+    expect(cookieSetMock).not.toHaveBeenCalled();
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/auth/callback/route.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/auth/callback/route.ts
@@ -3,6 +3,7 @@ import { getOnboardingStatus } from "@/app/api/helpers";
 import { sanitizeAuthNext } from "@/lib/auth-redirect";
 import { getServerSession } from "@/lib/auth/server/getServerSession";
 import { rollbackSession } from "@/lib/auth/server/rollbackSession";
+import { markAccountCreated } from "@/services/analytics/account-created-server";
 import {
   scheduleAccountCreatedGoal,
   wasAccountCreated,
@@ -43,6 +44,7 @@ export async function GET(request: Request) {
       const createUserResponse = await postV1GetOrCreateUser();
       if (wasAccountCreated(createUserResponse)) {
         await scheduleAccountCreatedGoal("google");
+        await markAccountCreated("google");
       }
 
       const { shouldShowOnboarding } = await getOnboardingStatus();

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/useSubscriptionTierSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/components/SubscriptionTierSection/useSubscriptionTierSection.ts
@@ -9,6 +9,10 @@ import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { getTierLabel } from "./helpers";
+import {
+  getSubscriptionValue,
+  trackAdsConversion,
+} from "@/services/analytics/google-ads";
 
 export type SubscriptionStatus = SubscriptionStatusResponse;
 
@@ -69,7 +73,10 @@ export function useSubscriptionTierSection() {
   async function changeTier(tier: string) {
     setTierError(null);
     try {
-      const successUrl = `${window.location.origin}${window.location.pathname}?subscription=success`;
+      // Stripe fills {CHECKOUT_SESSION_ID}; plan and cycle let the return page
+      // report the subscription to Google Ads. This surface has no cycle
+      // toggle, so the backend default (monthly) is what gets charged.
+      const successUrl = `${window.location.origin}${window.location.pathname}?subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=${tier}&cycle=monthly`;
       const cancelUrl = `${window.location.origin}${window.location.pathname}?subscription=cancelled`;
       const result = await doUpdateTier({
         data: {
@@ -79,6 +86,9 @@ export function useSubscriptionTierSection() {
         },
       });
       if (result.status === 200 && result.data.url) {
+        trackAdsConversion("begin_checkout", {
+          value: getSubscriptionValue(tier, "monthly"),
+        });
         window.location.href = result.data.url;
         return;
       }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -13,9 +13,13 @@
 
 import { fireEvent } from "@testing-library/react";
 import { http, HttpResponse, type JsonBodyType } from "msw";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "@/mocks/mock-server";
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
 
 import { AutoRefillCard } from "../components/AutomationCreditsTab/AutoRefillCard/AutoRefillCard";
@@ -1226,5 +1230,85 @@ describe("Card mutation flows", () => {
     expect(
       screen.queryByRole("button", { name: /manage subscription/i }),
     ).toBeNull();
+  });
+});
+
+describe("YourPlanCard begin_checkout", () => {
+  const originalLocation = window.location;
+
+  function stubLocation() {
+    const location = {
+      origin: "http://localhost",
+      pathname: "/settings/billing",
+      href: "http://localhost/settings/billing",
+    };
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: location,
+    });
+    return location;
+  }
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+    removeGtagShim();
+    vi.unstubAllEnvs();
+  });
+
+  function freeAccount(checkoutURL: string | null) {
+    server.use(
+      jsonHandler("get", "/api/credits/subscription", {
+        tier: "NO_TIER",
+        monthly_cost: 0,
+        has_active_stripe_subscription: false,
+        status: "inactive",
+        // What Stripe actually charges, which is what Ads should bid on —
+        // deliberately not the $50 the plan card computes.
+        tier_costs: { PRO: 4900 },
+      }),
+      jsonHandler("get", "/api/credits/manage", { url: null }),
+      jsonHandler("post", "/api/credits/subscription", { url: checkoutURL }),
+    );
+  }
+
+  it("reports begin_checkout with the authoritative price once Stripe returns a URL", async () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
+    const gtagCalls = installGtagShim();
+    const location = stubLocation();
+    freeAccount("https://checkout.stripe.com/pay/cs_test");
+
+    render(<YourPlanCard />);
+    fireEvent.click(await screen.findByRole("button", { name: /get pro/i }));
+
+    await waitFor(() => {
+      expect(gtagCalls).toContainEqual([
+        "event",
+        "conversion",
+        { send_to: "AW-123/BC", value: 49, currency: "USD" },
+      ]);
+    });
+    expect(location.href).toBe("https://checkout.stripe.com/pay/cs_test");
+  });
+
+  it("reports no begin_checkout when the tier changes in place", async () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
+    const gtagCalls = installGtagShim();
+    stubLocation();
+    freeAccount(null);
+
+    render(<YourPlanCard />);
+    fireEvent.click(await screen.findByRole("button", { name: /get pro/i }));
+
+    await waitFor(() => {
+      expect(gtagCalls.length).toBeGreaterThanOrEqual(0);
+    });
+    expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -1261,19 +1261,27 @@ describe("YourPlanCard begin_checkout", () => {
   });
 
   function freeAccount(checkoutURL: string | null) {
+    const hits = { get: 0, post: 0 };
     server.use(
-      jsonHandler("get", "/api/credits/subscription", {
-        tier: "NO_TIER",
-        monthly_cost: 0,
-        has_active_stripe_subscription: false,
-        status: "inactive",
-        // What Stripe actually charges, which is what Ads should bid on —
-        // deliberately not the $50 the plan card computes.
-        tier_costs: { PRO: 4900 },
+      http.get("*/api/credits/subscription", () => {
+        hits.get += 1;
+        return HttpResponse.json({
+          tier: "NO_TIER",
+          monthly_cost: 0,
+          has_active_stripe_subscription: false,
+          status: "inactive",
+          // What Stripe actually charges, which is what Ads should bid on —
+          // deliberately not the $50 the plan card computes.
+          tier_costs: { PRO: 4900 },
+        });
       }),
       jsonHandler("get", "/api/credits/manage", { url: null }),
-      jsonHandler("post", "/api/credits/subscription", { url: checkoutURL }),
+      http.post("*/api/credits/subscription", () => {
+        hits.post += 1;
+        return HttpResponse.json({ url: checkoutURL });
+      }),
     );
+    return hits;
   }
 
   it("reports begin_checkout with the authoritative price once Stripe returns a URL", async () => {
@@ -1301,14 +1309,17 @@ describe("YourPlanCard begin_checkout", () => {
     vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS", "begin_checkout=BC");
     const gtagCalls = installGtagShim();
     stubLocation();
-    freeAccount(null);
+    const hits = freeAccount(null);
 
     render(<YourPlanCard />);
-    fireEvent.click(await screen.findByRole("button", { name: /get pro/i }));
+    await waitFor(() => expect(hits.get).toBe(1));
+    fireEvent.click(screen.getByRole("button", { name: /get pro/i }));
 
-    await waitFor(() => {
-      expect(gtagCalls.length).toBeGreaterThanOrEqual(0);
-    });
+    // The in-place branch refetches the subscription after the POST resolves,
+    // so a second GET is proof the whole path ran — not just that the request
+    // was sent.
+    await waitFor(() => expect(hits.post).toBe(1));
+    await waitFor(() => expect(hits.get).toBeGreaterThanOrEqual(2));
     expect(gtagCalls.filter((call) => call[1] === "conversion")).toEqual([]);
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/__tests__/billing-cards.test.tsx
@@ -363,7 +363,11 @@ describe("YourPlanCard cycle toggle", () => {
   });
 
   it("fires updateTier with billing_cycle on confirm", async () => {
-    let capturedBody: { tier?: string; billing_cycle?: string } | null = null;
+    let capturedBody: {
+      tier?: string;
+      billing_cycle?: string;
+      success_url?: string;
+    } | null = null;
     server.use(
       jsonHandler("get", "/api/credits/subscription", {
         tier: "PRO",
@@ -394,6 +398,11 @@ describe("YourPlanCard cycle toggle", () => {
       expect(capturedBody).not.toBeNull();
       expect(capturedBody?.tier).toBe("PRO");
       expect(capturedBody?.billing_cycle).toBe("yearly");
+      // Stripe fills {CHECKOUT_SESSION_ID}; plan and cycle let the return page
+      // report the subscription value to Google Ads.
+      expect(capturedBody?.success_url).toContain(
+        "?subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=PRO&cycle=yearly",
+      );
     });
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -14,6 +14,7 @@ import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models
 import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import {
+  centsToUSD,
   getSubscriptionValue,
   trackAdsConversion,
 } from "@/services/analytics/google-ads";
@@ -210,8 +211,12 @@ export function useYourPlanCard() {
         // A Checkout URL is the only proof that Stripe Checkout actually
         // starts: paid users are modified in place and get no URL, which is
         // not a checkout start.
+        // /credits/subscription returns what Stripe actually charges; the
+        // plan-card figure is only the fallback when the tier isn't priced there.
+        const cents =
+          cycle === "yearly" ? tierCostsYearly[tier] : tierCosts[tier];
         trackAdsConversion("begin_checkout", {
-          value: getSubscriptionValue(tier, cycle),
+          value: centsToUSD(cents) ?? getSubscriptionValue(tier, cycle),
         });
         // Navigating away — don't refetch (would set state on an
         // unmounting component while Stripe Checkout takes over).

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -196,13 +196,6 @@ export function useYourPlanCard() {
     // report the subscription to Google Ads.
     const successUrl = `${window.location.origin}${window.location.pathname}?subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=${tier}&cycle=${cycle}`;
     const cancelUrl = `${window.location.origin}${window.location.pathname}?subscription=cancelled`;
-    // Only a free account goes through Checkout; paid users are modified in
-    // place, which is not a checkout start.
-    if (!isPaid) {
-      trackAdsConversion("begin_checkout", {
-        value: getSubscriptionValue(tier, cycle),
-      });
-    }
     try {
       const result = await updateTier({
         data: {
@@ -214,6 +207,12 @@ export function useYourPlanCard() {
       });
       const url = (result?.data as { url?: string } | undefined)?.url;
       if (url) {
+        // A Checkout URL is the only proof that Stripe Checkout actually
+        // starts: paid users are modified in place and get no URL, which is
+        // not a checkout start.
+        trackAdsConversion("begin_checkout", {
+          value: getSubscriptionValue(tier, cycle),
+        });
         // Navigating away — don't refetch (would set state on an
         // unmounting component while Stripe Checkout takes over).
         window.location.href = url;

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/useYourPlanCard.ts
@@ -13,6 +13,10 @@ import type { SubscriptionTierRequestBillingCycle } from "@/app/api/__generated_
 import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models/subscriptionTierRequestTier";
 import { ApiError } from "@/lib/autogpt-server-api/helpers";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import {
+  getSubscriptionValue,
+  trackAdsConversion,
+} from "@/services/analytics/google-ads";
 
 import { formatCents, formatShortDate } from "../../../helpers";
 
@@ -187,8 +191,18 @@ export function useYourPlanCard() {
     tier: SubscriptionTierRequestTier,
     billingCycle?: SubscriptionTierRequestBillingCycle,
   ) {
-    const successUrl = `${window.location.origin}${window.location.pathname}?subscription=success`;
+    const cycle = billingCycle ?? "monthly";
+    // Stripe fills {CHECKOUT_SESSION_ID}; plan and cycle let the return page
+    // report the subscription to Google Ads.
+    const successUrl = `${window.location.origin}${window.location.pathname}?subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=${tier}&cycle=${cycle}`;
     const cancelUrl = `${window.location.origin}${window.location.pathname}?subscription=cancelled`;
+    // Only a free account goes through Checkout; paid users are modified in
+    // place, which is not a checkout start.
+    if (!isPaid) {
+      trackAdsConversion("begin_checkout", {
+        value: getSubscriptionValue(tier, cycle),
+      });
+    }
     try {
       const result = await updateTier({
         data: {

--- a/autogpt_platform/frontend/src/app/providers.tsx
+++ b/autogpt_platform/frontend/src/app/providers.tsx
@@ -26,10 +26,12 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
       <NuqsAdapter>
         <PostHogProvider>
           <BackendAPIProvider>
-            <SentryUserTracker />
-            <PostHogUserTracker />
-            <AdsConversionTracker />
+            {/* All four read useSearchParams (directly or via useAuth), which
+                bails out of static rendering unless it sits under Suspense. */}
             <Suspense fallback={null}>
+              <SentryUserTracker />
+              <PostHogUserTracker />
+              <AdsConversionTracker />
               <PostHogPageViewTracker />
             </Suspense>
             <CredentialsProvider>

--- a/autogpt_platform/frontend/src/app/providers.tsx
+++ b/autogpt_platform/frontend/src/app/providers.tsx
@@ -12,6 +12,7 @@ import {
   PostHogProvider,
   PostHogUserTracker,
 } from "@/providers/posthog/posthog-provider";
+import { AdsConversionTracker } from "@/services/analytics/AdsConversionTracker";
 import { LaunchDarklyProvider } from "@/services/feature-flags/feature-flag-provider";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider, ThemeProviderProps } from "next-themes";
@@ -27,6 +28,7 @@ export function Providers({ children, ...props }: ThemeProviderProps) {
           <BackendAPIProvider>
             <SentryUserTracker />
             <PostHogUserTracker />
+            <AdsConversionTracker />
             <Suspense fallback={null}>
               <PostHogPageViewTracker />
             </Suspense>

--- a/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/CookieConsentBanner.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/CookieConsentBanner.tsx
@@ -47,7 +47,8 @@ export function CookieConsentBanner() {
                   className="text-neutral-600 dark:text-neutral-400"
                 >
                   AutoGPT uses essential cookies for login and optional cookies
-                  for analytics and error tracking to improve our service.
+                  for analytics, advertising measurement and error tracking to
+                  improve our service.
                 </Text>
               </div>
             </div>

--- a/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/__tests__/CookieConsentBanner.test.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/__tests__/CookieConsentBanner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@/tests/integrations/test-utils";
+import { fireEvent, render, screen } from "@/tests/integrations/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 let pathname = "/marketplace";
@@ -37,5 +37,16 @@ describe("CookieConsentBanner", () => {
     // the positive case needs before asserting absence.
     await Promise.resolve();
     expect(screen.queryByText("We use cookies")).toBeNull();
+  });
+
+  test("lets the visitor decide on advertising cookies separately", async () => {
+    pathname = "/marketplace";
+    render(<CookieConsentBanner />);
+    fireEvent.click(await screen.findByRole("button", { name: "Settings" }));
+
+    expect(
+      await screen.findByLabelText("Toggle advertising cookies"),
+    ).toBeDefined();
+    expect(screen.getByText("Advertising")).toBeDefined();
   });
 });

--- a/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/components/CookieSettingsModal/CookieSettingsModal.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/components/CookieSettingsModal/CookieSettingsModal.tsx
@@ -20,6 +20,8 @@ export function CookieSettingsModal({ isOpen, onClose }: Props) {
     setAnalytics,
     monitoring,
     setMonitoring,
+    advertising,
+    setAdvertising,
     handleSavePreferences,
     handleAcceptAll,
     handleRejectAll,
@@ -112,6 +114,32 @@ export function CookieSettingsModal({ isOpen, onClose }: Props) {
                 checked={monitoring}
                 onCheckedChange={setMonitoring}
                 aria-label="Toggle monitoring cookies"
+              />
+            </div>
+          </div>
+
+          <div className="border-t border-neutral-200 dark:border-neutral-800" />
+
+          <div className="space-y-2">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1 space-y-1">
+                <Text
+                  variant="body-medium"
+                  className="text-neutral-900 dark:text-neutral-100"
+                >
+                  {COOKIE_CATEGORIES.advertising.name}
+                </Text>
+                <Text
+                  variant="body"
+                  className="text-neutral-600 dark:text-neutral-400"
+                >
+                  {COOKIE_CATEGORIES.advertising.description}
+                </Text>
+              </div>
+              <Switch
+                checked={advertising}
+                onCheckedChange={setAdvertising}
+                aria-label="Toggle advertising cookies"
               />
             </div>
           </div>

--- a/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/components/CookieSettingsModal/useCookieSettingsModal.ts
+++ b/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/components/CookieSettingsModal/useCookieSettingsModal.ts
@@ -12,16 +12,19 @@ export function useCookieSettingsModal({ onClose }: Props) {
 
   const [analytics, setAnalytics] = useState(consent.analytics);
   const [monitoring, setMonitoring] = useState(consent.monitoring);
+  const [advertising, setAdvertising] = useState(consent.advertising);
 
   useEffect(() => {
     setAnalytics(consent.analytics);
     setMonitoring(consent.monitoring);
-  }, [consent.analytics, consent.monitoring]);
+    setAdvertising(consent.advertising);
+  }, [consent.analytics, consent.monitoring, consent.advertising]);
 
   function handleSavePreferences() {
     handleUpdateConsent({
       analytics,
       monitoring,
+      advertising,
     });
     onClose();
   }
@@ -29,9 +32,11 @@ export function useCookieSettingsModal({ onClose }: Props) {
   function handleAcceptAll() {
     setAnalytics(true);
     setMonitoring(true);
+    setAdvertising(true);
     handleUpdateConsent({
       analytics: true,
       monitoring: true,
+      advertising: true,
     });
     onClose();
   }
@@ -39,9 +44,11 @@ export function useCookieSettingsModal({ onClose }: Props) {
   function handleRejectAll() {
     setAnalytics(false);
     setMonitoring(false);
+    setAdvertising(false);
     handleUpdateConsent({
       analytics: false,
       monitoring: false,
+      advertising: false,
     });
     onClose();
   }
@@ -51,6 +58,8 @@ export function useCookieSettingsModal({ onClose }: Props) {
     setAnalytics,
     monitoring,
     setMonitoring,
+    advertising,
+    setAdvertising,
     handleSavePreferences,
     handleAcceptAll,
     handleRejectAll,

--- a/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/useCookieConsent.ts
+++ b/autogpt_platform/frontend/src/components/molecules/CookieConsentBanner/useCookieConsent.ts
@@ -40,6 +40,7 @@ export function useCookieConsent() {
     handleUpdateConsent({
       analytics: true,
       monitoring: true,
+      advertising: true,
     });
   }, [handleUpdateConsent]);
 
@@ -47,6 +48,7 @@ export function useCookieConsent() {
     handleUpdateConsent({
       analytics: false,
       monitoring: false,
+      advertising: false,
     });
   }, [handleUpdateConsent]);
 

--- a/autogpt_platform/frontend/src/services/analytics/AdsConversionTracker.test.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/AdsConversionTracker.test.tsx
@@ -1,0 +1,178 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
+import { ACCOUNT_CREATED_COOKIE } from "./account-created-cookie";
+
+let pathname = "/copilot";
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+const auth = vi.hoisted(() => ({
+  state: {
+    user: { id: "user-1", email: "ada@example.com" } as {
+      id: string;
+      email: string;
+    } | null,
+    isUserLoading: false,
+  },
+}));
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => auth.state,
+}));
+
+import { AdsConversionTracker } from "./AdsConversionTracker";
+
+let pushed: unknown[][] = [];
+
+function conversions() {
+  return pushed.filter(([, name]) => name === "conversion");
+}
+
+function pageViews() {
+  return pushed.filter(([, name]) => name === "page_view");
+}
+
+describe("AdsConversionTracker", () => {
+  beforeEach(() => {
+    pushed = installGtagShim();
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0`;
+    window.history.replaceState({}, "", "/copilot");
+    pathname = "/copilot";
+    auth.state = {
+      user: { id: "user-1", email: "ada@example.com" },
+      isUserLoading: false,
+    };
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv(
+      "NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS",
+      "sign_up=SU,subscribe=SB,top_up=TU",
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    removeGtagShim();
+  });
+
+  it("fires sign_up once for a just-created account and clears the flag", () => {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+
+    const { rerender } = render(<AdsConversionTracker />);
+    rerender(<AdsConversionTracker />);
+
+    expect(conversions()).toEqual([
+      [
+        "event",
+        "conversion",
+        {
+          send_to: "AW-123/SU",
+          transaction_id: "user-1",
+          user_data: { email: "ada@example.com" },
+        },
+      ],
+    ]);
+    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=email`);
+  });
+
+  it("waits for the session before firing sign_up", () => {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=google; Path=/`;
+    auth.state = { user: null, isUserLoading: true };
+
+    const { rerender } = render(<AdsConversionTracker />);
+    expect(conversions()).toEqual([]);
+
+    auth.state = {
+      user: { id: "user-2", email: "bob@example.com" },
+      isUserLoading: false,
+    };
+    rerender(<AdsConversionTracker />);
+
+    expect(conversions()).toHaveLength(1);
+    expect(conversions()[0][2]).toMatchObject({ transaction_id: "user-2" });
+  });
+
+  it("does not fire sign_up for a returning user", () => {
+    render(<AdsConversionTracker />);
+
+    expect(conversions()).toEqual([]);
+  });
+
+  it("picks up a flag set after mount on the next client-side navigation", () => {
+    const { rerender } = render(<AdsConversionTracker />);
+    expect(conversions()).toEqual([]);
+
+    // The email signup action sets the flag, then router.replace()s onward.
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+    pathname = "/onboarding";
+    rerender(<AdsConversionTracker />);
+
+    expect(conversions()).toHaveLength(1);
+    expect(conversions()[0][2]).toMatchObject({ send_to: "AW-123/SU" });
+  });
+
+  it("fires subscribe with the plan price when returning from Stripe", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/onboarding?step=2&subscription=success&session_id=cs_1&plan=MAX&cycle=yearly",
+    );
+
+    render(<AdsConversionTracker />);
+
+    expect(conversions()).toEqual([
+      [
+        "event",
+        "conversion",
+        {
+          send_to: "AW-123/SB",
+          value: 3264,
+          currency: "USD",
+          transaction_id: "cs_1",
+          user_data: { email: "ada@example.com" },
+        },
+      ],
+    ]);
+  });
+
+  it("does not fire subscribe on a cancelled checkout", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/onboarding?step=1&subscription=cancelled",
+    );
+
+    render(<AdsConversionTracker />);
+
+    expect(conversions()).toEqual([]);
+  });
+
+  it("fires top_up when a credits purchase returns", () => {
+    window.history.replaceState({}, "", "/settings/billing?topup=success");
+
+    render(<AdsConversionTracker />);
+
+    expect(conversions()).toEqual([
+      [
+        "event",
+        "conversion",
+        { send_to: "AW-123/TU", user_data: { email: "ada@example.com" } },
+      ],
+    ]);
+  });
+
+  it("sends a page_view to the Ads tag on client-side navigation only", () => {
+    const { rerender } = render(<AdsConversionTracker />);
+    expect(pageViews()).toEqual([]);
+
+    pathname = "/library";
+    rerender(<AdsConversionTracker />);
+
+    expect(pageViews()).toEqual([
+      ["event", "page_view", { send_to: "AW-123", page_path: "/library" }],
+    ]);
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/AdsConversionTracker.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/AdsConversionTracker.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useAdsConversionTracker } from "./useAdsConversionTracker";
+
+export function AdsConversionTracker() {
+  useAdsConversionTracker();
+  return null;
+}

--- a/autogpt_platform/frontend/src/services/analytics/__tests__/AdsConversionTracker.test.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/__tests__/AdsConversionTracker.test.tsx
@@ -234,6 +234,9 @@ describe("AdsConversionTracker", () => {
     const { rerender } = render(<AdsConversionTracker />);
 
     pushed = installGtagShim();
+    // The navigation that triggers the retry also strips the query — the
+    // snapshot taken at mount is what has to carry it.
+    window.history.replaceState({}, "", "/library");
     pathname = "/library";
     rerender(<AdsConversionTracker />);
 

--- a/autogpt_platform/frontend/src/services/analytics/__tests__/AdsConversionTracker.test.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/__tests__/AdsConversionTracker.test.tsx
@@ -52,6 +52,15 @@ describe("AdsConversionTracker", () => {
       "NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS",
       "sign_up=SU,subscribe=SB,top_up=TU",
     );
+    // Identifiers only ride along on an affirmative yes, so the cases below
+    // that assert them start from an answered banner.
+    consent.save({
+      hasConsented: true,
+      timestamp: 1,
+      analytics: true,
+      monitoring: true,
+      advertising: true,
+    });
   });
 
   afterEach(() => {
@@ -255,13 +264,6 @@ describe("AdsConversionTracker", () => {
   });
 
   it("keeps the identifiers when the visitor accepted advertising", () => {
-    consent.save({
-      hasConsented: true,
-      timestamp: 1,
-      analytics: true,
-      monitoring: true,
-      advertising: true,
-    });
     document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
 
     render(<AdsConversionTracker />);
@@ -270,6 +272,17 @@ describe("AdsConversionTracker", () => {
       transaction_id: "user-1",
       user_data: { email: "ada@example.com" },
     });
+  });
+
+  it("drops the identifiers while the banner is unanswered", () => {
+    consent.clear();
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+
+    render(<AdsConversionTracker />);
+
+    expect(conversions()).toEqual([
+      ["event", "conversion", { send_to: "AW-123/SU" }],
+    ]);
   });
 
   it("sends a page_view to the Ads tag on client-side navigation only", () => {

--- a/autogpt_platform/frontend/src/services/analytics/__tests__/AdsConversionTracker.test.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/__tests__/AdsConversionTracker.test.tsx
@@ -4,7 +4,8 @@ import {
   installGtagShim,
   removeGtagShim,
 } from "@/tests/integrations/gtag-shim";
-import { ACCOUNT_CREATED_COOKIE } from "./account-created-cookie";
+import { ACCOUNT_CREATED_COOKIE } from "../account-created-cookie";
+import { consent } from "@/services/consent/cookies";
 
 let pathname = "/copilot";
 vi.mock("next/navigation", () => ({
@@ -24,7 +25,7 @@ vi.mock("@/lib/auth/hooks/useAuth", () => ({
   useAuth: () => auth.state,
 }));
 
-import { AdsConversionTracker } from "./AdsConversionTracker";
+import { AdsConversionTracker } from "../AdsConversionTracker";
 
 let pushed: unknown[][] = [];
 
@@ -56,6 +57,7 @@ describe("AdsConversionTracker", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     removeGtagShim();
+    consent.clear();
   });
 
   it("fires sign_up once for a just-created account and clears the flag", () => {
@@ -150,8 +152,12 @@ describe("AdsConversionTracker", () => {
     expect(conversions()).toEqual([]);
   });
 
-  it("fires top_up when a credits purchase returns", () => {
-    window.history.replaceState({}, "", "/settings/billing?topup=success");
+  it("fires top_up with the Stripe session as the dedup key", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/settings/billing?topup=success&session_id=cs_top_1",
+    );
 
     render(<AdsConversionTracker />);
 
@@ -159,9 +165,111 @@ describe("AdsConversionTracker", () => {
       [
         "event",
         "conversion",
-        { send_to: "AW-123/TU", user_data: { email: "ada@example.com" } },
+        {
+          send_to: "AW-123/TU",
+          transaction_id: "cs_top_1",
+          user_data: { email: "ada@example.com" },
+        },
       ],
     ]);
+  });
+
+  it("reports nothing while the session is absent, even once loading is done", () => {
+    // The regression: on the post-signup client navigation the effect runs
+    // with isUserLoading already false but no user yet. Reporting there sends
+    // a conversion with no dedup id and no enhanced-conversion email.
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+    auth.state = { user: null, isUserLoading: false };
+
+    const { rerender } = render(<AdsConversionTracker />);
+    expect(conversions()).toEqual([]);
+    expect(document.cookie).toContain(`${ACCOUNT_CREATED_COOKIE}=email`);
+
+    auth.state = {
+      user: { id: "user-3", email: "cleo@example.com" },
+      isUserLoading: false,
+    };
+    rerender(<AdsConversionTracker />);
+
+    expect(conversions()).toHaveLength(1);
+    expect(conversions()[0][2]).toMatchObject({
+      transaction_id: "user-3",
+      user_data: { email: "cleo@example.com" },
+    });
+  });
+
+  it("keeps the account-created flag when the tag has not loaded yet", () => {
+    removeGtagShim();
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+
+    const { rerender } = render(<AdsConversionTracker />);
+    expect(document.cookie).toContain(`${ACCOUNT_CREATED_COOKIE}=email`);
+
+    // The tag loads afterInteractive; the next navigation retries.
+    pushed = installGtagShim();
+    pathname = "/library";
+    rerender(<AdsConversionTracker />);
+
+    expect(conversions()).toHaveLength(1);
+    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=email`);
+  });
+
+  it("retries the checkout return until it reaches the tag", () => {
+    removeGtagShim();
+    window.history.replaceState(
+      {},
+      "",
+      "/settings/billing?subscription=success&session_id=cs_2&plan=PRO&cycle=monthly",
+    );
+
+    const { rerender } = render(<AdsConversionTracker />);
+
+    pushed = installGtagShim();
+    pathname = "/library";
+    rerender(<AdsConversionTracker />);
+
+    expect(conversions()).toHaveLength(1);
+    expect(conversions()[0][2]).toMatchObject({
+      send_to: "AW-123/SB",
+      transaction_id: "cs_2",
+    });
+  });
+
+  it("drops the identifiers when the visitor rejected advertising", () => {
+    consent.save({
+      hasConsented: true,
+      timestamp: 1,
+      analytics: true,
+      monitoring: true,
+      advertising: false,
+    });
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+
+    render(<AdsConversionTracker />);
+
+    // The aggregate conversion still counts — Consent Mode keeps it
+    // cookieless — but nothing identifying rides along.
+    expect(conversions()).toEqual([
+      ["event", "conversion", { send_to: "AW-123/SU" }],
+    ]);
+  });
+
+  it("keeps the identifiers when the visitor accepted advertising", () => {
+    consent.save({
+      hasConsented: true,
+      timestamp: 1,
+      analytics: true,
+      monitoring: true,
+      advertising: true,
+    });
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+
+    render(<AdsConversionTracker />);
+
+    expect(conversions()[0][2]).toMatchObject({
+      transaction_id: "user-1",
+      user_data: { email: "ada@example.com" },
+    });
   });
 
   it("sends a page_view to the Ads tag on client-side navigation only", () => {

--- a/autogpt_platform/frontend/src/services/analytics/account-created-cookie.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/account-created-cookie.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  ACCOUNT_CREATED_COOKIE,
+  consumeAccountCreatedFlag,
+} from "./account-created-cookie";
+
+describe("consumeAccountCreatedFlag", () => {
+  beforeEach(() => {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0`;
+  });
+
+  it("returns the signup method once and clears the flag", () => {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=google; Path=/`;
+
+    expect(consumeAccountCreatedFlag()).toBe("google");
+    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=google`);
+    expect(consumeAccountCreatedFlag()).toBeNull();
+  });
+
+  it("returns nothing when no account was just created", () => {
+    expect(consumeAccountCreatedFlag()).toBeNull();
+  });
+
+  it("discards a value that is not a known signup method", () => {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=weird; Path=/`;
+
+    expect(consumeAccountCreatedFlag()).toBeNull();
+    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=weird`);
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/account-created-cookie.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/account-created-cookie.test.ts
@@ -1,30 +1,40 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   ACCOUNT_CREATED_COOKIE,
-  consumeAccountCreatedFlag,
+  clearAccountCreatedFlag,
+  readAccountCreatedFlag,
 } from "./account-created-cookie";
 
-describe("consumeAccountCreatedFlag", () => {
+describe("account-created flag", () => {
   beforeEach(() => {
-    document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0`;
+    clearAccountCreatedFlag();
   });
 
-  it("returns the signup method once and clears the flag", () => {
+  it("reads the signup method without consuming it", () => {
     document.cookie = `${ACCOUNT_CREATED_COOKIE}=google; Path=/`;
 
-    expect(consumeAccountCreatedFlag()).toBe("google");
-    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=google`);
-    expect(consumeAccountCreatedFlag()).toBeNull();
+    expect(readAccountCreatedFlag()).toBe("google");
+    // Reading twice still works: the flag survives until the conversion is
+    // actually reported.
+    expect(readAccountCreatedFlag()).toBe("google");
+  });
+
+  it("clears the flag so a reload cannot report twice", () => {
+    document.cookie = `${ACCOUNT_CREATED_COOKIE}=email; Path=/`;
+
+    clearAccountCreatedFlag();
+
+    expect(readAccountCreatedFlag()).toBeNull();
+    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=email`);
   });
 
   it("returns nothing when no account was just created", () => {
-    expect(consumeAccountCreatedFlag()).toBeNull();
+    expect(readAccountCreatedFlag()).toBeNull();
   });
 
   it("discards a value that is not a known signup method", () => {
     document.cookie = `${ACCOUNT_CREATED_COOKIE}=weird; Path=/`;
 
-    expect(consumeAccountCreatedFlag()).toBeNull();
-    expect(document.cookie).not.toContain(`${ACCOUNT_CREATED_COOKIE}=weird`);
+    expect(readAccountCreatedFlag()).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/services/analytics/account-created-cookie.ts
+++ b/autogpt_platform/frontend/src/services/analytics/account-created-cookie.ts
@@ -5,9 +5,10 @@ export const SIGNUP_METHODS = ["email", "google"] as const;
 export type SignupMethod = (typeof SIGNUP_METHODS)[number];
 
 // The server sets this flag when it provisions a brand-new account (see
-// account-created-server.ts); the browser reads it once to report the
-// Google Ads sign-up conversion, then clears it so a reload can't report twice.
-export function consumeAccountCreatedFlag(): SignupMethod | null {
+// account-created-server.ts). Reading and clearing are separate on purpose:
+// the flag is the only record that a signup happened, so it must survive until
+// the conversion has actually reached the tag.
+export function readAccountCreatedFlag(): SignupMethod | null {
   if (typeof document === "undefined") return null;
 
   const prefix = `${ACCOUNT_CREATED_COOKIE}=`;
@@ -16,9 +17,15 @@ export function consumeAccountCreatedFlag(): SignupMethod | null {
     .find((part) => part.startsWith(prefix));
   if (!entry) return null;
 
-  document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0`;
   const value = entry.slice(prefix.length);
   return isSignupMethod(value) ? value : null;
+}
+
+// Called once the sign-up conversion is reported, so a reload can't report
+// twice.
+export function clearAccountCreatedFlag(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0`;
 }
 
 function isSignupMethod(value: string): value is SignupMethod {

--- a/autogpt_platform/frontend/src/services/analytics/account-created-cookie.ts
+++ b/autogpt_platform/frontend/src/services/analytics/account-created-cookie.ts
@@ -1,0 +1,26 @@
+export const ACCOUNT_CREATED_COOKIE = "agpt_account_created";
+export const ACCOUNT_CREATED_COOKIE_MAX_AGE_SECONDS = 600;
+
+export const SIGNUP_METHODS = ["email", "google"] as const;
+export type SignupMethod = (typeof SIGNUP_METHODS)[number];
+
+// The server sets this flag when it provisions a brand-new account (see
+// account-created-server.ts); the browser reads it once to report the
+// Google Ads sign-up conversion, then clears it so a reload can't report twice.
+export function consumeAccountCreatedFlag(): SignupMethod | null {
+  if (typeof document === "undefined") return null;
+
+  const prefix = `${ACCOUNT_CREATED_COOKIE}=`;
+  const entry = document.cookie
+    .split("; ")
+    .find((part) => part.startsWith(prefix));
+  if (!entry) return null;
+
+  document.cookie = `${ACCOUNT_CREATED_COOKIE}=; Path=/; Max-Age=0`;
+  const value = entry.slice(prefix.length);
+  return isSignupMethod(value) ? value : null;
+}
+
+function isSignupMethod(value: string): value is SignupMethod {
+  return SIGNUP_METHODS.includes(value as SignupMethod);
+}

--- a/autogpt_platform/frontend/src/services/analytics/account-created-server.ts
+++ b/autogpt_platform/frontend/src/services/analytics/account-created-server.ts
@@ -1,0 +1,26 @@
+import * as Sentry from "@sentry/nextjs";
+import { cookies } from "next/headers";
+import {
+  ACCOUNT_CREATED_COOKIE,
+  ACCOUNT_CREATED_COOKIE_MAX_AGE_SECONDS,
+  type SignupMethod,
+} from "./account-created-cookie";
+
+// Flags a brand-new account for the browser, which reports the Google Ads
+// sign-up conversion on the next page it renders (AdsConversionTracker).
+// Best effort: a tracking failure must never fail the signup itself.
+export async function markAccountCreated(method: SignupMethod): Promise<void> {
+  try {
+    const cookieStore = await cookies();
+    cookieStore.set(ACCOUNT_CREATED_COOKIE, method, {
+      path: "/",
+      maxAge: ACCOUNT_CREATED_COOKIE_MAX_AGE_SECONDS,
+      sameSite: "lax",
+      httpOnly: false,
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { analytics_provider: "google_ads", analytics_goal: "signup" },
+    });
+  }
+}

--- a/autogpt_platform/frontend/src/services/analytics/account-created-server.ts
+++ b/autogpt_platform/frontend/src/services/analytics/account-created-server.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { environment } from "@/services/environment";
 import { cookies } from "next/headers";
 import {
   ACCOUNT_CREATED_COOKIE,
@@ -16,7 +17,11 @@ export async function markAccountCreated(method: SignupMethod): Promise<void> {
       path: "/",
       maxAge: ACCOUNT_CREATED_COOKIE_MAX_AGE_SECONDS,
       sameSite: "lax",
+      // Readable by the browser by design — that's how the conversion fires.
       httpOnly: false,
+      // ...but not settable over plaintext by a sibling subdomain, which would
+      // forge a sign-up. Local stacks run on http.
+      secure: !environment.isLocal(),
     });
   } catch (error) {
     Sentry.captureException(error, {

--- a/autogpt_platform/frontend/src/services/analytics/consent-mode.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/consent-mode.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { ConsentPreferences } from "@/services/consent/cookies";
+import {
+  buildConsentModeScript,
+  CONSENT_DENIED_BY_DEFAULT_REGIONS,
+} from "./consent-mode";
+
+function preferences(
+  overrides: Partial<ConsentPreferences> = {},
+): ConsentPreferences {
+  return {
+    hasConsented: true,
+    timestamp: 1,
+    analytics: false,
+    monitoring: false,
+    advertising: false,
+    ...overrides,
+  };
+}
+
+describe("buildConsentModeScript", () => {
+  it("grants by default, denies in the EEA, UK and Switzerland, and passes click IDs through URLs", () => {
+    const script = buildConsentModeScript(null);
+
+    expect(script).toContain(
+      `gtag('consent','default',{"ad_storage":"granted","ad_user_data":"granted","ad_personalization":"granted","analytics_storage":"granted"});`,
+    );
+    expect(script).toContain(
+      `gtag('consent','default',{"ad_storage":"denied","ad_user_data":"denied","ad_personalization":"denied","analytics_storage":"denied","region":${JSON.stringify(CONSENT_DENIED_BY_DEFAULT_REGIONS)}});`,
+    );
+    expect(CONSENT_DENIED_BY_DEFAULT_REGIONS).toEqual(
+      expect.arrayContaining(["DE", "FR", "ES", "GB", "CH", "NO", "IS", "LI"]),
+    );
+    expect(script).toContain(`gtag('set','url_passthrough',true);`);
+    expect(script).not.toContain("'update'");
+  });
+
+  it("sends no update while the visitor has not answered the banner", () => {
+    const script = buildConsentModeScript(
+      preferences({ hasConsented: false, analytics: true }),
+    );
+
+    expect(script).not.toContain("'update'");
+  });
+
+  it("updates every signal from the stored answer", () => {
+    const script = buildConsentModeScript(
+      preferences({ analytics: true, advertising: false }),
+    );
+
+    expect(script).toContain(
+      `gtag('consent','update',{"analytics_storage":"granted","ad_storage":"denied","ad_user_data":"denied","ad_personalization":"denied"});`,
+    );
+  });
+
+  it("grants the advertising signals once advertising is accepted", () => {
+    const script = buildConsentModeScript(
+      preferences({ analytics: false, advertising: true }),
+    );
+
+    expect(script).toContain(
+      `gtag('consent','update',{"analytics_storage":"denied","ad_storage":"granted","ad_user_data":"granted","ad_personalization":"granted"});`,
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/consent-mode.ts
+++ b/autogpt_platform/frontend/src/services/analytics/consent-mode.ts
@@ -1,0 +1,88 @@
+import type { ConsentPreferences } from "@/services/consent/cookies";
+
+const EU_MEMBER_STATES = [
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DK",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SK",
+  "SI",
+  "ES",
+  "SE",
+];
+
+// EEA (EU + IS, LI, NO), the UK and Switzerland start with every Google
+// signal denied until the visitor answers the banner; everywhere else the tag
+// runs with consent granted by default. Mirrored on agpt.co so a click ID
+// collected there is handled the same way here.
+export const CONSENT_DENIED_BY_DEFAULT_REGIONS = [
+  ...EU_MEMBER_STATES,
+  "IS",
+  "LI",
+  "NO",
+  "GB",
+  "CH",
+];
+
+type Signal = "granted" | "denied";
+
+function signal(granted: boolean): Signal {
+  return granted ? "granted" : "denied";
+}
+
+// Consent Mode v2 commands for the Google tag init script. Must run before
+// gtag('config', …) so the first hit already carries the right signals.
+export function buildConsentModeScript(
+  preferences: ConsentPreferences | null,
+): string {
+  const lines = [
+    `gtag('consent','default',${JSON.stringify({
+      ad_storage: "granted",
+      ad_user_data: "granted",
+      ad_personalization: "granted",
+      analytics_storage: "granted",
+    })});`,
+    `gtag('consent','default',${JSON.stringify({
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+      analytics_storage: "denied",
+      region: CONSENT_DENIED_BY_DEFAULT_REGIONS,
+    })});`,
+    // Carries the ad click ID across pages in the URL while cookies are denied.
+    `gtag('set','url_passthrough',true);`,
+  ];
+
+  if (preferences?.hasConsented) {
+    const ads = signal(preferences.advertising);
+    lines.push(
+      `gtag('consent','update',${JSON.stringify({
+        analytics_storage: signal(preferences.analytics),
+        ad_storage: ads,
+        ad_user_data: ads,
+        ad_personalization: ads,
+      })});`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/autogpt_platform/frontend/src/services/analytics/google-ads.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/google-ads.test.ts
@@ -3,12 +3,23 @@ import {
   installGtagShim,
   removeGtagShim,
 } from "@/tests/integrations/gtag-shim";
+import { consent } from "@/services/consent/cookies";
 import {
   getSubscriptionValue,
   parseConversionLabels,
   trackAdsConversion,
   trackAdsPageView,
 } from "./google-ads";
+
+function answerBanner(advertising: boolean) {
+  consent.save({
+    hasConsented: true,
+    timestamp: 1,
+    analytics: true,
+    monitoring: true,
+    advertising,
+  });
+}
 
 let pushed: unknown[][] = [];
 
@@ -20,11 +31,13 @@ describe("trackAdsConversion", () => {
       "NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS",
       "sign_up=SIGNUP,subscribe=SUB",
     );
+    answerBanner(true);
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     removeGtagShim();
+    consent.clear();
   });
 
   it("sends the conversion to the action label with value, dedup id and user data", () => {
@@ -47,6 +60,39 @@ describe("trackAdsConversion", () => {
           user_data: { email: "ada@example.com" },
         },
       ],
+    ]);
+  });
+
+  it("withholds the identifiers until the banner is answered", () => {
+    // Unanswered: Consent Mode denies ad_user_data in the EEA/UK/CH and the
+    // browser can't tell which region it's in, so nothing identifying goes out.
+    consent.clear();
+
+    trackAdsConversion("subscribe", {
+      value: 50,
+      transactionID: "cs_123",
+      email: "ada@example.com",
+    });
+
+    expect(pushed).toEqual([
+      [
+        "event",
+        "conversion",
+        { send_to: "AW-123/SUB", value: 50, currency: "USD" },
+      ],
+    ]);
+  });
+
+  it("withholds the identifiers when advertising was rejected", () => {
+    answerBanner(false);
+
+    trackAdsConversion("subscribe", {
+      transactionID: "cs_123",
+      email: "ada@example.com",
+    });
+
+    expect(pushed).toEqual([
+      ["event", "conversion", { send_to: "AW-123/SUB" }],
     ]);
   });
 

--- a/autogpt_platform/frontend/src/services/analytics/google-ads.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/google-ads.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
+import {
+  getSubscriptionValue,
+  parseConversionLabels,
+  trackAdsConversion,
+  trackAdsPageView,
+} from "./google-ads";
+
+let pushed: unknown[][] = [];
+
+describe("trackAdsConversion", () => {
+  beforeEach(() => {
+    pushed = installGtagShim();
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+    vi.stubEnv(
+      "NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS",
+      "sign_up=SIGNUP,subscribe=SUB",
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    removeGtagShim();
+  });
+
+  it("sends the conversion to the action label with value, dedup id and user data", () => {
+    const sent = trackAdsConversion("subscribe", {
+      value: 50,
+      transactionID: "cs_123",
+      email: "ada@example.com",
+    });
+
+    expect(sent).toBe(true);
+    expect(pushed).toEqual([
+      [
+        "event",
+        "conversion",
+        {
+          send_to: "AW-123/SUB",
+          value: 50,
+          currency: "USD",
+          transaction_id: "cs_123",
+          user_data: { email: "ada@example.com" },
+        },
+      ],
+    ]);
+  });
+
+  it("sends only the destination when no options are given", () => {
+    trackAdsConversion("sign_up");
+
+    expect(pushed).toEqual([
+      ["event", "conversion", { send_to: "AW-123/SIGNUP" }],
+    ]);
+  });
+
+  it("does nothing when the Google Ads tag is not configured", () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "");
+
+    expect(trackAdsConversion("sign_up")).toBe(false);
+    expect(pushed).toEqual([]);
+  });
+
+  it("does nothing for an action without a label", () => {
+    expect(trackAdsConversion("top_up")).toBe(false);
+    expect(pushed).toEqual([]);
+  });
+});
+
+describe("trackAdsPageView", () => {
+  beforeEach(() => {
+    pushed = installGtagShim();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    removeGtagShim();
+  });
+
+  it("sends a page_view to the Ads tag only", () => {
+    vi.stubEnv("NEXT_PUBLIC_GOOGLE_ADS_ID", "AW-123");
+
+    trackAdsPageView("/library");
+
+    expect(pushed).toEqual([
+      ["event", "page_view", { send_to: "AW-123", page_path: "/library" }],
+    ]);
+  });
+
+  it("does nothing when the tag is not configured", () => {
+    expect(trackAdsPageView("/library")).toBe(false);
+    expect(pushed).toEqual([]);
+  });
+});
+
+describe("parseConversionLabels", () => {
+  it("reads key=label pairs and ignores unknown or malformed parts", () => {
+    expect(
+      parseConversionLabels(
+        " sign_up=AbC , subscribe=DeF,unknown=X,,broken,top_up= ",
+      ),
+    ).toEqual({ sign_up: "AbC", subscribe: "DeF" });
+  });
+
+  it("returns nothing for an unset value", () => {
+    expect(parseConversionLabels(undefined)).toEqual({});
+  });
+});
+
+describe("getSubscriptionValue", () => {
+  it("prices monthly plans at the monthly rate", () => {
+    expect(getSubscriptionValue("PRO", "monthly")).toBe(50);
+    expect(getSubscriptionValue("MAX", "monthly")).toBe(320);
+  });
+
+  it("prices yearly plans at the discounted annual total", () => {
+    expect(getSubscriptionValue("PRO", "yearly")).toBe(510);
+    expect(getSubscriptionValue("MAX", "yearly")).toBe(3264);
+  });
+
+  it("has no value for unknown plans", () => {
+    expect(getSubscriptionValue("TEAM", "monthly")).toBeUndefined();
+    expect(getSubscriptionValue(null, null)).toBeUndefined();
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/google-ads.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/google-ads.test.ts
@@ -107,7 +107,7 @@ describe("parseConversionLabels", () => {
   });
 
   it("returns nothing for an unset value", () => {
-    expect(parseConversionLabels(undefined)).toEqual({});
+    expect(parseConversionLabels("")).toEqual({});
   });
 });
 

--- a/autogpt_platform/frontend/src/services/analytics/google-ads.ts
+++ b/autogpt_platform/frontend/src/services/analytics/google-ads.ts
@@ -1,0 +1,87 @@
+import {
+  PLANS,
+  YEARLY_PRICE_FACTOR,
+} from "@/components/molecules/PlanCard/plans";
+import { environment } from "@/services/environment";
+import { gtag } from "./gtag";
+
+// One entry per conversion action in the Google Ads account. The action's
+// label comes from NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS so the account can
+// be rewired without a deploy.
+export const ADS_CONVERSIONS = [
+  "sign_up",
+  "begin_checkout",
+  "subscribe",
+  "onboarding_complete",
+  "top_up",
+] as const;
+export type AdsConversion = (typeof ADS_CONVERSIONS)[number];
+
+interface ConversionOptions {
+  value?: number;
+  currency?: string;
+  // Google Ads counts one conversion per transaction_id, so a refresh of the
+  // page that fired it does not count twice.
+  transactionID?: string;
+  // Enhanced conversions: gtag hashes the address before it leaves the browser.
+  email?: string;
+}
+
+export function trackAdsConversion(
+  name: AdsConversion,
+  options: ConversionOptions = {},
+): boolean {
+  const adsID = environment.getGoogleAdsID();
+  if (!adsID) return false;
+  const label = parseConversionLabels(
+    environment.getGoogleAdsConversionLabels(),
+  )[name];
+  if (!label) return false;
+
+  const params: Record<string, unknown> = { send_to: `${adsID}/${label}` };
+  if (options.value !== undefined) {
+    params.value = options.value;
+    params.currency = options.currency ?? "USD";
+  }
+  if (options.transactionID) params.transaction_id = options.transactionID;
+  if (options.email) params.user_data = { email: options.email };
+
+  return gtag("event", "conversion", params);
+}
+
+// Client-side navigations don't reload the tag, so the Ads destination gets
+// its page views from the router. GA4 is left alone on purpose.
+export function trackAdsPageView(path: string): boolean {
+  const adsID = environment.getGoogleAdsID();
+  if (!adsID) return false;
+  return gtag("event", "page_view", { send_to: adsID, page_path: path });
+}
+
+// "sign_up=AbCdEf,subscribe=GhIjKl" → { sign_up: "AbCdEf", subscribe: "GhIjKl" }
+export function parseConversionLabels(
+  raw: string | undefined,
+): Partial<Record<AdsConversion, string>> {
+  const labels: Partial<Record<AdsConversion, string>> = {};
+  for (const part of (raw ?? "").split(",")) {
+    const [key, label] = part.split("=").map((piece) => piece.trim());
+    if (isAdsConversion(key) && label) labels[key] = label;
+  }
+  return labels;
+}
+
+function isAdsConversion(value: string | undefined): value is AdsConversion {
+  return ADS_CONVERSIONS.includes(value as AdsConversion);
+}
+
+// USD amount Stripe charges for a plan on the given cycle, for the
+// conversion's value. Unknown plans (Team, contact sales) have no value.
+export function getSubscriptionValue(
+  plan: string | null,
+  cycle: string | null,
+): number | undefined {
+  const monthly = PLANS.find((candidate) => candidate.key === plan)?.usdMonthly;
+  if (monthly == null) return undefined;
+  const amount =
+    cycle === "yearly" ? monthly * YEARLY_PRICE_FACTOR * 12 : monthly;
+  return Math.round(amount * 100) / 100;
+}

--- a/autogpt_platform/frontend/src/services/analytics/google-ads.ts
+++ b/autogpt_platform/frontend/src/services/analytics/google-ads.ts
@@ -42,10 +42,8 @@ export function trackAdsConversion(
     params.value = options.value;
     params.currency = options.currency ?? "USD";
   }
-  // A visitor who answered the banner and said no to advertising still counts
-  // as an aggregate (cookieless) conversion, but never carries identifiers.
-  // Consent Mode asks Google to redact these; dropping them here means the
-  // recorded "no" does not depend on the vendor honouring that.
+  // Identifiers ride along only on an affirmative yes. The aggregate
+  // (cookieless) conversion still counts either way.
   if (mayReportIdentifiers()) {
     if (options.transactionID) params.transaction_id = options.transactionID;
     if (options.email) params.user_data = { email: options.email };
@@ -54,9 +52,15 @@ export function trackAdsConversion(
   return gtag("event", "conversion", params);
 }
 
+// An unanswered banner is not a yes. Outside the EEA/UK/CH the Consent Mode
+// default is `granted`, but that gate lives in the tag's `region` parameter and
+// Google resolves it by IP — the browser has no region signal of its own. So
+// treating "no answer" as consent would hand Google an email it was told to
+// redact for every unanswered visitor in a denied-by-default region, which is
+// the vendor dependency this gate exists to remove.
 function mayReportIdentifiers(): boolean {
   const preferences = consent.load();
-  return !preferences.hasConsented || preferences.advertising;
+  return preferences.hasConsented && preferences.advertising;
 }
 
 // The labels come from a build-time env var; parse once per distinct value so

--- a/autogpt_platform/frontend/src/services/analytics/google-ads.ts
+++ b/autogpt_platform/frontend/src/services/analytics/google-ads.ts
@@ -2,6 +2,7 @@ import {
   PLANS,
   YEARLY_PRICE_FACTOR,
 } from "@/components/molecules/PlanCard/plans";
+import { consent } from "@/services/consent/cookies";
 import { environment } from "@/services/environment";
 import { gtag } from "./gtag";
 
@@ -33,9 +34,7 @@ export function trackAdsConversion(
 ): boolean {
   const adsID = environment.getGoogleAdsID();
   if (!adsID) return false;
-  const label = parseConversionLabels(
-    environment.getGoogleAdsConversionLabels(),
-  )[name];
+  const label = conversionLabels()[name];
   if (!label) return false;
 
   const params: Record<string, unknown> = { send_to: `${adsID}/${label}` };
@@ -43,10 +42,35 @@ export function trackAdsConversion(
     params.value = options.value;
     params.currency = options.currency ?? "USD";
   }
-  if (options.transactionID) params.transaction_id = options.transactionID;
-  if (options.email) params.user_data = { email: options.email };
+  // A visitor who answered the banner and said no to advertising still counts
+  // as an aggregate (cookieless) conversion, but never carries identifiers.
+  // Consent Mode asks Google to redact these; dropping them here means the
+  // recorded "no" does not depend on the vendor honouring that.
+  if (mayReportIdentifiers()) {
+    if (options.transactionID) params.transaction_id = options.transactionID;
+    if (options.email) params.user_data = { email: options.email };
+  }
 
   return gtag("event", "conversion", params);
+}
+
+function mayReportIdentifiers(): boolean {
+  const preferences = consent.load();
+  return !preferences.hasConsented || preferences.advertising;
+}
+
+// The labels come from a build-time env var; parse once per distinct value so
+// a conversion doesn't re-split the string every time.
+let cachedLabelsRaw: string | undefined;
+let cachedLabels: Partial<Record<AdsConversion, string>> = {};
+
+function conversionLabels(): Partial<Record<AdsConversion, string>> {
+  const raw = environment.getGoogleAdsConversionLabels();
+  if (raw !== cachedLabelsRaw) {
+    cachedLabelsRaw = raw;
+    cachedLabels = parseConversionLabels(raw);
+  }
+  return cachedLabels;
 }
 
 // Client-side navigations don't reload the tag, so the Ads destination gets
@@ -59,10 +83,10 @@ export function trackAdsPageView(path: string): boolean {
 
 // "sign_up=AbCdEf,subscribe=GhIjKl" → { sign_up: "AbCdEf", subscribe: "GhIjKl" }
 export function parseConversionLabels(
-  raw: string | undefined,
+  raw: string,
 ): Partial<Record<AdsConversion, string>> {
   const labels: Partial<Record<AdsConversion, string>> = {};
-  for (const part of (raw ?? "").split(",")) {
+  for (const part of raw.split(",")) {
     const [key, label] = part.split("=").map((piece) => piece.trim());
     if (isAdsConversion(key) && label) labels[key] = label;
   }
@@ -79,9 +103,22 @@ export function getSubscriptionValue(
   plan: string | null,
   cycle: string | null,
 ): number | undefined {
-  const monthly = PLANS.find((candidate) => candidate.key === plan)?.usdMonthly;
-  if (monthly == null) return undefined;
-  const amount =
-    cycle === "yearly" ? monthly * YEARLY_PRICE_FACTOR * 12 : monthly;
+  const definition = PLANS.find((candidate) => candidate.key === plan);
+  const monthly = definition?.usdMonthly;
+  if (!definition || monthly == null) return undefined;
+  if (cycle !== "yearly") return roundUSD(monthly);
+  // usdYearly is the amount Stripe actually charges wherever the surface knows
+  // it; the factor is only the fallback the pricing cards compute from
+  // (computePricing.ts). Bidding on the displayed number matters.
+  return roundUSD(definition.usdYearly ?? monthly * YEARLY_PRICE_FACTOR * 12);
+}
+
+// Stripe amounts arrive in cents; Ads wants the major unit.
+export function centsToUSD(cents: number | undefined): number | undefined {
+  if (cents == null) return undefined;
+  return roundUSD(cents / 100);
+}
+
+function roundUSD(amount: number): number {
   return Math.round(amount * 100) / 100;
 }

--- a/autogpt_platform/frontend/src/services/analytics/gtag.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/gtag.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeGtagShim } from "@/tests/integrations/gtag-shim";
+import { gtag } from "./gtag";
+
+describe("gtag", () => {
+  afterEach(() => {
+    removeGtagShim();
+  });
+
+  it("forwards the command to the tag's own shim", () => {
+    const shim = vi.fn();
+    window.gtag = shim;
+
+    expect(gtag("event", "conversion", { send_to: "AW-1/x" })).toBe(true);
+
+    expect(shim).toHaveBeenCalledWith("event", "conversion", {
+      send_to: "AW-1/x",
+    });
+  });
+
+  it("drops the command when the tag has not been set up", () => {
+    removeGtagShim();
+
+    expect(gtag("event", "conversion", { send_to: "AW-1/x" })).toBe(false);
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/gtag.ts
+++ b/autogpt_platform/frontend/src/services/analytics/gtag.ts
@@ -1,0 +1,18 @@
+export const DATA_LAYER_NAME = "dataLayer";
+
+declare global {
+  interface Window {
+    // The tag's own command shim, defined by the init script in SetupAnalytics.
+    // gtag.js only executes dataLayer entries that are real `arguments`
+    // objects, which only that shim can produce; everything routes through it.
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function gtag(...args: unknown[]): boolean {
+  if (typeof window === "undefined") return false;
+  const tag = window.gtag;
+  if (typeof tag !== "function") return false;
+  tag(...args);
+  return true;
+}

--- a/autogpt_platform/frontend/src/services/analytics/index.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/index.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { consent } from "@/services/consent/cookies";
+import {
+  installGtagShim,
+  removeGtagShim,
+} from "@/tests/integrations/gtag-shim";
 import { analytics, flushDatafastQueue } from "./index";
 
 vi.mock("@/services/consent/cookies", () => ({
@@ -155,5 +159,30 @@ describe("sendDatafastEvent", () => {
     );
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
+  });
+});
+
+describe("sendGAEvent", () => {
+  afterEach(() => {
+    removeGtagShim();
+  });
+
+  it("routes the command through the tag's own gtag shim", () => {
+    // Regression: the arguments used to be spread into the dataLayer as a
+    // plain array, and gtag.js only executes real `arguments` objects — so
+    // every custom GA event was silently dropped.
+    const calls = installGtagShim();
+
+    analytics.sendGAEvent("event", "tour_start", { scenario: "chat" });
+
+    expect(calls).toEqual([["event", "tour_start", { scenario: "chat" }]]);
+  });
+
+  it("drops the event when the tag never loaded", () => {
+    removeGtagShim();
+
+    expect(() =>
+      analytics.sendGAEvent("event", "tour_start", {}),
+    ).not.toThrow();
   });
 });

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -44,7 +44,7 @@ export function SetupAnalytics(props: SetupProps) {
             strategy="afterInteractive"
             dangerouslySetInnerHTML={{
               __html: buildGoogleTagInitScript({
-                gaID: gaId,
+                GAID: gaId,
                 adsID,
                 debugMode,
                 preferences,
@@ -76,14 +76,14 @@ export function SetupAnalytics(props: SetupProps) {
 }
 
 interface InitScriptArgs {
-  gaID: string;
+  GAID: string;
   adsID: string;
   debugMode?: boolean;
   preferences: ConsentPreferences | null;
 }
 
 function buildGoogleTagInitScript({
-  gaID,
+  GAID,
   adsID,
   debugMode,
   preferences,
@@ -96,7 +96,7 @@ function buildGoogleTagInitScript({
     `function gtag(){window['${DATA_LAYER_NAME}'].push(arguments);}`,
     buildConsentModeScript(preferences),
     `gtag('js', new Date());`,
-    `gtag('config', ${JSON.stringify(gaID)}${debugMode ? ", { 'debug_mode': true }" : ""});`,
+    `gtag('config', ${JSON.stringify(GAID)}${debugMode ? ", { 'debug_mode': true }" : ""});`,
     adsID
       ? `gtag('config', ${JSON.stringify(adsID)}, { 'allow_enhanced_conversions': true });`
       : "",

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -6,11 +6,15 @@
 "use client";
 
 import type { GAParams } from "@/types/google";
-import { consent } from "@/services/consent/cookies";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { consent, type ConsentPreferences } from "@/services/consent/cookies";
 import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { useEffect, useState } from "react";
 import { environment } from "../environment";
+import { buildConsentModeScript } from "./consent-mode";
+import { DATA_LAYER_NAME, gtag } from "./gtag";
+import { isTourPath, resolveAnalyticsLoading } from "./loading-policy";
 
 type DatafastEvent = [name: string, metadata: Record<string, unknown>];
 
@@ -21,8 +25,6 @@ declare global {
   }
 }
 
-let currDataLayerName: string | undefined = undefined;
-
 type SetupProps = {
   ga: GAParams;
   host: string;
@@ -30,37 +32,29 @@ type SetupProps = {
 
 export function SetupAnalytics(props: SetupProps) {
   const { ga, host } = props;
-  const { gaId, debugMode, dataLayerName = "dataLayer", nonce } = ga;
-  const isProductionDomain = host.includes("platform.agpt.co");
+  const { gaId, debugMode, nonce } = ga;
+  const adsId = environment.getGoogleAdsID();
 
-  // Check for user consent
-  const [hasAnalyticsConsent, setHasAnalyticsConsent] = useState(false);
+  // Stored consent is only readable in the browser; the tag waits for it so
+  // the init script can replay the visitor's answer through Consent Mode.
+  const [preferences, setPreferences] = useState<ConsentPreferences | null>(
+    null,
+  );
+  useMountEffect(() => {
+    setPreferences(consent.load());
+  });
 
-  useEffect(() => {
-    // Check consent on mount
-    setHasAnalyticsConsent(consent.hasConsentFor("analytics"));
-  }, []);
-
-  // The public tour hides the cookie banner, so DataFast loads there without
-  // the consent gate — otherwise tour funnel events would never fire for
-  // first-touch visitors.
   const pathname = usePathname();
-  const isPublicTourPage = isTourPath(pathname);
-
-  // Datafa.st journey analytics only on production AND with consent
-  const dataFastEnabled =
-    isProductionDomain && (hasAnalyticsConsent || isPublicTourPage);
-  // We collect analytics too for open source developers running the platform locally
-  // BUT only with consent
-  const googleAnalyticsEnabled =
-    (environment.isLocal() || isProductionDomain) && hasAnalyticsConsent;
-
-  if (currDataLayerName === undefined) {
-    currDataLayerName = dataLayerName;
-  }
+  const { googleTag: googleTagEnabled, dataFast: dataFastEnabled } =
+    resolveAnalyticsLoading({
+      host,
+      pathname,
+      isLocal: environment.isLocal(),
+      preferences,
+    });
 
   useEffect(() => {
-    if (!googleAnalyticsEnabled) return;
+    if (!googleTagEnabled) return;
 
     // Google Analytics: feature usage signal (same as original implementation)
     performance.mark("mark_feature_usage", {
@@ -68,27 +62,26 @@ export function SetupAnalytics(props: SetupProps) {
         feature: "custom-ga",
       },
     });
-  }, [googleAnalyticsEnabled]);
+  }, [googleTagEnabled]);
 
   return (
     <>
-      {/* Google Analytics */}
-      {googleAnalyticsEnabled ? (
+      {/* Google tag: GA4 + Google Ads */}
+      {googleTagEnabled ? (
         <>
           <Script
             id="_custom-ga-init"
             strategy="afterInteractive"
             dangerouslySetInnerHTML={{
-              __html: `
-            window['${dataLayerName}'] = window['${dataLayerName}'] || [];
-            function gtag(){window['${dataLayerName}'].push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${gaId}' ${debugMode ? ",{ 'debug_mode': true }" : ""});
-          `,
+              __html: buildGoogleTagInitScript({
+                gaId,
+                adsId,
+                debugMode,
+                preferences,
+              }),
             }}
             nonce={nonce}
           />
-          {/* Google Tag Manager */}
           <Script
             id="_custom-ga"
             strategy="afterInteractive"
@@ -112,23 +105,38 @@ export function SetupAnalytics(props: SetupProps) {
   );
 }
 
+interface InitScriptArgs {
+  gaId: string;
+  adsId: string;
+  debugMode?: boolean;
+  preferences: ConsentPreferences | null;
+}
+
+function buildGoogleTagInitScript({
+  gaId,
+  adsId,
+  debugMode,
+  preferences,
+}: InitScriptArgs): string {
+  return [
+    `window['${DATA_LAYER_NAME}'] = window['${DATA_LAYER_NAME}'] || [];`,
+    `function gtag(){window['${DATA_LAYER_NAME}'].push(arguments);}`,
+    buildConsentModeScript(preferences),
+    `gtag('js', new Date());`,
+    `gtag('config', '${gaId}'${debugMode ? ", { 'debug_mode': true }" : ""});`,
+    adsId
+      ? `gtag('config', '${adsId}', { 'allow_enhanced_conversions': true });`
+      : "",
+  ].join("\n");
+}
+
 export const analytics = {
   sendGAEvent,
   sendDatafastEvent,
 };
 
 function sendGAEvent(...args: unknown[]) {
-  if (typeof window === "undefined") return;
-  if (currDataLayerName === undefined) return;
-
-  const dataLayer = window[currDataLayerName];
-  if (!dataLayer) return;
-
-  if (Array.isArray(dataLayer)) {
-    dataLayer.push(...args);
-  } else {
-    console.warn(`Custom GA: dataLayer ${currDataLayerName} does not exist`);
-  }
+  gtag(...args);
 }
 
 // Module scope means the queue survives client-side navigation: queued events
@@ -178,11 +186,4 @@ export function flushDatafastQueue() {
   // A successful drain ends the blocked episode; warn again if a later one
   // overflows too.
   datafastQueueOverflowWarned = false;
-}
-
-// Segment-boundary match: /tourism must not inherit the tour's consent
-// exemption.
-function isTourPath(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return pathname === "/tour" || pathname.startsWith("/tour/");
 }

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -6,15 +6,13 @@
 "use client";
 
 import type { GAParams } from "@/types/google";
-import { useMountEffect } from "@/hooks/useMountEffect";
 import { consent, type ConsentPreferences } from "@/services/consent/cookies";
-import { usePathname } from "next/navigation";
 import Script from "next/script";
-import { useEffect, useState } from "react";
 import { environment } from "../environment";
 import { buildConsentModeScript } from "./consent-mode";
 import { DATA_LAYER_NAME, gtag } from "./gtag";
-import { isTourPath, resolveAnalyticsLoading } from "./loading-policy";
+import { isTourPath } from "./loading-policy";
+import { useSetupAnalytics } from "./useSetupAnalytics";
 
 type DatafastEvent = [name: string, metadata: Record<string, unknown>];
 
@@ -34,35 +32,8 @@ export function SetupAnalytics(props: SetupProps) {
   const { ga, host } = props;
   const { gaId, debugMode, nonce } = ga;
   const adsId = environment.getGoogleAdsID();
-
-  // Stored consent is only readable in the browser; the tag waits for it so
-  // the init script can replay the visitor's answer through Consent Mode.
-  const [preferences, setPreferences] = useState<ConsentPreferences | null>(
-    null,
-  );
-  useMountEffect(() => {
-    setPreferences(consent.load());
-  });
-
-  const pathname = usePathname();
-  const { googleTag: googleTagEnabled, dataFast: dataFastEnabled } =
-    resolveAnalyticsLoading({
-      host,
-      pathname,
-      isLocal: environment.isLocal(),
-      preferences,
-    });
-
-  useEffect(() => {
-    if (!googleTagEnabled) return;
-
-    // Google Analytics: feature usage signal (same as original implementation)
-    performance.mark("mark_feature_usage", {
-      detail: {
-        feature: "custom-ga",
-      },
-    });
-  }, [googleTagEnabled]);
+  const { preferences, googleTagEnabled, dataFastEnabled } =
+    useSetupAnalytics(host);
 
   return (
     <>

--- a/autogpt_platform/frontend/src/services/analytics/index.tsx
+++ b/autogpt_platform/frontend/src/services/analytics/index.tsx
@@ -19,7 +19,6 @@ type DatafastEvent = [name: string, metadata: Record<string, unknown>];
 declare global {
   interface Window {
     datafast?: (...event: DatafastEvent) => void;
-    [key: string]: unknown[] | ((...args: unknown[]) => void) | unknown;
   }
 }
 
@@ -31,7 +30,7 @@ type SetupProps = {
 export function SetupAnalytics(props: SetupProps) {
   const { ga, host } = props;
   const { gaId, debugMode, nonce } = ga;
-  const adsId = environment.getGoogleAdsID();
+  const adsID = environment.getGoogleAdsID();
   const { preferences, googleTagEnabled, dataFastEnabled } =
     useSetupAnalytics(host);
 
@@ -45,8 +44,8 @@ export function SetupAnalytics(props: SetupProps) {
             strategy="afterInteractive"
             dangerouslySetInnerHTML={{
               __html: buildGoogleTagInitScript({
-                gaId,
-                adsId,
+                gaID: gaId,
+                adsID,
                 debugMode,
                 preferences,
               }),
@@ -77,26 +76,29 @@ export function SetupAnalytics(props: SetupProps) {
 }
 
 interface InitScriptArgs {
-  gaId: string;
-  adsId: string;
+  gaID: string;
+  adsID: string;
   debugMode?: boolean;
   preferences: ConsentPreferences | null;
 }
 
 function buildGoogleTagInitScript({
-  gaId,
-  adsId,
+  gaID,
+  adsID,
   debugMode,
   preferences,
 }: InitScriptArgs): string {
+  // The IDs come from env vars and go into a nonce-bearing inline script, so
+  // they are escaped rather than interpolated raw: a stray quote in a misfilled
+  // env var would otherwise become CSP-blessed script.
   return [
     `window['${DATA_LAYER_NAME}'] = window['${DATA_LAYER_NAME}'] || [];`,
     `function gtag(){window['${DATA_LAYER_NAME}'].push(arguments);}`,
     buildConsentModeScript(preferences),
     `gtag('js', new Date());`,
-    `gtag('config', '${gaId}'${debugMode ? ", { 'debug_mode': true }" : ""});`,
-    adsId
-      ? `gtag('config', '${adsId}', { 'allow_enhanced_conversions': true });`
+    `gtag('config', ${JSON.stringify(gaID)}${debugMode ? ", { 'debug_mode': true }" : ""});`,
+    adsID
+      ? `gtag('config', ${JSON.stringify(adsID)}, { 'allow_enhanced_conversions': true });`
       : "",
   ].join("\n");
 }

--- a/autogpt_platform/frontend/src/services/analytics/loading-policy.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/loading-policy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { ConsentPreferences } from "@/services/consent/cookies";
+import { resolveAnalyticsLoading } from "./loading-policy";
+
+function preferences(
+  overrides: Partial<ConsentPreferences> = {},
+): ConsentPreferences {
+  return {
+    hasConsented: true,
+    timestamp: 1,
+    analytics: false,
+    monitoring: false,
+    advertising: false,
+    ...overrides,
+  };
+}
+
+const production = {
+  host: "platform.agpt.co",
+  pathname: "/marketplace",
+  isLocal: false,
+};
+
+describe("resolveAnalyticsLoading", () => {
+  it("loads the Google tag on production once preferences are known, even unanswered", () => {
+    const result = resolveAnalyticsLoading({
+      ...production,
+      preferences: preferences({ hasConsented: false }),
+    });
+
+    expect(result.googleTag).toBe(true);
+    expect(result.dataFast).toBe(false);
+  });
+
+  it("waits for the stored preferences before loading anything", () => {
+    const result = resolveAnalyticsLoading({
+      ...production,
+      preferences: null,
+    });
+
+    expect(result).toEqual({ googleTag: false, dataFast: false });
+  });
+
+  it("keeps the Google tag off non-production cloud domains", () => {
+    const result = resolveAnalyticsLoading({
+      ...production,
+      host: "dev-builder.agpt.co",
+      preferences: preferences({ analytics: true, advertising: true }),
+    });
+
+    expect(result.googleTag).toBe(false);
+  });
+
+  it("loads the Google tag locally only with analytics consent", () => {
+    const local = { host: "localhost:3000", pathname: "/", isLocal: true };
+
+    expect(
+      resolveAnalyticsLoading({ ...local, preferences: preferences() })
+        .googleTag,
+    ).toBe(false);
+    expect(
+      resolveAnalyticsLoading({
+        ...local,
+        preferences: preferences({ analytics: true }),
+      }).googleTag,
+    ).toBe(true);
+  });
+
+  it("loads DataFast on production with analytics consent", () => {
+    const result = resolveAnalyticsLoading({
+      ...production,
+      preferences: preferences({ analytics: true }),
+    });
+
+    expect(result.dataFast).toBe(true);
+  });
+
+  it("loads DataFast on the public tour without consent", () => {
+    const result = resolveAnalyticsLoading({
+      ...production,
+      pathname: "/tour/chat",
+      preferences: preferences({ hasConsented: false }),
+    });
+
+    expect(result.dataFast).toBe(true);
+  });
+
+  it("does not treat /tourism as the tour", () => {
+    const result = resolveAnalyticsLoading({
+      ...production,
+      pathname: "/tourism",
+      preferences: preferences({ hasConsented: false }),
+    });
+
+    expect(result.dataFast).toBe(false);
+  });
+});

--- a/autogpt_platform/frontend/src/services/analytics/loading-policy.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/loading-policy.test.ts
@@ -51,6 +51,51 @@ describe("resolveAnalyticsLoading", () => {
     expect(result.googleTag).toBe(false);
   });
 
+  it("rejects hostnames that merely contain the production host", () => {
+    const consented = preferences({ analytics: true, advertising: true });
+
+    for (const host of [
+      "platform.agpt.co.example.com",
+      "notplatform.agpt.co",
+      "platform.agpt.co.evil.co",
+      "agpt.co",
+    ]) {
+      const result = resolveAnalyticsLoading({
+        ...production,
+        host,
+        preferences: consented,
+      });
+
+      expect({ host, ...result }).toEqual({
+        host,
+        googleTag: false,
+        dataFast: false,
+      });
+    }
+  });
+
+  it("accepts the production host with a port, odd casing or a trailing dot", () => {
+    const consented = preferences({ analytics: true, advertising: true });
+
+    for (const host of [
+      "platform.agpt.co:443",
+      "Platform.AGPT.co",
+      "platform.agpt.co.",
+    ]) {
+      const result = resolveAnalyticsLoading({
+        ...production,
+        host,
+        preferences: consented,
+      });
+
+      expect({ host, ...result }).toEqual({
+        host,
+        googleTag: true,
+        dataFast: true,
+      });
+    }
+  });
+
   it("loads the Google tag locally only with analytics consent", () => {
     const local = { host: "localhost:3000", pathname: "/", isLocal: true };
 

--- a/autogpt_platform/frontend/src/services/analytics/loading-policy.ts
+++ b/autogpt_platform/frontend/src/services/analytics/loading-policy.ts
@@ -1,0 +1,40 @@
+import type { ConsentPreferences } from "@/services/consent/cookies";
+
+interface LoadingArgs {
+  host: string;
+  pathname: string | null;
+  isLocal: boolean;
+  preferences: ConsentPreferences | null;
+}
+
+export function resolveAnalyticsLoading({
+  host,
+  pathname,
+  isLocal,
+  preferences,
+}: LoadingArgs) {
+  // Stored consent is only readable in the browser; nothing loads until it is.
+  if (!preferences) return { googleTag: false, dataFast: false };
+
+  const isProductionDomain = host.includes("platform.agpt.co");
+  const hasAnalyticsConsent = preferences.hasConsented && preferences.analytics;
+
+  return {
+    // Production loads the Google tag before the visitor answers: Consent Mode
+    // keeps it cookieless where consent is required (see consent-mode.ts).
+    // Open-source developers running locally only send analytics after opting in.
+    googleTag: isProductionDomain || (isLocal && hasAnalyticsConsent),
+    // The public tour hides the cookie banner, so DataFast loads there without
+    // the consent gate — otherwise tour funnel events would never fire for
+    // first-touch visitors.
+    dataFast:
+      isProductionDomain && (hasAnalyticsConsent || isTourPath(pathname)),
+  };
+}
+
+// Segment-boundary match: /tourism must not inherit the tour's consent
+// exemption.
+export function isTourPath(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return pathname === "/tour" || pathname.startsWith("/tour/");
+}

--- a/autogpt_platform/frontend/src/services/analytics/loading-policy.ts
+++ b/autogpt_platform/frontend/src/services/analytics/loading-policy.ts
@@ -16,7 +16,7 @@ export function resolveAnalyticsLoading({
   // Stored consent is only readable in the browser; nothing loads until it is.
   if (!preferences) return { googleTag: false, dataFast: false };
 
-  const isProductionDomain = host.includes("platform.agpt.co");
+  const isProductionDomain = isProductionHost(host);
   const hasAnalyticsConsent = preferences.hasConsented && preferences.analytics;
 
   return {
@@ -37,4 +37,15 @@ export function resolveAnalyticsLoading({
 export function isTourPath(pathname: string | null): boolean {
   if (!pathname) return false;
   return pathname === "/tour" || pathname.startsWith("/tour/");
+}
+
+const PRODUCTION_HOST = "platform.agpt.co";
+
+// The Host header is client-controlled, so a substring match would hand the
+// production tag to `platform.agpt.co.example.com` (and to
+// `notplatform.agpt.co`). Compare the hostname exactly, minus the port, the
+// casing and the root-label dot a client can legally send.
+function isProductionHost(host: string): boolean {
+  const hostname = host.toLowerCase().split(":")[0].replace(/\.$/, "");
+  return hostname === PRODUCTION_HOST;
 }

--- a/autogpt_platform/frontend/src/services/analytics/useAdsConversionTracker.ts
+++ b/autogpt_platform/frontend/src/services/analytics/useAdsConversionTracker.ts
@@ -15,6 +15,7 @@ export function useAdsConversionTracker() {
   const { user, isUserLoading } = useAuth();
   const pathname = usePathname();
   const checkoutReportedRef = useRef(false);
+  const checkoutParamsRef = useRef<URLSearchParams | null>(null);
   const lastTrackedPathRef = useRef<string | null>(null);
 
   // Waits for the session itself, not just for loading to finish: on the
@@ -24,15 +25,21 @@ export function useAdsConversionTracker() {
   // Re-runs on navigation because the email signup sets the flag and then
   // moves on client-side, without a reload.
   useEffect(() => {
+    // Snapshot before the session guard. Stripe's result is only in the URL on
+    // the landing render, and a client-side navigation — including the credits
+    // page stripping its own query — can drop it before a retry runs, which
+    // would latch the ref on an empty query and lose the conversion for good.
+    const checkoutParams =
+      checkoutParamsRef.current ?? new URLSearchParams(window.location.search);
+    checkoutParamsRef.current = checkoutParams;
+
     if (isUserLoading || !user) return;
 
     if (!checkoutReportedRef.current) {
-      // Stripe sends the user back with a full page load, so the checkout
-      // result is only ever in the URL at mount time. Latch only once it
-      // actually reached the tag — the tag loads afterInteractive and may not
-      // exist yet on this pass.
+      // Latch only once it actually reached the tag — the tag loads
+      // afterInteractive and may not exist yet on this pass.
       checkoutReportedRef.current = trackCheckoutReturn(
-        new URLSearchParams(window.location.search),
+        checkoutParams,
         user.email,
       );
     }

--- a/autogpt_platform/frontend/src/services/analytics/useAdsConversionTracker.ts
+++ b/autogpt_platform/frontend/src/services/analytics/useAdsConversionTracker.ts
@@ -1,7 +1,10 @@
 import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
-import { consumeAccountCreatedFlag } from "./account-created-cookie";
+import {
+  clearAccountCreatedFlag,
+  readAccountCreatedFlag,
+} from "./account-created-cookie";
 import {
   getSubscriptionValue,
   trackAdsConversion,
@@ -14,29 +17,36 @@ export function useAdsConversionTracker() {
   const checkoutReportedRef = useRef(false);
   const lastTrackedPathRef = useRef<string | null>(null);
 
-  // Waits for the session so the user id (dedup) and email (enhanced
-  // conversions) can ride along. Re-runs on navigation because the email
-  // signup sets the flag and then moves on client-side, without a reload.
+  // Waits for the session itself, not just for loading to finish: on the
+  // post-signup client navigation the effect runs once with `user` still
+  // undefined, and a conversion sent then carries no id to dedup on and no
+  // email for enhanced conversions. Nothing here is reported without a user.
+  // Re-runs on navigation because the email signup sets the flag and then
+  // moves on client-side, without a reload.
   useEffect(() => {
-    if (isUserLoading) return;
+    if (isUserLoading || !user) return;
 
     if (!checkoutReportedRef.current) {
-      checkoutReportedRef.current = true;
       // Stripe sends the user back with a full page load, so the checkout
-      // result is only ever in the URL at mount time.
-      trackCheckoutReturn(
+      // result is only ever in the URL at mount time. Latch only once it
+      // actually reached the tag — the tag loads afterInteractive and may not
+      // exist yet on this pass.
+      checkoutReportedRef.current = trackCheckoutReturn(
         new URLSearchParams(window.location.search),
-        user?.email,
+        user.email,
       );
     }
 
-    const method = consumeAccountCreatedFlag();
+    const method = readAccountCreatedFlag();
     if (!method) return;
-    trackAdsConversion("sign_up", {
-      transactionID: user?.id,
-      email: user?.email,
+    const reported = trackAdsConversion("sign_up", {
+      transactionID: user.id,
+      email: user.email,
     });
-  }, [user?.id, isUserLoading, pathname]);
+    // The flag is the only record that a signup happened; keep it until the
+    // conversion is really out, so the next navigation can retry.
+    if (reported) clearAccountCreatedFlag();
+  }, [user, isUserLoading, pathname]);
 
   // The tag's own config call already reports the first page; only
   // client-side navigations need a page_view from here.
@@ -51,18 +61,26 @@ export function useAdsConversionTracker() {
   }, [pathname]);
 }
 
-function trackCheckoutReturn(params: URLSearchParams, email?: string) {
+// Returns whether the checkout result has been dealt with: true when there was
+// nothing to report, or when every conversion reached the tag.
+function trackCheckoutReturn(params: URLSearchParams, email?: string): boolean {
   const sessionID = params.get("session_id") ?? undefined;
+  let handled = true;
 
   if (params.get("subscription") === "success") {
-    trackAdsConversion("subscribe", {
-      value: getSubscriptionValue(params.get("plan"), params.get("cycle")),
-      transactionID: sessionID,
-      email,
-    });
+    handled =
+      trackAdsConversion("subscribe", {
+        value: getSubscriptionValue(params.get("plan"), params.get("cycle")),
+        transactionID: sessionID,
+        email,
+      }) && handled;
   }
 
   if (params.get("topup") === "success") {
-    trackAdsConversion("top_up", { transactionID: sessionID, email });
+    handled =
+      trackAdsConversion("top_up", { transactionID: sessionID, email }) &&
+      handled;
   }
+
+  return handled;
 }

--- a/autogpt_platform/frontend/src/services/analytics/useAdsConversionTracker.ts
+++ b/autogpt_platform/frontend/src/services/analytics/useAdsConversionTracker.ts
@@ -1,0 +1,68 @@
+import { useAuth } from "@/lib/auth/hooks/useAuth";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { consumeAccountCreatedFlag } from "./account-created-cookie";
+import {
+  getSubscriptionValue,
+  trackAdsConversion,
+  trackAdsPageView,
+} from "./google-ads";
+
+export function useAdsConversionTracker() {
+  const { user, isUserLoading } = useAuth();
+  const pathname = usePathname();
+  const checkoutReportedRef = useRef(false);
+  const lastTrackedPathRef = useRef<string | null>(null);
+
+  // Waits for the session so the user id (dedup) and email (enhanced
+  // conversions) can ride along. Re-runs on navigation because the email
+  // signup sets the flag and then moves on client-side, without a reload.
+  useEffect(() => {
+    if (isUserLoading) return;
+
+    if (!checkoutReportedRef.current) {
+      checkoutReportedRef.current = true;
+      // Stripe sends the user back with a full page load, so the checkout
+      // result is only ever in the URL at mount time.
+      trackCheckoutReturn(
+        new URLSearchParams(window.location.search),
+        user?.email,
+      );
+    }
+
+    const method = consumeAccountCreatedFlag();
+    if (!method) return;
+    trackAdsConversion("sign_up", {
+      transactionID: user?.id,
+      email: user?.email,
+    });
+  }, [user?.id, isUserLoading, pathname]);
+
+  // The tag's own config call already reports the first page; only
+  // client-side navigations need a page_view from here.
+  useEffect(() => {
+    if (lastTrackedPathRef.current === null) {
+      lastTrackedPathRef.current = pathname;
+      return;
+    }
+    if (pathname === lastTrackedPathRef.current) return;
+    lastTrackedPathRef.current = pathname;
+    trackAdsPageView(pathname);
+  }, [pathname]);
+}
+
+function trackCheckoutReturn(params: URLSearchParams, email?: string) {
+  const sessionID = params.get("session_id") ?? undefined;
+
+  if (params.get("subscription") === "success") {
+    trackAdsConversion("subscribe", {
+      value: getSubscriptionValue(params.get("plan"), params.get("cycle")),
+      transactionID: sessionID,
+      email,
+    });
+  }
+
+  if (params.get("topup") === "success") {
+    trackAdsConversion("top_up", { transactionID: sessionID, email });
+  }
+}

--- a/autogpt_platform/frontend/src/services/analytics/useSetupAnalytics.ts
+++ b/autogpt_platform/frontend/src/services/analytics/useSetupAnalytics.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { consent, type ConsentPreferences } from "@/services/consent/cookies";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { environment } from "../environment";
+import { resolveAnalyticsLoading } from "./loading-policy";
+
+export function useSetupAnalytics(host: string) {
+  // Stored consent is only readable in the browser; the tag waits for it so
+  // the init script can replay the visitor's answer through Consent Mode.
+  const [preferences, setPreferences] = useState<ConsentPreferences | null>(
+    null,
+  );
+  useMountEffect(() => {
+    setPreferences(consent.load());
+  });
+
+  const pathname = usePathname();
+  const { googleTag, dataFast } = resolveAnalyticsLoading({
+    host,
+    pathname,
+    isLocal: environment.isLocal(),
+    preferences,
+  });
+
+  useEffect(() => {
+    if (!googleTag) return;
+
+    // Google Analytics: feature usage signal (same as original implementation)
+    performance.mark("mark_feature_usage", {
+      detail: {
+        feature: "custom-ga",
+      },
+    });
+  }, [googleTag]);
+
+  return {
+    preferences,
+    googleTagEnabled: googleTag,
+    dataFastEnabled: dataFast,
+  };
+}

--- a/autogpt_platform/frontend/src/services/consent/cookies.test.ts
+++ b/autogpt_platform/frontend/src/services/consent/cookies.test.ts
@@ -10,6 +10,7 @@ function preferences(analytics: boolean): ConsentPreferences {
     timestamp: Date.now(),
     analytics,
     monitoring: false,
+    advertising: false,
   };
 }
 
@@ -64,5 +65,29 @@ describe("analytics consent cookie", () => {
     consent.clear();
 
     expect(document.cookie).not.toContain(`${COOKIE_NAME}=granted`);
+  });
+
+  it("keeps an answer stored before the advertising category existed, as advertising denied", () => {
+    localStorage.setItem(
+      Key.COOKIE_CONSENT,
+      JSON.stringify({
+        hasConsented: true,
+        timestamp: 1,
+        analytics: true,
+        monitoring: false,
+      }),
+    );
+
+    const loaded = consent.load();
+
+    expect(loaded.hasConsented).toBe(true);
+    expect(loaded.analytics).toBe(true);
+    expect(loaded.advertising).toBe(false);
+  });
+
+  it("persists advertising consent", () => {
+    consent.save({ ...preferences(true), advertising: true });
+
+    expect(consent.load().advertising).toBe(true);
   });
 });

--- a/autogpt_platform/frontend/src/services/consent/cookies.ts
+++ b/autogpt_platform/frontend/src/services/consent/cookies.ts
@@ -12,6 +12,7 @@ export interface ConsentPreferences {
   timestamp: number;
   analytics: boolean;
   monitoring: boolean;
+  advertising: boolean;
 }
 
 export const DEFAULT_CONSENT: ConsentPreferences = {
@@ -19,6 +20,7 @@ export const DEFAULT_CONSENT: ConsentPreferences = {
   timestamp: Date.now(),
   analytics: false,
   monitoring: false,
+  advertising: false,
 };
 
 export const COOKIE_CATEGORIES = {
@@ -37,6 +39,12 @@ export const COOKIE_CATEGORIES = {
     name: "Error Monitoring & Session Replay",
     description:
       "Record errors and user sessions to help us fix bugs faster (Sentry - includes screen recording)",
+    alwaysActive: false,
+  },
+  advertising: {
+    name: "Advertising",
+    description:
+      "Measure which ads bring people to AutoGPT so we only pay for the ones that work (Google Ads conversion tracking)",
     alwaysActive: false,
   },
 } as const;
@@ -64,8 +72,18 @@ function load(): ConsentPreferences {
       return DEFAULT_CONSENT;
     }
 
-    syncAnalyticsConsentCookie(parsed.hasConsented && parsed.analytics);
-    return parsed;
+    // Answers stored before the advertising category existed count as a no
+    // for it rather than being thrown away and asked again.
+    const preferences: ConsentPreferences = {
+      ...parsed,
+      advertising:
+        typeof parsed.advertising === "boolean" ? parsed.advertising : false,
+    };
+
+    syncAnalyticsConsentCookie(
+      preferences.hasConsented && preferences.analytics,
+    );
+    return preferences;
   } catch (error) {
     syncAnalyticsConsentCookie(false);
     Sentry.captureException(error);

--- a/autogpt_platform/frontend/src/services/environment/index.ts
+++ b/autogpt_platform/frontend/src/services/environment/index.ts
@@ -89,6 +89,14 @@ function getLaunchDarklyClientId() {
   return process.env.NEXT_PUBLIC_LAUNCHDARKLY_CLIENT_ID;
 }
 
+function getGoogleAdsID() {
+  return process.env.NEXT_PUBLIC_GOOGLE_ADS_ID || "";
+}
+
+function getGoogleAdsConversionLabels() {
+  return process.env.NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS;
+}
+
 function isProductionBuild() {
   return process.env.NODE_ENV === "production";
 }
@@ -151,6 +159,8 @@ export const environment = {
   getPreviewStealingDev,
   getPostHogCredentials,
   getLaunchDarklyClientId,
+  getGoogleAdsID,
+  getGoogleAdsConversionLabels,
   // Assertions
   isServerSide,
   isClientSide,

--- a/autogpt_platform/frontend/src/services/environment/index.ts
+++ b/autogpt_platform/frontend/src/services/environment/index.ts
@@ -94,7 +94,7 @@ function getGoogleAdsID() {
 }
 
 function getGoogleAdsConversionLabels() {
-  return process.env.NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS;
+  return process.env.NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS || "";
 }
 
 function isProductionBuild() {

--- a/autogpt_platform/frontend/src/tests/integrations/gtag-shim.ts
+++ b/autogpt_platform/frontend/src/tests/integrations/gtag-shim.ts
@@ -1,0 +1,14 @@
+// Stands in for the `gtag()` shim the Google tag init script defines on
+// window, recording each command so tests can assert on what would reach the
+// dataLayer.
+export function installGtagShim(): unknown[][] {
+  const calls: unknown[][] = [];
+  window.gtag = (...args: unknown[]) => {
+    calls.push(args);
+  };
+  return calls;
+}
+
+export function removeGtagShim() {
+  delete window.gtag;
+}

--- a/autogpt_platform/frontend/src/types/google.ts
+++ b/autogpt_platform/frontend/src/types/google.ts
@@ -26,7 +26,6 @@ export type GTMParams = {
 
 export type GAParams = {
   gaId: string;
-  dataLayerName?: string;
   debugMode?: boolean;
   nonce?: string;
 };


### PR DESCRIPTION
### Why / What / How

**Why:** We were accepted into a Google Ads partner program. Their team won't schedule the kickoff until conversion tracking is live, so Google Ads can optimize toward real signups and subscriptions instead of clicks. Today the platform loads gtag.js for GA4 only, behind the cookie banner, and has no Google Ads tag, no advertising consent category and no conversion events.

**What:**
- Google Ads tag (`AW-…`) configured next to GA4, driven by `NEXT_PUBLIC_GOOGLE_ADS_ID` and `NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS`. Both are empty by default, so nothing fires outside production.
- Conversions on the journey: `sign_up` (email and Google), `begin_checkout` (plan selected), `subscribe` (return from Stripe, with the plan price), `onboarding_complete`, `top_up`. Plus an Ads `page_view` on client-side navigation.
- Consent Mode v2: region-scoped defaults (every signal denied in the EEA, UK and Switzerland until the visitor answers the banner, granted elsewhere), `url_passthrough` so the click ID survives without cookies, and a new "Advertising" category in the cookie banner and settings.
- Fix on the way: `analytics.sendGAEvent` spread its arguments into the dataLayer, but gtag.js only executes real `arguments` objects, so the existing custom GA events never reached Google. Commands now go through the tag's own `gtag()` shim.

**How:**
- `services/analytics/google-ads.ts` — `trackAdsConversion(name, { value, currency, transactionID, email })` sends `gtag('event', 'conversion', { send_to: 'AW-…/label', … })`. Labels come from env (`sign_up=AbC,subscribe=DeF,…`) so the account can be rewired without a deploy.
- `services/analytics/account-created-server.ts` sets a 10-minute `agpt_account_created` cookie at the exact spot the DataFast signup goal already fires (signup server action and the OAuth callback). `AdsConversionTracker` (mounted in `providers.tsx`) consumes it once the session is known and fires `sign_up` with `transaction_id = user.id`; it also reads `subscription=success&session_id=…&plan=…&cycle=…` and `topup=success` on landing for `subscribe` / `top_up`. Stripe fills `{CHECKOUT_SESSION_ID}` in the success URL, which Google uses to dedupe refreshes.
- `SetupAnalytics` waits for the stored consent, loads the tag on the production domain regardless of the answer (Consent Mode keeps it cookieless where consent is required) and replays the stored answer with `gtag('consent', 'update', …)`. Local development keeps the analytics opt-in gate. The policy is a pure function in `loading-policy.ts`, the consent commands in `consent-mode.ts`.
- Enhanced conversions: the email goes along as `user_data` (gtag hashes it client-side) on `sign_up`, `subscribe` and `top_up`; needs the Enhanced conversions toggle in the Ads account.
- Companion PR on the marketing site (tag on agpt.co, Get Started click, same consent defaults): Significant-Gravitas/autogpt-marketing-site#34.

### Changes 🏗️

- New `services/analytics/gtag.ts`, `google-ads.ts`, `consent-mode.ts`, `loading-policy.ts`, `account-created-cookie.ts`, `account-created-server.ts`, `AdsConversionTracker.tsx` + `useAdsConversionTracker.ts`, each with tests.
- `services/analytics/index.tsx`: consent-aware tag loading, Consent Mode commands and Ads config in the init script; `sendGAEvent` routed through the tag shim.
- `services/consent/cookies.ts` + cookie banner / settings modal: `advertising` category (older stored answers count as "no" instead of re-prompting).
- `signup/actions.ts`, `auth/callback/route.ts`: flag a brand-new account for the browser.
- `useSubscriptionStep.ts`, `useYourPlanCard.ts`: `begin_checkout` and `session_id`/`plan`/`cycle` on the Stripe success URL.
- `useOnboardingPage.ts`: `onboarding_complete` when `ONBOARDING_COMPLETE` is posted.
- `providers.tsx`: mounts `AdsConversionTracker`.
- `environment`: `getGoogleAdsID()`, `getGoogleAdsConversionLabels()`.
- Configuration: `NEXT_PUBLIC_GOOGLE_ADS_ID` and `NEXT_PUBLIC_GOOGLE_ADS_CONVERSION_LABELS` added to `.env.default` (empty). Production needs both set once the ads team's IDs exist; until then the tag config line and every conversion are no-ops.
- Behaviour change to be aware of: on production the Google tag (GA4 + Ads) now loads before the banner is answered — cookieless and denied in the EEA/UK/CH, granted by default elsewhere. Previously nothing loaded until "Analytics" was accepted. DataFast is unchanged.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] Vitest: new tests for the gtag shim, consent-mode script, loading policy, Google Ads helper, account-created cookie and `AdsConversionTracker`; extended the signup action, OAuth callback, cookie banner, consent cookie, SubscriptionStep, onboarding page and billing plan card tests (173 passing across the touched files); `pnpm format`, `pnpm lint`, `pnpm types` clean
  - [ ] Production with the env vars set: Tag Assistant shows the `AW-` config and the consent state for the region; walk signup → plan → Stripe → onboarding and see each conversion fire with its label; Google Ads flips the actions to "Recording conversions"
  - [ ] Cookie banner: Settings shows the Advertising toggle; Accept all / Reject all include it; a previously stored answer does not re-prompt

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
