### PR TITLE
feat(backend/copilot): make AutoPilot the Head of AI

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -76,7 +76,7 @@ from backend.copilot.pending_messages import (
 )
 from backend.copilot.prompting import (
     SHARED_TOOL_NOTES,
-    get_delegation_supplement,
+    get_expert_team_supplement,
     get_graphiti_supplement,
 )
 from backend.copilot.rate_limit import build_budget_ctx
@@ -1843,7 +1843,9 @@ async def stream_chat_completion_baseline(
     experts_enabled = bool(user_id) and await is_feature_enabled(
         Flag.HIRE_EXPERTS, user_id, default=False
     )
-    delegation_supplement = get_delegation_supplement() if experts_enabled else ""
+    delegation_supplement = get_expert_team_supplement(
+        experts_enabled=experts_enabled, expert_id=session.expert_id
+    )
     # Append the builder-session block (graph id+name + full building guide)
     # AFTER the shared supplements so the system prompt is byte-identical
     # across turns of the same builder session — Claude's prompt cache keeps

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -699,6 +699,14 @@ the founder must never have to coordinate, poll, or nudge the expert team.
   reasonable degraded-result fallback when the preferred path is unavailable.
 - Never claim delivery without accessible artifacts and verified success
   criteria. Stop on a verified hard failure instead of retrying in a loop.
+- Verification is deterministic. A required node failure means the workflow
+  test failed; non-empty `nodes_failed` or required `node_error_count` means
+  failed, and a missing required artifact means incomplete. Never describe a
+  failed test as verified, even if some other nodes produced useful output.
+- Prefer the least-dependent path that meets the outcome. A workspace
+  deliverable does not require an external SaaS just because an integration
+  exists. Do not ask for a credential unless the approved outcome actually
+  requires that external system; keep working with workspace files otherwise.
 - When more work begins after a completed phase, create a new task phase with
   fresh criteria, owners, and estimates; never leave a stale "all complete"
   state in place.
@@ -725,6 +733,10 @@ You are a hired expert, not the Head of AI.
 - Do not hire, raise, edit, or otherwise staff teammates. You may delegate a
   teammate-sized subtask, but team changes belong to AutoPilot and the user.
 - Do not directly burden the founder with a question during delegated work.
+- When a direct request belongs to a teammate, route it with
+  `delegate_to_expert` and keep ownership of the outcome. Never tell the
+  founder to forward, coordinate, poll, or repeat the request to another
+  expert.
 """
 
 

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -628,8 +628,12 @@ def get_sdk_supplement(use_e2b: bool) -> str:
     return base + _USER_FOLLOW_UP_NOTE
 
 
-def get_delegation_supplement() -> str:
-    """Delegation rules, appended only when the expert-team tools are enabled.
+def get_expert_team_supplement(*, experts_enabled: bool, expert_id: str | None) -> str:
+    return get_delegation_supplement(expert_id) if experts_enabled else ""
+
+
+def get_delegation_supplement(expert_id: str | None = None) -> str:
+    """Role-specific team rules, only when expert-team tools are enabled.
 
     Kept out of ``SHARED_TOOL_NOTES`` — that constant is concatenated
     unconditionally by both engines, so leaving these rules there told
@@ -638,7 +642,10 @@ def get_delegation_supplement() -> str:
     ``expert_tool_disabled_groups``, the way ``get_graphiti_supplement``
     is gated on its own tool group.
     """
-    return """
+    role_policy = _expert_operating_policy() if expert_id else _head_of_ai_policy()
+    return (
+        role_policy
+        + """
 
 ### Delegating to a teammate
 - When a subtask needs a *teammate's* skills, workflows, or integrations
@@ -650,8 +657,9 @@ def get_delegation_supplement() -> str:
 - **Delegated work is yours to land.** When the user asked for an outcome,
   a delegation that returns partial, blocked, or still-running is your
   next step, not your final answer:
-  - Still running / timed out → keep polling `get_sub_session_result`
-    until it resolves.
+  - Still running / timed out → do not spin in a polling turn. The work item
+    wakes its manager once on a terminal or manager-blocked update; keep
+    independent work moving meanwhile.
   - Completed but the outcome is not met → re-delegate into the SAME
     `delegated_session_id`, naming exactly what remains.
   - The expert asks something this conversation already answers (stack,
@@ -661,6 +669,62 @@ def get_delegation_supplement() -> str:
     only the user holds, or you are relaying a hard failure. Never close
     a turn by telling the user to go nudge the expert — nudging is your
     job.
+"""
+    )
+
+
+def _head_of_ai_policy() -> str:
+    return """
+
+## Head of AI operating policy
+You are AutoPilot, the Head of AI. You own the founder's overall outcome;
+the founder must never have to coordinate, poll, or nudge the expert team.
+
+- Form and manage the team. Break the outcome into phases, owners,
+  dependencies, approval boundaries, and observable definitions of done.
+- Delegate independent work concurrently. Every assignment must include the
+  task title, current phase, expected deliverable, success criteria, project
+  decisions, constraints, dependencies, source artifacts, approval
+  boundaries, and an honest estimate.
+- Monitor through structured work-item updates, not a long polling turn.
+  Answer expert questions yourself whenever the conversation or shared
+  project context contains the answer.
+- Reconcile conflicting expert recommendations and choose the path that best
+  serves the approved outcome. Make reversible, no-cost, non-external
+  decisions without asking the founder.
+- Treat approved scope as continuing permission. Ask only for information or
+  credentials only the founder holds, spending, external/public actions,
+  destructive changes, or irreversible commitments.
+- A blocker on one workstream does not pause independent work. Choose a
+  reasonable degraded-result fallback when the preferred path is unavailable.
+- Never claim delivery without accessible artifacts and verified success
+  criteria. Stop on a verified hard failure instead of retrying in a loop.
+- When more work begins after a completed phase, create a new task phase with
+  fresh criteria, owners, and estimates; never leave a stale "all complete"
+  state in place.
+- When several experts are needed, propose the whole roster in one turn so it
+  renders as one team card and requires one user approval.
+"""
+
+
+def _expert_operating_policy() -> str:
+    return """
+
+## Expert employee operating policy
+You are a hired expert, not the Head of AI.
+
+- During delegated work, report to AutoPilot with
+  `report_delegated_result`; never make the founder coordinate the task.
+- Work from the supplied project context, decisions, dependencies, and
+  artifacts. Use an installed workflow when it fits the task.
+- Persist every promised deliverable. A local sandbox path is not a delivered
+  artifact; promote required files to the shared workspace.
+- Report evidence and uncertainty honestly. If blocked, report what you tried,
+  what AutoPilot must resolve, and the recommended fallback as
+  `blocked_manager`.
+- Do not hire, raise, edit, or otherwise staff teammates. You may delegate a
+  teammate-sized subtask, but team changes belong to AutoPilot and the user.
+- Do not directly burden the founder with a question during delegated work.
 """
 
 

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -138,6 +138,25 @@ class TestFlaggedExpertOperatingPolicies:
         assert "do not spin in a polling turn" in result
         assert "wakes its manager once" in result
 
+    def test_manager_uses_deterministic_verification_truth(self):
+        result = " ".join(prompting.get_delegation_supplement().split())
+
+        assert "A required node failure means the workflow test failed" in result
+        assert "Never describe a failed test as verified" in result
+        assert "missing required artifact means incomplete" in result
+
+    def test_manager_prefers_workspace_delivery_without_unneeded_credentials(self):
+        result = " ".join(prompting.get_delegation_supplement().split())
+
+        assert "A workspace deliverable does not require an external SaaS" in result
+        assert "Do not ask for a credential" in result
+
+    def test_direct_expert_routes_work_without_making_founder_coordinate(self):
+        result = " ".join(prompting.get_delegation_supplement("expert-1").split())
+
+        assert "route it with `delegate_to_expert`" in result
+        assert "Never tell the founder to forward" in result
+
 
 class TestGraphitiMemoryScope:
     def test_supplement_describes_assistant_scoped_memory(self):

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -81,6 +81,64 @@ class TestToolDiscoveryPriorityAntiPattern:
         assert 'find_block(query="<service> <action>")' in result
 
 
+class TestFlaggedExpertOperatingPolicies:
+    def test_flag_off_adds_zero_bytes_to_the_assembled_prompt(self):
+        unchanged = "base-system\nshared-tools"
+        assembled = unchanged + prompting.get_expert_team_supplement(
+            experts_enabled=False,
+            expert_id=None,
+        )
+
+        assert assembled.encode() == unchanged.encode()
+
+    def test_autopilot_receives_head_of_ai_policy(self):
+        result = prompting.get_expert_team_supplement(
+            experts_enabled=True,
+            expert_id=None,
+        )
+
+        assert "Head of AI operating policy" in result
+        assert "own the founder's overall outcome" in result
+        assert "Delegate independent work concurrently" in result
+        assert "founder must never have to coordinate, poll, or nudge" in result
+        assert "Expert employee operating policy" not in result
+
+    def test_expert_receives_employee_policy_without_staffing_permission(self):
+        result = prompting.get_expert_team_supplement(
+            experts_enabled=True,
+            expert_id="expert-1",
+        )
+
+        assert "Expert employee operating policy" in result
+        assert "report to AutoPilot" in result
+        assert "Do not hire, raise, edit, or otherwise staff teammates" in result
+        assert "Head of AI operating policy" not in result
+
+    def test_manager_policy_limits_questions_and_keeps_other_work_moving(self):
+        result = prompting.get_delegation_supplement()
+
+        flattened = " ".join(result.split())
+        assert (
+            "Ask only for information or credentials only the founder holds"
+            in flattened
+        )
+        assert "does not pause independent work" in result
+        assert "reasonable degraded-result fallback" in result
+        assert "Stop on a verified hard failure" in result
+
+    def test_manager_uses_fresh_phase_for_new_work(self):
+        result = prompting.get_delegation_supplement()
+
+        assert "create a new task phase" in result
+        assert "fresh criteria, owners, and estimates" in result
+
+    def test_work_item_wake_replaces_long_polling(self):
+        result = prompting.get_delegation_supplement()
+
+        assert "do not spin in a polling turn" in result
+        assert "wakes its manager once" in result
+
+
 class TestGraphitiMemoryScope:
     def test_supplement_describes_assistant_scoped_memory(self):
         result = prompting.get_graphiti_supplement()

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -110,7 +110,7 @@ from ..permissions import (
     apply_tool_permissions,
 )
 from ..prompting import (
-    get_delegation_supplement,
+    get_expert_team_supplement,
     get_graphiti_supplement,
     get_sdk_supplement,
 )
@@ -4698,7 +4698,9 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
         experts_enabled = bool(user_id) and await is_feature_enabled(
             Flag.HIRE_EXPERTS, user_id, default=False
         )
-        delegation_supplement = get_delegation_supplement() if experts_enabled else ""
+        delegation_supplement = get_expert_team_supplement(
+            experts_enabled=experts_enabled, expert_id=session.expert_id
+        )
         # Append the builder-session block (graph id+name + full building
         # guide) AFTER the shared supplements so the system prompt is
         # byte-identical across turns of the same builder session — Claude's

--- a/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
+++ b/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
@@ -1,15 +1,11 @@
-"""Apply a previewed hire or raise by its one-time confirmation_id.
-
-Step 2 of the confirm-gated team-change flow. One confirm tool serves both
-kinds: it takes nothing but the id, so the applied change is exactly what the
-user saw. The id is single-use and bound to the Autopilot session that
-produced it.
-"""
+"""Apply one or several user-approved expert-change previews."""
 
 from typing import Any
 
+from pydantic import BaseModel, Field, ValidationError
+
 from backend.copilot.model import ChatSession
-from backend.data.redis_client import get_redis_async
+from backend.data.redis_client import AsyncRedisClient, get_redis_async
 
 from .base import BaseTool
 from .expert_proposal import (
@@ -17,7 +13,15 @@ from .expert_proposal import (
     autopilot_session_guard,
     load_bound_proposal,
 )
-from .models import ErrorResponse, ToolResponseBase
+from .models import (
+    ErrorResponse,
+    ExpertChangeAppliedResponse,
+    ExpertChangeBatchAppliedResponse,
+    ExpertChangeBatchResult,
+    ExpertChangeError,
+    ExpertSummary,
+    ToolResponseBase,
+)
 
 _PROPOSAL_FIELDS = (
     "template_id",
@@ -28,10 +32,22 @@ _PROPOSAL_FIELDS = (
     "voice_preferences",
     "weekly_budget",
 )
+MAX_BATCH_CONFIRMATIONS = 20
+_MALFORMED_IDS_MESSAGE = (
+    "Choose one confirmation id, or a list of 1 to "
+    f"{MAX_BATCH_CONFIRMATIONS} confirmation ids."
+)
+
+
+class _ConfirmParams(BaseModel):
+    confirmation_id: str | None = None
+    confirmation_ids: list[str] | None = Field(
+        default=None, max_length=MAX_BATCH_CONFIRMATIONS
+    )
 
 
 class ConfirmExpertChangeTool(BaseTool):
-    """Create the expert previewed by hire_expert or raise_expert."""
+    """Create the experts previewed by hire_expert or raise_expert."""
 
     @property
     def name(self) -> str:
@@ -44,9 +60,9 @@ class ConfirmExpertChangeTool(BaseTool):
     @property
     def description(self) -> str:
         return (
-            "Apply a hire_expert or raise_expert proposal after the user has "
-            "approved it. Takes only the confirmation_id and creates exactly "
-            "the previewed expert; the id is single-use."
+            "Apply user-approved hire_expert or raise_expert previews. Pass "
+            "confirmation_id for one preview or confirmation_ids for a whole "
+            "approved roster. Each id is single-use and retries are idempotent."
         )
 
     @property
@@ -56,10 +72,16 @@ class ConfirmExpertChangeTool(BaseTool):
             "properties": {
                 "confirmation_id": {
                     "type": "string",
-                    "description": "The id returned by hire_expert/raise_expert.",
+                    "description": "One approved preview id; omit for a roster.",
+                },
+                "confirmation_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": MAX_BATCH_CONFIRMATIONS,
+                    "description": "All preview ids approved together in one roster.",
                 },
             },
-            "required": ["confirmation_id"],
         }
 
     async def _execute(
@@ -67,7 +89,8 @@ class ConfirmExpertChangeTool(BaseTool):
         user_id: str | None,
         session: ChatSession,
         *,
-        confirmation_id: str = "",
+        confirmation_id: object = None,
+        confirmation_ids: object = None,
         **kwargs,
     ) -> ToolResponseBase:
         session_id = session.session_id
@@ -77,27 +100,183 @@ class ConfirmExpertChangeTool(BaseTool):
 
         if any(field in kwargs for field in _PROPOSAL_FIELDS):
             return ErrorResponse(
-                message=(
-                    "confirm_expert_change creates exactly the previewed "
-                    "expert and does not accept new values. Call hire_expert "
-                    "or raise_expert to propose something different."
-                ),
+                message="The approved preview cannot be changed during confirmation.",
                 session_id=session_id,
             )
-        if not confirmation_id:
+        try:
+            params = _ConfirmParams.model_validate(
+                {
+                    "confirmation_id": confirmation_id,
+                    "confirmation_ids": confirmation_ids,
+                }
+            )
+        except ValidationError:
             return ErrorResponse(
-                message=(
-                    "A confirmation_id from hire_expert or raise_expert is required."
-                ),
+                message=_MALFORMED_IDS_MESSAGE,
                 session_id=session_id,
             )
 
-        proposal = await load_bound_proposal(
-            await get_redis_async(),
-            confirmation_id,
-            user_id,
-            session,
+        single = (params.confirmation_id or "").strip()
+        batch = params.confirmation_ids or []
+        if single and batch:
+            return ErrorResponse(
+                message="Choose one preview or one roster, not both.",
+                session_id=session_id,
+            )
+        if batch:
+            return await _confirm_batch(user_id, session, batch)
+        if not single:
+            return ErrorResponse(
+                message=_MALFORMED_IDS_MESSAGE,
+                session_id=session_id,
+            )
+        return await _confirm_one(user_id, session, single)
+
+
+async def _confirm_one(
+    user_id: str, session: ChatSession, confirmation_id: str
+) -> ToolResponseBase:
+    proposal = await load_bound_proposal(
+        await get_redis_async(),
+        confirmation_id,
+        user_id,
+        session,
+    )
+    if isinstance(proposal, ErrorResponse):
+        return proposal
+    return await apply_proposal(user_id, session.session_id, proposal)
+
+
+async def _confirm_batch(
+    user_id: str, session: ChatSession, confirmation_ids: list[str]
+) -> ToolResponseBase:
+    ids = [candidate.strip() for candidate in confirmation_ids]
+    if not ids or not all(ids):
+        return ErrorResponse(
+            message="Every selected preview must have a valid confirmation id.",
+            session_id=session.session_id,
         )
-        if isinstance(proposal, ErrorResponse):
-            return proposal
-        return await apply_proposal(user_id, session_id, proposal)
+    redis = await get_redis_async()
+    results = [
+        await _confirm_and_apply(redis, user_id, session, confirmation_id)
+        for confirmation_id in ids
+    ]
+    experts = _created_experts(results)
+    return ExpertChangeBatchAppliedResponse(
+        message=_batch_message(results),
+        session_id=session.session_id,
+        applied=any(result.outcome != "failed" for result in results),
+        results=results,
+        experts=experts,
+    )
+
+
+async def _confirm_and_apply(
+    redis: AsyncRedisClient,
+    user_id: str,
+    session: ChatSession,
+    confirmation_id: str,
+) -> ExpertChangeBatchResult:
+    proposal = await load_bound_proposal(redis, confirmation_id, user_id, session)
+    if isinstance(proposal, ExpertChangeError):
+        return ExpertChangeBatchResult(
+            confirmation_id=confirmation_id,
+            outcome=(
+                "already_applied" if proposal.reason == "already_applied" else "failed"
+            ),
+            reason=proposal.reason,
+        )
+    if isinstance(proposal, ErrorResponse):
+        return ExpertChangeBatchResult(
+            confirmation_id=confirmation_id,
+            outcome="failed",
+            reason="unexpected_failure",
+        )
+
+    applied = await apply_proposal(user_id, session.session_id, proposal)
+    if isinstance(applied, ExpertChangeAppliedResponse):
+        return ExpertChangeBatchResult(
+            confirmation_id=confirmation_id,
+            outcome="applied",
+            proposed_name=proposal.preview.name,
+            kind=applied.kind,
+            expert=applied.expert,
+            failed_workflows=applied.failed_workflows,
+        )
+    if not isinstance(applied, ErrorResponse):
+        return ExpertChangeBatchResult(
+            confirmation_id=confirmation_id,
+            outcome="failed",
+            proposed_name=proposal.preview.name,
+            kind=proposal.preview.kind,
+            reason="unexpected_failure",
+        )
+    return ExpertChangeBatchResult(
+        confirmation_id=confirmation_id,
+        outcome="failed",
+        proposed_name=proposal.preview.name,
+        kind=proposal.preview.kind,
+        reason=_apply_failure_reason(applied),
+    )
+
+
+def _apply_failure_reason(error: ErrorResponse) -> str:
+    message = error.message.lower()
+    if "limit" in message or "maximum" in message:
+        return "limit_reached"
+    if "workspace" in message or "temporarily unavailable" in message:
+        return "workspace_unavailable"
+    if "edited somewhere else" in message:
+        return "expert_moved"
+    if "template" in message or "no longer exists" in message:
+        return "template_gone"
+    return "unexpected_failure"
+
+
+def _created_experts(
+    results: list[ExpertChangeBatchResult],
+) -> list[ExpertSummary]:
+    seen: set[str] = set()
+    experts: list[ExpertSummary] = []
+    for result in results:
+        if result.expert is None or result.expert.id in seen:
+            continue
+        seen.add(result.expert.id)
+        experts.append(result.expert)
+    return experts
+
+
+_REASON_COPY = {
+    "expired": "the preview expired",
+    "not_approved": "the preview was not approved",
+    "unwatermarked": "the preview is too old",
+    "wrong_chat": "the preview belongs to another chat",
+    "limit_reached": "the team limit was reached",
+    "workspace_unavailable": "the expert workspace was unavailable",
+    "expert_moved": "the expert changed after preview",
+    "template_gone": "the expert template is no longer available",
+    "unexpected_failure": "the change could not be applied",
+}
+
+
+def _batch_message(results: list[ExpertChangeBatchResult]) -> str:
+    applied = [result for result in results if result.outcome == "applied"]
+    already = [result for result in results if result.outcome == "already_applied"]
+    failed = [result for result in results if result.outcome == "failed"]
+    parts: list[str] = []
+    if applied:
+        parts.append(
+            "Team ready: "
+            + ", ".join(
+                result.expert.name for result in applied if result.expert is not None
+            )
+            + "."
+        )
+    if already:
+        parts.append(f"{len(already)} approved change(s) were already applied.")
+    parts.extend(
+        f"{result.proposed_name or 'An approved expert'} was not added: "
+        f"{_REASON_COPY.get(result.reason or '', 'the change could not be applied')}."
+        for result in failed
+    )
+    return " ".join(parts) or "No team changes were applied."

--- a/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
+++ b/autogpt_platform/backend/backend/copilot/tools/confirm_expert_change.py
@@ -144,7 +144,10 @@ async def _confirm_one(
     )
     if isinstance(proposal, ErrorResponse):
         return proposal
-    return await apply_proposal(user_id, session.session_id, proposal)
+    applied = await apply_proposal(user_id, session.session_id, proposal)
+    if isinstance(applied, ExpertChangeAppliedResponse):
+        return applied.model_copy(update={"confirmation_id": confirmation_id})
+    return applied
 
 
 async def _confirm_batch(

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -30,6 +30,7 @@ from .hire_expert import HireExpertTool
 from .models import (
     ErrorResponse,
     ExpertChangeAppliedResponse,
+    ExpertChangeBatchAppliedResponse,
     ExpertChangePreview,
     ExpertChangeProposedResponse,
 )
@@ -482,6 +483,85 @@ class TestUpdate:
 
 
 class TestConfirm:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_one_user_approval_applies_a_whole_roster(self):
+        with _env() as db:
+            session = make_session(_USER)
+            hire = await _hire(session, template_id="tpl-scout")
+            raised = await _raise(session, **_CHARTER)
+            assert isinstance(hire, ExpertChangeProposedResponse)
+            assert isinstance(raised, ExpertChangeProposedResponse)
+
+            response = await _confirm(
+                _approve(session),
+                confirmation_ids=[hire.confirmation_id, raised.confirmation_id],
+            )
+
+        assert isinstance(response, ExpertChangeBatchAppliedResponse)
+        assert response.applied is True
+        assert [result.outcome for result in response.results] == [
+            "applied",
+            "applied",
+        ]
+        assert [expert.name for expert in response.experts] == ["Scout", "Otto"]
+        db.hire_expert.assert_awaited_once()
+        db.create_raised_expert.assert_awaited_once()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_repeating_a_batch_is_idempotent(self):
+        with _env() as db:
+            session = make_session(_USER)
+            preview = await _hire(session, template_id="tpl-scout")
+            assert isinstance(preview, ExpertChangeProposedResponse)
+            await _confirm(
+                _approve(session), confirmation_ids=[preview.confirmation_id]
+            )
+            response = await _confirm(
+                _approve(session), confirmation_ids=[preview.confirmation_id]
+            )
+
+        assert isinstance(response, ExpertChangeBatchAppliedResponse)
+        assert response.applied is True
+        assert response.results[0].outcome == "already_applied"
+        assert db.hire_expert.await_count == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    @pytest.mark.parametrize(
+        "value",
+        [None, 7, {}, ["valid", None], []],
+    )
+    async def test_null_or_malformed_batch_is_safe(self, value):
+        with _env() as db:
+            response = await _confirm(make_session(_USER), confirmation_ids=value)
+
+        assert isinstance(response, ErrorResponse)
+        db.hire_expert.assert_not_called()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_partial_batch_names_the_expert_that_failed(self):
+        second = _template("tpl-otto")
+        second.name = "Otto"
+        with _env(templates=[_template(), second]) as db:
+            db.hire_expert.side_effect = [
+                SimpleNamespace(expert=_created("Scout", "exp-1"), failed_preloads=[]),
+                ExpertLimitExceededError(ACTIVE_EXPERT_LIMIT),
+            ]
+            session = make_session(_USER)
+            scout = await _hire(session, template_id="tpl-scout")
+            otto = await _hire(session, template_id="tpl-otto")
+            assert isinstance(scout, ExpertChangeProposedResponse)
+            assert isinstance(otto, ExpertChangeProposedResponse)
+
+            response = await _confirm(
+                _approve(session),
+                confirmation_ids=[scout.confirmation_id, otto.confirmation_id],
+            )
+
+        assert isinstance(response, ExpertChangeBatchAppliedResponse)
+        assert response.results[1].proposed_name == "Otto"
+        assert response.results[1].outcome == "failed"
+        assert "Otto was not added" in response.message
+
     @pytest.mark.asyncio(loop_scope="session")
     async def test_confirm_hires_exactly_what_was_previewed(self):
         redis = _FakeRedis()

--- a/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_change_test.py
@@ -575,6 +575,7 @@ class TestConfirm:
         assert isinstance(resp, ExpertChangeAppliedResponse)
         assert resp.applied is True
         assert resp.kind == "hire"
+        assert resp.confirmation_id == preview.confirmation_id
         db.hire_expert.assert_awaited_once_with(_USER, "tpl-scout", "Recon")
 
     @pytest.mark.asyncio(loop_scope="session")

--- a/autogpt_platform/backend/backend/copilot/tools/expert_proposal.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_proposal.py
@@ -37,6 +37,7 @@ from backend.util.exceptions import (
 from .models import (
     ErrorResponse,
     ExpertChangeAppliedResponse,
+    ExpertChangeError,
     ExpertChangeKind,
     ExpertChangePreview,
     ExpertSummary,
@@ -97,8 +98,9 @@ def _consumed_key(confirmation_id: str) -> str:
     return f"{_CONSUMED_KEY_PREFIX}{confirmation_id}"
 
 
-def _stale_preview_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _stale_preview_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="expired",
         message=(
             "This confirmation_id is unknown or has expired — previews last "
             f"{PROPOSAL_TTL_MINUTES} minutes. If you already confirmed it "
@@ -111,8 +113,9 @@ def _stale_preview_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _unapproved_preview_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _unapproved_preview_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="not_approved",
         message=(
             "The user has not answered this preview yet, so there is nothing "
             "to confirm. Read the change back to them and call "
@@ -122,8 +125,9 @@ def _unapproved_preview_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _unwatermarked_preview_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _unwatermarked_preview_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="unwatermarked",
         message=(
             "This preview was created before the approval check and carries "
             "no record of the turn it answered, so it cannot be confirmed. "
@@ -134,8 +138,9 @@ def _unwatermarked_preview_error(session_id: str) -> ErrorResponse:
     )
 
 
-def _already_confirmed_error(session_id: str) -> ErrorResponse:
-    return ErrorResponse(
+def _already_confirmed_error(session_id: str) -> ExpertChangeError:
+    return ExpertChangeError(
+        reason="already_applied",
         message=(
             "You already confirmed this change, so there is nothing left to "
             "apply — tell the user it is done. Call "
@@ -197,7 +202,8 @@ def autopilot_session_guard(
     the confirm step.
     """
     if not user_id:
-        return ErrorResponse(
+        return ExpertChangeError(
+            reason="wrong_chat",
             message="Please sign in to change the team.",
             session_id=session.session_id,
         )
@@ -359,13 +365,12 @@ def _hire_message(name: str, failed_workflows: list[str]) -> str:
     told to name them rather than announce an unqualified success.
     """
     if not failed_workflows:
-        return f"{name} is hired and on the team. Tell the user who joined and what they own."
+        return f"{name} is Hired and ready on the team."
     workflows = ", ".join(failed_workflows)
     return (
         f"{name} joined the team, but {len(failed_workflows)} of their "
-        f"workflows could not be installed: {workflows}. Tell the user who "
-        "joined, name the workflows that failed, and say those need to be "
-        f"added from {name}'s team page before that part of the job can run."
+        f"workflows could not be installed: {workflows}. Add them from "
+        f"{name}'s team page before that part of the job can run."
     )
 
 
@@ -388,10 +393,7 @@ async def _apply_raise(
     except Exception as e:
         return _raise_failure_response(e, session_id)
     return ExpertChangeAppliedResponse(
-        message=(
-            f"{result.expert.name} is raised and on the team. Tell the user "
-            "who joined and what they own."
-        ),
+        message=f"{result.expert.name} is Raised and ready on the team.",
         session_id=session_id,
         kind="raise",
         expert=_summary(result.expert),
@@ -441,7 +443,7 @@ async def _apply_update(
     if updated is None:
         return _stale_expert_error(session_id)
     return ExpertChangeAppliedResponse(
-        message=f"{updated.name} is updated. Tell the user exactly what changed.",
+        message=f"{updated.name} is Updated.",
         session_id=session_id,
         kind="update",
         expert=_summary(updated),
@@ -520,8 +522,7 @@ def _raise_failure_response(error: Exception, session_id: str) -> ErrorResponse:
         )
     if isinstance(error, RaisedExpertLifetimeLimitExceededError):
         return _limit_error(
-            f"This account has raised its lifetime maximum of {error.limit} "
-            "experts.",
+            f"This account has raised its lifetime maximum of {error.limit} experts.",
             session_id,
         )
     return _unexpected_failure(error, session_id, "raise_expert")

--- a/autogpt_platform/backend/backend/copilot/tools/hire_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/hire_expert.py
@@ -137,12 +137,7 @@ class HireExpertTool(BaseTool):
             ),
         )
         return ExpertChangeProposedResponse(
-            message=(
-                "Nothing hired yet. Show the user who would join, what they "
-                "own, and that the hire draws on the shared weekly budget. "
-                "Only after they explicitly approve, call "
-                "confirm_expert_change with this confirmation_id."
-            ),
+            message=f"{preview.name} is ready for review. Nothing has been hired yet.",
             session_id=session_id,
             preview=preview,
             confirmation_id=confirmation_id,

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -127,6 +127,7 @@ class ResponseType(str, Enum):
     EXPERT_SOUL_UPDATED = "expert_soul_updated"
     EXPERT_CHANGE_PROPOSED = "expert_change_proposed"
     EXPERT_CHANGE_APPLIED = "expert_change_applied"
+    EXPERT_CHANGE_BATCH_APPLIED = "expert_change_batch_applied"
     TEAM_ROSTER = "team_roster"
 
 
@@ -329,6 +330,10 @@ class ErrorResponse(ToolResponseBase):
     execution_id: str | None = None
     error: str | None = None
     details: dict[str, Any] | None = None
+
+
+class ExpertChangeError(ErrorResponse):
+    reason: str
 
 
 class SubSessionProgressSnapshot(BaseModel):
@@ -657,6 +662,26 @@ class ExpertChangeAppliedResponse(ToolResponseBase):
     kind: ExpertChangeKind
     expert: ExpertSummary
     failed_workflows: list[str] = Field(default_factory=list)
+
+
+ExpertChangeOutcome = Literal["applied", "already_applied", "failed"]
+
+
+class ExpertChangeBatchResult(BaseModel):
+    confirmation_id: str
+    outcome: ExpertChangeOutcome
+    proposed_name: str | None = None
+    kind: ExpertChangeKind | None = None
+    expert: ExpertSummary | None = None
+    failed_workflows: list[str] = Field(default_factory=list)
+    reason: str | None = None
+
+
+class ExpertChangeBatchAppliedResponse(ToolResponseBase):
+    type: ResponseType = ResponseType.EXPERT_CHANGE_BATCH_APPLIED
+    applied: bool
+    results: list[ExpertChangeBatchResult]
+    experts: list[ExpertSummary]
 
 
 # Agent generation models

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -661,6 +661,7 @@ class ExpertChangeAppliedResponse(ToolResponseBase):
     applied: bool = True
     kind: ExpertChangeKind
     expert: ExpertSummary
+    confirmation_id: str | None = None
     failed_workflows: list[str] = Field(default_factory=list)
 
 

--- a/autogpt_platform/backend/backend/copilot/tools/raise_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/raise_expert.py
@@ -253,13 +253,7 @@ class RaiseExpertTool(BaseTool):
             ),
         )
         return ExpertChangeProposedResponse(
-            message=(
-                "Nothing created yet. Read the full charter back to the "
-                "user — name, role, color, what this expert owns, where "
-                "they stop, voice and weekly budget — and only after they "
-                "explicitly approve, call confirm_expert_change with this "
-                "confirmation_id."
-            ),
+            message=f"{preview.name}'s charter is ready for review. Nothing has been created yet.",
             session_id=session_id,
             preview=preview,
             confirmation_id=confirmation_id,

--- a/autogpt_platform/backend/backend/copilot/tools/update_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/update_expert.py
@@ -23,7 +23,6 @@ from backend.data.redis_client import get_redis_async
 
 from .base import BaseTool
 from .expert_proposal import (
-    PROPOSAL_TTL_MINUTES,
     ExpertChangeProposal,
     ExpertSoulSnapshot,
     autopilot_session_guard,
@@ -191,13 +190,7 @@ class UpdateExpertTool(BaseTool):
             ),
         )
         return ExpertChangeProposedResponse(
-            message=(
-                f"Nothing changed yet. Show the user exactly how {expert.name} "
-                "would be rewritten, including anything this replaces. Only "
-                "after they explicitly approve, call confirm_expert_change "
-                f"with this confirmation_id; it expires in "
-                f"{PROPOSAL_TTL_MINUTES} minutes."
-            ),
+            message=f"{expert.name}'s update is ready for review. Nothing has changed yet.",
             session_id=session_id,
             preview=preview,
             confirmation_id=confirmation_id,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -50,6 +50,10 @@ import { ThinkingIndicator } from "./components/ThinkingIndicator";
 import { UserMessageClamp } from "./components/UserMessageClamp";
 import { Clock01Icon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import {
+  ExpertConfirmationContext,
+  getAppliedExpertConfirmationIDs,
+} from "../ToolChain/ExpertConfirmationContext";
 
 interface Props {
   messages: UIMessage<unknown, UIDataTypes, UITools>[];
@@ -312,6 +316,13 @@ export function ChatMessagesContainer({
   // Bubble restyle ships with the brain-dump experience.
   const isBrainDumpEnabled = useGetFlag(Flag.ONBOARDING_BRAIN_DUMP);
   const isFounderMode = useGetFlag(Flag.HIRE_EXPERTS);
+  const appliedExpertConfirmationIDs = useMemo(
+    () =>
+      isFounderMode
+        ? getAppliedExpertConfirmationIDs(messages)
+        : new Set<string>(),
+    [isFounderMode, messages],
+  );
   // Hide the container for one frame when messages first load so
   // StickToBottom can scroll to the bottom before the user sees it.
   const [settled, setSettled] = useState(false);
@@ -460,7 +471,7 @@ export function ChatMessagesContainer({
   });
 
   return (
-    <>
+    <ExpertConfirmationContext.Provider value={appliedExpertConfirmationIDs}>
       <ThreadHeader
         expertIdentity={expertIdentity}
         readOnly={readOnly}
@@ -796,6 +807,6 @@ export function ChatMessagesContainer({
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
-    </>
+    </ExpertConfirmationContext.Provider>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -311,6 +311,7 @@ export function ChatMessagesContainer({
   );
   // Bubble restyle ships with the brain-dump experience.
   const isBrainDumpEnabled = useGetFlag(Flag.ONBOARDING_BRAIN_DUMP);
+  const isFounderMode = useGetFlag(Flag.HIRE_EXPERTS);
   // Hide the container for one frame when messages first load so
   // StickToBottom can scroll to the bottom before the user sees it.
   const [settled, setSettled] = useState(false);
@@ -624,6 +625,7 @@ export function ChatMessagesContainer({
                       compactionPhase={compactionPhase}
                       liveCompactionCallId={liveCompactionCallId}
                       liveCompactionStats={liveCompactionStats}
+                      founderMode={isFounderMode}
                     />
                   ) : (
                     <UserMessageClamp>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/ChainMessageParts.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/ChainMessageParts.tsx
@@ -18,6 +18,7 @@ interface Props {
   compactionPhase?: CompactionPhase | null;
   liveCompactionCallId?: string | null;
   liveCompactionStats?: CompactionStats;
+  founderMode?: boolean;
 }
 
 export function ChainMessageParts({
@@ -31,6 +32,7 @@ export function ChainMessageParts({
   compactionPhase,
   liveCompactionCallId,
   liveCompactionStats,
+  founderMode = false,
 }: Props) {
   const segments = buildChainSegments(parts, isChainableToolPart);
   const lastChainSegmentIndex = segments.findLastIndex(
@@ -47,6 +49,7 @@ export function ChainMessageParts({
             isCurrentlyStreaming && segmentIndex === lastChainSegmentIndex
           }
           readOnly={readOnly}
+          founderMode={founderMode}
         />
       );
     }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
@@ -130,6 +130,7 @@ export function ChainRowView({ row, isLast }: Props) {
   const hasContent = isReasoning
     ? !!row.reasoningText
     : !row.supersededSubSession &&
+      !row.groupedProposal &&
       ((row.output !== undefined && row.output !== "") ||
         liveSubSession ||
         pendingExpertChange);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -7,7 +7,7 @@ import {
   PencilIcon,
 } from "@hugeicons/core-free-icons";
 import Link from "next/link";
-import { useId, useState } from "react";
+import { useContext, useId, useState } from "react";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { CARD } from "./ResultCards";
 import { asItems, asObject, str } from "./resultHelpers";
 import { useCardResize } from "./useCardResize";
+import { ExpertConfirmationContext } from "./ExpertConfirmationContext";
 
 export const EXPERT_CHANGE_TOOLS = new Set([
   "hire_expert",
@@ -30,7 +31,7 @@ interface Props {
 
 const APPLIED_LABELS: Record<string, string> = {
   hire: "Hired",
-  raise: "Raised",
+  raise: "Hired",
   update: "Updated",
 };
 
@@ -112,9 +113,14 @@ function ExpertBatchNotice({ result }: { result: Record<string, unknown> }) {
  *  offers the two things the user does next: adjust them or talk to them. */
 function ExpertSingleCard({ output, applied: forcedApplied }: Props) {
   const [expanded, setExpanded] = useState(false);
+  const appliedConfirmationIDs = useContext(ExpertConfirmationContext);
   const detailsID = useId();
   const { contentRef, height } = useCardResize(expanded);
-  const applied = forcedApplied ?? output.applied === true;
+  const confirmationID = str(output, "confirmation_id");
+  const applied =
+    forcedApplied ??
+    (output.applied === true ||
+      (!!confirmationID && appliedConfirmationIDs.has(confirmationID)));
   const expert = asObject(output.expert) ?? asObject(output.preview);
   if (!expert) return null;
 
@@ -125,7 +131,8 @@ function ExpertSingleCard({ output, applied: forcedApplied }: Props) {
   const boundaries = str(expert, "boundaries");
   const budget =
     typeof expert.weekly_budget === "number" ? expert.weekly_budget : null;
-  const appliedLabel = APPLIED_LABELS[str(output, "kind") ?? ""] ?? "Done";
+  const appliedKind = str(output, "kind") ?? str(expert, "kind") ?? "";
+  const appliedLabel = APPLIED_LABELS[appliedKind] ?? "Done";
   const failed = applied ? failedWorkflows(output) : [];
   const clampable = !!about || !!boundaries;
   const clamp = expanded ? undefined : "line-clamp-2";

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -13,7 +13,7 @@ import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
 import { cn } from "@/lib/utils";
 import { CARD } from "./ResultCards";
-import { asObject, str } from "./resultHelpers";
+import { asItems, asObject, str } from "./resultHelpers";
 import { useCardResize } from "./useCardResize";
 
 export const EXPERT_CHANGE_TOOLS = new Set([
@@ -25,6 +25,7 @@ export const EXPERT_CHANGE_TOOLS = new Set([
 
 interface Props {
   output: Record<string, unknown>;
+  applied?: boolean;
 }
 
 const APPLIED_LABELS: Record<string, string> = {
@@ -41,15 +42,79 @@ function failedWorkflows(output: Record<string, unknown>): string[] {
   );
 }
 
+export function ExpertChangeCard({ output }: Props) {
+  const results = asItems(output.results);
+  if (!results) return <ExpertSingleCard output={output} />;
+  return (
+    <div className="flex flex-col gap-1.5">
+      {results.map((result) =>
+        str(result, "outcome") === "applied" ? (
+          <ExpertSingleCard
+            key={expertResultKey(result)}
+            output={result}
+            applied
+          />
+        ) : (
+          <ExpertBatchNotice key={expertResultKey(result)} result={result} />
+        ),
+      )}
+    </div>
+  );
+}
+
+function expertResultKey(result: Record<string, unknown>) {
+  return (
+    str(result, "confirmation_id") ??
+    ["proposed_name", "kind", "outcome", "reason"]
+      .map((field) => str(result, field) ?? "")
+      .join(":")
+  );
+}
+
+const REASON_COPY: Record<string, string> = {
+  already_applied: "This expert was already added. Nothing was repeated.",
+  expired: "This preview expired before approval.",
+  not_approved: "This preview was not approved.",
+  unwatermarked: "This preview is too old to apply.",
+  wrong_chat: "This preview belongs to another chat.",
+  limit_reached: "Your team is at its current limit.",
+  workspace_unavailable: "The expert workspace was temporarily unavailable.",
+  expert_moved: "This expert changed after the preview.",
+  template_gone: "This expert is no longer available.",
+  unexpected_failure: "This change could not be applied.",
+};
+
+function ExpertBatchNotice({ result }: { result: Record<string, unknown> }) {
+  const done = str(result, "outcome") === "already_applied";
+  const name = str(result, "proposed_name");
+  const reason = str(result, "reason") ?? "unexpected_failure";
+  return (
+    <div className={cn(CARD, "w-full rounded-3xl p-2.5")}>
+      <p className="flex items-center gap-1.5 text-[13px] font-medium text-zinc-800">
+        {done && (
+          <Icon
+            icon={CheckmarkCircle02Icon}
+            size={13}
+            className="text-emerald-600"
+          />
+        )}
+        {name ? `${name}: ` : ""}
+        {done ? "Already Hired" : "Not added"}
+      </p>
+      <p className="mt-1 text-xs text-zinc-500">{REASON_COPY[reason]}</p>
+    </div>
+  );
+}
+
 /** An expert inside the chain — either a hire/raise preview awaiting the
  *  user's OK (given in chat, nothing created yet) or the teammate
  *  ``confirm_expert_change`` actually created. Once they exist, the card
  *  offers the two things the user does next: adjust them or talk to them. */
-export function ExpertChangeCard({ output }: Props) {
+function ExpertSingleCard({ output, applied: forcedApplied }: Props) {
   const [expanded, setExpanded] = useState(false);
   const detailsID = useId();
   const { contentRef, height } = useCardResize(expanded);
-  const applied = output.applied === true;
+  const applied = forcedApplied ?? output.applied === true;
   const expert = asObject(output.expert) ?? asObject(output.preview);
   if (!expert) return null;
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertConfirmationContext.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertConfirmationContext.ts
@@ -1,0 +1,68 @@
+import { createContext } from "react";
+import type { UIDataTypes, UIMessage, UITools } from "ai";
+
+const EMPTY_CONFIRMATIONS = new Set<string>();
+
+export const ExpertConfirmationContext =
+  createContext<ReadonlySet<string>>(EMPTY_CONFIRMATIONS);
+
+export function getAppliedExpertConfirmationIDs(
+  messages: UIMessage<unknown, UIDataTypes, UITools>[],
+): ReadonlySet<string> {
+  const confirmationIDs = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!("output" in part)) continue;
+      const output = objectOutput(part.output);
+      if (!output) continue;
+      addSingleConfirmation(output, confirmationIDs);
+      addBatchConfirmations(output, confirmationIDs);
+    }
+  }
+  return confirmationIDs;
+}
+
+function addSingleConfirmation(
+  output: Record<string, unknown>,
+  confirmationIDs: Set<string>,
+) {
+  if (output.type !== "expert_change_applied" || output.applied !== true)
+    return;
+  const confirmationID = stringValue(output.confirmation_id);
+  if (confirmationID) confirmationIDs.add(confirmationID);
+}
+
+function addBatchConfirmations(
+  output: Record<string, unknown>,
+  confirmationIDs: Set<string>,
+) {
+  if (!Array.isArray(output.results)) return;
+  for (const value of output.results) {
+    const result = objectOutput(value);
+    if (
+      !result ||
+      !["applied", "already_applied"].includes(String(result.outcome))
+    ) {
+      continue;
+    }
+    const confirmationID = stringValue(result.confirmation_id);
+    if (confirmationID) confirmationIDs.add(confirmationID);
+  }
+}
+
+function objectOutput(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "string") {
+    try {
+      return objectOutput(JSON.parse(value));
+    } catch {
+      return null;
+    }
+  }
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useContext } from "react";
 import { Button } from "@/components/atoms/Button/Button";
+import { ExpertConfirmationContext } from "../ExpertConfirmationContext";
 import type { TeamProposal } from "../helpers";
 import { ProposedExpertRow } from "./components/ProposedExpertRow";
 import { useTeamPreviewCard } from "./useTeamPreviewCard";
@@ -10,15 +12,18 @@ interface Props {
 }
 
 export function TeamPreviewCard({ proposals }: Props) {
+  const appliedConfirmationIDs = useContext(ExpertConfirmationContext);
   const {
     canConfirm,
+    confirmed,
     kept,
     openId,
     removedIds,
     hireSelected,
     toggleOpen,
     toggleRemoved,
-  } = useTeamPreviewCard(proposals);
+  } = useTeamPreviewCard(proposals, appliedConfirmationIDs);
+  const allConfirmed = confirmed.length === proposals.length;
 
   return (
     <div className="rounded-2xl bg-white p-4 ring-1 ring-zinc-200/70">
@@ -27,9 +32,13 @@ export function TeamPreviewCard({ proposals }: Props) {
           {proposals.length} experts for your team
         </p>
         <p className="shrink-0 text-xs text-zinc-400">
-          {kept.length === proposals.length
-            ? "Nothing created yet"
-            : `${kept.length} of ${proposals.length} selected`}
+          {allConfirmed
+            ? "Team ready"
+            : confirmed.length > 0
+              ? `${confirmed.length} Hired · ${kept.length} selected`
+              : kept.length === proposals.length
+                ? "Nothing created yet"
+                : `${kept.length} of ${proposals.length} selected`}
         </p>
       </div>
       <div className="mt-1.5 flex flex-col divide-y divide-zinc-100">
@@ -37,6 +46,7 @@ export function TeamPreviewCard({ proposals }: Props) {
           <ProposedExpertRow
             key={proposal.confirmationId}
             proposal={proposal}
+            confirmed={appliedConfirmationIDs.has(proposal.confirmationId)}
             removed={removedIds.includes(proposal.confirmationId)}
             open={openId === proposal.confirmationId}
             onToggleRemoved={() => toggleRemoved(proposal.confirmationId)}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import type { TeamProposal } from "../helpers";
+import { ProposedExpertRow } from "./components/ProposedExpertRow";
+import { useTeamPreviewCard } from "./useTeamPreviewCard";
+
+interface Props {
+  proposals: TeamProposal[];
+}
+
+export function TeamPreviewCard({ proposals }: Props) {
+  const {
+    canConfirm,
+    kept,
+    openId,
+    removedIds,
+    hireSelected,
+    toggleOpen,
+    toggleRemoved,
+  } = useTeamPreviewCard(proposals);
+
+  return (
+    <div className="rounded-2xl bg-white p-4 ring-1 ring-zinc-200/70">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-medium text-zinc-800">
+          {proposals.length} experts for your team
+        </p>
+        <p className="shrink-0 text-xs text-zinc-400">
+          {kept.length === proposals.length
+            ? "Nothing created yet"
+            : `${kept.length} of ${proposals.length} selected`}
+        </p>
+      </div>
+      <div className="mt-1.5 flex flex-col divide-y divide-zinc-100">
+        {proposals.map((proposal) => (
+          <ProposedExpertRow
+            key={proposal.confirmationId}
+            proposal={proposal}
+            removed={removedIds.includes(proposal.confirmationId)}
+            open={openId === proposal.confirmationId}
+            onToggleRemoved={() => toggleRemoved(proposal.confirmationId)}
+            onToggleOpen={() => toggleOpen(proposal.confirmationId)}
+          />
+        ))}
+      </div>
+      {canConfirm && (
+        <div className="mt-3 flex flex-wrap items-center gap-2.5">
+          <Button
+            variant="primary"
+            size="small"
+            disabled={kept.length === 0}
+            onClick={hireSelected}
+          >
+            Hire selected
+          </Button>
+          <span className="text-xs text-zinc-400">
+            {kept.length === 0
+              ? "Put someone back, or tell me who to draft instead."
+              : "To change a charter, say what should be different."}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDown01Icon,
   ArrowTurnBackwardIcon,
   Cancel01Icon,
+  CheckmarkCircle02Icon,
 } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
@@ -14,6 +15,7 @@ import { proposalName } from "../helpers";
 
 interface Props {
   proposal: TeamProposal;
+  confirmed: boolean;
   removed: boolean;
   open: boolean;
   onToggleRemoved: () => void;
@@ -22,6 +24,7 @@ interface Props {
 
 export function ProposedExpertRow({
   proposal,
+  confirmed,
   removed,
   open,
   onToggleRemoved,
@@ -76,17 +79,24 @@ export function ProposedExpertRow({
             />
           )}
         </button>
-        <button
-          type="button"
-          onClick={onToggleRemoved}
-          aria-label={removed ? `Put ${name} back` : `Remove ${name}`}
-          className="flex size-7 shrink-0 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
-        >
-          <Icon
-            icon={removed ? ArrowTurnBackwardIcon : Cancel01Icon}
-            size={14}
-          />
-        </button>
+        {confirmed ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-md bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700">
+            <Icon icon={CheckmarkCircle02Icon} size={11} />
+            Hired
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={onToggleRemoved}
+            aria-label={removed ? `Put ${name} back` : `Remove ${name}`}
+            className="flex size-7 shrink-0 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+          >
+            <Icon
+              icon={removed ? ArrowTurnBackwardIcon : Cancel01Icon}
+              size={14}
+            />
+          </button>
+        )}
       </div>
       {hasCharter && (
         <div className={ACCORDION_PANEL + " " + accordionState(open)}>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  ArrowDown01Icon,
+  ArrowTurnBackwardIcon,
+  Cancel01Icon,
+} from "@hugeicons/core-free-icons";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import { ACCORDION_PANEL, accordionState } from "../../accordion";
+import type { TeamProposal } from "../../helpers";
+import { str } from "../../resultHelpers";
+import { proposalName } from "../helpers";
+
+interface Props {
+  proposal: TeamProposal;
+  removed: boolean;
+  open: boolean;
+  onToggleRemoved: () => void;
+  onToggleOpen: () => void;
+}
+
+export function ProposedExpertRow({
+  proposal,
+  removed,
+  open,
+  onToggleRemoved,
+  onToggleOpen,
+}: Props) {
+  const { preview } = proposal;
+  const name = proposalName(proposal);
+  const role = str(preview, "role");
+  const about = str(preview, "about");
+  const boundaries = str(preview, "boundaries");
+  const voice = str(preview, "voice_preferences");
+  const budget =
+    typeof preview.weekly_budget === "number" ? preview.weekly_budget : null;
+  const hasCharter = !!(about || boundaries || voice) || budget !== null;
+
+  return (
+    <div className={"py-2.5 " + (removed ? "opacity-40" : "")}>
+      <div className="flex items-center gap-2.5">
+        <ExpertAvatar
+          name={name}
+          avatarUrl={str(preview, "avatar_url")}
+          size={28}
+        />
+        <button
+          type="button"
+          onClick={onToggleOpen}
+          disabled={!hasCharter}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        >
+          <span
+            className={
+              "shrink-0 text-[13px] font-medium text-zinc-800 " +
+              (removed ? "line-through" : "")
+            }
+          >
+            {name}
+          </span>
+          {role && (
+            <span className="min-w-0 truncate text-xs text-zinc-400">
+              {role}
+            </span>
+          )}
+          {hasCharter && (
+            <Icon
+              icon={ArrowDown01Icon}
+              size={12}
+              className={
+                "shrink-0 text-zinc-400 transition-transform duration-300 ease-out-quint " +
+                (open ? "rotate-180" : "")
+              }
+            />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={onToggleRemoved}
+          aria-label={removed ? `Put ${name} back` : `Remove ${name}`}
+          className="flex size-7 shrink-0 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+        >
+          <Icon
+            icon={removed ? ArrowTurnBackwardIcon : Cancel01Icon}
+            size={14}
+          />
+        </button>
+      </div>
+      {hasCharter && (
+        <div className={ACCORDION_PANEL + " " + accordionState(open)}>
+          <div aria-hidden={!open} className="min-h-0 overflow-hidden">
+            <div className="flex flex-col gap-1 pl-[38px] pt-1.5 text-xs text-zinc-500">
+              {about && <p>{about}</p>}
+              {boundaries && (
+                <p className="text-zinc-400">Stops at: {boundaries}</p>
+              )}
+              {voice && <p className="text-zinc-400">Sounds like: {voice}</p>}
+              {budget !== null && (
+                <p className="text-zinc-400">Weekly budget: {budget} credits</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/helpers.ts
@@ -1,0 +1,19 @@
+import type { TeamProposal } from "../helpers";
+import { str } from "../resultHelpers";
+
+export function proposalName(proposal: TeamProposal): string {
+  return str(proposal.preview, "name") ?? "New expert";
+}
+
+export function joinNames(names: string[]): string {
+  if (names.length < 2) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+export function buildConfirmMessage(proposals: TeamProposal[]): string {
+  const names = joinNames(proposals.map(proposalName));
+  if (proposals.length === 1) {
+    return `I approve ${names}. Add them to my team.`;
+  }
+  return `I approve ${names}. Add them to my team in one step.`;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useContext, useState } from "react";
+import { CopilotChatActionsContext } from "../../CopilotChatActionsProvider/useCopilotChatActions";
+import type { TeamProposal } from "../helpers";
+import { buildConfirmMessage } from "./helpers";
+
+export function useTeamPreviewCard(proposals: TeamProposal[]) {
+  const actions = useContext(CopilotChatActionsContext);
+  const [removedIds, setRemovedIds] = useState<readonly string[]>([]);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const kept = proposals.filter(
+    (proposal) => !removedIds.includes(proposal.confirmationId),
+  );
+
+  function toggleRemoved(confirmationId: string) {
+    setRemovedIds((previous) =>
+      previous.includes(confirmationId)
+        ? previous.filter((id) => id !== confirmationId)
+        : [...previous, confirmationId],
+    );
+  }
+
+  function toggleOpen(confirmationId: string) {
+    setOpenId((previous) =>
+      previous === confirmationId ? null : confirmationId,
+    );
+  }
+
+  function hireSelected() {
+    if (!actions || kept.length === 0) return;
+    actions.onSend(buildConfirmMessage(kept));
+  }
+
+  return {
+    canConfirm: actions !== null,
+    kept,
+    openId,
+    removedIds,
+    hireSelected,
+    toggleOpen,
+    toggleRemoved,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
@@ -5,11 +5,20 @@ import { CopilotChatActionsContext } from "../../CopilotChatActionsProvider/useC
 import type { TeamProposal } from "../helpers";
 import { buildConfirmMessage } from "./helpers";
 
-export function useTeamPreviewCard(proposals: TeamProposal[]) {
+export function useTeamPreviewCard(
+  proposals: TeamProposal[],
+  appliedConfirmationIDs: ReadonlySet<string>,
+) {
   const actions = useContext(CopilotChatActionsContext);
   const [removedIds, setRemovedIds] = useState<readonly string[]>([]);
   const [openId, setOpenId] = useState<string | null>(null);
-  const kept = proposals.filter(
+  const confirmed = proposals.filter((proposal) =>
+    appliedConfirmationIDs.has(proposal.confirmationId),
+  );
+  const pending = proposals.filter(
+    (proposal) => !appliedConfirmationIDs.has(proposal.confirmationId),
+  );
+  const kept = pending.filter(
     (proposal) => !removedIds.includes(proposal.confirmationId),
   );
 
@@ -33,7 +42,8 @@ export function useTeamPreviewCard(proposals: TeamProposal[]) {
   }
 
   return {
-    canConfirm: actions !== null,
+    canConfirm: actions !== null && pending.length > 0,
+    confirmed,
     kept,
     openId,
     removedIds,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -33,6 +33,7 @@ import { ChainRowView } from "./ChainRowView";
 import {
   type ChainRow,
   getChainHeading,
+  groupTeamProposalRows,
   isLiftedSetupRow,
   markSupersededSubSessionRows,
   toChainRow,
@@ -102,19 +103,21 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
 
   const rows = useMemo(
     () =>
-      markSupersededSubSessionRows(
-        parts
-          .map((part, i) => toChainRow(part, i))
-          .filter((row): row is ChainRow => row !== null)
-          // Unanswered clarifying questions and setup cards render their work
-          // in the card below the chain — their rows are lifted out of view.
-          .map((row) =>
-            pendingQuestions?.callIds.includes(row.key)
-              ? { ...row, requiresAction: true, lifted: true }
-              : isLiftedSetupRow(row)
-                ? { ...row, lifted: true }
-                : row,
-          ),
+      groupTeamProposalRows(
+        markSupersededSubSessionRows(
+          parts
+            .map((part, i) => toChainRow(part, i))
+            .filter((row): row is ChainRow => row !== null)
+            // Unanswered clarifying questions and setup cards render their work
+            // in the card below the chain — their rows are lifted out of view.
+            .map((row) =>
+              pendingQuestions?.callIds.includes(row.key)
+                ? { ...row, requiresAction: true, lifted: true }
+                : isLiftedSetupRow(row)
+                  ? { ...row, lifted: true }
+                  : row,
+            ),
+        ),
       ),
     [parts, pendingQuestions],
   );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -50,9 +50,15 @@ interface Props {
    *  cards and the Proceed draft are the owner's work — a reader gets no
    *  Connect prompt and no write into the composer store. */
   readOnly?: boolean;
+  founderMode?: boolean;
 }
 
-export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
+export function ToolChain({
+  parts,
+  isStreaming,
+  readOnly = false,
+  founderMode = false,
+}: Props) {
   const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
   const panelId = useId();
   const reducedMotion = useReducedMotion();
@@ -101,26 +107,23 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
     [sentMessageCount, actionEntries],
   );
 
-  const rows = useMemo(
-    () =>
-      groupTeamProposalRows(
-        markSupersededSubSessionRows(
-          parts
-            .map((part, i) => toChainRow(part, i))
-            .filter((row): row is ChainRow => row !== null)
-            // Unanswered clarifying questions and setup cards render their work
-            // in the card below the chain — their rows are lifted out of view.
-            .map((row) =>
-              pendingQuestions?.callIds.includes(row.key)
-                ? { ...row, requiresAction: true, lifted: true }
-                : isLiftedSetupRow(row)
-                  ? { ...row, lifted: true }
-                  : row,
-            ),
+  const rows = useMemo(() => {
+    const mapped = markSupersededSubSessionRows(
+      parts
+        .map((part, i) => toChainRow(part, i))
+        .filter((row): row is ChainRow => row !== null)
+        // Unanswered clarifying questions and setup cards render their work
+        // in the card below the chain — their rows are lifted out of view.
+        .map((row) =>
+          pendingQuestions?.callIds.includes(row.key)
+            ? { ...row, requiresAction: true, lifted: true }
+            : isLiftedSetupRow(row)
+              ? { ...row, lifted: true }
+              : row,
         ),
-      ),
-    [parts, pendingQuestions],
-  );
+    );
+    return founderMode ? groupTeamProposalRows(mapped) : mapped;
+  }, [parts, pendingQuestions, founderMode]);
   if (rows.length === 0) return null;
 
   const shownRows = rows.filter((row) => !row.lifted);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
@@ -54,6 +54,7 @@ import {
   stripBaseFields,
 } from "./resultHelpers";
 import { SubSessionPendingCard } from "./SubSessionLive";
+import { TeamPreviewCard } from "./TeamPreviewCard/TeamPreviewCard";
 import {
   FileCard,
   KeyValueList,
@@ -279,6 +280,11 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
     }
     case "hire_expert":
     case "raise_expert":
+      if (row.groupedProposal) return null;
+      if (row.teamProposals)
+        return <TeamPreviewCard proposals={row.teamProposals} />;
+      if (output) return <ExpertChangeCard output={output} />;
+      return row.state === "running" ? <ExpertChangeCardSkeleton /> : null;
     case "update_expert":
     case "confirm_expert_change":
       if (output) return <ExpertChangeCard output={output} />;

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -114,6 +114,67 @@ describe("expert change cards", () => {
     expect(screen.queryByText(/Couldn't set up/)).toBeNull();
   });
 
+  it("renders every applied roster member as Hired or Raised", () => {
+    render(
+      <ToolResult
+        row={row("confirm_expert_change", {
+          type: "expert_change_batch_applied",
+          message: "Team ready: Otto, Scout.",
+          applied: true,
+          results: [
+            {
+              confirmation_id: "c-1",
+              outcome: "applied",
+              kind: "hire",
+              expert: { id: "exp-otto", name: "Otto", role: "Inbox" },
+            },
+            {
+              confirmation_id: "c-2",
+              outcome: "applied",
+              kind: "raise",
+              expert: { id: "exp-scout", name: "Scout", role: "Research" },
+            },
+          ],
+          experts: [],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Otto")).toBeDefined();
+    expect(screen.getByText("Scout")).toBeDefined();
+    expect(screen.getByText("Hired")).toBeDefined();
+    expect(screen.getByText("Raised")).toBeDefined();
+  });
+
+  it("never exposes internal failure instructions or ids", () => {
+    render(
+      <ToolResult
+        row={row("confirm_expert_change", {
+          type: "expert_change_batch_applied",
+          message: "Internal result",
+          applied: false,
+          results: [
+            {
+              confirmation_id: "private-id",
+              proposed_name: "Scout",
+              outcome: "failed",
+              reason: "expired",
+              error: "Call hire_expert again with confirmation_id private-id.",
+            },
+          ],
+          experts: [],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Scout: Not added")).toBeDefined();
+    expect(
+      screen.getByText("This preview expired before approval."),
+    ).toBeDefined();
+    expect(screen.queryByText(/private-id/)).toBeNull();
+    expect(screen.queryByText(/hire_expert/)).toBeNull();
+  });
+
   it("renders a handoff as the receiving teammate's sub-session", () => {
     render(
       <ToolResult

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -68,7 +68,7 @@ describe("expert change cards", () => {
     expect(screen.getByText("Otto")).toBeDefined();
     expect(screen.queryByText("Needs your OK")).toBeNull();
     // The applied state must be readable, not colour-and-glyph only.
-    expect(screen.getByText("Raised")).toBeDefined();
+    expect(screen.getByText("Hired")).toBeDefined();
     expect(
       screen.getByRole("link", { name: /Edit/ }).getAttribute("href"),
     ).toBe("/team/exp-otto");
@@ -114,7 +114,7 @@ describe("expert change cards", () => {
     expect(screen.queryByText(/Couldn't set up/)).toBeNull();
   });
 
-  it("renders every applied roster member as Hired or Raised", () => {
+  it("renders every applied roster member as Hired", () => {
     render(
       <ToolResult
         row={row("confirm_expert_change", {
@@ -142,8 +142,7 @@ describe("expert change cards", () => {
 
     expect(screen.getByText("Otto")).toBeDefined();
     expect(screen.getByText("Scout")).toBeDefined();
-    expect(screen.getByText("Hired")).toBeDefined();
-    expect(screen.getByText("Raised")).toBeDefined();
+    expect(screen.getAllByText("Hired")).toHaveLength(2);
   });
 
   it("never exposes internal failure instructions or ids", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertConfirmationContext.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertConfirmationContext.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { UIMessage } from "ai";
+import { getAppliedExpertConfirmationIDs } from "../ExpertConfirmationContext";
+
+describe("getAppliedExpertConfirmationIDs", () => {
+  it("collects successful single and batch confirmations", () => {
+    const messages = [
+      messageWithOutput({
+        type: "expert_change_applied",
+        applied: true,
+        confirmation_id: "single",
+      }),
+      messageWithOutput({
+        type: "expert_change_batch_applied",
+        results: [
+          { confirmation_id: "applied", outcome: "applied" },
+          { confirmation_id: "retried", outcome: "already_applied" },
+          { confirmation_id: "failed", outcome: "failed" },
+        ],
+      }),
+    ];
+
+    expect([...getAppliedExpertConfirmationIDs(messages)]).toEqual([
+      "single",
+      "applied",
+      "retried",
+    ]);
+  });
+
+  it("ignores malformed and failed outputs", () => {
+    const messages = [
+      messageWithOutput("not json"),
+      messageWithOutput({
+        type: "expert_change_applied",
+        applied: false,
+        confirmation_id: "not-applied",
+      }),
+    ];
+
+    expect(getAppliedExpertConfirmationIDs(messages).size).toBe(0);
+  });
+});
+
+function messageWithOutput(output: unknown): UIMessage {
+  return {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-confirm_expert_change",
+        state: "output-available",
+        toolCallId: crypto.randomUUID(),
+        input: {},
+        output,
+      },
+    ],
+  } as UIMessage;
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, render, screen } from "@/tests/integrations/test-utils";
 import type { MessagePart } from "../../ChatMessagesContainer/helpers";
 import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import { ToolChain } from "../ToolChain";
+import { ExpertConfirmationContext } from "../ExpertConfirmationContext";
 
 interface Charter {
   id: string;
@@ -40,11 +41,21 @@ const TEAM: Charter[] = [
   { id: "c-3", name: "Bea", role: "Ops" },
 ];
 
-function renderTeam(onSend: (message: string) => void, team = TEAM) {
+function renderTeam(
+  onSend: (message: string) => void,
+  team = TEAM,
+  appliedConfirmationIDs: ReadonlySet<string> = new Set(),
+) {
   return render(
-    <CopilotChatActionsProvider onSend={onSend}>
-      <ToolChain parts={team.map(raisePart)} isStreaming={false} founderMode />
-    </CopilotChatActionsProvider>,
+    <ExpertConfirmationContext.Provider value={appliedConfirmationIDs}>
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ToolChain
+          parts={team.map(raisePart)}
+          isStreaming={false}
+          founderMode
+        />
+      </CopilotChatActionsProvider>
+    </ExpertConfirmationContext.Provider>,
   );
 }
 
@@ -111,5 +122,32 @@ describe("TeamPreviewCard", () => {
 
     expect(screen.getByText("Needs your OK")).toBeDefined();
     expect(screen.queryByRole("button", { name: "Hire selected" })).toBeNull();
+  });
+
+  it("reconciles an approved roster instead of asking again", () => {
+    renderTeam(vi.fn(), TEAM, new Set(TEAM.map((expert) => expert.id)));
+
+    expect(screen.getByText("Team ready")).toBeDefined();
+    expect(screen.getAllByText("Hired")).toHaveLength(3);
+    expect(screen.queryByRole("button", { name: "Hire selected" })).toBeNull();
+  });
+
+  it("confirms only experts that have not already been hired", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend, TEAM, new Set(["c-1"]));
+
+    await user.click(screen.getByRole("button", { name: "Hire selected" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      "I approve Scout and Bea. Add them to my team in one step.",
+    );
+  });
+
+  it("reconciles a single expert preview", () => {
+    renderTeam(vi.fn(), [TEAM[0]], new Set(["c-1"]));
+
+    expect(screen.getByText("Hired")).toBeDefined();
+    expect(screen.queryByText("Needs your OK")).toBeNull();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
@@ -43,7 +43,7 @@ const TEAM: Charter[] = [
 function renderTeam(onSend: (message: string) => void, team = TEAM) {
   return render(
     <CopilotChatActionsProvider onSend={onSend}>
-      <ToolChain parts={team.map(raisePart)} isStreaming={false} />
+      <ToolChain parts={team.map(raisePart)} isStreaming={false} founderMode />
     </CopilotChatActionsProvider>,
   );
 }
@@ -82,14 +82,22 @@ describe("TeamPreviewCard", () => {
     const onSend = vi.fn();
     const { rerender } = render(
       <CopilotChatActionsProvider onSend={onSend}>
-        <ToolChain parts={TEAM.slice(0, 2).map(raisePart)} isStreaming />
+        <ToolChain
+          parts={TEAM.slice(0, 2).map(raisePart)}
+          isStreaming
+          founderMode
+        />
       </CopilotChatActionsProvider>,
     );
     await user.click(screen.getByRole("button", { name: "Remove Scout" }));
 
     rerender(
       <CopilotChatActionsProvider onSend={onSend}>
-        <ToolChain parts={TEAM.map(raisePart)} isStreaming={false} />
+        <ToolChain
+          parts={TEAM.map(raisePart)}
+          isStreaming={false}
+          founderMode
+        />
       </CopilotChatActionsProvider>,
     );
     await user.click(screen.getByRole("button", { name: "Hire selected" }));

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/TeamPreviewCard.test.tsx
@@ -1,0 +1,107 @@
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@/tests/integrations/test-utils";
+import type { MessagePart } from "../../ChatMessagesContainer/helpers";
+import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
+import { ToolChain } from "../ToolChain";
+
+interface Charter {
+  id: string;
+  name: string;
+  role: string;
+}
+
+function raisePart({ id, name, role }: Charter): MessagePart {
+  return {
+    type: "tool-raise_expert",
+    state: "output-available",
+    toolCallId: `call-${id}`,
+    input: { name },
+    output: {
+      type: "expert_change_proposed",
+      message: "Ready for review.",
+      applied: false,
+      confirmation_id: id,
+      preview: {
+        kind: "raise",
+        name,
+        role,
+        about: `You own ${role.toLowerCase()}.`,
+        boundaries: "You never act externally without approval.",
+        weekly_budget: 2000,
+      },
+    },
+  } as MessagePart;
+}
+
+const TEAM: Charter[] = [
+  { id: "c-1", name: "Otto", role: "Inbox triage" },
+  { id: "c-2", name: "Scout", role: "Research" },
+  { id: "c-3", name: "Bea", role: "Ops" },
+];
+
+function renderTeam(onSend: (message: string) => void, team = TEAM) {
+  return render(
+    <CopilotChatActionsProvider onSend={onSend}>
+      <ToolChain parts={team.map(raisePart)} isStreaming={false} />
+    </CopilotChatActionsProvider>,
+  );
+}
+
+describe("TeamPreviewCard", () => {
+  afterEach(cleanup);
+
+  it("renders one roster card and one approval", () => {
+    renderTeam(vi.fn());
+
+    expect(screen.getByText("3 experts for your team")).toBeDefined();
+    expect(screen.getByText("Otto")).toBeDefined();
+    expect(screen.getByText("Scout")).toBeDefined();
+    expect(screen.getByText("Bea")).toBeDefined();
+    expect(
+      screen.getAllByRole("button", { name: "Hire selected" }),
+    ).toHaveLength(1);
+    expect(screen.queryByText("Needs your OK")).toBeNull();
+  });
+
+  it("confirms the selected roster in one call", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    renderTeam(onSend);
+
+    await user.click(screen.getByRole("button", { name: "Remove Scout" }));
+    await user.click(screen.getByRole("button", { name: "Hire selected" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      "I approve Otto and Bea. Add them to my team in one step.",
+    );
+  });
+
+  it("keeps removed selections when another proposal streams in", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    const { rerender } = render(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ToolChain parts={TEAM.slice(0, 2).map(raisePart)} isStreaming />
+      </CopilotChatActionsProvider>,
+    );
+    await user.click(screen.getByRole("button", { name: "Remove Scout" }));
+
+    rerender(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ToolChain parts={TEAM.map(raisePart)} isStreaming={false} />
+      </CopilotChatActionsProvider>,
+    );
+    await user.click(screen.getByRole("button", { name: "Hire selected" }));
+
+    expect(onSend.mock.calls[0][0]).not.toContain("Mina");
+    expect(onSend.mock.calls[0][0]).toContain("Bea");
+  });
+
+  it("keeps the single-expert approval card", () => {
+    renderTeam(vi.fn(), [TEAM[0]]);
+
+    expect(screen.getByText("Needs your OK")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Hire selected" })).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -91,6 +91,28 @@ describe("ToolChain", () => {
     expect(container.textContent).toBe("");
   });
 
+  it("groups team proposals only when hire-experts is enabled", () => {
+    const proposals = ["Kit", "Remy"].map((name, index) =>
+      toolPart("hire_expert", "output-available", {
+        toolCallId: `hire-${index}`,
+        output: {
+          type: "expert_change_proposed",
+          confirmation_id: `confirm-${index}`,
+          preview: { name, role: "Specialist" },
+        },
+      }),
+    );
+    const { rerender } = render(
+      <ToolChain parts={proposals} isStreaming={false} />,
+    );
+
+    expect(screen.queryByText("2 experts for your team")).toBeNull();
+
+    rerender(<ToolChain parts={proposals} isStreaming={false} founderMode />);
+
+    expect(screen.getByText("2 experts for your team")).toBeDefined();
+  });
+
   it("collapses a settled chain to a summary heading and expands on click", async () => {
     const user = userEvent.setup();
     render(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
@@ -6,7 +6,7 @@ import {
   getToolCategory,
 } from "../../tools/GenericTool/helpers";
 import { type ChainCategory, getCatalogLabel } from "./toolCatalog";
-import { asObject, integrationIconSrc } from "./resultHelpers";
+import { asObject, integrationIconSrc, str } from "./resultHelpers";
 
 export type ChainRowState = "running" | "done" | "error";
 
@@ -30,6 +30,13 @@ export interface ChainRow {
    *  row line but renders no card, so one delegation never stacks
    *  duplicate cards down the chain. */
   supersededSubSession?: boolean;
+  teamProposals?: TeamProposal[];
+  groupedProposal?: boolean;
+}
+
+export interface TeamProposal {
+  confirmationId: string;
+  preview: Record<string, unknown>;
 }
 
 const SUB_SESSION_CARD_TOOLS = new Set([
@@ -75,6 +82,42 @@ export function markSupersededSubSessionRows(rows: ChainRow[]): ChainRow[] {
   return rows.map((row) =>
     supersededKeys.has(row.key) ? { ...row, supersededSubSession: true } : row,
   );
+}
+
+const TEAM_PROPOSAL_TOOLS = new Set(["hire_expert", "raise_expert"]);
+
+function teamProposalOf(row: ChainRow): TeamProposal | null {
+  if (!row.tool || !TEAM_PROPOSAL_TOOLS.has(row.tool)) return null;
+  const output = asObject(row.output);
+  if (!output || output.type !== "expert_change_proposed") return null;
+  const confirmationId = str(output, "confirmation_id");
+  const preview = asObject(output.preview);
+  return confirmationId && preview ? { confirmationId, preview } : null;
+}
+
+export function groupTeamProposalRows(rows: ChainRow[]): ChainRow[] {
+  const proposed = new Map<string, TeamProposal>();
+  for (const row of rows) {
+    const proposal = teamProposalOf(row);
+    if (proposal) proposed.set(row.key, proposal);
+  }
+  if (proposed.size < 2) return rows;
+
+  const proposals = [...proposed.values()];
+  const carrierKey = [...proposed.keys()][0];
+  return rows.map((row) => {
+    const proposal = proposed.get(row.key);
+    if (!proposal) return row;
+    if (row.key === carrierKey) {
+      return { ...row, teamProposals: proposals, text: "Review the new team" };
+    }
+    return {
+      ...row,
+      groupedProposal: true,
+      requiresAction: false,
+      text: `Drafted ${str(proposal.preview, "name") ?? "a new expert"}`,
+    };
+  });
 }
 
 const ACTION_RESPONSE_TYPES = new Set([

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -24784,6 +24784,7 @@
           "expert_soul_updated",
           "expert_change_proposed",
           "expert_change_applied",
+          "expert_change_batch_applied",
           "team_roster"
         ],
         "title": "ResponseType",


### PR DESCRIPTION
### Why / What / How

AutoPilot behaved like a conversational assistant instead of the accountable manager of an AI team. It delegated without enough context, asked founders to coordinate experts, polled inefficiently, and produced fragile multi-card hiring approvals.

This PR adds a manager-only Head of AI operating policy and an expert employee policy when `hire-experts` is enabled. It also rebuilds team approval as one idempotent roster confirmation. Prompt assembly remains byte-identical when the flag is off, and expert sessions never receive staffing permissions.

### Changes 🏗️

- Add the flagged Head of AI manager supplement for ownership, phased planning, concurrent delegation, question routing, autonomous reversible decisions, fallbacks, and hard-failure stopping.
- Add the flagged expert supplement for manager reporting, supplied-context use, persistent artifacts, honest uncertainty, and manager-routed blockers.
- Rebuild team approval into one roster card and one batch confirmation.
- Make confirmation idempotent and robust to null, malformed, partial-failure, and retry cases.
- Reconcile approved experts as Hired and keep internal instructions out of user copy.

### Stack

- Depends on: #14197
- Next: #14199

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Prompt byte-identity tests with `hire-experts` disabled
  - [x] Manager-versus-expert prompt and authorization tests
  - [x] Batch team approval, malformed input, retry, and partial-failure tests
  - [x] Backend lint/type checks and focused frontend integration tests

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] No configuration changes are required
