### PR TITLE
fix(backend/copilot): bound expert delegation results

### DIFF
--- a/autogpt_platform/backend/backend/copilot/model.py
+++ b/autogpt_platform/backend/backend/copilot/model.py
@@ -139,6 +139,7 @@ class ChatSessionMetadata(BaseModel):
     # accepts a cross-expert sub only when it names the caller here.
     delegated_by_expert_id: str | None = None
     delegated_by_session_id: str | None = None
+    delegated_deliverable_mode: Literal["message", "workspace_files"] = "message"
 
     # Set by ``handoff_to_expert`` alongside the delegation fields: a handoff
     # transfers ownership rather than borrowing a teammate, so the receiving
@@ -483,6 +484,7 @@ class ChatSession(ChatSessionInfo):
         expert_id: str | None = None,
         delegated_by_expert_id: str | None = None,
         delegated_by_session_id: str | None = None,
+        delegated_deliverable_mode: Literal["message", "workspace_files"] = "message",
         handed_off_from_expert_id: str | None = None,
     ) -> Self:
         return cls(
@@ -503,6 +505,7 @@ class ChatSession(ChatSessionInfo):
                 llm_credential_id=llm_credential_id,
                 delegated_by_expert_id=delegated_by_expert_id,
                 delegated_by_session_id=delegated_by_session_id,
+                delegated_deliverable_mode=delegated_deliverable_mode,
                 handed_off_from_expert_id=handed_off_from_expert_id,
             ),
             organization_id=organization_id,
@@ -1301,6 +1304,7 @@ async def create_chat_session(
     expert_id: str | None = None,
     delegated_by_expert_id: str | None = None,
     delegated_by_session_id: str | None = None,
+    delegated_deliverable_mode: Literal["message", "workspace_files"] = "message",
     handed_off_from_expert_id: str | None = None,
 ) -> ChatSession:
     """Create a new chat session and persist it.
@@ -1324,6 +1328,8 @@ async def create_chat_session(
             (None = plain AutoPilot). Provenance only.
         delegated_by_session_id: Session that delegated this session's work.
             Doubles as the poll capability for cross-expert delegation.
+        delegated_deliverable_mode: Whether the delegated result is complete
+            as a message or must include persistent workspace files.
         handed_off_from_expert_id: Expert that handed this work off for good,
             set only by ``handoff_to_expert``. Provenance only.
 
@@ -1351,6 +1357,7 @@ async def create_chat_session(
         expert_id=expert_id,
         delegated_by_expert_id=delegated_by_expert_id,
         delegated_by_session_id=delegated_by_session_id,
+        delegated_deliverable_mode=delegated_deliverable_mode,
         handed_off_from_expert_id=handed_off_from_expert_id,
     )
 

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
@@ -44,6 +44,7 @@ from backend.copilot.sdk.session_waiter import run_copilot_turn_via_queue
 from backend.data.db_accessors import experts_db
 
 from .base import BaseTool
+from .delegated_results import DeliverableMode, delegated_response_from_outcome
 from .expert_delegation import (
     chain_refusal,
     resolve_target_expert,
@@ -51,12 +52,7 @@ from .expert_delegation import (
     unknown_target_message,
 )
 from .models import DelegatedExpertInfo, ErrorResponse, ToolResponseBase
-from .run_sub_session import (
-    MAX_SUB_SESSION_WAIT_SECONDS,
-    apply_delegated_expert,
-    list_sub_workspace_files,
-    response_from_outcome,
-)
+from .run_sub_session import MAX_SUB_SESSION_WAIT_SECONDS, list_sub_workspace_files
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +122,15 @@ class DelegateToExpertTool(BaseTool):
                     ),
                     "default": 60,
                 },
+                "deliverable_mode": {
+                    "type": "string",
+                    "enum": ["message", "workspace_files"],
+                    "description": (
+                        "Use workspace_files when completion requires one or "
+                        "more persistent files; otherwise use message."
+                    ),
+                    "default": "message",
+                },
             },
             "required": ["expert_id", "prompt"],
         }
@@ -140,6 +145,7 @@ class DelegateToExpertTool(BaseTool):
         system_context: str = "",
         delegated_session_id: str = "",
         wait_for_result: int = 60,
+        deliverable_mode: DeliverableMode = "message",
         **kwargs,
     ) -> ToolResponseBase:
         target_id = expert_id.strip()
@@ -149,6 +155,8 @@ class DelegateToExpertTool(BaseTool):
             return self._error("prompt is required", session)
         if user_id is None:
             return self._error("Authentication required", session)
+        if deliverable_mode not in ("message", "workspace_files"):
+            return self._error("deliverable_mode is invalid", session)
         if target_id == session.expert_id:
             return self._error(
                 "You are that expert — do the work yourself, or use "
@@ -177,6 +185,7 @@ class DelegateToExpertTool(BaseTool):
             session=session,
             target=target,
             delegated_session_id=delegated_session_id.strip(),
+            deliverable_mode=deliverable_mode,
         )
         if isinstance(inner_session_id, ErrorResponse):
             return inner_session_id
@@ -186,7 +195,12 @@ class DelegateToExpertTool(BaseTool):
         outcome, result = await run_copilot_turn_via_queue(
             session_id=inner_session_id,
             user_id=user_id,
-            message=_handoff_message(caller, system_context, prompt),
+            message=_handoff_message(
+                caller,
+                system_context,
+                prompt,
+                deliverable_mode=deliverable_mode,
+            ),
             timeout=max(0, min(wait_for_result, MAX_SUB_SESSION_WAIT_SECONDS)),
             permissions=get_current_permissions(),
             tool_call_id=(
@@ -200,17 +214,15 @@ class DelegateToExpertTool(BaseTool):
             if outcome == "completed"
             else None
         )
-        return apply_delegated_expert(
-            response_from_outcome(
-                outcome=outcome,
-                result=result,
-                inner_session_id=inner_session_id,
-                parent_session_id=session.session_id,
-                elapsed=elapsed,
-                workspace_files=workspace_files,
-                actor=target.name,
-            ),
-            DelegatedExpertInfo(
+        return delegated_response_from_outcome(
+            outcome=outcome,
+            result=result,
+            inner_session_id=inner_session_id,
+            parent_session_id=session.session_id,
+            elapsed=elapsed,
+            workspace_files=workspace_files,
+            deliverable_mode=deliverable_mode,
+            expert=DelegatedExpertInfo(
                 id=target.id,
                 name=target.name,
                 role=target.role,
@@ -253,6 +265,7 @@ class DelegateToExpertTool(BaseTool):
         session: ChatSession,
         target: Expert,
         delegated_session_id: str,
+        deliverable_mode: DeliverableMode,
     ) -> str | ErrorResponse:
         """Reuse a prior delegation thread with this teammate, or open one.
 
@@ -269,6 +282,7 @@ class DelegateToExpertTool(BaseTool):
                 expert_id=target.id,
                 delegated_by_expert_id=session.expert_id,
                 delegated_by_session_id=session.session_id,
+                delegated_deliverable_mode=deliverable_mode,
                 origin=child_session_origin(session.metadata),
             )
             return new_session.session_id
@@ -298,6 +312,12 @@ class DelegateToExpertTool(BaseTool):
                 "empty to open a fresh one.",
                 session,
             )
+        if prior.metadata.delegated_deliverable_mode != deliverable_mode:
+            return self._error(
+                "That delegation thread uses a different deliverable mode. "
+                "Leave delegated_session_id empty to start a fresh task.",
+                session,
+            )
         return delegated_session_id
 
     async def _caller_name(self, user_id: str, caller_expert_id: str | None) -> str:
@@ -314,7 +334,13 @@ class DelegateToExpertTool(BaseTool):
         return caller.name if caller else "a teammate"
 
 
-def _handoff_message(caller: str, system_context: str, prompt: str) -> str:
+def _handoff_message(
+    caller: str,
+    system_context: str,
+    prompt: str,
+    *,
+    deliverable_mode: DeliverableMode,
+) -> str:
     """Frame the task so the teammate knows a colleague — not the user — asked.
 
     Without this the delegated prompt reads as the user speaking, and the
@@ -330,4 +356,11 @@ def _handoff_message(caller: str, system_context: str, prompt: str) -> str:
     )
     if system_context.strip():
         preamble += f"\n\n[Context: {system_context.strip()}]"
+    if deliverable_mode == "workspace_files":
+        preamble += (
+            "\n\n[Persistent files are required. Before reporting completion, "
+            "promote every promised output with "
+            "write_workspace_file(source_path=...). Local sandbox paths are "
+            "not deliverables.]"
+        )
     return f"{preamble}\n\n{prompt}"

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from backend.copilot.sdk.session_waiter import SessionResult
+from backend.copilot.sdk.stream_accumulator import ToolCallEntry
 
 from .delegate_to_expert import DelegateToExpertTool
 from .expert_delegation import CALLER_NAME_LIMIT
@@ -109,6 +110,9 @@ def mock_sessions(monkeypatch):
         sess.dry_run = kwargs.get("dry_run", False)
         sess.metadata.delegated_by_expert_id = kwargs.get("delegated_by_expert_id")
         sess.metadata.delegated_by_session_id = kwargs.get("delegated_by_session_id")
+        sess.metadata.delegated_deliverable_mode = kwargs.get(
+            "delegated_deliverable_mode", "message"
+        )
         # Without this the MagicMock answers any origin assertion truthily, so
         # a test for origin propagation would pass with the kwarg dropped.
         sess.metadata.origin = kwargs.get("origin")
@@ -364,6 +368,85 @@ class TestValidation:
 
 class TestDelegation:
     @pytest.mark.asyncio
+    async def test_completed_result_is_bounded_and_omits_tool_transcript(
+        self, roster, mock_turn, mock_sessions, monkeypatch
+    ):
+        result = SessionResult()
+        result.response_text = "x" * 50_000
+        result.tool_calls = [
+            ToolCallEntry(
+                tool_call_id=f"tc-{index}",
+                tool_name="web_search",
+                input={"query": "q" * 2_000},
+                output="raw search payload" * 2_000,
+                success=True,
+            )
+            for index in range(100)
+        ]
+        mock_turn.return_value = ("completed", result)
+        monkeypatch.setattr(
+            "backend.copilot.tools.delegate_to_expert.list_sub_workspace_files",
+            AsyncMock(return_value=[]),
+        )
+
+        response = await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id=None),
+            expert_id="expert-b",
+            prompt="research the market",
+        )
+
+        assert type(response).__name__ == "DelegatedExpertStatusResponse"
+        assert response.tool_calls is None
+        assert response.response is None
+        assert response.summary is not None
+        assert len(response.summary) <= 12_000
+        assert response.tool_call_count == 100
+        packet = response.model_dump_json(exclude_none=True).encode("utf-8")
+        assert len(packet) < 16 * 1024
+
+    @pytest.mark.asyncio
+    async def test_file_deliverable_without_workspace_artifacts_is_incomplete(
+        self, roster, mock_turn, mock_sessions, monkeypatch
+    ):
+        result = SessionResult()
+        result.response_text = "The scaffold is in my local sandbox."
+        mock_turn.return_value = ("completed", result)
+        monkeypatch.setattr(
+            "backend.copilot.tools.delegate_to_expert.list_sub_workspace_files",
+            AsyncMock(return_value=[]),
+        )
+
+        response = await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id=None),
+            expert_id="expert-b",
+            prompt="create the starter app",
+            deliverable_mode="workspace_files",
+        )
+
+        assert type(response).__name__ == "DelegatedExpertStatusResponse"
+        assert response.status == "incomplete"
+        assert response.artifact_count == 0
+        assert response.blockers
+
+    @pytest.mark.asyncio
+    async def test_file_deliverable_requires_workspace_promotion(
+        self, roster, mock_turn, mock_sessions
+    ):
+        await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id=None),
+            expert_id="expert-b",
+            prompt="create the starter app",
+            deliverable_mode="workspace_files",
+            wait_for_result=0,
+        )
+
+        message = mock_turn.await_args.kwargs["message"]
+        assert "write_workspace_file(source_path=...)" in message
+
+    @pytest.mark.asyncio
     async def test_sub_runs_in_target_scope_with_provenance(
         self, roster, mock_turn, mock_sessions
     ):
@@ -525,6 +608,54 @@ class TestHandoffReentry:
 
 
 class TestPollScope:
+    @pytest.mark.asyncio
+    async def test_completed_poll_uses_the_bounded_delegated_contract(
+        self, roster, mock_turn, mock_sessions, monkeypatch
+    ):
+        parent = _session(session_id="s1", expert_id="expert-a")
+        await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=parent,
+            expert_id="expert-b",
+            prompt="research",
+            wait_for_result=0,
+        )
+        completed = SessionResult()
+        completed.response_text = "done"
+        completed.tool_calls = [
+            ToolCallEntry(
+                tool_call_id="tc-1",
+                tool_name="web_search",
+                input={},
+                output="raw payload",
+                success=True,
+            )
+        ]
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.stream_registry.get_session",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.wait_for_session_result",
+            AsyncMock(return_value=("completed", completed)),
+        )
+        monkeypatch.setattr(
+            "backend.copilot.tools.get_sub_session_result.list_sub_workspace_files",
+            AsyncMock(return_value=[]),
+        )
+
+        response = await GetSubSessionResultTool()._execute(
+            user_id="alice",
+            session=parent,
+            sub_session_id="inner-1",
+            wait_if_running=1,
+        )
+
+        assert type(response).__name__ == "DelegatedExpertStatusResponse"
+        assert response.summary == "done"
+        assert response.tool_call_count == 1
+        assert response.tool_calls is None
+
     @pytest.mark.asyncio
     async def test_delegator_can_poll_across_expert_scope(
         self, roster, mock_turn, mock_sessions, monkeypatch

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
@@ -406,6 +406,49 @@ class TestDelegation:
         assert len(packet) < 16 * 1024
 
     @pytest.mark.asyncio
+    async def test_completed_result_redacts_developer_only_summary_content(
+        self, roster, mock_turn, mock_sessions, monkeypatch
+    ):
+        result = SessionResult()
+        result.response_text = "\n".join(
+            [
+                "Prepared /tmp/private/report.json",
+                "tool_call_id=call-1 graph_id=graph-1",
+                '{"query":"secret search payload"}',
+                "$ cat /tmp/private/report.json",
+                "<expert_identity>internal instructions</expert_identity>",
+                "Deliverable is ready.",
+            ]
+        )
+        mock_turn.return_value = ("completed", result)
+        monkeypatch.setattr(
+            "backend.copilot.tools.delegate_to_expert.list_sub_workspace_files",
+            AsyncMock(return_value=[]),
+        )
+
+        response = await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id=None),
+            expert_id="expert-b",
+            prompt="research the market",
+        )
+
+        assert response.summary is not None
+        assert "Prepared a workspace file" in response.summary
+        assert "Deliverable is ready." in response.summary
+        assert not any(
+            value in response.summary
+            for value in (
+                "/tmp",
+                "tool_call_id",
+                "graph_id",
+                "secret search payload",
+                "$ cat",
+                "internal instructions",
+            )
+        )
+
+    @pytest.mark.asyncio
     async def test_file_deliverable_without_workspace_artifacts_is_incomplete(
         self, roster, mock_turn, mock_sessions, monkeypatch
     ):

--- a/autogpt_platform/backend/backend/copilot/tools/delegated_results.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegated_results.py
@@ -1,5 +1,6 @@
 """Bounded result packets for work delegated to a hired expert."""
 
+import re
 from typing import Literal
 
 from backend.copilot.active_turns import running_turn_limit_message
@@ -21,6 +22,31 @@ _MAX_ARTIFACT_PREVIEW = 25
 _MAX_ARTIFACT_NAME_CHARS = 160
 _MAX_ARTIFACT_PATH_CHARS = 400
 _MAX_MIME_TYPE_CHARS = 100
+_INTERNAL_CONTEXT_BLOCK = re.compile(
+    r"<(?:user_context|memory_context|env_context|budget_context|"
+    r"session_context|available_skills|expert_identity|expert_workflows|"
+    r"team_context)\b[^>]*>[\s\S]*?</(?:user_context|memory_context|"
+    r"env_context|budget_context|session_context|available_skills|"
+    r"expert_identity|expert_workflows|team_context)>",
+    re.IGNORECASE,
+)
+_ABSOLUTE_PATH = re.compile(
+    r"(?:[a-z]:\\(?:users|temp|windows|workspace)\\|"
+    r"/(?:Users|home|tmp|private|var|opt|workspace|mnt)/)[^\s,;)]+",
+    re.IGNORECASE,
+)
+_UUID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-" r"[89ab][0-9a-f]{3}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+_INTERNAL_ID = re.compile(
+    r"\b(?:tool(?:_call)?|graph|block|session|execution|node(?:_exec)?)"
+    r"[_-]?id\s*[:=]\s*[\"']?[a-z0-9._:-]+[\"']?",
+    re.IGNORECASE,
+)
+_SHELL_OUTPUT_LINE = re.compile(
+    r"^\s*(?:\$\s|stdout\s*:|stderr\s*:|exit\s+code\s*:)", re.IGNORECASE
+)
 
 
 def delegated_response_from_outcome(
@@ -124,7 +150,30 @@ def _artifact(file: WorkspaceFileInfoData) -> DelegatedArtifact:
 
 
 def _summary_preview(text: str) -> str:
-    return _clip(text, MAX_DELEGATED_SUMMARY_CHARS)
+    return _clip(_safe_summary(text), MAX_DELEGATED_SUMMARY_CHARS)
+
+
+def _safe_summary(text: str) -> str:
+    """Remove developer-only material before a manager can relay the result."""
+    without_context = _INTERNAL_CONTEXT_BLOCK.sub("", text)
+    safe_lines: list[str] = []
+    for line in without_context.splitlines():
+        stripped = line.strip()
+        if _SHELL_OUTPUT_LINE.match(line):
+            continue
+        if (stripped.startswith("{") and stripped.endswith("}")) or (
+            stripped.startswith("[") and stripped.endswith("]")
+        ):
+            continue
+        safe_lines.append(
+            _UUID.sub(
+                "reference",
+                _INTERNAL_ID.sub(
+                    "internal reference", _ABSOLUTE_PATH.sub("a workspace file", line)
+                ),
+            ).rstrip()
+        )
+    return "\n".join(safe_lines).strip()
 
 
 def _clip(value: str, limit: int) -> str:

--- a/autogpt_platform/backend/backend/copilot/tools/delegated_results.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegated_results.py
@@ -1,0 +1,162 @@
+"""Bounded result packets for work delegated to a hired expert."""
+
+from typing import Literal
+
+from backend.copilot.active_turns import running_turn_limit_message
+from backend.copilot.sdk.session_waiter import SessionOutcome, SessionResult
+
+from .models import (
+    DelegatedArtifact,
+    DelegatedExpertInfo,
+    DelegatedExpertStatusResponse,
+    WorkspaceFileInfoData,
+)
+from .run_sub_session import _sub_session_link, _workspace_files_from_tool_calls
+
+DeliverableMode = Literal["message", "workspace_files"]
+
+MAX_DELEGATED_PACKET_BYTES = 16 * 1024
+MAX_DELEGATED_SUMMARY_CHARS = 12_000
+_MAX_ARTIFACT_PREVIEW = 25
+_MAX_ARTIFACT_NAME_CHARS = 160
+_MAX_ARTIFACT_PATH_CHARS = 400
+_MAX_MIME_TYPE_CHARS = 100
+
+
+def delegated_response_from_outcome(
+    *,
+    outcome: SessionOutcome,
+    result: SessionResult,
+    inner_session_id: str,
+    parent_session_id: str | None,
+    elapsed: float,
+    expert: DelegatedExpertInfo,
+    deliverable_mode: DeliverableMode,
+    workspace_files: list[WorkspaceFileInfoData] | None = None,
+) -> DelegatedExpertStatusResponse:
+    """Translate a delegated turn without returning its tool transcript."""
+    link = _sub_session_link(inner_session_id)
+    common = {
+        "session_id": parent_session_id,
+        "sub_session_id": inner_session_id,
+        "sub_autopilot_session_id": inner_session_id,
+        "sub_autopilot_session_link": link,
+        "elapsed_seconds": round(max(0, elapsed), 2),
+        "expert": expert,
+        "deliverable_mode": deliverable_mode,
+        "tool_call_count": len(result.tool_calls),
+    }
+
+    if outcome == "queued":
+        return _fit_packet(
+            DelegatedExpertStatusResponse(
+                message=f"{expert.name}'s next task is queued.",
+                status="queued",
+                **common,
+            )
+        )
+    if outcome == "running":
+        return _fit_packet(
+            DelegatedExpertStatusResponse(
+                message=f"{expert.name} is working.",
+                status="running",
+                **common,
+            )
+        )
+    if outcome == "rejected_concurrent_turn_cap":
+        return _fit_packet(
+            DelegatedExpertStatusResponse(
+                message=running_turn_limit_message(),
+                status="error",
+                blockers=["The concurrent expert-work limit was reached."],
+                **common,
+            )
+        )
+    if outcome == "failed":
+        return _fit_packet(
+            DelegatedExpertStatusResponse(
+                message=f"{expert.name} could not complete the delegated task.",
+                status="error",
+                blockers=["The delegated expert turn failed."],
+                **common,
+            )
+        )
+
+    files = workspace_files
+    if files is None:
+        files = _workspace_files_from_tool_calls(result.tool_calls)
+    artifacts = [_artifact(file) for file in files[:_MAX_ARTIFACT_PREVIEW]]
+    artifact_count = len(files)
+    missing_files = deliverable_mode == "workspace_files" and not artifacts
+    status = "incomplete" if missing_files else "completed"
+    blockers = (
+        [
+            "The task required persistent files, but the expert did not promote "
+            "any output with write_workspace_file(source_path=...)."
+        ]
+        if missing_files
+        else []
+    )
+    message = (
+        f"{expert.name} finished, but the required files are not accessible."
+        if missing_files
+        else f"{expert.name} completed the delegated task."
+    )
+    response = DelegatedExpertStatusResponse(
+        message=message,
+        status=status,
+        summary=_summary_preview(result.response_text),
+        blockers=blockers,
+        artifacts=artifacts,
+        artifact_count=artifact_count,
+        **common,
+    )
+    return _fit_packet(response)
+
+
+def _artifact(file: WorkspaceFileInfoData) -> DelegatedArtifact:
+    return DelegatedArtifact(
+        name=_clip(file.name, _MAX_ARTIFACT_NAME_CHARS),
+        read_path=_clip(file.path, _MAX_ARTIFACT_PATH_CHARS),
+        mime_type=_clip(file.mime_type, _MAX_MIME_TYPE_CHARS),
+        size_bytes=max(0, file.size_bytes),
+    )
+
+
+def _summary_preview(text: str) -> str:
+    return _clip(text, MAX_DELEGATED_SUMMARY_CHARS)
+
+
+def _clip(value: str, limit: int) -> str:
+    if limit <= 0:
+        return ""
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+def _fit_packet(
+    response: DelegatedExpertStatusResponse,
+) -> DelegatedExpertStatusResponse:
+    """Fit the serialized model-facing packet below the hard byte ceiling."""
+    while _packet_size(response) >= MAX_DELEGATED_PACKET_BYTES and response.artifacts:
+        response = response.model_copy(update={"artifacts": response.artifacts[:-1]})
+    if _packet_size(response) < MAX_DELEGATED_PACKET_BYTES or not response.summary:
+        return response
+
+    low = 0
+    high = len(response.summary)
+    while low < high:
+        midpoint = (low + high + 1) // 2
+        candidate = response.model_copy(
+            update={"summary": _clip(response.summary, midpoint)}
+        )
+        if _packet_size(candidate) < MAX_DELEGATED_PACKET_BYTES:
+            low = midpoint
+        else:
+            high = midpoint - 1
+    return response.model_copy(update={"summary": _clip(response.summary, low)})
+
+
+def _packet_size(response: DelegatedExpertStatusResponse) -> int:
+    return len(response.model_dump_json(exclude_none=True).encode("utf-8"))

--- a/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
@@ -20,7 +20,7 @@ re-verified on every call by loading the ChatSession and comparing its
 import json
 import logging
 import time
-from typing import Any
+from typing import Any, Literal
 
 from backend.copilot import stream_registry
 from backend.copilot.executor.utils import enqueue_cancel_task
@@ -34,6 +34,7 @@ from backend.copilot.sdk.stream_accumulator import ToolCallEntry
 from backend.data.db_accessors import experts_db
 
 from .base import BaseTool
+from .delegated_results import delegated_response_from_outcome
 from .models import (
     DelegatedExpertInfo,
     ErrorResponse,
@@ -247,6 +248,17 @@ class GetSubSessionResultTool(BaseTool):
             if outcome == "completed"
             else None
         )
+        if delegate is not None:
+            return delegated_response_from_outcome(
+                outcome=outcome,
+                result=result,
+                inner_session_id=inner_session_id,
+                parent_session_id=session.session_id,
+                elapsed=elapsed,
+                workspace_files=workspace_files,
+                deliverable_mode=_delegated_deliverable_mode(sub),
+                expert=delegate,
+            )
         return apply_delegated_expert(
             response_from_outcome(
                 outcome=outcome,
@@ -258,6 +270,13 @@ class GetSubSessionResultTool(BaseTool):
             ),
             delegate,
         )
+
+
+def _delegated_deliverable_mode(
+    sub: ChatSession,
+) -> Literal["message", "workspace_files"]:
+    mode = sub.metadata.delegated_deliverable_mode
+    return mode if mode in ("message", "workspace_files") else "message"
 
 
 def _in_caller_scope(sub: ChatSession, session: ChatSession) -> bool:

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -392,7 +392,13 @@ class SubSessionStatusResponse(ToolResponseBase):
 
     type: ResponseType = ResponseType.MCP_TOOL_OUTPUT
     status: Literal[
-        "running", "completed", "cancelled", "error", "queued", "transferred"
+        "running",
+        "completed",
+        "incomplete",
+        "cancelled",
+        "error",
+        "queued",
+        "transferred",
     ] = Field(
         description=(
             "Current state of the sub-AutoPilot run.  ``queued`` means the "
@@ -467,6 +473,31 @@ class SubSessionStatusResponse(ToolResponseBase):
             "and the sub is still running."
         ),
     )
+
+
+class DelegatedCriterionState(BaseModel):
+    criterion: str
+    status: Literal["met", "unmet", "unknown"]
+    evidence: str | None = None
+
+
+class DelegatedArtifact(BaseModel):
+    name: str
+    read_path: str
+    mime_type: str
+    size_bytes: int
+
+
+class DelegatedExpertStatusResponse(SubSessionStatusResponse):
+    """Compact result contract returned only for cross-expert delegation."""
+
+    deliverable_mode: Literal["message", "workspace_files"]
+    summary: str | None = None
+    criteria: list[DelegatedCriterionState] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    artifacts: list[DelegatedArtifact] = Field(default_factory=list)
+    artifact_count: int = 0
+    tool_call_count: int = 0
 
 
 class InputValidationErrorResponse(ToolResponseBase):

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -16793,6 +16793,12 @@
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Delegated By Session Id"
           },
+          "delegated_deliverable_mode": {
+            "type": "string",
+            "enum": ["message", "workspace_files"],
+            "title": "Delegated Deliverable Mode",
+            "default": "message"
+          },
           "handed_off_from_expert_id": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Handed Off From Expert Id"
@@ -17729,7 +17735,8 @@
             "default": {
               "dry_run": false,
               "llm_auth_provider": "platform",
-              "kind": "normal"
+              "kind": "normal",
+              "delegated_deliverable_mode": "message"
             }
           },
           "expert_id": {
@@ -25059,7 +25066,8 @@
             "default": {
               "dry_run": false,
               "llm_auth_provider": "platform",
-              "kind": "normal"
+              "kind": "normal",
+              "delegated_deliverable_mode": "message"
             }
           },
           "expert_id": {


### PR DESCRIPTION
### Why / What / How

Delegated expert runs could return enormous tool transcripts and local-only paths to AutoPilot, causing context blowups, repeated condensation, raw internal leakage, and inaccessible founder deliverables.

This PR introduces a dedicated, bounded manager completion packet for expert delegation. It exposes only status, summary, criteria, blockers, artifacts, elapsed time, tool-call count, and the expert-session link. File-delivery tasks must promote outputs to workspace files; missing required artifacts make the task incomplete. All behavior is gated by `Flag.HIRE_EXPERTS`, preserving the flag-off path.

### Changes 🏗️

- Separate expert delegation results from ordinary sub-session results.
- Cap manager packets below 16 KB and summary previews at 12,000 characters.
- Add `deliverable_mode` for message and workspace-file tasks.
- Require persistent workspace artifacts for file-producing work.
- Sanitize founder-facing summaries, blockers, artifact metadata, and errors.
- Add regression coverage for 100-tool-call runs, missing files, packet bounds, and flag-off behavior.

### Stack

- Base: `dev`
- Next: #14197

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Focused delegated-result and sub-session backend tests
  - [x] Tool schema and feature-flag tests
  - [x] Ruff and Pyright on changed backend code

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] No configuration changes are required
