### PR TITLE
fix(frontend): scope all credit state to authenticated identity (#14224)

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/credits/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/__legacy__/ui/button";
 import useCredits from "@/hooks/useCredits";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { useSearchParams, useRouter } from "next/navigation";
 import {
   useToast,
@@ -67,6 +68,8 @@ function CoPilotUsageSection() {
 }
 
 export default function CreditsPage() {
+  const { user, isLoggedIn } = useAuth();
+  const identityKey = user?.id ?? null;
   const api = useBackendAPI();
   const {
     requestTopUp,
@@ -78,9 +81,10 @@ export default function CreditsPage() {
     refundTopUp,
     refundRequests,
   } = useCredits({
-    fetchInitialAutoTopUpConfig: true,
-    fetchInitialRefundRequests: true,
-    fetchInitialTransactionHistory: true,
+    identityKey,
+    fetchInitialAutoTopUpConfig: isLoggedIn,
+    fetchInitialRefundRequests: isLoggedIn,
+    fetchInitialTransactionHistory: isLoggedIn,
   });
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -93,6 +97,7 @@ export default function CreditsPage() {
     CreditTransaction[]
   >([]);
   const openRefundModal = () => {
+    if (!identityKey) return;
     api.getTransactionHistory(null, 20, "TOP_UP").then((history) => {
       setTopUpTransactions(history.transactions);
       setIsRefundModalOpen(true);

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/components/WalletRefill.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/components/WalletRefill.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/molecules/Toast/use-toast";
 import { TopUpForm } from "@/components/layout/TopUpPrompt/TopUpForm/TopUpForm";
 import useCredits from "@/hooks/useCredits";
+import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
@@ -38,11 +39,14 @@ const autoRefillSchema = z
   });
 
 export function WalletRefill() {
+  const { user, isLoggedIn } = useAuth();
+  const identityKey = user?.id ?? null;
   const { toast } = useToast();
   const toastOnFail = useToastOnFail();
 
   const { autoTopUpConfig, updateAutoTopUpConfig } = useCredits({
-    fetchInitialAutoTopUpConfig: true,
+    identityKey,
+    fetchInitialAutoTopUpConfig: isLoggedIn,
   });
 
   const [isLoading, setIsLoading] = useState(false);

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/useWallet.ts
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/useWallet.ts
@@ -7,16 +7,20 @@ import {
   WebSocketNotification,
 } from "@/lib/autogpt-server-api";
 import { useBackendAPI } from "@/lib/autogpt-server-api/context";
+import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { useOnboarding } from "@/providers/onboarding/onboarding-provider";
 import confetti, { type Options as ConfettiOptions } from "canvas-confetti";
 import { useEffect, useRef, useState } from "react";
 import { getTaskGroups } from "./helpers";
 
 export function useWallet() {
+  const { user, isLoggedIn } = useAuth();
+  const identityKey = user?.id ?? null;
   const { state, updateState } = useOnboarding();
   const api = useBackendAPI();
   const { credits, formatCredits, fetchCredits } = useCredits({
-    fetchInitialCredits: true,
+    identityKey,
+    fetchInitialCredits: isLoggedIn,
   });
 
   const groups = getTaskGroups(state);

--- a/autogpt_platform/frontend/src/hooks/__tests__/useCredits.test.tsx
+++ b/autogpt_platform/frontend/src/hooks/__tests__/useCredits.test.tsx
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import useCredits from "../useCredits";
+import AutoGPTServerAPI from "@/lib/autogpt-server-api";
+
+let authenticatedUserId: string | null = "user-a";
+
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: authenticatedUserId ? { id: authenticatedUserId } : null,
+    isLoggedIn: Boolean(authenticatedUserId),
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+describe("useCredits hook authentication and identity scoping", () => {
+  beforeEach(() => {
+    authenticatedUserId = "user-a";
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("does not emit billing requests and exposes empty state when logged out", async () => {
+    authenticatedUserId = null;
+    const getUserCreditSpy = vi
+      .spyOn(AutoGPTServerAPI.prototype, "getUserCredit")
+      .mockResolvedValue({ credits: 500 });
+    const getAutoTopUpConfigSpy = vi
+      .spyOn(AutoGPTServerAPI.prototype, "getAutoTopUpConfig")
+      .mockResolvedValue({ amount: 10, threshold: 5 });
+    const getTransactionHistorySpy = vi
+      .spyOn(AutoGPTServerAPI.prototype, "getTransactionHistory")
+      .mockResolvedValue({ transactions: [], next_transaction_time: null });
+    const getRefundRequestsSpy = vi
+      .spyOn(AutoGPTServerAPI.prototype, "getRefundRequests")
+      .mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useCredits({
+        fetchInitialCredits: true,
+        fetchInitialAutoTopUpConfig: true,
+        fetchInitialTransactionHistory: true,
+        fetchInitialRefundRequests: true,
+      }),
+    );
+
+    // Call manual fetch triggers as well
+    act(() => {
+      result.current.fetchCredits();
+      result.current.fetchAutoTopUpConfig();
+      result.current.fetchTransactionHistory();
+      result.current.fetchRefundRequests();
+    });
+
+    expect(getUserCreditSpy).not.toHaveBeenCalled();
+    expect(getAutoTopUpConfigSpy).not.toHaveBeenCalled();
+    expect(getTransactionHistorySpy).not.toHaveBeenCalled();
+    expect(getRefundRequestsSpy).not.toHaveBeenCalled();
+
+    expect(result.current.credits).toBeNull();
+    expect(result.current.autoTopUpConfig).toBeNull();
+    expect(result.current.transactionHistory).toEqual({
+      transactions: [],
+      next_transaction_time: null,
+    });
+    expect(result.current.refundRequests).toEqual([]);
+  });
+
+  test("populates all state values for the authenticated identity", async () => {
+    authenticatedUserId = "user-a";
+    vi.spyOn(AutoGPTServerAPI.prototype, "getUserCredit").mockResolvedValue({
+      credits: 1250,
+    });
+    vi.spyOn(
+      AutoGPTServerAPI.prototype,
+      "getAutoTopUpConfig",
+    ).mockResolvedValue({ amount: 20, threshold: 5 });
+    vi.spyOn(
+      AutoGPTServerAPI.prototype,
+      "getTransactionHistory",
+    ).mockResolvedValue({
+      transactions: [
+        {
+          transaction_key: "tx-1",
+          amount: 500,
+          type: "TOP_UP",
+          created_at: new Date("2026-08-29T10:00:00Z"),
+        } as any,
+      ],
+      next_transaction_time: new Date("2026-08-29T10:00:00Z"),
+    });
+    vi.spyOn(AutoGPTServerAPI.prototype, "getRefundRequests").mockResolvedValue(
+      [{ id: "ref-1", status: "PENDING" } as any],
+    );
+
+    const { result } = renderHook(() =>
+      useCredits({
+        fetchInitialCredits: true,
+        fetchInitialAutoTopUpConfig: true,
+        fetchInitialTransactionHistory: true,
+        fetchInitialRefundRequests: true,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.credits).toBe(1250);
+      expect(result.current.autoTopUpConfig).toEqual({
+        amount: 20,
+        threshold: 5,
+      });
+      expect(result.current.transactionHistory.transactions).toHaveLength(1);
+      expect(result.current.refundRequests).toHaveLength(1);
+    });
+  });
+
+  test("immediately clears and refetches with fresh cursor on account switch without remounting", async () => {
+    let currentId = "user-a";
+    const historyCalls: Array<{ cursor: Date | null | undefined }> = [];
+
+    vi.spyOn(AutoGPTServerAPI.prototype, "getUserCredit").mockImplementation(
+      async () => ({
+        credits: currentId === "user-a" ? 100 : 200,
+      }),
+    );
+    vi.spyOn(
+      AutoGPTServerAPI.prototype,
+      "getAutoTopUpConfig",
+    ).mockImplementation(async () => ({
+      amount: currentId === "user-a" ? 10 : 30,
+      threshold: 5,
+    }));
+    vi.spyOn(
+      AutoGPTServerAPI.prototype,
+      "getTransactionHistory",
+    ).mockImplementation(async (cursor) => {
+      historyCalls.push({ cursor });
+      return {
+        transactions: [
+          {
+            transaction_key: `tx-${currentId}`,
+            amount: 100,
+            type: "TOP_UP",
+            created_at: new Date("2026-08-29"),
+          } as any,
+        ],
+        next_transaction_time: new Date("2026-08-29T12:00:00Z"),
+      };
+    });
+    vi.spyOn(
+      AutoGPTServerAPI.prototype,
+      "getRefundRequests",
+    ).mockImplementation(async () => [{ id: `refund-${currentId}` } as any]);
+
+    const { result, rerender } = renderHook(
+      ({ identityKey }) =>
+        useCredits({
+          identityKey,
+          fetchInitialCredits: true,
+          fetchInitialAutoTopUpConfig: true,
+          fetchInitialTransactionHistory: true,
+          fetchInitialRefundRequests: true,
+        }),
+      {
+        initialProps: { identityKey: "user-a" as string | null },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.credits).toBe(100);
+      expect(result.current.autoTopUpConfig?.amount).toBe(10);
+      expect(
+        result.current.transactionHistory.transactions[0].transaction_key,
+      ).toBe("tx-user-a");
+      expect(result.current.refundRequests[0].id).toBe("refund-user-a");
+    });
+
+    expect(historyCalls).toEqual([{ cursor: null }]);
+
+    // Switch account to user-b
+    currentId = "user-b";
+    rerender({ identityKey: "user-b" });
+
+    // Stale user-a data should be immediately hidden
+    expect(result.current.credits).toBeNull();
+    expect(result.current.autoTopUpConfig).toBeNull();
+    expect(result.current.transactionHistory.transactions).toHaveLength(0);
+    expect(result.current.refundRequests).toHaveLength(0);
+
+    // Wait for user-b data to resolve from a fresh cursor
+    await waitFor(() => {
+      expect(result.current.credits).toBe(200);
+      expect(result.current.autoTopUpConfig?.amount).toBe(30);
+      expect(
+        result.current.transactionHistory.transactions[0].transaction_key,
+      ).toBe("tx-user-b");
+      expect(result.current.refundRequests[0].id).toBe("refund-user-b");
+    });
+
+    // Verify user-b started from fresh cursor (cursor: null)
+    expect(historyCalls).toHaveLength(2);
+    expect(historyCalls[1]).toEqual({ cursor: null });
+
+    // Now log out (identityKey: null)
+    rerender({ identityKey: null });
+
+    expect(result.current.credits).toBeNull();
+    expect(result.current.autoTopUpConfig).toBeNull();
+    expect(result.current.transactionHistory).toEqual({
+      transactions: [],
+      next_transaction_time: null,
+    });
+    expect(result.current.refundRequests).toEqual([]);
+  });
+
+  test("ignores inflight responses started for a previous identity", async () => {
+    let resolveCreditsUserA: (value: { credits: number }) => void;
+    const creditsPromiseUserA = new Promise<{ credits: number }>((resolve) => {
+      resolveCreditsUserA = resolve;
+    });
+
+    vi.spyOn(AutoGPTServerAPI.prototype, "getUserCredit").mockImplementation(
+      async () => {
+        if (authenticatedUserId === "user-a") {
+          return creditsPromiseUserA;
+        }
+        return { credits: 200 };
+      },
+    );
+
+    const { result, rerender } = renderHook(
+      ({ identityKey }) =>
+        useCredits({
+          identityKey,
+          fetchInitialCredits: true,
+        }),
+      {
+        initialProps: { identityKey: "user-a" as string | null },
+      },
+    );
+
+    // User switches identity to user-b while user-a's request is inflight
+    authenticatedUserId = "user-b";
+    rerender({ identityKey: "user-b" });
+
+    // Now user-a's delayed request completes
+    await act(async () => {
+      resolveCreditsUserA({ credits: 9999 });
+    });
+
+    // Credits should resolve to user-b's data, NOT user-a's 9999
+    await waitFor(() => {
+      expect(result.current.credits).toBe(200);
+    });
+  });
+});

--- a/autogpt_platform/frontend/src/hooks/useCredits.ts
+++ b/autogpt_platform/frontend/src/hooks/useCredits.ts
@@ -3,6 +3,7 @@ import {
   RefundRequest,
   TransactionHistory,
 } from "@/lib/autogpt-server-api/types";
+import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -27,118 +28,152 @@ export default function useCredits({
   fetchAutoTopUpConfig: () => void;
   updateAutoTopUpConfig: (amount: number, threshold: number) => Promise<void>;
   transactionHistory: TransactionHistory;
-  fetchTransactionHistory: () => void;
+  fetchTransactionHistory: (resetCursor?: boolean) => void;
   refundRequests: RefundRequest[];
   fetchRefundRequests: () => void;
   formatCredits: (credit: number | null) => string;
 } {
+  const auth = useAuth();
+  const resolvedIdentityKey =
+    identityKey !== undefined ? identityKey : (auth?.user?.id ?? null);
+
   const [credits, setCredits] = useState<number | null>(null);
   const [autoTopUpConfig, setAutoTopUpConfig] = useState<{
     amount: number;
     threshold: number;
   } | null>(null);
-  const identityKeyRef = useRef(identityKey);
-  const [stateIdentityKey, setStateIdentityKey] = useState(identityKey);
-
-  useEffect(() => {
-    identityKeyRef.current = identityKey;
-    setStateIdentityKey(identityKey);
-    setCredits(null);
-    setAutoTopUpConfig(null);
-  }, [identityKey]);
-
-  const api = useMemo(() => new AutoGPTServerAPI(), []);
-  const router = useRouter();
-
-  const fetchCredits = useCallback(async () => {
-    const requestIdentityKey = identityKey;
-    const response = await api.getUserCredit();
-    if (identityKeyRef.current !== requestIdentityKey) return;
-    setCredits(response.credits ?? null);
-  }, [api, identityKey]);
-
-  useEffect(() => {
-    if (!fetchInitialCredits) return;
-    fetchCredits();
-  }, [fetchCredits, fetchInitialCredits]);
-
-  const fetchAutoTopUpConfig = useCallback(async () => {
-    const requestIdentityKey = identityKey;
-    const response = await api.getAutoTopUpConfig();
-    if (identityKeyRef.current !== requestIdentityKey) return;
-    setAutoTopUpConfig(response);
-  }, [api, identityKey]);
-
-  useEffect(() => {
-    if (!fetchInitialAutoTopUpConfig) return;
-    fetchAutoTopUpConfig();
-  }, [fetchAutoTopUpConfig, fetchInitialAutoTopUpConfig]);
-
-  const updateAutoTopUpConfig = useCallback(
-    async (amount: number, threshold: number) => {
-      await api.setAutoTopUpConfig({ amount, threshold });
-      fetchAutoTopUpConfig();
-    },
-    [api, fetchAutoTopUpConfig],
-  );
-
-  const requestTopUp = useCallback(
-    async (credit_amount: number) => {
-      const response = await api.requestTopUp(credit_amount);
-      router.push(response.checkout_url);
-    },
-    [api, router],
-  );
-
-  const refundTopUp = useCallback(
-    async (transaction_key: string, reason: string) => {
-      const refunded_amount = await api.refundTopUp(transaction_key, reason);
-      await fetchCredits();
-      setTransactionHistory(await api.getTransactionHistory());
-      return refunded_amount;
-    },
-    [api, fetchCredits],
-  );
-
   const [transactionHistory, setTransactionHistory] =
     useState<TransactionHistory>({
       transactions: [],
       next_transaction_time: null,
     });
-
-  const fetchTransactionHistory = useCallback(async () => {
-    const response = await api.getTransactionHistory(
-      transactionHistory.next_transaction_time,
-      20,
-    );
-    setTransactionHistory({
-      transactions: [
-        ...transactionHistory.transactions,
-        ...response.transactions,
-      ],
-      next_transaction_time: response.next_transaction_time,
-    });
-  }, [api, transactionHistory]);
-
-  useEffect(() => {
-    if (!fetchInitialTransactionHistory) return;
-    fetchTransactionHistory();
-    // Note: We only need to fetch transaction history once.
-    // Hence, we should avoid `fetchTransactionHistory` to the dependency array.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchInitialTransactionHistory]);
-
   const [refundRequests, setRefundRequests] = useState<RefundRequest[]>([]);
 
-  const fetchRefundRequests = useCallback(async () => {
-    const response = await api.getRefundRequests();
-    setRefundRequests(response);
-  }, [api]);
+  const identityKeyRef = useRef(resolvedIdentityKey);
+  identityKeyRef.current = resolvedIdentityKey;
+  const [stateIdentityKey, setStateIdentityKey] = useState(resolvedIdentityKey);
+  const cursorRef = useRef<Date | null>(null);
 
   useEffect(() => {
-    if (!fetchInitialRefundRequests) return;
+    identityKeyRef.current = resolvedIdentityKey;
+    setStateIdentityKey(resolvedIdentityKey);
+    cursorRef.current = null;
+    setCredits(null);
+    setAutoTopUpConfig(null);
+    setTransactionHistory({
+      transactions: [],
+      next_transaction_time: null,
+    });
+    setRefundRequests([]);
+  }, [resolvedIdentityKey]);
+
+  const api = useMemo(() => new AutoGPTServerAPI(), []);
+  const router = useRouter();
+
+  const fetchCredits = useCallback(async () => {
+    const requestIdentityKey = resolvedIdentityKey;
+    if (!requestIdentityKey) return;
+    const response = await api.getUserCredit();
+    if (identityKeyRef.current !== requestIdentityKey) return;
+    setCredits(response.credits ?? null);
+  }, [api, resolvedIdentityKey]);
+
+  useEffect(() => {
+    if (!fetchInitialCredits || !resolvedIdentityKey) return;
+    fetchCredits();
+  }, [fetchCredits, fetchInitialCredits, resolvedIdentityKey]);
+
+  const fetchAutoTopUpConfig = useCallback(async () => {
+    const requestIdentityKey = resolvedIdentityKey;
+    if (!requestIdentityKey) return;
+    const response = await api.getAutoTopUpConfig();
+    if (identityKeyRef.current !== requestIdentityKey) return;
+    setAutoTopUpConfig(response);
+  }, [api, resolvedIdentityKey]);
+
+  useEffect(() => {
+    if (!fetchInitialAutoTopUpConfig || !resolvedIdentityKey) return;
+    fetchAutoTopUpConfig();
+  }, [fetchAutoTopUpConfig, fetchInitialAutoTopUpConfig, resolvedIdentityKey]);
+
+  const updateAutoTopUpConfig = useCallback(
+    async (amount: number, threshold: number) => {
+      const requestIdentityKey = resolvedIdentityKey;
+      if (!requestIdentityKey) return;
+      await api.setAutoTopUpConfig({ amount, threshold });
+      if (identityKeyRef.current !== requestIdentityKey) return;
+      fetchAutoTopUpConfig();
+    },
+    [api, fetchAutoTopUpConfig, resolvedIdentityKey],
+  );
+
+  const requestTopUp = useCallback(
+    async (credit_amount: number) => {
+      const requestIdentityKey = resolvedIdentityKey;
+      if (!requestIdentityKey) return;
+      const response = await api.requestTopUp(credit_amount);
+      if (identityKeyRef.current !== requestIdentityKey) return;
+      router.push(response.checkout_url);
+    },
+    [api, router, resolvedIdentityKey],
+  );
+
+  const refundTopUp = useCallback(
+    async (transaction_key: string, reason: string) => {
+      const requestIdentityKey = resolvedIdentityKey;
+      if (!requestIdentityKey) return 0;
+      const refunded_amount = await api.refundTopUp(transaction_key, reason);
+      if (identityKeyRef.current !== requestIdentityKey) return refunded_amount;
+      await fetchCredits();
+      if (identityKeyRef.current !== requestIdentityKey) return refunded_amount;
+      const updatedHistory = await api.getTransactionHistory(null, 20);
+      if (identityKeyRef.current !== requestIdentityKey) return refunded_amount;
+      cursorRef.current = updatedHistory.next_transaction_time;
+      setTransactionHistory(updatedHistory);
+      return refunded_amount;
+    },
+    [api, fetchCredits, resolvedIdentityKey],
+  );
+
+  const fetchTransactionHistory = useCallback(
+    async (resetCursor = false) => {
+      const requestIdentityKey = resolvedIdentityKey;
+      if (!requestIdentityKey) return;
+      const cursor = resetCursor ? null : cursorRef.current;
+      const response = await api.getTransactionHistory(cursor, 20);
+      if (identityKeyRef.current !== requestIdentityKey) return;
+      cursorRef.current = response.next_transaction_time;
+      setTransactionHistory((prev) => ({
+        transactions: resetCursor
+          ? response.transactions
+          : [...prev.transactions, ...response.transactions],
+        next_transaction_time: response.next_transaction_time,
+      }));
+    },
+    [api, resolvedIdentityKey],
+  );
+
+  useEffect(() => {
+    if (!fetchInitialTransactionHistory || !resolvedIdentityKey) return;
+    fetchTransactionHistory(true);
+  }, [
+    fetchInitialTransactionHistory,
+    resolvedIdentityKey,
+    fetchTransactionHistory,
+  ]);
+
+  const fetchRefundRequests = useCallback(async () => {
+    const requestIdentityKey = resolvedIdentityKey;
+    if (!requestIdentityKey) return;
+    const response = await api.getRefundRequests();
+    if (identityKeyRef.current !== requestIdentityKey) return;
+    setRefundRequests(response);
+  }, [api, resolvedIdentityKey]);
+
+  useEffect(() => {
+    if (!fetchInitialRefundRequests || !resolvedIdentityKey) return;
     fetchRefundRequests();
-  }, [fetchRefundRequests, fetchInitialRefundRequests]);
+  }, [fetchInitialRefundRequests, resolvedIdentityKey, fetchRefundRequests]);
 
   const formatCredits = useCallback((credit: number | null) => {
     if (credit === null) {
@@ -149,17 +184,22 @@ export default function useCredits({
     return `${sign}$${(value / 100).toFixed(2)}`;
   }, []);
 
+  const isCurrentIdentityActive =
+    stateIdentityKey === resolvedIdentityKey && resolvedIdentityKey !== null;
+
   return {
-    credits: stateIdentityKey === identityKey ? credits : null,
+    credits: isCurrentIdentityActive ? credits : null,
     fetchCredits,
     requestTopUp,
     refundTopUp,
-    autoTopUpConfig: stateIdentityKey === identityKey ? autoTopUpConfig : null,
+    autoTopUpConfig: isCurrentIdentityActive ? autoTopUpConfig : null,
     fetchAutoTopUpConfig,
     updateAutoTopUpConfig,
-    transactionHistory,
+    transactionHistory: isCurrentIdentityActive
+      ? transactionHistory
+      : { transactions: [], next_transaction_time: null },
     fetchTransactionHistory,
-    refundRequests,
+    refundRequests: isCurrentIdentityActive ? refundRequests : [],
     fetchRefundRequests,
     formatCredits,
   };


### PR DESCRIPTION
## Summary
Fixes #14224.

Follow-up to #14223. Ensures that all stateful `useCredits` values are strictly scoped to the authenticated identity across the frontend lifecycle.

## Changes 🏗️
- **Identity Scoping**: In `useCredits`, all user-specific state (`credits`, `autoTopUpConfig`, `transactionHistory`, and `refundRequests`) is scoped to the active `identityKey`. If `stateIdentityKey !== identityKey` or logged out, states evaluate to `null` or empty without leaking previous user data.
- **Immediate State Reset**: On account switch or logout, immediately clears `credits`, `autoTopUpConfig`, `transactionHistory`, and `refundRequests`, and resets the cursor reference.
- **Stale Response Protection**: Drop in-flight responses if the user switched identities before the API call resolved.
- **Fresh Cursor Refetching**: On identity change, transaction history refetches from a fresh cursor (`null`).
- **Protected Request Guard**: Emits no billing endpoints while logged out.
- **Call Sites Updated**:
  - `useWallet`: Passed `identityKey` and gated `fetchInitialCredits: isLoggedIn`.
  - `WalletRefill`: Passed `identityKey` and gated `fetchInitialAutoTopUpConfig: isLoggedIn`.
  - `CreditsPage`: Passed `identityKey`, gated initial queries on `isLoggedIn`, and guarded `openRefundModal`.
- **Regression Coverage**: Added `src/hooks/__tests__/useCredits.test.tsx` testing immediate reset, fresh cursor querying, stale response dropping, and unauthenticated call suppression across identity switches without remounting.

## Verification
- `pnpm vitest run src/hooks/__tests__/useCredits.test.tsx` (4 passed)
- `pnpm vitest run src/components/layout/TopUpPrompt/__tests__/TopUpPromptProvider.test.tsx` (10 passed)
- `pnpm types` (`tsc --noEmit` passed with 0 errors)
- `pnpm prettier --check` (all files formatted cleanly)