### PR TITLE
fix(platform): stop GET /onboarding/completed 500ing for unprovisioned users

### DIFF
--- a/autogpt_platform/autogpt_libs/autogpt_libs/auth/dependencies_test.py
+++ b/autogpt_platform/autogpt_libs/autogpt_libs/auth/dependencies_test.py
@@ -584,17 +584,18 @@ class TestEnsurePlatformUser:
         import types
 
         db_mod = types.ModuleType("backend.data.db")
-        db_mod.prisma = Mock()
+        prisma = Mock()
         # A list means "successive calls" -- used to model the row appearing
         # between the initial probe and the post-failure re-check.
-        db_mod.prisma.user.find_unique = (
+        prisma.user.find_unique = (
             AsyncMock(side_effect=list(existing_user))
             if isinstance(existing_user, list)
             else AsyncMock(return_value=existing_user)
         )
+        setattr(db_mod, "prisma", prisma)
 
         user_mod = types.ModuleType("backend.data.user")
-        user_mod.get_or_create_user_with_status = provisioner
+        setattr(user_mod, "get_or_create_user_with_status", provisioner)
 
         mocker.patch.dict(
             sys.modules,
@@ -698,17 +699,18 @@ class TestRequestContextProvisioning:
         org_member.Org = Mock(deletedAt=None)
 
         db_mod = types.ModuleType("backend.data.db")
-        db_mod.prisma = Mock()
+        prisma = Mock()
         # No personal org -> the self-heal branch.
-        db_mod.prisma.orgmember.find_first = AsyncMock(return_value=None)
-        db_mod.prisma.orgmember.find_unique = AsyncMock(return_value=org_member)
+        prisma.orgmember.find_first = AsyncMock(return_value=None)
+        prisma.orgmember.find_unique = AsyncMock(return_value=org_member)
+        setattr(db_mod, "prisma", prisma)
 
         async def _default_team(_user_id):
             calls.append("get_user_default_team")
             return "org-1", "team-1"
 
         orgs_mod = types.ModuleType("backend.api.features.orgs.db")
-        orgs_mod.get_user_default_team = _default_team
+        setattr(orgs_mod, "get_user_default_team", _default_team)
 
         mocker.patch.dict(
             sys.modules,

--- a/autogpt_platform/backend/backend/data/onboarding.py
+++ b/autogpt_platform/backend/backend/data/onboarding.py
@@ -55,13 +55,58 @@ class UserOnboardingUpdate(pydantic.BaseModel):
     onboardingAgentExecutionId: Optional[str] = None
 
 
-async def get_user_onboarding(user_id: str):
+async def get_user_onboarding(user_id: str) -> UserOnboarding:
+    """Read a user's onboarding state, creating nothing.
+
+    A user with no row yet gets an unsaved all-defaults one. Creating it here
+    instead would need a ``User`` row to hang the FK off, and a valid session
+    can outrun that row: the auth provider issues one as soon as the auth
+    identity exists, while the platform row is only created when the client
+    calls ``POST /api/v1/auth/user`` — a call that can fail or never run. This
+    read runs on every page load, so for those accounts the FK violation was a
+    500 on each one, for as long as the user kept browsing.
+
+    Callers that persist need the row to exist; they use
+    ``ensure_user_onboarding``.
+    """
+    onboarding = await UserOnboarding.prisma().find_unique(where={"userId": user_id})
+    return onboarding or _default_user_onboarding(user_id)
+
+
+async def ensure_user_onboarding(user_id: str) -> UserOnboarding:
+    """Read a user's onboarding state, creating the row if it is missing.
+
+    For write paths, which follow up with an ``update`` that has nothing to
+    target otherwise. Unlike the read above this does require a provisioned
+    ``User``, which is correct: there is no onboarding progress to record for
+    an account the platform does not have.
+    """
     return await UserOnboarding.prisma().upsert(
         where={"userId": user_id},
         data={
             "create": UserOnboardingCreateInput(userId=user_id),
             "update": {},
         },
+    )
+
+
+def _default_user_onboarding(user_id: str) -> UserOnboarding:
+    """An unsaved row mirroring the column defaults in ``schema.prisma``.
+
+    ``id``/``createdAt`` are placeholders: the API model this is serialized
+    through exposes neither, so they never reach a client.
+    """
+    return UserOnboarding(
+        id="",
+        createdAt=datetime.now(timezone.utc),
+        completedSteps=[],
+        walletShown=False,
+        notified=[],
+        rewardedFor=[],
+        integrations=[],
+        agentRuns=0,
+        consecutiveRunDays=0,
+        userId=user_id,
     )
 
 
@@ -169,7 +214,7 @@ async def complete_onboarding_step(user_id: str, step: OnboardingStep):
     """
     Completes the specified onboarding step for the user if not already completed.
     """
-    onboarding = await get_user_onboarding(user_id)
+    onboarding = await ensure_user_onboarding(user_id)
     if step not in onboarding.completedSteps:
         await UserOnboarding.prisma().update(
             where={"userId": user_id},
@@ -323,7 +368,7 @@ async def increment_onboarding_runs(user_id: str):
     Increment a user's run counters and trigger any onboarding milestones.
     """
     user_timezone = await _get_user_timezone(user_id)
-    onboarding = await get_user_onboarding(user_id)
+    onboarding = await ensure_user_onboarding(user_id)
     new_run_count = onboarding.agentRuns + 1
     last_run_at, consecutive_run_days = _calculate_consecutive_run_days(
         onboarding.lastRunAt, onboarding.consecutiveRunDays, user_timezone

--- a/autogpt_platform/backend/backend/data/onboarding_test.py
+++ b/autogpt_platform/backend/backend/data/onboarding_test.py
@@ -7,7 +7,9 @@ import pytest_mock
 from backend.data.onboarding import (
     OnboardingStep,
     _reward_user,
+    ensure_user_onboarding,
     format_onboarding_for_extraction,
+    get_user_onboarding,
 )
 
 
@@ -154,3 +156,52 @@ def test_onboarding_step_values_are_plain_strings():
     # Legacy values that have been retired (e.g. VISIT_COPILOT) must not appear
     # in the active set — existing rows containing them remain inert strings.
     assert "VISIT_COPILOT" not in {step.value for step in OnboardingStep}
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_get_user_onboarding_does_not_write_for_unprovisioned_user(
+    mocker: pytest_mock.MockerFixture,
+):
+    # A valid session can outrun the platform User row it hangs off. This read
+    # runs on every page load, so it has to answer from what is already there:
+    # creating a row for a user that does not exist yet trips the FK to User
+    # and 500s the request instead.
+    mock_prisma = mocker.patch("backend.data.onboarding.UserOnboarding.prisma")
+    mock_prisma.return_value.find_unique = AsyncMock(return_value=None)
+    mock_prisma.return_value.upsert = AsyncMock()
+
+    onboarding = await get_user_onboarding("user-1")
+
+    mock_prisma.return_value.upsert.assert_not_called()
+    assert onboarding.userId == "user-1"
+    assert onboarding.completedSteps == []
+    assert onboarding.agentRuns == 0
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_get_user_onboarding_returns_the_stored_row(
+    mocker: pytest_mock.MockerFixture,
+):
+    stored = Mock(userId="user-1", completedSteps=["ONBOARDING_COMPLETE"])
+    mock_prisma = mocker.patch("backend.data.onboarding.UserOnboarding.prisma")
+    mock_prisma.return_value.find_unique = AsyncMock(return_value=stored)
+    mock_prisma.return_value.upsert = AsyncMock()
+
+    assert await get_user_onboarding("user-1") is stored
+    mock_prisma.return_value.upsert.assert_not_called()
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ensure_user_onboarding_creates_the_row(
+    mocker: pytest_mock.MockerFixture,
+):
+    # Write paths still need the row to exist: each one follows up with an
+    # `update`, which has nothing to target if the row was never created.
+    mock_prisma = mocker.patch("backend.data.onboarding.UserOnboarding.prisma")
+    mock_prisma.return_value.upsert = AsyncMock(return_value=Mock())
+
+    await ensure_user_onboarding("user-1")
+
+    assert mock_prisma.return_value.upsert.call_args.kwargs["where"] == {
+        "userId": "user-1"
+    }

--- a/autogpt_platform/frontend/src/providers/onboarding/__tests__/onboarding-provider-routing.test.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/__tests__/onboarding-provider-routing.test.tsx
@@ -37,12 +37,13 @@ vi.mock("@/hooks/useOnboardingTimezoneDetection", () => ({
 }));
 
 let mockIsCompleted = false;
+let mockCompletedStatus = 200;
 const completedCallCount = { value: 0 };
 vi.mock("@/app/api/__generated__/endpoints/onboarding/onboarding", () => ({
   getV1CheckIfOnboardingIsCompleted: () => {
     completedCallCount.value += 1;
     return Promise.resolve({
-      status: 200,
+      status: mockCompletedStatus,
       data: { is_completed: mockIsCompleted },
     });
   },
@@ -59,6 +60,7 @@ describe("OnboardingProvider routing — logged-in user", () => {
     mockPathname = "/signup";
     mockIsLoggedIn = true;
     mockIsCompleted = false;
+    mockCompletedStatus = 200;
     completedCallCount.value = 0;
   });
 
@@ -156,6 +158,45 @@ describe("OnboardingProvider routing — logged-in user", () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(routerReplace).not.toHaveBeenCalled();
     expect(completedCallCount.value).toBe(0);
+  });
+
+  test("a persistently failing completion check stops retrying as the user navigates", async () => {
+    // An account with no platform User row 500s this check on every call. The
+    // init guard used to be re-armed on every failure, so each navigation shot
+    // off another doomed request and the user generated 5xx for as long as they
+    // browsed. Retries are bounded now: enough for a transient blip to recover,
+    // not enough to keep a broken account hammering the endpoint.
+    mockCompletedStatus = 500;
+    mockPathname = "/copilot";
+
+    const { rerender } = render(
+      <OnboardingProvider>
+        <div data-testid="child" />
+      </OnboardingProvider>,
+    );
+
+    await waitFor(() => expect(completedCallCount.value).toBe(1));
+
+    for (const path of [
+      "/library",
+      "/marketplace",
+      "/copilot",
+      "/library",
+      "/profile",
+      "/marketplace",
+    ]) {
+      mockPathname = path;
+      rerender(
+        <OnboardingProvider>
+          <div data-testid="child" />
+        </OnboardingProvider>,
+      );
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    // The first attempt plus MAX_INIT_ATTEMPTS retries, and then silence —
+    // not one request per navigation.
+    expect(completedCallCount.value).toBe(4);
   });
 
   test("incomplete user already on /onboarding stays put", async () => {

--- a/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
+++ b/autogpt_platform/frontend/src/providers/onboarding/onboarding-provider.tsx
@@ -37,6 +37,8 @@ import {
 
 type FrontendOnboardingStep = PostV1CompleteOnboardingStepStep;
 
+const MAX_INIT_ATTEMPTS = 3;
+
 const OnboardingContext = createContext<
   | {
       state: UserOnboarding | null;
@@ -86,6 +88,7 @@ export default function OnboardingProvider({
   const [state, setState] = useState<UserOnboarding | null>(null);
   const [step, setStep] = useState(1);
   const hasInitialized = useRef(false);
+  const failedInitCount = useRef(0);
   const isMounted = useRef(true);
   const pendingUpdatesRef = useRef<Set<Promise<void>>>(new Set());
   const { toast } = useToast();
@@ -218,7 +221,14 @@ export default function OnboardingProvider({
           variant: "destructive",
         });
 
-        hasInitialized.current = false; // Allow retry on next render
+        // Re-arming unconditionally means a persistent failure is retried on
+        // every navigation, so an account that always 500s here keeps emitting
+        // 5xx for as long as the user browses. Bound it: a transient blip
+        // still recovers, a broken account goes quiet.
+        if (failedInitCount.current < MAX_INIT_ATTEMPTS) {
+          failedInitCount.current += 1;
+          hasInitialized.current = false;
+        }
       }
     }
 


### PR DESCRIPTION
### Why / What / How

**Why.** `AutoGPT_REST_API_Critical_5xx_Error_Rate` paged at 2026-08-25 05:51:30 UTC: `/api/onboarding/completed` GET at a 25% 5xx rate.

The endpoint 500s for any account that has a valid session but no platform `User` row:

```json
{"detail": "Foreign key constraint failed on the field: `UserOnboarding_userId_fkey (index)`",
 "hint": "Check server logs and dependent services.",
 "message": "Failed to process GET /api/onboarding/completed"}
```

Backend: [AUTOGPT-SERVER-97W](https://significant-gravitas.sentry.io/issues/AUTOGPT-SERVER-97W) · surfaced client-side as [BUILDER-8QN](https://significant-gravitas.sentry.io/issues/BUILDER-8QN) (212 occurrences, 46 users since Aug 5).

`get_user_onboarding` upserted a `UserOnboarding` row on a **read** path. That row's FK points at `User`, and a valid session can exist before the platform `User` row does — Better Auth issues one as soon as the auth identity is created, while the platform row is only created when the client calls `POST /auth/user`, a call that can fail or never run. When the row is missing, the `create` half of the upsert violates the FK.

`OnboardingProvider` calls this endpoint from the root layout on **every page load**, and its error handler re-armed the init guard on every failure, so a stuck account fired another doomed request on every navigation. Overnight, when overall traffic is low, one such user was enough to drag the endpoint's error ratio to 25%. This is not an outage — it is a small number of permanently-broken accounts, each retrying.

**What / How.** The defect is that a read path performs a write, so the read no longer writes.

- `get_user_onboarding` reads only (`find_unique`) and returns an unsaved all-defaults row for a user that has none. The FK can no longer fire, and a semantically-correct answer replaces the 500 — an account with no onboarding record has definitively not completed onboarding. As a side benefit the most-called endpoint in the app stops writing to the database on every page load.
- `ensure_user_onboarding` keeps the upsert for the write paths (`complete_onboarding_step`, `increment_onboarding_runs`), which follow up with an `update` that has nothing to target unless the row exists. Those still require a provisioned `User`, which is correct: there is no onboarding progress to record for an account the platform does not have.
- The provider's init retries are bounded, so a transient blip still recovers while a broken account stops re-requesting on every navigation.

**Relationship to #14147.** That PR provisions the missing `User` row on first authenticated touch and addresses the same root cause, but only via `get_request_context`. This endpoint authenticates with `get_user_id` and never reaches it, so it is not covered. #14147 also merged ~9 minutes after this alert fired and is not in the deployed release (`65e80c71`), so production has the original bug either way. The two changes are complementary: #14147 heals the account, this stops the read path from 500ing in the meantime.

### Changes 🏗️

- `backend/data/onboarding.py` — split `get_user_onboarding` (read-only, returns a transient default) from `ensure_user_onboarding` (upsert); point `complete_onboarding_step` and `increment_onboarding_runs` at the latter.
- `frontend/src/providers/onboarding/onboarding-provider.tsx` — bound init retries at `MAX_INIT_ATTEMPTS` instead of re-arming on every failure.
- `autogpt_libs/auth/dependencies_test.py` — drive-by: four module-attribute assignments replaced with `setattr`; pyright rejects them on `ModuleType` and they were failing the local `Typecheck - Backend` pre-commit hook.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `get_user_onboarding` performs no write and returns usable defaults when the row is absent (the incident case)
  - [x] `get_user_onboarding` returns the stored row unchanged when one exists, still without writing
  - [x] `ensure_user_onboarding` still upserts, so write paths keep their row
  - [x] A persistently failing completion check stops retrying as the user navigates, instead of one request per navigation
  - [x] `backend/data/onboarding_test.py` — 18 passed
  - [x] `autogpt_libs/auth/dependencies_test.py` — 41 passed (unchanged behaviour after the `setattr` refactor)
  - [x] `pnpm test:unit src/providers/onboarding` — 17 passed
  - [x] `poetry run lint --skip-pyright` and `pnpm lint` (the checks CI runs) both clean

Not run locally: the API-level onboarding tests pull in the session-scoped autouse fixture that needs the full docker stack. They mock `get_user_onboarding` by name, which this change preserves, so they should be unaffected — CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012T3hxRvGNLnqJXrktP1Aih

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path onboarding reads on every page load and completion-check behavior for edge-case accounts; write paths are isolated to `ensure_user_onboarding` with targeted tests.
> 
> **Overview**
> Fixes **5xx on `GET /api/onboarding/completed`** when a user has a valid session but no platform `User` row. The read path no longer upserts `UserOnboarding` (which violated the `User` FK); it **`find_unique`s only** and returns an in-memory default when no row exists, so “not completed” is answered without writing.
> 
> **`ensure_user_onboarding`** keeps the upsert for write paths (`complete_onboarding_step`, `increment_onboarding_runs`). **`OnboardingProvider`** caps init retries at **`MAX_INIT_ATTEMPTS` (3)** so persistent failures do not re-hit the API on every navigation.
> 
> Tests cover read-vs-write behavior and bounded client retries. Auth dependency tests use **`setattr`** on stub modules for pyright.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bafb6301bb53576861b1ae0dfaebec9c74f1a051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->