### PR TITLE
Add Web Metadata Extractor blocks (security headers + tech stack)

### DIFF
--- a/autogpt_platform/backend/backend/blocks/webmetadata/_api.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/_api.py
@@ -9,9 +9,7 @@ RAPIDAPI_HOST = "web-metadata-and-contact-extractor.p.rapidapi.com"
 BASE_URL = f"https://{RAPIDAPI_HOST}"
 
 
-async def call_endpoint(
-    credentials: APIKeyCredentials, path: str, url: str
-) -> dict:
+async def call_endpoint(credentials: APIKeyCredentials, path: str, url: str) -> dict:
     """GET one of the API's /api/v1/* endpoints for the given target URL."""
     response = await Requests().get(
         f"{BASE_URL}{path}",

--- a/autogpt_platform/backend/backend/blocks/webmetadata/_api.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/_api.py
@@ -1,0 +1,24 @@
+"""
+Thin client for the Web Metadata Extractor API's RapidAPI gateway, shared by
+all blocks in this provider.
+"""
+
+from backend.sdk import APIKeyCredentials, Requests
+
+RAPIDAPI_HOST = "web-metadata-and-contact-extractor.p.rapidapi.com"
+BASE_URL = f"https://{RAPIDAPI_HOST}"
+
+
+async def call_endpoint(
+    credentials: APIKeyCredentials, path: str, url: str
+) -> dict:
+    """GET one of the API's /api/v1/* endpoints for the given target URL."""
+    response = await Requests().get(
+        f"{BASE_URL}{path}",
+        headers={
+            "X-RapidAPI-Key": credentials.api_key.get_secret_value(),
+            "X-RapidAPI-Host": RAPIDAPI_HOST,
+        },
+        params={"url": url},
+    )
+    return response.json()

--- a/autogpt_platform/backend/backend/blocks/webmetadata/_config.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/_config.py
@@ -10,12 +10,8 @@ from backend.sdk import BlockCostType, ProviderBuilder
 # Auth is a single RapidAPI key, free tier: 1,000 requests/month, no card.
 webmetadata_extractor = (
     ProviderBuilder("web_metadata_extractor")
-    .with_description(
-        "Security headers, tech-stack, and SEO intelligence for any URL"
-    )
-    .with_api_key(
-        "WEB_METADATA_EXTRACTOR_API_KEY", "Web Metadata Extractor API Key"
-    )
+    .with_description("Security headers, tech-stack, and SEO intelligence for any URL")
+    .with_api_key("WEB_METADATA_EXTRACTOR_API_KEY", "Web Metadata Extractor API Key")
     .with_base_cost(1, BlockCostType.RUN)
     .build()
 )

--- a/autogpt_platform/backend/backend/blocks/webmetadata/_config.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/_config.py
@@ -1,0 +1,21 @@
+"""
+Shared configuration for all Web Metadata Extractor blocks.
+"""
+
+from backend.sdk import BlockCostType, ProviderBuilder
+
+# Web Metadata Extractor (https://webmetadataextractor.com) is a single REST
+# API for SEO/OpenGraph metadata, HTTP security-header grading, tech-stack
+# fingerprinting, public contact discovery, and clean Markdown extraction.
+# Auth is a single RapidAPI key, free tier: 1,000 requests/month, no card.
+webmetadata_extractor = (
+    ProviderBuilder("web_metadata_extractor")
+    .with_description(
+        "Security headers, tech-stack, and SEO intelligence for any URL"
+    )
+    .with_api_key(
+        "WEB_METADATA_EXTRACTOR_API_KEY", "Web Metadata Extractor API Key"
+    )
+    .with_base_cost(1, BlockCostType.RUN)
+    .build()
+)

--- a/autogpt_platform/backend/backend/blocks/webmetadata/security_headers_audit.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/security_headers_audit.py
@@ -1,0 +1,105 @@
+from typing import Any
+
+from pydantic import SecretStr
+
+from backend.sdk import (
+    APIKeyCredentials,
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+    CredentialsMetaInput,
+    SchemaField,
+)
+
+from ._api import call_endpoint
+from ._config import webmetadata_extractor
+
+TEST_CREDENTIALS = APIKeyCredentials(
+    id="d6e9d3f5-8a1b-4c2e-9d7f-3b5a6c8e1f02",
+    provider="web_metadata_extractor",
+    api_key=SecretStr("mock-web-metadata-extractor-api-key"),
+    title="Mock Web Metadata Extractor API key",
+    expires_at=None,
+)
+TEST_CREDENTIALS_INPUT = {
+    "provider": TEST_CREDENTIALS.provider,
+    "id": TEST_CREDENTIALS.id,
+    "type": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.title,
+}
+
+
+class SecurityHeadersAuditBlock(Block):
+    """
+    Grades a URL's HTTP security headers (HSTS, CSP, X-Frame-Options,
+    X-Content-Type-Options, Referrer-Policy, Permissions-Policy) the same
+    way a browser-facing security scanner would — useful for agents doing
+    due diligence on a vendor/competitor site, or gating a deploy pipeline
+    on a minimum security score.
+    """
+
+    class Input(BlockSchemaInput):
+        credentials: CredentialsMetaInput = webmetadata_extractor.credentials_field(
+            description="Web Metadata Extractor API key (free tier: 1,000 requests/month, no card required)."
+        )
+        url: str = SchemaField(
+            description="The URL to audit", placeholder="https://example.com"
+        )
+
+    class Output(BlockSchemaOutput):
+        security_score_percentage: float = SchemaField(
+            description="Overall security-headers score, 0-100"
+        )
+        security_header_grades: dict[str, str] = SchemaField(
+            description="Per-header grade: missing, weak, report-only, reasonable, or strong"
+        )
+        security_headers: dict[str, Any] = SchemaField(
+            description="The raw header values that were graded"
+        )
+
+    def __init__(self):
+        super().__init__(
+            id="52d51ab9-1b71-40be-8dc5-673a0282d4fb",
+            description="Grades a URL's HTTP security headers (HSTS, CSP, X-Frame-Options, etc.) with a 0-100 score.",
+            categories={BlockCategory.SEARCH, BlockCategory.DEVELOPER_TOOLS},
+            input_schema=self.Input,
+            output_schema=self.Output,
+            test_input={
+                "url": "https://example.com",
+                "credentials": TEST_CREDENTIALS_INPUT,
+            },
+            test_credentials=TEST_CREDENTIALS,
+            test_output=[
+                ("security_score_percentage", 85.0),
+                (
+                    "security_header_grades",
+                    {"strict_transport_security": "strong"},
+                ),
+                ("security_headers", dict),
+            ],
+            test_mock={
+                "_fetch_security_audit": lambda *args, **kwargs: {
+                    "security_score_percentage": 85.0,
+                    "security_header_grades": {"strict_transport_security": "strong"},
+                    "security_headers": {
+                        "strict_transport_security": "max-age=31536000"
+                    },
+                }
+            },
+        )
+
+    async def _fetch_security_audit(
+        self, credentials: APIKeyCredentials, url: str
+    ) -> dict:
+        """Private method so the network call can be mocked in tests."""
+        return await call_endpoint(credentials, "/api/v1/security", url)
+
+    async def run(
+        self, input_data: Input, *, credentials: APIKeyCredentials, **kwargs
+    ) -> BlockOutput:
+        data = await self._fetch_security_audit(credentials, input_data.url)
+        yield "security_score_percentage", data.get("security_score_percentage", 0)
+        yield "security_header_grades", data.get("security_header_grades", {})
+        yield "security_headers", data.get("security_headers", {})

--- a/autogpt_platform/backend/backend/blocks/webmetadata/tech_stack_detector.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/tech_stack_detector.py
@@ -83,14 +83,20 @@ class TechStackDetectorBlock(Block):
                 (
                     "technology",
                     TechnologyDetail(
-                        name="WordPress", category="cms", confidence=0.9
+                        name="WordPress",
+                        category="cms",
+                        confidence=0.9,
+                        evidence=["wp-content"],
                     ),
                 ),
                 (
                     "technologies",
                     [
                         TechnologyDetail(
-                            name="WordPress", category="cms", confidence=0.9
+                            name="WordPress",
+                            category="cms",
+                            confidence=0.9,
+                            evidence=["wp-content"],
                         )
                     ],
                 ),

--- a/autogpt_platform/backend/backend/blocks/webmetadata/tech_stack_detector.py
+++ b/autogpt_platform/backend/backend/blocks/webmetadata/tech_stack_detector.py
@@ -1,0 +1,137 @@
+from typing import Any
+
+from pydantic import BaseModel, SecretStr
+
+from backend.sdk import (
+    APIKeyCredentials,
+    Block,
+    BlockCategory,
+    BlockOutput,
+    BlockSchemaInput,
+    BlockSchemaOutput,
+    CredentialsMetaInput,
+    SchemaField,
+)
+
+from ._api import call_endpoint
+from ._config import webmetadata_extractor
+
+TEST_CREDENTIALS = APIKeyCredentials(
+    id="d6e9d3f5-8a1b-4c2e-9d7f-3b5a6c8e1f02",
+    provider="web_metadata_extractor",
+    api_key=SecretStr("mock-web-metadata-extractor-api-key"),
+    title="Mock Web Metadata Extractor API key",
+    expires_at=None,
+)
+TEST_CREDENTIALS_INPUT = {
+    "provider": TEST_CREDENTIALS.provider,
+    "id": TEST_CREDENTIALS.id,
+    "type": TEST_CREDENTIALS.type,
+    "title": TEST_CREDENTIALS.title,
+}
+
+
+class TechnologyDetail(BaseModel):
+    name: str
+    category: str
+    confidence: float
+    evidence: list[str] = []
+
+
+class TechStackDetectorBlock(Block):
+    """
+    Fingerprints the CMS/framework/analytics/e-commerce stack a URL is built
+    on (WordPress, Shopify, Next.js, Cloudflare, Google Tag Manager, and
+    40+ others) from response headers and page markers — useful for an
+    agent qualifying leads by platform, or picking the right integration
+    approach for a target site.
+    """
+
+    class Input(BlockSchemaInput):
+        credentials: CredentialsMetaInput = webmetadata_extractor.credentials_field(
+            description="Web Metadata Extractor API key (free tier: 1,000 requests/month, no card required)."
+        )
+        url: str = SchemaField(
+            description="The URL to inspect", placeholder="https://example.com"
+        )
+
+    class Output(BlockSchemaOutput):
+        detected_technologies: list[str] = SchemaField(
+            description="Names of every technology detected"
+        )
+        technology: TechnologyDetail = SchemaField(
+            description="A single detected technology, with category/confidence/evidence"
+        )
+        technologies: list[TechnologyDetail] = SchemaField(
+            description="All detected technologies, with category/confidence/evidence"
+        )
+
+    def __init__(self):
+        super().__init__(
+            id="528a009b-4094-4292-b431-f257b52f9c29",
+            description="Fingerprints the CMS/framework/analytics stack (WordPress, Shopify, Next.js, etc.) a URL is built on.",
+            categories={BlockCategory.SEARCH, BlockCategory.DATA},
+            input_schema=self.Input,
+            output_schema=self.Output,
+            test_input={
+                "url": "https://example.com",
+                "credentials": TEST_CREDENTIALS_INPUT,
+            },
+            test_credentials=TEST_CREDENTIALS,
+            test_output=[
+                ("detected_technologies", ["WordPress"]),
+                (
+                    "technology",
+                    TechnologyDetail(
+                        name="WordPress", category="cms", confidence=0.9
+                    ),
+                ),
+                (
+                    "technologies",
+                    [
+                        TechnologyDetail(
+                            name="WordPress", category="cms", confidence=0.9
+                        )
+                    ],
+                ),
+            ],
+            test_mock={
+                "_fetch_tech_stack": lambda *args, **kwargs: {
+                    "detected_technologies": ["WordPress"],
+                    "technology_details": [
+                        {
+                            "name": "WordPress",
+                            "category": "cms",
+                            "confidence": 0.9,
+                            "evidence": ["wp-content"],
+                        }
+                    ],
+                }
+            },
+        )
+
+    async def _fetch_tech_stack(
+        self, credentials: APIKeyCredentials, url: str
+    ) -> dict[str, Any]:
+        """Private method so the network call can be mocked in tests."""
+        return await call_endpoint(credentials, "/api/v1/tech-stack", url)
+
+    async def run(
+        self, input_data: Input, *, credentials: APIKeyCredentials, **kwargs
+    ) -> BlockOutput:
+        data = await self._fetch_tech_stack(credentials, input_data.url)
+
+        yield "detected_technologies", data.get("detected_technologies", [])
+
+        technologies = [
+            TechnologyDetail(
+                name=t.get("name", ""),
+                category=t.get("category", ""),
+                confidence=t.get("confidence", 0.0),
+                evidence=t.get("evidence", []),
+            )
+            for t in data.get("technology_details", [])
+        ]
+        for technology in technologies:
+            yield "technology", technology
+        yield "technologies", technologies

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
 import random
+import re
 from collections.abc import Awaitable
 from typing import Any, cast
 
+from graphiti_core.driver.driver import GraphDriver
 from graphiti_core.driver.falkordb import STOPWORDS
 from graphiti_core.driver.falkordb_driver import FalkorDriver
 from graphiti_core.helpers import validate_group_ids
@@ -31,6 +33,74 @@ _PENDING_QUEUE_OVERFLOW = "max pending queries exceeded"
 # one wait into minutes. At default settings total backoff stays well within the
 # warm-context timeout budget.
 _MAX_RETRY_DELAY_SECONDS = 2.0
+
+
+# Cypher clauses that mutate the graph. Deliberately CONSERVATIVE: anything
+# matching takes the write path, so a false positive merely preserves today's
+# behaviour, while a false negative would send a real write to RO_QUERY and
+# fail it. The runtime fallback below covers that case anyway.
+_WRITE_CLAUSE_RE = re.compile(
+    r"\b(CREATE|MERGE|SET|DELETE|DETACH|REMOVE|DROP|FOREACH)\b", re.IGNORECASE
+)
+
+# FalkorDB's error when the graph key does not exist yet.
+_EMPTY_KEY_ERROR = "invalid graph operation on empty key"
+
+# FalkorDB's error when a write is attempted through GRAPH.RO_QUERY:
+# "graph.RO_QUERY is to be executed only on read-only queries".
+#
+# Match the full phrase, not a bare "read-only" substring. A spurious match
+# would send a genuine READ down the write path and materialize the graph —
+# the exact bug this routing exists to prevent. Redis's own replica error says
+# "read only" with no hyphen, so it cannot collide with this.
+_RO_VIOLATION = "read-only quer"
+
+
+# Quoted string literals, and // or /* */ comments. Stripped before clause
+# detection so a value like ``{kind: 'CREATE'}`` in an otherwise read-only
+# query is not mistaken for a write clause — that misread would send the query
+# down the graph-materializing path and reintroduce the very bug this fixes.
+_CYPHER_NOISE_RE = re.compile(
+    r"'(?:[^'\\]|\\.)*'"  # single-quoted literal
+    r"|\"(?:[^\"\\]|\\.)*\""  # double-quoted literal
+    r"|`(?:[^`]|``)*`"  # back-quoted identifier
+    r"|//[^\n]*"  # line comment
+    r"|/\*.*?\*/",  # block comment
+    re.DOTALL,
+)
+
+
+# Procedure calls that WRITE but contain no standalone clause keyword, so
+# _WRITE_CLAUSE_RE alone misses them: `\bCREATE\b` does not match
+# `createNodeIndex` — there is no word boundary between "create" and "Node".
+# graphiti-core builds its three fulltext indices this way
+# (graphiti_core/graph_queries.py), so every one of them was classified
+# read-only and bounced off RO_QUERY on the first write for every new group.
+_WRITE_PROCEDURE_RE = re.compile(
+    r"\bdb\.idx\.fulltext\.(createNodeIndex|createRelationshipIndex|drop)\b"
+    r"|\bdb\.create\.",
+    re.IGNORECASE,
+)
+
+
+def _strip_cypher_noise(cypher_query_: str) -> str:
+    """Blank out literals/comments so only real clause keywords remain."""
+    return _CYPHER_NOISE_RE.sub(" ", cypher_query_ or "")
+
+
+def _is_read_only_cypher(cypher_query_: str) -> bool:
+    """True when the query contains no mutating clause.
+
+    Read-only queries go to ``GRAPH.RO_QUERY``. This matters far more than
+    performance: ``GRAPH.QUERY`` MATERIALIZES THE GRAPH even for a pure MATCH,
+    so routing reads through it silently creates an empty, permanently
+    resident graph for every user merely looked at. That is what filled
+    FalkorDB to its maxmemory ceiling twice (2026-08-16 and again 2026-08-23,
+    the latter in a single weekly community-rebuild sweep: 91 -> 19,033
+    graphs, 100% of sampled ones empty).
+    """
+    text = _strip_cypher_noise(cypher_query_)
+    return not (_WRITE_CLAUSE_RE.search(text) or _WRITE_PROCEDURE_RE.search(text))
 
 
 def _is_pending_queue_overflow(exc: Exception) -> bool:
@@ -94,6 +164,31 @@ class AutoGPTFalkorDriver(FalkorDriver):
         """
         await super().build_indices_and_constraints()
 
+    def clone(self, database: str) -> "GraphDriver":
+        """Clone onto the SUBCLASS, never a plain upstream ``FalkorDriver``.
+
+        Upstream's ``clone()`` constructs a bare ``FalkorDriver``, which would
+        re-enable the init-time ``build_indices`` task (#14052) *and* route
+        every read back through ``graph.query`` — resurrecting both mass
+        graph-materialization bugs with no test covering it.
+
+        Not exercised today: every AutoGPT call site passes a single group_id.
+        graphiti-core clones only when ``group_id != driver._database`` or when
+        a search spans 2+ groups, so this is one line of insurance against a
+        future multi-group read.
+        """
+        if database == self._database:
+            return self
+        # Upstream also special-cases ``default_group_id`` ('\\_') and maps it to
+        # a 'default_db' database. That branch is unreachable here: both
+        # graphiti.py clone sites call validate_group_id() first, whose
+        # ^[a-zA-Z0-9_-]+$ pattern rejects the backslash, and the group_id=None
+        # path never clones. Noted rather than mirrored — if it ever did become
+        # reachable, this would create a graph literally named '\\_'.
+        return AutoGPTFalkorDriver(
+            falkor_db=self.client, database=database, build_indices=False
+        )
+
     async def execute_query(
         self, cypher_query_, **kwargs
     ) -> tuple[list[dict[str, Any]], list[str], None] | None:
@@ -118,12 +213,56 @@ class AutoGPTFalkorDriver(FalkorDriver):
         # runtime call upstream ``FalkorDriver.execute_query`` makes.
         params = cast(dict[str, object], convert_datetimes_to_strings(dict(kwargs)))
         attempts = max(1, graphiti_config.falkordb_query_max_attempts)
+        read_only = _is_read_only_cypher(cypher_query_)
 
-        for attempt in range(attempts):
+        attempt = 0
+        while attempt < attempts:
             try:
-                result = await cast(Awaitable[Any], graph.query(cypher_query_, params))
-                return self._to_records(result)
+                return self._to_records(
+                    await self._dispatch(graph, cypher_query_, params, read_only)
+                )
             except Exception as e:
+                message = str(e).lower()
+                if read_only and _EMPTY_KEY_ERROR in message:
+                    # No graph for this group yet, which simply means no
+                    # memories. Return an empty result rather than raising —
+                    # and deliberately do NOT retry via ``graph.query``, since
+                    # that would materialize the graph and reintroduce the bug
+                    # this routing exists to prevent.
+                    #
+                    # CAVEAT: FalkorDB checks key existence BEFORE
+                    # read-only-ness, so a MISCLASSIFIED WRITE against a
+                    # missing graph lands here rather than in the RO-violation
+                    # branch below, and is silently dropped. The classifier
+                    # covers every write in graphiti-core and this repo today
+                    # (clause keywords + write procedures), but log the query
+                    # so a future novel write clause is traceable rather than
+                    # invisible. Debug level because a genuine read against a
+                    # group with no memories yet is entirely normal and common.
+                    logger.debug(
+                        "Read on a group with no graph yet; returning empty. "
+                        "Query: %s",
+                        cypher_query_,
+                    )
+                    return [], [], None
+                if read_only and _RO_VIOLATION in message:
+                    # The classifier called a write read-only. Degrade to the
+                    # write path and log the query so the missing clause or
+                    # procedure can be added to _WRITE_CLAUSE_RE /
+                    # _WRITE_PROCEDURE_RE.
+                    #
+                    # `read_only = False` + `continue` retries on the SAME
+                    # attempt: the counter is not advanced here, so the write
+                    # actually runs. Consuming an attempt instead would, on the
+                    # final attempt or with max_attempts=1, skip the write
+                    # entirely and fall through to the "unreachable" assertion.
+                    logger.warning(
+                        "Query classified read-only but rejected by RO_QUERY; "
+                        "retrying as a write. Query: %s",
+                        cypher_query_,
+                    )
+                    read_only = False
+                    continue
                 if "already indexed" in str(e):
                     _UPSTREAM_QUERY_LOGGER.info(f"Index already exists: {e}")
                     return None
@@ -136,6 +275,7 @@ class AutoGPTFalkorDriver(FalkorDriver):
                         delay,
                     )
                     await asyncio.sleep(delay)
+                    attempt += 1
                     continue
                 # ``params`` hold user memory content (names, facts) — omit them
                 # from this Sentry-routed log to avoid leaking PII. The exception
@@ -145,6 +285,18 @@ class AutoGPTFalkorDriver(FalkorDriver):
                 )
                 raise
         raise AssertionError("unreachable: loop returns or raises on every path")
+
+    @staticmethod
+    async def _dispatch(graph, cypher_query_, params, read_only: bool) -> Any:
+        """Issue one attempt on the read-only or writing transport.
+
+        ``GRAPH.RO_QUERY`` cannot materialize a graph; ``GRAPH.QUERY`` does,
+        even for a bare MATCH. Keeping the choice here means every caller goes
+        through one place.
+        """
+        if read_only:
+            return await cast(Awaitable[Any], graph.ro_query(cypher_query_, params))
+        return await cast(Awaitable[Any], graph.query(cypher_query_, params))
 
     @staticmethod
     def _pending_queue_retry_delay(attempt: int) -> float:

--- a/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/falkordb_driver_test.py
@@ -21,6 +21,13 @@ def _set_query(driver: AutoGPTFalkorDriver, side_effect) -> AsyncMock:
     return query
 
 
+def _set_ro_query(driver: AutoGPTFalkorDriver, side_effect) -> AsyncMock:
+    """Wire ``graph.ro_query`` (reached via ``_get_graph``) to ``side_effect``."""
+    ro_query = AsyncMock(side_effect=side_effect)
+    driver.client.select_graph.return_value.ro_query = ro_query
+    return ro_query
+
+
 def _overflow() -> Exception:
     return Exception("Max pending queries exceeded")
 
@@ -187,7 +194,7 @@ async def test_execute_query_success_returns_upstream_shaped_records(
 ) -> None:
     """Happy path: no retry, and results are shaped like upstream
     (list-of-dicts, header, None)."""
-    _set_query(driver, [_FakeResult([("n.count", "count")], [[5]])])
+    _set_ro_query(driver, [_FakeResult([("n.count", "count")], [[5]])])
 
     records, header, meta = await driver.execute_query("MATCH (n) RETURN count(n)")
 
@@ -202,7 +209,7 @@ async def test_execute_query_retries_pending_queue_overflow_then_succeeds(
 ) -> None:
     """Two transient overflows are retried; the third attempt succeeds and its
     result is returned (memory op recovers instead of being dropped)."""
-    query = _set_query(
+    query = _set_ro_query(
         driver,
         [_overflow(), _overflow(), _FakeResult([("x", "count")], [[1]])],
     )
@@ -226,7 +233,7 @@ async def test_execute_query_raises_after_exhausting_retries(
 ) -> None:
     """A sustained overflow exhausts the budget, then raises AND logs exactly
     one terminal error under the upstream logger (so Sentry sees one event)."""
-    query = _set_query(driver, _overflow())
+    query = _set_ro_query(driver, _overflow())
 
     # max_attempts=4 (non-default) proves the knob controls the attempt count.
     with patch.object(fdb.asyncio, "sleep", new=AsyncMock()) as sleep, patch.object(
@@ -266,7 +273,7 @@ async def test_execute_query_non_overflow_error_fails_fast(
 ) -> None:
     """A genuine query error (Cypher typo, missing graph, teardown) is not
     retried — it raises on the first attempt and logs once."""
-    query = _set_query(driver, ValueError("syntax error near RETRN"))
+    query = _set_ro_query(driver, ValueError("syntax error near RETRN"))
 
     with patch.object(fdb.asyncio, "sleep", new=AsyncMock()) as sleep, patch.object(
         fdb, "_UPSTREAM_QUERY_LOGGER"
@@ -296,3 +303,183 @@ async def test_execute_query_already_indexed_returns_none_without_retry(
     assert query.await_count == 1
     sleep.assert_not_awaited()
     upstream_logger.error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Read-only query routing.
+#
+# GRAPH.QUERY materializes the graph even for a pure MATCH, so routing reads
+# through it silently creates an empty, permanently resident graph for every
+# user merely looked at. That filled FalkorDB to maxmemory twice — most
+# recently a single weekly community-rebuild sweep took prod from 91 to 19,033
+# graphs, 100% of sampled ones empty. Reads must use GRAPH.RO_QUERY.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cypher,expected_read_only",
+    [
+        ("MATCH (n) RETURN count(n)", True),
+        ("MATCH (n:Entity) WHERE n.group_id = $g RETURN n.name", True),
+        ("CALL db.idx.fulltext.queryNodes('Entity', $q) YIELD node RETURN node", True),
+        ("CREATE INDEX FOR (n:Entity) ON (n.uuid)", False),
+        ("MERGE (n:Entity {uuid: $u})", False),
+        ("MATCH (n) SET n.x = 1", False),
+        ("MATCH (n) DETACH DELETE n", False),
+        ("MATCH (n) REMOVE n.x", False),
+    ],
+)
+def test_read_only_cypher_classification(cypher, expected_read_only) -> None:
+    assert fdb._is_read_only_cypher(cypher) is expected_read_only
+
+
+@pytest.mark.asyncio
+async def test_read_only_query_uses_ro_query(driver: AutoGPTFalkorDriver) -> None:
+    """A MATCH must go to ro_query and must never touch the creating path."""
+    ro = _set_ro_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited_once()
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_query_uses_query(driver: AutoGPTFalkorDriver) -> None:
+    ro = _set_ro_query(driver, [_FakeResult([], [])])
+    write = _set_query(driver, [_FakeResult([], [])])
+    await driver.execute_query("MERGE (n:Entity {uuid: $u})", u="x")
+    write.assert_awaited_once()
+    ro.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_graph_returns_empty_without_creating(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """The regression guard.
+
+    A read against a group with no graph yet must yield an empty result, NOT
+    an error and NOT a fallback to ``graph.query`` — that fallback would
+    materialize the graph, which is the entire bug.
+    """
+    ro = _set_ro_query(driver, Exception("ERR Invalid graph operation on empty key"))
+    write = _set_query(driver, [_FakeResult([], [])])
+    records, header, _ = await driver.execute_query("MATCH (n) RETURN count(n)")
+    assert records == []
+    assert header == []
+    ro.assert_awaited_once()
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ro_violation_falls_back_to_write(driver: AutoGPTFalkorDriver) -> None:
+    """If the classifier is wrong, degrade to the write path rather than fail."""
+    ro = _set_ro_query(
+        driver, Exception("graph.RO_QUERY is to be executed only on read-only queries")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited_once()
+    write.assert_awaited_once()
+
+
+# --- regression guards for the review findings on the read-only routing ----
+
+
+@pytest.mark.parametrize(
+    "cypher",
+    [
+        "MATCH (n {kind: 'CREATE'}) RETURN n",
+        'MATCH (n) WHERE n.name = "DELETE" RETURN n',
+        "MATCH (n) RETURN n // SET is only mentioned in this comment",
+        "/* MERGE */ MATCH (n) RETURN n",
+    ],
+)
+def test_write_keywords_inside_literals_stay_read_only(cypher) -> None:
+    """A write keyword inside a string literal or comment must not flip the
+    query onto the graph-materializing path."""
+    assert fdb._is_read_only_cypher(cypher) is True
+
+
+@pytest.mark.asyncio
+async def test_ro_violation_on_final_attempt_still_writes(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """The RO fallback must not consume a retry.
+
+    With max_attempts=1 (or on the last attempt) a fallback that burned an
+    attempt would exit the loop having never issued the write, hitting the
+    "unreachable" AssertionError.
+    """
+    ro = _set_ro_query(
+        driver, Exception("graph.RO_QUERY is to be executed only on read-only queries")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    with patch(
+        "backend.copilot.graphiti.config.graphiti_config.falkordb_query_max_attempts",
+        1,
+    ):
+        records, _, _ = await driver.execute_query("MATCH (n) RETURN count(n)")
+    assert records == [{"n": 1}]
+    ro.assert_awaited_once()
+    write.assert_awaited_once()
+
+
+# --- guards for the fulltext index-creation writes -------------------------
+
+
+@pytest.mark.parametrize(
+    "cypher",
+    [
+        # graphiti-core builds all three fulltext indices this way. `\bCREATE\b`
+        # does NOT match `createNodeIndex`, so these were classified read-only
+        # and bounced off RO_QUERY on every new group's first write.
+        (
+            "CALL db.idx.fulltext.createNodeIndex({label: 'Episodic', stopwords: []},"
+            " 'content', 'source', 'source_description', 'group_id')"
+        ),
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Entity'}, 'name')",
+        "CALL db.idx.fulltext.createNodeIndex({label: 'Community'}, 'name')",
+        "CALL db.idx.fulltext.drop('Entity')",
+    ],
+)
+def test_write_procedures_are_not_read_only(cypher) -> None:
+    assert fdb._is_read_only_cypher(cypher) is False
+
+
+def test_fulltext_query_procedure_stays_read_only() -> None:
+    """The search path must keep using RO_QUERY."""
+    assert (
+        fdb._is_read_only_cypher(
+            "CALL db.idx.fulltext.queryNodes('Entity', $query) YIELD node RETURN node"
+        )
+        is True
+    )
+
+
+def test_clone_returns_subclass_with_indices_disabled() -> None:
+    """Upstream clone() builds a plain FalkorDriver, which would re-enable the
+    init-time index task and route reads back through the creating path."""
+    driver = AutoGPTFalkorDriver(falkor_db=MagicMock())
+    driver._database = "user_a"
+    cloned = driver.clone("user_b")
+    assert isinstance(cloned, AutoGPTFalkorDriver)
+    assert cloned._build_indices_at_init is False
+    assert driver.clone("user_a") is driver
+
+
+@pytest.mark.asyncio
+async def test_unrelated_readonly_wording_does_not_trigger_write_fallback(
+    driver: AutoGPTFalkorDriver,
+) -> None:
+    """A spurious RO-violation match would send a genuine READ down the write
+    path and materialize the graph. Redis's replica error ("read only", no
+    hyphen) must not be mistaken for FalkorDB's RO_QUERY rejection."""
+    ro = _set_ro_query(
+        driver, Exception("READONLY You can't write against a read only replica.")
+    )
+    write = _set_query(driver, [_FakeResult([("x", "n")], [[1]])])
+    with pytest.raises(Exception, match="read only replica"):
+        await driver.execute_query("MATCH (n) RETURN count(n)")
+    ro.assert_awaited()
+    write.assert_not_called()

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -195,6 +195,7 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [Stripe Link MPP Pay](block-integrations/stripe_link/mpp.md#stripe-link-mpp-pay) | MPP step 3 of 3: spend an approved Shared Payment Token at the merchant's endpoint |
 | [Stripe Link Retrieve Card](block-integrations/stripe_link/spend_request.md#stripe-link-retrieve-card) | Get the one-time virtual card number and CVC for an approved spend request, to type into a normal checkout form |
 | [Stripe Subscription Trigger](block-integrations/stripe/triggers.md#stripe-subscription-trigger) | Triggers on Stripe subscription events (new, upgrade, cancel) |
+| [Tech Stack Detector](block-integrations/webmetadata/tech_stack_detector.md#tech-stack-detector) | Fingerprints the CMS/framework/analytics stack (WordPress, Shopify, Next |
 
 ## Text Processing
 
@@ -558,6 +559,7 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 | [Github Update File](block-integrations/github/repo_files.md#github-update-file) | This block updates an existing file in a GitHub repository |
 | [Instantiate Code Sandbox](block-integrations/misc.md#instantiate-code-sandbox) | Instantiate a sandbox environment with internet access in which you can execute code with the Execute Code Step block |
 | [MCP Tool](block-integrations/mcp/block.md#mcp-tool) | Connect to any MCP server and execute its tools |
+| [Security Headers Audit](block-integrations/webmetadata/security_headers_audit.md#security-headers-audit) | Grades a URL's HTTP security headers (HSTS, CSP, X-Frame-Options, etc |
 | [Slant3D Order Webhook](block-integrations/slant3d/webhook.md#slant3d-order-webhook) | This block triggers on Slant3D order status updates and outputs the event details, including tracking information when orders are shipped |
 
 ## Media Generation

--- a/docs/integrations/SUMMARY.md
+++ b/docs/integrations/SUMMARY.md
@@ -167,5 +167,7 @@
 * [Video Loop](block-integrations/video/loop.md)
 * [Video Narration](block-integrations/video/narration.md)
 * [Video Text Overlay](block-integrations/video/text_overlay.md)
+* [Webmetadata Security Headers Audit](block-integrations/webmetadata/security_headers_audit.md)
+* [Webmetadata Tech Stack Detector](block-integrations/webmetadata/tech_stack_detector.md)
 * [Wolfram LLM API](block-integrations/wolfram/llm_api.md)
 * [Zerobounce Validate Emails](block-integrations/zerobounce/validate_emails.md)

--- a/docs/integrations/block-integrations/webmetadata/security_headers_audit.md
+++ b/docs/integrations/block-integrations/webmetadata/security_headers_audit.md
@@ -1,0 +1,40 @@
+# Webmetadata Security Headers Audit
+<!-- MANUAL: file_description -->
+Blocks backed by the [Web Metadata Extractor API](https://webmetadataextractor.com/) (free tier: 1,000 requests/month, no card required).
+<!-- END MANUAL -->
+
+## Security Headers Audit
+
+### What it is
+Grades a URL's HTTP security headers (HSTS, CSP, X-Frame-Options, etc.) with a 0-100 score.
+
+### How it works
+<!-- MANUAL: how_it_works -->
+The block sends the target URL to the API's `/api/v1/security` endpoint, which fetches the page once and inspects six response headers: `Strict-Transport-Security`, `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy`. Each header is graded independently as `missing`, `weak`, `report-only`, `reasonable`, or `strong` based on its actual directive values (e.g. a CSP with `unsafe-inline` grades weaker than one without it), and the per-header grades are combined into a single 0-100 score.
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| url | The URL to audit | str | Yes |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| error | Error message if the operation failed | str |
+| security_score_percentage | Overall security-headers score, 0-100 | float |
+| security_header_grades | Per-header grade: missing, weak, report-only, reasonable, or strong | Dict[str, str] |
+| security_headers | The raw header values that were graded | Dict[str, Any] |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+**Vendor/Competitor Due Diligence**: Have an agent check a prospective vendor's or a competitor's site for baseline security hygiene before a partnership or comparison report.
+
+**Deploy Pipeline Gate**: Chain this block after a deploy step and branch the graph on `security_score_percentage` to alert or block a release that regresses below a minimum score.
+
+**Bulk Portfolio Audit**: Loop this block over a list of URLs (e.g. all the sites a client manages) to flag which ones are missing HSTS or CSP and need remediation.
+<!-- END MANUAL -->
+
+---

--- a/docs/integrations/block-integrations/webmetadata/tech_stack_detector.md
+++ b/docs/integrations/block-integrations/webmetadata/tech_stack_detector.md
@@ -1,0 +1,40 @@
+# Webmetadata Tech Stack Detector
+<!-- MANUAL: file_description -->
+Blocks backed by the [Web Metadata Extractor API](https://webmetadataextractor.com/) (free tier: 1,000 requests/month, no card required).
+<!-- END MANUAL -->
+
+## Tech Stack Detector
+
+### What it is
+Fingerprints the CMS/framework/analytics stack (WordPress, Shopify, Next.js, etc.) a URL is built on.
+
+### How it works
+<!-- MANUAL: how_it_works -->
+The block sends the target URL to the API's `/api/v1/tech-stack` endpoint, which fetches the page once and matches its response headers and HTML markers against 40+ known technology signatures (CMS, e-commerce, frameworks, analytics, hosting/CDN). Each match is returned with a category (e.g. `cms`, `analytics`), a confidence score, and the specific evidence string that triggered the detection (e.g. `wp-content` for WordPress).
+<!-- END MANUAL -->
+
+### Inputs
+
+| Input | Description | Type | Required |
+|-------|-------------|------|----------|
+| url | The URL to inspect | str | Yes |
+
+### Outputs
+
+| Output | Description | Type |
+|--------|-------------|------|
+| error | Error message if the operation failed | str |
+| detected_technologies | Names of every technology detected | List[str] |
+| technology | A single detected technology, with category/confidence/evidence | TechnologyDetail |
+| technologies | All detected technologies, with category/confidence/evidence | List[TechnologyDetail] |
+
+### Possible use case
+<!-- MANUAL: use_case -->
+**Lead Qualification by Platform**: Have an agent scan a list of prospect URLs and route Shopify sites to one outreach template and WordPress sites to another.
+
+**Integration Feasibility Check**: Before proposing an integration with a target site, detect whether it's built on a platform (e.g. Webflow) that would block or complicate the approach.
+
+**Competitive Landscape Mapping**: Loop this block over a category of competitor sites to build a quick report of which frameworks/analytics tools are common in that market.
+<!-- END MANUAL -->
+
+---


### PR DESCRIPTION
## What

Two new blocks under a new `web_metadata_extractor` provider (single API key, [free tier](https://rapidapi.com/josejuanjocoding/api/web-metadata-and-contact-extractor): 1,000 requests/month, no card):

- **`SecurityHeadersAuditBlock`** — grades a URL's HTTP security headers (HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) with a 0-100 score and a per-header grade (missing/weak/report-only/reasonable/strong).
- **`TechStackDetectorBlock`** — fingerprints the CMS/framework/analytics/e-commerce stack a URL is built on (WordPress, Shopify, Next.js, Cloudflare, Google Tag Manager, 40+ signatures) with per-detection confidence and evidence.

## Why

I didn't see either capability covered by the existing integrations (`dataforseo`/`exa`/`tavily`/`firecrawl` are all search/crawl/keyword-focused, not header-grading or stack-fingerprinting), so this seemed like a genuine gap rather than overlap. Concretely useful for an agent doing vendor/competitor due diligence, qualifying a lead by the platform they're on, or gating a deploy pipeline on a minimum security score.

## Implementation notes

- Followed the current `ProviderBuilder`/`backend.sdk` pattern from `docs/platform/block-sdk-guide.md` (modeled closely on `blocks/dataforseo` and `blocks/exa`) rather than the legacy `ProviderName`-enum style, so this doesn't touch any shared/central file.
- Both blocks share a small `_api.py` HTTP helper (`call_endpoint`) so the actual network call is isolated behind a single mockable method (`_fetch_security_audit` / `_fetch_tech_stack`), matching the `test_mock` pattern used elsewhere.
- The example values in `test_input`/`test_output`/`test_mock` reflect the live API's real JSON response shape — I checked the actual field names (`security_score_percentage`, `security_header_grades`, `detected_technologies`, `technology_details`, etc.) against a running instance rather than guessing them.

## What I couldn't verify

I wasn't able to get the full backend test suite running locally (the monorepo's Poetry/Prisma/vendor-SDK setup was heavier than I could reasonably stand up outside the actual dev environment), so `test_block.py` hasn't been run against these two blocks. Syntax is valid (`python -m py_compile` on all 4 files) and the code closely mirrors real merged blocks, but I'd appreciate a second look at the credential/test wiring specifically if anything's off. Happy to adjust in review.