### PR TITLE
feat(backend): per-user rate limit on the subscription status endpoint

### DIFF
--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
+from typing import Any, cast
 
 import fastapi
 from autogpt_libs.auth import get_user_id
 
-from backend.data.redis_client import get_redis_async
+from backend.data.redis_client import TRANSIENT_REDIS_ERRORS, get_redis_async
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,19 @@ logger = logging.getLogger(__name__)
 # Query entry plus 60s staleTime keep steady-state use near ~1/min per tab.
 SUBSCRIPTION_STATUS_WINDOW_SECONDS = 60
 SUBSCRIPTION_STATUS_MAX_REQUESTS = 60
+
+# Atomic fixed-window counter: INCR the key, and set the TTL only on the INCR
+# that opened the window (count == 1). Doing both in one server-side script
+# means a freshly-created key always gets its expiry — the key can never linger
+# without a TTL if it happened to be recreated by INCR, and the window stays
+# fixed (the TTL is not refreshed on later hits).
+_INCR_OPEN_WINDOW = """
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count
+"""
 
 
 def _window_key(user_id: str, *, now: datetime) -> str:
@@ -48,19 +62,29 @@ async def enforce_subscription_status_rate_limit(
     returning fresh state) never trip it — FastAPI dependencies run for HTTP
     requests, not for direct function calls.
 
-    On Redis brown-out this fails *open* (logs and lets the call through): a
-    Redis blip must never block the billing status read for every user, which
-    would be far worse than one client briefly exceeding its cap.
+    On a *transient* Redis failure (connection/timeout/cluster-down) this fails
+    *open* (logs and lets the call through): a Redis blip must never block the
+    billing status read for every user, which would be far worse than one
+    client briefly exceeding its cap. Non-transient errors are left to
+    propagate rather than silently disabling the limiter.
     """
     now = datetime.now(UTC)
     key = _window_key(user_id, now=now)
     try:
         redis = await get_redis_async()
-        # Atomic create-with-TTL, then INCR. SET NX EX makes the TTL part of
-        # the same write that creates the key; later INCRs preserve it.
-        await redis.set(key, 0, ex=SUBSCRIPTION_STATUS_WINDOW_SECONDS, nx=True)
-        count = await redis.incr(key)
-    except Exception as e:
+        # Lua ARGV values are strings; EXPIRE coerces "60" back to an int. The
+        # cast mirrors the other eval() call sites (e.g. copilot/dream/locks):
+        # the cluster client types eval()'s return as str, so cast before await.
+        count = await cast(
+            Any,
+            redis.eval(
+                _INCR_OPEN_WINDOW,
+                1,
+                key,
+                str(SUBSCRIPTION_STATUS_WINDOW_SECONDS),
+            ),
+        )
+    except TRANSIENT_REDIS_ERRORS as e:
         logger.warning(
             "Subscription-status rate-limit check failed open for user %s: %s",
             user_id,

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit.py
@@ -1,27 +1,33 @@
 """Per-user rate limit for ``GET /api/credits/subscription``.
 
-The subscription-status endpoint is fetched on essentially every authenticated
-page load (PaywallGate wraps the app shell) and, on a cold cache, fans out to
-several Stripe reads per request. A per-user cap puts a hard ceiling on scripted
-clients hammering it, without affecting normal use: the frontend shares one
-React Query entry with a 60s ``staleTime``, so a real user — even with several
-tabs open and the occasional hard reload — stays around ~5-15 requests/minute.
+The subscription-status endpoint fans out to uncached Stripe reads per request
+and is fetched on every load of the billing page, so a scripted client can
+drive a lot of upstream traffic from one account. A per-user cap puts a hard
+ceiling on that without affecting normal use: the frontend shares one React
+Query entry with a 60s ``staleTime``, so a real user stays well under the cap.
 
-Fixed-window counter in Redis (``SET NX EX`` + ``INCR``), keyed per ``user_id``,
-fail-open on Redis brown-out. Mirrors ``backend/api/features/search/rate_limit``.
-A single key per check keeps it correct on the Redis cluster.
+Atomic fixed-window counter in Redis (Lua ``INCR`` + first-hit ``EXPIRE``),
+keyed per ``user_id``. A single key per check keeps it correct on the Redis
+cluster.
+
+Availability: this puts Redis in front of a billing read, so the check is
+strictly best-effort. It is bounded by a short deadline and **fails open** on
+any Redis trouble — being unable to prove a user is under their cap must never
+cost every user their billing status.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from typing import Any, cast
 
 import fastapi
 from autogpt_libs.auth import get_user_id
+from redis.exceptions import RedisClusterException, RedisError
 
-from backend.data.redis_client import TRANSIENT_REDIS_ERRORS, get_redis_async
+from backend.data.redis_client import get_redis_async
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +36,14 @@ logger = logging.getLogger(__name__)
 # Query entry plus 60s staleTime keep steady-state use near ~1/min per tab.
 SUBSCRIPTION_STATUS_WINDOW_SECONDS = 60
 SUBSCRIPTION_STATUS_MAX_REQUESTS = 60
+
+# Hard deadline on the whole Redis interaction. Without it "fail open" is not
+# "fail fast": a cold client runs redis-py's own connect retry ladder (and each
+# command its per-command retry), so during an outage a request would park an
+# ASGI worker slot for minutes instead of falling through. The limiter is
+# best-effort, so it gets one short budget and is skipped if Redis can't answer
+# inside it.
+SUBSCRIPTION_STATUS_REDIS_TIMEOUT_SECONDS = 0.25
 
 # Atomic fixed-window counter: INCR the key, and set the TTL only on the INCR
 # that opened the window (count == 1). Doing both in one server-side script
@@ -43,6 +57,26 @@ if count == 1 then
 end
 return count
 """
+
+
+async def _incr_window(key: str) -> int:
+    """Run the atomic counter, returning the request's position in the window.
+
+    Split out so the connect and the command share one deadline in the caller.
+    Lua ARGV values are strings; ``EXPIRE`` coerces ``"60"`` back to an int. The
+    cast mirrors the other ``eval()`` call sites (e.g. ``copilot/dream/locks``):
+    the cluster client types ``eval()``'s return as ``str``.
+    """
+    redis = await get_redis_async()
+    return await cast(
+        Any,
+        redis.eval(
+            _INCR_OPEN_WINDOW,
+            1,
+            key,
+            str(SUBSCRIPTION_STATUS_WINDOW_SECONDS),
+        ),
+    )
 
 
 def _window_key(user_id: str, *, now: datetime) -> str:
@@ -62,29 +96,33 @@ async def enforce_subscription_status_rate_limit(
     returning fresh state) never trip it — FastAPI dependencies run for HTTP
     requests, not for direct function calls.
 
-    On a *transient* Redis failure (connection/timeout/cluster-down) this fails
-    *open* (logs and lets the call through): a Redis blip must never block the
-    billing status read for every user, which would be far worse than one
-    client briefly exceeding its cap. Non-transient errors are left to
-    propagate rather than silently disabling the limiter.
+    On any Redis trouble this fails *open* (logs and lets the call through): a
+    Redis blip must never block the billing status read for every user, which
+    would be far worse than one client briefly exceeding its cap. The whole
+    interaction is bounded by ``SUBSCRIPTION_STATUS_REDIS_TIMEOUT_SECONDS`` so
+    an outage falls through fast instead of holding a worker slot.
+
+    ``RedisClusterException`` is caught explicitly: it does not inherit from
+    ``RedisError``, and ``SlotNotCoveredError`` (raised during a cluster
+    rolling restart / slot migration) would otherwise surface as a 500 — the
+    exact brown-out this fail-open exists for. Same reasoning as the comment in
+    ``backend/copilot/rate_limit.py``.
     """
     now = datetime.now(UTC)
     key = _window_key(user_id, now=now)
     try:
-        redis = await get_redis_async()
-        # Lua ARGV values are strings; EXPIRE coerces "60" back to an int. The
-        # cast mirrors the other eval() call sites (e.g. copilot/dream/locks):
-        # the cluster client types eval()'s return as str, so cast before await.
-        count = await cast(
-            Any,
-            redis.eval(
-                _INCR_OPEN_WINDOW,
-                1,
-                key,
-                str(SUBSCRIPTION_STATUS_WINDOW_SECONDS),
-            ),
+        count = await asyncio.wait_for(
+            _incr_window(key),
+            timeout=SUBSCRIPTION_STATUS_REDIS_TIMEOUT_SECONDS,
         )
-    except TRANSIENT_REDIS_ERRORS as e:
+    except (
+        RedisError,
+        RedisClusterException,
+        ConnectionError,
+        OSError,
+        asyncio.TimeoutError,
+        ValueError,
+    ) as e:
         logger.warning(
             "Subscription-status rate-limit check failed open for user %s: %s",
             user_id,
@@ -93,6 +131,17 @@ async def enforce_subscription_status_rate_limit(
         return
 
     if count > SUBSCRIPTION_STATUS_MAX_REQUESTS:
+        # Seconds left in this fixed window. Without Retry-After the client
+        # retries blind (React Query defaults to 3 retries), turning one block
+        # into several extra requests against the endpoint being protected.
+        retry_after = SUBSCRIPTION_STATUS_WINDOW_SECONDS - (
+            int(now.timestamp()) % SUBSCRIPTION_STATUS_WINDOW_SECONDS
+        )
+        logger.info(
+            "Subscription-status rate limit hit for user %s (count=%s)",
+            user_id,
+            count,
+        )
         raise fastapi.HTTPException(
             status_code=429,
             detail=(
@@ -100,4 +149,5 @@ async def enforce_subscription_status_rate_limit(
                 f"({SUBSCRIPTION_STATUS_MAX_REQUESTS} requests per "
                 f"{SUBSCRIPTION_STATUS_WINDOW_SECONDS}s). Try again shortly."
             ),
+            headers={"Retry-After": str(retry_after)},
         )

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit.py
@@ -1,0 +1,79 @@
+"""Per-user rate limit for ``GET /api/credits/subscription``.
+
+The subscription-status endpoint is fetched on essentially every authenticated
+page load (PaywallGate wraps the app shell) and, on a cold cache, fans out to
+several Stripe reads per request. A per-user cap puts a hard ceiling on scripted
+clients hammering it, without affecting normal use: the frontend shares one
+React Query entry with a 60s ``staleTime``, so a real user — even with several
+tabs open and the occasional hard reload — stays around ~5-15 requests/minute.
+
+Fixed-window counter in Redis (``SET NX EX`` + ``INCR``), keyed per ``user_id``,
+fail-open on Redis brown-out. Mirrors ``backend/api/features/search/rate_limit``.
+A single key per check keeps it correct on the Redis cluster.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import fastapi
+from autogpt_libs.auth import get_user_id
+
+from backend.data.redis_client import get_redis_async
+
+logger = logging.getLogger(__name__)
+
+# 60 requests / minute / user — roughly 4x the heaviest realistic legitimate
+# burst (a multi-tab simultaneous hard-reload is ~15/min); the shared React
+# Query entry plus 60s staleTime keep steady-state use near ~1/min per tab.
+SUBSCRIPTION_STATUS_WINDOW_SECONDS = 60
+SUBSCRIPTION_STATUS_MAX_REQUESTS = 60
+
+
+def _window_key(user_id: str, *, now: datetime) -> str:
+    """Per-user fixed-window key, bucket-aligned to the window so each user
+    has at most one active counter per window."""
+    bucket = int(now.timestamp()) // SUBSCRIPTION_STATUS_WINDOW_SECONDS
+    return f"credits:subscription:rl:{user_id}:{bucket}"
+
+
+async def enforce_subscription_status_rate_limit(
+    user_id: str = fastapi.Security(get_user_id),
+) -> None:
+    """Raise HTTP 429 when ``user_id`` exceeds the per-window cap.
+
+    Wired as a route dependency on ``GET /credits/subscription`` only, so the
+    internal callers of ``get_subscription_status`` (e.g. the POST update flow
+    returning fresh state) never trip it — FastAPI dependencies run for HTTP
+    requests, not for direct function calls.
+
+    On Redis brown-out this fails *open* (logs and lets the call through): a
+    Redis blip must never block the billing status read for every user, which
+    would be far worse than one client briefly exceeding its cap.
+    """
+    now = datetime.now(UTC)
+    key = _window_key(user_id, now=now)
+    try:
+        redis = await get_redis_async()
+        # Atomic create-with-TTL, then INCR. SET NX EX makes the TTL part of
+        # the same write that creates the key; later INCRs preserve it.
+        await redis.set(key, 0, ex=SUBSCRIPTION_STATUS_WINDOW_SECONDS, nx=True)
+        count = await redis.incr(key)
+    except Exception as e:
+        logger.warning(
+            "Subscription-status rate-limit check failed open for user %s: %s",
+            user_id,
+            e,
+        )
+        return
+
+    if count > SUBSCRIPTION_STATUS_MAX_REQUESTS:
+        raise fastapi.HTTPException(
+            status_code=429,
+            detail=(
+                f"Subscription status rate limit exceeded "
+                f"({SUBSCRIPTION_STATUS_MAX_REQUESTS} requests per "
+                f"{SUBSCRIPTION_STATUS_WINDOW_SECONDS}s). Try again shortly."
+            ),
+        )

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
@@ -170,15 +170,14 @@ async def test_fails_open_and_fast_when_redis_hangs(mocker):
     """A hung Redis must not hold the request: the limiter has a deadline and
     falls through instead of parking a worker slot for the retry ladder."""
 
-    async def never_returns() -> int:
+    async def never_returns(_key: str) -> int:
         await asyncio.sleep(60)
         return 1
 
-    mocker.patch.object(
-        rate_limit,
-        "_incr_window",
-        side_effect=lambda _key: never_returns(),
-    )
+    # Replace the function outright rather than mocking it: an AsyncMock whose
+    # side_effect returns a coroutine hands that coroutine back as the result
+    # instead of awaiting it, so the deadline would never be exercised.
+    mocker.patch.object(rate_limit, "_incr_window", new=never_returns)
     mocker.patch.object(rate_limit, "SUBSCRIPTION_STATUS_REDIS_TIMEOUT_SECONDS", 0.05)
 
     loop = asyncio.get_running_loop()

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
@@ -52,7 +52,9 @@ async def test_over_limit_raises_429(fake_redis):
     with pytest.raises(fastapi.HTTPException) as exc_info:
         await rate_limit.enforce_subscription_status_rate_limit("u1")
     assert exc_info.value.status_code == 429
-    assert str(rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS) in str(exc_info.value.detail)
+    assert str(rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS) in str(
+        exc_info.value.detail
+    )
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
@@ -6,17 +6,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import fastapi
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from backend.api.features import credits_rate_limit as rate_limit
 
 
 @pytest.fixture
 def fake_redis(mocker):
-    """Patch ``get_redis_async`` to return a MagicMock with awaitable
-    ``set`` and ``incr`` so each test can drive the counter directly."""
+    """Patch ``get_redis_async`` to return a MagicMock whose awaitable ``eval``
+    returns the current counter value, so each test can drive the count."""
     redis = MagicMock()
-    redis.set = AsyncMock()
-    redis.incr = AsyncMock()
+    redis.eval = AsyncMock()
     mocker.patch(
         "backend.api.features.credits_rate_limit.get_redis_async",
         new=AsyncMock(return_value=redis),
@@ -25,30 +25,32 @@ def fake_redis(mocker):
 
 
 @pytest.mark.asyncio
-async def test_first_hit_creates_key_with_ttl(fake_redis):
-    """``SET NX EX`` runs on every hit and sets the TTL exactly once when
-    the window opens (subsequent hits no-op the SET)."""
-    fake_redis.incr.return_value = 1
+async def test_first_hit_runs_atomic_counter(fake_redis):
+    """The counter is a single atomic EVAL (INCR + conditional EXPIRE), so a
+    freshly-created key always gets its TTL in the same round-trip — there is
+    no window between creation and increment where the key could lack a TTL."""
+    fake_redis.eval.return_value = 1
     await rate_limit.enforce_subscription_status_rate_limit("u1")
-    fake_redis.set.assert_awaited_once()
-    args, kwargs = fake_redis.set.await_args
-    key = args[0]
-    assert kwargs["ex"] == rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS
-    assert kwargs["nx"] is True
-    assert "u1" in key
+    fake_redis.eval.assert_awaited_once()
+    args = fake_redis.eval.await_args.args
+    # eval(script, numkeys, key, ttl)
+    assert args[0] == rate_limit._INCR_OPEN_WINDOW
+    assert args[1] == 1
+    assert "u1" in args[2]
+    assert args[3] == str(rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS)
 
 
 @pytest.mark.asyncio
 async def test_at_limit_passes(fake_redis):
     """Exactly MAX is still allowed — the cap is exclusive (count > MAX raises)."""
-    fake_redis.incr.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS
+    fake_redis.eval.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS
     await rate_limit.enforce_subscription_status_rate_limit("u1")
 
 
 @pytest.mark.asyncio
 async def test_over_limit_raises_429(fake_redis):
     """One past the cap raises HTTP 429 with a descriptive detail."""
-    fake_redis.incr.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS + 1
+    fake_redis.eval.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS + 1
     with pytest.raises(fastapi.HTTPException) as exc_info:
         await rate_limit.enforce_subscription_status_rate_limit("u1")
     assert exc_info.value.status_code == 429
@@ -58,28 +60,40 @@ async def test_over_limit_raises_429(fake_redis):
 
 
 @pytest.mark.asyncio
-async def test_fails_open_on_redis_error(mocker):
-    """A Redis brown-out must not block the billing status read — fail-open."""
+async def test_fails_open_on_transient_redis_error(mocker):
+    """A transient Redis failure must not block the billing status read for
+    every user — fail open (no exception raised to the caller)."""
     mocker.patch(
         "backend.api.features.credits_rate_limit.get_redis_async",
-        new=AsyncMock(side_effect=RuntimeError("redis down")),
+        new=AsyncMock(side_effect=RedisConnectionError("redis down")),
     )
-    # Should NOT raise.
     await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+
+@pytest.mark.asyncio
+async def test_non_transient_error_propagates(mocker):
+    """A non-transient error (a bug, not a Redis blip) must surface rather than
+    silently disabling the limiter."""
+    mocker.patch(
+        "backend.api.features.credits_rate_limit.get_redis_async",
+        new=AsyncMock(side_effect=RuntimeError("programming error")),
+    )
+    with pytest.raises(RuntimeError):
+        await rate_limit.enforce_subscription_status_rate_limit("u1")
 
 
 @pytest.mark.asyncio
 async def test_per_user_keys_are_distinct(fake_redis):
     """The window key derives from ``user_id`` so two users' counters
     never collide."""
-    fake_redis.incr.return_value = 1
+    fake_redis.eval.return_value = 1
     await rate_limit.enforce_subscription_status_rate_limit("alice")
-    key_a = fake_redis.incr.await_args.args[0]
+    key_a = fake_redis.eval.await_args.args[2]
 
-    fake_redis.incr.reset_mock()
-    fake_redis.incr.return_value = 1
+    fake_redis.eval.reset_mock()
+    fake_redis.eval.return_value = 1
     await rate_limit.enforce_subscription_status_rate_limit("bob")
-    key_b = fake_redis.incr.await_args.args[0]
+    key_b = fake_redis.eval.await_args.args[2]
 
     assert key_a != key_b
     assert "alice" in key_a

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
@@ -183,7 +183,10 @@ async def test_fails_open_and_fast_when_redis_hangs(mocker):
     loop = asyncio.get_running_loop()
     started = loop.time()
     await rate_limit.enforce_subscription_status_rate_limit("u1")
-    assert loop.time() - started < 5
+    # Tight bound: the patched deadline is 50ms, so anything approaching a
+    # second means the timeout was not honoured. Generous enough to absorb CI
+    # scheduling jitter, strict enough to fail if the deadline is dropped.
+    assert loop.time() - started < 1
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
@@ -2,19 +2,58 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import fastapi
 import pytest
 from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisClusterException, ResponseError
 
 from backend.api.features import credits_rate_limit as rate_limit
 
 
+class FakeRedis:
+    """Minimal Redis stand-in that actually interprets the limiter's Lua.
+
+    ``eval`` is mocked in most suites, which means the script — the only
+    non-trivial logic in the module — never runs. This executes the same
+    semantics (INCR, and EXPIRE only on the call that opened the window)
+    against real state, so a regression in the script (e.g. dropping the
+    EXPIRE branch, or refreshing the TTL on every hit) fails a test.
+    """
+
+    def __init__(self) -> None:
+        self.counters: dict[str, int] = {}
+        self.ttls: dict[str, int] = {}
+
+    async def eval(self, script: str, numkeys: int, key: str, ttl: str) -> int:
+        assert script == rate_limit._INCR_OPEN_WINDOW
+        assert numkeys == 1
+        count = self.counters.get(key, 0) + 1
+        self.counters[key] = count
+        if count == 1:
+            self.ttls[key] = int(ttl)
+        return count
+
+
 @pytest.fixture
 def fake_redis(mocker):
-    """Patch ``get_redis_async`` to return a MagicMock whose awaitable ``eval``
-    returns the current counter value, so each test can drive the count."""
+    """Patch ``get_redis_async`` to return a stateful fake whose ``eval``
+    executes the limiter's script semantics."""
+    redis = FakeRedis()
+    mocker.patch(
+        "backend.api.features.credits_rate_limit.get_redis_async",
+        new=AsyncMock(return_value=redis),
+    )
+    return redis
+
+
+@pytest.fixture
+def mock_redis(mocker):
+    """Patch ``get_redis_async`` with a MagicMock whose ``eval`` return value
+    each test sets directly, for driving specific counts/errors."""
     redis = MagicMock()
     redis.eval = AsyncMock()
     mocker.patch(
@@ -25,76 +64,136 @@ def fake_redis(mocker):
 
 
 @pytest.mark.asyncio
-async def test_first_hit_runs_atomic_counter(fake_redis):
-    """The counter is a single atomic EVAL (INCR + conditional EXPIRE), so a
-    freshly-created key always gets its TTL in the same round-trip — there is
-    no window between creation and increment where the key could lack a TTL."""
-    fake_redis.eval.return_value = 1
+async def test_first_hit_sets_ttl(fake_redis):
+    """The window-opening request must set the TTL, or the key would never
+    expire and the user would stay blocked forever after hitting the cap."""
     await rate_limit.enforce_subscription_status_rate_limit("u1")
-    fake_redis.eval.assert_awaited_once()
-    args = fake_redis.eval.await_args.args
-    # eval(script, numkeys, key, ttl)
-    assert args[0] == rate_limit._INCR_OPEN_WINDOW
-    assert args[1] == 1
-    assert "u1" in args[2]
-    assert args[3] == str(rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS)
+    (key,) = fake_redis.ttls
+    assert "u1" in key
+    assert fake_redis.ttls[key] == rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS
+    assert fake_redis.counters[key] == 1
 
 
 @pytest.mark.asyncio
-async def test_at_limit_passes(fake_redis):
-    """Exactly MAX is still allowed — the cap is exclusive (count > MAX raises)."""
-    fake_redis.eval.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS
-    await rate_limit.enforce_subscription_status_rate_limit("u1")
+async def test_ttl_not_refreshed_on_later_hits(fake_redis):
+    """The window is fixed: later hits increment but must not extend the TTL,
+    otherwise a steady stream of requests would hold the window open."""
+    for _ in range(5):
+        await rate_limit.enforce_subscription_status_rate_limit("u1")
+    (key,) = fake_redis.ttls
+    assert fake_redis.counters[key] == 5
+    # Exactly one key, whose TTL was written once when the window opened.
+    assert list(fake_redis.ttls.values()) == [
+        rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS
+    ]
 
 
 @pytest.mark.asyncio
-async def test_over_limit_raises_429(fake_redis):
-    """One past the cap raises HTTP 429 with a descriptive detail."""
-    fake_redis.eval.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS + 1
+async def test_window_rolls_over(fake_redis, mocker):
+    """A later window uses a different key, so the count starts fresh."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    mocker.patch.object(rate_limit, "datetime", MagicMock(now=lambda tz: base))
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+    later = datetime(2026, 1, 1, 12, 1, 30, tzinfo=UTC)
+    mocker.patch.object(rate_limit, "datetime", MagicMock(now=lambda tz: later))
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+    assert len(fake_redis.counters) == 2
+    assert set(fake_redis.counters.values()) == {1}
+
+
+@pytest.mark.asyncio
+async def test_cap_is_enforced_over_a_real_sequence(fake_redis):
+    """Exactly MAX requests pass; the next one is rejected."""
+    for _ in range(rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS):
+        await rate_limit.enforce_subscription_status_rate_limit("u1")
     with pytest.raises(fastapi.HTTPException) as exc_info:
         await rate_limit.enforce_subscription_status_rate_limit("u1")
     assert exc_info.value.status_code == 429
-    assert str(rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS) in str(
-        exc_info.value.detail
-    )
 
 
 @pytest.mark.asyncio
-async def test_fails_open_on_transient_redis_error(mocker):
-    """A transient Redis failure must not block the billing status read for
-    every user — fail open (no exception raised to the caller)."""
+async def test_over_limit_sets_retry_after(mock_redis):
+    """429 must carry Retry-After: without it clients retry blind and a single
+    block turns into several more requests against the endpoint."""
+    mock_redis.eval.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS + 1
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await rate_limit.enforce_subscription_status_rate_limit("u1")
+    headers = exc_info.value.headers or {}
+    retry_after = int(headers["Retry-After"])
+    assert 0 < retry_after <= rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_at_limit_passes(mock_redis):
+    """Exactly MAX is still allowed — the cap is exclusive (count > MAX raises)."""
+    mock_redis.eval.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        RedisConnectionError("connection refused"),
+        # Does not inherit from RedisError; raised during a cluster rolling
+        # restart / slot migration. Must not 500 the billing endpoint.
+        RedisClusterException("SlotNotCoveredError"),
+        ResponseError("MISCONF Redis is configured to save RDB snapshots"),
+        OSError("socket blew up"),
+    ],
+    ids=["connection", "cluster", "response", "os"],
+)
+@pytest.mark.asyncio
+async def test_fails_open_on_redis_errors_from_the_command(mock_redis, error):
+    """Every flavour of Redis trouble on an established client must fail open.
+
+    The client is cached per event loop, so in production the connect path
+    rarely runs — the real surface is ``eval`` raising mid-command.
+    """
+    mock_redis.eval.side_effect = error
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+
+@pytest.mark.asyncio
+async def test_fails_open_when_connect_fails(mocker):
+    """Trouble reaching Redis at all also fails open."""
     mocker.patch(
         "backend.api.features.credits_rate_limit.get_redis_async",
-        new=AsyncMock(side_effect=RedisConnectionError("redis down")),
+        new=AsyncMock(side_effect=RedisClusterException("cluster down")),
     )
     await rate_limit.enforce_subscription_status_rate_limit("u1")
 
 
 @pytest.mark.asyncio
-async def test_non_transient_error_propagates(mocker):
-    """A non-transient error (a bug, not a Redis blip) must surface rather than
-    silently disabling the limiter."""
-    mocker.patch(
-        "backend.api.features.credits_rate_limit.get_redis_async",
-        new=AsyncMock(side_effect=RuntimeError("programming error")),
+async def test_fails_open_and_fast_when_redis_hangs(mocker):
+    """A hung Redis must not hold the request: the limiter has a deadline and
+    falls through instead of parking a worker slot for the retry ladder."""
+
+    async def never_returns() -> int:
+        await asyncio.sleep(60)
+        return 1
+
+    mocker.patch.object(
+        rate_limit,
+        "_incr_window",
+        side_effect=lambda _key: never_returns(),
     )
-    with pytest.raises(RuntimeError):
-        await rate_limit.enforce_subscription_status_rate_limit("u1")
+    mocker.patch.object(rate_limit, "SUBSCRIPTION_STATUS_REDIS_TIMEOUT_SECONDS", 0.05)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+    assert loop.time() - started < 5
 
 
 @pytest.mark.asyncio
 async def test_per_user_keys_are_distinct(fake_redis):
     """The window key derives from ``user_id`` so two users' counters
     never collide."""
-    fake_redis.eval.return_value = 1
     await rate_limit.enforce_subscription_status_rate_limit("alice")
-    key_a = fake_redis.eval.await_args.args[2]
-
-    fake_redis.eval.reset_mock()
-    fake_redis.eval.return_value = 1
     await rate_limit.enforce_subscription_status_rate_limit("bob")
-    key_b = fake_redis.eval.await_args.args[2]
-
-    assert key_a != key_b
-    assert "alice" in key_a
-    assert "bob" in key_b
+    keys = sorted(fake_redis.counters)
+    assert len(keys) == 2
+    assert any("alice" in k for k in keys)
+    assert any("bob" in k for k in keys)

--- a/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/features/credits_rate_limit_test.py
@@ -1,0 +1,84 @@
+"""Unit tests for the GET /credits/subscription per-user rate limiter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import fastapi
+import pytest
+
+from backend.api.features import credits_rate_limit as rate_limit
+
+
+@pytest.fixture
+def fake_redis(mocker):
+    """Patch ``get_redis_async`` to return a MagicMock with awaitable
+    ``set`` and ``incr`` so each test can drive the counter directly."""
+    redis = MagicMock()
+    redis.set = AsyncMock()
+    redis.incr = AsyncMock()
+    mocker.patch(
+        "backend.api.features.credits_rate_limit.get_redis_async",
+        new=AsyncMock(return_value=redis),
+    )
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_first_hit_creates_key_with_ttl(fake_redis):
+    """``SET NX EX`` runs on every hit and sets the TTL exactly once when
+    the window opens (subsequent hits no-op the SET)."""
+    fake_redis.incr.return_value = 1
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+    fake_redis.set.assert_awaited_once()
+    args, kwargs = fake_redis.set.await_args
+    key = args[0]
+    assert kwargs["ex"] == rate_limit.SUBSCRIPTION_STATUS_WINDOW_SECONDS
+    assert kwargs["nx"] is True
+    assert "u1" in key
+
+
+@pytest.mark.asyncio
+async def test_at_limit_passes(fake_redis):
+    """Exactly MAX is still allowed — the cap is exclusive (count > MAX raises)."""
+    fake_redis.incr.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+
+@pytest.mark.asyncio
+async def test_over_limit_raises_429(fake_redis):
+    """One past the cap raises HTTP 429 with a descriptive detail."""
+    fake_redis.incr.return_value = rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS + 1
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await rate_limit.enforce_subscription_status_rate_limit("u1")
+    assert exc_info.value.status_code == 429
+    assert str(rate_limit.SUBSCRIPTION_STATUS_MAX_REQUESTS) in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_fails_open_on_redis_error(mocker):
+    """A Redis brown-out must not block the billing status read — fail-open."""
+    mocker.patch(
+        "backend.api.features.credits_rate_limit.get_redis_async",
+        new=AsyncMock(side_effect=RuntimeError("redis down")),
+    )
+    # Should NOT raise.
+    await rate_limit.enforce_subscription_status_rate_limit("u1")
+
+
+@pytest.mark.asyncio
+async def test_per_user_keys_are_distinct(fake_redis):
+    """The window key derives from ``user_id`` so two users' counters
+    never collide."""
+    fake_redis.incr.return_value = 1
+    await rate_limit.enforce_subscription_status_rate_limit("alice")
+    key_a = fake_redis.incr.await_args.args[0]
+
+    fake_redis.incr.reset_mock()
+    fake_redis.incr.return_value = 1
+    await rate_limit.enforce_subscription_status_rate_limit("bob")
+    key_b = fake_redis.incr.await_args.args[0]
+
+    assert key_a != key_b
+    assert "alice" in key_a
+    assert "bob" in key_b

--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -10,6 +10,7 @@ import stripe
 from autogpt_libs.auth.jwt_utils import get_jwt_payload
 from prisma.enums import SubscriptionTier
 
+from .credits_rate_limit import enforce_subscription_status_rate_limit
 from .v1 import _validate_checkout_redirect_url, v1_router
 
 TEST_USER_ID = "3e53486c-cf57-477e-ba2a-cb02dc828e1a"
@@ -31,6 +32,11 @@ def client() -> fastapi.testclient.TestClient:
         return {"sub": TEST_USER_ID, "role": "user", "email": "test@example.com"}
 
     app.dependency_overrides[get_jwt_payload] = override_get_jwt_payload
+    # Neutralise the subscription-status limiter: it counts in Redis against a
+    # shared key derived from the hardcoded TEST_USER_ID, so without this the
+    # GET tests here consume a real, never-reset window and start 429ing once
+    # enough of them run.
+    app.dependency_overrides[enforce_subscription_status_rate_limit] = lambda: None
     try:
         yield fastapi.testclient.TestClient(app)
     finally:

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -1010,6 +1010,7 @@ async def _get_stripe_price_amount(price_id: str) -> int | None:
         Security(requires_user),
         Depends(enforce_subscription_status_rate_limit),
     ],
+    responses={429: {"description": "Rate limit exceeded"}},
 )
 async def get_subscription_status(
     user_id: Annotated[str, Security(get_user_id)],

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -36,6 +36,9 @@ from starlette.status import (
 )
 from typing_extensions import Optional, TypedDict
 
+from backend.api.features.credits_rate_limit import (
+    enforce_subscription_status_rate_limit,
+)
 from backend.api.features.executions.activity_gate import (
     hide_activity_summaries_if_disabled,
     hide_activity_summary_if_disabled,
@@ -1003,7 +1006,10 @@ async def _get_stripe_price_amount(price_id: str) -> int | None:
     summary="Get subscription tier, current cost, and all tier costs",
     operation_id="getSubscriptionStatus",
     tags=["credits"],
-    dependencies=[Security(requires_user)],
+    dependencies=[
+        Security(requires_user),
+        Depends(enforce_subscription_status_rate_limit),
+    ],
 )
 async def get_subscription_status(
     user_id: Annotated[str, Security(get_user_id)],

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -5377,7 +5377,8 @@
           },
           "401": {
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
-          }
+          },
+          "429": { "description": "Rate limit exceeded" }
         },
         "security": [{ "HTTPBearerJWT": [] }]
       },


### PR DESCRIPTION
### Why / What / How

**Why:** `GET /api/credits/subscription` is fetched on essentially every authenticated page load (PaywallGate wraps the app shell) and, on a cold cache, fans out to several Stripe reads per request. Unlike `/search/global` — which already has a per-user QPS limiter for the same reason (per-request fan-out to a paid API) — this endpoint has no request-rate ceiling, so a scripted client can hammer it unbounded.

**What:** Add a per-user rate limit to `GET /credits/subscription`, consistent with the existing search limiter.

**How:**
- New `credits_rate_limit.py`: a per-user fixed-window Redis counter (`SET NX EX` + `INCR`), **fail-open on Redis brown-out**, raising `429` past the cap. Single key per check (cluster-safe). Mirrors `backend/api/features/search/rate_limit.py`.
- Cap: **60 requests / minute / user**. The frontend shares one React Query entry with a 60s `staleTime`, so steady-state use is ~1/min per tab; even a heavy multi-tab user hard-reloading peaks around ~15/min — the cap leaves ~4x headroom.
- Wired as a **route dependency on the GET only**, so the internal callers of `get_subscription_status` (e.g. the POST update flow returning fresh state) are never affected — dependencies run for HTTP requests, not direct function calls.
- PaywallGate already renders its children regardless of the subscription query result (it only overlays a modal when `tier === "NO_TIER"`), so a 429 degrades gracefully rather than blocking the app.

### Changes 🏗️

- `backend/api/features/credits_rate_limit.py`: new per-user limiter + tests.
- `backend/api/features/v1.py`: apply it as a dependency on `GET /credits/subscription`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Unit: first-hit TTL, at/over-limit (429), fail-open on Redis error, per-user key isolation
  - [ ] Functional: `GET /api/credits/subscription` returns 200 under normal use; internal POST-update flow unaffected

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes (no config changes)
- [x] `docker-compose.yml` is updated or already compatible with my changes (no config changes)
