### PR TITLE
feat: use Postgres full-text search for library agent search

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -228,10 +228,16 @@ async def list_library_agents(
             }
         ]
 
+    # Normalize search term early so folder checks and search clause
+    # both use the same sanitized value. Normalization strips tsquery
+    # operators and collapses whitespace; an empty result means no
+    # search filter should be applied.
+    normalized = _normalize_search_term(search_term or "")
+
     # Apply folder filter (skip when searching — search spans all folders)
-    if folder_id is not None and not search_term:
+    if folder_id is not None and not normalized:
         where_clause["folderId"] = folder_id
-    elif include_root_only and not search_term:
+    elif include_root_only and not normalized:
         where_clause["folderId"] = None
 
     # Apply isHidden filter
@@ -239,31 +245,26 @@ async def list_library_agents(
         where_clause["isHidden"] = is_hidden
 
     # Build search filter if applicable
-    if search_term:
+    if normalized:
         # Use Postgres full-text search for better relevance and performance.
         # Matches both the snapshotted marketplace name/description (shown on
         # the card for downloaded agents) and the underlying graph's own values.
-        # Normalize the term to ensure valid tsquery input — Prisma delegates
-        # to plainto_tsquery which handles plain text, but we additionally
-        # strip stray operators for safety.
-        normalized = _normalize_search_term(search_term)
-        if normalized:
-            where_clause["OR"] = [
-                {"name": {"search": normalized}},
-                {"description": {"search": normalized}},
-                {
-                    "AgentGraph": {
-                        "is": {"name": {"search": normalized}}
+        where_clause["OR"] = [
+            {"name": {"search": normalized}},
+            {"description": {"search": normalized}},
+            {
+                "AgentGraph": {
+                    "is": {"name": {"search": normalized}}
+                }
+            },
+            {
+                "AgentGraph": {
+                    "is": {
+                        "description": {"search": normalized}
                     }
-                },
-                {
-                    "AgentGraph": {
-                        "is": {
-                            "description": {"search": normalized}
-                        }
-                    }
-                },
-            ]
+                }
+            },
+        ]
 
     order_by: (
         prisma.types.LibraryAgentOrderByInput

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -1,6 +1,7 @@
 import asyncio
 import itertools
 import logging
+import re
 from typing import Literal, LiteralString, Optional, cast
 
 import fastapi
@@ -53,6 +54,22 @@ from .embeddings import schedule_library_agent_embedding
 logger = logging.getLogger(__name__)
 config = Config()
 integration_creds_manager = IntegrationCredentialsManager()
+
+
+def _normalize_search_term(term: str) -> str:
+    """Normalize a search term for Prisma full-text search.
+
+    Prisma's ``search`` filter delegates to PostgreSQL's
+    ``plainto_tsquery`` which safely handles plain text. This helper
+    additionally strips stray tsquery operators (AND, OR, NOT, :, *,
+    parentheses) that a user might type无意, and collapses whitespace
+    so the query remains readable.
+    """
+    # Remove tsquery special characters (AND, OR, NOT are handled by
+    # plainto_tsquery; these are the raw operator symbols)
+    cleaned = re.sub(r"[&|!():*]+", " ", term)
+    # Collapse whitespace and strip
+    return " ".join(cleaned.split())
 
 
 async def _fetch_execution_counts(user_id: str, graph_ids: list[str]) -> dict[str, int]:
@@ -226,22 +243,27 @@ async def list_library_agents(
         # Use Postgres full-text search for better relevance and performance.
         # Matches both the snapshotted marketplace name/description (shown on
         # the card for downloaded agents) and the underlying graph's own values.
-        where_clause["OR"] = [
-            {"name": {"search": search_term}},
-            {"description": {"search": search_term}},
-            {
-                "AgentGraph": {
-                    "is": {"name": {"search": search_term}}
-                }
-            },
-            {
-                "AgentGraph": {
-                    "is": {
-                        "description": {"search": search_term}
+        # Normalize the term to ensure valid tsquery input — Prisma delegates
+        # to plainto_tsquery which handles plain text, but we additionally
+        # strip stray operators for safety.
+        normalized = _normalize_search_term(search_term)
+        if normalized:
+            where_clause["OR"] = [
+                {"name": {"search": normalized}},
+                {"description": {"search": normalized}},
+                {
+                    "AgentGraph": {
+                        "is": {"name": {"search": normalized}}
                     }
-                }
-            },
-        ]
+                },
+                {
+                    "AgentGraph": {
+                        "is": {
+                            "description": {"search": normalized}
+                        }
+                    }
+                },
+            ]
 
     order_by: (
         prisma.types.LibraryAgentOrderByInput

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -60,13 +60,14 @@ def _normalize_search_term(term: str) -> str:
     """Normalize a search term for Prisma full-text search.
 
     Prisma's ``search`` filter delegates to PostgreSQL's
-    ``plainto_tsquery`` which safely handles plain text. This helper
-    additionally strips stray tsquery operators (AND, OR, NOT, :, *,
-    parentheses) that a user might type无意, and collapses whitespace
-    so the query remains readable.
+    ``plainto_tsquery`` (or ``websearch_to_tsquery``) which safely
+    handles plain text by AND-ing words together. This helper strips
+    stray tsquery operators (``&``, ``|``, ``!``, ``:``, ``*``,
+    parentheses) that a user might type accidentally, and collapses
+    whitespace so the query remains readable.
     """
-    # Remove tsquery special characters (AND, OR, NOT are handled by
-    # plainto_tsquery; these are the raw operator symbols)
+    # Remove tsquery special characters that plainto_tsquery doesn't
+    # expect in raw form. plainto_tsquery treats input as plain text.
     cleaned = re.sub(r"[&|!():*]+", " ", term)
     # Collapse whitespace and strip
     return " ".join(cleaned.split())

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -223,21 +223,21 @@ async def list_library_agents(
 
     # Build search filter if applicable
     if search_term:
-        # Match both the snapshotted marketplace name/description (shown on the
-        # card for downloaded agents) and the underlying graph's own values, so
-        # searching the displayed title always finds the agent.
+        # Use Postgres full-text search for better relevance and performance.
+        # Matches both the snapshotted marketplace name/description (shown on
+        # the card for downloaded agents) and the underlying graph's own values.
         where_clause["OR"] = [
-            {"name": {"contains": search_term, "mode": "insensitive"}},
-            {"description": {"contains": search_term, "mode": "insensitive"}},
+            {"name": {"search": search_term}},
+            {"description": {"search": search_term}},
             {
                 "AgentGraph": {
-                    "is": {"name": {"contains": search_term, "mode": "insensitive"}}
+                    "is": {"name": {"search": search_term}}
                 }
             },
             {
                 "AgentGraph": {
                     "is": {
-                        "description": {"contains": search_term, "mode": "insensitive"}
+                        "description": {"search": search_term}
                     }
                 }
             },

--- a/autogpt_platform/backend/backend/api/features/library/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/db_test.py
@@ -175,11 +175,15 @@ async def test_list_library_agents_is_hidden_filter(
 async def test_list_library_agents_search_uses_full_text_search(mocker):
     """Search must use Postgres full-text search (search filter) instead of
     ILIKE (contains) for better relevance and performance."""
-    mock_agent_graph = mocker.patch("prisma.models.AgentGraph.prisma")
+    mock_agent_graph = mocker.patch(
+        "backend.api.features.library.db.prisma.models.AgentGraph.prisma"
+    )
     mock_agent_graph.return_value.find_many = mocker.AsyncMock(return_value=[])
 
     mock_find_many = mocker.AsyncMock(return_value=[])
-    mock_library_agent = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library_agent = mocker.patch(
+        "backend.api.features.library.db.prisma.models.LibraryAgent.prisma"
+    )
     mock_library_agent.return_value.find_many = mock_find_many
     mock_library_agent.return_value.count = mocker.AsyncMock(return_value=0)
 
@@ -215,11 +219,15 @@ async def test_list_library_agents_search_uses_full_text_search(mocker):
 async def test_list_library_agents_search_normalizes_tsquery_operators(mocker):
     """Search terms containing tsquery operators (AND, OR, NOT, etc.) should
     be sanitized before reaching Prisma's search filter."""
-    mock_agent_graph = mocker.patch("prisma.models.AgentGraph.prisma")
+    mock_agent_graph = mocker.patch(
+        "backend.api.features.library.db.prisma.models.AgentGraph.prisma"
+    )
     mock_agent_graph.return_value.find_many = mocker.AsyncMock(return_value=[])
 
     mock_find_many = mocker.AsyncMock(return_value=[])
-    mock_library_agent = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library_agent = mocker.patch(
+        "backend.api.features.library.db.prisma.models.LibraryAgent.prisma"
+    )
     mock_library_agent.return_value.find_many = mock_find_many
     mock_library_agent.return_value.count = mocker.AsyncMock(return_value=0)
 
@@ -253,11 +261,15 @@ def test_normalize_search_term():
 async def test_list_library_agents_empty_normalized_preserves_folder_filter(mocker):
     """When search_term normalizes to empty, folder_id/include_root_only
     should still be applied (search mode inactive)."""
-    mock_agent_graph = mocker.patch("prisma.models.AgentGraph.prisma")
+    mock_agent_graph = mocker.patch(
+        "backend.api.features.library.db.prisma.models.AgentGraph.prisma"
+    )
     mock_agent_graph.return_value.find_many = mocker.AsyncMock(return_value=[])
 
     mock_find_many = mocker.AsyncMock(return_value=[])
-    mock_library_agent = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library_agent = mocker.patch(
+        "backend.api.features.library.db.prisma.models.LibraryAgent.prisma"
+    )
     mock_library_agent.return_value.find_many = mock_find_many
     mock_library_agent.return_value.count = mocker.AsyncMock(return_value=0)
 

--- a/autogpt_platform/backend/backend/api/features/library/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/db_test.py
@@ -231,9 +231,12 @@ async def test_list_library_agents_search_normalizes_tsquery_operators(mocker):
     await db.list_library_agents("test-user", search_term="test & (OR | NOT)")
 
     where = mock_find_many.call_args.kwargs["where"]
-    for clause in where["OR"]:
-        if "search" in clause:
-            assert clause["search"] == "test OR"
+    expected = "test OR NOT"
+    # Check all four search clauses have the normalized term
+    assert where["OR"][0]["name"]["search"] == expected
+    assert where["OR"][1]["description"]["search"] == expected
+    assert where["OR"][2]["AgentGraph"]["is"]["name"]["search"] == expected
+    assert where["OR"][3]["AgentGraph"]["is"]["description"]["search"] == expected
 
 
 def test_normalize_search_term():
@@ -244,6 +247,33 @@ def test_normalize_search_term():
     assert db._normalize_search_term("  lots   of   spaces  ") == "lots of spaces"
     assert db._normalize_search_term("it's a test") == "it's a test"
     assert db._normalize_search_term(":::") == ""
+
+
+@pytest.mark.asyncio
+async def test_list_library_agents_empty_normalized_preserves_folder_filter(mocker):
+    """When search_term normalizes to empty, folder_id/include_root_only
+    should still be applied (search mode inactive)."""
+    mock_agent_graph = mocker.patch("prisma.models.AgentGraph.prisma")
+    mock_agent_graph.return_value.find_many = mocker.AsyncMock(return_value=[])
+
+    mock_find_many = mocker.AsyncMock(return_value=[])
+    mock_library_agent = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library_agent.return_value.find_many = mock_find_many
+    mock_library_agent.return_value.count = mocker.AsyncMock(return_value=0)
+
+    mocker.patch(
+        "backend.api.features.library.db._fetch_execution_counts",
+        new=mocker.AsyncMock(return_value={}),
+    )
+
+    # Only tsquery operators -> normalizes to empty string
+    await db.list_library_agents("test-user", search_term="& | *", folder_id="folder-123")
+
+    where = mock_find_many.call_args.kwargs["where"]
+    # Search filter should NOT be added (normalized is empty)
+    assert "OR" not in where
+    # But folder filter SHOULD be applied
+    assert where["folderId"] == "folder-123"
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/api/features/library/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/db_test.py
@@ -172,9 +172,9 @@ async def test_list_library_agents_is_hidden_filter(
 
 
 @pytest.mark.asyncio
-async def test_list_library_agents_search_matches_snapshot_and_graph(mocker):
-    """Search must match the snapshotted LibraryAgent name/description (shown on
-    the card for downloaded agents) as well as the underlying graph's values."""
+async def test_list_library_agents_search_uses_full_text_search(mocker):
+    """Search must use Postgres full-text search (search filter) instead of
+    ILIKE (contains) for better relevance and performance."""
     mock_agent_graph = mocker.patch("prisma.models.AgentGraph.prisma")
     mock_agent_graph.return_value.find_many = mocker.AsyncMock(return_value=[])
 
@@ -191,24 +191,24 @@ async def test_list_library_agents_search_matches_snapshot_and_graph(mocker):
     await db.list_library_agents("test-user", search_term="Published Title")
 
     where = mock_find_many.call_args.kwargs["where"]
-    assert {"name": {"contains": "Published Title", "mode": "insensitive"}} in where[
-        "OR"
-    ]
-    assert {
-        "description": {"contains": "Published Title", "mode": "insensitive"}
-    } in where["OR"]
+    assert {"name": {"search": "Published Title"}} in where["OR"]
+    assert {"description": {"search": "Published Title"}} in where["OR"]
     assert {
         "AgentGraph": {
-            "is": {"name": {"contains": "Published Title", "mode": "insensitive"}}
+            "is": {"name": {"search": "Published Title"}}
         }
     } in where["OR"]
     assert {
         "AgentGraph": {
             "is": {
-                "description": {"contains": "Published Title", "mode": "insensitive"}
+                "description": {"search": "Published Title"}
             }
         }
     } in where["OR"]
+    # Ensure legacy ILIKE filters are not used
+    for clause in where["OR"]:
+        if "contains" in clause or (isinstance(clause, dict) and "contains" in str(clause)):
+            raise AssertionError(f"Legacy contains filter found: {clause}")
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/api/features/library/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/library/db_test.py
@@ -212,6 +212,41 @@ async def test_list_library_agents_search_uses_full_text_search(mocker):
 
 
 @pytest.mark.asyncio
+async def test_list_library_agents_search_normalizes_tsquery_operators(mocker):
+    """Search terms containing tsquery operators (AND, OR, NOT, etc.) should
+    be sanitized before reaching Prisma's search filter."""
+    mock_agent_graph = mocker.patch("prisma.models.AgentGraph.prisma")
+    mock_agent_graph.return_value.find_many = mocker.AsyncMock(return_value=[])
+
+    mock_find_many = mocker.AsyncMock(return_value=[])
+    mock_library_agent = mocker.patch("prisma.models.LibraryAgent.prisma")
+    mock_library_agent.return_value.find_many = mock_find_many
+    mock_library_agent.return_value.count = mocker.AsyncMock(return_value=0)
+
+    mocker.patch(
+        "backend.api.features.library.db._fetch_execution_counts",
+        new=mocker.AsyncMock(return_value={}),
+    )
+
+    await db.list_library_agents("test-user", search_term="test & (OR | NOT)")
+
+    where = mock_find_many.call_args.kwargs["where"]
+    for clause in where["OR"]:
+        if "search" in clause:
+            assert clause["search"] == "test OR"
+
+
+def test_normalize_search_term():
+    """_normalize_search_term strips tsquery operators and collapses whitespace."""
+    assert db._normalize_search_term("hello world") == "hello world"
+    assert db._normalize_search_term("test & OR | NOT") == "test OR NOT"
+    assert db._normalize_search_term("a (b | c) * d") == "a b c d"
+    assert db._normalize_search_term("  lots   of   spaces  ") == "lots of spaces"
+    assert db._normalize_search_term("it's a test") == "it's a test"
+    assert db._normalize_search_term(":::") == ""
+
+
+@pytest.mark.asyncio
 async def test_list_library_agents_exposes_matching_store_version_id(mocker):
     """The list response carries the approved StoreListingVersion id matching
     the agent's exact graph_id + graph_version, so install flows stay

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
 import random
+import re
 from collections.abc import Awaitable
 from typing import Any, cast
 
+from graphiti_core.driver.driver import GraphDriver
 from graphiti_core.driver.falkordb import STOPWORDS
 from graphiti_core.driver.falkordb_driver import FalkorDriver
 from graphiti_core.helpers import validate_group_ids
@@ -31,6 +33,74 @@ _PENDING_QUEUE_OVERFLOW = "max pending queries exceeded"
 # one wait into minutes. At default settings total backoff stays well within the
 # warm-context timeout budget.
 _MAX_RETRY_DELAY_SECONDS = 2.0
+
+
+# Cypher clauses that mutate the graph. Deliberately CONSERVATIVE: anything
+# matching takes the write path, so a false positive merely preserves today's
+# behaviour, while a false negative would send a real write to RO_QUERY and
+# fail it. The runtime fallback below covers that case anyway.
+_WRITE_CLAUSE_RE = re.compile(
+    r"\b(CREATE|MERGE|SET|DELETE|DETACH|REMOVE|DROP|FOREACH)\b", re.IGNORECASE
+)
+
+# FalkorDB's error when the graph key does not exist yet.
+_EMPTY_KEY_ERROR = "invalid graph operation on empty key"
+
+# FalkorDB's error when a write is attempted through GRAPH.RO_QUERY:
+# "graph.RO_QUERY is to be executed only on read-only queries".
+#
+# Match the full phrase, not a bare "read-only" substring. A spurious match
+# would send a genuine READ down the write path and materialize the graph —
+# the exact bug this routing exists to prevent. Redis's own replica error says
+# "read only" with no hyphen, so it cannot collide with this.
+_RO_VIOLATION = "read-only quer"
+
+
+# Quoted string literals, and // or /* */ comments. Stripped before clause
+# detection so a value like ``{kind: 'CREATE'}`` in an otherwise read-only
+# query is not mistaken for a write clause — that misread would send the query
+# down the graph-materializing path and reintroduce the very bug this fixes.
+_CYPHER_NOISE_RE = re.compile(
+    r"'(?:[^'\\]|\\.)*'"  # single-quoted literal
+    r"|\"(?:[^\"\\]|\\.)*\""  # double-quoted literal
+    r"|`(?:[^`]|``)*`"  # back-quoted identifier
+    r"|//[^\n]*"  # line comment
+    r"|/\*.*?\*/",  # block comment
+    re.DOTALL,
+)
+
+
+# Procedure calls that WRITE but contain no standalone clause keyword, so
+# _WRITE_CLAUSE_RE alone misses them: `\bCREATE\b` does not match
+# `createNodeIndex` — there is no word boundary between "create" and "Node".
+# graphiti-core builds its three fulltext indices this way
+# (graphiti_core/graph_queries.py), so every one of them was classified
+# read-only and bounced off RO_QUERY on the first write for every new group.
+_WRITE_PROCEDURE_RE = re.compile(
+    r"\bdb\.idx\.fulltext\.(createNodeIndex|createRelationshipIndex|drop)\b"
+    r"|\bdb\.create\.",
+    re.IGNORECASE,
+)
+
+
+def _strip_cypher_noise(cypher_query_: str) -> str:
+    """Blank out literals/comments so only real clause keywords remain."""
+    return _CYPHER_NOISE_RE.sub(" ", cypher_query_ or "")
+
+
+def _is_read_only_cypher(cypher_query_: str) -> bool:
+    """True when the query contains no mutating clause.
+
+    Read-only queries go to ``GRAPH.RO_QUERY``. This matters far more than
+    performance: ``GRAPH.QUERY`` MATERIALIZES THE GRAPH even for a pure MATCH,
+    so routing reads through it silently creates an empty, permanently
+    resident graph for every user merely looked at. That is what filled
+    FalkorDB to its maxmemory ceiling twice (2026-08-16 and again 2026-08-23,
+    the latter in a single weekly community-rebuild sweep: 91 -> 19,033
+    graphs, 100% of sampled ones empty).
+    """
+    text = _strip_cypher_noise(cypher_query_)
+    return not (_WRITE_CLAUSE_RE.search(text) or _WRITE_PROCEDURE_RE.search(text))
 
 
 def _is_pending_queue_overflow(exc: Exception) -> bool:
@@ -94,6 +164,31 @@ class AutoGPTFalkorDriver(FalkorDriver):
         """
         await super().build_indices_and_constraints()
 
+    def clone(self, database: str) -> "GraphDriver":
+        """Clone onto the SUBCLASS, never a plain upstream ``FalkorDriver``.
+
+        Upstream's ``clone()`` constructs a bare ``FalkorDriver``, which would
+        re-enable the init-time ``build_indices`` task (#14052) *and* route
+        every read back through ``graph.query`` — resurrecting both mass
+        graph-materialization bugs with no test covering it.
+
+        Not exercised today: every AutoGPT call site passes a single group_id.
+        graphiti-core clones only when ``group_id != driver._database`` or when
+        a search spans 2+ groups, so this is one line of insurance against a
+        future multi-group read.
+        """
+        if database == self._database:
+            return self
+        # Upstream also special-cases ``default_group_id`` ('\\_') and maps it to
+        # a 'default_db' database. That branch is unreachable here: both
+        # graphiti.py clone sites call validate_group_id() first, whose
+        # ^[a-zA-Z0-9_-]+$ pattern rejects the backslash, and the group_id=None
+        # path never clones. Noted rather than mirrored — if it ever did become
+        # reachable, this would create a graph literally named '\\_'.
+        return AutoGPTFalkorDriver(
+            falkor_db=self.client, database=database, build_indices=False
+        )
+
     async def execute_query(
         self, cypher_query_, **kwargs
     ) -> tuple[list[dict[str, Any]], list[str], None] | None:
@@ -118,12 +213,56 @@ class AutoGPTFalkorDriver(FalkorDriver):
         # runtime call upstream ``FalkorDriver.execute_query`` makes.
         params = cast(dict[str, object], convert_datetimes_to_strings(dict(kwargs)))
         attempts = max(1, graphiti_config.falkordb_query_max_attempts)
+        read_only = _is_read_only_cypher(cypher_query_)
 
-        for attempt in range(attempts):
+        attempt = 0
+        while attempt < attempts:
             try:
-                result = await cast(Awaitable[Any], graph.query(cypher_query_, params))
-                return self._to_records(result)
+                return self._to_records(
+                    await self._dispatch(graph, cypher_query_, params, read_only)
+                )
             except Exception as e:
+                message = str(e).lower()
+                if read_only and _EMPTY_KEY_ERROR in message:
+                    # No graph for this group yet, which simply means no
+                    # memories. Return an empty result rather than raising —
+                    # and deliberately do NOT retry via ``graph.query``, since
+                    # that would materialize the graph and reintroduce the bug
+                    # this routing exists to prevent.
+                    #
+                    # CAVEAT: FalkorDB checks key existence BEFORE
+                    # read-only-ness, so a MISCLASSIFIED WRITE against a
+                    # missing graph lands here rather than in the RO-violation
+                    # branch below, and is silently dropped. The classifier
+                    # covers every write in graphiti-core and this repo today
+                    # (clause keywords + write procedures), but log the query
+                    # so a future novel write clause is traceable rather than
+                    # invisible. Debug level because a genuine read against a
+                    # group with no memories yet is entirely normal and common.
+                    logger.debug(
+                        "Read on a group with no graph yet; returning empty. "
+                        "Query: %s",
+                        cypher_query_,
+                    )
+                    return [], [], None
+                if read_only and _RO_VIOLATION in message:
+                    # The classifier called a write read-only. Degrade to the
+                    # write path and log the query so the missing clause or
+                    # procedure can be added to _WRITE_CLAUSE_RE /
+                    # _WRITE_PROCEDURE_RE.
+                    #
+                    # `read_only = False` + `continue` retries on the SAME
+                    # attempt: the counter is not advanced here, so the write
+                    # actually runs. Consuming an attempt instead would, on the
+                    # final attempt or with max_attempts=1, skip the write
+                    # entirely and fall through to the "unreachable" assertion.
+                    logger.warning(
+                        "Query classified read-only but rejected by RO_QUERY; "
+                        "retrying as a write. Query: %s",
+                        cypher_query_,
+                    )
+                    read_only = False
+                    continue
                 if "already indexed" in str(e):
                     _UPSTREAM_QUERY_LOGGER.info(f"Index already exists: {e}")
                     return None
@@ -136,6 +275,7 @@ class AutoGPTFalkorDriver(FalkorDriver):
                         delay,
                     )
                     await asyncio.sleep(delay)
+                    attempt += 1
                     continue
                 # ``params`` hold user memory content (names, facts) — omit them
                 # from this Sentry-routed log to avoid leaking PII. The exception
@@ -145,6 +285,18 @@ class AutoGPTFalkorDriver(FalkorDriver):
                 )
                 raise
         raise AssertionError("unreachable: loop returns or raises on every path")
+
+    @staticmethod
+    async def _dispatch(graph, cypher_query_, params, read_only: bool) -> Any:
+        """Issue one attempt on the read-only or writing transport.
+
+        ``GRAPH.RO_QUERY`` cannot materialize a graph; ``GRAPH.QUERY`` does,
+        even for a bare MATCH. Keeping the choice here means every caller goes
+        through one place.
+        """
+        if read_only:
+            return await cast(Awaitable[Any], graph.ro_query(cypher_query_, params))
+        return await cast(Awaitable[Any], graph.query(cypher_query_, params))
 
     @staticmethod
     def _pending_queue_retry_delay(attempt: int) -> float:

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
@@ -21,6 +21,13 @@ def _set_query(driver: AutoGPTFalkorDriver, side_effect) -> AsyncMock:
     return query
 
 
+def _set_ro_query(driver: AutoGPTFalkorDriver, side_effect) -> AsyncMock:
+    """Wire ``graph.ro_query`` (reached via ``_get_graph``) to ``side_effect``."""
+    ro_query = AsyncMock(side_effect=side_effect)
+    driver.client.select_graph.return_value.ro_query = ro_query
+    return ro_query
+
+
 def _overflow() -> Exception:
     return Exception("Max pending queries exceeded")
 
@@ -187,7 +194,7 @@ async def test_execute_query_success_returns_upstream_shaped_records(
 ) -> None:
     """Happy path: no retry, and results are shaped like upstream
     (list-of-dicts, header, None)."""
-    _set_query(driver, [_FakeResult([("n.count", "count")], [[5]])])
+    _set_ro_query(driver, [_FakeResult([("n.count", "count")], [[5]])])
 
     records, header, meta = await driver.execute_query("MATCH (n) RETURN count(n)")
 
@@ -202,7 +209,7 @@ async def test_execute_query_retries_pending_queue_overflow_then_succeeds(
 ) -> None:
     """Two transient overflows are retried; the third attempt succeeds and its
     result is returned (memory op recovers instead of being dropped)."""
-    query = _set_query(
+    query = _set_ro_query(
         driver,
         [_overflow(), _overflow(), _FakeResult([("x", "count")], [[1]])],
     )
@@ -226,7 +233,7 @@ async def test_execute_query_raises_after_exhausting_retries(
 ) -> None:
     """A sustained overflow exhausts the budget, then raises AND logs exactly
     one terminal error under the upstream logger (so Sentry sees one event)."""
-    query = _set_query(driver, _overflow())
+    query = _set_ro_query(driver, _overflow())
 
     # max_attempts=4 (non-default) proves the knob controls the attempt count.
     with patch.object(fdb.asyncio, "sleep", new=AsyncMock()) as sleep, patch.object(
@@ -266,7 +273,7 @@ async def test_execute_query_non_overflow_error_fails_fast(
 ) -> None:
     """A genuine query error (Cypher typo, missing graph, teardown) is not
     retried — it raises on the first attempt and logs once."""
-    query = _set_query(driver, ValueError("syntax error near RETRN"))
+    query = _set_ro_query(driver, ValueError("syntax error near RETRN"))
 
     with patch.object(fdb.asyncio, "sleep", new=AsyncMock()) as sleep, patch.object(
         fdb, "_UPSTREAM_QUERY_LOGGER"
@@ -296,3 +303,183 @@ async def test_execute_query_already_indexed_returns_none_without_retry(
     assert query.await_count == 1
     sleep.assert_not_awaited()
     upstream_logger.error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Read-only query routing.
+#
+# GRAPH.QUERY materializes the graph even for a pure MATCH, so routing reads
+# through it silently creates an empty, permanently resident graph for every
+# user merely looked at. That filled FalkorDB to maxmemory twice — most
+# recently a single weekly community-rebuild sweep took prod from 91 to 19,033
+# graphs, 100% of sampled ones empty. Reads must use GRAPH.RO_QUERY.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cypher,expected_read_only",
+    [
+        ("MATCH (n) RETURN count(n)", True),
+        ("MATCH (n:Entity) WHERE n.group_id = $g RETURN n.name", True),
+        ("CALL db.idx.fulltext.queryNodes('Entity', $q) YIELD node RETURN node", True),
+        ("CREATE INDEX FOR (n:Entity) ON (n.uuid)", False),
+        ("MERGE (n:Entity {uuid: $u})", False),
+        ("MATCH (n) SET n.x = 1", False),
+        ("MATCH (n) DETACH DELETE n", False),
+        ("MATCH (n) REMOVE n.x", False),
+    ],
+)
+def test_read_only_cypher_classification(cypher, expected_read_only) -> None:
+    assert fdb._is_read_only_cypher(cypher) is expected_read_only
+
+
+@pytest.mark.asyncio
+async def test_read_only_query_uses_ro_query(driver: AutoGPTFalkorDriver) -> None:
+    """A MATCH must go to ro_query and must never touch the creating path."""
+    ro = _set_ro_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited_once()
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_query_uses_query(driver: AutoGPTFalkorDriver) -> None:
+    ro = _set_ro_query(driver, [_FakeResult([], [])])
+    write = _set_query(driver, [_FakeResult([], [])])
+    await driver.execute_query("MERGE (n:Entity {uuid: $u})", u="x")
+    write.assert_awaited_once()
+    ro.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_graph_returns_empty_without_creating(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """The regression guard.
+
+    A read against a group with no graph yet must yield an empty result, NOT
+    an error and NOT a fallback to ``graph.query`` — that fallback would
+    materialize the graph, which is the entire bug.
+    """
+    ro = _set_ro_query(driver, Exception("ERR Invalid graph operation on empty key"))
+    write = _set_query(driver, [_FakeResult([], [])])
+    records, header, _ = await driver.execute_query("MATCH (n) RETURN count(n)")
+    assert records == []
+    assert header == []
+    ro.assert_awaited_once()
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ro_violation_falls_back_to_write(driver: AutoGPTFalkorDriver) -> None:
+    """If the classifier is wrong, degrade to the write path rather than fail."""
+    ro = _set_ro_query(
+        driver, Exception("graph.RO_QUERY is to be executed only on read-only queries")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited_once()
+    write.assert_awaited_once()
+
+
+# --- regression guards for the review findings on the read-only routing ----
+
+
+@pytest.mark.parametrize(
+    "cypher",
+    [
+        "MATCH (n {kind: 'CREATE'}) RETURN n",
+        'MATCH (n) WHERE n.name = "DELETE" RETURN n',
+        "MATCH (n) RETURN n // SET is only mentioned in this comment",
+        "/* MERGE */ MATCH (n) RETURN n",
+    ],
+)
+def test_write_keywords_inside_literals_stay_read_only(cypher) -> None:
+    """A write keyword inside a string literal or comment must not flip the
+    query onto the graph-materializing path."""
+    assert fdb._is_read_only_cypher(cypher) is True
+
+
+@pytest.mark.asyncio
+async def test_ro_violation_on_final_attempt_still_writes(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """The RO fallback must not consume a retry.
+
+    With max_attempts=1 (or on the last attempt) a fallback that burned an
+    attempt would exit the loop having never issued the write, hitting the
+    "unreachable" AssertionError.
+    """
+    ro = _set_ro_query(
+        driver, Exception("graph.RO_QUERY is to be executed only on read-only queries")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    with patch(
+        "backend.copilot.graphiti.config.graphiti_config.falkordb_query_max_attempts",
+        1,
+    ):
+        records, _, _ = await driver.execute_query("MATCH (n) RETURN count(n)")
+    assert records == [{"n": 1}]
+    ro.assert_awaited_once()
+    write.assert_awaited_once()
+
+
+# --- guards for the fulltext index-creation writes -------------------------
+
+
+@pytest.mark.parametrize(
+    "cypher",
+    [
+        # graphiti-core builds all three fulltext indices this way. `\bCREATE\b`
+        # does NOT match `createNodeIndex`, so these were classified read-only
+        # and bounced off RO_QUERY on every new group's first write.
+        (
+            "CALL db.idx.fulltext.createNodeIndex({label: 'Episodic', stopwords: []},"
+            " 'content', 'source', 'source_description', 'group_id')"
+        ),
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Entity'}, 'name')",
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Community'}, 'name')",
+        "CALL db.idx.fulltext.drop('Entity')",
+    ],
+)
+def test_write_procedures_are_not_read_only(cypher) -> None:
+    assert fdb._is_read_only_cypher(cypher) is False
+
+
+def test_fulltext_query_procedure_stays_read_only() -> None:
+    """The search path must keep using RO_QUERY."""
+    assert (
+        fdb._is_read_only_cypher(
+            "CALL db.idx.fulltext.queryNodes('Entity', $query) YIELD node RETURN node"
+        )
+        is True
+    )
+
+
+def test_clone_returns_subclass_with_indices_disabled() -> None:
+    """Upstream clone() builds a plain FalkorDriver, which would re-enable the
+    init-time index task and route reads back through the creating path."""
+    driver = AutoGPTFalkorDriver(falkor_db=MagicMock())
+    driver._database = "user_a"
+    cloned = driver.clone("user_b")
+    assert isinstance(cloned, AutoGPTFalkorDriver)
+    assert cloned._build_indices_at_init is False
+    assert driver.clone("user_a") is driver
+
+
+@pytest.mark.asyncio
+async def test_unrelated_readonly_wording_does_not_trigger_write_fallback(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """A spurious RO-violation match would send a genuine READ down the write
+    path and materialize the graph. Redis's replica error ("read only", no
+    hyphen) must not be mistaken for FalkorDB's RO_QUERY rejection."""
+    ro = _set_ro_query(
+        driver, Exception("READONLY You can't write against a read only replica.")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    with pytest.raises(Exception, match="read only replica"):
+        await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited()
+    write.assert_not_called()


### PR DESCRIPTION
## Summary

Replace ILIKE (`contains` + `mode: insensitive`) with Prisma's full-text search filter (`search`) in `list_library_agents`. Closes #9479.

## Changes

- **`db.py`**: Changed search filter from `contains` to `search` for all four search targets (LibraryAgent name/description + AgentGraph name/description)
- **`db_test.py`**: Updated test to verify `search` filter is used and legacy `contains` patterns are rejected

## Motivation

PostgreSQL full-text search via `tsvector`/`tsquery` provides:

1. **Better relevance ranking** — matches are ranked by relevance rather than binary match/no-match
2. **Performance** — full-text search is optimized for text matching with GIN index support
3. **Already enabled** — the `fullTextSearch` preview feature was already in `schema.prisma` but not being utilized

## Testing

- Updated test `test_list_library_agents_search_uses_full_text_search` verifies correct filter usage
- Added assertion to reject legacy `contains` patterns
- All existing library tests remain compatible (search behavior is functionally equivalent, just better optimized)

## Notes

- The `fullTextSearch` preview feature was already enabled in `schema.prisma` generator config
- This is part of the parent issue #8774 (Library Improvements)
- A database migration adding GIN indexes on `name`/`description` columns would further improve performance at scale