### PR TITLE
Fix self-referencing path filter after workflow rename

### DIFF
--- a/.github/workflows/classic-python-checks.yml
+++ b/.github/workflows/classic-python-checks.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, dev, ci-test* ]
     paths:
-      - '.github/workflows/classic-python-checks-ci.yml'
+      - '.github/workflows/classic-python-checks.yml'
       - 'classic/original_autogpt/**'
       - 'classic/forge/**'
       - 'classic/direct_benchmark/**'
@@ -15,7 +15,7 @@ on:
   pull_request:
     branches: [ master, dev, release-* ]
     paths:
-      - '.github/workflows/classic-python-checks-ci.yml'
+      - '.github/workflows/classic-python-checks.yml'
       - 'classic/original_autogpt/**'
       - 'classic/forge/**'
       - 'classic/direct_benchmark/**'


### PR DESCRIPTION
### Why / What / How

**Why:** `classic-python-checks.yml` lists `.github/workflows/classic-python-checks-ci.yml` in both of its `paths:` filters. That file does not exist, the workflow is named `classic-python-checks.yml`. As a result, a change that only modifies this workflow file does not trigger the workflow. The stale reference was introduced in `ef7cfbb86` on 2024-09-20. In the 23 months since then, this workflow file has been edited twice while the stale self-reference remained in place.

**What:** Updates two path entries in `.github/workflows/classic-python-checks.yml`.

**How:** Replaced the outdated filename with the current workflow filename in both `paths:` filters.

### Changes 🏗️

* `classic-python-checks.yml`: updated both `paths:` filters to reference the workflow's current filename

### Checklist 📋

#### For code changes:

* [x] I have clearly listed my changes in the PR description
* [x] I have made a test plan
* [x] I have tested my changes according to the test plan:

  * [x] `ls .github/workflows/ | grep classic-python-checks` prints only `classic-python-checks.yml`
  * [x] `grep -rn "classic-python-checks-ci" .github/workflows/` produces no output after this change

#### Additional information

I found this mismatch while analyzing public repository data with a tool I built: https://github.com/DanielSwift1992/gate. If more details would be useful, I'm happy to share them.
