### PR TITLE
fix(frontend): send the DataFast signup goal under the name the funnel expects

### DIFF
--- a/autogpt_platform/frontend/src/services/analytics/datafast-server.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/datafast-server.test.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { after } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  resetConfigErrorReportingForTests,
   scheduleAccountCreatedGoal,
   wasAccountCreated,
 } from "./datafast-server";
@@ -16,6 +17,9 @@ const VISITOR_ID = "a3ab2331-989f-4cfa-91c6-2461c9e3c6bd";
 describe("DataFast server-side account creation tracking", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Misconfiguration is reported once per server instance; give each test a
+    // clean instance so the assertions stay independent of test order.
+    resetConfigErrorReportingForTests();
     vi.stubEnv("DATAFAST_API_KEY", "df_test");
     vi.stubEnv("NEXT_PUBLIC_BEHAVE_AS", "LOCAL");
     vi.mocked(cookies).mockResolvedValue({
@@ -54,9 +58,11 @@ describe("DataFast server-side account creation tracking", () => {
           Authorization: "Bearer df_test",
           "Content-Type": "application/json",
         },
+        // The goal name has to match the "Create Account" step of the DataFast
+        // "Site to Paid" funnel; any other name drops out of the funnel.
         body: JSON.stringify({
           datafast_visitor_id: VISITOR_ID,
-          name: "signup",
+          name: "signup_completed",
           metadata: { method: "email" },
         }),
       }),
@@ -95,10 +101,12 @@ describe("DataFast server-side account creation tracking", () => {
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
-  it("reports a missing website API key in cloud", async () => {
+  it("reports a missing website API key in cloud once per server instance", async () => {
     vi.stubEnv("DATAFAST_API_KEY", "");
     vi.stubEnv("NEXT_PUBLIC_BEHAVE_AS", "CLOUD");
 
+    await scheduleAccountCreatedGoal("email");
+    await scheduleAccountCreatedGoal("google");
     await scheduleAccountCreatedGoal("email");
 
     expect(after).not.toHaveBeenCalled();

--- a/autogpt_platform/frontend/src/services/analytics/datafast-server.ts
+++ b/autogpt_platform/frontend/src/services/analytics/datafast-server.ts
@@ -8,6 +8,8 @@ import {
 import { environment } from "@/services/environment";
 
 const DATAFAST_GOALS_URL = "https://datafa.st/api/v1/goals";
+// Must match the "Create Account" step of the DataFast "Site to Paid" funnel.
+const ACCOUNT_CREATED_GOAL = "signup_completed";
 const DATAFAST_VISITOR_COOKIE = "datafast_visitor_id";
 const USER_CREATED_HEADER = "X-AutoGPT-User-Created";
 const VISITOR_ID_PATTERN =
@@ -54,10 +56,31 @@ export async function scheduleAccountCreatedGoal(method: SignupMethod) {
   }
 }
 
+const reportedConfigErrors = new Set<string>();
+
+/**
+ * A missing or malformed key is one deploy-time mistake, not one failure per
+ * signup. Report it once per server instance so a misconfiguration stays
+ * visible without burying the project in thousands of identical events.
+ */
+function reportConfigurationError(message: string) {
+  if (reportedConfigErrors.has(message)) return;
+  reportedConfigErrors.add(message);
+  reportTrackingError(new Error(message));
+}
+
+/** Restores the once-per-instance reporting state between tests. */
+export function resetConfigErrorReportingForTests() {
+  reportedConfigErrors.clear();
+}
+
 function reportTrackingError(error: unknown) {
   try {
     Sentry.captureException(error, {
-      tags: { analytics_provider: "datafast", analytics_goal: "signup" },
+      tags: {
+        analytics_provider: "datafast",
+        analytics_goal: ACCOUNT_CREATED_GOAL,
+      },
     });
   } catch {
     console.error("Failed to report DataFast signup goal error");
@@ -78,13 +101,15 @@ async function getGoalContext(
 
   const apiKey = process.env.DATAFAST_API_KEY?.trim();
   if (!apiKey) {
-    if (!environment.isCloud()) return null;
-
-    throw new Error("DATAFAST_API_KEY must be configured in cloud");
+    if (environment.isCloud()) {
+      reportConfigurationError("DATAFAST_API_KEY must be configured in cloud");
+    }
+    return null;
   }
 
   if (!apiKey.startsWith("df_")) {
-    throw new Error("DATAFAST_API_KEY must use a df_ website key");
+    reportConfigurationError("DATAFAST_API_KEY must use a df_ website key");
+    return null;
   }
 
   return { apiKey, method, visitorID };
@@ -99,7 +124,7 @@ async function sendAccountCreatedGoal(context: GoalContext) {
     },
     body: JSON.stringify({
       datafast_visitor_id: context.visitorID,
-      name: "signup",
+      name: ACCOUNT_CREATED_GOAL,
       metadata: { method: context.method },
     }),
     cache: "no-store",


### PR DESCRIPTION
### Why

The DataFast "👤 Create Account" funnel step has **never** recorded a single event. Two independent bugs, either one of which is enough to zero out the step:

1. **The goal name does not match the funnel.** The code sends `signup`, but the "Site to Paid" funnel step matches `signup_completed`. Querying the DataFast API for the site's full history (2025-09-30 → today) returns 45 goals — neither name appears at all.
2. **`DATAFAST_API_KEY` is not set in Vercel production**, so the request is never made. That is an ops fix, not a code one, but it also produced ~4,400 handled Sentry events in 20 days, because a deploy-time misconfiguration was being reported once per signup:

   | Issue | Path | Events (20d) |
   |---|---|---|
   | BUILDER-8R0 | `POST /signup` | 1,522 |
   | BUILDER-8QZ | `GET /auth/callback` | 2,913 |

Signup itself was never affected — `scheduleAccountCreatedGoal` swallows the error. The errors are raised *after* the consent-cookie and visitor-ID checks, which confirms the rest of the pipeline works: consent mirroring and `datafast_visitor_id` both land correctly.

### What changed

- Send the goal as `signup_completed`, via a named constant tied by comment to the funnel step it has to match.
- Report a missing or malformed `DATAFAST_API_KEY` **once per server instance** instead of once per signup, and return `null` rather than throwing. Same visibility for a real misconfiguration, without burying the signal — which is why this went unnoticed for 20 days.
- Cover the once-per-instance reporting with a test.

### Still required after merge

Set `DATAFAST_API_KEY` in the **Vercel production** environment (a `df_` website key from DataFast → Website Settings → API). Production only — there is a single DataFast website record shared by all environments, so a key in dev would write dev traffic into production analytics.

Once both are in place, expect roughly 220 `signup_completed` goals/day and both Sentry issues to go quiet.

### Testing

- `vitest run src/services/analytics src/app/(no-navbar)/signup src/app/(platform)/auth/callback` — 54 passed
- `tsc --noEmit`, `eslint`, `prettier` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013giMLqpaUWaT4iZemCK3CK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics goal naming and cloud misconfiguration reporting on signup/auth callback paths; signup success is unchanged because tracking errors are still isolated from account creation.
> 
> **Overview**
> Fixes DataFast **Create Account** funnel tracking by sending the goal as **`signup_completed`** (via `ACCOUNT_CREATED_GOAL`) instead of **`signup`**, so events match the **Site to Paid** funnel step name.
> 
> When **`DATAFAST_API_KEY`** is missing in cloud or malformed, the server now **reports to Sentry once per instance** (deduped by message) and **returns without scheduling** the goal, instead of throwing on every signup. That keeps misconfiguration visible without thousands of duplicate Sentry events. Tests call **`resetConfigErrorReportingForTests`** in `beforeEach` and assert a single **`captureException`** after multiple signup attempts in cloud with no key.
> 
> **Ops still required:** set a production **`df_`** website key in Vercel so requests are actually sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708a01668d44b04edf70730ddecb00a73b5e45d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->