### PR TITLE
feat(frontend): tag the settings-billing paying surfaces for DataFast

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/BalanceCard/BalanceCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/AutomationCreditsTab/BalanceCard/BalanceCard.tsx
@@ -112,6 +112,8 @@ export function BalanceCard({ index = 0 }: Props) {
                 disabled={!isValid || isAdding}
                 loading={isAdding}
                 onClick={handleSubmit}
+                data-fast-goal="credit_topup_checkout"
+                data-fast-goal-surface="settings_billing"
               >
                 Continue to checkout
               </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/PaymentMethodCard/PaymentMethodCard.tsx
@@ -47,6 +47,8 @@ export function PaymentMethodCard({ index = 0 }: Props) {
           variant="secondary"
           size="small"
           onClick={onManage}
+          data-fast-goal="billing_portal_open"
+          data-fast-goal-surface="settings_payment_method"
           disabled={!canManage}
           loading={isOpening}
         >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchCycleDialog.tsx
@@ -69,6 +69,8 @@ export function SwitchCycleDialog({
             variant="primary"
             size="small"
             onClick={onConfirm}
+            data-fast-goal="subscription_cycle_confirm"
+            data-fast-goal-surface="settings_billing"
             disabled={isSaving}
             loading={isSaving}
           >

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchTierDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/SwitchTierDialog.tsx
@@ -55,6 +55,8 @@ export function SwitchTierDialog({
             onClick={onConfirm}
             disabled={isSaving}
             loading={isSaving}
+            data-fast-goal="subscription_change_confirm"
+            data-fast-goal-surface="settings_billing"
           >
             {confirmLabel ?? `Upgrade to ${targetTierLabel}`}
           </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
@@ -185,6 +185,10 @@ export function YourPlanCard({ index = 0 }: Props) {
               onClick={onUpgrade}
               disabled={isUpdatingTier}
               loading={isUpdatingTier && !plan.nextTierIsTeamLink}
+              data-fast-goal="subscription_upgrade_click"
+              data-fast-goal-from={plan.label}
+              data-fast-goal-to={plan.nextTierLabel}
+              data-fast-goal-surface="settings_billing"
               rightIcon={
                 plan.nextTierIsTeamLink ? (
                   <Icon icon={LinkSquare01Icon} size={14} aria-hidden="true" />

--- a/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/billing/components/SubscriptionTab/YourPlanCard/YourPlanCard.tsx
@@ -172,6 +172,8 @@ export function YourPlanCard({ index = 0 }: Props) {
               size="small"
               onClick={onManage}
               disabled={!canManagePortal}
+              data-fast-goal="billing_portal_open"
+              data-fast-goal-surface="settings_billing"
             >
               Manage subscription
             </Button>

--- a/autogpt_platform/frontend/src/components/atoms/Button/Button.tsx
+++ b/autogpt_platform/frontend/src/components/atoms/Button/Button.tsx
@@ -112,8 +112,16 @@ export function Button(props: ButtonProps) {
       );
     }
 
+    // Spread first so `className` and `disabled` below still win. Without this
+    // the loading branch silently drops every extra prop the caller passed —
+    // aria-label, data-testid, analytics data-* — the moment a click flips it
+    // into loading, which is exactly when a click listener needs to read them.
     const loadingButton = (
-      <button className={loadingClassName} disabled>
+      <button
+        {...(restProps as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+        className={loadingClassName}
+        disabled
+      >
         <Icon icon={Loading03Icon} className="h-4 w-4 animate-spin" />
         {children}
       </button>


### PR DESCRIPTION
### Why / What / How

**Why.** I audited every way a user can give us money. There are **seven in-product paths, and exactly one of them reported anything** — the onboarding paywall, and only as of today's #14184.

That is why this morning's subscriber appears in no funnel. Their DataFast trace: first seen `agpt.co/` on Aug 19, `signin_click` → **`platform.agpt.co/login`** on Aug 24 (never `/signup`), six visits to `/settings/billing`, then a $20 Stripe payment on Aug 26. They never signed up and never saw the onboarding paywall, so no funnel we have can contain them.

For the beta cohort this is structural, not incidental. Those users already have accounts. They never touch `/signup` or the onboarding wizard — every conversion they make happens on a surface that reported nothing.

**What.** Tags the money moments on the settings-billing surfaces.

**How.** Declaratively, via `data-fast-goal`. DataFast's script handles these with a single delegated `click` listener on `document` (plus `keydown` for Enter/Space), resolved with `closest("[data-fast-goal]")` — so this adds **no logic whatsoever** to code that moves money, which is the right risk profile here. Each `data-fast-goal-*` suffix becomes a metadata key.

### Changes 🏗️

| Goal | Where | Why it matters |
|---|---|---|
| `subscription_upgrade_click` | `YourPlanCard` | The "Get <plan>" button — **unpaid accounts go straight to Stripe from here**, never through the dialog, so this is the main settings-billing conversion |
| `subscription_change_confirm` | `SwitchTierDialog` | The confirm for an existing paid plan changing tier |
| `subscription_cycle_confirm` | `SwitchCycleDialog` | Monthly ↔ yearly switch |
| `credit_topup_checkout` | `BalanceCard` | A wholly separate revenue stream from subscriptions, previously unmeasured |
| `billing_portal_open` | `YourPlanCard`, `PaymentMethodCard` | See below |

All carry `data-fast-goal-surface` so they stay separable from the onboarding paywall's goals.

**On `billing_portal_open`.** The Stripe billing portal is the one path we can never instrument: it's Stripe-hosted, `create_billing_portal_session` (`credit.py:363`) attaches no visitor metadata and has nowhere to put it, and users can upgrade, downgrade **or cancel** entirely inside it. Recording the entry at least bounds how much revenue movement leaves our view, instead of that movement being silently absent from every funnel.

**Note on top-ups.** `credit_topup_checkout` measures the click only — the payments themselves already attribute correctly, since `top_up_intent` forwards the DataFast visitor and session IDs into Stripe metadata (`credit.py:1193`). The gap was purely the funnel, not the revenue data.

### Also fixed: `Button` dropped props while loading

Review found that `Button`'s loading branch rendered `<button className={...} disabled>` with **no `restProps`**, so a button whose `loading` is bound to the pending state its own click produces loses its `data-fast-goal` attributes in the same tick — and DataFast's document-level listener then finds nothing when `closest()` runs. That silently broke most of the tags here (`SwitchTierDialog`, `BalanceCard`, `PaymentMethodCard` all bind `loading`), not just the one flagged.

Fixed in the atom rather than per call site: the same branch was also discarding `aria-label`, `type` and `data-testid`, so this is a real bug beyond analytics. `restProps` is spread first so the explicit `className` and `disabled` still win.

Because that is a shared atom, I ran the full frontend suite both ways — **5982/5990 with the fix, 5981/5990 without**, and the failing set differs run to run (the same tour, copilot and marketplace files flake either way and pass in isolation). No behaviour change attributable to the fix.

### Not in this PR

- **`_top_up_credits`** (`credit.py:1088`, auto-refill via `PaymentIntent`) does **not** forward DataFast metadata. Automatic charges have no user session to attribute, so this may be correct — but it means auto-refill revenue will always appear unattributed, and that's worth a deliberate decision rather than an accident.
- **The legacy credits page** (`profile/(user)/credits`) still routes and still sells subscriptions through `SubscriptionTierSection`. It's untagged here because it appears to be superseded by `settings/billing`; if it's still reachable in production it needs the same treatment, and if it isn't, it should be deleted.
- **A duplicate-payment bug**, found while tracing the subscriber above: two `payment` events three seconds apart carrying the *identical* Stripe `providerRefId` (`pi_3U8dBYEVwK4k8ivI0kp2dPQU`), $20 each, for one charge. Any revenue total read out of DataFast is currently inflated. Filed separately from this PR since it's a data/webhook issue, not a frontend one.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm test:unit` — 100 settings/billing tests pass (5 files), unchanged
  - [x] `pnpm types` — clean
  - [x] `pnpm lint` / `pnpm format` — clean
  - [x] Attributes only; no behaviour change to any checkout call
  - [ ] Post-merge on prod: confirm the four goals appear in the DataFast goals list
  - [ ] Post-merge: build the upgrade funnel (`/settings/billing` → `subscription_change_confirm` → `payment`)

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

No configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics attributes only on billing UI plus a small Button prop-forwarding fix; no changes to checkout, Stripe, or subscription API behavior.
> 
> **Overview**
> Adds **declarative DataFast goal tags** (`data-fast-goal`, `data-fast-goal-surface`, and tier metadata on upgrade clicks) on settings billing actions: credit top-up checkout, Stripe billing portal entry, subscription upgrade, and confirm clicks in tier/cycle switch dialogs. Surfaces are distinguished from the onboarding paywall via `data-fast-goal-surface` values like `settings_billing` and `settings_payment_method`.
> 
> **Fixes `Button` in the loading state** so caller props (including `data-fast-goal*` and other `data-*` / `aria-*`) are forwarded to the DOM instead of being dropped when `loading` is true—so goals still fire on the click that starts an async billing action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ccd6fb2b0590f33894a4f8a63ac58ac56e1d5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
