### PR TITLE
fix(frontend): keep the DataFast signup goal named `signup`

### DIFF
--- a/autogpt_platform/frontend/src/services/analytics/datafast-server.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/datafast-server.test.ts
@@ -17,8 +17,6 @@ const VISITOR_ID = "a3ab2331-989f-4cfa-91c6-2461c9e3c6bd";
 describe("DataFast server-side account creation tracking", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Misconfiguration is reported once per server instance; give each test a
-    // clean instance so the assertions stay independent of test order.
     resetConfigErrorReportingForTests();
     vi.stubEnv("DATAFAST_API_KEY", "df_test");
     vi.stubEnv("NEXT_PUBLIC_BEHAVE_AS", "LOCAL");
@@ -58,8 +56,6 @@ describe("DataFast server-side account creation tracking", () => {
           Authorization: "Bearer df_test",
           "Content-Type": "application/json",
         },
-        // The goal name has to match the "✍️ Signup" step of the DataFast
-        // "Site to Paid" funnel; any other name drops out of the funnel.
         body: JSON.stringify({
           datafast_visitor_id: VISITOR_ID,
           name: "signup",

--- a/autogpt_platform/frontend/src/services/analytics/datafast-server.test.ts
+++ b/autogpt_platform/frontend/src/services/analytics/datafast-server.test.ts
@@ -58,11 +58,11 @@ describe("DataFast server-side account creation tracking", () => {
           Authorization: "Bearer df_test",
           "Content-Type": "application/json",
         },
-        // The goal name has to match the "Create Account" step of the DataFast
+        // The goal name has to match the "✍️ Signup" step of the DataFast
         // "Site to Paid" funnel; any other name drops out of the funnel.
         body: JSON.stringify({
           datafast_visitor_id: VISITOR_ID,
-          name: "signup_completed",
+          name: "signup",
           metadata: { method: "email" },
         }),
       }),

--- a/autogpt_platform/frontend/src/services/analytics/datafast-server.ts
+++ b/autogpt_platform/frontend/src/services/analytics/datafast-server.ts
@@ -8,7 +8,6 @@ import {
 import { environment } from "@/services/environment";
 
 const DATAFAST_GOALS_URL = "https://datafa.st/api/v1/goals";
-// Must match the "✍️ Signup" step of the DataFast "Site to Paid" funnel.
 const ACCOUNT_CREATED_GOAL = "signup";
 const DATAFAST_VISITOR_COOKIE = "datafast_visitor_id";
 const USER_CREATED_HEADER = "X-AutoGPT-User-Created";
@@ -58,18 +57,12 @@ export async function scheduleAccountCreatedGoal(method: SignupMethod) {
 
 const reportedConfigErrors = new Set<string>();
 
-/**
- * A missing or malformed key is one deploy-time mistake, not one failure per
- * signup. Report it once per server instance so a misconfiguration stays
- * visible without burying the project in thousands of identical events.
- */
 function reportConfigurationError(message: string) {
   if (reportedConfigErrors.has(message)) return;
   reportedConfigErrors.add(message);
   reportTrackingError(new Error(message));
 }
 
-/** Restores the once-per-instance reporting state between tests. */
 export function resetConfigErrorReportingForTests() {
   reportedConfigErrors.clear();
 }

--- a/autogpt_platform/frontend/src/services/analytics/datafast-server.ts
+++ b/autogpt_platform/frontend/src/services/analytics/datafast-server.ts
@@ -8,8 +8,8 @@ import {
 import { environment } from "@/services/environment";
 
 const DATAFAST_GOALS_URL = "https://datafa.st/api/v1/goals";
-// Must match the "Create Account" step of the DataFast "Site to Paid" funnel.
-const ACCOUNT_CREATED_GOAL = "signup_completed";
+// Must match the "✍️ Signup" step of the DataFast "Site to Paid" funnel.
+const ACCOUNT_CREATED_GOAL = "signup";
 const DATAFAST_VISITOR_COOKIE = "datafast_visitor_id";
 const USER_CREATED_HEADER = "X-AutoGPT-User-Created";
 const VISITOR_ID_PATTERN =


### PR DESCRIPTION
### Why

#14167 renamed the goal to `signup_completed`, matching the "Site to Paid" funnel step as it read at the time. Since that merged, two things changed:

- **`DATAFAST_API_KEY` was set in Vercel production**, so the goal started landing. DataFast now records 4 `signup` completions (last 3 days).
- **The funnel step was updated to match what production actually sends.** Step 3 is now "✍️ Signup" with `goalName: "signup"` (updated `2026-08-25T20:27Z`, after #14167 merged at `19:16Z`).

So `signup` is the correct name. Shipping `signup_completed` to production would silently zero out the funnel step that is now working — the same failure #14167 set out to fix, in the opposite direction.

### What changed

- Point `ACCOUNT_CREATED_GOAL` back at `signup`.
- Drop the explanatory comments #14167 added around the goal constant and the misconfiguration reporting.

The behaviour from #14167 is otherwise unchanged: a missing or malformed `DATAFAST_API_KEY` is reported once per server instance rather than once per signup.

### Testing

- `vitest run src/services/analytics src/app/(no-navbar)/signup src/app/(platform)/auth/callback` — 54 passed
- Funnel definition and goal counts verified against the DataFast API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013giMLqpaUWaT4iZemCK3CK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics goal string and test expectations only; no auth, data, or signup flow logic changes.
> 
> **Overview**
> Reverts the server-side DataFast **account created** goal from `signup_completed` back to **`signup`** so production events align with the updated “Site to Paid” funnel step (`goalName: "signup"`).
> 
> The POST body to `https://datafa.st/api/v1/goals` and related tests now expect `name: "signup"` again via `ACCOUNT_CREATED_GOAL`. Explanatory comments added in the prior rename are removed; **once-per-instance** Sentry reporting for missing or malformed `DATAFAST_API_KEY` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1156a4f94397fb741a2c30fccedd06b682191a82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->