### PR TITLE
fix(platform): bound expert autonomy and live state

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/models.py
+++ b/autogpt_platform/backend/backend/api/features/experts/models.py
@@ -28,9 +28,7 @@ ExpertWorkStatus = Literal[
     "failed",
 ]
 ExpertWorkConfidence = Literal["verified", "likely", "unknown", "disqualified"]
-ProjectArtifactVerification = Literal[
-    "verified", "likely", "unknown", "disqualified"
-]
+ProjectArtifactVerification = Literal["verified", "likely", "unknown", "disqualified"]
 
 AI_DISCLOSURE_RULE = "The expert discloses that it is AI when acting externally."
 EXTERNAL_ACTION_APPROVAL_RULE = "External actions require approval."

--- a/autogpt_platform/backend/backend/copilot/autonomy_budget.py
+++ b/autogpt_platform/backend/backend/copilot/autonomy_budget.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+FLAGGED_AUTONOMY_MAX_TOOL_CALLS = 36
+FLAGGED_AUTONOMY_MAX_ELAPSED_SECONDS = 8 * 60
+FLAGGED_AUTONOMY_MAX_AGENT_ROUNDS = 36
+FLAGGED_AUTONOMY_MAX_UNCHANGED_RESULTS = 2
+
+_NON_PROGRESS_TYPES = {
+    "error",
+    "input_validation_error",
+    "no_results",
+    "review_required",
+    "setup_requirements",
+}
+_NON_PROGRESS_STATUSES = {
+    "blocked",
+    "blocked_manager",
+    "cancelled",
+    "error",
+    "failed",
+    "incomplete",
+    "needs_setup",
+    "partial",
+    "rejected",
+}
+
+
+@dataclass
+class AutonomyDecision:
+    allowed: bool
+    reason: Literal["elapsed", "tool_calls", "unchanged"] | None = None
+    message: str | None = None
+
+
+@dataclass
+class _AutonomyState:
+    started_at: float
+    tool_calls: int = 0
+    last_non_progress: dict[str, str] = field(default_factory=dict)
+    unchanged_counts: dict[str, int] = field(default_factory=dict)
+
+
+_state: ContextVar[_AutonomyState | None] = ContextVar(
+    "expert_autonomy_budget", default=None
+)
+
+
+def start_autonomy_budget(*, enabled: bool) -> None:
+    _state.set(_AutonomyState(started_at=time.monotonic()) if enabled else None)
+
+
+def bounded_agent_rounds(configured: int, *, enabled: bool) -> int:
+    if not enabled:
+        return configured
+    return min(configured, FLAGGED_AUTONOMY_MAX_AGENT_ROUNDS)
+
+
+def before_tool(
+    tool_name: str, arguments: dict[str, Any] | None = None
+) -> AutonomyDecision:
+    state = _state.get()
+    if state is None:
+        return AutonomyDecision(allowed=True)
+
+    elapsed = time.monotonic() - state.started_at
+    if elapsed >= FLAGGED_AUTONOMY_MAX_ELAPSED_SECONDS:
+        return _stopped("elapsed")
+    if state.tool_calls >= FLAGGED_AUTONOMY_MAX_TOOL_CALLS:
+        return _stopped("tool_calls")
+    path_key = _path_key(tool_name, arguments)
+    if (
+        state.unchanged_counts.get(path_key, 0)
+        >= FLAGGED_AUTONOMY_MAX_UNCHANGED_RESULTS
+    ):
+        return _stopped("unchanged")
+
+    state.tool_calls += 1
+    return AutonomyDecision(allowed=True)
+
+
+def after_tool(
+    tool_name: str, result: Any, arguments: dict[str, Any] | None = None
+) -> None:
+    state = _state.get()
+    if state is None:
+        return
+    path_key = _path_key(tool_name, arguments)
+    fingerprint = _non_progress_fingerprint(result)
+    if fingerprint is None:
+        state.last_non_progress.pop(path_key, None)
+        state.unchanged_counts.pop(path_key, None)
+        return
+    if state.last_non_progress.get(path_key) == fingerprint:
+        state.unchanged_counts[path_key] = state.unchanged_counts.get(path_key, 1) + 1
+    else:
+        state.last_non_progress[path_key] = fingerprint
+        state.unchanged_counts[path_key] = 1
+
+
+def _path_key(tool_name: str, arguments: dict[str, Any] | None) -> str:
+    try:
+        encoded = json.dumps(arguments or {}, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        encoded = repr(arguments)
+    digest = hashlib.sha256(encoded.encode()).hexdigest()[:16]
+    return f"{tool_name}:{digest}"
+
+
+def _non_progress_fingerprint(result: Any) -> str | None:
+    payload = _payload(result)
+    response_type = str(payload.get("type", "")).lower()
+    status = str(payload.get("status", "")).lower()
+    is_error = bool(payload.get("isError")) or payload.get("success") is False
+    if (
+        not is_error
+        and response_type not in _NON_PROGRESS_TYPES
+        and status not in _NON_PROGRESS_STATUSES
+    ):
+        return None
+    stable = {
+        "type": response_type,
+        "status": status,
+        "error": str(payload.get("error", ""))[:300],
+        "blocker": str(payload.get("blocker", ""))[:300],
+        "message": str(payload.get("message", ""))[:300],
+    }
+    return json.dumps(stable, sort_keys=True)
+
+
+def _payload(result: Any) -> dict[str, Any]:
+    if hasattr(result, "model_dump"):
+        dumped = result.model_dump(mode="json", exclude_none=True)
+        if not isinstance(dumped, dict):
+            return {}
+        output = dumped.get("output")
+        if isinstance(output, str):
+            try:
+                nested = json.loads(output)
+                if isinstance(nested, dict):
+                    return {**nested, "success": dumped.get("success", True)}
+            except json.JSONDecodeError:
+                pass
+        return dumped
+    if isinstance(result, dict):
+        content = result.get("content")
+        if isinstance(content, list) and content:
+            first = content[0]
+            if isinstance(first, dict) and isinstance(first.get("text"), str):
+                try:
+                    nested = json.loads(first["text"])
+                    if isinstance(nested, dict):
+                        return {**nested, "isError": result.get("isError", False)}
+                except json.JSONDecodeError:
+                    pass
+        return result
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _stopped(
+    reason: Literal["elapsed", "tool_calls", "unchanged"],
+) -> AutonomyDecision:
+    reason_text = {
+        "elapsed": "this turn reached its elapsed-time limit",
+        "tool_calls": "this turn reached its tool-call limit",
+        "unchanged": "this tool returned the same blocked or failed state twice",
+    }[reason]
+    return AutonomyDecision(
+        allowed=False,
+        reason=reason,
+        message=(
+            f"STOP: {reason_text}. Do not retry this path in the current turn. "
+            "Finish now with a concise manager handoff containing: Delivered, "
+            "Blocked, the safest useful degraded fallback, and Next. Keep any "
+            "independent work moving in a later event-driven continuation."
+        ),
+    )

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -33,6 +33,7 @@ from backend.copilot.anthropic_rate_card import (
     compute_anthropic_cost_usd,
     get_max_output_tokens,
 )
+from backend.copilot.autonomy_budget import bounded_agent_rounds
 from backend.copilot.baseline.reasoning import (
     BaselineReasoningEmitter,
     anthropic_thinking_extra_body,
@@ -2135,6 +2136,7 @@ async def stream_chat_completion_baseline(
         sandbox=e2b_sandbox,
         sdk_cwd=working_dir,
         permissions=permissions,
+        autonomy_enabled=experts_enabled,
     )
 
     yield StreamStart(messageId=message_id, sessionId=session_id)
@@ -2203,6 +2205,9 @@ async def stream_chat_completion_baseline(
     # turn. Without this, earlier-round chatter would suppress a fallback
     # that should fire.
     text_len_before_final_round: list[int] = [0]
+    max_tool_rounds = bounded_agent_rounds(
+        config.agent_max_turns, enabled=experts_enabled
+    )
 
     async def _run_tool_call_loop() -> None:
         # Read/write the current session via ``_session_holder`` so this
@@ -2211,7 +2216,6 @@ async def stream_chat_completion_baseline(
         # but the holder is typed non-optional after the preflight guard
         # above.
         try:
-            max_tool_rounds = config.agent_max_turns
             async for loop_result in tool_call_loop(
                 messages=openai_messages,
                 tools=tools,
@@ -2394,9 +2398,7 @@ async def stream_chat_completion_baseline(
         # Either way, we check the terminal round's text contribution — an
         # empty one means the user got no explanation and we need to emit
         # the fallback notice.
-        budget_reached = bool(
-            loop_result and loop_result.iterations >= config.agent_max_turns
-        )
+        budget_reached = bool(loop_result and loop_result.iterations >= max_tool_rounds)
         if budget_reached:
             if loop_result and not loop_result.finished_naturally:
                 logger.warning(

--- a/autogpt_platform/backend/backend/copilot/context.py
+++ b/autogpt_platform/backend/backend/copilot/context.py
@@ -10,6 +10,7 @@ import re
 from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
+from backend.copilot.autonomy_budget import start_autonomy_budget
 from backend.copilot.model import ChatSession
 from backend.data.db_accessors import workspace_db
 from backend.util.workspace import WorkspaceManager
@@ -73,6 +74,7 @@ def set_execution_context(
     sandbox: "AsyncSandbox | None" = None,
     sdk_cwd: str | None = None,
     permissions: "CopilotPermissions | None" = None,
+    autonomy_enabled: bool = False,
 ) -> None:
     """Set per-turn context variables used by file-resolution tool handlers."""
     _current_user_id.set(user_id)
@@ -81,6 +83,7 @@ def set_execution_context(
     _current_sdk_cwd.set(sdk_cwd or "")
     _current_project_dir.set(_encode_cwd_for_cli(sdk_cwd) if sdk_cwd else "")
     _current_permissions.set(permissions)
+    start_autonomy_budget(enabled=autonomy_enabled)
 
 
 def get_execution_context() -> tuple[str | None, ChatSession | None]:

--- a/autogpt_platform/backend/backend/copilot/prompting.py
+++ b/autogpt_platform/backend/backend/copilot/prompting.py
@@ -742,6 +742,10 @@ the founder must never have to coordinate, poll, or nudge the expert team.
   reasonable degraded-result fallback when the preferred path is unavailable.
 - Never claim delivery without accessible artifacts and verified success
   criteria. Stop on a verified hard failure instead of retrying in a loop.
+- Treat the autonomy guard as terminal for the current path. When it reports
+  an elapsed, tool-call, or unchanged-state limit, do not retry or paraphrase
+  the same call. End the turn with Delivered, Blocked, the safest degraded
+  fallback, and Next; later progress must start from an event-driven update.
 - Verification is deterministic. A required node failure means the workflow
   test failed; non-empty `nodes_failed` or required `node_error_count` means
   failed, and a missing required artifact means incomplete. Never describe a
@@ -774,6 +778,8 @@ You are a hired expert, not the Head of AI.
 - Report evidence and uncertainty honestly. If blocked, report what you tried,
   what AutoPilot must resolve, and the recommended fallback as
   `blocked_manager`.
+- Treat an autonomy-guard stop as a manager blocker. Do not retry the same
+  path or hide the failure; report the useful partial result and fallback.
 - Do not hire, raise, edit, or otherwise staff teammates. You may delegate a
   teammate-sized subtask, but team changes belong to AutoPilot and the user.
 - Do not directly burden the founder with a question during delegated work.

--- a/autogpt_platform/backend/backend/copilot/prompting_test.py
+++ b/autogpt_platform/backend/backend/copilot/prompting_test.py
@@ -134,6 +134,24 @@ class TestFlaggedExpertOperatingPolicies:
         assert "create a new task phase" in result
         assert "fresh criteria, owners, and estimates" in result
 
+    def test_manager_treats_autonomy_guard_as_terminal(self):
+        result = " ".join(prompting.get_delegation_supplement().split())
+
+        assert "autonomy guard as terminal for the current path" in result
+        assert "do not retry or paraphrase the same call" in result
+        assert "Delivered, Blocked, the safest degraded fallback, and Next" in result
+
+    def test_expert_reports_autonomy_guard_to_manager(self):
+        result = " ".join(
+            prompting.get_expert_team_supplement(
+                experts_enabled=True,
+                expert_id="expert-1",
+            ).split()
+        )
+
+        assert "Treat an autonomy-guard stop as a manager blocker" in result
+        assert "report the useful partial result and fallback" in result
+
     def test_work_item_wake_replaces_long_polling(self):
         result = prompting.get_delegation_supplement()
 

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -65,6 +65,7 @@ from backend.util.prompt import (
 )
 from backend.util.settings import Settings
 
+from ..autonomy_budget import bounded_agent_rounds
 from ..config import ChatConfig, CopilotLLMModel, CopilotMode
 from ..constants import (
     COPILOT_ERROR_PREFIX,
@@ -4743,6 +4744,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             sandbox=e2b_sandbox,
             sdk_cwd=sdk_cwd,
             permissions=permissions,
+            autonomy_enabled=experts_enabled,
         )
 
         if (
@@ -4904,7 +4906,9 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
             stderr=_on_stderr,
             # max_turns: hard cap on agentic tool-use loops per query to
             # prevent runaway execution from burning budget.
-            max_turns=config.agent_max_turns,
+            max_turns=bounded_agent_rounds(
+                config.agent_max_turns, enabled=experts_enabled
+            ),
             # effort: applies to models with extended thinking (Sonnet,
             # Opus, Mythos) and Kimi K2.6 via OpenRouter's ``reasoning``
             # extension (#12871).

--- a/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/tool_adapter.py
@@ -17,6 +17,11 @@ from typing import TYPE_CHECKING, Any
 from claude_agent_sdk import create_sdk_mcp_server, tool
 from mcp.types import ToolAnnotations
 
+from backend.copilot.autonomy_budget import (
+    after_tool,
+    before_tool,
+    start_autonomy_budget,
+)
 from backend.copilot.context import (
     _current_permissions,
     _current_project_dir,
@@ -127,6 +132,7 @@ def set_execution_context(
     sandbox: "AsyncSandbox | None" = None,
     sdk_cwd: str | None = None,
     permissions: "CopilotPermissions | None" = None,
+    autonomy_enabled: bool = False,
 ) -> None:
     """Set the execution context for tool calls.
 
@@ -149,6 +155,7 @@ def set_execution_context(
     _pending_tool_outputs.set({})
     _stash_event.set(asyncio.Event())
     _consecutive_tool_failures.set({})
+    start_autonomy_budget(enabled=autonomy_enabled)
 
 
 def reset_stash_event() -> None:
@@ -742,6 +749,14 @@ def _make_truncating_wrapper(
     """
 
     async def wrapper(args: dict[str, Any]) -> dict[str, Any]:
+        autonomy = before_tool(tool_name, args)
+        if not autonomy.allowed:
+            logger.warning(
+                "Expert autonomy guard stopped SDK tool: tool=%s reason=%s",
+                tool_name,
+                autonomy.reason,
+            )
+            return _mcp_error(autonomy.message or "This work path has stopped.")
         # Detect empty-args truncation: args is empty AND the original tool
         # declared at least one *required* property. Tools whose params are all
         # optional (filters-only tools like list_schedules) legitimately accept
@@ -758,8 +773,10 @@ def _make_truncating_wrapper(
             stop_msg = _check_circuit_breaker(tool_name, args)
             _record_tool_failure(tool_name, args)
             if stop_msg:
-                return _mcp_error(stop_msg)
-            return _mcp_error(
+                error = _mcp_error(stop_msg)
+                after_tool(tool_name, error, args)
+                return error
+            error = _mcp_error(
                 f"Your call to {tool_name} arrived with empty arguments. "
                 f"This means the arguments were dropped in transit: either "
                 f"your response hit the output-token limit mid-call, or an "
@@ -772,11 +789,15 @@ def _make_truncating_wrapper(
                 f"as that argument's value. Object parameters such as "
                 f"agent_json accept this file-reference string directly."
             )
+            after_tool(tool_name, error, args)
+            return error
 
         original_args = args
         stop_msg = _check_circuit_breaker(tool_name, original_args)
         if stop_msg:
-            return _mcp_error(stop_msg)
+            error = _mcp_error(stop_msg)
+            after_tool(tool_name, error, original_args)
+            return error
 
         user_id, session = get_execution_context()
         if session is not None:
@@ -786,13 +807,24 @@ def _make_truncating_wrapper(
                 )
             except FileRefExpansionError as exc:
                 _record_tool_failure(tool_name, original_args)
-                return _mcp_error(
+                error = _mcp_error(
                     f"@@agptfile: reference could not be resolved: {exc}. "
                     "Ensure the file exists before referencing it. "
                     "For sandbox paths use bash_exec to verify the file exists first; "
                     "for workspace files use a workspace:// URI."
                 )
-        result = await fn(args)
+                after_tool(tool_name, error, original_args)
+                return error
+        try:
+            result = await fn(args)
+        except Exception as error:
+            after_tool(
+                tool_name,
+                {"isError": True, "error": type(error).__name__, "message": str(error)},
+                original_args,
+            )
+            raise
+        after_tool(tool_name, result, original_args)
         truncated = truncate(result, _MCP_MAX_CHARS)
 
         if truncated.get("isError"):

--- a/autogpt_platform/backend/backend/copilot/tools/__init__.py
+++ b/autogpt_platform/backend/backend/copilot/tools/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from openai.types.chat import ChatCompletionToolParam
 
+from backend.copilot.autonomy_budget import after_tool, before_tool
 from backend.copilot.response_model import StreamToolOutputAvailable
 from backend.copilot.tracking import track_tool_called
 
@@ -322,6 +323,26 @@ async def execute_tool(
             success=False,
         )
 
+    autonomy = before_tool(tool_name, parameters)
+    if not autonomy.allowed:
+        logger.warning(
+            "Expert autonomy guard stopped tool: tool=%s user=%s session=%s reason=%s",
+            tool_name,
+            user_id,
+            session.session_id,
+            autonomy.reason,
+        )
+        return StreamToolOutputAvailable(
+            toolCallId=tool_call_id,
+            toolName=tool_name,
+            output=ErrorResponse(
+                message=autonomy.message or "This work path has stopped.",
+                error="autonomy_guard",
+                session_id=session.session_id,
+            ).model_dump_json(),
+            success=False,
+        )
+
     # Track tool call in PostHog
     logger.info(
         f"Tracking tool call: tool={tool_name}, user={user_id}, "
@@ -334,4 +355,14 @@ async def execute_tool(
         tool_call_id=tool_call_id,
     )
 
-    return await tool.execute(user_id, session, tool_call_id, **parameters)
+    try:
+        result = await tool.execute(user_id, session, tool_call_id, **parameters)
+    except Exception as error:
+        after_tool(
+            tool_name,
+            {"isError": True, "error": type(error).__name__, "message": str(error)},
+            parameters,
+        )
+        raise
+    after_tool(tool_name, result, parameters)
+    return result

--- a/autogpt_platform/backend/backend/copilot/tools/autonomy_budget_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/autonomy_budget_test.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+
+from backend.copilot import autonomy_budget
+
+
+@pytest.fixture(autouse=True)
+def reset_budget():
+    autonomy_budget.start_autonomy_budget(enabled=False)
+    yield
+    autonomy_budget.start_autonomy_budget(enabled=False)
+
+
+def _mcp_result(payload: dict, *, error: bool = False):
+    return {
+        "content": [{"type": "text", "text": json.dumps(payload)}],
+        "isError": error,
+    }
+
+
+def test_flag_off_keeps_configured_rounds_and_has_no_tool_guard(monkeypatch):
+    monkeypatch.setattr(autonomy_budget, "FLAGGED_AUTONOMY_MAX_TOOL_CALLS", 1)
+    autonomy_budget.start_autonomy_budget(enabled=False)
+
+    assert autonomy_budget.bounded_agent_rounds(100, enabled=False) == 100
+    assert autonomy_budget.before_tool("run_agent").allowed
+    assert autonomy_budget.before_tool("run_agent").allowed
+
+
+def test_flag_on_caps_agent_rounds():
+    assert autonomy_budget.bounded_agent_rounds(100, enabled=True) == 36
+    assert autonomy_budget.bounded_agent_rounds(12, enabled=True) == 12
+
+
+def test_repeated_unchanged_failure_stops_only_that_path():
+    autonomy_budget.start_autonomy_budget(enabled=True)
+    failed = _mcp_result(
+        {"type": "error", "status": "failed", "message": "Required node failed"},
+        error=True,
+    )
+
+    assert autonomy_budget.before_tool("run_agent").allowed
+    autonomy_budget.after_tool("run_agent", failed)
+    assert autonomy_budget.before_tool("run_agent").allowed
+    autonomy_budget.after_tool("run_agent", failed)
+
+    stopped = autonomy_budget.before_tool("run_agent")
+    fallback = autonomy_budget.before_tool("write_workspace_file")
+
+    assert stopped.allowed is False
+    assert stopped.reason == "unchanged"
+    assert "Do not retry" in (stopped.message or "")
+    assert "degraded fallback" in (stopped.message or "")
+    assert fallback.allowed is True
+
+
+def test_changed_arguments_allow_a_degraded_path_with_the_same_tool():
+    autonomy_budget.start_autonomy_budget(enabled=True)
+    failed = _mcp_result({"type": "error", "message": "source unavailable"}, error=True)
+    original = {"source": "primary"}
+
+    assert autonomy_budget.before_tool("search", original).allowed
+    autonomy_budget.after_tool("search", failed, original)
+    assert autonomy_budget.before_tool("search", original).allowed
+    autonomy_budget.after_tool("search", failed, original)
+
+    assert autonomy_budget.before_tool("search", original).allowed is False
+    assert autonomy_budget.before_tool("search", {"source": "fallback"}).allowed
+
+
+def test_meaningful_progress_resets_unchanged_state():
+    autonomy_budget.start_autonomy_budget(enabled=True)
+    failed = _mcp_result({"type": "error", "message": "temporary"}, error=True)
+
+    assert autonomy_budget.before_tool("validate_agent_graph").allowed
+    autonomy_budget.after_tool("validate_agent_graph", failed)
+    assert autonomy_budget.before_tool("validate_agent_graph").allowed
+    autonomy_budget.after_tool(
+        "validate_agent_graph",
+        _mcp_result({"type": "agent_builder_validation_result", "status": "delivered"}),
+    )
+    assert autonomy_budget.before_tool("validate_agent_graph").allowed
+
+
+def test_tool_call_and_elapsed_limits_stop_with_structured_reason(monkeypatch):
+    monkeypatch.setattr(autonomy_budget, "FLAGGED_AUTONOMY_MAX_TOOL_CALLS", 2)
+    autonomy_budget.start_autonomy_budget(enabled=True)
+    assert autonomy_budget.before_tool("one").allowed
+    assert autonomy_budget.before_tool("two").allowed
+    calls_stopped = autonomy_budget.before_tool("three")
+    assert calls_stopped.reason == "tool_calls"
+
+    now = [100.0]
+    monkeypatch.setattr(autonomy_budget.time, "monotonic", lambda: now[0])
+    autonomy_budget.start_autonomy_budget(enabled=True)
+    now[0] += autonomy_budget.FLAGGED_AUTONOMY_MAX_ELAPSED_SECONDS
+    elapsed_stopped = autonomy_budget.before_tool("run_agent")
+    assert elapsed_stopped.reason == "elapsed"

--- a/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
@@ -12,7 +12,11 @@ from typing import Any, cast
 
 import pytest
 
-from backend.copilot.tools import TOOL_REGISTRY
+from backend.copilot.tools import (
+    TOOL_REGISTRY,
+    expert_tool_disabled_groups,
+    tool_names_in_groups,
+)
 
 # Character budget (~4 chars/token heuristic, targeting ~8000 tokens).
 # Bumped 32000 -> 32500 on PR #12699 to fit two pieces of load-bearing
@@ -113,9 +117,10 @@ from backend.copilot.tools import TOOL_REGISTRY
 # same confirm gate) and raise_expert's color palette enum + persona-name
 # guidance. Merged registry measures 59625 chars; ~1.4k headroom.
 # Bumped 61_000 -> 64_000 for persisted delegated-work fields and the compact
-# report_delegated_result handoff tool. These fields replace unstructured
-# manager/expert polling with one bounded lifecycle packet.
-_CHAR_BUDGET = 64_000
+# report_delegated_result handoff tool. The limit applies to a real session,
+# not the registry inventory: AutoPilot and expert-only tools are mutually
+# exclusive, and flag-off sessions receive neither group.
+_SESSION_CHAR_BUDGET = 64_000
 
 
 @pytest.fixture(scope="module")
@@ -209,22 +214,42 @@ def test_browser_act_action_enum_complete() -> None:
     )
 
 
-def test_total_schema_char_budget() -> None:
-    """Assert total tool schema size stays under the character budget.
+@pytest.mark.parametrize(
+    "mode,experts_enabled,expert_id",
+    [
+        ("flag-off", False, None),
+        ("autopilot", True, None),
+        ("expert", True, "expert-1"),
+    ],
+)
+def test_session_schema_char_budget(
+    mode: str, experts_enabled: bool, expert_id: str | None
+) -> None:
+    """Assert every real session schema stays under the character budget.
 
     This locks in the 34% token reduction from #12398 and prevents future
     description bloat from eroding the gains. Uses character count with a
-    ~4 chars/token heuristic; see ``_CHAR_BUDGET`` above for the current
-    value and its change history.  Character count is tokenizer-agnostic
-    — no dependency on GPT or Claude tokenizers — while still providing a
-    stable regression gate.
+    ~4 chars/token heuristic. The registry contains mutually exclusive
+    AutoPilot and expert tools, so measuring all entries together overstates
+    every prompt. This mirrors the shared engine gate without depending on
+    environment-specific tool availability.
     """
-    schemas = [tool.as_openai_tool() for tool in TOOL_REGISTRY.values()]
+    disabled = expert_tool_disabled_groups(
+        experts_enabled=experts_enabled,
+        expert_id=expert_id,
+    )
+    hidden = tool_names_in_groups(disabled)
+    schemas = [
+        tool.as_openai_tool()
+        for name, tool in TOOL_REGISTRY.items()
+        if name not in hidden
+    ]
     serialized = json.dumps(schemas)
     total_chars = len(serialized)
-    assert total_chars < _CHAR_BUDGET, (
-        f"Tool schemas use {total_chars} chars (~{total_chars // 4} tokens), "
-        f"exceeding budget of {_CHAR_BUDGET} chars (~{_CHAR_BUDGET // 4} tokens). "
+    assert total_chars < _SESSION_CHAR_BUDGET, (
+        f"{mode} tool schemas use {total_chars} chars (~{total_chars // 4} tokens), "
+        f"exceeding budget of {_SESSION_CHAR_BUDGET} chars "
+        f"(~{_SESSION_CHAR_BUDGET // 4} tokens). "
         f"Description bloat detected — trim descriptions or raise the budget intentionally."
     )
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useCopilotPage.ts
@@ -1,5 +1,6 @@
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { useAuth } from "@/lib/auth/hooks/useAuth";
+import { useExpertLiveStateHealth } from "@/hooks/useExpertLiveStateHealth";
 import { isValidUUID } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import type { UIMessage } from "ai";
@@ -66,6 +67,10 @@ export function useCopilotPage() {
   const { user, isUserLoading, isLoggedIn } = useAuth();
   const isModeToggleEnabled = useGetFlag(Flag.CHAT_MODE_OPTION);
   const isExpertsEnabled = useGetFlag(Flag.HIRE_EXPERTS);
+  useExpertLiveStateHealth({
+    surface: "copilot",
+    hireExpertsEnabled: isExpertsEnabled,
+  });
   const isBrainDumpEnabled = useGetFlag(Flag.ONBOARDING_BRAIN_DUMP);
   const [expertIdParam] = useQueryState("expertId", parseAsString);
   const expertId = isExpertsEnabled ? expertIdParam : null;

--- a/autogpt_platform/frontend/src/app/(platform)/home/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from "next/navigation";
 import { getGreetingName } from "@/app/(platform)/copilot/components/EmptySession/helpers";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { LiveUpdatesStatus } from "@/components/molecules/LiveUpdatesStatus/LiveUpdatesStatus";
+import { useExpertLiveStateHealth } from "@/hooks/useExpertLiveStateHealth";
 import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
 import { AgentTeam } from "./components/AgentTeam/AgentTeam";
@@ -25,6 +27,11 @@ export default function HomePage() {
   const { user } = useAuth();
   const { dashboard, isLoading, isError, refetch } = useHomePage({
     enabled: Boolean(enabled) && ready,
+  });
+  const liveStateHealth = useExpertLiveStateHealth({
+    surface: "home",
+    hireExpertsEnabled: Boolean(enabled) && ready,
+    onFallbackRefresh: refetch,
   });
 
   if (!ready || isLoading) {
@@ -55,6 +62,7 @@ export default function HomePage() {
           name={getGreetingName(user)}
           dashboard={dashboard}
         />
+        <LiveUpdatesStatus health={liveStateHealth} />
         {dashboard.team.total === 0 ? (
           <BuildFirstTeam />
         ) : (

--- a/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
@@ -5,6 +5,8 @@ import { AITeamIcon } from "@/components/atoms/AITeamIcon/AITeamIcon";
 import { Text } from "@/components/atoms/Text/Text";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
 import { InstallWorkflowPicker } from "@/components/molecules/InstallWorkflowPicker/InstallWorkflowPicker";
+import { LiveUpdatesStatus } from "@/components/molecules/LiveUpdatesStatus/LiveUpdatesStatus";
+import { useExpertLiveStateHealth } from "@/hooks/useExpertLiveStateHealth";
 import { cn } from "@/lib/utils";
 import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
 import { notFound } from "next/navigation";
@@ -51,6 +53,11 @@ export default function TeamPage() {
     isCreatingPod,
     assignPod,
   } = useTeamPage({ enabled: Boolean(enabled) && ready });
+  const liveStateHealth = useExpertLiveStateHealth({
+    surface: "team",
+    hireExpertsEnabled: Boolean(enabled) && ready,
+    onFallbackRefresh: refetch,
+  });
 
   if (!ready) {
     return (
@@ -104,6 +111,7 @@ export default function TeamPage() {
         </div>
         <CreateMenu onNewPod={openNewPod} />
       </div>
+      <LiveUpdatesStatus health={liveStateHealth} />
       <TeamRoster
         isLoading={isLoading}
         podGroups={podGroups}

--- a/autogpt_platform/frontend/src/components/molecules/LiveUpdatesStatus/LiveUpdatesStatus.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/LiveUpdatesStatus/LiveUpdatesStatus.tsx
@@ -1,0 +1,14 @@
+import type { LiveStateHealth } from "@/hooks/useExpertLiveStateHealth";
+
+interface Props {
+  health: LiveStateHealth;
+}
+
+export function LiveUpdatesStatus({ health }: Props) {
+  if (health !== "polling") return null;
+  return (
+    <p role="status" className="text-xs text-zinc-500">
+      Live updates are reconnecting. Progress is refreshing automatically.
+    </p>
+  );
+}

--- a/autogpt_platform/frontend/src/hooks/useExpertLiveStateHealth.test.tsx
+++ b/autogpt_platform/frontend/src/hooks/useExpertLiveStateHealth.test.tsx
@@ -1,0 +1,133 @@
+import { act, render, renderHook, screen } from "@testing-library/react";
+import * as Sentry from "@sentry/nextjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LiveUpdatesStatus } from "@/components/molecules/LiveUpdatesStatus/LiveUpdatesStatus";
+import {
+  liveStateHealthTestUtils,
+  useExpertLiveStateHealth,
+} from "./useExpertLiveStateHealth";
+
+const api = vi.hoisted(() => {
+  let connectHandler: (() => void) | null = null;
+  let disconnectHandler: (() => void) | null = null;
+  let notificationHandler: (() => void) | null = null;
+  return {
+    connectWebSocket: vi.fn().mockResolvedValue(undefined),
+    onWebSocketConnect: vi.fn((handler: () => void) => {
+      connectHandler = handler;
+      return vi.fn();
+    }),
+    onWebSocketDisconnect: vi.fn((handler: () => void) => {
+      disconnectHandler = handler;
+      return vi.fn();
+    }),
+    onWebSocketMessage: vi.fn((method: string, handler: () => void) => {
+      if (method === "notification") notificationHandler = handler;
+      return vi.fn();
+    }),
+    connect() {
+      connectHandler?.();
+    },
+    disconnect() {
+      disconnectHandler?.();
+    },
+    notify() {
+      notificationHandler?.();
+    },
+    reset() {
+      connectHandler = null;
+      disconnectHandler = null;
+      notificationHandler = null;
+      this.connectWebSocket.mockClear();
+      this.onWebSocketConnect.mockClear();
+      this.onWebSocketDisconnect.mockClear();
+      this.onWebSocketMessage.mockClear();
+    },
+  };
+});
+
+vi.mock("@/lib/autogpt-server-api/context", () => ({
+  useBackendAPI: () => api,
+}));
+vi.mock("@sentry/nextjs", () => ({ captureMessage: vi.fn() }));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  api.reset();
+  liveStateHealthTestUtils.reset();
+  vi.mocked(Sentry.captureMessage).mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useExpertLiveStateHealth", () => {
+  it("falls back to bounded polling and returns to live updates", () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useExpertLiveStateHealth({
+        surface: "home",
+        hireExpertsEnabled: true,
+        onFallbackRefresh: refresh,
+      }),
+    );
+
+    expect(result.current).toBe("connecting");
+    act(() => vi.advanceTimersByTime(4_000));
+    expect(result.current).toBe("polling");
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(refresh).toHaveBeenCalledTimes(3);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "expert_live_state_polling_fallback",
+      expect.objectContaining({
+        tags: expect.objectContaining({ surface: "home" }),
+      }),
+    );
+
+    act(() => api.connect());
+    expect(result.current).toBe("live");
+    act(() => api.notify());
+    expect(refresh).toHaveBeenCalledTimes(5);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(refresh).toHaveBeenCalledTimes(5);
+  });
+
+  it("records a cross-surface hire-experts mismatch", () => {
+    const home = renderHook(() =>
+      useExpertLiveStateHealth({
+        surface: "home",
+        hireExpertsEnabled: true,
+      }),
+    );
+    const team = renderHook(() =>
+      useExpertLiveStateHealth({
+        surface: "team",
+        hireExpertsEnabled: false,
+      }),
+    );
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "hire_experts_surface_flag_mismatch",
+      expect.objectContaining({ level: "error" }),
+    );
+    home.unmount();
+    team.unmount();
+  });
+});
+
+describe("LiveUpdatesStatus", () => {
+  it("explains the automatic polling fallback without technical detail", () => {
+    const { rerender } = render(<LiveUpdatesStatus health="live" />);
+    expect(screen.queryByRole("status")).toBeNull();
+
+    rerender(<LiveUpdatesStatus health="polling" />);
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain(
+      "Progress is refreshing automatically",
+    );
+    expect(status.textContent).not.toMatch(/websocket/i);
+  });
+});

--- a/autogpt_platform/frontend/src/hooks/useExpertLiveStateHealth.ts
+++ b/autogpt_platform/frontend/src/hooks/useExpertLiveStateHealth.ts
@@ -1,0 +1,116 @@
+"use client";
+
+import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+import * as Sentry from "@sentry/nextjs";
+import { useEffect, useState } from "react";
+
+export type ExpertSurface = "copilot" | "home" | "team";
+export type LiveStateHealth = "connecting" | "live" | "polling";
+
+const surfaceFlags = new Map<ExpertSurface, boolean>();
+const lastTransportReport = new Map<ExpertSurface, LiveStateHealth>();
+
+interface Args {
+  surface: ExpertSurface;
+  hireExpertsEnabled: boolean;
+  onFallbackRefresh?: () => void | Promise<unknown>;
+}
+
+export function useExpertLiveStateHealth({
+  surface,
+  hireExpertsEnabled,
+  onFallbackRefresh,
+}: Args) {
+  const api = useBackendAPI();
+  const [health, setHealth] = useState<LiveStateHealth>("connecting");
+
+  useEffect(() => {
+    surfaceFlags.set(surface, hireExpertsEnabled);
+    reportFlagParity();
+    let disposed = false;
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    let detachConnect = () => {};
+    let detachDisconnect = () => {};
+    let detachNotification = () => {};
+
+    function activatePolling() {
+      if (disposed) return;
+      setHealth("polling");
+      reportTransport(surface, "polling");
+    }
+
+    function activateLive() {
+      if (disposed) return;
+      if (fallbackTimer !== null) clearTimeout(fallbackTimer);
+      fallbackTimer = null;
+      setHealth("live");
+      reportTransport(surface, "live");
+      void onFallbackRefresh?.();
+    }
+
+    if (hireExpertsEnabled) {
+      fallbackTimer = setTimeout(activatePolling, 4_000);
+      detachConnect = api.onWebSocketConnect(activateLive);
+      detachDisconnect = api.onWebSocketDisconnect(activatePolling);
+      detachNotification = api.onWebSocketMessage("notification", () => {
+        void onFallbackRefresh?.();
+      });
+      void api.connectWebSocket().catch(activatePolling);
+    } else {
+      setHealth("connecting");
+    }
+
+    return () => {
+      disposed = true;
+      detachConnect();
+      detachDisconnect();
+      detachNotification();
+      surfaceFlags.delete(surface);
+      lastTransportReport.delete(surface);
+      if (fallbackTimer !== null) clearTimeout(fallbackTimer);
+    };
+  }, [api, hireExpertsEnabled, onFallbackRefresh, surface]);
+
+  useEffect(() => {
+    if (health !== "polling") return;
+    void onFallbackRefresh?.();
+    const timer = setInterval(() => {
+      void onFallbackRefresh?.();
+    }, 5_000);
+    return () => clearInterval(timer);
+  }, [health, onFallbackRefresh]);
+
+  return health;
+}
+
+function reportTransport(surface: ExpertSurface, health: LiveStateHealth) {
+  if (lastTransportReport.get(surface) === health) return;
+  lastTransportReport.set(surface, health);
+  if (health !== "polling") return;
+  Sentry.captureMessage("expert_live_state_polling_fallback", {
+    level: "warning",
+    tags: {
+      surface,
+      live_state_transport: health,
+      hire_experts: String(surfaceFlags.get(surface) ?? false),
+    },
+  });
+}
+
+function reportFlagParity() {
+  const entries = [...surfaceFlags.entries()];
+  if (entries.length < 2) return;
+  const values = new Set(entries.map(([, value]) => value));
+  if (values.size < 2) return;
+  Sentry.captureMessage("hire_experts_surface_flag_mismatch", {
+    level: "error",
+    contexts: { surfaces: Object.fromEntries(entries) },
+  });
+}
+
+export const liveStateHealthTestUtils = {
+  reset() {
+    surfaceFlags.clear();
+    lastTransportReport.clear();
+  },
+};


### PR DESCRIPTION
### Why / What / How

The clean-slate audit found that flagged AutoPilot could retry a blocked path too long and that Home and Team could become stale when live transport disconnected.

This PR adds a per-turn autonomy budget only when hire-experts is enabled. It caps flagged sessions at 36 agent rounds and 36 tool calls, refuses additional tool calls after eight elapsed minutes, and stops a tool path after the same blocked or failed result occurs twice. Different arguments and useful degraded fallbacks remain available. Flag-off rounds and execution stay unchanged.

It also adds founder-safe live-state health across Copilot, Home, and Team. A disconnected surface refreshes automatically every five seconds, returns to live notifications on reconnect, and emits surface/flag telemetry without exposing transport details to the founder.

### Changes 🏗️

- Add a shared autonomy budget to baseline and SDK execution paths.
- Preserve disabled-tool enforcement before the autonomy guard.
- Add manager and expert stop/handoff prompt rules.
- Add live connection health, notification refresh, bounded polling fallback, and cleanup-safe React effects.
- Show a concise reconnecting status on Home and Team.
- Measure the 64 KB tool-schema ceiling against real flag-off, AutoPilot, and expert sessions rather than mutually exclusive registry inventory.
- Keep every new behavior behind hire-experts.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Autonomy-budget focused suite: 6 passed
  - [x] Tool schema and flag-gating suite: 231 passed
  - [x] Changed backend stack tests: 1,068 passed
  - [x] Changed frontend stack tests: 530 passed
  - [x] Page-level live-state regression suite: 91 passed
  - [x] Backend and frontend lint, formatting, and type checks
  - [x] React Doctor: no correctness errors
  - [x] Prisma schema validation

#### For configuration changes:

- [x] .env.default is already compatible
- [x] docker-compose.yml is already compatible
- [x] No configuration changes