### PR TITLE
feat(frontend): report a DataFast `paywall_view` goal from onboarding

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
@@ -50,6 +50,12 @@ export function SubscriptionStep() {
               key={cycle}
               type="button"
               onClick={() => setBilling(cycle)}
+              // Read by DataFast's script directly (delegated click listener on
+              // document), the same way the marketing site tags its CTAs — no
+              // JS needed. The `-cycle` suffix becomes the `cycle` metadata key.
+              data-fast-goal="paywall_billing_toggle"
+              data-fast-goal-cycle={cycle}
+              data-fast-goal-surface="onboarding_paywall"
               className={cn(
                 "rounded-full border-none px-4 py-1.5 text-xs font-medium transition-all",
                 billing === cycle

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
@@ -17,21 +17,19 @@ describe("trackPaywallView", () => {
     sessionStorage.clear();
   });
 
-  it("reports the impression tagged with the pricing variant", () => {
-    trackPaywallView("control");
+  it("reports the paywall impression", () => {
+    trackPaywallView();
 
     expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
-    expect(sendDatafastEvent).toHaveBeenCalledWith("paywall_view", {
-      variant: "control",
-    });
+    expect(sendDatafastEvent).toHaveBeenCalledWith("paywall_view", {});
   });
 
   // Cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
   // full navigation, remounting the paywall. Without the session guard that
   // second mount would inflate the funnel's denominator.
   it("reports at most once per session", () => {
-    trackPaywallView("monthly-pro");
-    trackPaywallView("monthly-pro");
+    trackPaywallView();
+    trackPaywallView();
 
     expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
   });
@@ -41,7 +39,7 @@ describe("trackPaywallView", () => {
       throw new Error("storage blocked");
     });
 
-    trackPaywallView("yearly-max");
+    trackPaywallView();
 
     expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
   });
@@ -54,6 +52,6 @@ describe("trackPaywallView", () => {
       throw new Error("datafast unavailable");
     });
 
-    expect(() => trackPaywallView("control")).not.toThrow();
+    expect(() => trackPaywallView()).not.toThrow();
   });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendDatafastEvent } = vi.hoisted(() => ({
+  sendDatafastEvent: vi.fn(),
+}));
+
+vi.mock("@/services/analytics", () => ({
+  analytics: { sendDatafastEvent },
+}));
+
+import { trackPaywallView } from "../tracking";
+
+describe("trackPaywallView", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sendDatafastEvent.mockReset();
+    sessionStorage.clear();
+  });
+
+  it("reports the impression tagged with the pricing variant", () => {
+    trackPaywallView("control");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+    expect(sendDatafastEvent).toHaveBeenCalledWith("paywall_view", {
+      variant: "control",
+    });
+  });
+
+  // Cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
+  // full navigation, remounting the paywall. Without the session guard that
+  // second mount would inflate the funnel's denominator.
+  it("reports at most once per session", () => {
+    trackPaywallView("monthly-pro");
+    trackPaywallView("monthly-pro");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports when sessionStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    trackPaywallView("yearly-max");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // This runs in a mount effect on the screen users pay from: if a third-party
+  // script failure escaped, React would unmount the paywall into an error
+  // boundary and there would be nothing to buy.
+  it("never throws when the DataFast script does", () => {
+    sendDatafastEvent.mockImplementation(() => {
+      throw new Error("datafast unavailable");
+    });
+
+    expect(() => trackPaywallView("control")).not.toThrow();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
@@ -1,5 +1,4 @@
 import { analytics } from "@/services/analytics";
-import type { SubscriptionPricingExperimentVariant } from "./helpers";
 
 const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
 
@@ -11,6 +10,11 @@ const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
  * reached the subscription screen" from "saw the price and declined" — which
  * is the only question that matters between signup and payment.
  *
+ * Deliberately untagged by pricing arm. `posthog.init` runs in an effect with
+ * no bootstrap, so the experiment variant is still unresolved when this step
+ * mounts and would record "control" for everyone; PostHog records arm
+ * assignment itself, so segmentation belongs there rather than here.
+ *
  * Fires at most once per tab. Two paths would otherwise double-count:
  * cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
  * full navigation that remounts this step, and a render committed before the
@@ -18,9 +22,7 @@ const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
  * the store default of step 1. A genuinely new view (new tab or session) finds
  * the key unset and reports normally.
  */
-export function trackPaywallView(
-  variant: SubscriptionPricingExperimentVariant | "control",
-) {
+export function trackPaywallView() {
   try {
     if (sessionStorage.getItem(PAYWALL_VIEW_SESSION_KEY)) return;
     sessionStorage.setItem(PAYWALL_VIEW_SESSION_KEY, "1");
@@ -30,7 +32,7 @@ export function trackPaywallView(
   }
 
   try {
-    analytics.sendDatafastEvent("paywall_view", { variant });
+    analytics.sendDatafastEvent("paywall_view", {});
   } catch {
     // sendDatafastEvent hands the event to the third-party DataFast script,
     // which it calls without a guard of its own. This runs in a mount effect on

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
@@ -1,0 +1,40 @@
+import { analytics } from "@/services/analytics";
+import type { SubscriptionPricingExperimentVariant } from "./helpers";
+
+const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
+
+/**
+ * Reports that the user was actually shown the paywall.
+ *
+ * Onboarding's steps all share the `/onboarding` URL (the `?step=` param is
+ * stripped by DataFast), so without this event the funnel can't tell "never
+ * reached the subscription screen" from "saw the price and declined" — which
+ * is the only question that matters between signup and payment.
+ *
+ * Fires at most once per tab. Two paths would otherwise double-count:
+ * cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
+ * full navigation that remounts this step, and a render committed before the
+ * wizard's init effect corrects `currentStep` can briefly mount the paywall at
+ * the store default of step 1. A genuinely new view (new tab or session) finds
+ * the key unset and reports normally.
+ */
+export function trackPaywallView(
+  variant: SubscriptionPricingExperimentVariant | "control",
+) {
+  try {
+    if (sessionStorage.getItem(PAYWALL_VIEW_SESSION_KEY)) return;
+    sessionStorage.setItem(PAYWALL_VIEW_SESSION_KEY, "1");
+  } catch {
+    // In-app browsers may block sessionStorage — double-counting a view beats
+    // dropping it, so fall through to report either way.
+  }
+
+  try {
+    analytics.sendDatafastEvent("paywall_view", { variant });
+  } catch {
+    // sendDatafastEvent hands the event to the third-party DataFast script,
+    // which it calls without a guard of its own. This runs in a mount effect on
+    // the screen users pay from, so an exception here would unmount the paywall
+    // into an error boundary. Analytics must never be able to take checkout down.
+  }
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -11,6 +11,8 @@ import {
   TEAM_INTAKE_FORM_URL,
 } from "@/components/molecules/PlanCard/plans";
 import { useSubscriptionPricingExperiment } from "./useSubscriptionPricingExperiment";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { trackPaywallView } from "./tracking";
 
 const PLAN_TO_TIER: Record<
   Exclude<PlanKey, typeof PLAN_KEYS.TEAM | typeof PLAN_KEYS.BUSINESS>,
@@ -37,7 +39,15 @@ export function useSubscriptionStep() {
 
   const { mutateAsync: updateTier, isPending: isUpdatingTier } =
     useUpdateSubscriptionTier();
-  const { billing, plans } = useSubscriptionPricingExperiment();
+  const { billing, plans, variant } = useSubscriptionPricingExperiment();
+
+  // This component only mounts once the paywall is genuinely on screen (the
+  // page gates on resolved flags and tier), so mount is the honest moment to
+  // report the impression. Reports the variant the user is looking at right
+  // now, so paywall → payment can be read per pricing arm.
+  useMountEffect(() => {
+    trackPaywallView(variant);
+  });
   // Local guard that flips synchronously on first click so the profile-save
   // phase (which runs before `isUpdatingTier` becomes true) can't be
   // re-entered by a fast double-click queueing duplicate POSTs.

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -39,14 +39,13 @@ export function useSubscriptionStep() {
 
   const { mutateAsync: updateTier, isPending: isUpdatingTier } =
     useUpdateSubscriptionTier();
-  const { billing, plans, variant } = useSubscriptionPricingExperiment();
+  const { billing, plans } = useSubscriptionPricingExperiment();
 
-  // This component only mounts once the paywall is genuinely on screen (the
-  // page gates on resolved flags and tier), so mount is the honest moment to
-  // report the impression. Reports the variant the user is looking at right
-  // now, so paywall → payment can be read per pricing arm.
+  // This step only mounts once the paywall is genuinely on screen, so mount is
+  // the honest moment to report the impression — and the one moment it can't
+  // be missed, whatever the flags resolve to afterwards.
   useMountEffect(() => {
-    trackPaywallView(variant);
+    trackPaywallView();
   });
   // Local guard that flips synchronously on first click so the profile-save
   // phase (which runs before `isUpdatingTier` becomes true) can't be


### PR DESCRIPTION
### Why / What / How

**Why.** Our DataFast signup → payment funnel has nothing between its two ends, so we can't tell *"never reached the subscription screen"* from *"saw the price and declined"* — the only question that matters in that gap. It isn't a tracking bug so much as a topology one: every onboarding step shares the `/onboarding` URL (the `?step=` param `useOnboardingPage` writes is stripped by DataFast, verified against the live API), so the whole wizard collapses into a single pageview.

**What.** Reports a `paywall_view` DataFast goal when the subscription step actually mounts, and tags the monthly/yearly toggle so we can see which billing cycle people were looking at.

**How.** A `trackPaywallView` helper (mirroring `app/(public)/tour/chat/tracking.ts`) called from a mount effect in `useSubscriptionStep`.

Client-side rather than through the existing server-side goal path in `services/analytics/datafast-server.ts`, for two reasons:

1. That path is not a consent bypass — `getGoalContext` needs the consent cookie *and* the `datafast_visitor_id` cookie, and only the client script sets the latter.
2. The server can't tell whether a given `/onboarding` request will render the paywall. The cohort flag, the tier query and the completed-user redirect all resolve client-side, so a server-side fire would false-positive for completed users, active-plan users, the no-paywall cohort, and `?step=>1` resumes.

**No cohort is encoded in the goal name, deliberately.** `page.tsx` renders this step only when `isPaymentEnabled && currentStep === PAYWALL_FIRST_STEPS.subscription`, and `isPaymentEnabled` already excludes users on an active plan — so the event firing *at all* implies "paywall-first cohort, no active plan", which is exactly the denominator we want. The no-paywall cohort stays silent.

### Changes 🏗️

- **`SubscriptionStep/tracking.ts`** (new) — `trackPaywallView()`, reporting the `paywall_view` goal.
- **`SubscriptionStep/useSubscriptionStep.ts`** — fires it via `useMountEffect`.
- **`SubscriptionStep/__tests__/tracking.test.ts`** (new) — 4 tests covering the guarantees below.
- **`SubscriptionStep/SubscriptionStep.tsx`** — tags the billing toggle with `data-fast-goal="paywall_billing_toggle"` + `cycle` / `surface` metadata.

**On the toggle:** this uses DataFast's declarative attributes rather than a handler, matching what the marketing site already does on its pricing CTAs. Reading `datafa.st/js/script.js` confirms it needs no JS of ours — the script attaches one delegated `click` listener (plus `keydown` for Enter/Space) to `document` and resolves targets with `closest("[data-fast-goal]")`, so React-mounted nodes work with no registration; each `data-fast-goal-*` suffix becomes a metadata key with dashes converted to underscores. Being a click, it carries none of the impression's hazards: it fires long after the script loads (no queue needed) and can't be triggered by a pre-init render (no dedupe guard needed).

**Not extended to the plan cards here.** `PlanCard` takes a closed `Props` with no rest spread and is shared with `PaywallGate/PaywallModal`, and it sits as a direct grid child carrying its own `order-*` classes, so a wrapper element would break the mobile ordering. That belongs in its own change.

Two guards, both load-bearing on the screen users pay from:

- **The send is wrapped.** `analytics.sendDatafastEvent` hands off to the third-party DataFast script *without a guard of its own* (`services/analytics/index.tsx:145-151`). This runs in a mount effect, so an escaping exception would unmount the paywall into an error boundary — i.e. nothing to buy.
- **Fires at most once per tab.** Cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a full navigation that remounts the step. Separately, `currentStep` defaults to `1` in the store and is excluded from `partialize`, so a commit can land with the paywall mounted before the wizard's init effect corrects the step — including on the *success* return for a user who just paid. A blocked `sessionStorage` still reports, since double-counting beats dropping.

No behaviour change: nothing here touches `handlePlanSelect`, the `updateTier` call, or the Stripe redirect.

Once merged, this unlocks the funnel we actually need — `signup` → `paywall_view` → `payment` — answering "of the people who saw a price, how many paid".

**Deliberately not tagged by pricing arm.** An earlier revision tagged the event with the `subscription-pricing-page-initial-state` variant; review correctly caught that `posthog.init` runs inside an effect with no `bootstrap` (`providers/posthog/posthog-provider.tsx:14-24`), so the variant is still unresolved at mount and every impression would record `"control"` — made permanent by the session guard. Gating the wizard on PostHog readiness would fix the label at the cost of delivering the impression at all, which is the wrong trade here. PostHog records arm assignment through its own exposure events, so per-arm analysis remains recoverable by joining on the visitor.

Follow-up, deliberately **not** in this PR: a `paywall_checkout_cancelled` event to separate "never clicked" from "abandoned at Stripe's card form". It needs its own design — after the cancel return, `subscription=cancelled` persists in the URL (the sync effect only replaces when `currentStep !== urlStep`, and on cancel-return both are `1`), so a refresh would re-fire it.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm test:unit` — 250 onboarding tests pass (16 files), including 4 new ones asserting: reports the impression; reports once per session; still reports when `sessionStorage` throws; never throws when the DataFast script throws
  - [x] `pnpm types` — clean
  - [x] `pnpm lint` / `pnpm format` — clean
  - [ ] Post-merge on prod: confirm `paywall_view` appears in the DataFast goals list and that its count tracks `signup` for the paywall-first cohort
  - [ ] Post-merge: build the `signup` → `paywall_view` → `payment` funnel and confirm step 2 is non-zero

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes — `DATAFAST_API_KEY` is only used by the existing server-side signup goal, which this doesn't touch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with explicit guards around third-party script failures; checkout and plan selection logic are unchanged.
> 
> **Overview**
> Adds **onboarding paywall analytics** so the signup → payment funnel can distinguish users who never reached pricing from those who saw it and declined.
> 
> On subscription step mount, **`trackPaywallView`** sends a client-side DataFast **`paywall_view`** goal (once per tab via `sessionStorage`, with try/catch so analytics failures cannot break checkout). **`useSubscriptionStep`** invokes it through **`useMountEffect`**. New unit tests cover single-fire behavior, blocked storage, and non-throwing sends.
> 
> The **monthly/yearly billing toggle** buttons get **`data-fast-goal`** attributes (`paywall_billing_toggle`, cycle, `onboarding_paywall` surface) so DataFast’s delegated click listener can record toggles without extra JS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39993ca80d35c854f3bc73b19b77250ada1c021c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


