### PR TITLE
feat(frontend): report each onboarding step to DataFast

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/tracking.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/__tests__/tracking.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendDatafastEvent } = vi.hoisted(() => ({
+  sendDatafastEvent: vi.fn(),
+}));
+
+vi.mock("@/services/analytics", () => ({
+  analytics: { sendDatafastEvent },
+}));
+
+import { NO_PAYWALL_STEPS, PAYWALL_FIRST_STEPS } from "../store";
+import { onboardingStepKey, trackOnboardingStep } from "../tracking";
+
+describe("onboardingStepKey", () => {
+  // Welcome is step 2 with the paywall first and step 1 without it, so the
+  // number alone can't identify a step across cohorts.
+  it("maps the same key across both step layouts", () => {
+    expect(
+      onboardingStepKey(PAYWALL_FIRST_STEPS, PAYWALL_FIRST_STEPS.welcome),
+    ).toBe("welcome");
+    expect(onboardingStepKey(NO_PAYWALL_STEPS, NO_PAYWALL_STEPS.welcome)).toBe(
+      "welcome",
+    );
+    expect(
+      onboardingStepKey(PAYWALL_FIRST_STEPS, PAYWALL_FIRST_STEPS.preparing),
+    ).toBe("preparing");
+    expect(
+      onboardingStepKey(NO_PAYWALL_STEPS, NO_PAYWALL_STEPS.preparing),
+    ).toBe("preparing");
+  });
+
+  // The paywall reports itself as `paywall_view`; reporting it again here would
+  // double-count the top of the funnel.
+  it("returns null for the subscription step", () => {
+    expect(
+      onboardingStepKey(PAYWALL_FIRST_STEPS, PAYWALL_FIRST_STEPS.subscription),
+    ).toBeNull();
+  });
+});
+
+describe("trackOnboardingStep", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sendDatafastEvent.mockReset();
+    sessionStorage.clear();
+  });
+
+  it("reports one goal per step name", () => {
+    trackOnboardingStep("welcome");
+    trackOnboardingStep("pain_points");
+
+    expect(sendDatafastEvent).toHaveBeenNthCalledWith(
+      1,
+      "onboarding_welcome",
+      {},
+    );
+    expect(sendDatafastEvent).toHaveBeenNthCalledWith(
+      2,
+      "onboarding_pain_points",
+      {},
+    );
+  });
+
+  it("reports each step at most once per session", () => {
+    trackOnboardingStep("role");
+    trackOnboardingStep("role");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let one step suppress another", () => {
+    trackOnboardingStep("role");
+    trackOnboardingStep("preparing");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("still reports when sessionStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    trackOnboardingStep("welcome");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("never throws when the DataFast script does", () => {
+    sendDatafastEvent.mockImplementation(() => {
+      throw new Error("datafast unavailable");
+    });
+
+    expect(() => trackOnboardingStep("welcome")).not.toThrow();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
@@ -50,6 +50,12 @@ export function SubscriptionStep() {
               key={cycle}
               type="button"
               onClick={() => setBilling(cycle)}
+              // Read by DataFast's script directly (delegated click listener on
+              // document), the same way the marketing site tags its CTAs — no
+              // JS needed. The `-cycle` suffix becomes the `cycle` metadata key.
+              data-fast-goal="paywall_billing_toggle"
+              data-fast-goal-cycle={cycle}
+              data-fast-goal-surface="onboarding_paywall"
               className={cn(
                 "rounded-full border-none px-4 py-1.5 text-xs font-medium transition-all",
                 billing === cycle

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/SubscriptionStep.tsx
@@ -89,6 +89,7 @@ export function SubscriptionStep() {
                 loading={isUpdatingTier && selectedPlan === plan.key}
                 disabled={isUpdatingTier && selectedPlan !== plan.key}
                 priceCaption="billing-period"
+                ctaGoalSurface="onboarding_paywall"
                 className={cn(
                   plan.key === PLAN_KEYS.MAX && "order-1 md:order-none",
                   plan.key === PLAN_KEYS.PRO && "order-2 md:order-none",

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
@@ -17,21 +17,19 @@ describe("trackPaywallView", () => {
     sessionStorage.clear();
   });
 
-  it("reports the impression tagged with the pricing variant", () => {
-    trackPaywallView("control");
+  it("reports the paywall impression", () => {
+    trackPaywallView();
 
     expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
-    expect(sendDatafastEvent).toHaveBeenCalledWith("paywall_view", {
-      variant: "control",
-    });
+    expect(sendDatafastEvent).toHaveBeenCalledWith("paywall_view", {});
   });
 
   // Cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
   // full navigation, remounting the paywall. Without the session guard that
   // second mount would inflate the funnel's denominator.
   it("reports at most once per session", () => {
-    trackPaywallView("monthly-pro");
-    trackPaywallView("monthly-pro");
+    trackPaywallView();
+    trackPaywallView();
 
     expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
   });
@@ -41,7 +39,7 @@ describe("trackPaywallView", () => {
       throw new Error("storage blocked");
     });
 
-    trackPaywallView("yearly-max");
+    trackPaywallView();
 
     expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
   });
@@ -54,6 +52,6 @@ describe("trackPaywallView", () => {
       throw new Error("datafast unavailable");
     });
 
-    expect(() => trackPaywallView("control")).not.toThrow();
+    expect(() => trackPaywallView()).not.toThrow();
   });
 });

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/__tests__/tracking.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendDatafastEvent } = vi.hoisted(() => ({
+  sendDatafastEvent: vi.fn(),
+}));
+
+vi.mock("@/services/analytics", () => ({
+  analytics: { sendDatafastEvent },
+}));
+
+import { trackPaywallView } from "../tracking";
+
+describe("trackPaywallView", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    sendDatafastEvent.mockReset();
+    sessionStorage.clear();
+  });
+
+  it("reports the impression tagged with the pricing variant", () => {
+    trackPaywallView("control");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+    expect(sendDatafastEvent).toHaveBeenCalledWith("paywall_view", {
+      variant: "control",
+    });
+  });
+
+  // Cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
+  // full navigation, remounting the paywall. Without the session guard that
+  // second mount would inflate the funnel's denominator.
+  it("reports at most once per session", () => {
+    trackPaywallView("monthly-pro");
+    trackPaywallView("monthly-pro");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports when sessionStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    trackPaywallView("yearly-max");
+
+    expect(sendDatafastEvent).toHaveBeenCalledTimes(1);
+  });
+
+  // This runs in a mount effect on the screen users pay from: if a third-party
+  // script failure escaped, React would unmount the paywall into an error
+  // boundary and there would be nothing to buy.
+  it("never throws when the DataFast script does", () => {
+    sendDatafastEvent.mockImplementation(() => {
+      throw new Error("datafast unavailable");
+    });
+
+    expect(() => trackPaywallView("control")).not.toThrow();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
@@ -1,5 +1,4 @@
 import { analytics } from "@/services/analytics";
-import type { SubscriptionPricingExperimentVariant } from "./helpers";
 
 const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
 
@@ -11,6 +10,11 @@ const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
  * reached the subscription screen" from "saw the price and declined" — which
  * is the only question that matters between signup and payment.
  *
+ * Deliberately untagged by pricing arm. `posthog.init` runs in an effect with
+ * no bootstrap, so the experiment variant is still unresolved when this step
+ * mounts and would record "control" for everyone; PostHog records arm
+ * assignment itself, so segmentation belongs there rather than here.
+ *
  * Fires at most once per tab. Two paths would otherwise double-count:
  * cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
  * full navigation that remounts this step, and a render committed before the
@@ -18,9 +22,7 @@ const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
  * the store default of step 1. A genuinely new view (new tab or session) finds
  * the key unset and reports normally.
  */
-export function trackPaywallView(
-  variant: SubscriptionPricingExperimentVariant | "control",
-) {
+export function trackPaywallView() {
   try {
     if (sessionStorage.getItem(PAYWALL_VIEW_SESSION_KEY)) return;
     sessionStorage.setItem(PAYWALL_VIEW_SESSION_KEY, "1");
@@ -30,7 +32,7 @@ export function trackPaywallView(
   }
 
   try {
-    analytics.sendDatafastEvent("paywall_view", { variant });
+    analytics.sendDatafastEvent("paywall_view", {});
   } catch {
     // sendDatafastEvent hands the event to the third-party DataFast script,
     // which it calls without a guard of its own. This runs in a mount effect on

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
@@ -1,0 +1,40 @@
+import { analytics } from "@/services/analytics";
+import type { SubscriptionPricingExperimentVariant } from "./helpers";
+
+const PAYWALL_VIEW_SESSION_KEY = "paywall_view_tracked";
+
+/**
+ * Reports that the user was actually shown the paywall.
+ *
+ * Onboarding's steps all share the `/onboarding` URL (the `?step=` param is
+ * stripped by DataFast), so without this event the funnel can't tell "never
+ * reached the subscription screen" from "saw the price and declined" — which
+ * is the only question that matters between signup and payment.
+ *
+ * Fires at most once per tab. Two paths would otherwise double-count:
+ * cancelling Stripe checkout returns to `?step=1&subscription=cancelled` as a
+ * full navigation that remounts this step, and a render committed before the
+ * wizard's init effect corrects `currentStep` can briefly mount the paywall at
+ * the store default of step 1. A genuinely new view (new tab or session) finds
+ * the key unset and reports normally.
+ */
+export function trackPaywallView(
+  variant: SubscriptionPricingExperimentVariant | "control",
+) {
+  try {
+    if (sessionStorage.getItem(PAYWALL_VIEW_SESSION_KEY)) return;
+    sessionStorage.setItem(PAYWALL_VIEW_SESSION_KEY, "1");
+  } catch {
+    // In-app browsers may block sessionStorage — double-counting a view beats
+    // dropping it, so fall through to report either way.
+  }
+
+  try {
+    analytics.sendDatafastEvent("paywall_view", { variant });
+  } catch {
+    // sendDatafastEvent hands the event to the third-party DataFast script,
+    // which it calls without a guard of its own. This runs in a mount effect on
+    // the screen users pay from, so an exception here would unmount the paywall
+    // into an error boundary. Analytics must never be able to take checkout down.
+  }
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/tracking.ts
@@ -40,3 +40,32 @@ export function trackPaywallView() {
     // into an error boundary. Analytics must never be able to take checkout down.
   }
 }
+
+const CHECKOUT_CANCELLED_SESSION_KEY = "paywall_checkout_cancelled_tracked";
+
+/**
+ * Reports that the user reached Stripe Checkout and came back without paying.
+ *
+ * Distinguishes "looked at the price and never clicked" from "picked a plan,
+ * saw the card form, and backed out" — two very different problems that
+ * `paywall_view` alone cannot separate, since Stripe is off-domain.
+ *
+ * Guarded per tab because the `subscription=cancelled` param persists after the
+ * return: the wizard's URL-sync effect only rewrites the query when the step
+ * changes, and on a cancel return the step is already correct, so a refresh
+ * would otherwise report the same abandonment again.
+ */
+export function trackPaywallCheckoutCancelled() {
+  try {
+    if (sessionStorage.getItem(CHECKOUT_CANCELLED_SESSION_KEY)) return;
+    sessionStorage.setItem(CHECKOUT_CANCELLED_SESSION_KEY, "1");
+  } catch {
+    // In-app browsers may block sessionStorage — double-counting beats dropping.
+  }
+
+  try {
+    analytics.sendDatafastEvent("paywall_checkout_cancelled", {});
+  } catch {
+    // Never let analytics take the checkout UI down; see trackPaywallView.
+  }
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -1,6 +1,10 @@
 import { useUpdateSubscriptionTier } from "@/app/api/__generated__/endpoints/credits/credits";
 import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models/subscriptionTierRequestTier";
 import { toast } from "@/components/molecules/Toast/use-toast";
+import {
+  getSubscriptionValue,
+  trackAdsConversion,
+} from "@/services/analytics/google-ads";
 import { environment } from "@/services/environment";
 import { useState } from "react";
 import { useSearchParams } from "next/navigation";
@@ -87,23 +91,31 @@ export function useSubscriptionStep() {
 
     setSelectedPlan(planKey);
     const tier = PLAN_TO_TIER[planKey];
+    const cycle = isYearly ? "yearly" : "monthly";
 
     try {
       // The paywall is the first step, so there's no profile to submit yet —
       // name / role / pain points are collected after payment. On a successful
       // checkout Stripe returns the user to Welcome to begin onboarding; on
-      // cancel, back to this paywall.
+      // cancel, back to this paywall. Stripe fills {CHECKOUT_SESSION_ID}; plan
+      // and cycle let the return page report the subscription to Google Ads.
       const baseUrl = `${window.location.origin}/onboarding`;
       const result = await updateTier({
         data: {
           tier,
-          success_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.welcome}&subscription=success`,
+          success_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.welcome}&subscription=success&session_id={CHECKOUT_SESSION_ID}&plan=${planKey}&cycle=${cycle}`,
           cancel_url: `${baseUrl}?step=${PAYWALL_FIRST_STEPS.subscription}&subscription=cancelled`,
-          billing_cycle: isYearly ? "yearly" : "monthly",
+          billing_cycle: cycle,
         },
       });
       const url = (result?.data as CheckoutResponse | undefined)?.url;
       if (url) {
+        // A Checkout URL is the only proof that Stripe Checkout actually
+        // starts — reporting earlier would count the in-place and failed
+        // paths as conversions.
+        trackAdsConversion("begin_checkout", {
+          value: getSubscriptionValue(planKey, cycle),
+        });
         // Navigating away — don't refetch (would set state on an
         // unmounting component while Stripe Checkout takes over).
         window.location.href = url;

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -11,6 +11,8 @@ import {
   TEAM_INTAKE_FORM_URL,
 } from "@/components/molecules/PlanCard/plans";
 import { useSubscriptionPricingExperiment } from "./useSubscriptionPricingExperiment";
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { trackPaywallView } from "./tracking";
 
 const PLAN_TO_TIER: Record<
   Exclude<PlanKey, typeof PLAN_KEYS.TEAM | typeof PLAN_KEYS.BUSINESS>,
@@ -37,7 +39,15 @@ export function useSubscriptionStep() {
 
   const { mutateAsync: updateTier, isPending: isUpdatingTier } =
     useUpdateSubscriptionTier();
-  const { billing, plans } = useSubscriptionPricingExperiment();
+  const { billing, plans, variant } = useSubscriptionPricingExperiment();
+
+  // This component only mounts once the paywall is genuinely on screen (the
+  // page gates on resolved flags and tier), so mount is the honest moment to
+  // report the impression. Reports the variant the user is looking at right
+  // now, so paywall → payment can be read per pricing arm.
+  useMountEffect(() => {
+    trackPaywallView(variant);
+  });
   // Local guard that flips synchronously on first click so the profile-save
   // phase (which runs before `isUpdatingTier` becomes true) can't be
   // re-entered by a fast double-click queueing duplicate POSTs.

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -39,14 +39,13 @@ export function useSubscriptionStep() {
 
   const { mutateAsync: updateTier, isPending: isUpdatingTier } =
     useUpdateSubscriptionTier();
-  const { billing, plans, variant } = useSubscriptionPricingExperiment();
+  const { billing, plans } = useSubscriptionPricingExperiment();
 
-  // This component only mounts once the paywall is genuinely on screen (the
-  // page gates on resolved flags and tier), so mount is the honest moment to
-  // report the impression. Reports the variant the user is looking at right
-  // now, so paywall → payment can be read per pricing arm.
+  // This step only mounts once the paywall is genuinely on screen, so mount is
+  // the honest moment to report the impression — and the one moment it can't
+  // be missed, whatever the flags resolve to afterwards.
   useMountEffect(() => {
-    trackPaywallView(variant);
+    trackPaywallView();
   });
   // Local guard that flips synchronously on first click so the profile-save
   // phase (which runs before `isUpdatingTier` becomes true) can't be

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/steps/SubscriptionStep/useSubscriptionStep.ts
@@ -3,6 +3,7 @@ import type { SubscriptionTierRequestTier } from "@/app/api/__generated__/models
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { environment } from "@/services/environment";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { PAYWALL_FIRST_STEPS, useOnboardingWizardStore } from "../../store";
 import { COUNTRIES } from "@/components/molecules/PlanCard/countries";
 import {
@@ -12,7 +13,7 @@ import {
 } from "@/components/molecules/PlanCard/plans";
 import { useSubscriptionPricingExperiment } from "./useSubscriptionPricingExperiment";
 import { useMountEffect } from "@/hooks/useMountEffect";
-import { trackPaywallView } from "./tracking";
+import { trackPaywallCheckoutCancelled, trackPaywallView } from "./tracking";
 
 const PLAN_TO_TIER: Record<
   Exclude<PlanKey, typeof PLAN_KEYS.TEAM | typeof PLAN_KEYS.BUSINESS>,
@@ -40,12 +41,18 @@ export function useSubscriptionStep() {
   const { mutateAsync: updateTier, isPending: isUpdatingTier } =
     useUpdateSubscriptionTier();
   const { billing, plans } = useSubscriptionPricingExperiment();
+  const searchParams = useSearchParams();
 
   // This step only mounts once the paywall is genuinely on screen, so mount is
   // the honest moment to report the impression — and the one moment it can't
   // be missed, whatever the flags resolve to afterwards.
   useMountEffect(() => {
     trackPaywallView();
+    // Stripe sends the user back here with `subscription=cancelled` after they
+    // abandon checkout, so the return lands on this same mount.
+    if (searchParams.get("subscription") === "cancelled") {
+      trackPaywallCheckoutCancelled();
+    }
   });
   // Local guard that flips synchronously on first click so the profile-save
   // phase (which runs before `isUpdatingTier` becomes true) can't be

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/tracking.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/tracking.ts
@@ -1,0 +1,67 @@
+import { analytics } from "@/services/analytics";
+import type { Step } from "./store";
+
+export type OnboardingStepKey =
+  | "welcome"
+  | "role"
+  | "pain_points"
+  | "preparing";
+
+const SENT_KEY_PREFIX = "onboarding_step_sent_";
+
+interface StepLayout {
+  welcome: number;
+  role: number;
+  painPoints: number;
+  preparing: number;
+}
+
+/**
+ * Maps a wizard step number to a stable key.
+ *
+ * Step numbers differ between the paywall-first and no-paywall layouts, so the
+ * number alone is meaningless across cohorts — Welcome is 2 for one and 1 for
+ * the other. Keying by name keeps a single funnel readable for both. The
+ * subscription step returns null: it is reported as `paywall_view` instead.
+ */
+export function onboardingStepKey(
+  steps: StepLayout,
+  step: Step,
+): OnboardingStepKey | null {
+  if (step === steps.welcome) return "welcome";
+  if (step === steps.role) return "role";
+  if (step === steps.painPoints) return "pain_points";
+  if (step === steps.preparing) return "preparing";
+  return null;
+}
+
+/**
+ * Reports that the user reached a wizard step, at most once per tab.
+ *
+ * The wizard's five steps share the `/onboarding` URL and the backend records
+ * only ONBOARDING_COMPLETE, so without this nothing distinguishes "abandoned on
+ * Role" from "abandoned on Preparing" — the drop between signup and copilot is
+ * a single opaque number.
+ *
+ * One goal per step rather than one goal carrying the step as metadata, because
+ * DataFast funnel steps match on goal name; metadata could not express an
+ * ordered funnel.
+ */
+export function trackOnboardingStep(key: OnboardingStepKey) {
+  const sentKey = `${SENT_KEY_PREFIX}${key}`;
+  try {
+    if (sessionStorage.getItem(sentKey)) return;
+    sessionStorage.setItem(sentKey, "1");
+  } catch {
+    // In-app browsers may block sessionStorage — double-counting a step beats
+    // dropping it, so fall through to report either way.
+  }
+
+  try {
+    analytics.sendDatafastEvent(`onboarding_${key}`, {});
+  } catch {
+    // sendDatafastEvent hands off to the third-party DataFast script, which it
+    // calls without a guard of its own. This runs inside the onboarding wizard,
+    // so an exception here would unmount the flow into an error boundary.
+  }
+}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -134,9 +134,11 @@ export function useOnboardingPage() {
     useState(true);
   const hasSubmitted = useRef(false);
   const hasInitialized = useRef(false);
-  // Set in the same batch as the init effect's `goToStep`, so the first
-  // render where this is true already carries the settled step.
-  const [isInitialized, setIsInitialized] = useState(false);
+  // Distinct from the `hasInitialized` ref above: that guards init running
+  // once, this says the chosen step has landed. Set in the same batch as the
+  // init effect's `goToStep`, so the first render where it is true already
+  // carries the settled step.
+  const [isStepSettled, setIsStepSettled] = useState(false);
 
   // Initialise store from URL on mount, clamp ?step= to the highest step
   // the user has actually reached. No-step URL resumes from the highest
@@ -162,21 +164,21 @@ export function useOnboardingPage() {
       urlStep === null ? ceiling : Math.min(urlStep, ceiling)
     ) as Step;
     goToStep(target);
-    setIsInitialized(true);
+    setIsStepSettled(true);
   }, [isReady, searchParams, goToStep, preparingStep, steps]);
 
   // Report the step the wizard is actually showing. `isOnboardingStateLoading`
   // is the same gate the page renders on — it also covers the window holding
   // the ONBOARDING_COMPLETE check that redirects finished users to /copilot —
-  // and `isInitialized` means the step above has settled, so a user resuming
+  // and `isStepSettled` means the step above has landed, so a user resuming
   // at Preparing never reports the store's default of Welcome on the way past.
   // Repeat visits to a step are dropped by `trackOnboardingStep` itself, so
   // going back and forward reports nothing new.
   useEffect(() => {
-    if (isOnboardingStateLoading || !isInitialized) return;
+    if (isOnboardingStateLoading || !isStepSettled) return;
     const key = onboardingStepKey(steps, currentStep);
     if (key) trackOnboardingStep(key);
-  }, [isOnboardingStateLoading, isInitialized, currentStep, steps]);
+  }, [isOnboardingStateLoading, isStepSettled, currentStep, steps]);
 
   // Sync store → URL when step changes; record the new ceiling.
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -134,6 +134,9 @@ export function useOnboardingPage() {
     useState(true);
   const hasSubmitted = useRef(false);
   const hasInitialized = useRef(false);
+  // Set in the same batch as the init effect's `goToStep`, so the first
+  // render where this is true already carries the settled step.
+  const [isInitialized, setIsInitialized] = useState(false);
 
   // Initialise store from URL on mount, clamp ?step= to the highest step
   // the user has actually reached. No-step URL resumes from the highest
@@ -159,27 +162,21 @@ export function useOnboardingPage() {
       urlStep === null ? ceiling : Math.min(urlStep, ceiling)
     ) as Step;
     goToStep(target);
+    setIsInitialized(true);
   }, [isReady, searchParams, goToStep, preparingStep, steps]);
 
-  // Report reaching a step, before the ceiling below is advanced past it.
-  //
-  // `>=` rather than `>` so a genuinely new user's first step still counts
-  // (their ceiling already reads 1). That same comparison discards the render
-  // that lands before the init effect above has clamped `currentStep`: a user
-  // resuming at step 3 transiently holds the store default of 1, and 1 >= 3 is
-  // false, so no spurious Welcome is reported. Going back re-renders an earlier
-  // step below the ceiling and is likewise ignored; the per-step guard in
-  // `trackOnboardingStep` covers coming forward again.
+  // Report the step the wizard is actually showing. `isOnboardingStateLoading`
+  // is the same gate the page renders on — it also covers the window holding
+  // the ONBOARDING_COMPLETE check that redirects finished users to /copilot —
+  // and `isInitialized` means the step above has settled, so a user resuming
+  // at Preparing never reports the store's default of Welcome on the way past.
+  // Repeat visits to a step are dropped by `trackOnboardingStep` itself, so
+  // going back and forward reports nothing new.
   useEffect(() => {
-    // Gated on exactly what the page renders on. While `isOnboardingStateLoading`
-    // is true the wizard is still `null`, and that window contains the
-    // ONBOARDING_COMPLETE check that redirects finished users to /copilot — so
-    // reporting on `isReady` alone counted people the UI never showed a step to.
-    if (!isReady || isOnboardingStateLoading) return;
-    if (currentStep < readHighestStep()) return;
+    if (isOnboardingStateLoading || !isInitialized) return;
     const key = onboardingStepKey(steps, currentStep);
     if (key) trackOnboardingStep(key);
-  }, [isReady, isOnboardingStateLoading, currentStep, steps]);
+  }, [isOnboardingStateLoading, isInitialized, currentStep, steps]);
 
   // Sync store → URL when step changes; record the new ceiling.
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -19,6 +19,7 @@ import {
   Step,
   useOnboardingWizardStore,
 } from "./store";
+import { onboardingStepKey, trackOnboardingStep } from "./tracking";
 
 const LD_INIT_TIMEOUT_SECONDS = 5;
 
@@ -158,6 +159,22 @@ export function useOnboardingPage() {
     ) as Step;
     goToStep(target);
   }, [isReady, searchParams, goToStep, preparingStep, steps]);
+
+  // Report reaching a step, before the ceiling below is advanced past it.
+  //
+  // `>=` rather than `>` so a genuinely new user's first step still counts
+  // (their ceiling already reads 1). That same comparison discards the render
+  // that lands before the init effect above has clamped `currentStep`: a user
+  // resuming at step 3 transiently holds the store default of 1, and 1 >= 3 is
+  // false, so no spurious Welcome is reported. Going back re-renders an earlier
+  // step below the ceiling and is likewise ignored; the per-step guard in
+  // `trackOnboardingStep` covers coming forward again.
+  useEffect(() => {
+    if (!isReady) return;
+    if (currentStep < readHighestStep()) return;
+    const key = onboardingStepKey(steps, currentStep);
+    if (key) trackOnboardingStep(key);
+  }, [isReady, currentStep, steps]);
 
   // Sync store → URL when step changes; record the new ceiling.
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/onboarding/useOnboardingPage.ts
@@ -171,11 +171,15 @@ export function useOnboardingPage() {
   // step below the ceiling and is likewise ignored; the per-step guard in
   // `trackOnboardingStep` covers coming forward again.
   useEffect(() => {
-    if (!isReady) return;
+    // Gated on exactly what the page renders on. While `isOnboardingStateLoading`
+    // is true the wizard is still `null`, and that window contains the
+    // ONBOARDING_COMPLETE check that redirects finished users to /copilot — so
+    // reporting on `isReady` alone counted people the UI never showed a step to.
+    if (!isReady || isOnboardingStateLoading) return;
     if (currentStep < readHighestStep()) return;
     const key = onboardingStepKey(steps, currentStep);
     if (key) trackOnboardingStep(key);
-  }, [isReady, currentStep, steps]);
+  }, [isReady, isOnboardingStateLoading, currentStep, steps]);
 
   // Sync store → URL when step changes; record the new ceiling.
   useEffect(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/PaywallGate/PaywallModal.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/PaywallGate/PaywallModal.tsx
@@ -160,6 +160,7 @@ export function PaywallModal() {
                     loading={isPending && selectedTier === plan.key}
                     disabled={isPending && selectedTier !== plan.key}
                     priceCaption="billing-period"
+                    ctaGoalSurface="upgrade_modal"
                   />
                 ))}
               </div>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/BalanceCard/BalanceCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/BalanceCard/BalanceCard.tsx
@@ -112,6 +112,8 @@ export function BalanceCard({ index = 0 }: Props) {
                 disabled={!isValid || isAdding}
                 loading={isAdding}
                 onClick={handleSubmit}
+                data-fast-goal="credit_topup_checkout"
+                data-fast-goal-surface="settings_billing"
               >
                 Continue to checkout
               </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/PaymentMethodCard/PaymentMethodCard.tsx
@@ -47,6 +47,8 @@ export function PaymentMethodCard({ index = 0 }: Props) {
           variant="secondary"
           size="small"
           onClick={onManage}
+          data-fast-goal="billing_portal_open"
+          data-fast-goal-surface="settings_payment_method"
           disabled={!canManage}
           loading={isOpening}
         >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -69,6 +69,8 @@ export function SwitchCycleDialog({
             variant="primary"
             size="small"
             onClick={onConfirm}
+            data-fast-goal="subscription_cycle_confirm"
+            data-fast-goal-surface="settings_billing"
             disabled={isSaving}
             loading={isSaving}
           >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchTierDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchTierDialog.tsx
@@ -55,6 +55,8 @@ export function SwitchTierDialog({
             onClick={onConfirm}
             disabled={isSaving}
             loading={isSaving}
+            data-fast-goal="subscription_change_confirm"
+            data-fast-goal-surface="settings_billing"
           >
             {confirmLabel ?? `Upgrade to ${targetTierLabel}`}
           </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
@@ -185,6 +185,10 @@ export function YourPlanCard({ index = 0 }: Props) {
               onClick={onUpgrade}
               disabled={isUpdatingTier}
               loading={isUpdatingTier && !plan.nextTierIsTeamLink}
+              data-fast-goal="subscription_upgrade_click"
+              data-fast-goal-from={plan.label}
+              data-fast-goal-to={plan.nextTierLabel}
+              data-fast-goal-surface="settings_billing"
               rightIcon={
                 plan.nextTierIsTeamLink ? (
                   <Icon icon={LinkSquare01Icon} size={14} aria-hidden="true" />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
@@ -172,6 +172,8 @@ export function YourPlanCard({ index = 0 }: Props) {
               size="small"
               onClick={onManage}
               disabled={!canManagePortal}
+              data-fast-goal="billing_portal_open"
+              data-fast-goal-surface="settings_billing"
             >
               Manage subscription
             </Button>

--- a/autogpt_platform/frontend/src/components/atoms/Button/Button.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Button/Button.tsx
@@ -112,8 +112,16 @@ export function Button(props: ButtonProps) {
       );
     }
 
+    // Spread first so `className` and `disabled` below still win. Without this
+    // the loading branch silently drops every extra prop the caller passed —
+    // aria-label, data-testid, analytics data-* — the moment a click flips it
+    // into loading, which is exactly when a click listener needs to read them.
     const loadingButton = (
-      <button className={loadingClassName} disabled>
+      <button
+        {...(restProps as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+        className={loadingClassName}
+        disabled
+      >
         <Icon icon={Loading03Icon} className="h-4 w-4 animate-spin" />
         {children}
       </button>

--- a/autogpt_platform/frontend/src/components/molecules/PlanCard/PlanCard.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/PlanCard/PlanCard.tsx
@@ -25,6 +25,10 @@ interface Props {
   // "charged-today" shows the prorated amount billed now; "billing-period"
   // shows a plain "billed monthly/annually" caption instead (paywall surface).
   priceCaption?: "charged-today" | "billing-period";
+  // Names the surface this card is rendered on to tag its CTA for DataFast.
+  // Omitted, the card reports nothing — each surface opts in so a shared goal
+  // never mixes clicks from the onboarding paywall and the upgrade modal.
+  ctaGoalSurface?: string;
 }
 
 export function PlanCard({
@@ -36,6 +40,7 @@ export function PlanCard({
   loading = false,
   disabled = false,
   priceCaption = "charged-today",
+  ctaGoalSurface,
 }: Props) {
   const { primaryPrice, chargedToday } = computePlanPricing({
     plan,
@@ -255,6 +260,12 @@ export function PlanCard({
               className="w-full"
               loading={loading}
               disabled={disabled}
+              {...(ctaGoalSurface && {
+                "data-fast-goal": "plan_cta_click",
+                "data-fast-goal-plan": plan.key.toLowerCase(),
+                "data-fast-goal-cycle": isYearly ? "yearly" : "monthly",
+                "data-fast-goal-surface": ctaGoalSurface,
+              })}
             >
               {plan.cta}
             </Button>


### PR DESCRIPTION
> Stacked on #14184. Base will retarget to `dev` automatically when that merges; review only the top commits until then.

### Why / What / How

**Why.** Once a user is past the paywall, we cannot see them again until they land on `/copilot`. The wizard's steps all share the `/onboarding` URL — the `?step=` param `useOnboardingPage` writes is stripped by DataFast — and the backend records only `ONBOARDING_COMPLETE`. The comment above `STEP_STORAGE_KEY` says so outright: *"the 5 in-wizard steps aren't tracked individually."*

**These are paying users.** `enable-platform-payment` is on for 100% of production (its fallthrough serves `true`, and all three targeting rules serve `true` as well, so they change nothing), and `isPaymentEnabled = flag && !userHasActivePlan`. The paywall is therefore step 1 for everyone without a plan, it has no skip control, and the only two `nextStep()` calls behind it are the local-dev shortcut and an in-place subscription change. In production the single way through is a completed Stripe checkout, which returns to `?step=welcome&subscription=success`.

So **everyone who reaches Welcome has already paid.** Abandoning the wizard after that isn't a lost signup, it's a customer who paid and never activated — and there's a concrete cost to it: the profile is submitted exactly once, on reaching Preparing (`useOnboardingPage.ts:200-210`), so anyone who leaves before that has been charged and has no name, role or pain points saved. Their copilot greeting and personalisation silently degrade.

**Scope note, corrected from an earlier revision of this description:** these goals do **not** explain the signup → copilot drop. Because payment sits *between* the paywall and Welcome, they only ever fire for someone who already paid or already had a plan. That drop is a paywall conversion problem and is one step wide — `signup → paywall_view → plan_cta_click → payment`, all of which #14184 and this PR already provide. What's here measures the post-purchase tail.

**What.** One goal per wizard step, plus the two remaining paywall blind spots.

**How.** Reporting hangs off the sessionStorage ceiling that already exists to guard resume — it knows when a user reaches a new furthest step — and runs *before* the effect that advances it.

The comparison is `>=`, not `>`, for two distinct reasons:
- a genuinely new user's first step still counts (their ceiling already reads `1`), and
- the render that lands *before* the init effect clamps `currentStep` is discarded. A user resuming at step 3 transiently holds the store default of `1`, and `1 >= 3` is false — so no spurious Welcome. Going back sits below the ceiling and is ignored; the per-step guard covers coming forward again.

Goals are keyed by **name, not number**. Welcome is step 2 with the paywall first and step 1 without it, so a number-based goal would mean different things for the two cohorts and make one funnel unreadable. And it's one goal *per* step rather than one goal carrying the step as metadata, because DataFast funnel steps match on goal name — metadata cannot express an ordered funnel.

### Changes 🏗️

- **`onboarding/tracking.ts`** (new) — `onboardingStepKey()` maps a step number to a cohort-independent key; `trackOnboardingStep()` reports `onboarding_welcome` / `onboarding_role` / `onboarding_pain_points` / `onboarding_preparing`, once per step per tab. The subscription step returns `null` — it already reports as `paywall_view`.
- **`onboarding/useOnboardingPage.ts`** — the reporting effect, placed before the ceiling-advancing effect.
- **`PlanCard.tsx`** — opt-in `ctaGoalSurface` prop tagging the CTA with `plan_cta_click` plus plan and billing cycle.
- **`SubscriptionStep.tsx`** — opts the onboarding paywall in as `onboarding_paywall`.
- **`PaywallModal.tsx`** — opts the upgrade modal in as `upgrade_modal`. `PaywallGate` wraps the whole platform (`PlatformChrome.tsx:51`), so this is what an existing unpaid account actually hits — beta accounts convert through here, and it reported nothing.
- **`SubscriptionStep/tracking.ts`** — `paywall_checkout_cancelled`, reported when Stripe returns the user with `subscription=cancelled`. Separates "never clicked" from "reached the card form and backed out", which `paywall_view` cannot see since Stripe is off-domain. Guarded per tab because that param **persists** after the return — the URL-sync effect only rewrites the query when the step changes — so a refresh would otherwise report it twice.
- **`onboarding/__tests__/tracking.test.ts`** (new) — 7 tests.

The plan-card and toggle tagging use DataFast's declarative attributes rather than handlers. Reading `datafa.st/js/script.js` confirms that needs no JS of ours: one delegated `click` listener (plus `keydown` for Enter/Space) on `document`, resolved with `closest("[data-fast-goal]")`, so React-mounted nodes work with no registration; each `data-fast-goal-*` suffix becomes a metadata key with dashes converted to underscores.

**Known limitation:** `plan_cta_click` is emitted by both the onboarding paywall and the upgrade modal, separated only by `data-fast-goal-surface` metadata. Funnel steps match on goal name and cannot filter on metadata, so the two are told apart only by the step preceding them. Happy to split it into two goal names if reviewers prefer.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm test:unit` — 287 tests pass (19 files), 7 new: key mapping is identical across both step layouts; the subscription step maps to `null`; one goal per step name; each step reported at most once per session; one step never suppresses another; still reports when `sessionStorage` throws; never throws when the DataFast script throws
  - [x] `pnpm types` — clean
  - [x] `pnpm lint` / `pnpm format` — clean
  - [ ] Post-merge on prod: confirm the four `onboarding_*` goals appear, and that their volume tracks `payment` rather than `signup`
  - [ ] Post-merge: build the post-purchase funnel (`payment` → `onboarding_welcome` → … → `onboarding_preparing`) and check whether paying users are stalling before the profile submits

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only additions with try/catch guards and sessionStorage dedupe; no changes to payment APIs or step routing beyond reading the cancel query param for tracking.
> 
> **Overview**
> Adds **post-paywall onboarding visibility** and closes a few **paywall funnel gaps** in DataFast, without changing checkout or wizard navigation behavior.
> 
> **Onboarding steps:** New `onboarding/tracking.ts` emits one goal per step (`onboarding_welcome`, `onboarding_role`, etc.), keyed by step name so paywall-first and no-paywall layouts share one funnel. `useOnboardingPage` waits for `isStepSettled` after URL/init clamping so resumed users don’t fire the wrong step; dedupe is per tab via `sessionStorage`. The subscription step is skipped here (still `paywall_view`).
> 
> **Paywall:** `trackPaywallCheckoutCancelled` fires when Stripe returns with `subscription=cancelled` (once per tab). `PlanCard` gains opt-in `ctaGoalSurface` so plan CTAs tag `plan_cta_click` with plan, cycle, and surface—onboarding uses `onboarding_paywall`, the platform upgrade modal uses `upgrade_modal`.
> 
> **Tests:** Vitest coverage for step key mapping and `trackOnboardingStep` behavior (dedupe, storage failures, analytics throws).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf4a193f649b2c48be966a39da9b6542380e112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->