### PR TITLE
docs: refresh agent guidance paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This guide provides context for coding agents when updating the **autogpt_platfo
 - `autogpt_platform/frontend` – Next.js + Typescript frontend.
 - `autogpt_platform/docker-compose.yml` – development stack.
 
-See `docs/content/platform/getting-started.md` for setup instructions.
+See `docs/platform/getting-started.md` for setup instructions.
 
 ## Code style
 
@@ -65,5 +65,7 @@ Scopes: - platform - platform/library - platform/marketplace - backend - backend
 - Keep out-of-scope changes under 20% of the PR.
 - Ensure PR descriptions are complete.
 - For changes touching `data/*.py`, validate user ID checks or explain why not needed.
-- If adding protected frontend routes, update `frontend/lib/supabase/middleware.ts`.
+- If adding protected frontend routes, update `autogpt_platform/frontend/src/middleware.ts`
+  (matcher config) and `autogpt_platform/frontend/src/lib/auth/middleware.ts`
+  (better-auth protection logic).
 - Use the linear ticket branch structure if given codex/open-1668-resume-dropped-runs


### PR DESCRIPTION
### Why / What / How

`AGENTS.md` currently directs contributors to two paths that no longer exist. This updates the setup guide reference and points protected-route work at the current Next.js matcher and better-auth middleware files.

Closes #14233.

### Changes 🏗️

- replace the removed `docs/content/platform/getting-started.md` path with `docs/platform/getting-started.md`
- replace the removed Supabase middleware path with the current matcher and better-auth middleware paths

### Checklist 📋

This is a documentation-only change; no runtime code or configuration is modified.

Test plan:
- [x] Verified both replacement paths exist on `master` through the GitHub Contents API
- [x] Verified both replaced paths return 404 / are absent on `master`
- [x] Ran `git diff --check`