### PR TITLE
fix(frontend): stop a tool result rendering its own discriminator

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/resultHelpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/resultHelpers.test.ts
@@ -67,6 +67,33 @@ describe("stripBaseFields", () => {
       }),
     ).toEqual({ result: 5 });
   });
+
+  it("drops a name that only echoes the discriminator", () => {
+    // no_results repeats its own type in `name`. Left in, it renders as a
+    // "Name no_results" row and makes the object two-keyed, so the card that
+    // handles a lone string array never runs and the suggestions come out raw.
+    expect(
+      stripBaseFields({
+        type: "no_results",
+        message: "Nothing found",
+        suggestions: ["Try broader keywords"],
+        name: "no_results",
+      }),
+    ).toEqual({ suggestions: ["Try broader keywords"] });
+  });
+
+  it("keeps a name that is real payload", () => {
+    // A folder, file, or block is named, and that name is the answer. It is
+    // only envelope when it repeats the type.
+    expect(
+      stripBaseFields({
+        type: "folder_created",
+        message: "Created",
+        name: "Testing",
+        id: "f1",
+      }),
+    ).toEqual({ name: "Testing", id: "f1" });
+  });
 });
 
 describe("resultItemKey", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/resultHelpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/resultHelpers.ts
@@ -38,8 +38,19 @@ const BASE_RESPONSE_KEYS = new Set(["type", "message", "session_id"]);
 export function stripBaseFields(
   obj: Record<string, unknown>,
 ): Record<string, unknown> {
+  // A couple of responses repeat their own discriminator in `name`
+  // ("no_results", "agents_found"). It is envelope, not payload, and left in
+  // it both renders as a field of its own and pushes the object past the
+  // single-key check that picks a real card -- so a no-results answer came out
+  // as a raw suggestions array labelled "Suggestions", with "Name no_results"
+  // under it. Only drop `name` when it is that echo: a payload whose name
+  // means something (a folder, a file, a block) never equals the type.
+  const type = obj.type;
   return Object.fromEntries(
-    Object.entries(obj).filter(([key]) => !BASE_RESPONSE_KEYS.has(key)),
+    Object.entries(obj).filter(
+      ([key, value]) =>
+        !BASE_RESPONSE_KEYS.has(key) && !(key === "name" && value === type),
+    ),
   );
 }
 


### PR DESCRIPTION
## What

Two copilot tool responses repeat their own type in a `name` field — `no_results` and `agents_found`. `stripBaseFields` removes the response envelope (`type`, `message`, `session_id`) before the chain picks a card, but `name` was not in that set, so it survived into the payload.

Two consequences, both user-visible:

1. **It rendered.** A search that found nothing showed `Name  no_results` as if it were part of the answer.
2. **It broke the card selection.** `shapeCard` only draws a lone string array as a chip list when the payload has exactly one key. With `name` still present the payload had two, so the suggestions rendered as a raw JSON array captioned "Suggestions".

Every empty docs search and every empty block search looked like this:

```
Searched docs for "schedule"
Suggestions   ["Try different keywords","Use more general terms","Check for typos in your query"]
Name          no_results
```

## The fix

`name` is dropped only when it equals `type`. A folder, file, or block is named, and there the name *is* the answer — it simply never equals the response type. Both cases are covered by tests.

## How it was found

Exercising the copilot's tools against a self-hosted single-container build, checking what each tool actually renders rather than only that it returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RMLrx2p5tbM5pHcJM1hEc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copilot tool-result presentation only; no auth, API, or persistence changes.
> 
> **Overview**
> **`stripBaseFields`** now treats a **`name`** field as envelope when it only repeats **`type`** (e.g. `no_results`, `agents_found`), so it is removed along with `type`, `message`, and `session_id`. Real names on create-style responses (folder/file/block) are unchanged because they do not match the discriminator.
> 
> That fixes two copilot UI bugs: empty-search results no longer show a spurious **Name no_results** row, and **`shapeCard`** can again match single-key payloads so suggestion lists render as chips instead of raw JSON under **Suggestions**.
> 
> Tests cover both the echo-drop and the keep-real-name cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b346506b45d75d4f61f21874ca1ee6ffeb62c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->