### PR TITLE
fix(frontend): clean up wallet timers

### DIFF
--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/__tests__/Wallet.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/__tests__/Wallet.test.tsx
@@ -1,13 +1,15 @@
-import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import { act, render, screen, waitFor } from "@/tests/integrations/test-utils";
 import {
   UserOnboarding,
   WebSocketNotification,
 } from "@/lib/autogpt-server-api";
 import userEvent from "@testing-library/user-event";
 import { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Wallet } from "../Wallet";
+import { TaskGroups } from "../components/WalletTaskGroups";
+import { getTaskGroups } from "../helpers";
 
 const confettiMock = vi.hoisted(() => vi.fn());
 const fetchCreditsMock = vi.hoisted(() => vi.fn());
@@ -112,6 +114,13 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  if (vi.isFakeTimers()) {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  }
+});
+
 describe("Wallet", () => {
   it("renders nothing until credits and onboarding state are both available", () => {
     creditsState.credits = null;
@@ -190,12 +199,55 @@ describe("Wallet", () => {
   });
 });
 
+describe("Wallet timer cleanup", () => {
+  it("cancels delayed task confetti when task groups unmount", () => {
+    vi.useFakeTimers();
+    const { unmount } = render(
+      <TaskGroups groups={getTaskGroups(onboardingState.state)} />,
+    );
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+    vi.runOnlyPendingTimers();
+
+    expect(confettiMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels the pending balance flash when the wallet unmounts", () => {
+    vi.useFakeTimers();
+    const { rerender, unmount } = render(<Wallet compact />);
+
+    creditsState.credits = 1479;
+    rerender(<Wallet compact />);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resets the balance flash after credits briefly become unavailable", () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(<Wallet compact />);
+
+    creditsState.credits = null;
+    rerender(<Wallet compact />);
+    creditsState.credits = 1479;
+    rerender(<Wallet compact />);
+
+    expect(container.querySelector(".bg-violet-400")?.className).toContain(
+      "opacity-50",
+    );
+
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(container.querySelector(".bg-violet-400")?.className).toContain(
+      "opacity-0",
+    );
+  });
+});
+
 describe("Wallet onboarding notifications", () => {
-  // Mounting <Wallet /> also mounts <TaskGroups />, whose celebration effect
-  // schedules its own confetti burst on a 300ms timer. That timer outlives the
-  // test that armed it and lands in a later one, so every assertion on
-  // confettiMock has to start from a clean slate after the render — otherwise
-  // the count depends on how fast the machine runs the suite.
   function emit(notification: WebSocketNotification) {
     const handler = onWebSocketMessageMock.mock.calls.at(-1)?.[1] as (
       n: WebSocketNotification,

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/components/WalletTaskGroups.tsx
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/components/WalletTaskGroups.tsx
@@ -13,6 +13,7 @@ interface Props {
 export function TaskGroups({ groups }: Props) {
   const { state, updateState } = useOnboarding();
   const refs = useRef<Record<string, HTMLDivElement | null>>({});
+  const confettiTimers = useRef(new Set<ReturnType<typeof setTimeout>>());
 
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
     const initialState: Record<string, boolean> = {};
@@ -83,7 +84,8 @@ export function TaskGroups({ groups }: Props) {
   }, []);
 
   const delayConfetti = useCallback((el: HTMLDivElement, count: number) => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
+      confettiTimers.current.delete(timer);
       if (!el) return;
       const rect = el.getBoundingClientRect();
       const shared: ConfettiOptions = {
@@ -104,6 +106,14 @@ export function TaskGroups({ groups }: Props) {
       confetti({ ...shared, angle: 45 });
       confetti({ ...shared, angle: 135 });
     }, 300);
+    confettiTimers.current.add(timer);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      confettiTimers.current.forEach(clearTimeout);
+      confettiTimers.current.clear();
+    };
   }, []);
 
   useEffect(() => {

--- a/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/useWallet.ts
+++ b/autogpt_platform/frontend/src/components/layout/Navbar/components/Wallet/useWallet.ts
@@ -27,6 +27,7 @@ export function useWallet() {
   const [topUpOpen, setTopUpOpen] = useState(false);
 
   const walletRef = useRef<HTMLButtonElement | null>(null);
+  const flashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const totalCount = groups.reduce((acc, group) => acc + group.tasks.length, 0);
 
@@ -140,10 +141,23 @@ export function useWallet() {
       return;
     }
     setFlash(true);
-    setTimeout(() => {
+    if (flashTimer.current !== null) {
+      clearTimeout(flashTimer.current);
+    }
+    flashTimer.current = setTimeout(() => {
+      flashTimer.current = null;
       setFlash(false);
     }, 300);
   }, [credits, prevCredits]);
+
+  useEffect(() => {
+    return () => {
+      if (flashTimer.current !== null) {
+        clearTimeout(flashTimer.current);
+        flashTimer.current = null;
+      }
+    };
+  }, []);
 
   return {
     state,


### PR DESCRIPTION
### Why / What / How

The frontend CI run on #14024 completed all tests, then failed during Happy DOM teardown when a delayed wallet confetti callback accessed `window` after it had been removed. The wallet also had a second uncancelled 300 ms balance-flash timer with the same lifecycle risk.

This PR makes both timers component-owned. Task-group confetti timers are tracked as a set and cancelled on unmount, while the balance flash keeps a single replaceable timer handle that is cancelled on unmount. The confetti cleanup is intentionally separate from the celebration effect so onboarding state updates do not cancel a valid in-flight celebration.

Failing run: https://github.com/Significant-Gravitas/AutoGPT/actions/runs/33204047905/job/98960589942

### Changes 🏗️

- Track and clear all delayed task-group confetti timers on unmount.
- Track, replace, and clear the wallet balance-flash timer without changing nullable-credit behavior.
- Add focused fake-timer regressions for both unmount paths and a transient unavailable-credit edge case.
- Remove the test comment that documented the now-fixed cross-test timer leak.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Focused wallet suite: 15/15 passing
  - [x] `pnpm lint`
  - [x] `pnpm types`
  - [ ] `pnpm test:unit`: 554/559 files and 5,988/5,994 tests pass locally; the six failures are unrelated assertions that hard-code en-US currency/date formatting while this Windows runner resolves `Intl` to en-GB. All wallet tests pass.

#### For configuration changes:

- [x] `.env.default` is already compatible with my changes
- [x] `docker-compose.yml` is already compatible with my changes
- [x] No configuration changes are included
