### PR TITLE
fix(frontend): make expert progress clear and truthful

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/work_items.py
+++ b/autogpt_platform/backend/backend/api/features/experts/work_items.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from typing import Literal, cast
+from urllib.parse import quote
 from uuid import uuid4
 
 import prisma.enums
@@ -307,5 +308,9 @@ def _to_model(row: prisma.models.ExpertWorkItem) -> ExpertWorkItem:
         updated_at=row.updatedAt,
         started_at=row.startedAt,
         completed_at=row.completedAt,
-        link=f"/copilot?sessionId={row.delegatedSessionId}&workItemId={row.id}",
+        link=(
+            f"/team/{quote(row.expertId, safe='')}"
+            f"?workItemId={quote(row.id, safe='')}"
+            f"#work-item-{quote(row.id, safe='')}"
+        ),
     )

--- a/autogpt_platform/backend/backend/api/features/experts/work_items_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/work_items_test.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import prisma.enums
+
+from .work_items import _to_model
+
+
+def test_work_item_link_targets_the_exact_team_history_row() -> None:
+    now = datetime(2026, 8, 28, tzinfo=timezone.utc)
+    row = SimpleNamespace(
+        id="work item/1",
+        expertId="expert/1",
+        managerSessionId="manager-1",
+        delegatedSessionId="delegated-1",
+        projectPhase="Launch",
+        taskTitle="Prepare launch plan",
+        expectedDeliverable="A launch plan",
+        deliverableMode="workspace_files",
+        successCriteria=[],
+        dependencies=[],
+        sourceArtifacts=[],
+        constraints=[],
+        approvalBoundaries=[],
+        estimateMinutes=30,
+        progress=100,
+        status=prisma.enums.ExpertWorkItemStatus.DELIVERED,
+        result="Done",
+        blocker=None,
+        confidence=prisma.enums.ExpertWorkConfidence.VERIFIED,
+        artifacts=[],
+        createdAt=now,
+        updatedAt=now,
+        startedAt=now,
+        completedAt=now,
+    )
+
+    item = _to_model(row)
+
+    assert item.link == (
+        "/team/expert%2F1?workItemId=work%20item%2F1#work-item-work%20item%2F1"
+    )

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
@@ -665,7 +665,7 @@ async def _record_work_outcome(
         artifacts=[
             ExpertWorkArtifact(
                 name=artifact.name,
-                uri=artifact.read_path,
+                uri=artifact.uri,
                 mime_type=artifact.mime_type,
                 size_bytes=artifact.size_bytes,
             )

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
@@ -21,7 +21,7 @@ from backend.copilot.sdk.stream_accumulator import ToolCallEntry
 from .delegate_to_expert import DelegateToExpertTool
 from .expert_delegation import CALLER_NAME_LIMIT
 from .get_sub_session_result import GetSubSessionResultTool
-from .models import ErrorResponse, SubSessionStatusResponse
+from .models import ErrorResponse, SubSessionStatusResponse, WorkspaceFileInfoData
 
 
 @pytest.fixture(autouse=True)
@@ -605,6 +605,40 @@ class TestDelegation:
         assert response.status == "incomplete"
         assert response.artifact_count == 0
         assert response.blockers
+
+    @pytest.mark.asyncio
+    async def test_promoted_file_has_a_safe_downloadable_uri(
+        self, roster, mock_turn, mock_sessions, monkeypatch
+    ):
+        result = SessionResult()
+        result.response_text = "The launch plan is ready."
+        mock_turn.return_value = ("completed", result)
+        monkeypatch.setattr(
+            "backend.copilot.tools.delegate_to_expert.list_sub_workspace_files",
+            AsyncMock(
+                return_value=[
+                    WorkspaceFileInfoData(
+                        file_id="file-1",
+                        name="launch-plan.md",
+                        path="/sessions/delegated-1/launch-plan.md",
+                        mime_type="text/markdown",
+                        size_bytes=1200,
+                    )
+                ]
+            ),
+        )
+
+        response = await DelegateToExpertTool()._execute(
+            user_id="alice",
+            session=_session(expert_id=None),
+            expert_id="expert-b",
+            prompt="create the launch plan",
+            deliverable_mode="workspace_files",
+        )
+
+        assert response.status == "completed"
+        assert response.artifacts[0].uri == "workspace://file-1#text/markdown"
+        assert response.artifacts[0].read_path.startswith("/sessions/")
 
     @pytest.mark.asyncio
     async def test_file_deliverable_requires_workspace_promotion(

--- a/autogpt_platform/backend/backend/copilot/tools/delegated_results.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegated_results.py
@@ -221,9 +221,14 @@ def _artifact(file: WorkspaceFileInfoData) -> DelegatedArtifact:
     return DelegatedArtifact(
         name=_clip(file.name, _MAX_ARTIFACT_NAME_CHARS),
         read_path=_clip(file.path, _MAX_ARTIFACT_PATH_CHARS),
+        uri=workspace_file_uri(file.file_id, file.mime_type),
         mime_type=_clip(file.mime_type, _MAX_MIME_TYPE_CHARS),
         size_bytes=max(0, file.size_bytes),
     )
+
+
+def workspace_file_uri(file_id: str, mime_type: str | None = None) -> str:
+    return f"workspace://{file_id}" + (f"#{mime_type}" if mime_type else "")
 
 
 def _summary_preview(text: str) -> str:

--- a/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
+++ b/autogpt_platform/backend/backend/copilot/tools/get_sub_session_result.py
@@ -293,7 +293,7 @@ class GetSubSessionResultTool(BaseTool):
                     artifacts=[
                         ExpertWorkArtifact(
                             name=artifact.name,
-                            uri=artifact.read_path,
+                            uri=artifact.uri,
                             mime_type=artifact.mime_type,
                             size_bytes=artifact.size_bytes,
                         )

--- a/autogpt_platform/backend/backend/copilot/tools/models.py
+++ b/autogpt_platform/backend/backend/copilot/tools/models.py
@@ -491,6 +491,7 @@ class DelegatedCriterionState(BaseModel):
 class DelegatedArtifact(BaseModel):
     name: str
     read_path: str
+    uri: str
     mime_type: str
     size_bytes: int
 

--- a/autogpt_platform/backend/backend/copilot/tools/report_delegated_result.py
+++ b/autogpt_platform/backend/backend/copilot/tools/report_delegated_result.py
@@ -14,6 +14,7 @@ from backend.copilot.sdk.session_waiter import run_copilot_turn_via_queue
 from backend.util.feature_flag import Flag, is_feature_enabled
 
 from .base import BaseTool
+from .delegated_results import workspace_file_uri
 from .models import DelegatedWorkReportedResponse, ErrorResponse, ToolResponseBase
 from .run_sub_session import list_sub_workspace_files
 
@@ -187,7 +188,7 @@ class ReportDelegatedResultTool(BaseTool):
             final_artifacts = [
                 ExpertWorkArtifact(
                     name=file.name,
-                    uri=file.path,
+                    uri=workspace_file_uri(file.file_id, file.mime_type),
                     mime_type=file.mime_type,
                     size_bytes=file.size_bytes,
                 )
@@ -257,7 +258,10 @@ def _manager_notice(item) -> str:
         parts.append(f"Manager blocker: {item.blocker}")
     if item.artifacts:
         parts.append(
-            "Artifacts: " + ", ".join(artifact.name for artifact in item.artifacts)
+            "Artifacts: "
+            + ", ".join(
+                f"{artifact.name} ({artifact.uri})" for artifact in item.artifacts
+            )
         )
     parts.append(
         "Resolve manager-level questions yourself when possible and keep other "

--- a/autogpt_platform/backend/backend/copilot/tools/report_delegated_result_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/report_delegated_result_test.py
@@ -5,11 +5,7 @@ import pytest
 
 from backend.api.features.experts.models import ExpertWorkArtifact, ExpertWorkItem
 
-from .models import (
-    DelegatedWorkReportedResponse,
-    ErrorResponse,
-    WorkspaceFileInfoData,
-)
+from .models import DelegatedWorkReportedResponse, ErrorResponse, WorkspaceFileInfoData
 from .report_delegated_result import ReportDelegatedResultTool
 
 NOW = datetime(2026, 8, 27, tzinfo=timezone.utc)

--- a/autogpt_platform/backend/backend/copilot/tools/report_delegated_result_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/report_delegated_result_test.py
@@ -3,9 +3,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.api.features.experts.models import ExpertWorkItem
+from backend.api.features.experts.models import ExpertWorkArtifact, ExpertWorkItem
 
-from .models import DelegatedWorkReportedResponse, ErrorResponse
+from .models import (
+    DelegatedWorkReportedResponse,
+    ErrorResponse,
+    WorkspaceFileInfoData,
+)
 from .report_delegated_result import ReportDelegatedResultTool
 
 NOW = datetime(2026, 8, 27, tzinfo=timezone.utc)
@@ -155,6 +159,49 @@ async def test_required_files_without_workspace_artifact_become_partial(
     assert isinstance(response, DelegatedWorkReportedResponse)
     assert report.await_args.kwargs["status"] == "partial"
     assert "not promoted" in report.await_args.kwargs["blocker"]
+
+
+@pytest.mark.asyncio
+async def test_promoted_files_are_persisted_as_workspace_uris(dependencies):
+    item, _, get_item, report, _, queue = dependencies
+    file_item = _item(deliverable_mode="workspace_files")
+    artifact = ExpertWorkArtifact(
+        name="launch-plan.md",
+        uri="workspace://file-1#text/markdown",
+        mime_type="text/markdown",
+        size_bytes=1200,
+    )
+    get_item.return_value = file_item
+    report.return_value = (
+        file_item.model_copy(update={"status": "delivered", "artifacts": [artifact]}),
+        True,
+    )
+    files = AsyncMock(
+        return_value=[
+            WorkspaceFileInfoData(
+                file_id="file-1",
+                name="launch-plan.md",
+                path="/sessions/delegated-1/launch-plan.md",
+                mime_type="text/markdown",
+                size_bytes=1200,
+            )
+        ]
+    )
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "backend.copilot.tools.report_delegated_result.list_sub_workspace_files",
+            files,
+        )
+        await ReportDelegatedResultTool()._execute(
+            "user-1",
+            _session(),
+            work_item_id="work-1",
+            status="delivered",
+            summary="Files are ready",
+        )
+
+    assert report.await_args.kwargs["artifacts"] == [artifact]
+    assert "workspace://file-1#text/markdown" in queue.await_args.kwargs["message"]
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/tools/workspace_files.py
+++ b/autogpt_platform/backend/backend/copilot/tools/workspace_files.py
@@ -4,8 +4,12 @@ import base64
 import logging
 import mimetypes
 import os
+import re
 from typing import Any, Optional
 
+import prisma.models
+
+from backend.api.features.experts import work_items
 from backend.api.features.store.exceptions import VirusDetectedError, VirusScanError
 from backend.copilot.context import (
     E2B_WORKDIR,
@@ -19,6 +23,7 @@ from backend.copilot.context import (
 )
 from backend.copilot.model import ChatSession
 from backend.copilot.tools.sandbox import make_session_path
+from backend.util.feature_flag import Flag, is_feature_enabled
 from backend.util.settings import Config
 from backend.util.workspace import WorkspaceManager
 
@@ -32,6 +37,76 @@ _MAX_FILE_SIZE_MB = Config().max_file_size_mb
 # Sentinel file_id used when a tool-result file is read directly from the local
 # host filesystem (rather than from workspace storage).
 _LOCAL_TOOL_RESULT_FILE_ID = "local"
+
+_TECHNICAL_ARTIFACT_NAMES = {"agent.json", "build_state.json"}
+_SDK_ARTIFACT_NAME = re.compile(r"^sdk-[0-9a-f-]{8,}\.json$", re.I)
+
+
+async def _workspace_artifact_metadata(
+    user_id: str,
+    session: ChatSession,
+    filename: str,
+    path: str | None,
+) -> dict[str, object]:
+    metadata: dict[str, object] = {"origin": "agent-created"}
+    try:
+        enabled = await is_feature_enabled(Flag.HIRE_EXPERTS, user_id, default=False)
+    except Exception:
+        logger.warning(
+            "Could not resolve founder artifact metadata flag", exc_info=True
+        )
+        return metadata
+    if not enabled:
+        return metadata
+
+    normalized_name = os.path.basename(filename).lower()
+    normalized_path = (path or "").strip().lower()
+    technical = (
+        normalized_name in _TECHNICAL_ARTIFACT_NAMES
+        or _SDK_ARTIFACT_NAME.fullmatch(normalized_name) is not None
+        or "/tool-outputs/" in f"/{normalized_path.lstrip('/')}"
+    )
+    metadata.update(
+        {
+            "audience": "internal" if technical else "founder",
+            "artifact_role": "diagnostic" if technical else "deliverable",
+            "title": filename,
+            "verification": "unknown",
+            "owner_type": "expert" if session.expert_id else "autopilot",
+            "owner_name": "AutoPilot",
+        }
+    )
+    if not session.expert_id:
+        return metadata
+
+    metadata["owner_id"] = session.expert_id
+    try:
+        expert = await prisma.models.Expert.prisma().find_first(
+            where={
+                "id": session.expert_id,
+                "ownerUserId": user_id,
+                "isTemplate": False,
+                "isArchived": False,
+            }
+        )
+        if expert is not None:
+            metadata["owner_name"] = expert.name
+        active_work = await work_items.get_active_work_for_session(
+            user_id=user_id,
+            delegated_session_id=session.session_id,
+            expert_id=session.expert_id,
+        )
+        if active_work is not None:
+            metadata.update(
+                {
+                    "work_item_id": active_work.id,
+                    "project_phase": active_work.project_phase,
+                    "purpose": active_work.expected_deliverable,
+                }
+            )
+    except Exception:
+        logger.warning("Could not enrich founder artifact metadata", exc_info=True)
+    return metadata
 
 
 async def _resolve_write_content(
@@ -894,13 +969,19 @@ class WriteWorkspaceFileTool(BaseTool):
 
         try:
             manager = await get_workspace_manager(user_id, session_id)
+            metadata = await _workspace_artifact_metadata(
+                user_id,
+                session,
+                filename,
+                path,
+            )
             rec = await manager.write_file(
                 content=content_bytes,
                 filename=filename,
                 path=path,
                 mime_type=mime_type,
                 overwrite=overwrite,
-                metadata={"origin": "agent-created"},
+                metadata=metadata,
             )
 
             # Build informative source label and message.

--- a/autogpt_platform/backend/backend/copilot/tools/workspace_files_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/workspace_files_test.py
@@ -3,8 +3,10 @@
 import base64
 import os
 import shutil
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import prisma.models
 import pytest
 
 from backend.copilot.context import SDK_PROJECTS_DIR, _current_project_dir
@@ -23,6 +25,7 @@ from backend.copilot.tools.workspace_files import (
     _read_local_tool_result,
     _resolve_write_content,
     _validate_ephemeral_path,
+    _workspace_artifact_metadata,
 )
 
 # Re-export so pytest discovers the session-scoped fixture
@@ -30,6 +33,14 @@ setup_test_data = setup_test_data
 
 # We need to mock make_session_path to return a known temp dir for tests.
 # The real one uses WORKSPACE_PREFIX = "/tmp/copilot-"
+
+
+@pytest.fixture(autouse=True)
+def disable_hire_experts_flag(monkeypatch):
+    monkeypatch.setattr(
+        "backend.copilot.tools.workspace_files.is_feature_enabled",
+        AsyncMock(return_value=False),
+    )
 
 
 @pytest.fixture
@@ -172,6 +183,78 @@ class TestResolveWriteContent:
         # source_path="" should be normalised to None, so only content counts
         result = await _resolve_write_content("hello", "", "", "s1")
         assert result == b"hello"
+
+
+async def test_workspace_artifact_metadata_keeps_legacy_shape_when_flag_off():
+    session = make_session("user-1")
+    with patch(
+        "backend.copilot.tools.workspace_files.is_feature_enabled",
+        new=AsyncMock(return_value=False),
+    ):
+        metadata = await _workspace_artifact_metadata(
+            "user-1", session, "report.md", "/report.md"
+        )
+
+    assert metadata == {"origin": "agent-created"}
+
+
+async def test_workspace_artifact_metadata_links_expert_work():
+    session = make_session("user-1")
+    session.expert_id = "expert-1"
+    expert_manager = SimpleNamespace(
+        find_first=AsyncMock(return_value=SimpleNamespace(name="Nova"))
+    )
+    active_work = SimpleNamespace(
+        id="work-1",
+        project_phase="Phase 1",
+        expected_deliverable="A verified lead list",
+    )
+    with (
+        patch(
+            "backend.copilot.tools.workspace_files.is_feature_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch.object(
+            prisma.models.Expert,
+            "prisma",
+            return_value=expert_manager,
+        ),
+        patch(
+            "backend.copilot.tools.workspace_files.work_items.get_active_work_for_session",
+            new=AsyncMock(return_value=active_work),
+        ),
+    ):
+        metadata = await _workspace_artifact_metadata(
+            "user-1", session, "leads.csv", "/leads.csv"
+        )
+
+    assert metadata == {
+        "origin": "agent-created",
+        "audience": "founder",
+        "artifact_role": "deliverable",
+        "title": "leads.csv",
+        "verification": "unknown",
+        "owner_type": "expert",
+        "owner_name": "Nova",
+        "owner_id": "expert-1",
+        "work_item_id": "work-1",
+        "project_phase": "Phase 1",
+        "purpose": "A verified lead list",
+    }
+
+
+async def test_workspace_artifact_metadata_marks_builder_files_internal():
+    session = make_session("user-1")
+    with patch(
+        "backend.copilot.tools.workspace_files.is_feature_enabled",
+        new=AsyncMock(return_value=True),
+    ):
+        metadata = await _workspace_artifact_metadata(
+            "user-1", session, "build_state.json", "/build_state.json"
+        )
+
+    assert metadata["audience"] == "internal"
+    assert metadata["artifact_role"] == "diagnostic"
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/main.test.tsx
@@ -15,9 +15,10 @@ import {
 } from "@/app/api/__generated__/endpoints/workspace/workspace.msw";
 import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
 
-const { setFlagStatusMock } = vi.hoisted(() => {
+const { setFlagStatusMock, hireExpertsFlagMock } = vi.hoisted(() => {
   return {
     setFlagStatusMock: vi.fn(() => ({ enabled: true, ready: true })),
+    hireExpertsFlagMock: vi.fn(() => true),
   };
 });
 
@@ -25,14 +26,19 @@ const { setFlagStatusMock } = vi.hoisted(() => {
 // flag overrides must persist across renders; restore the default afterward.
 afterEach(() => {
   setFlagStatusMock.mockReturnValue({ enabled: true, ready: true });
+  hireExpertsFlagMock.mockReturnValue(true);
 });
 
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
   Flag: {
     ARTIFACTS_PAGE: "artifacts-page",
     AUTOGPT_NEW_LAYOUT: "autogpt-new-layout",
+    HIRE_EXPERTS: "hire-experts",
   },
-  useGetFlag: (flag: string) => flag !== "autogpt-new-layout",
+  useGetFlag: (flag: string) =>
+    flag === "hire-experts"
+      ? hireExpertsFlagMock()
+      : flag !== "autogpt-new-layout",
   useFlagStatus: () => setFlagStatusMock(),
 }));
 
@@ -150,6 +156,62 @@ describe("ArtifactsPage - basic rendering", () => {
     expect(await screen.findByText("report.pdf")).toBeDefined();
     expect(screen.getByText("data.csv")).toBeDefined();
     expect(screen.getAllByTestId("artifacts-list-item").length).toBe(2);
+  });
+
+  test("shows founder deliverables before technical files", async () => {
+    useStorageHandler();
+    server.use(
+      getListWorkspaceFilesMockHandler({
+        files: [
+          makeFile({
+            id: "deliverable",
+            name: "phase0_positioning_icp.md",
+            metadata: {
+              title: "Positioning brief",
+              owner_name: "Maya",
+              purpose: "Choose the first customer segment",
+              verification: "verified",
+            },
+          }),
+          makeFile({ id: "sdk", name: "sdk-12345678-abcd.json" }),
+          makeFile({ id: "agent", name: "agent.json" }),
+          makeFile({ id: "state", name: "build_state.json" }),
+        ],
+        offset: 0,
+        has_more: false,
+      }),
+    );
+
+    render(<ArtifactsPage />);
+
+    expect(await screen.findByText("Positioning brief")).toBeDefined();
+    expect(screen.getByText(/Maya · Verified ·/)).toBeDefined();
+    expect(screen.queryByText("agent.json")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Technical files (3)" }),
+    );
+
+    expect(await screen.findByText("agent.json")).toBeDefined();
+    expect(screen.getByText("build_state.json")).toBeDefined();
+    expect(screen.getByText("sdk-12345678-abcd.json")).toBeDefined();
+  });
+
+  test("keeps legacy file visibility unchanged when hire experts is off", async () => {
+    hireExpertsFlagMock.mockReturnValue(false);
+    useStorageHandler();
+    server.use(
+      getListWorkspaceFilesMockHandler({
+        files: [makeFile({ id: "agent", name: "agent.json" })],
+        offset: 0,
+        has_more: false,
+      }),
+    );
+
+    render(<ArtifactsPage />);
+
+    expect(await screen.findByText("agent.json")).toBeDefined();
+    expect(screen.queryByText(/technical files/i)).toBeNull();
   });
 
   test("renders the error card when the API fails", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactCard/ArtifactCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactCard/ArtifactCard.tsx
@@ -40,10 +40,17 @@ import {
   MoreHorizontalIcon,
 } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import {
+  workspaceFileOwner,
+  workspaceFilePurpose,
+  workspaceFileTitle,
+  workspaceFileVerification,
+} from "@/lib/workspace-file-visibility";
 
 interface Props {
   file: WorkspaceFileItem;
   onOpen: (file: WorkspaceFileItem) => void;
+  founderMode?: boolean;
 }
 
 const CARD_VARIANTS: Variants = {
@@ -62,13 +69,17 @@ const REDUCED_CARD_VARIANTS: Variants = {
   show: { opacity: 1, transition: { duration: 0.2 } },
 };
 
-export function ArtifactCard({ file, onOpen }: Props) {
+export function ArtifactCard({ file, onOpen, founderMode = false }: Props) {
   const origin = deriveFileOrigin(file.path);
   const goLabel = origin.kind === "session" ? "Open chat" : "Open in Builder";
   const typeIcon = getFileTypeIcon(file.mime_type, file.name);
   const reduceMotion = useReducedMotion();
   const [isMoveOpen, setIsMoveOpen] = useState(false);
   const dragImageRef = useRef<HTMLElement | null>(null);
+  const displayTitle = founderMode ? workspaceFileTitle(file) : file.name;
+  const owner = founderMode ? workspaceFileOwner(file) : "";
+  const purpose = founderMode ? workspaceFilePurpose(file) : "";
+  const verification = founderMode ? workspaceFileVerification(file) : "";
 
   // Clean up a leftover drag-image node if the card unmounts mid-drag (before
   // dragend fires), so the off-screen element isn't leaked into the DOM.
@@ -122,15 +133,33 @@ export function ArtifactCard({ file, onOpen }: Props) {
             <Text
               variant="body-medium"
               className="truncate text-zinc-900"
-              title={file.name}
+              title={displayTitle}
             >
-              {file.name}
+              {displayTitle}
             </Text>
-            <Text variant="small" className="truncate text-zinc-500">
-              {getFileTypeLabel(file.mime_type, file.name)} ·{" "}
-              {formatFileSize(file.size_bytes)} ·{" "}
-              {formatRelativeDate(file.created_at)}
-            </Text>
+            {founderMode ? (
+              <>
+                <Text variant="small" className="truncate text-zinc-500">
+                  {owner ? `${owner} · ` : ""}
+                  {verification ? `${verification} · ` : ""}
+                  {formatRelativeDate(file.created_at)}
+                </Text>
+                {purpose ? (
+                  <Text
+                    variant="small"
+                    className="mt-0.5 line-clamp-2 text-zinc-500"
+                  >
+                    {purpose}
+                  </Text>
+                ) : null}
+              </>
+            ) : (
+              <Text variant="small" className="truncate text-zinc-500">
+                {getFileTypeLabel(file.mime_type, file.name)} ·{" "}
+                {formatFileSize(file.size_bytes)} ·{" "}
+                {formatRelativeDate(file.created_at)}
+              </Text>
+            )}
           </div>
           <div className="pointer-events-auto">
             <CardMenu

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsList.tsx
@@ -18,10 +18,15 @@ interface Props {
   isError: boolean;
   error: unknown;
   hasSearchTerm: boolean;
-  hasMore: boolean;
-  isLoadingMore: boolean;
-  onLoadMore: () => void;
+  pagination: {
+    hasMore: boolean;
+    isLoading: boolean;
+    onLoadMore: () => void;
+  };
   listKey: string;
+  founderView?: {
+    hasHiddenTechnicalFiles: boolean;
+  };
 }
 
 const GRID_VARIANTS: Variants = {
@@ -37,13 +42,13 @@ export function ArtifactsList({
   isError,
   error,
   hasSearchTerm,
-  hasMore,
-  isLoadingMore,
-  onLoadMore,
+  pagination,
   listKey,
+  founderView,
 }: Props) {
   const reduceMotion = useReducedMotion();
   const [openFile, setOpenFile] = useState<WorkspaceFileItem | null>(null);
+  const founderMode = founderView !== undefined;
 
   if (isLoading) {
     return (
@@ -71,15 +76,28 @@ export function ArtifactsList({
 
   if (files.length === 0) {
     return (
-      <div
-        className="flex min-h-[20rem] flex-col items-center justify-center gap-4 p-8 text-center"
-        data-testid="artifacts-empty"
-      >
-        <FileTypeMarquee />
-        <Text variant="h5" className="text-zinc-700">
-          {hasSearchTerm ? "No files match your search" : "No files yet"}
-        </Text>
-      </div>
+      <>
+        <div
+          className="flex min-h-[20rem] flex-col items-center justify-center gap-4 p-8 text-center"
+          data-testid="artifacts-empty"
+        >
+          <FileTypeMarquee />
+          <Text variant="h5" className="text-zinc-700">
+            {founderView?.hasHiddenTechnicalFiles
+              ? "No deliverables yet"
+              : hasSearchTerm
+                ? "No files match your search"
+                : "No files yet"}
+          </Text>
+        </div>
+        {founderMode ? (
+          <LoadMoreSentinel
+            hasMore={pagination.hasMore}
+            isLoading={pagination.isLoading}
+            onLoadMore={pagination.onLoadMore}
+          />
+        ) : null}
+      </>
     );
   }
 
@@ -94,13 +112,18 @@ export function ArtifactsList({
         animate={reduceMotion ? undefined : "show"}
       >
         {files.map((file) => (
-          <ArtifactCard key={file.id} file={file} onOpen={setOpenFile} />
+          <ArtifactCard
+            key={file.id}
+            file={file}
+            onOpen={setOpenFile}
+            founderMode={founderMode}
+          />
         ))}
       </motion.ul>
       <LoadMoreSentinel
-        hasMore={hasMore}
-        isLoading={isLoadingMore}
-        onLoadMore={onLoadMore}
+        hasMore={pagination.hasMore}
+        isLoading={pagination.isLoading}
+        onLoadMore={pagination.onLoadMore}
       />
       {openFile ? (
         <FileViewerModal

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/page.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { notFound } from "next/navigation";
 import { motion, useReducedMotion } from "framer-motion";
 import type { Transition, Variants } from "framer-motion";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
-import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
+import {
+  Flag,
+  useFlagStatus,
+  useGetFlag,
+} from "@/services/feature-flags/use-get-flag";
 import { usePlatformChrome } from "@/app/(platform)/PlatformChrome/usePlatformChrome";
+import { isTechnicalWorkspaceFile } from "@/lib/workspace-file-visibility";
 import { ArtifactsSearchBar } from "./components/ArtifactsSearchBar/ArtifactsSearchBar";
 import { ArtifactsList } from "./components/ArtifactsList/ArtifactsList";
 import { OriginFilter } from "./components/OriginFilter/OriginFilter";
@@ -42,11 +48,14 @@ const CLASSIC_MAIN =
   "container min-h-screen space-y-6 pb-20 pt-16 sm:px-8 md:px-12";
 
 export default function ArtifactsPage() {
+  // anchor: existing AutoGPT Files; diverge by showing founder deliverables before diagnostics
   const { enabled: isEnabled, ready: flagReady } = useFlagStatus(
     Flag.ARTIFACTS_PAGE,
   );
+  const isFounderMode = useGetFlag(Flag.HIRE_EXPERTS);
   const { showNewLayout } = usePlatformChrome();
   const reduceMotion = useReducedMotion();
+  const [showTechnicalFiles, setShowTechnicalFiles] = useState(false);
   const {
     files,
     isLoading,
@@ -67,6 +76,13 @@ export default function ArtifactsPage() {
 
   const isSearching = searchTerm.length > 0;
   const selectedFolder = folders.find((f) => f.id === selectedFolderId);
+  const technicalFileCount = isFounderMode
+    ? files.filter(isTechnicalWorkspaceFile).length
+    : 0;
+  const visibleFiles =
+    isFounderMode && !showTechnicalFiles
+      ? files.filter((file) => !isTechnicalWorkspaceFile(file))
+      : files;
 
   useEffect(() => {
     document.title = "Files – AutoGPT Platform";
@@ -96,11 +112,13 @@ export default function ArtifactsPage() {
             variant={showNewLayout ? "large" : "body"}
             className="max-w-prose text-zinc-600"
           >
-            Every file your agents generate or use in the Builder lives here —
-            ready to reuse, download, or share.
+            {isFounderMode
+              ? "The deliverables your AI team creates, ready to review, download, or share."
+              : "Every file your agents generate or use in the Builder lives here — ready to reuse, download, or share."}
           </Text>
         </motion.div>
         <motion.div
+          className="flex items-center gap-2"
           variants={variants}
           initial="hidden"
           animate="show"
@@ -123,12 +141,24 @@ export default function ArtifactsPage() {
           <StorageUsage />
         </motion.div>
         <motion.div
+          className="flex items-center gap-2"
           variants={variants}
           initial="hidden"
           animate="show"
           transition={{ delay: reduceMotion ? 0 : 0.24 }}
         >
           <OriginFilter value={originFilter} onChange={setOriginFilter} />
+          {isFounderMode && technicalFileCount > 0 ? (
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setShowTechnicalFiles((current) => !current)}
+            >
+              {showTechnicalFiles
+                ? "Hide technical files"
+                : `Technical files (${technicalFileCount})`}
+            </Button>
+          ) : null}
         </motion.div>
       </div>
       {selectedFolderId !== null ? (
@@ -162,15 +192,25 @@ export default function ArtifactsPage() {
         transition={{ delay: reduceMotion ? 0 : 0.32 }}
       >
         <ArtifactsList
-          files={files}
+          files={visibleFiles}
+          founderView={
+            isFounderMode
+              ? {
+                  hasHiddenTechnicalFiles:
+                    !showTechnicalFiles && technicalFileCount > 0,
+                }
+              : undefined
+          }
           isLoading={isLoading}
           isError={isError}
           error={error}
           hasSearchTerm={searchTerm.length > 0}
-          hasMore={hasMore}
-          isLoadingMore={isLoadingMore}
-          onLoadMore={loadMore}
-          listKey={`${originFilter}|${debouncedSearch}|${selectedFolderId ?? "root"}`}
+          pagination={{
+            hasMore,
+            isLoading: isLoadingMore,
+            onLoadMore: loadMore,
+          }}
+          listKey={`${originFilter}|${debouncedSearch}|${selectedFolderId ?? "root"}|${showTechnicalFiles}`}
         />
       </motion.div>
     </main>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionsSection.tsx
@@ -111,7 +111,7 @@ export function QuestionsSection({ requests, isReady, onProceed }: Props) {
                 aria-current={i === current ? "step" : undefined}
                 onClick={() => setStep(i)}
                 className={
-                  "rounded-full transition-all duration-300 " +
+                  "rounded-full transition-[width,height,border-color,background-color] duration-300 " +
                   (i === current
                     ? "size-2.5 border-2 border-zinc-800"
                     : i < current
@@ -121,15 +121,6 @@ export function QuestionsSection({ requests, isReady, onProceed }: Props) {
               />
             ))}
           </span>
-          <button
-            type="button"
-            aria-label="Next question"
-            disabled={isLast}
-            onClick={() => setStep(current + 1)}
-            className="flex size-6 items-center justify-center rounded-lg text-zinc-400 transition-colors enabled:hover:bg-zinc-100 enabled:hover:text-zinc-600 disabled:opacity-35"
-          >
-            <Icon icon={ArrowRight01Icon} size={14} />
-          </button>
         </span>
 
         <button
@@ -138,7 +129,7 @@ export function QuestionsSection({ requests, isReady, onProceed }: Props) {
           disabled={!actionEnabled}
           onClick={handleAction}
           className={
-            "flex size-8 items-center justify-center rounded-full transition-all duration-200 enabled:active:scale-95 " +
+            "flex size-8 items-center justify-center rounded-full transition-[transform,background-color,color] duration-200 enabled:active:scale-95 " +
             (actionEnabled
               ? "bg-zinc-800 text-white hover:bg-zinc-900"
               : "bg-zinc-100 text-zinc-400")

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -406,11 +406,10 @@ describe("ChainActionCard", () => {
       expect(screen.getByText("Answer a few questions")).toBeDefined();
       expect(screen.getByText("Which region?")).toBeDefined();
 
-      const nextButtons = screen.getAllByRole("button", {
+      const nextButton = screen.getByRole("button", {
         name: "Next question",
-      }) as HTMLButtonElement[];
-      // The round action is answer-gated; the pager chevron is not.
-      expect(nextButtons.filter((button) => button.disabled)).toHaveLength(1);
+      }) as HTMLButtonElement;
+      expect(nextButton.disabled).toBe(true);
     });
 
     it("advances to the next question once answered", () => {
@@ -423,11 +422,10 @@ describe("ChainActionCard", () => {
         ],
       });
 
-      const [action] = (
-        screen.getAllByRole("button", {
-          name: "Next question",
-        }) as HTMLButtonElement[]
-      ).filter((button) => !button.disabled);
+      const action = screen.getByRole("button", {
+        name: "Next question",
+      }) as HTMLButtonElement;
+      expect(action.disabled).toBe(false);
       fireEvent.click(action);
 
       expect(screen.getByText("Which format?")).toBeDefined();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
@@ -134,6 +134,7 @@ export const ChatContainer = ({
 }: ChatContainerProps) => {
   const isArtifactsEnabled = useGetFlag(Flag.ARTIFACTS);
   const isTaskBarEnabled = useGetFlag(Flag.TASK_PROGRESS_BAR);
+  const isFounderMode = useGetFlag(Flag.HIRE_EXPERTS);
   // The composer and the message column only slide aside while the floating
   // files card is shown; this host is the one that mounts the card.
   const areFilesOpen = useAreWorkspaceFileCardsOpen();
@@ -204,12 +205,18 @@ export const ChatContainer = ({
   // it does not run per stream delta — serializing every part is not free.
   const devtoolBreakdownKeyRef = useRef("");
   useEffect(() => {
-    if (!sessionId || !isTokenDevtoolEnabled() || messages.length === 0) return;
+    if (
+      isFounderMode ||
+      !sessionId ||
+      !isTokenDevtoolEnabled() ||
+      messages.length === 0
+    )
+      return;
     const key = breakdownCacheKey(sessionId, messages, isStreaming);
     if (key === devtoolBreakdownKeyRef.current) return;
     devtoolBreakdownKeyRef.current = key;
     updateHistoryBreakdown(sessionId, messages);
-  }, [sessionId, messages, isStreaming]);
+  }, [sessionId, messages, isStreaming, isFounderMode]);
 
   // Retry: re-send the last user message (used by ErrorCard on transient errors).
   const handleRetry = useCallback(() => {
@@ -322,6 +329,7 @@ export const ChatContainer = ({
                         <TaskProgressBar
                           todos={getLatestTaskList(messages) ?? []}
                           isStreaming={isStreaming}
+                          founderMode={isFounderMode}
                         />
                       </div>
                     )}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
@@ -327,7 +327,11 @@ export const ChatContainer = ({
                     {isTaskBarEnabled && (
                       <div className="relative z-10">
                         <TaskProgressBar
-                          todos={getLatestTaskList(messages) ?? []}
+                          todos={
+                            getLatestTaskList(messages, {
+                              currentTurnOnly: isFounderMode,
+                            }) ?? []
+                          }
                           isStreaming={isStreaming}
                           founderMode={isFounderMode}
                         />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/ChatInput.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/ChatInput.tsx
@@ -111,6 +111,7 @@ export function ChatInput({
   const showModeToggle = useGetFlag(Flag.CHAT_MODE_OPTION);
   const showDryRunToggle = showModeToggle;
   const showWorkspaceFiles = useGetFlag(Flag.CHAT_WORKSPACE_FILES);
+  const isFounderMode = useGetFlag(Flag.HIRE_EXPERTS);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
@@ -273,7 +274,8 @@ export function ChatInput({
       : placeholder;
 
   // Narrows to string, so neither render site needs to re-test sessionId.
-  const devtoolSessionId = isTokenDevtoolEnabled() ? sessionId : null;
+  const devtoolSessionId =
+    !isFounderMode && isTokenDevtoolEnabled() ? sessionId : null;
   const hasTrayItems =
     (showModeToggle && !isStreaming) ||
     (showDryRunToggle && !hasSession) ||

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/__tests__/ChatInput.test.tsx
@@ -87,9 +87,16 @@ vi.mock("@/app/(platform)/copilot/store", () => ({
 }));
 
 let mockFlagValue = false;
+let mockFounderFlagValue = false;
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
-  Flag: { CHAT_MODE_OPTION: "CHAT_MODE_OPTION" },
-  useGetFlag: () => mockFlagValue,
+  Flag: {
+    CHAT_MODE_OPTION: "CHAT_MODE_OPTION",
+    CHAT_WORKSPACE_FILES: "CHAT_WORKSPACE_FILES",
+    HIRE_EXPERTS: "HIRE_EXPERTS",
+    ONBOARDING_BRAIN_DUMP: "ONBOARDING_BRAIN_DUMP",
+  },
+  useGetFlag: (flag: string) =>
+    flag === "HIRE_EXPERTS" ? mockFounderFlagValue : mockFlagValue,
 }));
 
 // Off by default so the rest of the suite sees the production-build behaviour.
@@ -261,6 +268,7 @@ afterEach(() => {
   mockCopilotLlmModel = "standard";
   mockCopilotLlmAuthProvider = "platform";
   mockFlagValue = false;
+  mockFounderFlagValue = false;
   mockTokenDevtoolEnabled = false;
   mockInitialPrompt = null;
 });
@@ -293,6 +301,14 @@ describe("ChatInput token devtool badge", () => {
   it("stays hidden before a session exists", () => {
     mockTokenDevtoolEnabled = true;
     render(<ChatInput onSend={mockOnSend} sessionId={null} />);
+
+    expect(screen.queryByRole("button", { name: /Token devtool/ })).toBeNull();
+  });
+
+  it("stays hidden for founders even when the devtool gate is on", () => {
+    mockFounderFlagValue = true;
+    mockTokenDevtoolEnabled = true;
+    render(<ChatInput onSend={mockOnSend} sessionId="session-1" />);
 
     expect(screen.queryByRole("button", { name: /Token devtool/ })).toBeNull();
   });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -525,7 +525,7 @@ export function ChatMessagesContainer({
                   from={message.role}
                   key={message.id}
                   data-message-id={message.id}
-                  className="duration-300 animate-in fade-in slide-in-from-bottom-2 fill-mode-both"
+                  className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both [animation-duration:300ms]"
                 >
                   <MessageContent className="group-[.is-assistant]:bg-transparent">
                     <WatcherCard metadata={watcherMetadata} />
@@ -552,10 +552,14 @@ export function ChatMessagesContainer({
                   from={message.role}
                   key={message.id}
                   data-message-id={message.id}
-                  className="duration-300 animate-in fade-in slide-in-from-bottom-2 fill-mode-both"
+                  className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both [animation-duration:300ms]"
                 >
                   <MessageContent className="group-[.is-assistant]:bg-transparent">
-                    <WorkCard metadata={runMetadata} preview={preview} />
+                    <WorkCard
+                      metadata={runMetadata}
+                      preview={preview}
+                      founderMode={isFounderMode}
+                    />
                   </MessageContent>
                 </Message>
               );
@@ -633,7 +637,7 @@ export function ChatMessagesContainer({
                 from={message.role}
                 key={message.id}
                 data-message-id={message.id}
-                className="duration-300 animate-in fade-in slide-in-from-bottom-2 fill-mode-both"
+                className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both [animation-duration:300ms]"
               >
                 <MessageContent
                   className={
@@ -759,7 +763,7 @@ export function ChatMessagesContainer({
           {showIndicator && lastMessage?.role !== "assistant" && (
             <Message
               from="assistant"
-              className="duration-300 animate-in fade-in slide-in-from-bottom-2 fill-mode-both"
+              className="animate-in fade-in slide-in-from-bottom-2 fill-mode-both [animation-duration:300ms]"
             >
               <MessageContent className="text-[1rem] leading-relaxed">
                 {indicator}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/ChatMessagesContainer.tsx
@@ -480,7 +480,7 @@ export function ChatMessagesContainer({
         areFilesOpen={areFilesOpen}
         hasFloatingControls={hasFloatingControls}
       />
-      <ChatMinimap messages={messages} />
+      {!isFounderMode ? <ChatMinimap messages={messages} /> : null}
       <Conversation
         key={sessionID ?? "new"}
         resize="instant"
@@ -581,7 +581,11 @@ export function ChatMessagesContainer({
             // tool calls can't split a chain. data-status surfaces via
             // ThinkingIndicator; data-compaction via CompactionCard.
             const renderableParts = message.parts.filter(
-              (p) => !isBookkeepingPart(p),
+              (part) =>
+                !isBookkeepingPart(part) &&
+                (!isFounderMode ||
+                  (part.type !== "reasoning" &&
+                    part.type !== "tool-context_compaction")),
             );
             // Only a message that is actively streaming can have a live
             // compaction phase — a stopped or failed turn must not leave an
@@ -676,7 +680,7 @@ export function ChatMessagesContainer({
                       ))}
                     </UserMessageClamp>
                   )}
-                  {isLastInTurn && !isCurrentlyStreaming && (
+                  {!isFounderMode && isLastInTurn && !isCurrentlyStreaming && (
                     <TurnStatsBar
                       turnMessages={getTurnMessages(messages, messageIndex)}
                       elapsedSeconds={
@@ -814,9 +818,11 @@ export function ChatMessagesContainer({
                 The assistant encountered an error. Please try sending your
                 message again.
               </summary>
-              <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words text-xs text-red-600">
-                {error instanceof Error ? error.message : String(error)}
-              </pre>
+              {!isFounderMode ? (
+                <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words text-xs text-red-600">
+                  {error instanceof Error ? error.message : String(error)}
+                </pre>
+              ) : null}
             </details>
           )}
           <TailSpacer

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/__tests__/ChatMessagesContainer.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/__tests__/ChatMessagesContainer.test.tsx
@@ -69,7 +69,20 @@ vi.mock("../components/AssistantMessageActions", () => ({
   AssistantMessageActions: () => null,
 }));
 vi.mock("../components/ChainMessageParts", () => ({
-  ChainMessageParts: () => <div data-testid="chain-message-parts" />,
+  ChainMessageParts: ({
+    parts,
+    founderMode,
+  }: {
+    parts: Array<{ type: string }>;
+    founderMode?: boolean;
+  }) => (
+    <div
+      data-testid="chain-message-parts"
+      data-founder-mode={String(Boolean(founderMode))}
+    >
+      {parts.map((part) => part.type).join(",")}
+    </div>
+  ),
 }));
 
 vi.mock("../components/QueueBadge", () => ({
@@ -99,7 +112,7 @@ vi.mock("../../ToolChain/ToolChain", () => ({
   ToolChain: () => <div data-testid="tool-chain" />,
 }));
 vi.mock("../../JobStatsBar/TurnStatsBar", () => ({
-  TurnStatsBar: () => null,
+  TurnStatsBar: () => <div data-testid="turn-stats">turn stats</div>,
 }));
 vi.mock("../../JobStatsBar/useElapsedTimer", () => ({
   useElapsedTimer: () => ({ elapsedSeconds: 0 }),
@@ -164,6 +177,10 @@ const baseProps = {
   onRetry: vi.fn(),
 };
 
+beforeEach(() => {
+  getFlagMock.mockReturnValue(false);
+});
+
 describe("ChatMessagesContainer — assistant rendering", () => {
   const messages = [
     {
@@ -213,6 +230,54 @@ describe("ChatMessagesContainer — assistant rendering", () => {
     rerender(<ChatMessagesContainer {...baseProps} messages={watcher} />);
 
     expect(screen.getByText("Lead Research needs attention")).toBeDefined();
+  });
+
+  it("hides reasoning, diagnostics, and raw errors for founders", () => {
+    getFlagMock.mockReturnValue(true);
+    render(
+      <ChatMessagesContainer
+        {...baseProps}
+        messages={
+          [
+            {
+              id: "assistant-private",
+              role: "assistant",
+              parts: [
+                {
+                  type: "reasoning",
+                  text: "private chain of thought",
+                  state: "done",
+                },
+                { type: "text", text: "Safe answer" },
+              ],
+            },
+          ] as any
+        }
+        error={new Error("raw SDK payload with session_id=secret")}
+        status="error"
+      />,
+    );
+
+    const chain = screen.getByTestId("chain-message-parts");
+    expect(chain.getAttribute("data-founder-mode")).toBe("true");
+    expect(chain.textContent).toBe("text");
+    expect(screen.queryByTestId("turn-stats")).toBeNull();
+    expect(screen.queryByText(/raw SDK payload/)).toBeNull();
+    expect(screen.getByText(/encountered an error/i)).toBeDefined();
+  });
+
+  it("keeps the legacy diagnostics visible when the expert flag is off", () => {
+    render(
+      <ChatMessagesContainer
+        {...baseProps}
+        messages={messages}
+        error={new Error("legacy SDK detail")}
+        status="error"
+      />,
+    );
+
+    expect(screen.getByTestId("turn-stats")).toBeDefined();
+    expect(screen.getByText("legacy SDK detail")).toBeDefined();
   });
 
   it("shows the thinking indicator inside a submitted assistant turn", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/ChainMessageParts.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/ChainMessageParts.tsx
@@ -67,6 +67,7 @@ export function ChainMessageParts({
         liveCompactionCallId={liveCompactionCallId}
         liveCompactionStats={liveCompactionStats}
         isCurrentlyStreaming={isCurrentlyStreaming}
+        founderMode={founderMode}
       />
     );
   });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/MessagePartRenderer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/MessagePartRenderer.tsx
@@ -1,5 +1,6 @@
 import { MessageResponse } from "@/components/ai-elements/message";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { founderSafeMarkdown } from "@/lib/founder-safe-text";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { StoppedTaskCard } from "./StoppedTaskCard";
 import { ToolUIPart, UIDataTypes, UIMessage, UITools } from "ai";
@@ -150,6 +151,7 @@ interface Props {
    *  only animates while it is; once the stream ends the row is history,
    *  however it was left. */
   isCurrentlyStreaming?: boolean;
+  founderMode?: boolean;
 }
 
 export function MessagePartRenderer({
@@ -164,6 +166,7 @@ export function MessagePartRenderer({
   liveCompactionCallId,
   liveCompactionStats,
   isCurrentlyStreaming,
+  founderMode = false,
 }: Props) {
   const key = `${messageID}-${partIndex}`;
 
@@ -187,9 +190,11 @@ export function MessagePartRenderer({
       );
     }
     case "text": {
-      const { markerType, markerText, cleanText } = parseSpecialMarkers(
-        part.text,
-      );
+      const visibleText = founderMode
+        ? founderSafeMarkdown(part.text, "AutoPilot shared an update.")
+        : part.text;
+      const { markerType, markerText, cleanText } =
+        parseSpecialMarkers(visibleText);
 
       if (markerType === "error" || markerType === "retryable_error") {
         const lowerMarker = markerText.toLowerCase();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/MessagePartRenderer.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/MessagePartRenderer.test.tsx
@@ -205,6 +205,35 @@ describe("MessagePartRenderer text branch", () => {
     );
   });
 
+  it("redacts developer-only details from founder-facing assistant text", () => {
+    const part = {
+      type: "text",
+      text: [
+        "Prepared /tmp/private/report.json",
+        "tool_call_id=call-1 graph_id=graph-1",
+        '{"query":"secret search payload"}',
+        "$ cat /tmp/private/report.json",
+        "Ready for review.",
+      ].join("\n"),
+    } as unknown as Part;
+
+    render(
+      <MessagePartRenderer
+        part={part}
+        messageID="m1"
+        partIndex={0}
+        founderMode
+      />,
+    );
+
+    const text = screen.getByTestId("message-response").textContent ?? "";
+    expect(text).toContain("Prepared a workspace file");
+    expect(text).toContain("Ready for review.");
+    expect(text).not.toMatch(
+      /\/tmp|tool_call_id|graph_id|secret search payload|\$ cat/,
+    );
+  });
+
   it("renders a <video> for video: alt, an <img> for image alt, and nothing for empty src", () => {
     const part = { type: "text", text: "media" } as unknown as Part;
     const { container } = render(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/useSessionFiles.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/components/FilesTab/useSessionFiles.ts
@@ -3,6 +3,8 @@
 import { useListWorkspaceFiles } from "@/app/api/__generated__/endpoints/workspace/workspace";
 import type { ListFilesResponse } from "@/app/api/__generated__/models/listFilesResponse";
 import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+import { isTechnicalWorkspaceFile } from "@/lib/workspace-file-visibility";
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { useCopilotStreamStore } from "../../../../copilotStreamStore";
 import { getMessageArtifacts } from "../../../ChatMessagesContainer/helpers";
 import { isUploadedFile } from "./helpers";
@@ -13,6 +15,7 @@ export interface SessionFile {
 }
 
 export function useSessionFiles(sessionId: string | null) {
+  const isFounderMode = useGetFlag(Flag.HIRE_EXPERTS);
   const messages = useCopilotStreamStore((s) =>
     sessionId ? s.messageSnapshots[sessionId] : undefined,
   );
@@ -36,10 +39,16 @@ export function useSessionFiles(sessionId: string | null) {
     }
   }
 
-  const files: SessionFile[] = (query.data?.files ?? []).map((item) => ({
-    item,
-    messageID: fileIdToMessageId.get(item.id) ?? null,
-  }));
+  const files: SessionFile[] = (query.data?.files ?? []).flatMap((item) =>
+    isFounderMode && isTechnicalWorkspaceFile(item)
+      ? []
+      : [
+          {
+            item,
+            messageID: fileIdToMessageId.get(item.id) ?? null,
+          },
+        ],
+  );
 
   const uploaded = files.filter((f) => isUploadedFile(f.item));
   const generated = files.filter((f) => !isUploadedFile(f.item));

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/TaskProgressBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/TaskProgressBar.tsx
@@ -47,12 +47,14 @@ interface Props {
   todos: TodoItem[];
   isStreaming?: boolean;
   defaultExpanded?: boolean;
+  founderMode?: boolean;
 }
 
 export function TaskProgressBar({
   todos,
   isStreaming = false,
   defaultExpanded = false,
+  founderMode = false,
 }: Props) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const reduceMotion = useReducedMotion();
@@ -87,7 +89,9 @@ export function TaskProgressBar({
                 variant="body-medium"
                 className="min-w-0 flex-1 truncate text-sm text-zinc-800"
               >
-                All tasks complete
+                {founderMode && isStreaming
+                  ? "Starting the next phase"
+                  : "All tasks complete"}
               </Text>
             </>
           ) : !expanded && current ? (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/__tests__/TaskProgressBar.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/__tests__/TaskProgressBar.test.tsx
@@ -88,6 +88,19 @@ describe("TaskProgressBar", () => {
     expect(screen.getByText("2/2")).toBeDefined();
   });
 
+  it("announces a new phase instead of stale completion while founders stream", () => {
+    render(
+      <TaskProgressBar
+        founderMode
+        isStreaming
+        todos={[todo("Step 1", "completed"), todo("Step 2", "completed")]}
+      />,
+    );
+
+    expect(screen.getByText("Starting the next phase")).toBeDefined();
+    expect(screen.queryByText("All tasks complete")).toBeNull();
+  });
+
   it("expands to reveal every task row when the header is clicked", () => {
     render(
       <TaskProgressBar

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/__tests__/helpers.test.ts
@@ -25,6 +25,14 @@ function messageWithTodoWrite(todos: unknown, state?: string): UIMessage {
   } as unknown as UIMessage;
 }
 
+function userMessage(id: string): UIMessage {
+  return {
+    id,
+    role: "user",
+    parts: [{ type: "text", text: "Start a new phase" }],
+  } as UIMessage;
+}
+
 describe("getLatestTaskList", () => {
   it("returns null when there are no TodoWrite parts", () => {
     const messages = [
@@ -71,6 +79,28 @@ describe("getLatestTaskList", () => {
 
   it("returns null when todos is not an array", () => {
     expect(getLatestTaskList([messageWithTodoWrite({})])).toBeNull();
+  });
+
+  it("does not reuse a completed plan from a previous founder turn", () => {
+    const messages = [
+      messageWithTodoWrite([todo("Old phase", "completed")]),
+      userMessage("new-request"),
+    ];
+
+    expect(getLatestTaskList(messages)).not.toBeNull();
+    expect(getLatestTaskList(messages, { currentTurnOnly: true })).toBeNull();
+  });
+
+  it("uses the plan created after the latest founder request", () => {
+    const messages = [
+      messageWithTodoWrite([todo("Old phase", "completed")]),
+      userMessage("new-request"),
+      messageWithTodoWrite([todo("New phase", "in_progress")]),
+    ];
+
+    expect(
+      getLatestTaskList(messages, { currentTurnOnly: true })?.[0].content,
+    ).toBe("New phase");
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/TaskProgressBar/helpers.ts
@@ -19,8 +19,14 @@ function isTodoItem(value: unknown): value is TodoItem {
 
 // Walks the message history backwards for the most recent TodoWrite tool call
 // and returns its task list (the copilot's live plan).
-export function getLatestTaskList(messages: UIMessage[]): TodoItem[] | null {
-  for (let i = messages.length - 1; i >= 0; i--) {
+export function getLatestTaskList(
+  messages: UIMessage[],
+  options: { currentTurnOnly?: boolean } = {},
+): TodoItem[] | null {
+  const latestUserMessage = options.currentTurnOnly
+    ? messages.findLastIndex((message) => message.role === "user")
+    : -1;
+  for (let i = messages.length - 1; i > latestUserMessage; i--) {
     const parts = messages[i]?.parts;
     if (!parts) continue;
     for (let j = parts.length - 1; j >= 0; j--) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ChainRowView.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils";
 import { useCopilotUIStore } from "../../store";
 import { ACCORDION_PANEL, accordionState, PANEL_REVEAL } from "./accordion";
 import { EXPERT_CHANGE_TOOLS } from "./ExpertCards";
-import type { ChainRow } from "./helpers";
+import { founderCanOpenRow, type ChainRow } from "./helpers";
 import { ProviderIcon, RowIcon } from "./RowIcon";
 import { useSubSessionEffectiveStatus } from "./SubSessionLive";
 import { SwapText } from "./SwapText";
@@ -47,6 +47,7 @@ function ReasoningStream({ text, live }: ReasoningStreamProps) {
 interface Props {
   row: ChainRow;
   isLast: boolean;
+  founderMode?: boolean;
 }
 
 const SUB_SESSION_TOOLS = new Set([
@@ -72,7 +73,7 @@ function isLiveSubSessionRow(row: ChainRow): boolean {
   );
 }
 
-export function ChainRowView({ row, isLast }: Props) {
+export function ChainRowView({ row, isLast, founderMode = false }: Props) {
   const [open, setOpen] = useState(row.requiresAction === true);
   const isReasoning = row.category === "reasoning";
   const artifactPanelOpen = useCopilotUIStore((s) => s.artifactPanel.isOpen);
@@ -127,13 +128,15 @@ export function ChainRowView({ row, isLast }: Props) {
     EXPERT_CHANGE_TOOLS.has(row.tool) &&
     row.output === undefined &&
     row.state === "running";
-  const hasContent = isReasoning
-    ? !!row.reasoningText
-    : !row.supersededSubSession &&
-      !row.groupedProposal &&
-      ((row.output !== undefined && row.output !== "") ||
-        liveSubSession ||
-        pendingExpertChange);
+  const hasContent =
+    (isReasoning
+      ? !!row.reasoningText
+      : !row.supersededSubSession &&
+        !row.groupedProposal &&
+        ((row.output !== undefined && row.output !== "") ||
+          liveSubSession ||
+          pendingExpertChange)) &&
+    (!founderMode || founderCanOpenRow(row));
   useEffect(() => {
     if (pendingExpertChange) setOpen(true);
   }, [pendingExpertChange]);
@@ -197,7 +200,7 @@ export function ChainRowView({ row, isLast }: Props) {
         ) : (
           <div className="flex h-7 items-center gap-1.5">{rowText}</div>
         )}
-        {row.detail && (
+        {!founderMode && row.detail && (
           <p className="animate-fade-in truncate text-xs text-red-400 motion-reduce:animate-none">
             {row.detail}
           </p>
@@ -217,7 +220,7 @@ export function ChainRowView({ row, isLast }: Props) {
                   live={liveReasoning}
                 />
               ) : (
-                <ToolResult row={row} />
+                <ToolResult row={row} founderMode={founderMode} />
               )}
             </div>
           </div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -27,6 +27,7 @@ export const EXPERT_CHANGE_TOOLS = new Set([
 interface Props {
   output: Record<string, unknown>;
   applied?: boolean;
+  founderMode?: boolean;
 }
 
 const APPLIED_LABELS: Record<string, string> = {
@@ -43,9 +44,10 @@ function failedWorkflows(output: Record<string, unknown>): string[] {
   );
 }
 
-export function ExpertChangeCard({ output }: Props) {
+export function ExpertChangeCard({ output, founderMode = false }: Props) {
   const results = asItems(output.results);
-  if (!results) return <ExpertSingleCard output={output} />;
+  if (!results)
+    return <ExpertSingleCard output={output} founderMode={founderMode} />;
   return (
     <div className="flex flex-col gap-1.5">
       {results.map((result) =>
@@ -54,6 +56,7 @@ export function ExpertChangeCard({ output }: Props) {
             key={expertResultKey(result)}
             output={result}
             applied
+            founderMode={founderMode}
           />
         ) : (
           <ExpertBatchNotice key={expertResultKey(result)} result={result} />
@@ -111,7 +114,11 @@ function ExpertBatchNotice({ result }: { result: Record<string, unknown> }) {
  *  user's OK (given in chat, nothing created yet) or the teammate
  *  ``confirm_expert_change`` actually created. Once they exist, the card
  *  offers the two things the user does next: adjust them or talk to them. */
-function ExpertSingleCard({ output, applied: forcedApplied }: Props) {
+function ExpertSingleCard({
+  output,
+  applied: forcedApplied,
+  founderMode = false,
+}: Props) {
   const [expanded, setExpanded] = useState(false);
   const appliedConfirmationIDs = useContext(ExpertConfirmationContext);
   const detailsID = useId();
@@ -195,7 +202,7 @@ function ExpertSingleCard({ output, applied: forcedApplied }: Props) {
               Stops at: {boundaries}
             </p>
           )}
-          {budget !== null && (
+          {!founderMode && budget !== null && (
             <p className="pl-9 text-sm text-zinc-600">
               Weekly budget: {budget} credits
             </p>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/TeamPreviewCard.tsx
@@ -9,9 +9,10 @@ import { useTeamPreviewCard } from "./useTeamPreviewCard";
 
 interface Props {
   proposals: TeamProposal[];
+  founderMode?: boolean;
 }
 
-export function TeamPreviewCard({ proposals }: Props) {
+export function TeamPreviewCard({ proposals, founderMode = false }: Props) {
   const appliedConfirmationIDs = useContext(ExpertConfirmationContext);
   const {
     canConfirm,
@@ -47,8 +48,9 @@ export function TeamPreviewCard({ proposals }: Props) {
             key={proposal.confirmationId}
             proposal={proposal}
             confirmed={appliedConfirmationIDs.has(proposal.confirmationId)}
-            removed={removedIds.includes(proposal.confirmationId)}
+            removed={removedIds.has(proposal.confirmationId)}
             open={openId === proposal.confirmationId}
+            founderMode={founderMode}
             onToggleRemoved={() => toggleRemoved(proposal.confirmationId)}
             onToggleOpen={() => toggleOpen(proposal.confirmationId)}
           />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/components/ProposedExpertRow.tsx
@@ -18,6 +18,7 @@ interface Props {
   confirmed: boolean;
   removed: boolean;
   open: boolean;
+  founderMode?: boolean;
   onToggleRemoved: () => void;
   onToggleOpen: () => void;
 }
@@ -27,6 +28,7 @@ export function ProposedExpertRow({
   confirmed,
   removed,
   open,
+  founderMode = false,
   onToggleRemoved,
   onToggleOpen,
 }: Props) {
@@ -38,7 +40,8 @@ export function ProposedExpertRow({
   const voice = str(preview, "voice_preferences");
   const budget =
     typeof preview.weekly_budget === "number" ? preview.weekly_budget : null;
-  const hasCharter = !!(about || boundaries || voice) || budget !== null;
+  const hasCharter =
+    !!(about || boundaries || voice) || (!founderMode && budget !== null);
 
   return (
     <div className={"py-2.5 " + (removed ? "opacity-40" : "")}>
@@ -107,7 +110,7 @@ export function ProposedExpertRow({
                 <p className="text-zinc-400">Stops at: {boundaries}</p>
               )}
               {voice && <p className="text-zinc-400">Sounds like: {voice}</p>}
-              {budget !== null && (
+              {!founderMode && budget !== null && (
                 <p className="text-zinc-400">Weekly budget: {budget} credits</p>
               )}
             </div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TeamPreviewCard/useTeamPreviewCard.ts
@@ -10,7 +10,7 @@ export function useTeamPreviewCard(
   appliedConfirmationIDs: ReadonlySet<string>,
 ) {
   const actions = useContext(CopilotChatActionsContext);
-  const [removedIds, setRemovedIds] = useState<readonly string[]>([]);
+  const [removedIds, setRemovedIds] = useState<ReadonlySet<string>>(new Set());
   const [openId, setOpenId] = useState<string | null>(null);
   const confirmed = proposals.filter((proposal) =>
     appliedConfirmationIDs.has(proposal.confirmationId),
@@ -19,14 +19,14 @@ export function useTeamPreviewCard(
     (proposal) => !appliedConfirmationIDs.has(proposal.confirmationId),
   );
   const kept = pending.filter(
-    (proposal) => !removedIds.includes(proposal.confirmationId),
+    (proposal) => !removedIds.has(proposal.confirmationId),
   );
 
   function toggleRemoved(confirmationId: string) {
     setRemovedIds((previous) =>
-      previous.includes(confirmationId)
-        ? previous.filter((id) => id !== confirmationId)
-        : [...previous, confirmationId],
+      previous.has(confirmationId)
+        ? new Set([...previous].filter((id) => id !== confirmationId))
+        : new Set(previous).add(confirmationId),
     );
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -34,6 +34,7 @@ import {
   type ChainRow,
   getChainHeading,
   groupTeamProposalRows,
+  toFounderRow,
   isLiftedSetupRow,
   markSupersededSubSessionRows,
   toChainRow,
@@ -111,6 +112,8 @@ export function ToolChain({
     const mapped = markSupersededSubSessionRows(
       parts
         .map((part, i) => toChainRow(part, i))
+        .filter((row): row is ChainRow => row !== null)
+        .map((row) => (founderMode ? toFounderRow(row) : row))
         .filter((row): row is ChainRow => row !== null)
         // Unanswered clarifying questions and setup cards render their work
         // in the card below the chain — their rows are lifted out of view.
@@ -301,6 +304,7 @@ export function ToolChain({
                             <ChainRowView
                               row={row}
                               isLast={i === visible.length - 1 && !showDone}
+                              founderMode={founderMode}
                             />
                           </ChainActionsContext.Provider>
                         </m.div>
@@ -334,7 +338,7 @@ export function ToolChain({
           <div className="hidden">
             <ChainActionsContext.Provider value={chainActions}>
               {liftedRows.map((row) => (
-                <ToolResult key={row.key} row={row} />
+                <ToolResult key={row.key} row={row} founderMode={founderMode} />
               ))}
             </ChainActionsContext.Provider>
           </div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
@@ -194,7 +194,11 @@ function setupRequirementsCard(row: ChainRow, output: Record<string, unknown>) {
   );
 }
 
-function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
+function toolCard(
+  row: ChainRow,
+  output: Record<string, unknown> | null,
+  founderMode: boolean,
+) {
   const input = asObject(row.input);
 
   if (output) {
@@ -212,6 +216,7 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
         (input ? str(input, "username_agent_slug", "agent_name") : null);
       if (output && name && str(output, "execution_id")) {
         const graphID = str(output, "graph_id");
+        const libraryAgentID = str(output, "library_agent_id");
         const executionID = str(output, "execution_id");
         return (
           <ExecutionCard
@@ -219,9 +224,11 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
             status={str(output, "status") ?? undefined}
             href={
               str(output, "library_agent_link") ??
-              (graphID && executionID
-                ? `/library/agents/${graphID}?activeTab=runs&activeItem=${executionID}`
-                : undefined)
+              (founderMode && libraryAgentID && executionID
+                ? `/library/agents/${libraryAgentID}?activeTab=runs&activeItem=${executionID}`
+                : graphID && executionID
+                  ? `/library/agents/${graphID}?activeTab=runs&activeItem=${executionID}`
+                  : undefined)
             }
           />
         );
@@ -268,7 +275,9 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
         row.tool === "handoff_to_expert" ||
         !!(output && asObject(output.expert));
       if (output && str(output, "status"))
-        return <SubSessionCard output={output} minimal={delegated} />;
+        return (
+          <SubSessionCard output={output} minimal={founderMode || delegated} />
+        );
       // A blocking delegate has no output while the teammate works — show
       // who's on it and what they were asked from the tool input instead.
       // Not for result polls: the delegation card above is already showing
@@ -282,12 +291,19 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
     case "raise_expert":
       if (row.groupedProposal) return null;
       if (row.teamProposals)
-        return <TeamPreviewCard proposals={row.teamProposals} />;
-      if (output) return <ExpertChangeCard output={output} />;
+        return (
+          <TeamPreviewCard
+            proposals={row.teamProposals}
+            founderMode={founderMode}
+          />
+        );
+      if (output)
+        return <ExpertChangeCard output={output} founderMode={founderMode} />;
       return row.state === "running" ? <ExpertChangeCardSkeleton /> : null;
     case "update_expert":
     case "confirm_expert_change":
-      if (output) return <ExpertChangeCard output={output} />;
+      if (output)
+        return <ExpertChangeCard output={output} founderMode={founderMode} />;
       // The expert is still being written — hold the card's shape so the
       // real one swaps in without the row jumping.
       return row.state === "running" ? <ExpertChangeCardSkeleton /> : null;
@@ -414,9 +430,10 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
 
 interface Props {
   row: ChainRow;
+  founderMode?: boolean;
 }
 
-export function ToolResult({ row }: Props) {
+export function ToolResult({ row, founderMode = false }: Props) {
   const output = asObject(row.output);
   const pendingQuestions = useContext(PendingQuestionsContext);
 
@@ -445,8 +462,9 @@ export function ToolResult({ row }: Props) {
     );
   }
 
-  const card = toolCard(row, output);
+  const card = toolCard(row, output, founderMode);
   if (card) return card;
+  if (founderMode) return null;
 
   if (!output) return <KeyValueList value={row.output} />;
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -356,6 +356,45 @@ describe("ToolChain", () => {
     expect(screen.getByText("Weekly budget: 2000 credits")).toBeDefined();
   });
 
+  it("hides raw diagnostics and budgets in founder mode", () => {
+    render(
+      <ToolChain
+        founderMode
+        parts={[
+          reasoningPart("Internal chain of thought"),
+          toolPart("bash_exec", "output-available", {
+            input: { command: "cat /tmp/private.json" },
+            output: "raw shell output",
+          }),
+          toolPart("web_search", "output-available", {
+            input: { query: "private search payload" },
+            output: { results: [{ id: "raw-result" }] },
+          }),
+          toolPart("hire_expert", "output-available", {
+            output: {
+              type: "expert_change_proposed",
+              confirmation_id: "conf-1",
+              preview: {
+                name: "Otto",
+                role: "Inbox triage",
+                weekly_budget: 2000,
+              },
+            },
+          }),
+        ]}
+        isStreaming={false}
+      />,
+    );
+
+    expect(screen.getByText("Otto")).toBeDefined();
+    expect(screen.queryByText("Internal chain of thought")).toBeNull();
+    expect(screen.queryByText(/cat \/tmp/)).toBeNull();
+    expect(screen.queryByText("raw shell output")).toBeNull();
+    expect(screen.queryByText(/private search payload/)).toBeNull();
+    expect(screen.queryByText(/raw-result/)).toBeNull();
+    expect(screen.queryByText(/Weekly budget/)).toBeNull();
+  });
+
   it("lets the user collapse an expert approval card", async () => {
     const user = userEvent.setup();
     render(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   isChainPart,
   isLiftedSetupRow,
   markSupersededSubSessionRows,
+  toFounderRow,
   toChainRow,
   type ChainRow,
 } from "../helpers";
@@ -218,6 +219,56 @@ describe("toChainRow", () => {
   it("does not require action for plain successful output", () => {
     const row = toChainRow(toolPart("run_block", {}, { ok: true }), 0);
     expect(row?.requiresAction).toBe(false);
+  });
+});
+
+describe("toFounderRow", () => {
+  it("removes reasoning and replaces raw tool details with semantic activity", () => {
+    expect(
+      toFounderRow({
+        key: "reasoning",
+        category: "reasoning",
+        text: "Thought",
+        reasoningText: "Internal chain of thought",
+        state: "done",
+      }),
+    ).toBeNull();
+
+    expect(
+      toFounderRow({
+        key: "search",
+        category: "web",
+        text: 'Searched the web for "secret query"',
+        detail: "raw search payload",
+        tool: "web_search",
+        input: { query: "secret query" },
+        output: { results: [{ id: "raw-result" }] },
+        state: "done",
+      }),
+    ).toMatchObject({
+      text: "Research complete",
+      detail: undefined,
+      reasoningText: undefined,
+    });
+  });
+
+  it("names an expert without repeating raw assignment fields", () => {
+    const row = toFounderRow({
+      key: "delegate",
+      category: "agent",
+      text: "Teammate handled",
+      tool: "delegate_to_expert",
+      input: {
+        task_title: "Inspect /tmp/private.json",
+        prompt: "raw instructions",
+      },
+      output: { expert: { name: "Remy" }, status: "completed" },
+      state: "done",
+    });
+
+    expect(row?.text).toBe("Remy reported back");
+    expect(row?.text).not.toContain("/tmp");
+    expect(row?.text).not.toContain("raw instructions");
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/helpers.ts
@@ -283,6 +283,93 @@ export function toChainRow(part: MessagePart, index: number): ChainRow | null {
   return null;
 }
 
+const FOUNDER_ACTIVITY: Record<ChainRow["category"], [string, string]> = {
+  reasoning: ["Working", "Worked"],
+  bash: ["Working", "Step complete"],
+  web: ["Researching", "Research complete"],
+  browser: ["Researching", "Research complete"],
+  "file-read": ["Reviewing source material", "Reviewed source material"],
+  "file-write": ["Saving a deliverable", "Saved a deliverable"],
+  "file-delete": ["Updating deliverables", "Updated deliverables"],
+  "file-list": ["Checking deliverables", "Checked deliverables"],
+  search: ["Finding relevant context", "Found relevant context"],
+  edit: ["Improving the work", "Improved the work"],
+  todo: ["Updating the plan", "Updated the plan"],
+  compaction: ["Organizing context", "Context organized"],
+  agent: ["Running a workflow", "Workflow finished"],
+  "agent-build": ["Creating a workflow", "Workflow created"],
+  plan: ["Planning the work", "Plan ready"],
+  block: ["Running a workflow step", "Workflow step finished"],
+  memory: ["Checking project context", "Project context updated"],
+  folder: ["Organizing work", "Work organized"],
+  schedule: ["Scheduling work", "Work scheduled"],
+  trigger: ["Setting up monitoring", "Monitoring ready"],
+  preset: ["Preparing workflow inputs", "Workflow inputs ready"],
+  chat: ["Sharing an update", "Update shared"],
+  mcp: ["Using a connected tool", "Connected tool finished"],
+  docs: ["Reviewing guidance", "Guidance reviewed"],
+  skill: ["Applying team learning", "Team learning updated"],
+  integration: ["Connecting a tool", "Tool connected"],
+  feature: ["Checking platform support", "Platform support checked"],
+  question: ["Preparing a question", "Question ready"],
+  team: ["Forming your team", "Team updated"],
+  info: ["Checking your workspace", "Workspace checked"],
+  narration: ["Working", "Progress updated"],
+  other: ["Working", "Step complete"],
+};
+
+const FOUNDER_OPEN_TOOLS = new Set([
+  "run_agent",
+  "schedule_agent",
+  "run_sub_session",
+  "get_sub_session_result",
+  "delegate_to_expert",
+  "handoff_to_expert",
+  "hire_expert",
+  "raise_expert",
+  "update_expert",
+  "confirm_expert_change",
+]);
+
+export function toFounderRow(row: ChainRow): ChainRow | null {
+  if (row.category === "reasoning") return null;
+  if (row.requiresAction) return { ...row, detail: undefined };
+
+  const output = asObject(row.output);
+  const expert = output ? asObject(output.expert) : null;
+  const workflow = output ? asObject(output.workflow) : null;
+  const expertName = expert ? str(expert, "name") : null;
+  const workflowName = workflow ? str(workflow, "name") : null;
+  const running = row.state === "running";
+  let text: string;
+
+  if (row.tool === "delegate_to_expert" || row.tool === "handoff_to_expert") {
+    text = running
+      ? `${expertName ?? "A teammate"} working`
+      : `${expertName ?? "A teammate"} reported back`;
+  } else if (row.tool === "install_expert_workflow") {
+    text = running
+      ? "Installing a workflow"
+      : workflowName && expertName
+        ? `Installed ${workflowName} on ${expertName}`
+        : "Workflow installed";
+  } else if (row.tool === "report_delegated_result") {
+    text = running ? "Reporting progress to AutoPilot" : "Progress reported";
+  } else {
+    const labels = FOUNDER_ACTIVITY[row.category];
+    text = running ? labels[0] : labels[1];
+  }
+
+  if (row.state === "error") text = "This step needs attention";
+  return { ...row, text, detail: undefined, reasoningText: undefined };
+}
+
+export function founderCanOpenRow(row: ChainRow) {
+  return Boolean(
+    row.requiresAction || (row.tool && FOUNDER_OPEN_TOOLS.has(row.tool)),
+  );
+}
+
 const CATEGORY_SUMMARY: Record<ChainRow["category"], string> = {
   reasoning: "thought it through",
   bash: "ran commands",

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/toolCatalog.agent.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/toolCatalog.agent.ts
@@ -155,6 +155,16 @@ export const AGENT_TOOL_CATALOG: Record<string, ToolMeta> = {
     done: "Handed over:",
     subject: (input) => quoted(input, "prompt", 45),
   },
+  report_delegated_result: {
+    category: "team",
+    running: "Reporting to AutoPilot",
+    done: "Reported to AutoPilot",
+  },
+  install_expert_workflow: {
+    category: "agent-build",
+    running: "Installing expert workflow",
+    done: "Installed expert workflow",
+  },
   hire_expert: {
     category: "team",
     running: "Drafting a hire",

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkCard/WorkCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkCard/WorkCard.tsx
@@ -4,17 +4,25 @@ import { Button } from "@/components/atoms/Button/Button";
 import { RunStatusBadge } from "@/components/molecules/RunStatusBadge/RunStatusBadge";
 import { buildRunLink } from "@/components/organisms/WorkOutputSheet/helpers";
 import { WorkOutputSheet } from "@/components/organisms/WorkOutputSheet/WorkOutputSheet";
+import { founderSafeText } from "@/lib/founder-safe-text";
 import { useState } from "react";
 import { type WorkRunMetadata } from "./helpers";
 
 interface Props {
   metadata: WorkRunMetadata;
   preview: string;
+  founderMode?: boolean;
 }
 
-export function WorkCard({ metadata, preview }: Props) {
+export function WorkCard({ metadata, preview, founderMode = false }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const runLink = buildRunLink(metadata.libraryAgentId, metadata.executionId);
+  const title = founderMode
+    ? founderSafeText(metadata.graphName, "Expert workflow")
+    : metadata.graphName;
+  const safePreview = founderMode
+    ? founderSafeText(preview, "The workflow produced an output.")
+    : preview;
 
   return (
     <div
@@ -23,9 +31,7 @@ export function WorkCard({ metadata, preview }: Props) {
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-zinc-900">
-            {metadata.graphName}
-          </p>
+          <p className="truncate text-sm font-medium text-zinc-900">{title}</p>
           <div className="mt-1">
             <RunStatusBadge status={metadata.status} />
           </div>
@@ -38,19 +44,20 @@ export function WorkCard({ metadata, preview }: Props) {
           Open
         </Button>
       </div>
-      {preview ? (
-        <p className="mt-2 line-clamp-2 text-sm text-zinc-500">{preview}</p>
+      {safePreview ? (
+        <p className="mt-2 line-clamp-2 text-sm text-zinc-500">{safePreview}</p>
       ) : null}
 
       <WorkOutputSheet
         open={isOpen}
         onOpenChange={setIsOpen}
-        title={metadata.graphName}
+        title={title}
         outputType={metadata.outputType}
         outputKey={metadata.outputKey}
         graphId={metadata.graphId}
         executionId={metadata.executionId}
         runLink={runLink}
+        founderMode={founderMode}
       />
     </div>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkCard/__tests__/WorkCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkCard/__tests__/WorkCard.test.tsx
@@ -46,4 +46,21 @@ describe("WorkCard", () => {
       screen.getByRole("link", { name: "Open run details" }),
     ).toBeDefined();
   });
+
+  it("redacts internal preview details in founder mode", () => {
+    render(
+      <WorkCard
+        metadata={{
+          ...baseMeta,
+          graphName: "Lead report /tmp/copilot-session/raw.json",
+        }}
+        preview="execution_id=exec-123 at /tmp/copilot-session/raw.json"
+        founderMode
+      />,
+    );
+
+    expect(screen.queryByText(/\/tmp\/copilot-session/)).toBeNull();
+    expect(screen.queryByText(/exec-123/)).toBeNull();
+    expect(screen.getAllByText(/workspace file/).length).toBeGreaterThan(0);
+  });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/home/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/__tests__/main.test.tsx
@@ -3,7 +3,6 @@ import { http, HttpResponse } from "msw";
 import { afterEach, expect, test, vi } from "vitest";
 import type { HomeAgentStatus } from "@/app/api/__generated__/models/homeAgentStatus";
 import type { HomeAttentionItem } from "@/app/api/__generated__/models/homeAttentionItem";
-import type { HomeBriefingOutcome } from "@/app/api/__generated__/models/homeBriefingOutcome";
 import type { HomeDashboardResponse } from "@/app/api/__generated__/models/homeDashboardResponse";
 import { server } from "@/mocks/mock-server";
 import { render, screen, waitFor } from "@/tests/integrations/test-utils";
@@ -135,6 +134,7 @@ const dashboard: HomeDashboardResponse = {
       link: "/library",
     },
   ],
+  work_items: [],
   upcoming_tasks: [
     {
       id: "upcoming-1",
@@ -190,24 +190,28 @@ test("renders every Home tile from the aggregate API", async () => {
   render(<HomePage />);
 
   expect(await screen.findByText(/Abhi/)).toBeDefined();
-  expect(screen.getByRole("heading", { name: "Needs you" })).toBeDefined();
+  expect(
+    screen.getByRole("heading", { name: "Needs your decision" }),
+  ).toBeDefined();
   expect(screen.getByLabelText("1 item needs your attention")).toBeDefined();
   expect(screen.getByText("Connect your calendar for Maria")).toBeDefined();
-  expect(screen.getByRole("heading", { name: "Your briefing" })).toBeDefined();
+  expect(screen.getByRole("heading", { name: "Delivered" })).toBeDefined();
   expect(screen.getByText("Your camera research is ready")).toBeDefined();
   expect(screen.getByText(/13 routine tasks completed quietly/)).toBeDefined();
   expect(screen.getByRole("heading", { name: "Your agents" })).toBeDefined();
   expect(
     screen.getByRole("link", { name: /View all 10 agents/ }),
   ).toBeDefined();
-  expect(screen.getByRole("heading", { name: "Now & next" })).toBeDefined();
+  expect(
+    screen.getByRole("heading", { name: "Working now & next" }),
+  ).toBeDefined();
   expect(
     screen.getAllByText("Checking recurring subscriptions").length,
   ).toBeGreaterThan(0);
   expect(screen.getByText("Spanish practice plan")).toBeDefined();
 });
 
-test("shows weekly spend per agent and on the team line", async () => {
+test("does not expose weekly spend or account balances", async () => {
   mockDashboard({
     ...dashboard,
     team: { ...dashboard.team, spend_cents: 1_250 },
@@ -224,16 +228,11 @@ test("shows weekly spend per agent and on the team line", async () => {
 
   render(<HomePage />);
 
-  // Spend sits in its own non-truncating element, so a long detail line can
-  // never clip the figure this tile exists to show.
-  const spend = await screen.findByText("· $9.00 this week");
-  expect(spend.className).toContain("shrink-0");
-  expect(
-    screen.getByText("1 working now · 7 ready · $12.50 this week"),
-  ).toBeDefined();
-  // An expert with no attributed spend keeps its detail line unadorned.
-  expect(screen.getByText("Ready for the next task")).toBeDefined();
+  expect(await screen.findByText("Ready for the next task")).toBeDefined();
+  expect(screen.queryByText("· $9.00 this week")).toBeNull();
+  expect(screen.queryByText(/\$12\.50 this week/)).toBeNull();
   expect(screen.queryByText("· $0.00 this week")).toBeNull();
+  expect(screen.queryByText("15,600")).toBeNull();
 });
 
 test("falls back to an Unknown badge for an unrecognised agent status", async () => {
@@ -292,7 +291,7 @@ test("keeps a Review deep link alongside the approval shortcuts", async () => {
   expect(reviewLink.getAttribute("href")).toBe("/library/runs/run-1");
 });
 
-test("shows calm, useful empty states without hiding the page structure", async () => {
+test("guides a clean-slate user to build their first AI team", async () => {
   mockDashboard({
     ...dashboard,
     attention: [],
@@ -311,33 +310,36 @@ test("shows calm, useful empty states without hiding the page structure", async 
 
   render(<HomePage />);
 
-  expect(await screen.findByText("You are all caught up")).toBeDefined();
-  expect(screen.getByText("No new outcomes yet")).toBeDefined();
-  expect(screen.getByText(/Nothing is scheduled/)).toBeDefined();
-  expect(screen.getByRole("link", { name: "Browse experts" })).toBeDefined();
+  expect(
+    await screen.findByRole("heading", { name: "Build your first AI team" }),
+  ).toBeDefined();
+  expect(screen.getByText("Product")).toBeDefined();
+  expect(screen.getByText("Engineering")).toBeDefined();
+  expect(screen.getByText("Marketing")).toBeDefined();
+  expect(screen.getByText("Sales")).toBeDefined();
+  expect(
+    screen
+      .getByRole("link", { name: "Start with AutoPilot" })
+      .getAttribute("href"),
+  ).toBe("/copilot");
+  expect(screen.queryByText("You are all caught up")).toBeNull();
 });
 
-test("filters briefing outcomes by their real status", async () => {
-  const user = userEvent.setup();
+test("keeps failed work in Risks instead of Delivered", async () => {
   mockDashboard(dashboard);
 
   render(<HomePage />);
 
-  await user.click(
-    await screen.findByRole("button", {
-      name: "Filter briefing outcomes: All",
-    }),
-  );
-  await user.click(screen.getByRole("menuitemradio", { name: "Failed" }));
-
   expect(
-    screen.getByText("Learning sessions could not be scheduled"),
+    await screen.findByText("Learning sessions could not be scheduled"),
   ).toBeDefined();
-  expect(screen.queryByText("Your camera research is ready")).toBeNull();
+  expect(screen.getByText("Your camera research is ready")).toBeDefined();
+  expect(
+    screen.queryByRole("button", { name: "Filter briefing outcomes: All" }),
+  ).toBeNull();
 });
 
-test("renders partial workflow delivery as needing attention", async () => {
-  const user = userEvent.setup();
+test("keeps partial workflow delivery in Risks instead of Delivered", async () => {
   mockDashboard({
     ...dashboard,
     briefing: {
@@ -356,46 +358,42 @@ test("renders partial workflow delivery as needing attention", async () => {
 
   render(<HomePage />);
 
-  await user.click(
-    await screen.findByRole("button", {
-      name: "Filter briefing outcomes: All",
-    }),
-  );
-  await user.click(
-    screen.getByRole("menuitemradio", { name: "Needs attention" }),
-  );
-
-  expect(screen.getByText("Lead research needs attention")).toBeDefined();
-  expect(screen.queryByText("Your camera research is ready")).toBeNull();
+  expect(
+    await screen.findByText("Lead research needs attention"),
+  ).toBeDefined();
+  expect(screen.getByText("Nothing delivered yet")).toBeDefined();
 });
 
-test("labels a filter option for an unrecognised briefing status", async () => {
-  const user = userEvent.setup();
+test("shows delegated risk confidence and scrubs internal details", async () => {
   mockDashboard({
     ...dashboard,
-    briefing: {
-      ...dashboard.briefing,
-      outcomes: [
-        dashboard.briefing.outcomes[0],
-        {
-          ...dashboard.briefing.outcomes[1],
-          status: "cancelled" as HomeBriefingOutcome["status"],
-        },
-      ],
-    },
+    work_items: [
+      {
+        id: "work-1",
+        title: "Review /tmp/internal/search.json",
+        expected_deliverable: "A safe recommendation",
+        status: "blocked_manager",
+        expert: maria,
+        progress: 60,
+        blocker: 'tool_call_id=abc graph_id=def {"query":"private payload"}',
+        confidence: "likely",
+        artifacts: [],
+        updated_at: NOW,
+        link: "/team/maria?workItemId=work-1#work-item-work-1",
+      },
+    ],
   });
 
   render(<HomePage />);
 
-  await user.click(
-    await screen.findByRole("button", {
-      name: "Filter briefing outcomes: All",
-    }),
+  const riskTitle = await screen.findByText("Review a workspace file");
+  const risk = riskTitle.closest("a");
+  expect(risk).not.toBeNull();
+  expect(risk?.getAttribute("href")).toBe(
+    "/team/maria?workItemId=work-1#work-item-work-1",
   );
-
-  expect(
-    screen.getByRole("menuitemradio", { name: "cancelled" }),
-  ).toBeDefined();
+  expect(screen.queryByText(/private payload/)).toBeNull();
+  expect(screen.queryByText(/tool_call_id/)).toBeNull();
 });
 
 test("shows a retryable page error when the aggregate cannot load", async () => {
@@ -419,7 +417,7 @@ test("shows a retryable page error when the aggregate cannot load", async () => 
   await user.click(screen.getByRole("button", { name: /try again/i }));
 
   expect(
-    await screen.findByRole("heading", { name: "Needs you" }),
+    await screen.findByRole("heading", { name: "Needs your decision" }),
   ).toBeDefined();
 });
 
@@ -460,7 +458,7 @@ test("renders the briefing unchanged when no narrative was generated", async () 
   render(<HomePage />);
 
   expect(
-    await screen.findByRole("heading", { name: "Your briefing" }),
+    await screen.findByRole("heading", { name: "Delivered" }),
   ).toBeDefined();
   expect(screen.getByText("Your camera research is ready")).toBeDefined();
 });

--- a/autogpt_platform/frontend/src/app/(platform)/home/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/__tests__/main.test.tsx
@@ -235,6 +235,36 @@ test("does not expose weekly spend or account balances", async () => {
   expect(screen.queryByText("15,600")).toBeNull();
 });
 
+test("redacts internal paths and identifiers from Home work summaries", async () => {
+  mockDashboard({
+    ...dashboard,
+    briefing: {
+      ...dashboard.briefing,
+      outcomes: [
+        {
+          ...dashboard.briefing.outcomes[0],
+          title: "Report from /tmp/copilot-session/raw.json",
+          summary:
+            "execution_id=exec-secret for 357dd4a1-acc7-4942-a317-c6d47e5ade6a",
+        },
+      ],
+    },
+    active_tasks: [
+      {
+        ...dashboard.active_tasks[0],
+        title: "Building /tmp/copilot-session/build_state.json",
+      },
+    ],
+  });
+
+  render(<HomePage />);
+
+  expect(await screen.findAllByText(/workspace file/)).not.toHaveLength(0);
+  expect(screen.queryByText(/\/tmp\/copilot-session/)).toBeNull();
+  expect(screen.queryByText(/exec-secret/)).toBeNull();
+  expect(screen.queryByText(/357dd4a1-acc7/)).toBeNull();
+});
+
 test("falls back to an Unknown badge for an unrecognised agent status", async () => {
   mockDashboard({
     ...dashboard,
@@ -345,7 +375,6 @@ test("keeps partial workflow delivery in Risks instead of Delivered", async () =
     briefing: {
       ...dashboard.briefing,
       outcomes: [
-        dashboard.briefing.outcomes[0],
         {
           ...dashboard.briefing.outcomes[1],
           status: "partial",

--- a/autogpt_platform/frontend/src/app/(platform)/home/__tests__/needs-you.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/__tests__/needs-you.test.tsx
@@ -105,9 +105,10 @@ function makeDashboard(attention: HomeAttentionItem[]): HomeDashboardResponse {
       outcomes: [],
     },
     active_tasks: [],
+    work_items: [],
     upcoming_tasks: [],
-    team: { total: 0, ready: 0, working: 0, needs_attention: 0 },
-    agents: [],
+    team: { total: 1, ready: 1, working: 0, needs_attention: 0 },
+    agents: [{ expert: maria, status: "ready", detail: "Ready" }],
     week: {
       run_count: 0,
       completed_count: 0,

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/AgentTeam.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/AgentTeam.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import type { HomeDashboardResponse } from "@/app/api/__generated__/models/homeDashboardResponse";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
-import { formatWeeklySpend } from "../../helpers";
 import { HomeTileEmpty } from "../HomeTileEmpty/HomeTileEmpty";
 import { HomeTile } from "../HomeTile/HomeTile";
 import { AgentRow } from "./components/AgentRow";
@@ -20,7 +19,6 @@ interface Props {
 export function AgentTeam({ dashboard, className }: Props) {
   const { team, agents } = dashboard;
   const readyCount = team.ready + team.working;
-  const teamSpend = formatWeeklySpend(team.spend_cents);
   const statusLine =
     team.working > 0
       ? `${team.working} working now · ${team.ready} ready`
@@ -52,8 +50,8 @@ export function AgentTeam({ dashboard, className }: Props) {
         </div>
       }
       header={
-        <Text variant="large" className="text-zinc-600" unmask={!teamSpend}>
-          {teamSpend ? `${statusLine} · ${teamSpend}` : statusLine}
+        <Text variant="large" className="text-zinc-600">
+          {statusLine}
         </Text>
       }
     >

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/components/AgentRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/components/AgentRow.tsx
@@ -4,7 +4,6 @@ import type { HomeAgentStatus } from "@/app/api/__generated__/models/homeAgentSt
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
-import { formatWeeklySpend } from "../../../helpers";
 import { formatUntil } from "../../NowNext/helpers";
 import { StatusBadge } from "./StatusBadge";
 
@@ -13,7 +12,6 @@ interface Props {
 }
 
 export function AgentRow({ agent }: Props) {
-  const spend = formatWeeklySpend(agent.spend_cents);
   return (
     <Link
       href={`/team/${agent.expert.id}`}
@@ -30,20 +28,9 @@ export function AgentRow({ agent }: Props) {
           </Text>
           <StatusBadge status={agent.status} />
         </div>
-        <div className="flex min-w-0 items-center gap-1 text-zinc-500">
-          <Text variant="small" className="min-w-0 truncate">
-            {agent.detail}
-          </Text>
-          {spend ? (
-            <Text
-              variant="small"
-              className="shrink-0 tabular-nums"
-              unmask={false}
-            >
-              {`· ${spend}`}
-            </Text>
-          ) : null}
-        </div>
+        <Text variant="small" className="truncate text-zinc-500">
+          {agent.detail}
+        </Text>
       </div>
       {agent.next_run_time ? (
         <Text

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/BuildFirstTeam/BuildFirstTeam.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/BuildFirstTeam/BuildFirstTeam.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+
+const FUNCTIONS = ["Product", "Engineering", "Marketing", "Sales"];
+
+export function BuildFirstTeam() {
+  return (
+    <section className="mx-auto mt-8 flex w-full max-w-3xl flex-col items-center rounded-[30px] bg-white px-6 py-12 text-center shadow-zinc-950 smooth-shadow-ring-sm sm:px-10">
+      <Text variant="h3" className="text-zinc-950">
+        Build your first AI team
+      </Text>
+      <Text variant="large" className="mt-3 max-w-xl text-pretty text-zinc-600">
+        Tell AutoPilot what you are building. It will propose the smallest team,
+        ask for one approval, and put each expert to work.
+      </Text>
+      <div className="mt-6 flex flex-wrap justify-center gap-2">
+        {FUNCTIONS.map((name) => (
+          <span
+            key={name}
+            className="rounded-full bg-zinc-100 px-3 py-1.5 text-sm font-medium text-zinc-700"
+          >
+            {name}
+          </span>
+        ))}
+      </div>
+      <Button
+        as="NextLink"
+        href="/copilot"
+        variant="primary"
+        size="large"
+        className="mt-7"
+      >
+        Start with AutoPilot
+      </Button>
+    </section>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/MorningBriefing.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/MorningBriefing.tsx
@@ -22,13 +22,16 @@ interface Props {
 
 export function MorningBriefing({ dashboard, className }: Props) {
   const { briefing } = dashboard;
+  const deliveredOutcomes = briefing.outcomes.filter(
+    (outcome) => outcome.status === "completed",
+  );
   const {
     filterOptions,
     hasFilters,
     selectedFilter,
     selectFilter,
     visibleOutcomes,
-  } = useMorningBriefing({ outcomes: briefing.outcomes });
+  } = useMorningBriefing({ outcomes: deliveredOutcomes });
 
   return (
     <HomeTile
@@ -45,17 +48,12 @@ export function MorningBriefing({ dashboard, className }: Props) {
               aria-hidden="true"
             />
             <Text variant="h5" className="text-zinc-950">
-              Your briefing
+              Delivered
             </Text>
           </div>
           <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
             <div className="flex items-center gap-3 text-xs font-medium tabular-nums text-zinc-500">
-              <span>{briefing.completed_count} completed</span>
-              {briefing.failed_count > 0 ? (
-                <span className="text-rose-700">
-                  {briefing.failed_count} failed
-                </span>
-              ) : null}
+              <span>{briefing.completed_count} delivered</span>
             </div>
             {hasFilters ? (
               <HomeTileFilter
@@ -70,7 +68,7 @@ export function MorningBriefing({ dashboard, className }: Props) {
       }
       header={
         <Text variant="large" className="text-zinc-600">
-          The outcomes worth knowing since{" "}
+          Finished work and evidence worth reviewing since{" "}
           {formatBriefingWindowStart(
             briefing.window_started_at,
             dashboard.timezone,
@@ -85,11 +83,11 @@ export function MorningBriefing({ dashboard, className }: Props) {
         </Text>
       ) : null}
 
-      {briefing.outcomes.length === 0 ? (
+      {deliveredOutcomes.length === 0 ? (
         <HomeTileEmpty
           icon={InboxIcon}
-          title="No new outcomes yet"
-          description="Completed work and useful exceptions will appear here."
+          title="Nothing delivered yet"
+          description="Verified outcomes and accessible deliverables will appear here."
         />
       ) : (
         <div className="-mx-4 divide-y divide-zinc-100 sm:-mx-5">

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/OutcomeRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/OutcomeRow.tsx
@@ -39,20 +39,16 @@ export function OutcomeRow({ outcome }: Props) {
       </span>
       <div className="min-w-0 flex-1">
         <Text variant="body-medium" className="text-pretty text-zinc-950">
-          {outcome.work_item_id
-            ? founderSafeText(outcome.title, "Expert deliverable")
-            : outcome.title}
+          {founderSafeText(outcome.title, "Expert deliverable")}
         </Text>
         <Text
           variant="body"
           className="mt-1 line-clamp-2 text-pretty text-zinc-600"
         >
-          {outcome.work_item_id
-            ? founderSafeText(
-                outcome.summary,
-                "The expert delivered an outcome for AutoPilot to review.",
-              )
-            : outcome.summary}
+          {founderSafeText(
+            outcome.summary,
+            "The expert delivered an outcome for AutoPilot to review.",
+          )}
         </Text>
         <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-400">
           {outcome.expert ? (
@@ -62,7 +58,9 @@ export function OutcomeRow({ outcome }: Props) {
               size={22}
             />
           ) : null}
-          <span>{outcome.expert?.name ?? outcome.agent_name}</span>
+          <span>
+            {outcome.expert?.name ?? founderAgentName(outcome.agent_name)}
+          </span>
           <span aria-hidden="true">·</span>
           <span>{formatOccurredAt(outcome.occurred_at)}</span>
           {outcome.duration_seconds ? (
@@ -114,6 +112,10 @@ export function OutcomeRow({ outcome }: Props) {
       {content}
     </Link>
   );
+}
+
+function founderAgentName(value: string) {
+  return value === "Agent task" ? "AutoPilot" : value;
 }
 
 function confidenceLabel(

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/OutcomeRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/OutcomeRow.tsx
@@ -9,7 +9,8 @@ import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
 import { cn } from "@/lib/utils";
-import { formatCurrency, formatDuration } from "../../../helpers";
+import { founderSafeText } from "@/lib/founder-safe-text";
+import { formatDuration } from "../../../helpers";
 
 interface Props {
   outcome: HomeBriefingOutcome;
@@ -38,13 +39,20 @@ export function OutcomeRow({ outcome }: Props) {
       </span>
       <div className="min-w-0 flex-1">
         <Text variant="body-medium" className="text-pretty text-zinc-950">
-          {outcome.title}
+          {outcome.work_item_id
+            ? founderSafeText(outcome.title, "Expert deliverable")
+            : outcome.title}
         </Text>
         <Text
           variant="body"
           className="mt-1 line-clamp-2 text-pretty text-zinc-600"
         >
-          {outcome.summary}
+          {outcome.work_item_id
+            ? founderSafeText(
+                outcome.summary,
+                "The expert delivered an outcome for AutoPilot to review.",
+              )
+            : outcome.summary}
         </Text>
         <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-zinc-400">
           {outcome.expert ? (
@@ -63,10 +71,21 @@ export function OutcomeRow({ outcome }: Props) {
               <span>{formatDuration(outcome.duration_seconds)}</span>
             </>
           ) : null}
-          {outcome.cost_cents ? (
+          {outcome.confidence ? (
             <>
               <span aria-hidden="true">·</span>
-              <span>{formatCurrency(outcome.cost_cents)}</span>
+              <span>{confidenceLabel(outcome.confidence)}</span>
+            </>
+          ) : null}
+          {(outcome.artifacts?.length ?? 0) > 0 ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>
+                {outcome.artifacts?.length ?? 0}{" "}
+                {outcome.artifacts?.length === 1
+                  ? "deliverable"
+                  : "deliverables"}
+              </span>
             </>
           ) : null}
         </div>
@@ -95,6 +114,12 @@ export function OutcomeRow({ outcome }: Props) {
       {content}
     </Link>
   );
+}
+
+function confidenceLabel(
+  value: NonNullable<HomeBriefingOutcome["confidence"]>,
+) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 function formatOccurredAt(value: Date | null | undefined) {

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/NeedsYou/components/NeedsYouTitle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/NeedsYou/components/NeedsYouTitle.tsx
@@ -31,7 +31,7 @@ export function NeedsYouTitle({
           aria-hidden="true"
         />
         <Text variant="h5" className="text-zinc-950">
-          Needs you
+          Needs your decision
         </Text>
       </div>
       <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/NowNext/NowNext.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/NowNext/NowNext.tsx
@@ -26,7 +26,7 @@ export function NowNext({ dashboard, className }: Props) {
             aria-hidden="true"
           />
           <Text variant="h5" className="text-zinc-950">
-            Now &amp; next
+            Working now &amp; next
           </Text>
         </div>
       }
@@ -51,7 +51,7 @@ export function NowNext({ dashboard, className }: Props) {
 
       <div>
         <Text variant="small" className="font-medium text-zinc-500">
-          Coming up
+          Next
         </Text>
         {dashboard.upcoming_tasks.length === 0 ? (
           <HomeTileEmpty

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/NowNext/components/ActiveRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/NowNext/components/ActiveRow.tsx
@@ -3,6 +3,7 @@ import type { HomeActiveTask } from "@/app/api/__generated__/models/homeActiveTa
 import { Text } from "@/components/atoms/Text/Text";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
 import { cn } from "@/lib/utils";
+import { founderSafeText } from "@/lib/founder-safe-text";
 import { formatRunningFor } from "../helpers";
 
 interface Props {
@@ -25,7 +26,9 @@ export function ActiveRow({ item }: Props) {
       </span>
       <div className="min-w-0 flex-1">
         <Text variant="body-medium" className="truncate text-zinc-900">
-          {item.title}
+          {item.work_item_id
+            ? founderSafeText(item.title, "Expert work in progress")
+            : item.title}
         </Text>
         <Text variant="small" className="truncate text-zinc-500">
           {item.status === "queued"

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/NowNext/components/ActiveRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/NowNext/components/ActiveRow.tsx
@@ -26,9 +26,7 @@ export function ActiveRow({ item }: Props) {
       </span>
       <div className="min-w-0 flex-1">
         <Text variant="body-medium" className="truncate text-zinc-900">
-          {item.work_item_id
-            ? founderSafeText(item.title, "Expert work in progress")
-            : item.title}
+          {founderSafeText(item.title, "Expert work in progress")}
         </Text>
         <Text variant="small" className="truncate text-zinc-500">
           {item.status === "queued"

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/WorkRisks/WorkRisks.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/WorkRisks/WorkRisks.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+import type { HomeDashboardResponse } from "@/app/api/__generated__/models/homeDashboardResponse";
+import { Text } from "@/components/atoms/Text/Text";
+import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import { founderSafeText } from "@/lib/founder-safe-text";
+import { HomeTile } from "../HomeTile/HomeTile";
+
+interface Props {
+  dashboard: HomeDashboardResponse;
+}
+
+export function WorkRisks({ dashboard }: Props) {
+  const workRisks = (dashboard.work_items ?? []).filter((item) =>
+    ["partial", "blocked_manager", "failed"].includes(item.status),
+  );
+  const runRisks = dashboard.briefing.outcomes.filter(
+    (outcome) => outcome.status === "failed" || outcome.status === "partial",
+  );
+  const riskCount = workRisks.length + runRisks.length;
+
+  return (
+    <HomeTile
+      title={<Text variant="h5">Risks</Text>}
+      header={
+        <Text variant="large" className="text-zinc-600">
+          Problems AutoPilot is resolving or may need to escalate.
+        </Text>
+      }
+      contentClassName="flex flex-col"
+    >
+      {riskCount === 0 ? (
+        <div className="py-6 text-center">
+          <Text variant="body-medium" className="text-zinc-800">
+            No known risks
+          </Text>
+          <Text variant="small" className="mt-1 text-zinc-500">
+            Your team can keep moving.
+          </Text>
+        </div>
+      ) : (
+        <div className="divide-y divide-zinc-100">
+          {workRisks.map((item) => (
+            <RiskRow
+              key={item.id}
+              href={item.link}
+              title={founderSafeText(item.title, "Expert work needs attention")}
+              description={founderSafeText(
+                item.blocker || item.expected_deliverable,
+                "AutoPilot is reviewing the next safe step.",
+              )}
+              expertName={item.expert.name}
+              expertAvatar={item.expert.avatar_url}
+              label={
+                item.status === "blocked_manager"
+                  ? "Needs AutoPilot"
+                  : item.status === "partial"
+                    ? "Partial"
+                    : "Failed"
+              }
+              confidence={confidenceLabel(item.confidence)}
+            />
+          ))}
+          {runRisks.map((outcome) => (
+            <RiskRow
+              key={outcome.id}
+              href={outcome.link}
+              title={outcome.title}
+              description={outcome.summary}
+              expertName={outcome.expert?.name ?? outcome.agent_name}
+              expertAvatar={outcome.expert?.avatar_url}
+              label={outcome.status === "partial" ? "Needs attention" : "Failed"}
+            />
+          ))}
+        </div>
+      )}
+    </HomeTile>
+  );
+}
+
+interface RowProps {
+  href?: string | null;
+  title: string;
+  description: string;
+  expertName: string;
+  expertAvatar?: string | null;
+  label: string;
+  confidence?: string;
+}
+
+function RiskRow({
+  href,
+  title,
+  description,
+  expertName,
+  expertAvatar,
+  label,
+  confidence,
+}: RowProps) {
+  const content = (
+    <>
+      <ExpertAvatar
+        name={expertName}
+        avatarUrl={expertAvatar ?? null}
+        size={32}
+      />
+      <div className="min-w-0 flex-1">
+        <Text variant="body-medium" className="line-clamp-1 text-zinc-900">
+          {title}
+        </Text>
+        <Text variant="small" className="mt-0.5 line-clamp-2 text-zinc-500">
+          {description}
+        </Text>
+        <div className="mt-1 flex items-center gap-1.5 text-xs text-zinc-400">
+          <span>{label}</span>
+          {confidence ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{confidence}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+  const className = "-mx-2 flex gap-3 rounded-xl px-2 py-3";
+  if (!href) return <div className={className}>{content}</div>;
+  return (
+    <Link
+      href={href}
+      className={`${className} transition-colors hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400`}
+    >
+      {content}
+    </Link>
+  );
+}
+
+function confidenceLabel(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/WorkRisks/WorkRisks.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/WorkRisks/WorkRisks.tsx
@@ -64,11 +64,21 @@ export function WorkRisks({ dashboard }: Props) {
             <RiskRow
               key={outcome.id}
               href={outcome.link}
-              title={outcome.title}
-              description={outcome.summary}
-              expertName={outcome.expert?.name ?? outcome.agent_name}
+              title={founderSafeText(outcome.title, "Work needs attention")}
+              description={founderSafeText(
+                outcome.summary,
+                "AutoPilot is reviewing the next safe step.",
+              )}
+              expertName={
+                outcome.expert?.name ??
+                (outcome.agent_name === "Agent task"
+                  ? "AutoPilot"
+                  : outcome.agent_name)
+              }
               expertAvatar={outcome.expert?.avatar_url}
-              label={outcome.status === "partial" ? "Needs attention" : "Failed"}
+              label={
+                outcome.status === "partial" ? "Needs attention" : "Failed"
+              }
             />
           ))}
         </div>

--- a/autogpt_platform/frontend/src/app/(platform)/home/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/page.tsx
@@ -7,10 +7,12 @@ import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
 import { AgentTeam } from "./components/AgentTeam/AgentTeam";
+import { BuildFirstTeam } from "./components/BuildFirstTeam/BuildFirstTeam";
 import { HomeHeader } from "./components/HomeHeader/HomeHeader";
 import { MorningBriefing } from "./components/MorningBriefing/MorningBriefing";
 import { NeedsYou } from "./components/NeedsYou/NeedsYou";
 import { NowNext } from "./components/NowNext/NowNext";
+import { WorkRisks } from "./components/WorkRisks/WorkRisks";
 import { getTimeOfDayGreeting } from "./helpers";
 import { useHomePage } from "./useHomePage";
 
@@ -53,16 +55,21 @@ export default function HomePage() {
           name={getGreetingName(user)}
           dashboard={dashboard}
         />
-        <div className={GRID_CLASS}>
-          <div className="flex min-w-0 flex-col gap-7 xl:col-span-8">
-            <NeedsYou dashboard={dashboard} />
-            <MorningBriefing dashboard={dashboard} />
+        {dashboard.team.total === 0 ? (
+          <BuildFirstTeam />
+        ) : (
+          <div className={GRID_CLASS}>
+            <div className="flex min-w-0 flex-col gap-7 xl:col-span-8">
+              <NeedsYou dashboard={dashboard} />
+              <NowNext dashboard={dashboard} />
+              <MorningBriefing dashboard={dashboard} />
+            </div>
+            <div className="flex min-w-0 flex-col gap-7 xl:col-span-4">
+              <AgentTeam dashboard={dashboard} />
+              <WorkRisks dashboard={dashboard} />
+            </div>
           </div>
-          <div className="flex min-w-0 flex-col gap-7 xl:col-span-4">
-            <AgentTeam dashboard={dashboard} />
-            <NowNext dashboard={dashboard} />
-          </div>
-        </div>
+        )}
       </div>
     </main>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/home/useHomePage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/home/useHomePage.ts
@@ -10,7 +10,7 @@ export function useHomePage({ enabled }: Args) {
     query: {
       select: (response) => okData(response) ?? null,
       enabled,
-      refetchInterval: 60_000,
+      refetchInterval: 5_000,
       refetchOnWindowFocus: true,
     },
   });

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/main.test.tsx
@@ -5,9 +5,12 @@ import {
   getGetExpertDetachPreviewMockHandler,
   getGetExpertMockHandler,
   getListExpertRunsMockHandler,
+  getListExpertWorkMockHandler,
   getResumeExpertSchedulesMockHandler,
 } from "@/app/api/__generated__/endpoints/experts/experts.msw";
 import { ExpertRun } from "@/app/api/__generated__/models/expertRun";
+import type { ExpertWorkItem } from "@/app/api/__generated__/models/expertWorkItem";
+import { getGetWorkspaceDownloadFileByIdUrl } from "@/app/api/__generated__/endpoints/workspace/workspace";
 import {
   getDeleteV1DeleteExecutionScheduleMockHandler,
   getGetV1ListExecutionSchedulesForAUserMockHandler,
@@ -149,11 +152,47 @@ const mariaRuns: ExpertRun[] = [
   },
 ];
 
+const mariaWork: ExpertWorkItem = {
+  id: "work-1",
+  expert_id: "expert-maria",
+  manager_session_id: "manager-1",
+  delegated_session_id: "delegated-1",
+  project_phase: "Launch",
+  task_title: "Prepare /tmp/private/launch-plan.md",
+  expected_deliverable: "A launch plan",
+  deliverable_mode: "workspace_files",
+  success_criteria: [],
+  dependencies: [],
+  source_artifacts: [],
+  constraints: [],
+  approval_boundaries: [],
+  estimate_minutes: 30,
+  progress: 100,
+  status: "delivered",
+  result: "Completed graph_id=secret with verified evidence.",
+  blocker: null,
+  confidence: "verified",
+  artifacts: [
+    {
+      name: "/tmp/private/launch-plan.md",
+      uri: "workspace://file-1#text/markdown",
+      mime_type: "text/markdown",
+      size_bytes: 1200,
+    },
+  ],
+  created_at: new Date("2026-08-28T00:00:00Z"),
+  updated_at: new Date("2026-08-28T00:30:00Z"),
+  started_at: new Date("2026-08-28T00:00:00Z"),
+  completed_at: new Date("2026-08-28T00:30:00Z"),
+  link: "/team/expert-maria?workItemId=work-1#work-item-work-1",
+};
+
 beforeEach(() => {
   server.use(
     getGetExpertMockHandler(maria),
     getGetV1ListExecutionSchedulesForAUserMockHandler([mariaSchedule]),
     getListExpertRunsMockHandler([]),
+    getListExpertWorkMockHandler([]),
   );
 });
 
@@ -229,6 +268,33 @@ describe("ExpertDetailPage", () => {
     expect(within(workList).queryByText("Needs review")).toBeNull();
   });
 
+  test("shows delegated work with safe text and downloadable deliverables", async () => {
+    server.use(getListExpertWorkMockHandler([mariaWork]));
+
+    render(<ExpertDetailPage />);
+
+    const workList = await screen.findByRole("list", { name: "Expert work" });
+    expect(
+      within(workList).getByText("Prepare a workspace file"),
+    ).toBeDefined();
+    expect(within(workList).getByText("Verified")).toBeDefined();
+    expect(within(workList).getByText("launch-plan.md")).toBeDefined();
+    expect(within(workList).queryByText(/graph_id/)).toBeNull();
+    expect(within(workList).queryByText(/\/tmp\/private/)).toBeNull();
+
+    const deliverable = within(workList).getByRole("link", {
+      name: "launch-plan.md",
+    });
+    expect(deliverable.getAttribute("href")).toBe(
+      getGetWorkspaceDownloadFileByIdUrl("file-1"),
+    );
+    expect(
+      within(workList)
+        .getByRole("link", { name: "Open thread" })
+        .getAttribute("href"),
+    ).toBe("/copilot?sessionId=delegated-1");
+  });
+
   test("filters work to runs that need review", async () => {
     server.use(getListExpertRunsMockHandler(mariaRuns));
 
@@ -248,7 +314,9 @@ describe("ExpertDetailPage", () => {
     render(<ExpertDetailPage />);
 
     await screen.findByRole("heading", { name: "Maria" });
-    expect(await screen.findByText(/No completed work yet/)).toBeDefined();
+    expect(
+      await screen.findByText(/No work yet. Delegated tasks and workflow runs/),
+    ).toBeDefined();
   });
 
   test("shows a retryable error when recent work fails to load", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertWorkSection/ExpertWorkSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertWorkSection/ExpertWorkSection.tsx
@@ -146,6 +146,7 @@ export function ExpertWorkSection({ expertId, enabled }: Props) {
           graphId={activeRun.graph_id}
           executionId={activeRun.execution_id}
           runLink={activeRun.link}
+          founderMode
         />
       ) : null}
     </section>

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertWorkSection/ExpertWorkSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertWorkSection/ExpertWorkSection.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useListExpertRuns } from "@/app/api/__generated__/endpoints/experts/experts";
+import {
+  useListExpertRuns,
+  useListExpertWork,
+} from "@/app/api/__generated__/endpoints/experts/experts";
 import { type ExpertRun } from "@/app/api/__generated__/models/expertRun";
+import { type ExpertWorkItem } from "@/app/api/__generated__/models/expertWorkItem";
 import { okData } from "@/app/api/helpers";
 import { isOutputType } from "@/components/organisms/WorkOutputSheet/helpers";
 import { WorkOutputSheet } from "@/components/organisms/WorkOutputSheet/WorkOutputSheet";
@@ -11,31 +15,68 @@ import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { RunStatusBadge } from "@/components/molecules/RunStatusBadge/RunStatusBadge";
 import { cn } from "@/lib/utils";
-import { useState } from "react";
+import {
+  founderSafeArtifactName,
+  founderSafeText,
+} from "@/lib/founder-safe-text";
+import { parseWorkspaceURI } from "@/lib/workspace-uri";
+import { getGetWorkspaceDownloadFileByIdUrl } from "@/app/api/__generated__/endpoints/workspace/workspace";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 
 interface Props {
   expertId: string;
   enabled: boolean;
 }
 
+const EMPTY_WORK_ITEMS: ExpertWorkItem[] = [];
+
 export function ExpertWorkSection({ expertId, enabled }: Props) {
   const [needsReviewOnly, setNeedsReviewOnly] = useState(false);
   const [activeRun, setActiveRun] = useState<ExpertRun | null>(null);
 
   const runsQuery = useListExpertRuns(expertId, {
-    query: { select: (res) => okData(res) ?? null, enabled },
+    query: {
+      select: (res) => okData(res) ?? null,
+      enabled,
+      refetchInterval: 5_000,
+    },
+  });
+  const workQuery = useListExpertWork(expertId, {
+    query: {
+      select: (res) => okData(res) ?? null,
+      enabled,
+      refetchInterval: 5_000,
+    },
   });
   const runs = runsQuery.data ?? [];
+  const workItems = workQuery.data ?? EMPTY_WORK_ITEMS;
   const reviewCount = runs.filter((run) => run.needs_review).length;
   const visibleRuns = needsReviewOnly
     ? runs.filter((run) => run.needs_review)
     : runs;
 
+  function handleRetry() {
+    runsQuery.refetch();
+    workQuery.refetch();
+  }
+
+  useEffect(() => {
+    if (workItems.length === 0 || typeof window === "undefined") return;
+    const target = new URLSearchParams(window.location.search).get(
+      "workItemId",
+    );
+    if (!target) return;
+    document
+      .getElementById(`work-item-${target}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [workItems]);
+
   return (
     <section>
       <div className="mb-2.5 flex items-center justify-between gap-2">
         <div className="text-xs font-medium uppercase tracking-[0.14em] text-zinc-400">
-          Work
+          Work history
         </div>
         {reviewCount > 0 ? (
           <button
@@ -54,25 +95,33 @@ export function ExpertWorkSection({ expertId, enabled }: Props) {
         ) : null}
       </div>
 
-      {runsQuery.isLoading ? (
+      {runsQuery.isLoading || workQuery.isLoading ? (
         <div className="space-y-3">
           <Skeleton className="h-16 w-full rounded-xl" />
           <Skeleton className="h-16 w-full rounded-xl" />
         </div>
-      ) : runsQuery.isError && runsQuery.data == null ? (
+      ) : (runsQuery.isError && runsQuery.data == null) ||
+        (workQuery.isError && workQuery.data == null) ? (
         <ErrorCard
           context="this expert's work"
           hint="We could not load this expert's recent work."
-          onRetry={() => runsQuery.refetch()}
+          onRetry={handleRetry}
         />
-      ) : visibleRuns.length === 0 ? (
+      ) : visibleRuns.length === 0 && workItems.length === 0 ? (
         <p className="text-sm text-zinc-500">
           {needsReviewOnly
             ? "Nothing is waiting on your review."
-            : "No completed work yet. Finished runs will show up here."}
+            : "No work yet. Delegated tasks and workflow runs will show up here."}
         </p>
       ) : (
         <ul className="flex flex-col gap-3" aria-label="Expert work">
+          {!needsReviewOnly
+            ? workItems.map((work) => (
+                <li key={work.id} id={`work-item-${work.id}`}>
+                  <ExpertWorkRow work={work} />
+                </li>
+              ))
+            : null}
           {visibleRuns.map((run) => (
             <li key={run.execution_id}>
               <ExpertRunRow run={run} onOpen={() => setActiveRun(run)} />
@@ -101,6 +150,99 @@ export function ExpertWorkSection({ expertId, enabled }: Props) {
       ) : null}
     </section>
   );
+}
+
+function ExpertWorkRow({ work }: { work: ExpertWorkItem }) {
+  return (
+    <article className="rounded-xl bg-white p-3 ring-1 ring-inset ring-zinc-200 target:ring-2 target:ring-zinc-900">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-zinc-900">
+            {founderSafeText(work.task_title, "Expert work")}
+          </p>
+          <p className="mt-1 line-clamp-2 text-sm text-zinc-500">
+            {founderSafeText(
+              work.result || work.blocker || work.expected_deliverable,
+              "AutoPilot is reviewing this work.",
+            )}
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Badge variant={workVariant(work.status)} size="small">
+              {workStatusLabel(work.status)}
+            </Badge>
+            <span className="text-xs text-zinc-400">
+              {confidenceLabel(work.confidence)}
+            </span>
+            {work.artifacts.length > 0 ? (
+              <span className="text-xs text-zinc-400">
+                {work.artifacts.length}{" "}
+                {work.artifacts.length === 1 ? "deliverable" : "deliverables"}
+              </span>
+            ) : null}
+          </div>
+          {work.artifacts.length > 0 ? (
+            <ul
+              className="mt-2 flex flex-wrap gap-1.5"
+              aria-label="Deliverables"
+            >
+              {work.artifacts.map((artifact) => (
+                <ArtifactItem
+                  key={`${artifact.name}-${artifact.uri}`}
+                  name={artifact.name}
+                  uri={artifact.uri}
+                />
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <Link
+          href={`/copilot?sessionId=${encodeURIComponent(work.delegated_session_id)}`}
+          className="shrink-0 rounded-lg px-2.5 py-1.5 text-sm font-medium text-zinc-700 ring-1 ring-inset ring-zinc-200 transition-colors hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+        >
+          Open thread
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function ArtifactItem({ name, uri }: { name: string; uri: string }) {
+  const workspace = parseWorkspaceURI(uri);
+  const label = founderSafeArtifactName(name);
+  const className =
+    "block max-w-full truncate rounded-md bg-zinc-50 px-2 py-1 text-xs text-zinc-600";
+  return (
+    <li className="max-w-full">
+      {workspace ? (
+        <a
+          href={getGetWorkspaceDownloadFileByIdUrl(workspace.fileID)}
+          className={`${className} transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400`}
+        >
+          {label}
+        </a>
+      ) : (
+        <span className={className}>{label}</span>
+      )}
+    </li>
+  );
+}
+
+function workStatusLabel(status: ExpertWorkItem["status"]) {
+  if (status === "blocked_manager") return "Needs AutoPilot";
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function confidenceLabel(confidence: ExpertWorkItem["confidence"]) {
+  return confidence.charAt(0).toUpperCase() + confidence.slice(1);
+}
+
+function workVariant(status: ExpertWorkItem["status"]) {
+  if (status === "delivered") return "success" as const;
+  if (status === "failed") return "error" as const;
+  if (status === "partial" || status === "blocked_manager") {
+    return "warning" as const;
+  }
+  return "info" as const;
 }
 
 function ExpertRunRow({ run, onOpen }: { run: ExpertRun; onOpen: () => void }) {

--- a/autogpt_platform/frontend/src/app/(platform)/team/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/__tests__/main.test.tsx
@@ -25,6 +25,7 @@ import { Expert } from "@/app/api/__generated__/models/expert";
 import { ExpertPod } from "@/app/api/__generated__/models/expertPod";
 import { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
+import type { HomeDashboardResponse } from "@/app/api/__generated__/models/homeDashboardResponse";
 import { server } from "@/mocks/mock-server";
 import {
   fireEvent,
@@ -105,6 +106,36 @@ const localOnlyAgent = makeLibraryAgent({
   store_listing_version_id: null,
 });
 
+const emptyHomeDashboard: HomeDashboardResponse = {
+  generated_at: new Date("2026-08-28T00:00:00Z"),
+  timezone: "UTC",
+  attention: [],
+  briefing: {
+    generated_at: new Date("2026-08-28T00:00:00Z"),
+    window_started_at: new Date("2026-08-27T00:00:00Z"),
+    completed_count: 0,
+    failed_count: 0,
+    routine_count: 0,
+    outcomes: [],
+  },
+  active_tasks: [],
+  work_items: [],
+  upcoming_tasks: [],
+  team: { total: 0, ready: 0, working: 0, needs_attention: 0 },
+  agents: [],
+  week: {
+    run_count: 0,
+    completed_count: 0,
+    review_count: 0,
+    failed_count: 0,
+    total_runtime_seconds: 0,
+    timed_run_count: 0,
+    total_cost_cents: 0,
+    credits_balance: 0,
+    daily: [],
+  },
+};
+
 function makeSchedule(
   over: Partial<GraphExecutionJobInfo> = {},
 ): GraphExecutionJobInfo {
@@ -127,6 +158,9 @@ beforeEach(() => {
     getGetV1ListExecutionSchedulesForAUserMockHandler([]),
     getListExpertPodsMockHandler([]),
     getGetV2ListLibraryAgentsMockHandler200(libraryResponse([])),
+    http.get(/\/api\/proxy\/api\/home(?:\?.*)?$/, () =>
+      HttpResponse.json(emptyHomeDashboard),
+    ),
   );
 });
 
@@ -240,7 +274,7 @@ describe("TeamPage", () => {
     render(<TeamPage />);
 
     const autopilot = await screen.findByText("Autopilot");
-    expect(screen.getByText(/runs the shop/i)).toBeDefined();
+    expect(screen.getByText(/runs the team/i)).toBeDefined();
 
     const maria = await screen.findByText("Maria");
     expect(
@@ -285,6 +319,60 @@ describe("TeamPage", () => {
     const card = screen.getByRole("link", { name: "View Maria" });
     expect(within(card).queryByText("Content Calendar")).toBeNull();
     expect(within(card).queryByText("SEO Audit")).toBeNull();
+  });
+
+  test("shows live delegated work and links to its exact history row", async () => {
+    server.use(
+      getListExpertsMockHandler([hiredMaria]),
+      http.get(/\/api\/proxy\/api\/home(?:\?.*)?$/, () =>
+        HttpResponse.json({
+          ...emptyHomeDashboard,
+          team: { total: 1, ready: 0, working: 1, needs_attention: 0 },
+          agents: [
+            {
+              expert: {
+                id: hiredMaria.id,
+                name: hiredMaria.name,
+                role: hiredMaria.role,
+                avatar_url: hiredMaria.avatar_url,
+              },
+              status: "working",
+              detail: "Preparing the launch plan",
+            },
+          ],
+          work_items: [
+            {
+              id: "work-1",
+              title: "Prepare the launch plan",
+              expected_deliverable: "A launch plan",
+              status: "running",
+              expert: {
+                id: hiredMaria.id,
+                name: hiredMaria.name,
+                role: hiredMaria.role,
+                avatar_url: hiredMaria.avatar_url,
+              },
+              progress: 40,
+              confidence: "unknown",
+              artifacts: [],
+              updated_at: new Date("2026-08-28T00:00:00Z"),
+              link: "/team/expert-maria?workItemId=work-1#work-item-work-1",
+            },
+          ],
+        }),
+      ),
+    );
+
+    render(<TeamPage />);
+
+    expect(await screen.findByText("Working")).toBeDefined();
+    expect(screen.getByText("Working now")).toBeDefined();
+    const workLink = screen.getByRole("link", {
+      name: /Working now Prepare the launch plan/,
+    });
+    expect(workLink.getAttribute("href")).toBe(
+      "/team/expert-maria?workItemId=work-1#work-item-work-1",
+    );
   });
 
   test("links the card content to the expert page", async () => {
@@ -348,7 +436,7 @@ describe("TeamPage", () => {
     expect(screen.getByText(/1 needs setup/)).toBeDefined();
   });
 
-  test("shows weekly spend as a progress bar on the expert card", async () => {
+  test("does not expose weekly budget or spend on the expert card", async () => {
     const budgetMaria: Expert = {
       ...hiredMaria,
       weekly_budget: 5000,
@@ -359,8 +447,8 @@ describe("TeamPage", () => {
     render(<TeamPage />);
 
     await screen.findByText("Maria");
-    expect(screen.getByText("Spend this week")).toBeDefined();
-    expect(screen.getByText("$12 / $50")).toBeDefined();
+    expect(screen.queryByText("Spend this week")).toBeNull();
+    expect(screen.queryByText("$12 / $50")).toBeNull();
   });
 
   test("paused expert offers one-click resume", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/AutopilotCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/AutopilotCard.tsx
@@ -16,13 +16,13 @@ export function AutopilotCard() {
         <div className="min-w-0 flex-1">
           <Text variant="large-medium">Autopilot</Text>
           <Text variant="small" className="text-zinc-500">
-            Generalist — runs the shop
+            Head of AI — runs the team
           </Text>
         </div>
       </div>
       <Text variant="body">
-        Your built-in generalist. It runs your workflows, answers questions, and
-        hands work to your hired experts.
+        Owns the outcome, assigns work, answers expert questions, and asks you
+        only for decisions it cannot safely make.
       </Text>
       <div className="mt-auto flex gap-2">
         <Button as="NextLink" href="/copilot" variant="secondary" size="small">

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertTeamCard/ExpertTeamCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertTeamCard/ExpertTeamCard.tsx
@@ -1,6 +1,8 @@
 import { Expert } from "@/app/api/__generated__/models/expert";
 import { ExpertPod } from "@/app/api/__generated__/models/expertPod";
 import { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
+import type { HomeAgentStatus } from "@/app/api/__generated__/models/homeAgentStatus";
+import type { HomeWorkItem } from "@/app/api/__generated__/models/homeWorkItem";
 import {
   Avatar,
   AvatarFallback,
@@ -22,17 +24,12 @@ import {
   Tick02Icon,
   UserGroupIcon,
 } from "@hugeicons/core-free-icons";
-import { creditsToUsdLabel } from "@/lib/credits";
 import Image from "next/image";
 import Link from "next/link";
 import { MouseEvent } from "react";
+import { founderSafeText } from "@/lib/founder-safe-text";
 
-import { SpendMeter } from "./components/SpendMeter";
-import {
-  getNeedsSetupCount,
-  getScheduleCountLabel,
-  getWeeklySpend,
-} from "../../helpers";
+import { getNeedsSetupCount, getScheduleCountLabel } from "../../helpers";
 import { FireExpertDialog } from "../FireExpertDialog/FireExpertDialog";
 import { FireExpertMenu } from "../FireExpertMenu/FireExpertMenu";
 import { useExpertTeamCard } from "./useExpertTeamCard";
@@ -42,6 +39,8 @@ const TEAM_CARD_BANNER_SRC = "/images/team-card-banner.jpg";
 interface Props {
   expert: Expert;
   schedules: GraphExecutionJobInfo[];
+  status: HomeAgentStatus | undefined;
+  workItems: HomeWorkItem[];
   pods: ExpertPod[];
   currentPod: ExpertPod | undefined;
   onInstallWorkflow: (expertId: string) => void;
@@ -52,6 +51,8 @@ interface Props {
 export function ExpertTeamCard({
   expert,
   schedules,
+  status,
+  workItems,
   pods,
   currentPod,
   onInstallWorkflow,
@@ -61,10 +62,15 @@ export function ExpertTeamCard({
   const workflowCount = expert.workflows.length;
   const needsSetupCount = getNeedsSetupCount(expert, schedules);
   const scheduleLabel = getScheduleCountLabel(schedules);
-  const weeklySpend = getWeeklySpend(expert);
   const { handleResume, isResuming, isFireOpen, openFire, closeFire } =
     useExpertTeamCard(expert.id);
   const isPaused = Boolean(expert.schedules_paused_at);
+  const activeWork = workItems.find((item) =>
+    ["queued", "running"].includes(item.status),
+  );
+  const deliveredCount = workItems.filter(
+    (item) => item.status === "delivered",
+  ).length;
 
   function handleInstallClick() {
     onInstallWorkflow(expert.id);
@@ -76,7 +82,7 @@ export function ExpertTeamCard({
   }
 
   return (
-    <div className="flex flex-col rounded-[1.75rem] border border-zinc-200 bg-white p-1 transition-all duration-200 hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-[0_16px_40px_-16px_rgba(16,24,40,0.18)]">
+    <div className="flex flex-col rounded-[1.75rem] border border-zinc-200 bg-white p-1 transition-[transform,border-color,box-shadow] duration-200 hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-[0_16px_40px_-16px_rgba(16,24,40,0.18)]">
       <div className="relative h-24 w-full overflow-hidden rounded-t-[1.5rem]">
         <Image
           src={TEAM_CARD_BANNER_SRC}
@@ -130,7 +136,12 @@ export function ExpertTeamCard({
               <AvatarFallback>{expert.name}</AvatarFallback>
             </Avatar>
             <div className="min-w-0 flex-1">
-              <Text variant="large-medium">{expert.name}</Text>
+              <div className="flex flex-wrap items-center gap-2">
+                <Text variant="large-medium">{expert.name}</Text>
+                <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-600">
+                  {statusLabel(status?.status)}
+                </span>
+              </div>
               <Text variant="small" className="text-zinc-500">
                 {expert.role}
               </Text>
@@ -139,27 +150,11 @@ export function ExpertTeamCard({
           <Text variant="body" className="line-clamp-2 min-h-12 text-zinc-600">
             {expert.tagline || expert.identity}
           </Text>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-baseline justify-between gap-2">
-              <Text variant="small" className="text-zinc-500">
-                Spend this week
-              </Text>
-              <Text
-                variant="small"
-                unmask={false}
-                className="tabular-nums text-zinc-500"
-              >
-                {weeklySpend
-                  ? `${creditsToUsdLabel(weeklySpend.spent)} / ${creditsToUsdLabel(weeklySpend.budget)}`
-                  : "No budget"}
-              </Text>
-            </div>
-            <SpendMeter
-              spent={weeklySpend?.spent ?? 0}
-              budget={weeklySpend?.budget ?? 1}
-              muted={!weeklySpend}
-            />
-          </div>
+          <Text variant="small" className="min-h-5 text-zinc-500">
+            {status?.detail
+              ? founderSafeText(status.detail, "Work is in progress")
+              : "Ready for the next task"}
+          </Text>
           <Text variant="small" className="min-h-5 text-zinc-500">
             {scheduleLabel ?? "No schedules yet"}
           </Text>
@@ -173,8 +168,26 @@ export function ExpertTeamCard({
                 setup
               </span>
             ) : null}
+            {deliveredCount > 0 ? (
+              <span className="text-xs text-zinc-400">
+                · {deliveredCount} delivered
+              </span>
+            ) : null}
           </div>
         </Link>
+        {activeWork ? (
+          <Link
+            href={activeWork.link}
+            className="rounded-xl bg-zinc-50 px-3 py-2 text-sm text-zinc-700 transition-colors hover:bg-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+          >
+            <span className="block text-xs font-medium text-zinc-400">
+              Working now
+            </span>
+            <span className="mt-0.5 block truncate font-medium">
+              {founderSafeText(activeWork.title, "Expert work in progress")}
+            </span>
+          </Link>
+        ) : null}
         {isPaused ? (
           <div className="flex items-center justify-between gap-2 rounded-xl bg-amber-50 px-3 py-2 ring-1 ring-inset ring-amber-200">
             <Text variant="small" className="text-amber-700">
@@ -261,4 +274,12 @@ export function ExpertTeamCard({
       />
     </div>
   );
+}
+
+function statusLabel(status: HomeAgentStatus["status"] | undefined) {
+  if (status === "working") return "Working";
+  if (status === "paused") return "Paused";
+  if (status === "needs_setup") return "Needs setup";
+  if (status === "failed") return "Needs attention";
+  return "Ready";
 }

--- a/autogpt_platform/frontend/src/app/(platform)/team/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/helpers.test.ts
@@ -3,12 +3,16 @@ import { ExpertPod } from "@/app/api/__generated__/models/expertPod";
 import { describe, expect, test } from "vitest";
 import { getAssignToastTitle, groupExpertsByPods } from "./helpers";
 
-function makeExpert(id: string, podId: string | null = null): Expert {
+function makeExpert(
+  id: string,
+  podId: string | null = null,
+  role = "Role",
+): Expert {
   return {
     id,
     name: id,
     avatar_url: null,
-    role: "Role",
+    role,
     tagline: null,
     bio: null,
     skills: [],
@@ -72,6 +76,25 @@ describe("groupExpertsByPods", () => {
     );
     expect(groups).toEqual([]);
     expect(ungrouped).toHaveLength(2);
+  });
+
+  test("orders team functions as Product, Engineering, Marketing, then Sales", () => {
+    const { ungrouped } = groupExpertsByPods(
+      [
+        makeExpert("sales", null, "Sales lead"),
+        makeExpert("marketing", null, "Marketing strategist"),
+        makeExpert("engineering", null, "Software engineer"),
+        makeExpert("product", null, "Product researcher"),
+      ],
+      [],
+    );
+
+    expect(ungrouped.map((expert) => expert.id)).toEqual([
+      "product",
+      "engineering",
+      "marketing",
+      "sales",
+    ]);
   });
 });
 

--- a/autogpt_platform/frontend/src/app/(platform)/team/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/helpers.ts
@@ -20,6 +20,28 @@ export const TEAM_GRID_CLASS =
 /** Mirrors `CreatePodRequest.name`'s `max_length` on the backend. */
 export const POD_NAME_MAX_LENGTH = 100;
 
+const FUNCTION_ORDER = [
+  ["product", "research", "strategy"],
+  ["engineer", "engineering", "developer", "coding", "technical"],
+  ["marketing", "content", "brand", "seo"],
+  ["sales", "revenue", "lead", "business development"],
+] as const;
+
+export function sortExpertsByFunction(experts: Expert[]) {
+  return [...experts].sort((left, right) => {
+    const rankDifference = functionRank(left) - functionRank(right);
+    return rankDifference || left.name.localeCompare(right.name);
+  });
+}
+
+function functionRank(expert: Expert) {
+  const description = `${expert.role} ${expert.tagline ?? ""}`.toLowerCase();
+  const rank = FUNCTION_ORDER.findIndex((terms) =>
+    terms.some((term) => description.includes(term)),
+  );
+  return rank === -1 ? FUNCTION_ORDER.length : rank;
+}
+
 interface AssignToastArgs {
   podId: string | null;
   destinationName?: string;
@@ -54,9 +76,9 @@ export function groupExpertsByPods(
   return {
     groups: pods.map((pod) => ({
       pod,
-      experts: membersByPod.get(pod.id) ?? [],
+      experts: sortExpertsByFunction(membersByPod.get(pod.id) ?? []),
     })),
-    ungrouped,
+    ungrouped: sortExpertsByFunction(ungrouped),
   };
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
@@ -32,6 +32,8 @@ export default function TeamPage() {
     ungroupedExperts,
     schedules,
     schedulesForExpert,
+    statusForExpert,
+    workItemsForExpert,
     isLoading,
     isError,
     refetch,
@@ -72,6 +74,8 @@ export default function TeamPage() {
         key={expert.id}
         expert={expert}
         schedules={schedulesForExpert(expert)}
+        status={statusForExpert(expert)}
+        workItems={workItemsForExpert(expert)}
         pods={pods}
         currentPod={podForExpert(expert)}
         onInstallWorkflow={installWorkflow}

--- a/autogpt_platform/frontend/src/app/(platform)/team/useTeamPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/useTeamPage.ts
@@ -8,6 +8,7 @@ import {
   useListExperts,
 } from "@/app/api/__generated__/endpoints/experts/experts";
 import { useGetV1ListExecutionSchedulesForAUser } from "@/app/api/__generated__/endpoints/schedules/schedules";
+import { useGetHomeDashboard } from "@/app/api/__generated__/endpoints/home/home";
 import { Expert } from "@/app/api/__generated__/models/expert";
 import { ExpertPod } from "@/app/api/__generated__/models/expertPod";
 import { okData } from "@/app/api/helpers";
@@ -42,6 +43,14 @@ export function useTeamPage({ enabled }: Args) {
   });
   const schedulesQuery = useGetV1ListExecutionSchedulesForAUser({
     query: { select: (res) => okData(res) ?? [], enabled },
+  });
+  const homeQuery = useGetHomeDashboard({
+    query: {
+      select: (res) => okData(res) ?? null,
+      enabled,
+      refetchInterval: 5_000,
+      refetchOnWindowFocus: true,
+    },
   });
   const pods = podsQuery.data ?? [];
   // Built once per render so each card resolves its pod in O(1) instead of
@@ -150,7 +159,20 @@ export function useTeamPage({ enabled }: Args) {
       expertsQuery.refetch(),
       podsQuery.refetch(),
       schedulesQuery.refetch(),
+      homeQuery.refetch(),
     ]);
+  }
+
+  function statusForExpert(expert: Expert) {
+    return homeQuery.data?.agents.find(
+      (status) => status.expert.id === expert.id,
+    );
+  }
+
+  function workItemsForExpert(expert: Expert) {
+    return (homeQuery.data?.work_items ?? []).filter(
+      (item) => item.expert.id === expert.id,
+    );
   }
 
   function closeSoul() {
@@ -186,13 +208,19 @@ export function useTeamPage({ enabled }: Args) {
     ungroupedExperts: ungrouped,
     schedules,
     schedulesForExpert,
+    statusForExpert,
+    workItemsForExpert,
     isLoading:
       enabled &&
       (expertsQuery.isLoading ||
         podsQuery.isLoading ||
-        schedulesQuery.isLoading),
+        schedulesQuery.isLoading ||
+        homeQuery.isLoading),
     isError:
-      expertsQuery.isError || podsQuery.isError || schedulesQuery.isError,
+      expertsQuery.isError ||
+      podsQuery.isError ||
+      schedulesQuery.isError ||
+      homeQuery.isError,
     refetch,
     installWorkflow,
     pickerExpertId,

--- a/autogpt_platform/frontend/src/components/organisms/WorkOutputSheet/WorkOutputSheet.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/WorkOutputSheet/WorkOutputSheet.tsx
@@ -6,6 +6,7 @@ import { MessageResponse } from "@/components/ai-elements/message";
 import { Button } from "@/components/atoms/Button/Button";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { Text } from "@/components/atoms/Text/Text";
+import { founderSafeMarkdown, founderSafeText } from "@/lib/founder-safe-text";
 import {
   Sheet,
   SheetContent,
@@ -36,6 +37,7 @@ interface Props {
   graphId: string;
   executionId: string;
   runLink?: string | null;
+  founderMode?: boolean;
 }
 
 export function WorkOutputSheet({
@@ -47,6 +49,7 @@ export function WorkOutputSheet({
   graphId,
   executionId,
   runLink,
+  founderMode = false,
 }: Props) {
   const shouldFetch = open && outputType !== "unknown";
   const detailsQuery = useGetV1GetExecutionDetails(graphId, executionId, {
@@ -72,7 +75,9 @@ export function WorkOutputSheet({
         className="flex w-full flex-col gap-4 overflow-y-auto sm:max-w-xl"
       >
         <SheetHeader className="text-left">
-          <SheetTitle className="truncate">{title}</SheetTitle>
+          <SheetTitle className="truncate">
+            {founderMode ? founderSafeText(title, "Work output") : title}
+          </SheetTitle>
         </SheetHeader>
         <WorkOutputBody
           outputType={outputType}
@@ -81,6 +86,7 @@ export function WorkOutputSheet({
           isLoading={shouldFetch && detailsQuery.isLoading}
           isError={detailsQuery.isError}
           runLink={runLink}
+          founderMode={founderMode}
         />
       </SheetContent>
     </Sheet>
@@ -94,6 +100,7 @@ interface BodyProps {
   isLoading: boolean;
   isError: boolean;
   runLink?: string | null;
+  founderMode: boolean;
 }
 
 function WorkOutputBody({
@@ -103,6 +110,7 @@ function WorkOutputBody({
   isLoading,
   isError,
   runLink,
+  founderMode,
 }: BodyProps) {
   if (outputType === "unknown") {
     return <RunLinkFallback runLink={runLink} />;
@@ -124,7 +132,14 @@ function WorkOutputBody({
   if (outputType === "table") {
     const rows = asTableRows(primary);
     if (!rows) return <RunLinkFallback runLink={runLink} />;
-    return <OutputTable title={title} rows={rows} runLink={runLink} />;
+    return (
+      <OutputTable
+        title={title}
+        rows={rows}
+        runLink={runLink}
+        founderMode={founderMode}
+      />
+    );
   }
 
   if (outputType === "image") {
@@ -132,9 +147,12 @@ function WorkOutputBody({
   }
 
   if (outputType === "doc" && typeof primary === "string") {
+    const document = founderMode
+      ? founderSafeMarkdown(primary, "The deliverable has no safe preview.")
+      : primary;
     return (
       <div className="prose prose-sm max-w-none">
-        <MessageResponse>{primary}</MessageResponse>
+        <MessageResponse>{document}</MessageResponse>
       </div>
     );
   }
@@ -172,16 +190,24 @@ function OutputTable({
   title,
   rows,
   runLink,
+  founderMode,
 }: {
   title: string;
   rows: Record<string, unknown>[];
   runLink?: string | null;
+  founderMode: boolean;
 }) {
   const visibleRows = rows.slice(0, MAX_PREVIEW_ROWS);
   const allColumns = tableColumns(visibleRows);
-  const columns = allColumns.slice(0, MAX_PREVIEW_COLUMNS);
+  const founderColumns = founderMode
+    ? allColumns.filter((column) => !isInternalColumn(column))
+    : allColumns;
+  const columns = founderColumns.slice(0, MAX_PREVIEW_COLUMNS);
+  const displayRows = founderMode
+    ? visibleRows.map((row) => sanitizeFounderRow(row, columns))
+    : visibleRows;
   const truncated =
-    rows.length > visibleRows.length || allColumns.length > columns.length;
+    rows.length > visibleRows.length || founderColumns.length > columns.length;
 
   return (
     <div className="space-y-3">
@@ -190,23 +216,42 @@ function OutputTable({
           variant="secondary"
           size="small"
           onClick={() =>
-            downloadCsv(`${title || "run"}.csv`, toCsv(visibleRows, columns))
+            downloadCsv(`${title || "run"}.csv`, toCsv(displayRows, columns))
           }
         >
           Export CSV
         </Button>
       </div>
-      <OutputTablePreview rows={visibleRows} columns={columns} />
+      <OutputTablePreview rows={displayRows} columns={columns} />
       {truncated ? (
         <OutputTableTruncationNotice
           visibleRowCount={visibleRows.length}
           rowCount={rows.length}
           visibleColumnCount={columns.length}
-          columnCount={allColumns.length}
+          columnCount={founderColumns.length}
           runLink={runLink}
         />
       ) : null}
     </div>
+  );
+}
+
+function isInternalColumn(column: string) {
+  const key = column
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return /^(?:graph|block|node|execution|tool_call|session|library_agent|credential|storage_path|source_path|raw|json)(?:_id|_ids|_path|_output)?$/.test(
+    key,
+  );
+}
+
+function sanitizeFounderRow(row: Record<string, unknown>, columns: string[]) {
+  return Object.fromEntries(
+    columns.map((column) => [
+      column,
+      founderSafeText(cellText(row[column]), "Not available"),
+    ]),
   );
 }
 

--- a/autogpt_platform/frontend/src/components/organisms/WorkOutputSheet/__tests__/WorkOutputSheet.test.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/WorkOutputSheet/__tests__/WorkOutputSheet.test.tsx
@@ -80,6 +80,40 @@ describe("WorkOutputSheet", () => {
     expect(screen.getByText("Heading text")).toBeDefined();
   });
 
+  it("redacts internal document details in founder mode", () => {
+    setOutputs({
+      result: [
+        "Report saved at /tmp/copilot-session/raw.json with execution_id=exec-123.",
+      ],
+    });
+    render(<WorkOutputSheet {...baseProps} outputType="doc" founderMode />);
+
+    expect(screen.queryByText(/\/tmp\/copilot-session/)).toBeNull();
+    expect(screen.queryByText(/exec-123/)).toBeNull();
+    expect(screen.getByText(/workspace file/)).toBeDefined();
+  });
+
+  it("hides internal table columns in founder mode", () => {
+    setOutputs({
+      result: [
+        [
+          {
+            company: "Acme",
+            graph_id: "graph-secret",
+            source_path: "/tmp/leads.csv",
+          },
+        ],
+      ],
+    });
+    render(<WorkOutputSheet {...baseProps} outputType="table" founderMode />);
+
+    expect(screen.getByText("company")).toBeDefined();
+    expect(screen.getByText("Acme")).toBeDefined();
+    expect(screen.queryByText("graph_id")).toBeNull();
+    expect(screen.queryByText("source_path")).toBeNull();
+    expect(screen.queryByText("graph-secret")).toBeNull();
+  });
+
   it("renders an image for image output", () => {
     setOutputs({ result: ["https://cdn.example.com/chart.png"] });
     render(<WorkOutputSheet {...baseProps} outputType="image" />);

--- a/autogpt_platform/frontend/src/lib/founder-safe-text.test.ts
+++ b/autogpt_platform/frontend/src/lib/founder-safe-text.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { founderSafeArtifactName, founderSafeText } from "./founder-safe-text";
+
+describe("founderSafeText", () => {
+  it("removes paths, ids, JSON, shell output, and internal context", () => {
+    const value = [
+      "Prepared /tmp/private/report.json",
+      "tool_call_id=call-1 graph_id=graph-1",
+      '{"query":"secret search payload"}',
+      "$ cat /tmp/private/report.json",
+      "<expert_identity>internal instructions</expert_identity>",
+    ].join("\n");
+
+    const safe = founderSafeText(value, "Safe update");
+
+    expect(safe).toContain("Prepared a workspace file");
+    expect(safe).not.toMatch(/\/tmp|tool_call_id|graph_id|secret|\$ cat/);
+    expect(safe).not.toContain("internal instructions");
+  });
+
+  it("uses a fallback for structured payloads", () => {
+    expect(founderSafeText('{"query":"secret"}', "Safe update")).toBe(
+      "Safe update",
+    );
+  });
+
+  it("shows only the public artifact name", () => {
+    expect(founderSafeArtifactName("/sessions/secret/launch-plan.md")).toBe(
+      "launch-plan.md",
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/lib/founder-safe-text.test.ts
+++ b/autogpt_platform/frontend/src/lib/founder-safe-text.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { founderSafeArtifactName, founderSafeText } from "./founder-safe-text";
+import {
+  founderSafeArtifactName,
+  founderSafeMarkdown,
+  founderSafeText,
+} from "./founder-safe-text";
 
 describe("founderSafeText", () => {
   it("removes paths, ids, JSON, shell output, and internal context", () => {
@@ -28,5 +32,25 @@ describe("founderSafeText", () => {
     expect(founderSafeArtifactName("/sessions/secret/launch-plan.md")).toBe(
       "launch-plan.md",
     );
+  });
+
+  it("preserves useful markdown structure while removing internal details", () => {
+    const safe = founderSafeMarkdown(
+      "## Delivered\n\n- Report: /tmp/private/report.md\n- Next step",
+      "Safe update",
+    );
+
+    expect(safe).toBe(
+      "## Delivered\n\n- Report: a workspace file\n- Next step",
+    );
+  });
+
+  it("preserves exact workspace artifact links", () => {
+    const uri =
+      "workspace://550e8400-e29b-41d4-a716-446655440000#text/markdown";
+
+    expect(
+      founderSafeMarkdown(`[Launch plan](${uri})`, "Safe update"),
+    ).toContain(uri);
   });
 });

--- a/autogpt_platform/frontend/src/lib/founder-safe-text.ts
+++ b/autogpt_platform/frontend/src/lib/founder-safe-text.ts
@@ -8,9 +8,20 @@ const UUID =
 const INTERNAL_ID =
   /\b(?:tool(?:_call)?|graph|block|session|execution|node(?:_exec)?)[_-]?id\s*[:=]\s*["']?[a-z0-9._:-]+["']?/gi;
 const INLINE_JSON = /\{[^{}\n]{1,2000}\}/g;
+const WORKSPACE_URI = /workspace:\/\/[^\s)\]]+/g;
 
-export function founderSafeText(value: string, fallback: string) {
-  const trimmed = value.trim();
+function sanitizeFounderText(
+  value: string,
+  fallback: string,
+  separator: string,
+) {
+  const workspaceUris: string[] = [];
+  const trimmed = value
+    .replace(WORKSPACE_URI, (uri) => {
+      const index = workspaceUris.push(uri) - 1;
+      return `__FOUNDER_WORKSPACE_${index}__`;
+    })
+    .trim();
   if (
     (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
     (trimmed.startsWith("[") && trimmed.endsWith("]"))
@@ -30,11 +41,24 @@ export function founderSafeText(value: string, fallback: string) {
       (line) =>
         !/^\s*(?:\$ |stdout\s*:|stderr\s*:|exit\s+code\s*:)/i.test(line),
     )
-    .join(" ")
-    .replace(/\s+/g, " ")
+    .join(separator)
+    .replace(separator === " " ? /\s+/g : /[\t ]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 
-  return safe || fallback;
+  const restored = safe.replace(
+    /__FOUNDER_WORKSPACE_(\d+)__/g,
+    (_, index: string) => workspaceUris[Number(index)] ?? "",
+  );
+  return restored || fallback;
+}
+
+export function founderSafeText(value: string, fallback: string) {
+  return sanitizeFounderText(value, fallback, " ");
+}
+
+export function founderSafeMarkdown(value: string, fallback: string) {
+  return sanitizeFounderText(value, fallback, "\n");
 }
 
 export function founderSafeArtifactName(value: string) {

--- a/autogpt_platform/frontend/src/lib/founder-safe-text.ts
+++ b/autogpt_platform/frontend/src/lib/founder-safe-text.ts
@@ -1,0 +1,43 @@
+const INTERNAL_BLOCK =
+  /<(?:user_context|memory_context|env_context|budget_context|session_context|available_skills|expert_identity|expert_workflows|team_context)\b[^>]*>[\s\S]*?<\/(?:user_context|memory_context|env_context|budget_context|session_context|available_skills|expert_identity|expert_workflows|team_context)>/gi;
+const CODE_FENCE = /```[\s\S]*?```/g;
+const ABSOLUTE_PATH =
+  /(?:[a-z]:\\(?:users|temp|windows|workspace)\\|\/(?:Users|home|tmp|private|var|opt|workspace|mnt)\/)[^\s,;)]+/gi;
+const UUID =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+const INTERNAL_ID =
+  /\b(?:tool(?:_call)?|graph|block|session|execution|node(?:_exec)?)[_-]?id\s*[:=]\s*["']?[a-z0-9._:-]+["']?/gi;
+const INLINE_JSON = /\{[^{}\n]{1,2000}\}/g;
+
+export function founderSafeText(value: string, fallback: string) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    return fallback;
+  }
+
+  const safe = trimmed
+    .replace(INTERNAL_BLOCK, "")
+    .replace(CODE_FENCE, "")
+    .replace(INLINE_JSON, "")
+    .replace(ABSOLUTE_PATH, "a workspace file")
+    .replace(INTERNAL_ID, "internal reference")
+    .replace(UUID, "reference")
+    .split("\n")
+    .filter(
+      (line) =>
+        !/^\s*(?:\$ |stdout\s*:|stderr\s*:|exit\s+code\s*:)/i.test(line),
+    )
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return safe || fallback;
+}
+
+export function founderSafeArtifactName(value: string) {
+  const name = value.split(/[\\/]/).at(-1)?.trim() ?? "";
+  return founderSafeText(name, "Deliverable");
+}

--- a/autogpt_platform/frontend/src/lib/workspace-file-visibility.test.ts
+++ b/autogpt_platform/frontend/src/lib/workspace-file-visibility.test.ts
@@ -1,0 +1,67 @@
+import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+import { describe, expect, it } from "vitest";
+import {
+  isTechnicalWorkspaceFile,
+  workspaceFileOwner,
+  workspaceFilePurpose,
+  workspaceFileTitle,
+  workspaceFileVerification,
+} from "./workspace-file-visibility";
+
+function file(overrides: Partial<WorkspaceFileItem> = {}): WorkspaceFileItem {
+  return {
+    id: "file-1",
+    name: "phase0_positioning_icp.md",
+    path: "/phase0_positioning_icp.md",
+    mime_type: "text/markdown",
+    size_bytes: 120,
+    origin: "generated",
+    created_at: "2026-08-28T00:00:00Z",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("workspace file visibility", () => {
+  it.each([
+    { name: "agent.json" },
+    { name: "build_state.json" },
+    { name: "sdk-12345678-abcd.json" },
+    { path: "/tool-outputs/search.json" },
+    { metadata: { audience: "internal" } },
+    { metadata: { artifact_role: "diagnostic" } },
+  ])("recognizes technical output: $name$path", (overrides) => {
+    expect(isTechnicalWorkspaceFile(file(overrides))).toBe(true);
+  });
+
+  it("keeps founder deliverables visible", () => {
+    expect(isTechnicalWorkspaceFile(file())).toBe(false);
+  });
+
+  it("keeps a user-uploaded technical-looking filename visible", () => {
+    expect(
+      isTechnicalWorkspaceFile(
+        file({ name: "agent.json", origin: "uploaded" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("reads semantic founder metadata without exposing identifiers", () => {
+    const deliverable = file({
+      metadata: {
+        title: "Positioning brief",
+        owner_name: "Maya",
+        purpose: "Choose the first customer segment",
+        verification: "verified",
+        work_item_id: "internal-work-id",
+      },
+    });
+
+    expect(workspaceFileTitle(deliverable)).toBe("Positioning brief");
+    expect(workspaceFileOwner(deliverable)).toBe("Maya");
+    expect(workspaceFilePurpose(deliverable)).toBe(
+      "Choose the first customer segment",
+    );
+    expect(workspaceFileVerification(deliverable)).toBe("Verified");
+  });
+});

--- a/autogpt_platform/frontend/src/lib/workspace-file-visibility.ts
+++ b/autogpt_platform/frontend/src/lib/workspace-file-visibility.ts
@@ -1,0 +1,44 @@
+import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+
+const TECHNICAL_NAMES = new Set(["agent.json", "build_state.json"]);
+const SDK_RESULT = /^sdk-[0-9a-f-]{8,}\.json$/i;
+const INTERNAL_ROLES = new Set(["diagnostic", "debug", "build"]);
+
+function metadataString(file: WorkspaceFileItem, key: string) {
+  const value = file.metadata?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function isTechnicalWorkspaceFile(file: WorkspaceFileItem) {
+  const name = file.name.trim().toLowerCase();
+  const path = file.path.toLowerCase();
+  const generated = file.origin === "generated";
+  return (
+    metadataString(file, "audience").toLowerCase() === "internal" ||
+    INTERNAL_ROLES.has(metadataString(file, "artifact_role").toLowerCase()) ||
+    (generated &&
+      (TECHNICAL_NAMES.has(name) ||
+        SDK_RESULT.test(name) ||
+        path.includes("/tool-outputs/")))
+  );
+}
+
+export function workspaceFileTitle(file: WorkspaceFileItem) {
+  return metadataString(file, "title") || file.name;
+}
+
+export function workspaceFileOwner(file: WorkspaceFileItem) {
+  return metadataString(file, "owner_name");
+}
+
+export function workspaceFilePurpose(file: WorkspaceFileItem) {
+  return metadataString(file, "purpose");
+}
+
+export function workspaceFileVerification(file: WorkspaceFileItem) {
+  const verification = metadataString(file, "verification").toLowerCase();
+  if (verification === "verified") return "Verified";
+  if (verification === "likely") return "Likely";
+  if (verification === "disqualified") return "Disqualified";
+  return verification ? "Unknown" : "";
+}


### PR DESCRIPTION
### Why / What / How

Founder-facing Copilot, Home, and Team exposed implementation details and disagreed about active work. Empty accounts lacked a useful starting point, completed cards went stale, and expert outputs were hard to verify or open.

This PR provides a concise, semantic founder experience under `hire-experts`: internal reasoning and diagnostics are hidden, live delegated/workflow state is reconciled, and cards link to the exact work item, artifact, expert session, or execution. The flag-off UI retains its existing diagnostics and behavior.

### Changes 🏗️

- Hide detailed reasoning, raw JSON, paths, UUIDs, tool/graph/block IDs, budgets, and token diagnostics in flagged founder UI.
- Add semantic Copilot activities and remove duplicate labels/questions.
- Replace stale completed-task state when a new phase starts.
- Add the clean-slate “Build your first AI team” Home experience.
- Show Needs your decision, Working now, Delivered, Next, and Risks with safe text.
- Order Product → Engineering → Marketing → Sales with AutoPilot above the team.
- Show Verified/Likely/Unknown/Disqualified confidence and exact artifact/work links.
- Reconcile Home, Team, Copilot, approval, delegation, and workflow state on short polling intervals.

### Stack

- Depends on: #14199
- Top preview for the clean-slate audit

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Full frontend suite: 563 files, 6,013 tests
  - [x] Focused backend work-link and workspace-artifact tests: 82 tests
  - [x] TypeScript, ESLint, Ruff, Pyright, React Doctor, and diff checks
  - [ ] Clean-slate browser audit on the top preview after deployment is ready

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] No configuration changes are required
