### PR TITLE
feat(platform): let users remove a workflow from an expert

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/errors.py
+++ b/autogpt_platform/backend/backend/api/features/experts/errors.py
@@ -27,6 +27,7 @@ __all__ = [
     "ExpertPodNameTakenError",
     "ExpertPodNotFoundError",
     "ExpertTemplateNotFoundError",
+    "ExpertWorkflowNotFoundError",
     "RaisedExpertLifetimeLimitExceededError",
 ]
 
@@ -40,6 +41,12 @@ class ExpertPodNotFoundError(Exception):
     def __init__(self, pod_id: str):
         super().__init__(f"Pod {pod_id} not found")
         self.pod_id = pod_id
+
+
+class ExpertWorkflowNotFoundError(Exception):
+    def __init__(self, workflow_id: str):
+        super().__init__(f"Workflow {workflow_id} not found")
+        self.workflow_id = workflow_id
 
 
 class ExpertPodNameTakenError(Exception):

--- a/autogpt_platform/backend/backend/api/features/experts/experts_db.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db.py
@@ -20,6 +20,7 @@ from backend.api.features.experts.errors import (
     ExpertPodNameTakenError,
     ExpertPodNotFoundError,
     ExpertTemplateNotFoundError,
+    ExpertWorkflowNotFoundError,
     RaisedExpertLifetimeLimitExceededError,
 )
 from backend.api.features.experts.models import (
@@ -1086,6 +1087,41 @@ async def install_workflow(
             raise
         return _to_workflow_ref(raced)
     return _to_workflow_ref(row)
+
+
+async def uninstall_workflow(user_id: str, expert_id: str, workflow_id: str) -> None:
+    """Detach a workflow from an expert: cancel its schedule, drop the row.
+
+    The LibraryAgent is left alone. It is the user's copy of the agent and
+    another expert may have installed the same listing, so deleting it here
+    would reach outside what the user asked to remove.
+    """
+    row = await prisma.models.ExpertWorkflow.prisma().find_first(
+        where={
+            "id": workflow_id,
+            "expertId": expert_id,
+            "Expert": {
+                "is": {
+                    "ownerUserId": user_id,
+                    "isTemplate": False,
+                    "isArchived": False,
+                    "visibility": ResourceVisibility.PRIVATE,
+                }
+            },
+        }
+    )
+    if row is None:
+        raise ExpertWorkflowNotFoundError(workflow_id)
+
+    # Schedule first: a schedule outliving its row is the one outcome that
+    # keeps firing unattended. Deletion is best-effort and logs by id, so a
+    # scheduler outage never blocks the detach the user asked for.
+    if row.scheduleId:
+        await scheduling.delete_schedule_best_effort(row.scheduleId, user_id, expert_id)
+
+    await prisma.models.ExpertWorkflow.prisma().delete_many(
+        where={"id": workflow_id, "expertId": expert_id}
+    )
 
 
 async def resolve_expert_for_graph(user_id: str, graph_id: str) -> str | None:

--- a/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
@@ -1874,6 +1874,78 @@ async def test_install_workflow_duplicate_returns_existing(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_uninstall_workflow_detaches_row_but_keeps_library_agent(
+    server: SpinTestServer, test_user
+):
+    slv_id = await _seed_store_listing(server)
+    template = await _seed_template(name="Maria", preload_listings=[])
+    hired = await experts_db.hire_expert(test_user.id, template.id, None)
+    installed = await experts_db.install_workflow(test_user.id, hired.expert.id, slv_id)
+    assert installed.library_agent_id is not None
+
+    await experts_db.uninstall_workflow(test_user.id, hired.expert.id, installed.id)
+
+    expert = await experts_db.get_expert(test_user.id, hired.expert.id)
+    assert expert is not None
+    assert expert.workflows == []
+    library_agent = await prisma.models.LibraryAgent.prisma().find_unique(
+        where={"id": installed.library_agent_id}
+    )
+    assert library_agent is not None
+    assert library_agent.isDeleted is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_uninstall_workflow_cancels_its_schedule(
+    server: SpinTestServer, test_user, mocker
+):
+    slv_id = await _seed_store_listing(server)
+    template = await _seed_template(name="Maria", preload_listings=[])
+    hired = await experts_db.hire_expert(test_user.id, template.id, None)
+    installed = await experts_db.install_workflow(test_user.id, hired.expert.id, slv_id)
+    await prisma.models.ExpertWorkflow.prisma().update(
+        where={"id": installed.id}, data={"scheduleId": "schedule-1"}
+    )
+    delete_schedule = mocker.patch.object(
+        scheduling, "delete_schedule_best_effort", new=AsyncMock()
+    )
+
+    await experts_db.uninstall_workflow(test_user.id, hired.expert.id, installed.id)
+
+    delete_schedule.assert_awaited_once_with(
+        "schedule-1", test_user.id, hired.expert.id
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_uninstall_workflow_rejects_other_users_workflow(
+    server: SpinTestServer, test_user, other_user
+):
+    slv_id = await _seed_store_listing(server)
+    template = await _seed_template(name="Maria", preload_listings=[])
+    hired = await experts_db.hire_expert(test_user.id, template.id, None)
+    installed = await experts_db.install_workflow(test_user.id, hired.expert.id, slv_id)
+
+    with pytest.raises(experts_db.ExpertWorkflowNotFoundError):
+        await experts_db.uninstall_workflow(
+            other_user.id, hired.expert.id, installed.id
+        )
+
+    expert = await experts_db.get_expert(test_user.id, hired.expert.id)
+    assert expert is not None
+    assert [w.id for w in expert.workflows] == [installed.id]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_uninstall_workflow_unknown_id_raises(server: SpinTestServer, test_user):
+    template = await _seed_template(name="Maria", preload_listings=[])
+    hired = await experts_db.hire_expert(test_user.id, template.id, None)
+
+    with pytest.raises(experts_db.ExpertWorkflowNotFoundError):
+        await experts_db.uninstall_workflow(test_user.id, hired.expert.id, "nope")
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_install_workflow_returns_concurrent_winner(
     server: SpinTestServer, test_user
 ):

--- a/autogpt_platform/backend/backend/api/features/experts/routes.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes.py
@@ -318,6 +318,26 @@ async def install_expert_workflow(
         raise fastapi.HTTPException(status_code=404, detail=str(e))
 
 
+@router.delete(
+    "/{expert_id}/workflows/{workflow_id}",
+    operation_id="uninstall_expert_workflow",
+    status_code=204,
+    responses={404: {"description": "Expert or workflow not found"}},
+)
+async def uninstall_expert_workflow(
+    expert_id: str,
+    workflow_id: str,
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> fastapi.Response:
+    """Detach a workflow from an expert and cancel its schedule. The agent
+    itself stays in the user's library."""
+    try:
+        await experts_db.uninstall_workflow(user_id, expert_id, workflow_id)
+    except experts_db.ExpertWorkflowNotFoundError as e:
+        raise fastapi.HTTPException(status_code=404, detail=str(e))
+    return fastapi.Response(status_code=204)
+
+
 @router.get(
     "/{expert_id}/detach-preview",
     operation_id="get_expert_detach_preview",

--- a/autogpt_platform/backend/backend/api/features/experts/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes_test.py
@@ -968,6 +968,42 @@ def test_install_workflow_unknown_expert_returns_404(
     assert response.status_code == 404
 
 
+# ─── Uninstall workflow ────────────────────────────────────────────────
+
+
+def test_uninstall_workflow_returns_204(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_uninstall = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.uninstall_workflow",
+        new_callable=AsyncMock,
+        return_value=None,
+    )
+
+    response = client.delete("/experts/expert-1/workflows/workflow-1")
+
+    assert response.status_code == 204
+    assert response.content == b""
+    assert mock_uninstall.await_args == mocker.call(
+        test_user_id, "expert-1", "workflow-1"
+    )
+
+
+def test_uninstall_workflow_unknown_workflow_returns_404(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.experts.routes.experts_db.uninstall_workflow",
+        new_callable=AsyncMock,
+        side_effect=experts_db.ExpertWorkflowNotFoundError("nope"),
+    )
+
+    response = client.delete("/experts/expert-1/workflows/nope")
+
+    assert response.status_code == 404
+
+
 # ─── Archive + list ────────────────────────────────────────────────────
 
 

--- a/autogpt_platform/backend/backend/api/features/experts/scheduling.py
+++ b/autogpt_platform/backend/backend/api/features/experts/scheduling.py
@@ -90,19 +90,19 @@ async def create_workflow_schedule(
             f"Failed to record schedule #{schedule.id} on workflow "
             f"#{workflow_row_id}; deleting it: {type(e).__name__}: {e}"
         )
-        await _delete_schedule_best_effort(schedule.id, user_id, expert_id)
+        await delete_schedule_best_effort(schedule.id, user_id, expert_id)
         return False
     if updated == 0:
         logger.info(
             f"Workflow #{workflow_row_id} already has a schedule; deleting "
             f"duplicate registration #{schedule.id}"
         )
-        await _delete_schedule_best_effort(schedule.id, user_id, expert_id)
+        await delete_schedule_best_effort(schedule.id, user_id, expert_id)
         return False
     return True
 
 
-async def _delete_schedule_best_effort(
+async def delete_schedule_best_effort(
     schedule_id: str, user_id: str, expert_id: str
 ) -> None:
     """Never leave a schedule firing with no row pointing at it. One

--- a/autogpt_platform/frontend/src/app/(platform)/team/__tests__/remove-workflow.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/__tests__/remove-workflow.test.tsx
@@ -1,0 +1,213 @@
+import {
+  getListExpertPodsMockHandler,
+  getListExpertsMockHandler,
+  getUninstallExpertWorkflowMockHandler,
+  getUninstallExpertWorkflowMockHandler404,
+} from "@/app/api/__generated__/endpoints/experts/experts.msw";
+import {
+  getGetV2ListLibraryAgentsMockHandler200,
+  getGetV2ListLibraryAgentsResponseMock200,
+} from "@/app/api/__generated__/endpoints/library/library.msw";
+import { getGetV1ListExecutionSchedulesForAUserMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { server } from "@/mocks/mock-server";
+import {
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import TeamPage from "../page";
+
+const toastMock = vi.hoisted(() => vi.fn());
+const { setFlagStatusMock } = vi.hoisted(() => ({
+  setFlagStatusMock: vi.fn(() => ({ enabled: true, ready: true })),
+}));
+
+vi.mock("@/components/molecules/Toast/use-toast", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/molecules/Toast/use-toast")
+    >();
+  return { ...actual, toast: toastMock };
+});
+
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    useFlagStatus: (flag: string) =>
+      flag === "hire-experts"
+        ? setFlagStatusMock()
+        : actual.useFlagStatus(flag as never),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/team",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+const hiredMaria: Expert = {
+  id: "expert-maria",
+  name: "Maria",
+  avatar_url: null,
+  role: "Marketing Strategist",
+  bio: null,
+  skills: [],
+  tagline: "Grows your brand while you sleep",
+  identity: "You are Maria, a senior marketing strategist.",
+  voice_preferences: "Warm, concise, and direct.",
+  boundaries: "Never invent customer evidence.",
+  protected_soul_rules: [],
+  is_template: false,
+  source_template_id: "template-maria",
+  is_archived: false,
+  workflows: [
+    {
+      id: "wf-1",
+      store_listing_version_id: "slv-1",
+      library_agent_id: "lib-1",
+      graph_id: "graph-1",
+      name: "Content Calendar",
+      description: null,
+    },
+    {
+      id: "wf-2",
+      store_listing_version_id: "slv-2",
+      library_agent_id: "lib-2",
+      graph_id: "graph-2",
+      name: "SEO Audit",
+      description: null,
+    },
+  ],
+} as unknown as Expert;
+
+function emptyLibrary() {
+  const base = getGetV2ListLibraryAgentsResponseMock200();
+  return {
+    ...base,
+    agents: [],
+    pagination: {
+      ...base.pagination,
+      total_items: 0,
+      current_page: 1,
+      page_size: 100,
+      total_pages: 0,
+    },
+  };
+}
+
+beforeEach(() => {
+  server.use(
+    getGetV1ListExecutionSchedulesForAUserMockHandler([]),
+    getListExpertPodsMockHandler([]),
+    getGetV2ListLibraryAgentsMockHandler200(emptyLibrary()),
+    getListExpertsMockHandler([hiredMaria]),
+  );
+});
+
+afterEach(() => {
+  setFlagStatusMock.mockReturnValue({ enabled: true, ready: true });
+  toastMock.mockReset();
+});
+
+async function openRemoveDialog(user: ReturnType<typeof userEvent.setup>) {
+  const group = await screen.findByRole("region", { name: "Maria runs" });
+  await user.click(
+    within(group).getByRole("button", {
+      name: "Remove Content Calendar from Maria",
+    }),
+  );
+}
+
+describe("TeamPage — removing a workflow", () => {
+  test("confirms before uninstalling, then reports success", async () => {
+    const user = userEvent.setup();
+    let deletedPath: string | undefined;
+    server.use(
+      getUninstallExpertWorkflowMockHandler(({ request }) => {
+        deletedPath = new URL(request.url).pathname;
+      }),
+    );
+
+    render(<TeamPage />);
+    await openRemoveDialog(user);
+
+    expect(
+      await screen.findByText("Remove Content Calendar?"),
+    ).toBeDefined();
+    await user.click(screen.getByTestId("remove-workflow-confirm"));
+
+    await waitFor(() =>
+      expect(deletedPath).toBe(
+        "/api/proxy/api/experts/expert-maria/workflows/wf-1",
+      ),
+    );
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Content Calendar removed from Maria",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Remove Content Calendar?")).toBeNull(),
+    );
+  });
+
+  test("cancelling leaves the workflow installed", async () => {
+    const user = userEvent.setup();
+    let requested = false;
+    server.use(
+      getUninstallExpertWorkflowMockHandler(() => {
+        requested = true;
+      }),
+    );
+
+    render(<TeamPage />);
+    await openRemoveDialog(user);
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Remove Content Calendar?")).toBeNull(),
+    );
+    expect(requested).toBe(false);
+    const group = await screen.findByRole("region", { name: "Maria runs" });
+    expect(within(group).getByText("Content Calendar")).toBeDefined();
+  });
+
+  test("keeps the dialog open and warns when the request fails", async () => {
+    const user = userEvent.setup();
+    server.use(getUninstallExpertWorkflowMockHandler404());
+
+    render(<TeamPage />);
+    await openRemoveDialog(user);
+    await user.click(await screen.findByTestId("remove-workflow-confirm"));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Could not remove Content Calendar",
+          variant: "destructive",
+        }),
+      ),
+    );
+    expect(screen.getByText("Remove Content Calendar?")).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/WhatRunsZone.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/WhatRunsZone.tsx
@@ -6,6 +6,7 @@ import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
 import { SECTION_INSET_CLASS } from "../../helpers";
 import { ExpertWorkflowGroup } from "./components/ExpertWorkflowGroup";
+import { RemoveWorkflowDialog } from "./components/RemoveWorkflowDialog/RemoveWorkflowDialog";
 import { WhatRunsFilters } from "./components/WhatRunsFilters";
 import { YourAgentsList } from "./components/YourAgentsList";
 import { WhatRunsFilter } from "./helpers";
@@ -39,6 +40,9 @@ export function WhatRunsZone({ experts, schedules }: Props) {
     adopt,
     pendingLibraryAgentIDs,
     adoptedTargetKeys,
+    workflowPendingRemoval,
+    askToRemoveWorkflow,
+    cancelWorkflowRemoval,
   } = useWhatRunsZone({
     experts,
     schedules,
@@ -69,7 +73,13 @@ export function WhatRunsZone({ experts, schedules }: Props) {
         {groups.length > 0 ? (
           <div className="flex flex-col gap-4">
             {groups.map((group) => (
-              <ExpertWorkflowGroup key={group.expert.id} group={group} />
+              <ExpertWorkflowGroup
+                key={group.expert.id}
+                group={group}
+                onRemoveWorkflow={(workflow) =>
+                  askToRemoveWorkflow(group.expert, workflow)
+                }
+              />
             ))}
           </div>
         ) : groupEmptyMessage ? (
@@ -106,6 +116,15 @@ export function WhatRunsZone({ experts, schedules }: Props) {
           )
         ) : null}
       </div>
+
+      {workflowPendingRemoval ? (
+        <RemoveWorkflowDialog
+          key={workflowPendingRemoval.workflow.id}
+          expert={workflowPendingRemoval.expert}
+          workflow={workflowPendingRemoval.workflow}
+          onClose={cancelWorkflowRemoval}
+        />
+      ) : null}
     </section>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/components/ExpertWorkflowGroup.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/components/ExpertWorkflowGroup.tsx
@@ -1,9 +1,11 @@
+import { ExpertWorkflowRef } from "@/app/api/__generated__/models/expertWorkflowRef";
 import { Badge } from "@/components/atoms/Badge/Badge";
+import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
 import { safeHumanizeCronExpression } from "@/lib/cron-expression-utils";
-import { FlashIcon } from "@hugeicons/core-free-icons";
+import { Delete02Icon, FlashIcon } from "@hugeicons/core-free-icons";
 import Link from "next/link";
 import { getLastRunLabel, workflowNeedsSetup } from "../../../helpers";
 import { STATUS_BADGE_CLASS } from "../constants";
@@ -11,9 +13,10 @@ import { ExpertWorkflowGroupData } from "../helpers";
 
 type Props = {
   group: ExpertWorkflowGroupData;
+  onRemoveWorkflow: (workflow: ExpertWorkflowRef) => void;
 };
 
-export function ExpertWorkflowGroup({ group }: Props) {
+export function ExpertWorkflowGroup({ group, onRemoveWorkflow }: Props) {
   const { expert, workflows } = group;
   const lastRun = getLastRunLabel(expert);
   const countLabel = `${workflows.length} ${workflows.length === 1 ? "workflow" : "workflows"}`;
@@ -114,6 +117,15 @@ export function ExpertWorkflowGroup({ group }: Props) {
                         </Badge>
                       ))
                     : null}
+                  <Button
+                    variant="icon"
+                    size="icon"
+                    className="size-8 shrink-0 p-0 text-zinc-400 hover:text-red-600"
+                    aria-label={`Remove ${workflow.name ?? "workflow"} from ${expert.name}`}
+                    onClick={() => onRemoveWorkflow(workflow)}
+                  >
+                    <Icon icon={Delete02Icon} size={16} aria-hidden="true" />
+                  </Button>
                 </div>
               </div>
             );

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/components/RemoveWorkflowDialog/RemoveWorkflowDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/components/RemoveWorkflowDialog/RemoveWorkflowDialog.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { ExpertWorkflowRef } from "@/app/api/__generated__/models/expertWorkflowRef";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { useRemoveWorkflowDialog } from "./useRemoveWorkflowDialog";
+
+type Props = {
+  expert: Expert;
+  workflow: ExpertWorkflowRef;
+  onClose: () => void;
+};
+
+export function RemoveWorkflowDialog({ expert, workflow, onClose }: Props) {
+  const workflowName = workflow.name ?? "Unnamed workflow";
+  const { isRemoving, handleRemove } = useRemoveWorkflowDialog({
+    expertId: expert.id,
+    expertName: expert.name,
+    workflowId: workflow.id,
+    workflowName,
+    graphID: workflow.graph_id ?? null,
+    onClose,
+  });
+
+  // Match the disabled Cancel button: while the request is in flight ESC and
+  // overlay clicks must not dismiss either, or the user loses the
+  // pending/success/failure feedback for a destructive action.
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && !isRemoving) onClose();
+  }
+
+  return (
+    <Dialog
+      controlled={{ isOpen: true, set: handleOpenChange }}
+      styling={{ maxWidth: "28rem" }}
+      title={`Remove ${workflowName}?`}
+    >
+      <Dialog.Content>
+        <div className="flex flex-col gap-4">
+          <Text variant="body" className="text-zinc-600">
+            {expert.name} stops running it and any schedule for it is cancelled.
+            The agent stays in your library, so you can add it back anytime.
+          </Text>
+          <Dialog.Footer>
+            <Button variant="secondary" disabled={isRemoving} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              loading={isRemoving}
+              onClick={handleRemove}
+              data-testid="remove-workflow-confirm"
+            >
+              Remove
+            </Button>
+          </Dialog.Footer>
+        </div>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/components/RemoveWorkflowDialog/useRemoveWorkflowDialog.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/components/RemoveWorkflowDialog/useRemoveWorkflowDialog.ts
@@ -1,0 +1,54 @@
+import { useUninstallExpertWorkflow } from "@/app/api/__generated__/endpoints/experts/experts";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { invalidateExpertRosterQueries } from "@/services/experts/invalidate-experts";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface Args {
+  expertId: string;
+  expertName: string;
+  workflowId: string;
+  workflowName: string;
+  graphID: string | null;
+  onClose: () => void;
+}
+
+export function useRemoveWorkflowDialog({
+  expertId,
+  expertName,
+  workflowId,
+  workflowName,
+  graphID,
+  onClose,
+}: Args) {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending: isRemoving } = useUninstallExpertWorkflow({
+    mutation: {
+      onSuccess: async () => {
+        await Promise.all([
+          invalidateExpertRosterQueries(queryClient),
+          invalidateAllScheduleQueries(queryClient, graphID ?? undefined),
+        ]);
+        toast({
+          title: `${workflowName} removed from ${expertName}`,
+          description: "The agent is still in your library.",
+        });
+        onClose();
+      },
+      onError: () => {
+        toast({
+          title: `Could not remove ${workflowName}`,
+          description: `${expertName} is still running it. Please try again.`,
+          variant: "destructive",
+        });
+      },
+    },
+  });
+
+  function handleRemove() {
+    mutate({ expertId, workflowId });
+  }
+
+  return { isRemoving, handleRemove };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/useWhatRunsZone.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/WhatRunsZone/useWhatRunsZone.ts
@@ -4,6 +4,7 @@ import {
 } from "@/app/api/__generated__/endpoints/experts/experts";
 import { useGetV2ListLibraryAgentsInfinite } from "@/app/api/__generated__/endpoints/library/library";
 import { Expert } from "@/app/api/__generated__/models/expert";
+import { ExpertWorkflowRef } from "@/app/api/__generated__/models/expertWorkflowRef";
 import { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
 import { getPaginationNextPageNumber, unpaginate } from "@/app/api/helpers";
@@ -45,6 +46,10 @@ export function useWhatRunsZone({ experts, schedules, enabled }: Args) {
   const [adoptedTargetKeys, setAdoptedTargetKeys] = useState<Set<string>>(
     new Set(),
   );
+  const [workflowPendingRemoval, setWorkflowPendingRemoval] = useState<{
+    expert: Expert;
+    workflow: ExpertWorkflowRef;
+  } | null>(null);
 
   const agentsQuery = useGetV2ListLibraryAgentsInfinite(
     { page: 1, page_size: AGENTS_PAGE_SIZE, is_hidden: false },
@@ -111,6 +116,14 @@ export function useWhatRunsZone({ experts, schedules, enabled }: Args) {
     }
   }
 
+  function askToRemoveWorkflow(expert: Expert, workflow: ExpertWorkflowRef) {
+    setWorkflowPendingRemoval({ expert, workflow });
+  }
+
+  function cancelWorkflowRemoval() {
+    setWorkflowPendingRemoval(null);
+  }
+
   return {
     filter,
     setFilter,
@@ -128,5 +141,8 @@ export function useWhatRunsZone({ experts, schedules, enabled }: Args) {
     adopt,
     pendingLibraryAgentIDs,
     adoptedTargetKeys,
+    workflowPendingRemoval,
+    askToRemoveWorkflow,
+    cancelWorkflowRemoval,
   };
 }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -6440,6 +6440,44 @@
         }
       }
     },
+    "/api/experts/{expert_id}/workflows/{workflow_id}": {
+      "delete": {
+        "tags": ["v2", "experts", "experts", "private"],
+        "summary": "Uninstall Expert Workflow",
+        "description": "Detach a workflow from an expert and cancel its schedule. The agent\nitself stays in the user's library.",
+        "operationId": "uninstall_expert_workflow",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "expert_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Expert Id" }
+          },
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Workflow Id" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "404": { "description": "Expert or workflow not found" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/files/upload": {
       "post": {
         "tags": ["v1", "files"],


### PR DESCRIPTION
### Why / What / How

**Why** — A workflow could be installed on an expert but never removed. Once adopted, the row sat on `/team` forever and its schedule kept firing; the only way out was firing the whole expert.

**What** — A trash button on every "What runs" row, behind a confirmation dialog, plus the API it needs: `DELETE /api/experts/{expert_id}/workflows/{workflow_id}`.

**How** — The endpoint mirrors `install_expert_workflow`. `experts_db.uninstall_workflow` looks the row up through the same ownership guard the install uses (`ownerUserId`, not a template, not archived, `PRIVATE`) and 404s otherwise, then cancels the schedule before dropping the row — a schedule outliving its row is the one outcome that keeps firing unattended, so it goes first. Schedule deletion stays best-effort (`delete_schedule_best_effort`, previously private, now shared): a scheduler outage logs by id and never blocks the detach the user asked for.

The `LibraryAgent` is deliberately left alone. It is the user's own copy and another expert may have installed the same listing, so deleting it would reach outside what the user asked to remove. The dialog says so.

On the frontend, `useWhatRunsZone` holds which `{expert, workflow}` is pending removal and `WhatRunsZone` renders a single `RemoveWorkflowDialog` for it — one dialog instance, not one per row. Success invalidates the expert roster and the schedule queries (a removed workflow changes both) and toasts; failure toasts and leaves the dialog open.

### Changes 🏗️

**Backend**
- `DELETE /api/experts/{expert_id}/workflows/{workflow_id}` → 204, 404 on unknown expert/workflow.
- `experts_db.uninstall_workflow()` — owner-scoped lookup, cancel schedule, delete row, leave the `LibraryAgent`.
- `ExpertWorkflowNotFoundError` added to `experts/errors.py`.
- `scheduling._delete_schedule_best_effort` → `delete_schedule_best_effort` (now called from the DB layer too).
- Tests: route 204/404; DB-level detach-keeps-library-agent, schedule cancellation, other-user rejection, unknown id.

**Frontend**
- Trash button on each `ExpertWorkflowGroup` row (`Delete02Icon`, `aria-label="Remove {workflow} from {expert}"`).
- New `RemoveWorkflowDialog` + `useRemoveWorkflowDialog` — destructive confirm, ESC/overlay blocked while the request is in flight, toasts on both paths.
- `useWhatRunsZone` tracks the pending removal.
- `openapi.json` regenerated for the new path (38 lines added, nothing else touched).
- Integration tests in `team/__tests__/remove-workflow.test.tsx`.

Scope is `/team` only — `/team/[expertId]`'s workflow list is unchanged and can reuse the same dialog in a follow-up.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [x] `pnpm types` clean; `pnpm lint` clean
  - [x] `vitest run src/app/(platform)/team/__tests__/` — 63 passing, including 3 new ones: confirm → `DELETE .../experts/expert-maria/workflows/wf-1` + success toast + dialog closes; cancel → no request, row still there; 404 → destructive toast, dialog stays open
  - [x] `poetry run format` (ruff/isort/black/pyright) clean on the experts feature
  - [ ] Backend tests not run locally (they need the docker postgres harness) — relying on CI for `routes_test.py` and `experts_db_test.py`
  - [ ] Manual pass on a running stack: remove a scheduled workflow, confirm the schedule disappears from `/library/followups` and the agent is still in the library

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
