### PR TITLE
fix(backend): require library membership AND marketplace submission for graph access

### DIFF
--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes.py
@@ -164,8 +164,8 @@ async def admin_add_agent_to_library(
     Add a pending marketplace agent to the admin's library for review.
     Uses admin-level access to bypass marketplace APPROVED-only checks.
 
-    The builder can load the graph because get_graph() checks library
-    membership as a fallback: "you added it, you keep it."
+    The builder can then load the graph: get_graph() grants a library
+    version that was submitted, and PENDING counts as submitted.
     """
     return await library_db.add_store_agent_to_library_as_admin(
         store_listing_version_id=store_listing_version_id,

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
@@ -16,6 +16,7 @@ import fastapi.testclient
 import pytest
 import pytest_mock
 from autogpt_libs.auth.jwt_utils import get_jwt_payload
+from prisma.enums import SubmissionStatus
 
 from backend.data.graph import get_graph_as_admin
 from backend.util.exceptions import NotFoundError
@@ -295,8 +296,16 @@ async def test_resolve_graph_regular_uses_get_graph() -> None:
 
     assert result is mock_graph_model
     assert resolved_slv is mock_slv
+    # `skip_access_check` is required here: the user is installing the agent
+    # precisely because it is not yet in their library, so get_graph() cannot
+    # authorize the read. `resolve_store_version_for_library(admin=False)`
+    # authorizes it instead, by matching the listing version against
+    # `installable_store_version_where()` — asserted just below.
     mock_regular.assert_awaited_once_with(
-        graph_id=GRAPH_ID, version=GRAPH_VERSION, user_id="regular-user-id"
+        graph_id=GRAPH_ID,
+        version=GRAPH_VERSION,
+        user_id="regular-user-id",
+        skip_access_check=True,
     )
     mock_admin.assert_not_awaited()
     mock_prisma.return_value.find_first.assert_awaited_once()
@@ -308,7 +317,13 @@ async def test_resolve_graph_regular_uses_get_graph() -> None:
 @pytest.mark.asyncio
 async def test_library_member_can_view_pending_agent_in_builder() -> None:
     """After adding a pending agent to their library, the user should be
-    able to load the graph in the builder via get_graph()."""
+    able to load the graph in the builder via get_graph().
+
+    This is why a PENDING submission counts as "submitted to the marketplace":
+    the admin review flow adds a not-yet-approved agent to the reviewer's
+    library and then opens it in the builder. Requiring APPROVED here would
+    break review.
+    """
     mock_graph = _make_mock_graph()
     mock_graph_model = MagicMock(name="GraphModel")
     mock_library_agent = MagicMock()
@@ -316,9 +331,6 @@ async def test_library_member_can_view_pending_agent_in_builder() -> None:
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
         patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
         patch(
             "backend.data.graph.GraphModel.from_db",
@@ -326,7 +338,6 @@ async def test_library_member_can_view_pending_agent_in_builder() -> None:
         ),
     ):
         mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
         mock_lib_prisma.return_value.find_first = AsyncMock(
             return_value=mock_library_agent
         )
@@ -340,3 +351,13 @@ async def test_library_member_can_view_pending_agent_in_builder() -> None:
         )
 
     assert result is mock_graph_model, "Library membership should grant graph access"
+    # The submission requirement travels in the same query as the library
+    # lookup, so PENDING must be one of the statuses it accepts.
+    lib_where = mock_lib_prisma.return_value.find_first.await_args.kwargs["where"]
+    statuses = {
+        clause["submissionStatus"]
+        for clause in lib_where["AgentGraph"]["is"]["StoreListingVersions"]["some"][
+            "OR"
+        ]
+    }
+    assert SubmissionStatus.PENDING in statuses

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
@@ -18,7 +18,7 @@ import pytest_mock
 from autogpt_libs.auth.jwt_utils import get_jwt_payload
 from prisma.enums import SubmissionStatus
 
-from backend.data.graph import get_graph_as_admin
+from backend.data.graph import get_graph, get_graph_as_admin
 from backend.util.exceptions import NotFoundError
 
 from .store_admin_routes import router as store_admin_router
@@ -335,8 +335,6 @@ async def test_library_member_can_view_pending_agent_in_builder() -> None:
             return_value=mock_library_agent
         )
 
-        from backend.data.graph import get_graph
-
         result = await get_graph(
             graph_id=GRAPH_ID,
             version=GRAPH_VERSION,
@@ -346,10 +344,9 @@ async def test_library_member_can_view_pending_agent_in_builder() -> None:
     assert result is mock_graph_model, "Library membership should grant graph access"
     # Review would break if PENDING were not an accepted status.
     lib_where = mock_lib_prisma.return_value.find_first.await_args.kwargs["where"]
-    statuses = {
-        clause["submissionStatus"]
-        for clause in lib_where["AgentGraph"]["is"]["StoreListingVersions"]["some"][
-            "OR"
-        ]
-    }
+    statuses = set(
+        lib_where["AgentGraph"]["is"]["StoreListingVersions"]["some"][
+            "submissionStatus"
+        ]["in"]
+    )
     assert SubmissionStatus.PENDING in statuses

--- a/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/admin/store_admin_routes_test.py
@@ -296,11 +296,8 @@ async def test_resolve_graph_regular_uses_get_graph() -> None:
 
     assert result is mock_graph_model
     assert resolved_slv is mock_slv
-    # `skip_access_check` is required here: the user is installing the agent
-    # precisely because it is not yet in their library, so get_graph() cannot
-    # authorize the read. `resolve_store_version_for_library(admin=False)`
-    # authorizes it instead, by matching the listing version against
-    # `installable_store_version_where()` — asserted just below.
+    # `skip_access_check` is required: the agent isn't in the user's library
+    # yet, so get_graph() would deny the install it is being called for.
     mock_regular.assert_awaited_once_with(
         graph_id=GRAPH_ID,
         version=GRAPH_VERSION,
@@ -317,12 +314,8 @@ async def test_resolve_graph_regular_uses_get_graph() -> None:
 @pytest.mark.asyncio
 async def test_library_member_can_view_pending_agent_in_builder() -> None:
     """After adding a pending agent to their library, the user should be
-    able to load the graph in the builder via get_graph().
-
-    This is why a PENDING submission counts as "submitted to the marketplace":
-    the admin review flow adds a not-yet-approved agent to the reviewer's
-    library and then opens it in the builder. Requiring APPROVED here would
-    break review.
+    able to load the graph in the builder via get_graph(). This is why
+    PENDING counts as submitted — requiring APPROVED would break review.
     """
     mock_graph = _make_mock_graph()
     mock_graph_model = MagicMock(name="GraphModel")
@@ -351,8 +344,7 @@ async def test_library_member_can_view_pending_agent_in_builder() -> None:
         )
 
     assert result is mock_graph_model, "Library membership should grant graph access"
-    # The submission requirement travels in the same query as the library
-    # lookup, so PENDING must be one of the statuses it accepts.
+    # Review would break if PENDING were not an accepted status.
     lib_where = mock_lib_prisma.return_value.find_first.await_args.kwargs["where"]
     statuses = {
         clause["submissionStatus"]

--- a/autogpt_platform/backend/backend/api/features/executions/review/review_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/review_routes_test.py
@@ -716,7 +716,7 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
 
     # Verify get_graph_settings was called with correct parameters
     mock_get_settings.assert_called_once_with(
-        user_id=test_user_id, graph_id="test_graph_789"
+        user_id=test_user_id, graph_id="test_graph_789", graph_version=1
     )
 
     # Verify add_graph_execution was called with proper ExecutionContext

--- a/autogpt_platform/backend/backend/api/features/executions/review/routes.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/routes.py
@@ -333,7 +333,9 @@ async def process_review_action(
             try:
                 user = await get_user_by_id(user_id)
                 settings = await get_graph_settings(
-                    user_id=user_id, graph_id=first_review.graph_id
+                    user_id=user_id,
+                    graph_id=first_review.graph_id,
+                    graph_version=first_review.graph_version,
                 )
 
                 user_timezone = (

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -77,6 +77,7 @@ from backend.integrations.providers import ProviderName, provider_key
 from backend.integrations.webhooks import get_webhook_manager
 from backend.util.exceptions import (
     ExpertRunPausedError,
+    GraphNotAccessibleError,
     GraphNotInLibraryError,
     MissingConfigError,
     NeedConfirmation,
@@ -1314,11 +1315,19 @@ async def _execute_webhook_preset_trigger(
     except GraphNotInLibraryError as e:
         logger.warning(
             f"Webhook #{webhook_id} execution blocked for "
-            f"deleted/archived graph #{preset.graph_id} (preset #{preset.id}): {e}"
+            f"deleted graph #{preset.graph_id} (preset #{preset.id}): {e}"
         )
         # Clean up orphaned webhook trigger for this graph
         await _cleanup_orphaned_webhook_for_graph(
             preset.graph_id, webhook.user_id, webhook_id
+        )
+    except GraphNotAccessibleError as e:
+        # Permanent, unlike the transient failures below: every future
+        # delivery fails the same way while the preset still reads as Active.
+        logger.error(
+            f"Webhook #{webhook_id} preset #{preset.id} is permanently blocked: "
+            f"user #{webhook.user_id} may not execute graph "
+            f"#{preset.graph_id} v{preset.graph_version}: {e}"
         )
     except Exception:
         logger.exception(

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -1250,20 +1250,14 @@ async def _execute_webhook_preset_trigger(
             )
             return
 
-    # Read-authorization must not decide this: `None` would then also mean
-    # "not allowed to read", and the write below would silently kill a live
-    # trigger. add_graph_execution() is the authorization gate for this path.
     graph = await get_graph(
-        preset.graph_id,
-        preset.graph_version,
-        user_id=webhook.user_id,
-        skip_access_check=True,
+        preset.graph_id, preset.graph_version, user_id=webhook.user_id
     )
     if not graph:
         logger.error(
             f"User #{webhook.user_id} has preset #{preset.id} for graph "
             f"#{preset.graph_id} v{preset.graph_version}, "
-            "but the graph version does not exist."
+            "but no access to the graph itself."
         )
         logger.info(f"Automatically deactivating broken preset #{preset.id}")
         await update_preset(preset.user_id, preset.id, is_active=False)

--- a/autogpt_platform/backend/backend/api/features/integrations/router.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/router.py
@@ -1250,14 +1250,20 @@ async def _execute_webhook_preset_trigger(
             )
             return
 
+    # Read-authorization must not decide this: `None` would then also mean
+    # "not allowed to read", and the write below would silently kill a live
+    # trigger. add_graph_execution() is the authorization gate for this path.
     graph = await get_graph(
-        preset.graph_id, preset.graph_version, user_id=webhook.user_id
+        preset.graph_id,
+        preset.graph_version,
+        user_id=webhook.user_id,
+        skip_access_check=True,
     )
     if not graph:
         logger.error(
             f"User #{webhook.user_id} has preset #{preset.id} for graph "
             f"#{preset.graph_id} v{preset.graph_version}, "
-            "but no access to the graph itself."
+            "but the graph version does not exist."
         )
         logger.info(f"Automatically deactivating broken preset #{preset.id}")
         await update_preset(preset.user_id, preset.id, is_active=False)

--- a/autogpt_platform/backend/backend/api/features/integrations/webhook_ingress_test.py
+++ b/autogpt_platform/backend/backend/api/features/integrations/webhook_ingress_test.py
@@ -582,6 +582,44 @@ async def test_preset_trigger_refuses_foreign_owner(mocker):
     add_exec.assert_not_awaited()
 
 
+async def test_preset_trigger_deactivates_only_when_the_graph_version_is_gone(mocker):
+    """The graph read here locates the webhook input node; authorization to run
+    happens in add_graph_execution. Without `skip_access_check` a read denial
+    also reads as `None` and permanently disables a live trigger, which is a
+    one-way write the user has to undo by hand.
+    """
+    from backend.api.features.integrations import router as ingress_router
+
+    mocker.patch.object(ingress_router, "add_graph_execution", new_callable=AsyncMock)
+    update = mocker.patch.object(
+        ingress_router, "update_preset", new_callable=AsyncMock
+    )
+    get_graph = mocker.patch.object(
+        ingress_router,
+        "get_graph",
+        new_callable=AsyncMock,
+        return_value=_make_trigger_graph(),
+    )
+    preset = _make_expert_preset()
+    preset.expert_id = None
+    webhook = _make_webhook(ProviderName.GITHUB)
+
+    await ingress_router._execute_webhook_preset_trigger(
+        preset, webhook, WEBHOOK_ID, "pull_request", {}
+    )
+
+    assert get_graph.await_args.kwargs["skip_access_check"] is True
+    update.assert_not_awaited()
+
+    # Only a genuinely missing graph version disables the preset.
+    get_graph.return_value = None
+    await ingress_router._execute_webhook_preset_trigger(
+        preset, webhook, WEBHOOK_ID, "pull_request", {}
+    )
+
+    update.assert_awaited_once_with(preset.user_id, preset.id, is_active=False)
+
+
 def _make_expert_preset(
     *,
     organization_id: str | None = "personal-org",
@@ -691,6 +729,7 @@ async def test_expert_preset_trigger_uses_current_tenancy_after_conversion(
     get_graph.assert_awaited_once()
     add_exec.assert_awaited_once()
     assert add_exec.await_args.kwargs["organization_id"] == "personal-org"
+    assert get_graph.await_args.kwargs["skip_access_check"] is True
     assert add_exec.await_args.kwargs["team_id"] == "personal-team"
     assert add_exec.await_args.kwargs["expert_id"] == "expert-1"
 

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -75,7 +75,15 @@ async def resolve_graph_model_for_library(
     *,
     admin: bool,
 ) -> GraphModel:
-    """Resolve the graph for an already-validated marketplace version."""
+    """Resolve the graph for an already-validated marketplace version.
+
+    The non-admin path passes `skip_access_check` because the caller has
+    already authorized this read: `resolve_store_version_for_library()`
+    matched the listing version against `installable_store_version_where()`,
+    and the graph id/version come from that same row. `get_graph()` cannot
+    authorize it itself — the user is installing the agent precisely because
+    it is not yet in their library.
+    """
     ag = _require_graph(store_listing_version)
 
     graph_model = (
@@ -84,7 +92,10 @@ async def resolve_graph_model_for_library(
         )
         if admin
         else await graph_db.get_graph(
-            graph_id=ag.id, version=ag.version, user_id=user_id
+            graph_id=ag.id,
+            version=ag.version,
+            user_id=user_id,
+            skip_access_check=True,
         )
     )
     if not graph_model:

--- a/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
+++ b/autogpt_platform/backend/backend/api/features/library/_add_to_library.py
@@ -77,12 +77,8 @@ async def resolve_graph_model_for_library(
 ) -> GraphModel:
     """Resolve the graph for an already-validated marketplace version.
 
-    The non-admin path passes `skip_access_check` because the caller has
-    already authorized this read: `resolve_store_version_for_library()`
-    matched the listing version against `installable_store_version_where()`,
-    and the graph id/version come from that same row. `get_graph()` cannot
-    authorize it itself — the user is installing the agent precisely because
-    it is not yet in their library.
+    `skip_access_check`: the agent isn't in the user's library yet, so
+    `get_graph()` would deny; `resolve_store_version_for_library()` authorized.
     """
     ag = _require_graph(store_listing_version)
 

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -2129,8 +2129,8 @@ async def create_preset(
     logger.debug(
         f"Creating preset ({repr(preset.name)}) for user #{user_id}",
     )
-    # A preset may only reference a graph the caller can access (own / store /
-    # library); get_graph() enforces that and a foreign/unknown graph is None.
+    # A preset may only reference a graph the caller can access (owned, or in
+    # their library and submitted); get_graph() enforces that, None if not.
     # The preset then inherits the graph's org/team (resource-follows-parent),
     # resolved here so callers can't forget it.
     graph = await graph_db.get_graph(

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1404,11 +1404,8 @@ async def get_my_agents(
 async def get_agent(store_listing_version_id: str) -> GraphModel:
     """Get agent using the version ID and store listing version ID.
 
-    Serves the public download endpoint, so authorization is the listing
-    itself: only a publicly installable version may be handed out. That check
-    replaces the graph-level one, hence `skip_access_check` — `get_graph()`
-    now only answers for the owner or for a library holder, and this caller is
-    neither.
+    Unauthenticated endpoint: the installable-listing check below *is* the
+    authorization, so `get_graph()` is told to skip its own (it would deny).
     """
     slv = await prisma.models.StoreListingVersion.prisma().find_first(
         where={

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -27,6 +27,7 @@ from . import exceptions as store_exceptions
 from . import model as store_model
 from .embeddings import ensure_embedding
 from .hybrid_search import hybrid_search
+from .store_listing_versions import installable_store_version_where
 
 logger = logging.getLogger(__name__)
 settings = Settings()
@@ -1401,9 +1402,19 @@ async def get_my_agents(
 
 
 async def get_agent(store_listing_version_id: str) -> GraphModel:
-    """Get agent using the version ID and store listing version ID."""
-    slv = await prisma.models.StoreListingVersion.prisma().find_unique(
-        where={"id": store_listing_version_id}
+    """Get agent using the version ID and store listing version ID.
+
+    Serves the public download endpoint, so authorization is the listing
+    itself: only a publicly installable version may be handed out. That check
+    replaces the graph-level one, hence `skip_access_check` — `get_graph()`
+    now only answers for the owner or for a library holder, and this caller is
+    neither.
+    """
+    slv = await prisma.models.StoreListingVersion.prisma().find_first(
+        where={
+            "id": store_listing_version_id,
+            **installable_store_version_where(),
+        }
     )
 
     if not slv:
@@ -1416,6 +1427,7 @@ async def get_agent(store_listing_version_id: str) -> GraphModel:
         version=slv.agentGraphVersion,
         user_id=None,
         for_export=True,
+        skip_access_check=True,
     )
     if not graph:
         raise NotFoundError(

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -1402,7 +1402,7 @@ async def get_my_agents(
 
 
 async def get_agent(store_listing_version_id: str) -> GraphModel:
-    """Get agent using the version ID and store listing version ID.
+    """Get the graph behind a store listing version, for public download.
 
     Unauthenticated endpoint: the installable-listing check below *is* the
     authorization, so `get_graph()` is told to skip its own (it would deny).

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -1167,9 +1167,8 @@ async def test_get_agent_requires_installable_listing_version(mocker):
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_get_agent_skips_graph_access_check(mocker):
-    """The caller is anonymous, so `get_graph()` can't authorize the read —
-    it is neither the owner nor a library holder. `get_agent()` authorizes
-    against the listing instead and passes `skip_access_check`."""
+    """The caller is anonymous, so `get_graph()` would deny — `get_agent()`
+    authorizes against the listing instead and passes `skip_access_check`."""
     mock_slv = mocker.Mock()
     mock_slv.agentGraphId = "graph-1"
     mock_slv.agentGraphVersion = 3

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -7,6 +7,8 @@ import prisma.models
 import pytest
 from prisma import Prisma
 
+from backend.util.exceptions import NotFoundError
+
 from . import db
 from .model import MyAgentsSortBy, Profile, SubmissionStats
 
@@ -1133,3 +1135,62 @@ async def test_get_store_submissions_without_org_strict_ownership(mocker):
     where = mock_client.find_many.call_args.kwargs["where"]
     assert where["user_id"] == "user-1"
     assert "AND" not in where
+
+
+# ---- Public agent download: the listing version is the authorization ---- #
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_agent_requires_installable_listing_version(mocker):
+    """`get_agent()` serves the unauthenticated download endpoint, so it must
+    gate on the listing version being publicly installable — APPROVED, not
+    deleted, available, on a listing that still exists."""
+    mock_client = AsyncMock()
+    mock_client.find_first.return_value = None
+    mocker.patch.object(
+        prisma.models.StoreListingVersion, "prisma", return_value=mock_client
+    )
+    mock_get_graph = mocker.patch.object(db, "get_graph", new_callable=AsyncMock)
+
+    with pytest.raises(NotFoundError):
+        await db.get_agent("version123")
+
+    where = mock_client.find_first.call_args.kwargs["where"]
+    assert where["id"] == "version123"
+    assert where["submissionStatus"] == prisma.enums.SubmissionStatus.APPROVED
+    assert where["isDeleted"] is False
+    assert where["isAvailable"] is True
+    assert where["StoreListing"] == {"is": {"isDeleted": False}}
+    # A non-installable version must never reach the graph.
+    mock_get_graph.assert_not_awaited()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_agent_skips_graph_access_check(mocker):
+    """The caller is anonymous, so `get_graph()` can't authorize the read —
+    it is neither the owner nor a library holder. `get_agent()` authorizes
+    against the listing instead and passes `skip_access_check`."""
+    mock_slv = mocker.Mock()
+    mock_slv.agentGraphId = "graph-1"
+    mock_slv.agentGraphVersion = 3
+
+    mock_client = AsyncMock()
+    mock_client.find_first.return_value = mock_slv
+    mocker.patch.object(
+        prisma.models.StoreListingVersion, "prisma", return_value=mock_client
+    )
+    mock_graph = mocker.Mock()
+    mock_get_graph = mocker.patch.object(
+        db, "get_graph", new_callable=AsyncMock, return_value=mock_graph
+    )
+
+    result = await db.get_agent("version123")
+
+    assert result is mock_graph
+    mock_get_graph.assert_awaited_once_with(
+        graph_id="graph-1",
+        version=3,
+        user_id=None,
+        for_export=True,
+        skip_access_check=True,
+    )

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1353,8 +1353,8 @@ async def get_graph(
     themselves: the executor, and the marketplace install/download paths,
     which validate the StoreListingVersion instead.
 
-    See also: `get_graph_as_admin()` which bypasses ownership and marketplace
-    checks for admin-only routes.
+    See also: `get_graph_as_admin()`, which bypasses this check entirely for
+    admin-only routes.
 
     Returns `None` if the record is not found or not accessible.
     """
@@ -1423,6 +1423,7 @@ SUBMITTED_TO_MARKETPLACE: Final = (
     SubmissionStatus.APPROVED,
     SubmissionStatus.REJECTED,
 )
+_SUBMITTED_STATUSES: Final = list(SUBMITTED_TO_MARKETPLACE)
 
 
 def graph_in_library_filter(
@@ -1443,7 +1444,13 @@ def graph_in_library_filter(
         "AgentGraph": {
             "is": {
                 "StoreListingVersions": {
-                    "some": {"submissionStatus": {"in": list(SUBMITTED_TO_MARKETPLACE)}}
+                    # agentGraphId is redundant -- the relation already pins
+                    # (id, version) -- but it gives the subquery an indexed
+                    # predicate instead of a scan over every listing version.
+                    "some": {
+                        "agentGraphId": graph_id,
+                        "submissionStatus": {"in": _SUBMITTED_STATUSES},
+                    }
                 }
             }
         },
@@ -1672,12 +1679,14 @@ async def delete_graph(
 
 
 async def get_graph_settings(user_id: str, graph_id: str) -> GraphSettings:
+    # Same membership question as the authorization predicates: an archived
+    # agent still runs, and falling back to defaults here would silently turn
+    # the user's sensitive_action_safe_mode back off.
     lib = await LibraryAgent.prisma().find_first(
         where={
             "userId": user_id,
             "agentGraphId": graph_id,
             "isDeleted": False,
-            "isArchived": False,
         },
         order={"agentGraphVersion": "desc"},
     )
@@ -1709,7 +1718,7 @@ async def validate_graph_execution_permissions(
        version was submitted to the marketplace (`graph_in_library_filter()`)
     3. It is published in the marketplace and is executed as a sub-agent.
        This is the only case where execute is allowed without read; see
-       SECRT-1125 and the invariant note at step 3.
+       SECRT-1125 and the INVARIANT comment in the body below.
 
     Args:
         graph_id: The ID of the graph to check
@@ -1723,7 +1732,7 @@ async def validate_graph_execution_permissions(
         GraphNotInLibraryError: If the graph is not in the user's library (deleted).
         NotAuthorizedError: If the user lacks execution permissions for other reasons
     """
-    graph, library_agent = await asyncio.gather(
+    graph, library_agent, any_live_library_entry = await asyncio.gather(
         AgentGraph.prisma().find_unique(
             where={"graphVersionId": {"id": graph_id, "version": graph_version}}
         ),
@@ -1732,6 +1741,16 @@ async def validate_graph_execution_permissions(
         LibraryAgent.prisma().find_first(
             where=graph_in_library_filter(user_id, graph_id, graph_version)
         ),
+        # Only the owner branch reads this, but an owner running their own
+        # unpublished agent never matches the filter above, so fetching it
+        # here keeps the common case at one round trip instead of two.
+        LibraryAgent.prisma().find_first(
+            where={
+                "userId": user_id,
+                "agentGraphId": graph_id,
+                "isDeleted": False,
+            }
+        ),
     )
 
     # Step 1: Check if user owns this graph
@@ -1739,21 +1758,11 @@ async def validate_graph_execution_permissions(
 
     # Step 2: Check if the exact graph version is readable from the library.
     version_readable_from_library = library_agent is not None
-    owner_has_live_library_entry = version_readable_from_library
-    if user_owns_graph and not version_readable_from_library:
-        # Owners are allowed to execute a new version as long as some live
-        # library entry still exists for the graph. Non-owners stay
-        # version-specific.
-        owner_has_live_library_entry = (
-            await LibraryAgent.prisma().find_first(
-                where={
-                    "userId": user_id,
-                    "agentGraphId": graph_id,
-                    "isDeleted": False,
-                }
-            )
-            is not None
-        )
+    # Owners may execute a new version while some live entry for the graph
+    # remains; non-owners stay version-specific.
+    owner_has_live_library_entry = version_readable_from_library or (
+        bool(user_owns_graph) and any_live_library_entry is not None
+    )
 
     # Step 3: Apply permission logic
     # INVARIANT: execution must never be more permissive than read access
@@ -1776,7 +1785,7 @@ async def validate_graph_execution_permissions(
     ):
         raise GraphNotInLibraryError(f"Graph #{graph_id} is not in your library")
 
-    # Step 6: Check execution-specific permissions (raises generic NotAuthorizedError)
+    # Step 4: Check execution-specific permissions (raises generic NotAuthorizedError)
     # Additional authorization checks beyond the above:
     # 1. Check if user has execution credits (future)
     # 2. Check if graph is suspended/disabled (future)

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Self, cast
+from typing import TYPE_CHECKING, Annotated, Any, Final, Literal, Optional, Self, cast
 
 from prisma.enums import SubmissionStatus
 from prisma.models import (
@@ -18,7 +18,7 @@ from prisma.types import (
     AgentGraphWhereInput,
     AgentNodeCreateInput,
     AgentNodeLinkCreateInput,
-    StoreListingVersionWhereInput,
+    LibraryAgentWhereInput,
 )
 from pydantic import BaseModel, BeforeValidator, Field
 from pydantic.fields import computed_field
@@ -1341,14 +1341,29 @@ async def get_graph(
     Retrieves a graph from the DB.
     Defaults to the version with `is_active` if `version` is not passed.
 
+    A caller may read a graph version when either:
+
+    1. it is theirs — owned by ``user_id``, or visible to them through the
+       org/team rules below, or
+    2. they have that exact version in their library AND that version has been
+       submitted to the marketplace.
+
+    Being in the library is *not* enough on its own, and neither is a
+    marketplace submission the caller never added to their library.
+
     With ``organization_id`` (from a membership-verified RequestContext),
     org/team visibility rules apply — a member can open any graph the
     list endpoints show them (own + org-home + member-team graphs).
 
+    ``skip_access_check=True`` drops all of that and fetches the row directly;
+    it is for callers that have already authorized the read themselves (the
+    executor, and the marketplace install/download paths, which validate the
+    StoreListingVersion instead).
+
     See also: `get_graph_as_admin()` which bypasses ownership and marketplace
     checks for admin-only routes.
 
-    Returns `None` if the record is not found.
+    Returns `None` if the record is not found or not accessible.
     """
     graph = None
 
@@ -1381,38 +1396,12 @@ async def get_graph(
             order={"version": "desc"},
         )
 
-    # Use store listed graph to find not owned graph
-    if graph is None:
-        store_where_clause: StoreListingVersionWhereInput = {
-            "agentGraphId": graph_id,
-            "submissionStatus": SubmissionStatus.APPROVED,
-            "isDeleted": False,
-        }
-        if version is not None:
-            store_where_clause["agentGraphVersion"] = version
-
-        if store_listing := await StoreListingVersion.prisma().find_first(
-            where=store_where_clause,
-            order={"agentGraphVersion": "desc"},
-            include={"AgentGraph": {"include": AGENT_GRAPH_INCLUDE}},
-        ):
-            graph = store_listing.AgentGraph
-
-    # Fall back to library membership: if the user has the agent in their
-    # library (non-deleted, non-archived), grant access even if the agent is
-    # no longer published. "You added it, you keep it."
-    if graph is None and user_id is not None:
-        library_where: dict[str, object] = {
-            "userId": user_id,
-            "agentGraphId": graph_id,
-            "isDeleted": False,
-            "isArchived": False,
-        }
-        if version is not None:
-            library_where["agentGraphVersion"] = version
-
+    # Non-owner access: the user must have this exact graph version in their
+    # library AND that version must have been submitted to the marketplace.
+    # Neither half grants access on its own — see `graph_in_library_filter()`.
+    if graph is None and user_id is not None and not skip_access_check:
         library_agent = await LibraryAgent.prisma().find_first(
-            where=library_where,
+            where=graph_in_library_filter(user_id, graph_id, version),
             include={"AgentGraph": {"include": AGENT_GRAPH_INCLUDE}},
             order={"agentGraphVersion": "desc"},
         )
@@ -1431,6 +1420,58 @@ async def get_graph(
         )
 
     return GraphModel.from_db(graph, for_export)
+
+
+# A graph version counts as "submitted to the marketplace" once its listing
+# version leaves DRAFT: PENDING, APPROVED and REJECTED all mean the creator
+# actually pushed it to the store at some point. Deleted or unavailable
+# listings still count — taking a listing down does not retroactively
+# un-submit the version, and users who downloaded it while it was live keep
+# their copy ("you added it, you keep it").
+SUBMITTED_TO_MARKETPLACE: Final = (
+    SubmissionStatus.PENDING,
+    SubmissionStatus.APPROVED,
+    SubmissionStatus.REJECTED,
+)
+
+
+def graph_in_library_filter(
+    user_id: str, graph_id: str, version: int | None
+) -> LibraryAgentWhereInput:
+    """Predicate for non-owner read access to a graph version.
+
+    A user who does not own a graph may read a version of it only when both:
+
+    1. the version is in their library (not deleted, not archived), and
+    2. that same version has been submitted to the marketplace.
+
+    Expressed as one joined query on purpose: `AgentGraph` on a `LibraryAgent`
+    row is the exact `(id, version)` pair, so the `StoreListingVersions.some`
+    clause can only match a submission of *that* version. Checking the two
+    halves in separate queries would let them resolve to different versions
+    when `version is None`.
+    """
+    where: LibraryAgentWhereInput = {
+        "userId": user_id,
+        "agentGraphId": graph_id,
+        "isDeleted": False,
+        "isArchived": False,
+        "AgentGraph": {
+            "is": {
+                "StoreListingVersions": {
+                    "some": {
+                        "OR": [
+                            {"submissionStatus": status}
+                            for status in SUBMITTED_TO_MARKETPLACE
+                        ]
+                    }
+                }
+            }
+        },
+    }
+    if version is not None:
+        where["agentGraphVersion"] = version
+    return where
 
 
 async def get_store_listed_graphs(graph_ids: list[str]) -> dict[str, GraphModel]:

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1341,24 +1341,17 @@ async def get_graph(
     Retrieves a graph from the DB.
     Defaults to the version with `is_active` if `version` is not passed.
 
-    A caller may read a graph version when either:
-
-    1. it is theirs — owned by ``user_id``, or visible to them through the
-       org/team rules below, or
-    2. they have that exact version in their library AND that version has been
-       submitted to the marketplace.
-
-    Being in the library is *not* enough on its own, and neither is a
-    marketplace submission the caller never added to their library.
+    Access: the caller owns it, or has that exact version in their library
+    AND that version was submitted to the marketplace. Neither half of the
+    latter suffices alone.
 
     With ``organization_id`` (from a membership-verified RequestContext),
     org/team visibility rules apply — a member can open any graph the
     list endpoints show them (own + org-home + member-team graphs).
 
-    ``skip_access_check=True`` drops all of that and fetches the row directly;
-    it is for callers that have already authorized the read themselves (the
-    executor, and the marketplace install/download paths, which validate the
-    StoreListingVersion instead).
+    ``skip_access_check=True`` is for callers that authorized the read
+    themselves: the executor, and the marketplace install/download paths,
+    which validate the StoreListingVersion instead.
 
     See also: `get_graph_as_admin()` which bypasses ownership and marketplace
     checks for admin-only routes.
@@ -1396,9 +1389,8 @@ async def get_graph(
             order={"version": "desc"},
         )
 
-    # Non-owner access: the user must have this exact graph version in their
-    # library AND that version must have been submitted to the marketplace.
-    # Neither half grants access on its own — see `graph_in_library_filter()`.
+    # The only non-owner path. A store listing on its own must not grant
+    # access, so there is deliberately no marketplace lookup beside this one.
     if graph is None and user_id is not None and not skip_access_check:
         library_agent = await LibraryAgent.prisma().find_first(
             where=graph_in_library_filter(user_id, graph_id, version),
@@ -1422,12 +1414,8 @@ async def get_graph(
     return GraphModel.from_db(graph, for_export)
 
 
-# A graph version counts as "submitted to the marketplace" once its listing
-# version leaves DRAFT: PENDING, APPROVED and REJECTED all mean the creator
-# actually pushed it to the store at some point. Deleted or unavailable
-# listings still count — taking a listing down does not retroactively
-# un-submit the version, and users who downloaded it while it was live keep
-# their copy ("you added it, you keep it").
+# PENDING is included so admin review can open a not-yet-approved submission
+# from the reviewer's library. A deleted listing still counts as once-submitted.
 SUBMITTED_TO_MARKETPLACE: Final = (
     SubmissionStatus.PENDING,
     SubmissionStatus.APPROVED,
@@ -1438,18 +1426,11 @@ SUBMITTED_TO_MARKETPLACE: Final = (
 def graph_in_library_filter(
     user_id: str, graph_id: str, version: int | None
 ) -> LibraryAgentWhereInput:
-    """Predicate for non-owner read access to a graph version.
+    """Non-owner read access: version in the user's library AND submitted.
 
-    A user who does not own a graph may read a version of it only when both:
-
-    1. the version is in their library (not deleted, not archived), and
-    2. that same version has been submitted to the marketplace.
-
-    Expressed as one joined query on purpose: `AgentGraph` on a `LibraryAgent`
-    row is the exact `(id, version)` pair, so the `StoreListingVersions.some`
-    clause can only match a submission of *that* version. Checking the two
-    halves in separate queries would let them resolve to different versions
-    when `version is None`.
+    One joined query, not two: `AgentGraph` here is the exact `(id, version)`
+    pair, so separate queries could match the library row and the submission
+    on different versions when `version is None`.
     """
     where: LibraryAgentWhereInput = {
         "userId": user_id,

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1391,8 +1391,8 @@ async def get_graph(
 
     # The only non-owner path. A store listing on its own must not grant
     # access, so there is deliberately no marketplace lookup beside this one.
-    # Deliberately stricter than validate_graph_execution_permissions(): read
-    # and execute disagree until that one is aligned (see PR #14205, note 1).
+    # validate_graph_execution_permissions() reuses this same filter, so
+    # execute can never be looser than read. See the invariant note there.
     if graph is None and user_id is not None and not skip_access_check:
         library_agent = await LibraryAgent.prisma().find_first(
             where=graph_in_library_filter(user_id, graph_id, version),

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1391,6 +1391,8 @@ async def get_graph(
 
     # The only non-owner path. A store listing on its own must not grant
     # access, so there is deliberately no marketplace lookup beside this one.
+    # Deliberately stricter than validate_graph_execution_permissions(): read
+    # and execute disagree until that one is aligned (see PR #14205, note 1).
     if graph is None and user_id is not None and not skip_access_check:
         library_agent = await LibraryAgent.prisma().find_first(
             where=graph_in_library_filter(user_id, graph_id, version),
@@ -1440,12 +1442,7 @@ def graph_in_library_filter(
         "AgentGraph": {
             "is": {
                 "StoreListingVersions": {
-                    "some": {
-                        "OR": [
-                            {"submissionStatus": status}
-                            for status in SUBMITTED_TO_MARKETPLACE
-                        ]
-                    }
+                    "some": {"submissionStatus": {"in": list(SUBMITTED_TO_MARKETPLACE)}}
                 }
             }
         },
@@ -1458,8 +1455,8 @@ def graph_in_library_filter(
 async def get_store_listed_graphs(graph_ids: list[str]) -> dict[str, GraphModel]:
     """Batch-fetch multiple store-listed graphs by their IDs.
 
-    Only returns graphs that have approved store listings (publicly available).
-    Does not require permission checks since store-listed graphs are public.
+    The APPROVED-listing filter below *is* the authorization: an approved
+    listing is public, so no per-caller permission check is applied.
 
     Args:
         graph_ids: List of graph IDs to fetch
@@ -1763,6 +1760,8 @@ async def validate_graph_execution_permissions(
     # Step 3: Apply permission logic
     # Access is granted if the user owns it, it's in the marketplace, OR
     # it's in the user's library ("you added it, you keep it").
+    # Looser than the read gate in graph_in_library_filter(): a library-only,
+    # never-submitted version still executes here but 404s on read.
     if not (
         user_owns_graph
         or user_has_in_library

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1437,8 +1437,9 @@ def graph_in_library_filter(
     where: LibraryAgentWhereInput = {
         "userId": user_id,
         "agentGraphId": graph_id,
+        # Archiving hides an agent, it does not revoke it; isDeleted is the
+        # membership signal.
         "isDeleted": False,
-        "isArchived": False,
         "AgentGraph": {
             "is": {
                 "StoreListingVersions": {
@@ -1703,10 +1704,12 @@ async def validate_graph_execution_permissions(
 
     ## Logic
     A user can execute a graph if any of these is true:
-    1. They own the graph and some version of it is still listed in their library
-    2. The graph is in the user's library (non-deleted, non-archived)
-    3. The graph is published in the marketplace and listed in their library
-    4. The graph is published in the marketplace and is being executed as a sub-agent
+    1. They own the graph and some version of it is still in their library
+    2. They can *read* the exact version -- it is in their library and that
+       version was submitted to the marketplace (`graph_in_library_filter()`)
+    3. It is published in the marketplace and is executed as a sub-agent.
+       This is the only case where execute is allowed without read; see
+       SECRT-1125 and the invariant note at step 3.
 
     Args:
         graph_id: The ID of the graph to check
@@ -1717,31 +1720,27 @@ async def validate_graph_execution_permissions(
 
     Raises:
         GraphNotAccessibleError: If the graph is not accessible to the user.
-        GraphNotInLibraryError: If the graph is not in the user's library (deleted/archived).
+        GraphNotInLibraryError: If the graph is not in the user's library (deleted).
         NotAuthorizedError: If the user lacks execution permissions for other reasons
     """
     graph, library_agent = await asyncio.gather(
         AgentGraph.prisma().find_unique(
             where={"graphVersionId": {"id": graph_id, "version": graph_version}}
         ),
+        # The read gate's own predicate, reused rather than restated, so the
+        # two can't drift apart.
         LibraryAgent.prisma().find_first(
-            where={
-                "userId": user_id,
-                "agentGraphId": graph_id,
-                "agentGraphVersion": graph_version,
-                "isDeleted": False,
-                "isArchived": False,
-            }
+            where=graph_in_library_filter(user_id, graph_id, graph_version)
         ),
     )
 
     # Step 1: Check if user owns this graph
     user_owns_graph = graph and graph.userId == user_id
 
-    # Step 2: Check if the exact graph version is in the library.
-    user_has_in_library = library_agent is not None
-    owner_has_live_library_entry = user_has_in_library
-    if user_owns_graph and not user_has_in_library:
+    # Step 2: Check if the exact graph version is readable from the library.
+    version_readable_from_library = library_agent is not None
+    owner_has_live_library_entry = version_readable_from_library
+    if user_owns_graph and not version_readable_from_library:
         # Owners are allowed to execute a new version as long as some live
         # library entry still exists for the graph. Non-owners stay
         # version-specific.
@@ -1751,28 +1750,30 @@ async def validate_graph_execution_permissions(
                     "userId": user_id,
                     "agentGraphId": graph_id,
                     "isDeleted": False,
-                    "isArchived": False,
                 }
             )
             is not None
         )
 
     # Step 3: Apply permission logic
-    # Access is granted if the user owns it, it's in the marketplace, OR
-    # it's in the user's library ("you added it, you keep it").
-    # Looser than the read gate in graph_in_library_filter(): a library-only,
-    # never-submitted version still executes here but 404s on read.
+    # INVARIANT: execution must never be more permissive than read access
+    # (`get_graph()` / `graph_in_library_filter()`). The one sanctioned
+    # exception is SECRT-1125: a non-owner may EXECUTE a marketplace-listed
+    # graph they are denied read of, because the graph -- and its run's
+    # intermediate outputs -- would let them reconstruct a non-public graph.
     if not (
         user_owns_graph
-        or user_has_in_library
+        or version_readable_from_library
         or await is_graph_published_in_marketplace(graph_id, graph_version)
     ):
         raise GraphNotAccessibleError(
             f"You do not have access to graph #{graph_id} v{graph_version}: "
-            "it is not owned by you, not in your library, "
-            "and not available in the Marketplace"
+            "it is not owned by you, not in your library as a submitted "
+            "version, and not available in the Marketplace"
         )
-    elif not (user_has_in_library or owner_has_live_library_entry or is_sub_graph):
+    elif not (
+        version_readable_from_library or owner_has_live_library_entry or is_sub_graph
+    ):
         raise GraphNotInLibraryError(f"Graph #{graph_id} is not in your library")
 
     # Step 6: Check execution-specific permissions (raises generic NotAuthorizedError)

--- a/autogpt_platform/backend/backend/data/graph.py
+++ b/autogpt_platform/backend/backend/data/graph.py
@@ -1678,18 +1678,37 @@ async def delete_graph(
     return entries_count
 
 
-async def get_graph_settings(user_id: str, graph_id: str) -> GraphSettings:
-    # Same membership question as the authorization predicates: an archived
-    # agent still runs, and falling back to defaults here would silently turn
-    # the user's sensitive_action_safe_mode back off.
-    lib = await LibraryAgent.prisma().find_first(
-        where={
-            "userId": user_id,
-            "agentGraphId": graph_id,
-            "isDeleted": False,
-        },
-        order={"agentGraphVersion": "desc"},
-    )
+async def get_graph_settings(
+    user_id: str, graph_id: str, graph_version: int | None = None
+) -> GraphSettings:
+    """Settings of the library entry for the version being run.
+
+    Falls back to the user's other live entries when that version has none,
+    which is how an owner running a version they never added to their library
+    still gets their own safe-mode settings instead of the defaults.
+    """
+    # Archived entries stay eligible -- an archived agent still runs -- but the
+    # running version's own entry wins, so a hidden version can never turn the
+    # user's sensitive_action_safe_mode back off.
+    lib = None
+    if graph_version is not None:
+        lib = await LibraryAgent.prisma().find_first(
+            where={
+                "userId": user_id,
+                "agentGraphId": graph_id,
+                "agentGraphVersion": graph_version,
+                "isDeleted": False,
+            },
+        )
+    if lib is None:
+        lib = await LibraryAgent.prisma().find_first(
+            where={
+                "userId": user_id,
+                "agentGraphId": graph_id,
+                "isDeleted": False,
+            },
+            order=[{"isArchived": "asc"}, {"agentGraphVersion": "desc"}],
+        )
     if not lib or not lib.settings:
         return GraphSettings()
 

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -26,6 +26,7 @@ from backend.data.graph import (
     Node,
     NodeModel,
     get_graph,
+    graph_in_library_filter,
     migrate_llm_models,
     validate_graph_execution_permissions,
 )
@@ -964,7 +965,8 @@ def test_mcp_credential_combine_no_discriminator_values():
 # --------------- get_graph access-control truth table --------------- #
 #
 # Access: owner, OR (in library AND submitted). "Submitted" is any status but
-# DRAFT. get_graph_as_admin() and skip_access_check=True bypass all of it.
+# DRAFT. Archiving hides an agent, it does not revoke it, so only isDeleted
+# ends membership. get_graph_as_admin() and skip_access_check=True bypass it.
 #
 # | User     | Owns? | Submitted   | Library          | Version | Result  | Test
 # |----------|-------|-------------|------------------|---------|---------|-----
@@ -975,7 +977,7 @@ def test_mcp_credential_combine_no_discriminator_values():
 # | regular  | no    | no          | not present      | v1      | DENIED  | test_get_graph_access_matrix
 # | regular  | no    | yes         | active, diff ver | v2      | DENIED  | test_get_graph_library_wrong_version_denied
 # | regular  | no    | yes         | deleted          | v1      | DENIED  | test_get_graph_deleted_library_agent_denied
-# | regular  | no    | yes         | archived         | v1      | DENIED  | test_get_graph_archived_library_agent_denied
+# | regular  | no    | yes         | archived         | v1      | ACCESS  | test_get_graph_archived_library_agent_allowed
 # | regular  | no    | yes         | null AgentGraph  | v1      | DENIED  | test_get_graph_library_with_null_agent_graph_denied
 # | anon     | no    | yes         | -                | v1      | DENIED  | test_get_graph_anonymous_denied_for_submitted_graph
 # | admin*   | no    | PENDING     | -                | v2      | ACCESS  | test_admin_can_access_pending_v2_via_get_graph_as_admin
@@ -1174,7 +1176,7 @@ async def test_get_graph_in_library_but_never_submitted_denied() -> None:
     assert lib_where["agentGraphId"] == graph_id
     assert lib_where["agentGraphVersion"] == 1
     assert lib_where["isDeleted"] is False
-    assert lib_where["isArchived"] is False
+    assert "isArchived" not in lib_where, "archiving hides, it does not revoke"
     # The submission requirement must be part of the same query, so the two
     # halves can never resolve to different graph versions.
     submitted_statuses = set(
@@ -1250,7 +1252,7 @@ async def test_get_graph_library_member_can_access_submitted_agent() -> None:
 
     assert result is mock_graph_model, "Library member should access submitted agent"
 
-    # Verify library query filters on non-deleted, non-archived
+    # Verify library query filters on non-deleted (archived stays readable)
     lib_call = mock_lib_prisma.return_value.find_first
     lib_call.assert_awaited_once()
     assert lib_call.await_args is not None
@@ -1258,7 +1260,7 @@ async def test_get_graph_library_member_can_access_submitted_agent() -> None:
     assert lib_where["userId"] == requester_id
     assert lib_where["agentGraphId"] == graph_id
     assert lib_where["isDeleted"] is False
-    assert lib_where["isArchived"] is False
+    assert "isArchived" not in lib_where
 
 
 @pytest.mark.asyncio
@@ -1292,11 +1294,13 @@ async def test_get_graph_deleted_library_agent_denied() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_graph_archived_library_agent_denied() -> None:
-    """If the user archived the agent in their library, they should
-    NOT get access, even though the version was submitted."""
+async def test_get_graph_archived_library_agent_allowed() -> None:
+    """Archiving is a display state, not a revocation: tidying an agent out of
+    the library view must not cost the user run history, forking, scheduling
+    or webhook presets. `isDeleted` is what ends membership."""
     requester_id = "library-user-id"
     graph_id = "graph-id"
+    mock_graph_model = MagicMock(name="GraphModel")
 
     ag_prisma, lib_prisma = _fake_graph_db(
         owner_id="original-creator-id",
@@ -1315,10 +1319,14 @@ async def test_get_graph_archived_library_agent_denied() -> None:
     with (
         patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
         patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+        patch(
+            "backend.data.graph.GraphModel.from_db",
+            return_value=mock_graph_model,
+        ),
     ):
         result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
 
-    assert result is None, "Archived library agent should not grant graph access"
+    assert result is mock_graph_model, "Archiving must not revoke graph access"
 
 
 @pytest.mark.asyncio
@@ -1676,9 +1684,15 @@ async def test_admin_can_access_pending_v2_via_get_graph_as_admin() -> None:
 # --------------- execution permission truth table --------------- #
 #
 # validate_graph_execution_permissions() has two gates:
-# 1. Accessible graph: owner OR exact-version library entry OR marketplace-published
-# 2. Runnable graph: exact-version library entry OR owner fallback to any live
-#    library entry for the graph OR sub-graph exception
+# 1. Accessible graph: owner OR the exact version is READABLE from the library
+#    (in library AND submitted -- the same graph_in_library_filter() the read
+#    path uses) OR marketplace-published
+# 2. Runnable graph: that readable entry OR owner fallback to any live library
+#    entry for the graph OR sub-graph exception
+#
+# INVARIANT: gate 1 must never be looser than get_graph()'s read rule. The one
+# exception is SECRT-1125 -- a marketplace-published graph runs as a sub-agent
+# without read, so the caller can't reconstruct a non-public graph from it.
 #
 # Desired owner behavior differs from non-owners:
 # owners should be allowed to run a new version when some non-archived/non-deleted
@@ -1687,11 +1701,12 @@ async def test_admin_can_access_pending_v2_via_get_graph_as_admin() -> None:
 #
 # | User     | Owns? | Marketplace | Library state                | is_sub_graph | Result   | Test
 # |----------|-------|-------------|------------------------------|--------------|----------|-----
-# | regular  | no    | no          | exact version present        | false        | ALLOW    | test_validate_graph_execution_permissions_library_member_same_version_allowed
+# | regular  | no    | submitted   | exact version present        | false        | ALLOW    | test_validate_graph_execution_permissions_library_member_same_version_allowed
+# | regular  | no    | no          | exact version, NEVER submitted| false        | DENY acc | test_validate_graph_execution_permissions_library_member_never_submitted_denied
 # | owner    | yes   | no          | exact version present        | false        | ALLOW    | test_validate_graph_execution_permissions_owner_same_version_in_library_allowed
 # | owner    | yes   | no          | previous version present     | false        | ALLOW    | test_validate_graph_execution_permissions_owner_previous_library_version_allowed
 # | owner    | yes   | no          | none present                 | false        | DENY lib | test_validate_graph_execution_permissions_owner_without_library_denied
-# | owner    | yes   | no          | only archived/deleted older  | false        | DENY lib | test_validate_graph_execution_permissions_owner_previous_archived_library_version_denied
+# | owner    | yes   | no          | only archived older          | false        | ALLOW    | test_validate_graph_execution_permissions_owner_previous_archived_library_version_allowed
 # | regular  | no    | yes         | none present                 | false        | DENY lib | test_validate_graph_execution_permissions_marketplace_graph_not_in_library_denied
 # | admin    | no    | no          | none present                 | false        | DENY acc | test_validate_graph_execution_permissions_admin_without_library_or_marketplace_denied
 # | regular  | no    | yes         | none present                 | true         | ALLOW    | test_validate_graph_execution_permissions_marketplace_sub_graph_without_library_allowed
@@ -1729,6 +1744,46 @@ async def test_validate_graph_execution_permissions_library_member_same_version_
     mock_is_published.assert_not_awaited()
     lib_where = mock_lib_prisma.return_value.find_first.call_args.kwargs["where"]
     assert lib_where["agentGraphVersion"] == graph_version
+    # The alignment itself: execute queries the read gate's own predicate, so
+    # it cannot be looser than read. Everything the read tests prove about
+    # graph_in_library_filter() therefore holds here too.
+    assert lib_where == graph_in_library_filter(requester_id, graph_id, graph_version)
+
+
+@pytest.mark.asyncio
+async def test_validate_graph_execution_permissions_library_member_never_submitted_denied() -> (
+    None
+):
+    """Library membership alone no longer grants execution. This is the gap the
+    alignment closes: before, a never-submitted version 404'd on read but still
+    ran, and the user paid for a run whose results they could never open."""
+    requester_id = "library-user-id"
+    graph_id = "graph-id"
+    graph_version = 2
+    mock_graph = MagicMock(userId="creator-user-id")
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
+        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
+        patch(
+            "backend.data.graph.is_graph_published_in_marketplace",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as mock_is_published,
+    ):
+        mock_ag_prisma.return_value.find_unique = AsyncMock(return_value=mock_graph)
+        # graph_in_library_filter() requires a submission, so an unsubmitted
+        # row is simply not found.
+        mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
+
+        with pytest.raises(GraphNotAccessibleError):
+            await validate_graph_execution_permissions(
+                user_id=requester_id,
+                graph_id=graph_id,
+                graph_version=graph_version,
+            )
+
+    mock_is_published.assert_awaited_once_with(graph_id, graph_version)
 
 
 @pytest.mark.asyncio
@@ -1845,14 +1900,15 @@ async def test_validate_graph_execution_permissions_owner_without_library_denied
         "userId": requester_id,
         "agentGraphId": graph_id,
         "isDeleted": False,
-        "isArchived": False,
-    }
+    }, "archiving hides an agent, it must not revoke the owner's run rights"
 
 
 @pytest.mark.asyncio
-async def test_validate_graph_execution_permissions_owner_previous_archived_library_version_denied() -> (
+async def test_validate_graph_execution_permissions_owner_previous_archived_library_version_allowed() -> (
     None
 ):
+    """An owner whose only remaining library entry is archived can still run a
+    new version: the fallback query must not filter on isArchived."""
     requester_id = "owner-user-id"
     graph_id = "graph-id"
     graph_version = 2
@@ -1868,14 +1924,15 @@ async def test_validate_graph_execution_permissions_owner_previous_archived_libr
         ) as mock_is_published,
     ):
         mock_ag_prisma.return_value.find_unique = AsyncMock(return_value=mock_graph)
-        mock_lib_prisma.return_value.find_first = AsyncMock(side_effect=[None, None])
+        mock_lib_prisma.return_value.find_first = AsyncMock(
+            side_effect=[None, MagicMock(name="ArchivedLibraryAgent")]
+        )
 
-        with pytest.raises(GraphNotInLibraryError):
-            await validate_graph_execution_permissions(
-                user_id=requester_id,
-                graph_id=graph_id,
-                graph_version=graph_version,
-            )
+        await validate_graph_execution_permissions(
+            user_id=requester_id,
+            graph_id=graph_id,
+            graph_version=graph_version,
+        )
 
     mock_is_published.assert_not_awaited()
     assert mock_lib_prisma.return_value.find_first.await_count == 2
@@ -1890,8 +1947,7 @@ async def test_validate_graph_execution_permissions_owner_previous_archived_libr
         "userId": requester_id,
         "agentGraphId": graph_id,
         "isDeleted": False,
-        "isArchived": False,
-    }
+    }, "archiving hides an agent, it must not revoke the owner's run rights"
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -1,12 +1,13 @@
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import fastapi.exceptions
 import prisma
 import pytest
 from prisma.enums import SubmissionStatus
+from prisma.models import AgentGraph, LibraryAgent, User
 from pytest_snapshot.plugin import Snapshot
 
 import backend.api.features.library.db as library_db
@@ -26,6 +27,7 @@ from backend.data.graph import (
     Node,
     NodeModel,
     get_graph,
+    get_graph_settings,
     graph_in_library_filter,
     migrate_llm_models,
     validate_graph_execution_permissions,
@@ -34,6 +36,7 @@ from backend.data.model import SchemaField
 from backend.data.user import DEFAULT_USER_ID
 from backend.usecases.sample import create_test_user
 from backend.util.exceptions import GraphNotAccessibleError, GraphNotInLibraryError
+from backend.util.json import SafeJson
 from backend.util.test import SpinTestServer
 
 
@@ -2153,6 +2156,78 @@ async def test_validate_graph_execution_permissions_library_wrong_version_denied
         "where"
     ]
     assert lib_where["agentGraphVersion"] == graph_version
+
+
+# ============================================================================
+# Tests for get_graph_settings version resolution (real DB)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "running_version, expected_session_id, expected_safe_mode",
+    [
+        (1, "settings-v1", True),
+        (2, "settings-v2", False),
+        (3, "settings-v1", True),
+    ],
+    ids=[
+        "live-version-keeps-its-own-settings",
+        "archived-version-keeps-its-own-settings",
+        "version-without-an-entry-falls-back-to-the-live-one",
+    ],
+)
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_graph_settings_resolves_against_the_running_version(
+    server: SpinTestServer,
+    running_version: int,
+    expected_session_id: str,
+    expected_safe_mode: bool,
+) -> None:
+    """An archived entry must not override the version actually running."""
+    user_id = f"graph-settings-{uuid4()}"
+    graph_id = str(uuid4())
+    await User.prisma().create(
+        data={"id": user_id, "email": f"{user_id}@example.com", "name": "Settings Test"}
+    )
+    try:
+        for version in (1, 2, 3):
+            await AgentGraph.prisma().create(
+                data={
+                    "id": graph_id,
+                    "version": version,
+                    "name": f"Settings Test v{version}",
+                    "description": "test",
+                    "userId": user_id,
+                    "isActive": version == 3,
+                }
+            )
+        for version, archived, safe_mode in ((1, False, True), (2, True, False)):
+            await LibraryAgent.prisma().create(
+                data={
+                    "userId": user_id,
+                    "agentGraphId": graph_id,
+                    "agentGraphVersion": version,
+                    "isArchived": archived,
+                    "isCreatedByUser": True,
+                    "settings": SafeJson(
+                        {
+                            "sensitive_action_safe_mode": safe_mode,
+                            "builder_chat_session_id": f"settings-v{version}",
+                        }
+                    ),
+                }
+            )
+
+        settings = await get_graph_settings(
+            user_id=user_id, graph_id=graph_id, graph_version=running_version
+        )
+
+        assert settings.builder_chat_session_id == expected_session_id
+        assert settings.sensitive_action_safe_mode is expected_safe_mode
+    finally:
+        await LibraryAgent.prisma().delete_many(where={"userId": user_id})
+        await AgentGraph.prisma().delete_many(where={"id": graph_id})
+        await User.prisma().delete_many(where={"id": user_id})
 
 
 # ============================================================================

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -1690,6 +1690,11 @@ async def test_admin_can_access_pending_v2_via_get_graph_as_admin() -> None:
 # 2. Runnable graph: that readable entry OR owner fallback to any live library
 #    entry for the graph OR sub-graph exception
 #
+# Both library lookups are issued in one asyncio.gather, so LibraryAgent
+# find_first is awaited twice on every call: [0] is the strict read predicate,
+# [1] the loose owner fallback. The fallback is only consulted for owners --
+# reading it for a non-owner would grant cross-version execution.
+#
 # INVARIANT: gate 1 must never be looser than get_graph()'s read rule. The one
 # exception is SECRT-1125 -- a marketplace-published graph runs as a sub-agent
 # without read, so the caller can't reconstruct a non-public graph from it.
@@ -1742,7 +1747,9 @@ async def test_validate_graph_execution_permissions_library_member_same_version_
         )
 
     mock_is_published.assert_not_awaited()
-    lib_where = mock_lib_prisma.return_value.find_first.call_args.kwargs["where"]
+    lib_where = mock_lib_prisma.return_value.find_first.await_args_list[0].kwargs[
+        "where"
+    ]
     assert lib_where["agentGraphVersion"] == graph_version
     # The alignment itself: execute queries the read gate's own predicate, so
     # it cannot be looser than read. Everything the read tests prove about
@@ -1754,9 +1761,9 @@ async def test_validate_graph_execution_permissions_library_member_same_version_
 async def test_validate_graph_execution_permissions_library_member_never_submitted_denied() -> (
     None
 ):
-    """Library membership alone no longer grants execution. This is the gap the
-    alignment closes: before, a never-submitted version 404'd on read but still
-    ran, and the user paid for a run whose results they could never open."""
+    """Library membership alone does not grant execution: the version must also
+    have been submitted. Execution is never more permissive than read, so a
+    version the user cannot open is a version they cannot run."""
     requester_id = "library-user-id"
     graph_id = "graph-id"
     graph_version = 2
@@ -1814,7 +1821,9 @@ async def test_validate_graph_execution_permissions_owner_same_version_in_librar
         )
 
     mock_is_published.assert_not_awaited()
-    lib_where = mock_lib_prisma.return_value.find_first.call_args.kwargs["where"]
+    lib_where = mock_lib_prisma.return_value.find_first.await_args_list[0].kwargs[
+        "where"
+    ]
     assert lib_where["agentGraphVersion"] == graph_version
 
 
@@ -1948,6 +1957,42 @@ async def test_validate_graph_execution_permissions_owner_previous_archived_libr
         "agentGraphId": graph_id,
         "isDeleted": False,
     }, "archiving hides an agent, it must not revoke the owner's run rights"
+
+
+@pytest.mark.asyncio
+async def test_validate_graph_execution_permissions_non_owner_other_version_denied() -> (
+    None
+):
+    """The owner fallback is fetched for everyone but must be read only for
+    owners. A non-owner holding a live entry for a *different* version of a
+    marketplace graph stays version-specific and is denied."""
+    requester_id = "library-user-id"
+    graph_id = "graph-id"
+    graph_version = 2
+    mock_graph = MagicMock(userId="creator-user-id")
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
+        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
+        patch(
+            "backend.data.graph.is_graph_published_in_marketplace",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        mock_ag_prisma.return_value.find_unique = AsyncMock(return_value=mock_graph)
+        # Strict predicate misses this version; the loose fallback finds the
+        # user's entry for another version of the same graph.
+        mock_lib_prisma.return_value.find_first = AsyncMock(
+            side_effect=[None, MagicMock(name="OtherVersionLibraryAgent")]
+        )
+
+        with pytest.raises(GraphNotInLibraryError):
+            await validate_graph_execution_permissions(
+                user_id=requester_id,
+                graph_id=graph_id,
+                graph_version=graph_version,
+            )
 
 
 @pytest.mark.asyncio
@@ -2104,7 +2149,9 @@ async def test_validate_graph_execution_permissions_library_wrong_version_denied
             )
 
     mock_is_published.assert_awaited_once_with(graph_id, graph_version)
-    lib_where = mock_lib_prisma.return_value.find_first.call_args.kwargs["where"]
+    lib_where = mock_lib_prisma.return_value.find_first.await_args_list[0].kwargs[
+        "where"
+    ]
     assert lib_where["agentGraphVersion"] == graph_version
 
 

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -19,6 +19,7 @@ from backend.blocks.code_executor import ExecuteCodeBlock
 from backend.blocks.io import AgentInputBlock, AgentOutputBlock
 from backend.blocks.llm import LEGACY_MODEL_MAPPINGS, LLMModel
 from backend.data.graph import (
+    SUBMITTED_TO_MARKETPLACE,
     Graph,
     GraphModel,
     Link,
@@ -979,18 +980,21 @@ def test_mcp_credential_combine_no_discriminator_values():
 # | anon     | no    | yes         | -                | v1      | DENIED  | test_get_graph_anonymous_denied_for_submitted_graph
 # | admin*   | no    | PENDING     | -                | v2      | ACCESS  | test_admin_can_access_pending_v2_via_get_graph_as_admin
 #
+# | regular  | no    | v1 only     | active, v1 + v2  | none    | v1      | test_get_graph_version_none_ignores_unsubmitted_newer_version
+# | regular  | no    | v1 + v2     | active, v1 + v2  | none    | v2      | test_get_graph_version_none_picks_latest_submitted_version
+#
 # Efficiency (no unnecessary queries):
 # | regular  | yes   | -           | -                | v1      | no lib  | test_get_graph_library_not_queried_when_owned
-# | anon     | -     | -           | -                | v1      | no lib  | test_get_graph_library_fallback_not_used_for_anonymous
+# | anon     | -     | -           | -                | v1      | no query| test_get_graph_anonymous_denied_for_submitted_graph
 #
 # * = via get_graph_as_admin (admin-only routes)
 
 
-def _make_mock_db_graph(user_id: str = "owner-user-id") -> MagicMock:
+def _make_mock_db_graph(user_id: str = "owner-user-id", version: int = 1) -> MagicMock:
     graph = MagicMock()
     graph.userId = user_id
     graph.id = "graph-id"
-    graph.version = 1
+    graph.version = version
     graph.Nodes = []
     return graph
 
@@ -1027,7 +1031,7 @@ def _library_row_matches(row: _LibraryRow, where: dict[str, Any]) -> bool:
     for key, expected in where.items():
         if key == "AgentGraph":
             some = expected["is"]["StoreListingVersions"]["some"]
-            statuses = {clause["submissionStatus"] for clause in some["OR"]}
+            statuses = set(some["submissionStatus"]["in"])
             assert statuses == {
                 SubmissionStatus.PENDING,
                 SubmissionStatus.APPROVED,
@@ -1071,7 +1075,9 @@ def _fake_graph_db(
         matches = [
             row for row in library_rows if _library_row_matches(row, kwargs["where"])
         ]
-        matches.sort(key=lambda row: row.agentGraphVersion, reverse=True)
+        order = kwargs["order"]["agentGraphVersion"]
+        assert order in ("asc", "desc"), f"unsupported order {order!r}"
+        matches.sort(key=lambda row: row.agentGraphVersion, reverse=order == "desc")
         return matches[0] if matches else None
 
     ag_prisma = MagicMock()
@@ -1171,12 +1177,11 @@ async def test_get_graph_in_library_but_never_submitted_denied() -> None:
     assert lib_where["isArchived"] is False
     # The submission requirement must be part of the same query, so the two
     # halves can never resolve to different graph versions.
-    submitted_statuses = {
-        clause["submissionStatus"]
-        for clause in lib_where["AgentGraph"]["is"]["StoreListingVersions"]["some"][
-            "OR"
-        ]
-    }
+    submitted_statuses = set(
+        lib_where["AgentGraph"]["is"]["StoreListingVersions"]["some"][
+            "submissionStatus"
+        ]["in"]
+    )
     assert SubmissionStatus.DRAFT not in submitted_statuses
 
 
@@ -1208,31 +1213,6 @@ async def test_get_graph_submitted_but_not_in_library_denied() -> None:
         result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
 
     assert result is None, "A marketplace listing alone must not grant graph access"
-
-
-@pytest.mark.asyncio
-async def test_get_graph_non_owner_pending_not_in_library_denied() -> None:
-    """A non-owner with no library membership and no marketplace submission
-    must be denied access."""
-    requester_id = "different-user-id"
-    graph_id = "graph-id"
-
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
-
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=requester_id,
-        )
-
-    assert (
-        result is None
-    ), "User without ownership, marketplace, or library access must be denied"
 
 
 @pytest.mark.asyncio
@@ -1344,48 +1324,37 @@ async def test_get_graph_archived_library_agent_denied() -> None:
 @pytest.mark.asyncio
 async def test_get_graph_anonymous_denied_for_submitted_graph() -> None:
     """Anonymous callers (user_id=None) have no library, so they can never
-    satisfy the access rule — not even for an approved marketplace agent.
-    The public download path goes through `store.db.get_agent()` instead.
+    satisfy the access rule — not even for a graph that is on the marketplace
+    and in someone's library. The public download path goes through
+    `store.db.get_agent()` instead.
+
+    Neither table is touched: with no user and no team there is nothing to
+    match on, so both lookups are skipped rather than run and discarded.
     """
     graph_id = "graph-id"
 
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id="some-other-user-id",
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
 
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=None,
-        )
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=1, user_id=None)
 
     assert result is None, "Anonymous callers must not reach a graph via get_graph"
-    mock_lib_prisma.return_value.find_first.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_get_graph_library_fallback_not_used_for_anonymous() -> None:
-    """Anonymous requests (user_id=None) must not trigger the library
-    lookup — there's no user to check library membership for."""
-    graph_id = "graph-id"
-
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=None,
-        )
-
-    assert result is None
-    # Library should never be queried for anonymous users
-    mock_lib_prisma.return_value.find_first.assert_not_called()
+    ag_prisma.return_value.find_first.assert_not_called()
+    lib_prisma.return_value.find_first.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1418,6 +1387,136 @@ async def test_get_graph_skip_access_check_bypasses_library_lookup() -> None:
     ag_where = mock_ag_prisma.return_value.find_first.await_args.kwargs["where"]
     assert "userId" not in ag_where, "skip_access_check must not scope by owner"
     mock_lib_prisma.return_value.find_first.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_graph_skip_access_check_denies_missing_graph_despite_library() -> (
+    None
+):
+    """The flag must gate the library branch itself, not just the owner scope:
+    a caller that authorized its own read gets the row or nothing, never a
+    second chance through someone's library."""
+    requester_id = "library-user-id"
+    missing_graph_id = "other-graph-id"
+
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=missing_graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(
+            graph_id=missing_graph_id,
+            version=1,
+            user_id=requester_id,
+            skip_access_check=True,
+        )
+
+    assert result is None, "skip_access_check must not fall back to the library"
+    lib_prisma.return_value.find_first.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_graph_version_none_ignores_unsubmitted_newer_version() -> None:
+    """Why the two halves are one joined query: with no version pinned, a newer
+    never-submitted library row must not shadow the submitted one — separate
+    queries would resolve the membership and the submission to different
+    versions and grant access to v2."""
+    requester_id = "library-user-id"
+    graph_id = "graph-id"
+    submitted_v1 = _make_mock_db_graph("original-creator-id", version=1)
+
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=2,
+                submitted=False,
+                agent_graph=_make_mock_db_graph("original-creator-id", version=2),
+            ),
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=submitted_v1,
+            ),
+        ],
+    )
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+        patch("backend.data.graph.GraphModel.from_db") as mock_from_db,
+    ):
+        result = await get_graph(graph_id=graph_id, version=None, user_id=requester_id)
+
+    assert result is mock_from_db.return_value
+    assert (
+        mock_from_db.call_args.args[0] is submitted_v1
+    ), "version=None must resolve to the submitted version, not the newest row"
+    lib_where = lib_prisma.return_value.find_first.await_args.kwargs["where"]
+    assert "agentGraphVersion" not in lib_where
+
+
+@pytest.mark.asyncio
+async def test_get_graph_version_none_picks_latest_submitted_version() -> None:
+    """With several submitted versions in the library and no version pinned,
+    the newest wins — same as the owner path's `order={"version": "desc"}`."""
+    requester_id = "library-user-id"
+    graph_id = "graph-id"
+    submitted_v2 = _make_mock_db_graph("original-creator-id", version=2)
+
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id", version=1),
+            ),
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=2,
+                submitted=True,
+                agent_graph=submitted_v2,
+            ),
+        ],
+    )
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+        patch("backend.data.graph.GraphModel.from_db") as mock_from_db,
+    ):
+        result = await get_graph(graph_id=graph_id, version=None, user_id=requester_id)
+
+    assert result is mock_from_db.return_value
+    assert mock_from_db.call_args.args[0] is submitted_v2
+
+
+def test_submitted_to_marketplace_is_every_status_but_draft() -> None:
+    """A new `SubmissionStatus` member has to be triaged by hand: silently
+    inheriting "submitted" would grant its holders read access to the graph."""
+    assert set(SUBMITTED_TO_MARKETPLACE) == set(SubmissionStatus) - {
+        SubmissionStatus.DRAFT
+    }
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -949,16 +949,8 @@ def test_mcp_credential_combine_no_discriminator_values():
 
 # --------------- get_graph access-control truth table --------------- #
 #
-# A caller may read a graph version when EITHER:
-#   1. they own it (or it is visible to them via org/team rules), OR
-#   2. they have that exact version in their library AND that version has
-#      been submitted to the marketplace (any status but DRAFT).
-#
-# Neither half of (2) grants access on its own. A marketplace submission the
-# caller never added to their library is not readable, and a library entry for
-# a version that was never submitted is not readable either.
-#
-# get_graph_as_admin() and skip_access_check=True bypass all of it.
+# Access: owner, OR (in library AND submitted). "Submitted" is any status but
+# DRAFT. get_graph_as_admin() and skip_access_check=True bypass all of it.
 #
 # | User     | Owns? | Submitted   | Library          | Version | Result  | Test
 # |----------|-------|-------------|------------------|---------|---------|-----
@@ -1016,10 +1008,8 @@ class _LibraryRow:
 def _library_row_matches(row: _LibraryRow, where: dict[str, Any]) -> bool:
     """Evaluate `graph_in_library_filter()`'s where-clause against a row.
 
-    Deliberately supports only the operators that predicate uses — scalar
-    equality plus the `AgentGraph.is.StoreListingVersions.some.OR[]` join —
-    and raises on anything else, so a future rewrite of the predicate can't
-    quietly start passing here without the matcher being updated too.
+    Raises on any operator it doesn't implement, so a rewritten predicate
+    can't silently keep passing here without this matcher being updated too.
     """
     for key, expected in where.items():
         if key == "AgentGraph":
@@ -1049,9 +1039,8 @@ def _fake_graph_db(
 ) -> tuple[MagicMock, MagicMock]:
     """Build AgentGraph/LibraryAgent prisma doubles that honour their where-clause.
 
-    The graph itself always exists and is owned by `owner_id`; the AgentGraph
-    lookup returns it only when the where-clause's ownership scoping matches,
-    which is what `get_graph()` relies on for the ownership tier.
+    The graph always exists and is owned by `owner_id`, so denial can only
+    come from the where-clause — never from a missing row.
     """
     db_graph = _make_mock_db_graph(owner_id)
 
@@ -1079,9 +1068,7 @@ def _fake_graph_db(
     return ag_prisma, lib_prisma
 
 
-# Every combination of (owner / not owner) x (in library / not) x (submitted /
-# not submitted). Access is expected iff the caller owns the graph, or has it
-# in their library AND the version was submitted to the marketplace.
+# Every combination of (owner / not) x (in library / not) x (submitted / not).
 @pytest.mark.parametrize(
     ("is_owner", "in_library", "submitted", "expect_access"),
     [
@@ -1345,10 +1332,7 @@ async def test_get_graph_archived_library_agent_denied() -> None:
 async def test_get_graph_anonymous_denied_for_submitted_graph() -> None:
     """Anonymous callers (user_id=None) have no library, so they can never
     satisfy the access rule — not even for an approved marketplace agent.
-
-    The public marketplace download path authorizes itself against the
-    StoreListingVersion and calls get_graph with skip_access_check instead;
-    see `store.db.get_agent()`.
+    The public download path goes through `store.db.get_agent()` instead.
     """
     graph_id = "graph-id"
 

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import fastapi.exceptions
 import prisma
 import pytest
+from prisma.enums import SubmissionStatus
 from pytest_snapshot.plugin import Snapshot
 
 import backend.api.features.store.model as store
@@ -948,28 +949,34 @@ def test_mcp_credential_combine_no_discriminator_values():
 
 # --------------- get_graph access-control truth table --------------- #
 #
-# Full matrix of access scenarios for get_graph() and get_graph_as_admin().
-# Access priority: ownership > marketplace APPROVED > library membership.
-# Library is version-specific. get_graph_as_admin bypasses everything.
+# A caller may read a graph version when EITHER:
+#   1. they own it (or it is visible to them via org/team rules), OR
+#   2. they have that exact version in their library AND that version has
+#      been submitted to the marketplace (any status but DRAFT).
 #
-# | User     | Owns? | Marketplace | Library          | Version | Result  | Test
+# Neither half of (2) grants access on its own. A marketplace submission the
+# caller never added to their library is not readable, and a library entry for
+# a version that was never submitted is not readable either.
+#
+# get_graph_as_admin() and skip_access_check=True bypass all of it.
+#
+# | User     | Owns? | Submitted   | Library          | Version | Result  | Test
 # |----------|-------|-------------|------------------|---------|---------|-----
-# | regular  | yes   | any         | any              | v1      | ACCESS  | test_get_graph_library_not_queried_when_owned
-# | regular  | no    | APPROVED    | any              | v1      | ACCESS  | test_get_graph_non_owner_approved_marketplace_agent
-# | regular  | no    | not listed  | active, same ver | v1      | ACCESS  | test_get_graph_library_member_can_access_unpublished
-# | regular  | no    | not listed  | active, diff ver | v2      | DENIED  | test_get_graph_library_wrong_version_denied
-# | regular  | no    | not listed  | deleted          | v1      | DENIED  | test_get_graph_deleted_library_agent_denied
-# | regular  | no    | not listed  | archived         | v1      | DENIED  | test_get_graph_archived_library_agent_denied
-# | regular  | no    | not listed  | not present      | v1      | DENIED  | test_get_graph_non_owner_pending_not_in_library_denied
-# | regular  | no    | PENDING     | active v1        | v2      | DENIED  | test_library_v1_does_not_grant_access_to_pending_v2
-# | regular  | no    | not listed  | null AgentGraph  | v1      | DENIED  | test_get_graph_library_with_null_agent_graph_denied
-# | anon     | no    | not listed  | -                | v1      | DENIED  | test_get_graph_library_fallback_not_used_for_anonymous
-# | anon     | no    | APPROVED    | -                | v1      | ACCESS  | test_get_graph_anonymous_approved_marketplace_access
+# | regular  | yes   | any         | any              | v1      | ACCESS  | test_get_graph_access_matrix / test_get_graph_library_not_queried_when_owned
+# | regular  | no    | yes         | active, same ver | v1      | ACCESS  | test_get_graph_access_matrix
+# | regular  | no    | yes         | not present      | v1      | DENIED  | test_get_graph_access_matrix / test_get_graph_submitted_but_not_in_library_denied
+# | regular  | no    | no          | active, same ver | v1      | DENIED  | test_get_graph_access_matrix / test_get_graph_in_library_but_never_submitted_denied
+# | regular  | no    | no          | not present      | v1      | DENIED  | test_get_graph_access_matrix
+# | regular  | no    | yes         | active, diff ver | v2      | DENIED  | test_get_graph_library_wrong_version_denied
+# | regular  | no    | yes         | deleted          | v1      | DENIED  | test_get_graph_deleted_library_agent_denied
+# | regular  | no    | yes         | archived         | v1      | DENIED  | test_get_graph_archived_library_agent_denied
+# | regular  | no    | yes         | null AgentGraph  | v1      | DENIED  | test_get_graph_library_with_null_agent_graph_denied
+# | anon     | no    | yes         | -                | v1      | DENIED  | test_get_graph_anonymous_denied_for_submitted_graph
 # | admin*   | no    | PENDING     | -                | v2      | ACCESS  | test_admin_can_access_pending_v2_via_get_graph_as_admin
 #
 # Efficiency (no unnecessary queries):
-# | regular  | yes   | -           | -                | v1      | no mkt/lib | test_get_graph_library_not_queried_when_owned
-# | regular  | no    | APPROVED    | -                | v1      | no lib     | test_get_graph_library_not_queried_when_marketplace_approved
+# | regular  | yes   | -           | -                | v1      | no lib  | test_get_graph_library_not_queried_when_owned
+# | anon     | -     | -           | -                | v1      | no lib  | test_get_graph_library_fallback_not_used_for_anonymous
 #
 # * = via get_graph_as_admin (admin-only routes)
 
@@ -983,59 +990,238 @@ def _make_mock_db_graph(user_id: str = "owner-user-id") -> MagicMock:
     return graph
 
 
+class _LibraryRow:
+    """A LibraryAgent row as far as the access check is concerned."""
+
+    def __init__(
+        self,
+        *,
+        user_id: str,
+        graph_id: str,
+        version: int,
+        submitted: bool,
+        is_deleted: bool = False,
+        is_archived: bool = False,
+        agent_graph: MagicMock | None = None,
+    ) -> None:
+        self.userId = user_id
+        self.agentGraphId = graph_id
+        self.agentGraphVersion = version
+        self.submitted = submitted
+        self.isDeleted = is_deleted
+        self.isArchived = is_archived
+        self.AgentGraph = agent_graph
+
+
+def _library_row_matches(row: _LibraryRow, where: dict[str, Any]) -> bool:
+    """Evaluate `graph_in_library_filter()`'s where-clause against a row.
+
+    Deliberately supports only the operators that predicate uses — scalar
+    equality plus the `AgentGraph.is.StoreListingVersions.some.OR[]` join —
+    and raises on anything else, so a future rewrite of the predicate can't
+    quietly start passing here without the matcher being updated too.
+    """
+    for key, expected in where.items():
+        if key == "AgentGraph":
+            some = expected["is"]["StoreListingVersions"]["some"]
+            statuses = {clause["submissionStatus"] for clause in some["OR"]}
+            assert statuses == {
+                SubmissionStatus.PENDING,
+                SubmissionStatus.APPROVED,
+                SubmissionStatus.REJECTED,
+            }, f"unexpected submitted-status set: {statuses}"
+            if not row.submitted:
+                return False
+        elif isinstance(expected, (str, int, bool)):
+            if getattr(row, key) != expected:
+                return False
+        else:
+            raise AssertionError(
+                f"matcher does not support where clause {key}={expected!r}"
+            )
+    return True
+
+
+def _fake_graph_db(
+    *,
+    owner_id: str,
+    library_rows: list[_LibraryRow],
+) -> tuple[MagicMock, MagicMock]:
+    """Build AgentGraph/LibraryAgent prisma doubles that honour their where-clause.
+
+    The graph itself always exists and is owned by `owner_id`; the AgentGraph
+    lookup returns it only when the where-clause's ownership scoping matches,
+    which is what `get_graph()` relies on for the ownership tier.
+    """
+    db_graph = _make_mock_db_graph(owner_id)
+
+    async def find_first_graph(**kwargs: Any) -> MagicMock | None:
+        where = kwargs["where"]
+        if where.get("id") != db_graph.id:
+            return None
+        if "version" in where and where["version"] != db_graph.version:
+            return None
+        if "userId" in where and where["userId"] != owner_id:
+            return None
+        return db_graph
+
+    async def find_first_library(**kwargs: Any) -> _LibraryRow | None:
+        matches = [
+            row for row in library_rows if _library_row_matches(row, kwargs["where"])
+        ]
+        matches.sort(key=lambda row: row.agentGraphVersion, reverse=True)
+        return matches[0] if matches else None
+
+    ag_prisma = MagicMock()
+    ag_prisma.return_value.find_first = AsyncMock(side_effect=find_first_graph)
+    lib_prisma = MagicMock()
+    lib_prisma.return_value.find_first = AsyncMock(side_effect=find_first_library)
+    return ag_prisma, lib_prisma
+
+
+# Every combination of (owner / not owner) x (in library / not) x (submitted /
+# not submitted). Access is expected iff the caller owns the graph, or has it
+# in their library AND the version was submitted to the marketplace.
+@pytest.mark.parametrize(
+    ("is_owner", "in_library", "submitted", "expect_access"),
+    [
+        (True, True, True, True),
+        (True, True, False, True),
+        (True, False, True, True),
+        (True, False, False, True),
+        (False, True, True, True),
+        (False, True, False, False),
+        (False, False, True, False),
+        (False, False, False, False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_get_graph_non_owner_approved_marketplace_agent() -> None:
-    """A non-owner should be able to access a graph that has an APPROVED
-    marketplace listing.  This is the normal marketplace download flow."""
+async def test_get_graph_access_matrix(
+    is_owner: bool, in_library: bool, submitted: bool, expect_access: bool
+) -> None:
     owner_id = "owner-user-id"
-    requester_id = "different-user-id"
+    requester_id = owner_id if is_owner else "different-user-id"
     graph_id = "graph-id"
-    mock_graph = _make_mock_db_graph(owner_id)
     mock_graph_model = MagicMock(name="GraphModel")
 
-    mock_listing = MagicMock()
-    mock_listing.AgentGraph = mock_graph
+    library_rows = (
+        [
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=submitted,
+                agent_graph=_make_mock_db_graph(owner_id),
+            )
+        ]
+        if in_library
+        else []
+    )
+    ag_prisma, lib_prisma = _fake_graph_db(owner_id=owner_id, library_rows=library_rows)
 
     with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
         patch(
             "backend.data.graph.GraphModel.from_db",
             return_value=mock_graph_model,
         ),
     ):
-        # First lookup (owned graph) returns None — requester != owner
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # Marketplace fallback finds an APPROVED listing
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=mock_listing)
+        result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
 
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=requester_id,
-        )
+    assert (result is not None) is expect_access, (
+        f"owner={is_owner} in_library={in_library} submitted={submitted} "
+        f"should {'grant' if expect_access else 'deny'} access"
+    )
 
-    assert result is not None, "Non-owner should access APPROVED marketplace agent"
+
+@pytest.mark.asyncio
+async def test_get_graph_in_library_but_never_submitted_denied() -> None:
+    """The graph version sits in the user's library but was never submitted to
+    the marketplace. Library membership alone must not grant access."""
+    requester_id = "library-user-id"
+    graph_id = "graph-id"
+
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=False,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
+
+    assert result is None, "Library membership without a submission must be denied"
+
+    lib_where = lib_prisma.return_value.find_first.await_args.kwargs["where"]
+    assert lib_where["userId"] == requester_id
+    assert lib_where["agentGraphId"] == graph_id
+    assert lib_where["agentGraphVersion"] == 1
+    assert lib_where["isDeleted"] is False
+    assert lib_where["isArchived"] is False
+    # The submission requirement must be part of the same query, so the two
+    # halves can never resolve to different graph versions.
+    submitted_statuses = {
+        clause["submissionStatus"]
+        for clause in lib_where["AgentGraph"]["is"]["StoreListingVersions"]["some"][
+            "OR"
+        ]
+    }
+    assert SubmissionStatus.DRAFT not in submitted_statuses
+
+
+@pytest.mark.asyncio
+async def test_get_graph_submitted_but_not_in_library_denied() -> None:
+    """The graph version was submitted to (and approved on) the marketplace,
+    but the user never added it to their library. Denied."""
+    requester_id = "different-user-id"
+    graph_id = "graph-id"
+
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            # Submitted, in *someone else's* library — not the requester's.
+            _LibraryRow(
+                user_id="some-other-user-id",
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
+
+    assert result is None, "A marketplace listing alone must not grant graph access"
 
 
 @pytest.mark.asyncio
 async def test_get_graph_non_owner_pending_not_in_library_denied() -> None:
-    """A non-owner with no library membership and no APPROVED marketplace
-    listing must be denied access."""
+    """A non-owner with no library membership and no marketplace submission
+    must be denied access."""
     requester_id = "different-user-id"
     graph_id = "graph-id"
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
         patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
     ):
         mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
         mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
 
         result = await get_graph(
@@ -1049,14 +1235,10 @@ async def test_get_graph_non_owner_pending_not_in_library_denied() -> None:
     ), "User without ownership, marketplace, or library access must be denied"
 
 
-# --------------- Library membership grants graph access --------------- #
-# "You added it, you keep it" — product decision from SECRT-2167.
-
-
 @pytest.mark.asyncio
-async def test_get_graph_library_member_can_access_unpublished() -> None:
-    """A user who has the agent in their library should be able to access it
-    even if it's no longer published in the marketplace."""
+async def test_get_graph_library_member_can_access_submitted_agent() -> None:
+    """A user who downloaded a marketplace agent keeps access to that version
+    even after the listing is taken down — the submission still happened."""
     requester_id = "library-user-id"
     graph_id = "graph-id"
     mock_graph = _make_mock_db_graph("original-creator-id")
@@ -1067,9 +1249,6 @@ async def test_get_graph_library_member_can_access_unpublished() -> None:
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
         patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
         patch(
             "backend.data.graph.GraphModel.from_db",
@@ -1078,9 +1257,7 @@ async def test_get_graph_library_member_can_access_unpublished() -> None:
     ):
         # Not owned
         mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # Not in marketplace (unpublished)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # But IS in user's library
+        # In the user's library, and the version was submitted
         mock_lib_prisma.return_value.find_first = AsyncMock(
             return_value=mock_library_agent
         )
@@ -1091,7 +1268,7 @@ async def test_get_graph_library_member_can_access_unpublished() -> None:
             user_id=requester_id,
         )
 
-    assert result is mock_graph_model, "Library member should access unpublished agent"
+    assert result is mock_graph_model, "Library member should access submitted agent"
 
     # Verify library query filters on non-deleted, non-archived
     lib_call = mock_lib_prisma.return_value.find_first
@@ -1107,54 +1284,79 @@ async def test_get_graph_library_member_can_access_unpublished() -> None:
 @pytest.mark.asyncio
 async def test_get_graph_deleted_library_agent_denied() -> None:
     """If the user soft-deleted the agent from their library, they should
-    NOT get access via the library fallback."""
+    NOT get access, even though the version was submitted."""
     requester_id = "library-user-id"
     graph_id = "graph-id"
 
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # Library query returns None because isDeleted=False filter excludes it
-        mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                is_deleted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
 
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=requester_id,
-        )
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
 
     assert result is None, "Deleted library agent should not grant graph access"
 
 
 @pytest.mark.asyncio
-async def test_get_graph_anonymous_approved_marketplace_access() -> None:
-    """Anonymous users (user_id=None) should still access APPROVED marketplace
-    agents — the marketplace fallback doesn't require authentication."""
+async def test_get_graph_archived_library_agent_denied() -> None:
+    """If the user archived the agent in their library, they should
+    NOT get access, even though the version was submitted."""
+    requester_id = "library-user-id"
     graph_id = "graph-id"
-    mock_graph = _make_mock_db_graph("creator-id")
-    mock_graph_model = MagicMock(name="GraphModel")
 
-    mock_listing = MagicMock()
-    mock_listing.AgentGraph = mock_graph
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                is_archived=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=1, user_id=requester_id)
+
+    assert result is None, "Archived library agent should not grant graph access"
+
+
+@pytest.mark.asyncio
+async def test_get_graph_anonymous_denied_for_submitted_graph() -> None:
+    """Anonymous callers (user_id=None) have no library, so they can never
+    satisfy the access rule — not even for an approved marketplace agent.
+
+    The public marketplace download path authorizes itself against the
+    StoreListingVersion and calls get_graph with skip_access_check instead;
+    see `store.db.get_agent()`.
+    """
+    graph_id = "graph-id"
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
-        patch(
-            "backend.data.graph.GraphModel.from_db",
-            return_value=mock_graph_model,
-        ),
+        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
     ):
         mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=mock_listing)
 
         result = await get_graph(
             graph_id=graph_id,
@@ -1162,26 +1364,21 @@ async def test_get_graph_anonymous_approved_marketplace_access() -> None:
             user_id=None,
         )
 
-    assert (
-        result is mock_graph_model
-    ), "Anonymous user should access APPROVED marketplace agent"
+    assert result is None, "Anonymous callers must not reach a graph via get_graph"
+    mock_lib_prisma.return_value.find_first.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_get_graph_library_fallback_not_used_for_anonymous() -> None:
     """Anonymous requests (user_id=None) must not trigger the library
-    fallback — there's no user to check library membership for."""
+    lookup — there's no user to check library membership for."""
     graph_id = "graph-id"
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
         patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
     ):
         mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
 
         result = await get_graph(
             graph_id=graph_id,
@@ -1195,8 +1392,40 @@ async def test_get_graph_library_fallback_not_used_for_anonymous() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_graph_skip_access_check_bypasses_library_lookup() -> None:
+    """`skip_access_check=True` fetches the row directly. Callers that use it
+    (the executor, the marketplace install/download paths) have authorized the
+    read themselves, so the library rule must not be applied on top."""
+    graph_id = "graph-id"
+    mock_graph = _make_mock_db_graph("original-creator-id")
+    mock_graph_model = MagicMock(name="GraphModel")
+
+    with (
+        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
+        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
+        patch(
+            "backend.data.graph.GraphModel.from_db",
+            return_value=mock_graph_model,
+        ),
+    ):
+        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=mock_graph)
+
+        result = await get_graph(
+            graph_id=graph_id,
+            version=1,
+            user_id="unrelated-user-id",
+            skip_access_check=True,
+        )
+
+    assert result is mock_graph_model
+    ag_where = mock_ag_prisma.return_value.find_first.await_args.kwargs["where"]
+    assert "userId" not in ag_where, "skip_access_check must not scope by owner"
+    mock_lib_prisma.return_value.find_first.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_graph_library_not_queried_when_owned() -> None:
-    """If the user owns the graph, the library fallback should NOT be
+    """If the user owns the graph, the library lookup should NOT be
     triggered — ownership is sufficient."""
     owner_id = "owner-user-id"
     graph_id = "graph-id"
@@ -1205,9 +1434,6 @@ async def test_get_graph_library_not_queried_when_owned() -> None:
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
         patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
         patch(
             "backend.data.graph.GraphModel.from_db",
@@ -1224,74 +1450,7 @@ async def test_get_graph_library_not_queried_when_owned() -> None:
         )
 
     assert result is mock_graph_model
-    # Neither marketplace nor library should be queried
-    mock_slv_prisma.return_value.find_first.assert_not_called()
     mock_lib_prisma.return_value.find_first.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_get_graph_library_not_queried_when_marketplace_approved() -> None:
-    """If the graph is APPROVED in the marketplace, the library fallback
-    should NOT be triggered — marketplace access is sufficient."""
-    requester_id = "different-user-id"
-    graph_id = "graph-id"
-    mock_graph = _make_mock_db_graph("original-creator-id")
-    mock_graph_model = MagicMock(name="GraphModel")
-
-    mock_listing = MagicMock()
-    mock_listing.AgentGraph = mock_graph
-
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-        patch(
-            "backend.data.graph.GraphModel.from_db",
-            return_value=mock_graph_model,
-        ),
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=mock_listing)
-
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=requester_id,
-        )
-
-    assert result is mock_graph_model
-    # Library should not be queried — marketplace was sufficient
-    mock_lib_prisma.return_value.find_first.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_get_graph_archived_library_agent_denied() -> None:
-    """If the user archived the agent in their library, they should
-    NOT get access via the library fallback."""
-    requester_id = "library-user-id"
-    graph_id = "graph-id"
-
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # Library query returns None because isArchived=False filter excludes it
-        mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
-
-        result = await get_graph(
-            graph_id=graph_id,
-            version=1,
-            user_id=requester_id,
-        )
-
-    assert result is None, "Archived library agent should not grant graph access"
 
 
 @pytest.mark.asyncio
@@ -1306,13 +1465,9 @@ async def test_get_graph_library_with_null_agent_graph_denied() -> None:
 
     with (
         patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
         patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
     ):
         mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
         mock_lib_prisma.return_value.find_first = AsyncMock(
             return_value=mock_library_agent
         )
@@ -1330,36 +1485,34 @@ async def test_get_graph_library_with_null_agent_graph_denied() -> None:
 
 @pytest.mark.asyncio
 async def test_get_graph_library_wrong_version_denied() -> None:
-    """Having version 1 in your library must NOT grant access to version 2."""
+    """Having version 1 in your library must NOT grant access to version 2,
+    even when both versions were submitted to the marketplace."""
     requester_id = "library-user-id"
     graph_id = "graph-id"
 
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # Library has version 1 but we're requesting version 2 —
-        # the where clause includes agentGraphVersion so this returns None
-        mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
 
-        result = await get_graph(
-            graph_id=graph_id,
-            version=2,
-            user_id=requester_id,
-        )
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=2, user_id=requester_id)
 
     assert (
         result is None
     ), "Library agent for version 1 must not grant access to version 2"
-    # Verify version was included in the library query
-    lib_call = mock_lib_prisma.return_value.find_first
-    lib_call.assert_called_once()
-    lib_where = lib_call.call_args.kwargs["where"]
+    lib_where = lib_prisma.return_value.find_first.await_args.kwargs["where"]
     assert lib_where["agentGraphVersion"] == 2
 
 
@@ -1370,25 +1523,24 @@ async def test_library_v1_does_not_grant_access_to_pending_v2() -> None:
     requester_id = "regular-user-id"
     graph_id = "graph-id"
 
-    with (
-        patch("backend.data.graph.AgentGraph.prisma") as mock_ag_prisma,
-        patch(
-            "backend.data.graph.StoreListingVersion.prisma",
-        ) as mock_slv_prisma,
-        patch("backend.data.graph.LibraryAgent.prisma") as mock_lib_prisma,
-    ):
-        # Not owned
-        mock_ag_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # v2 is not APPROVED in marketplace
-        mock_slv_prisma.return_value.find_first = AsyncMock(return_value=None)
-        # Library has v1 but not v2 — version filter excludes it
-        mock_lib_prisma.return_value.find_first = AsyncMock(return_value=None)
+    ag_prisma, lib_prisma = _fake_graph_db(
+        owner_id="original-creator-id",
+        library_rows=[
+            _LibraryRow(
+                user_id=requester_id,
+                graph_id=graph_id,
+                version=1,
+                submitted=True,
+                agent_graph=_make_mock_db_graph("original-creator-id"),
+            )
+        ],
+    )
 
-        result = await get_graph(
-            graph_id=graph_id,
-            version=2,
-            user_id=requester_id,
-        )
+    with (
+        patch("backend.data.graph.AgentGraph.prisma", ag_prisma),
+        patch("backend.data.graph.LibraryAgent.prisma", lib_prisma),
+    ):
+        result = await get_graph(graph_id=graph_id, version=2, user_id=requester_id)
 
     assert result is None, "Regular user with v1 in library must not access pending v2"
 

--- a/autogpt_platform/backend/backend/data/graph_test.py
+++ b/autogpt_platform/backend/backend/data/graph_test.py
@@ -9,6 +9,7 @@ import pytest
 from prisma.enums import SubmissionStatus
 from pytest_snapshot.plugin import Snapshot
 
+import backend.api.features.library.db as library_db
 import backend.api.features.store.model as store
 from backend.api.model import CreateGraph
 from backend.blocks._base import BlockSchema, BlockSchemaInput
@@ -406,12 +407,13 @@ async def test_access_store_listing_graph(server: SpinTestServer):
         categories=[],
     )
 
-    # First we check the graph an not be accessed by a different user
+    # First we check the graph can not be accessed by a different user
+    other_user = await create_test_user(alt_user=True)
     with pytest.raises(fastapi.exceptions.HTTPException) as exc_info:
         await server.agent_server.test_get_graph(
             created_graph.id,
             created_graph.version,
-            "3e53486c-cf57-477e-ba2a-cb02dc828e1b",
+            other_user.id,
         )
     assert exc_info.value.status_code == 404
     assert "Graph" in str(exc_info.value.detail)
@@ -432,19 +434,30 @@ async def test_access_store_listing_graph(server: SpinTestServer):
 
     assert slv_id is not None
 
-    admin_user = await create_test_user(alt_user=True)
     await server.agent_server.test_review_store_listing(
         store.ReviewSubmissionRequest(
             store_listing_version_id=slv_id,
             is_approved=True,
             comments="Test comments",
         ),
-        user_id=admin_user.id,
+        user_id=other_user.id,
     )
 
-    # Now we check the graph can be accessed by a user that does not own the graph
+    # An approved listing on its own grants nothing: without a library entry
+    # the non-owner still can't read the graph.
+    with pytest.raises(fastapi.exceptions.HTTPException) as exc_info:
+        await server.agent_server.test_get_graph(
+            created_graph.id, created_graph.version, other_user.id
+        )
+    assert exc_info.value.status_code == 404
+
+    # Adding it to their library is what unlocks it — and the install itself
+    # has to work without prior access to the graph.
+    await library_db.add_store_agent_to_library(
+        store_listing_version_id=slv_id, user_id=other_user.id
+    )
     got_graph = await server.agent_server.test_get_graph(
-        created_graph.id, created_graph.version, "3e53486c-cf57-477e-ba2a-cb02dc828e1b"
+        created_graph.id, created_graph.version, other_user.id
     )
     assert got_graph is not None
 

--- a/autogpt_platform/backend/backend/executor/automod/manager.py
+++ b/autogpt_platform/backend/backend/executor/automod/manager.py
@@ -53,16 +53,30 @@ class AutoModManager:
             return None
 
         # Get graph model and collect all inputs
-        # The execution is already authorized; without this, a graph the user
-        # may run but not read reads back as None and skips moderation.
         graph_model = await db_client.get_graph(
             graph_exec.graph_id,
             user_id=graph_exec.user_id,
             version=graph_exec.graph_version,
-            skip_access_check=True,
         )
 
-        if not graph_model or not graph_model.nodes:
+        # No graph means the inputs can't be collected at all — that is
+        # moderation failing to run, not content passing it.
+        if not graph_model:
+            logger.warning(
+                f"Cannot moderate inputs for graph execution "
+                f"{graph_exec.graph_exec_id}: graph #{graph_exec.graph_id} "
+                f"v{graph_exec.graph_version} is gone or not readable by its runner"
+            )
+            if self.config.fail_open:
+                return None
+            return ModerationError(
+                message="Execution failed due to input content moderation error",
+                user_id=graph_exec.user_id,
+                graph_exec_id=graph_exec.graph_exec_id,
+                moderation_type="input",
+            )
+
+        if not graph_model.nodes:
             return None
 
         all_inputs = []

--- a/autogpt_platform/backend/backend/executor/automod/manager.py
+++ b/autogpt_platform/backend/backend/executor/automod/manager.py
@@ -52,20 +52,24 @@ class AutoModManager:
             logger.debug(f"AutoMod feature not enabled for user {graph_exec.user_id}")
             return None
 
-        # Get graph model and collect all inputs
+        # Get graph model and collect all inputs.
+        # add_graph_execution() already authorized this run, and SECRT-1125
+        # lets a marketplace sub-agent run without read access — gating the
+        # read here would deny exactly those runs.
         graph_model = await db_client.get_graph(
             graph_exec.graph_id,
             user_id=graph_exec.user_id,
             version=graph_exec.graph_version,
+            skip_access_check=True,
         )
 
-        # No graph means the inputs can't be collected at all — that is
-        # moderation failing to run, not content passing it.
+        # The graph version is gone, so the inputs can't be collected at all —
+        # that is moderation failing to run, not content passing it.
         if not graph_model:
             logger.warning(
                 f"Cannot moderate inputs for graph execution "
                 f"{graph_exec.graph_exec_id}: graph #{graph_exec.graph_id} "
-                f"v{graph_exec.graph_version} is gone or not readable by its runner"
+                f"v{graph_exec.graph_version} no longer exists"
             )
             if self.config.fail_open:
                 return None

--- a/autogpt_platform/backend/backend/executor/automod/manager.py
+++ b/autogpt_platform/backend/backend/executor/automod/manager.py
@@ -53,10 +53,13 @@ class AutoModManager:
             return None
 
         # Get graph model and collect all inputs
+        # The execution is already authorized; without this, a graph the user
+        # may run but not read reads back as None and skips moderation.
         graph_model = await db_client.get_graph(
             graph_exec.graph_id,
             user_id=graph_exec.user_id,
             version=graph_exec.graph_version,
+            skip_access_check=True,
         )
 
         if not graph_model or not graph_model.nodes:

--- a/autogpt_platform/backend/backend/executor/automod/manager_test.py
+++ b/autogpt_platform/backend/backend/executor/automod/manager_test.py
@@ -1,0 +1,99 @@
+"""Input-moderation behaviour when the graph can't be resolved.
+
+`moderate_graph_execution_inputs()` needs the graph's nodes to collect the
+inputs it moderates. When the lookup comes back empty it has to decide between
+letting an unmoderated execution through and killing a run it cannot vet; the
+`automod_fail_open` setting is what makes that an operator choice rather than
+an accident of control flow.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.util.exceptions import ModerationError
+
+from .manager import AutoModManager
+
+
+@pytest.mark.asyncio
+async def test_missing_graph_fails_closed_by_default() -> None:
+    """A graph that doesn't resolve means moderation could not run. Reporting
+    that as "passed" would let the execution through unvetted."""
+    manager, db_client = _manager_with_graph(None, fail_open=False)
+
+    result = await manager.moderate_graph_execution_inputs(
+        db_client=db_client, graph_exec=_graph_exec()
+    )
+
+    assert isinstance(result, ModerationError)
+
+
+@pytest.mark.asyncio
+async def test_missing_graph_passes_when_fail_open_is_set() -> None:
+    """`automod_fail_open` is the operator's explicit choice to keep executions
+    running when moderation is unavailable."""
+    manager, db_client = _manager_with_graph(None, fail_open=True)
+
+    result = await manager.moderate_graph_execution_inputs(
+        db_client=db_client, graph_exec=_graph_exec()
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_graph_without_nodes_passes() -> None:
+    """An empty graph is not a failure to moderate -- there is genuinely
+    nothing to moderate -- so it must not take the fail-closed branch."""
+    manager, db_client = _manager_with_graph(MagicMock(nodes=[]), fail_open=False)
+
+    result = await manager.moderate_graph_execution_inputs(
+        db_client=db_client, graph_exec=_graph_exec()
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_graph_lookup_is_scoped_to_the_running_user() -> None:
+    """Whatever the resolution of the sub-agent case, the lookup must stay
+    tied to the user the execution runs as."""
+    manager, db_client = _manager_with_graph(MagicMock(nodes=[]), fail_open=False)
+
+    await manager.moderate_graph_execution_inputs(
+        db_client=db_client, graph_exec=_graph_exec()
+    )
+
+    assert db_client.get_graph.await_args.kwargs["user_id"] == "runner-user-id"
+    assert db_client.get_graph.await_args.kwargs["version"] == 3
+
+
+def _graph_exec() -> MagicMock:
+    return MagicMock(
+        user_id="runner-user-id",
+        graph_id="graph-id",
+        graph_version=3,
+        graph_exec_id="exec-id",
+        nodes_input_masks=None,
+    )
+
+
+def _manager_with_graph(graph, *, fail_open: bool) -> tuple[AutoModManager, MagicMock]:
+    with patch.object(AutoModManager, "_load_config") as load_config:
+        load_config.return_value = MagicMock(enabled=True, fail_open=fail_open)
+        manager = AutoModManager()
+
+    db_client = MagicMock()
+    db_client.get_graph = AsyncMock(return_value=graph)
+    return manager, db_client
+
+
+@pytest.fixture(autouse=True)
+def _automod_flag_enabled():
+    with patch(
+        "backend.executor.automod.manager.is_feature_enabled",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        yield

--- a/autogpt_platform/backend/backend/executor/automod/manager_test.py
+++ b/autogpt_platform/backend/backend/executor/automod/manager_test.py
@@ -1,10 +1,11 @@
 """Input-moderation behaviour when the graph can't be resolved.
 
 `moderate_graph_execution_inputs()` needs the graph's nodes to collect the
-inputs it moderates. When the lookup comes back empty it has to decide between
-letting an unmoderated execution through and killing a run it cannot vet; the
-`automod_fail_open` setting is what makes that an operator choice rather than
-an accident of control flow.
+inputs it moderates. The read bypasses the caller's access check — the run is
+already authorized by then — so an empty lookup means the version is gone, not
+that the runner may not read it. Whether that kills the run or lets it through
+unmoderated is the `automod_fail_open` operator setting, not an accident of
+control flow.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,7 +19,7 @@ from .manager import AutoModManager
 
 @pytest.mark.asyncio
 async def test_missing_graph_fails_closed_by_default() -> None:
-    """A graph that doesn't resolve means moderation could not run. Reporting
+    """A graph that no longer exists means moderation could not run. Reporting
     that as "passed" would let the execution through unvetted."""
     manager, db_client = _manager_with_graph(None, fail_open=False)
 
@@ -56,15 +57,22 @@ async def test_graph_without_nodes_passes() -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_lookup_is_scoped_to_the_running_user() -> None:
-    """Whatever the resolution of the sub-agent case, the lookup must stay
-    tied to the user the execution runs as."""
-    manager, db_client = _manager_with_graph(MagicMock(nodes=[]), fail_open=False)
+async def test_marketplace_sub_agent_run_is_moderated_not_denied() -> None:
+    """SECRT-1125 lets a user execute a marketplace graph they cannot read, as
+    a sub-agent. Resolving the graph through their read gate would return None
+    for exactly those runs and fail them closed on an unrelated error, so the
+    read is bypassed: the run was already authorized by add_graph_execution().
+    """
+    graph = MagicMock(nodes=[])
+    manager, db_client = _manager_with_graph(graph, fail_open=False)
 
-    await manager.moderate_graph_execution_inputs(
+    result = await manager.moderate_graph_execution_inputs(
         db_client=db_client, graph_exec=_graph_exec()
     )
 
+    assert result is None, "an authorized sub-agent run must not be failed here"
+    assert db_client.get_graph.await_args.kwargs["skip_access_check"] is True
+    # Still the runner's own execution, and still version-specific.
     assert db_client.get_graph.await_args.kwargs["user_id"] == "runner-user-id"
     assert db_client.get_graph.await_args.kwargs["version"] == 3
 

--- a/autogpt_platform/backend/backend/executor/utils.py
+++ b/autogpt_platform/backend/backend/executor/utils.py
@@ -1415,7 +1415,11 @@ async def add_graph_execution(
     # Generate execution context if it's not provided
     if execution_context is None:
         user = await udb.get_user_by_id(user_id)
-        settings = await gdb.get_graph_settings(user_id=user_id, graph_id=graph_id)
+        settings = await gdb.get_graph_settings(
+            user_id=user_id,
+            graph_id=graph_id,
+            graph_version=graph_exec.graph_version,
+        )
         workspace = await wdb.get_or_create_workspace(user_id)
 
         execution_context = ExecutionContext(

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -13031,7 +13031,7 @@
       "post": {
         "tags": ["v2", "admin", "store", "admin"],
         "summary": "Admin Add Pending Agent to Library",
-        "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can load the graph because get_graph() checks library\nmembership as a fallback: \"you added it, you keep it.\"",
+        "description": "Add a pending marketplace agent to the admin's library for review.\nUses admin-level access to bypass marketplace APPROVED-only checks.\n\nThe builder can then load the graph: get_graph() grants a library\nversion that was submitted, and PENDING counts as submitted.",
         "operationId": "postV2Admin add pending agent to library",
         "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [


### PR DESCRIPTION
This PR tightens `get_graph()`'s read-access check: a graph version is now readable only if you own it (or it's org/team-visible), or it's *both* in your library *and* has been submitted to the marketplace — closing two tiers that previously granted read access on their own. Before this PR, an APPROVED marketplace listing opened the full graph (nodes, links, structure) to **any** caller including unauthenticated ones, and library membership alone opened a graph that had never been offered publicly.

### Why / What / How

**What.** Read access to a graph version is now:

```
owner (or org/team-visible)
  OR (the version is in the caller's library
      AND that version has been submitted to the marketplace)
```

Neither half of the second clause grants anything on its own.

**How.** The two removed tiers collapse into a single joined query, `graph_in_library_filter()` in `backend/data/graph.py`. It is one query on purpose: `AgentGraph` on a `LibraryAgent` row is the exact `(id, version)` pair, so the `StoreListingVersions.some` clause can only match a submission of *that* version. Checking the two halves in separate queries would let them resolve to different versions when `version is None`.

**"Submitted" means the listing version left `DRAFT`** — `PENDING`, `APPROVED` and `REJECTED` all count. That is deliberate: the admin review flow adds a **PENDING** agent to the reviewer's library and then opens it in the builder (`store_admin_routes.admin_add_agent_to_library`), so requiring `APPROVED` would break review. Deleted/unavailable listings still count as submitted — taking a listing down does not retroactively un-submit a version, and users who downloaded it while it was live keep their copy.

### Changes 🏗️

- **`backend/data/graph.py`** — `get_graph()` loses the standalone marketplace tier and the standalone library tier; both are replaced by `graph_in_library_filter()`. The ownership/org/team tier and `skip_access_check` are unchanged. `get_graph_as_admin()` is untouched.
- **`backend/api/features/store/db.py`** — `get_agent()` serves the **unauthenticated** `GET /store/listings/versions/{id}/graph/download` endpoint and used to rely on the removed marketplace tier. It now authorizes against the listing itself (`installable_store_version_where()`: APPROVED + available + not deleted + listing not deleted) and passes `skip_access_check`. This is a tightening: previously *any* listing version would download as long as *some* approved version existed for that graph version. **User-visible:** a public download link for a retired version (`isAvailable=False`) now 404s instead of serving the graph.
- **`backend/api/features/library/_add_to_library.py`** — `resolve_graph_model_for_library()` (marketplace install) reads the graph precisely because the user does *not* have it in their library yet, so `get_graph()` cannot authorize it. `resolve_store_version_for_library(admin=False)` already matched the listing against `installable_store_version_where()`; the non-admin path now passes `skip_access_check` on the back of that. The admin path (`get_graph_as_admin`) is unchanged.
- **`backend/executor/automod/manager.py`** — input moderation collapsed "no graph" into `if not graph_model or not graph_model.nodes: return None`, i.e. an unresolvable graph read back as *moderation passed*. Being unable to gather the inputs is moderation failing to **run**, not content passing it, so it now returns a `ModerationError`, gated on the existing `automod_fail_open` setting (default `False`). An empty node list still passes — there is genuinely nothing to moderate. The read passes `skip_access_check=True`: `add_graph_execution()` has already authorized the run by the time moderation happens, and gating it here would deny the marketplace sub-agent runs SECRT-1125 permits. `None` therefore means only that the graph version is gone.
- **`backend/data/graph.py` (`get_graph_settings`)** — now asks the same membership question as the two authorization predicates. Since archived rows grant read and execute, an archived agent fired by a webhook or schedule was falling back to `GraphSettings()` defaults, silently flipping the user's `sensitive_action_safe_mode` from `True` to `False`. It takes the executing `graph_version` and resolves settings against that version's own library entry, falling back to the user's live entries only when the running version has none — the owner case, where someone runs a version they never added to their library.
- **Tests** — rewritten `get_graph` access-control truth table in `backend/data/graph_test.py`, including a parametrized matrix over all 8 combinations of (owner / not) × (in library / not) × (submitted / not), driven through prisma doubles that actually evaluate the where-clause rather than returning canned rows. Plus new coverage for `store.db.get_agent()`.

### Reviewer notes — things worth a decision

**1. ~~A second, divergent copy of this check exists.~~ Aligned.** `validate_graph_execution_permissions()` implemented its own looser rule, so a library entry for a never-submitted version lost *read* access but kept *execute* permission — the user could pay for a run whose results they could never open. It now queries `graph_in_library_filter()` itself rather than restating the rule, so the two cannot drift. **The invariant is recorded at the check: execution must never be more permissive than read access.** The one sanctioned exception is **SECRT-1125** — a marketplace-published graph may be executed as a sub-agent without read, because the graph and its run's intermediate outputs would otherwise let the caller reconstruct a non-public graph.

**2. ~~Newly-denied access silently deactivates webhook presets.~~ Fixed.** `backend/api/features/integrations/router.py` (~L1253) called `get_graph()` when a webhook fires and, on denial, **wrote** `is_active=False` to the preset — a one-way write the user must undo by hand, and this PR widens the set of denials substantially. That call now passes `skip_access_check=True`: the read only locates the webhook input node, and execution remains gated downstream at `add_graph_execution()` → `validate_and_construct_node_execution_input()` → `validate_graph_execution_permissions()`. `None` there now means the graph version is genuinely gone, which is the case the deactivation was written for. Scoped to this call site: the justification is the downstream execution-permission gate on this path, not the preset's existence.

**3. Viewing your own past runs can 404.** `v1.get_graph_execution` and `external/v1.get_graph_execution_results` re-check graph access before returning an execution's results. A user who ran a marketplace agent and later **deleted** it from their library previously kept access via the marketplace tier; now they don't. Archiving no longer has this effect — see the archive note below.

**4. `store.db.get_available_graph()` is a separate read path that bypasses all of this.** `GET /store/listings/versions/{id}/graph` (auth required, but no ownership/library/approval check) filters only on `isAvailable` + `isDeleted` — no `submissionStatus`. Any logged-in user holding a listing-version UUID gets a `200` for a DRAFT/PENDING/REJECTED submission.

  **Corrected scope:** this returns **metadata only**, not graph structure. Verified against a running stack: `nodes: 0` and `links: 0`, including for an APPROVED listing whose graph has 4 nodes. What it exposes is `name`, `description`, `instructions`, `input_schema`, `output_schema`, `credentials_input_schema`, and the owner's `user_id`/`organization_id`/`team_id` for an unpublished or rejected submission. An earlier version of this note said "graph outline", which overstated it. Pre-existing and unchanged by this PR; the follow-up ticket should use this narrower scope.

**5. Admin-added DRAFT submissions.** `resolve_store_version_for_library(admin=True)` does not filter on status, so an admin can add a `DRAFT` listing version to their library — and would then be denied when opening it in the builder. Reviews are `PENDING`, so this shouldn't bite in practice.

**6. Archiving hides, it does not revoke.** `isArchived` is deliberately **not** part of either authorization predicate — `isDeleted` is the membership signal. Archiving is a reversible library-tidying gesture (`library/db.py` filters it from lists and exposes it as a user toggle), so it must not cost the user run history, forking, scheduling or webhook presets. This applies to the owner-fallback query in `validate_graph_execution_permissions()` too. `get_graph_settings()` no longer filters archived rows either, but it resolves settings against the **version being run** rather than the highest live entry, so an archived version can be executed with its own safety settings without overriding another version's.

**7. `LibraryAgent.can_access_graph`** (`library/model.py:346`) is `AgentGraph.userId == agent.userId`, i.e. "created by this user". Despite the name it is a UI flag, not an authorization gate, and is unrelated to the check above.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit: all 8 combinations of (owner / not owner) × (in library / not) × (submitted / not). Both negative cases — *in library but never submitted* and *submitted but not in library* — are denied. The prisma doubles evaluate the where-clause rather than returning canned rows, so these prove the predicate, not the mock
  - [x] Unit: deleted / archived library rows, wrong-version library rows, null `AgentGraph` relation, anonymous callers, `skip_access_check` bypass
  - [x] Unit: `store.db.get_agent()` rejects a non-installable listing version without ever reading the graph, and passes `skip_access_check` for installable ones
  - [x] Integration (`test_access_store_listing_graph`, real Postgres): non-owner denied before listing → **still denied after APPROVAL** → allowed only once the agent is in their library. The last step also exercises the marketplace install path, which must resolve the graph for a user who by definition cannot yet read it
  - [x] **Manual:** download an approved agent from the marketplace UI and open it in the builder
  - [x] **Manual:** remove an agent from your library and confirm the builder now 404s on it
  - [x] **Manual:** admin review flow — add a PENDING submission to your library and open it in the builder
  - [x] **Manual:** unauthenticated `GET /store/listings/versions/{id}/graph/download` for an approved listing, and confirm a PENDING one 404s

> The four manual items were not run by me — they were executed against a local stack by `autogpt-pr-reviewer[bot]`'s QA pass on `8c19278` ([review](https://github.com/Significant-Gravitas/AutoGPT/pull/14205#pullrequestreview-5079081246)), 16 scenarios, all four passing. The sharpest evidence there is an isolated predicate proof: same library row, same graph, flip `submissionStatus` DRAFT→PENDING and nothing else — `404` → `200`.

> **CI note.** The first push was red on `test (3.11/3.12/3.13)` — one failing test, identically on all three: `test_access_store_listing_graph`, which asserted that an APPROVED listing *on its own* lets a non-owner read the graph. That is precisely the tier this PR removes, so the test encoded the pre-change contract. It was updated to the new rule and made strictly stronger (it now asserts the post-approval denial that did not exist before) rather than relaxed. 13211 tests passed alongside it.
>
> pytest is not run locally in this worktree. Every touched test module was imported (ruling out stale imports), 43 synchronous bodies and 41 DB-free async bodies were executed directly — 0 failures. `test_access_store_listing_graph` needs `SpinTestServer` + Postgres and was **not** executed locally; CI is the authority on it.

> **Verified (settings-resolution fix).** pytest does run against a local Postgres after all, and the settings fix was built on that. I reproduced the reported defect against the real `get_graph_settings` on a real database before changing anything, then executed `data/graph_test.py` (99), `executions/review/review_routes_test.py` (15), `executor/utils_test.py` (50), `util/architecture_test.py` (3) and `blocks/test/test_block.py` (1060 passed, 84 skipped). Three mutations of the fix were made and each failed exactly the regression rows that encode it. Evidence in [this comment](https://github.com/Significant-Gravitas/AutoGPT/pull/14205#issuecomment-5551834339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


