### PR TITLE
fix(copilot): clear pending questions ahead of expert identity guards (#14118)

### DIFF
--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -1638,6 +1638,17 @@ async def stream_chat_completion_baseline(
             f"Session {session_id} not found. Please create a new session first."
         )
 
+    # Strip any user-injected <user_context> tags on every turn.
+    # Only the server-injected prefix on the first message is trusted.
+    if message:
+        message = strip_user_context_tags(message)
+
+    # A reply is the only thing that clears a Home "Needs You" question.
+    # Cleared ahead of identity guards so user answers resolve pending questions
+    # regardless of subsequent identity build/organization validation.
+    if is_user_message and message and message.strip():
+        await clear_pending_question(session)
+
     expert_session_suffix = await build_expert_identity_suffix(
         session.user_id,
         session.expert_id,
@@ -1656,17 +1667,6 @@ async def stream_chat_completion_baseline(
     prune_orphan_tool_calls(
         session.messages, log_prefix=f"[Baseline] [{session_id[:12]}]"
     )
-
-    # Strip any user-injected <user_context> tags on every turn.
-    # Only the server-injected prefix on the first message is trusted.
-    if message:
-        message = strip_user_context_tags(message)
-
-    # A reply is the only thing that clears a Home "Needs You" question.
-    # Unconditional on the append result: the HTTP path pre-saves the user
-    # message, so the append is a no-op dedup there.
-    if is_user_message and message and message.strip():
-        await clear_pending_question(session)
 
     if maybe_append_user_message(session, message, is_user_message):
         if is_user_message:

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -4405,6 +4405,17 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
     # Type narrowing: session is guaranteed ChatSession after the check above
     session = cast(ChatSession, session)
 
+    # Strip any user-injected <user_context> tags on every turn.
+    # Only the server-injected prefix on the first message is trusted.
+    if message:
+        message = strip_user_context_tags(message)
+
+    # A reply is the only thing that clears a Home "Needs You" question.
+    # Cleared ahead of identity guards so user answers resolve pending questions
+    # regardless of subsequent identity build/organization validation.
+    if is_user_message and message and message.strip():
+        await clear_pending_question(session)
+
     expert_session_suffix = await build_expert_identity_suffix(
         session.user_id,
         session.expert_id,
@@ -4452,17 +4463,6 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
     # row(s) below _stamp_turn_messages' start_index — unstamped — exactly
     # on the error-recovery turns whose routing we most want recorded.
     pre_turn_message_count = len(session.messages)
-
-    # Strip any user-injected <user_context> tags on every turn.
-    # Only the server-injected prefix on the first message is trusted.
-    if message:
-        message = strip_user_context_tags(message)
-
-    # A reply is the only thing that clears a Home "Needs You" question.
-    # Unconditional on the append result: the HTTP path pre-saves the user
-    # message, so the append is a no-op dedup there.
-    if is_user_message and message and message.strip():
-        await clear_pending_question(session)
 
     _user_message_appended = maybe_append_user_message(
         session, message, is_user_message

--- a/autogpt_platform/backend/backend/copilot/tools/ask_question_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/ask_question_test.py
@@ -420,3 +420,30 @@ async def test_clearing_a_session_with_no_question_touches_nothing(
         await clear_pending_question(session)
 
     db.clear_session_pending_question.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clearing_pending_question_clears_metadata_and_persists(
+    tool: AskQuestionTool, session: ChatSession
+):
+    db = MagicMock()
+    db.set_session_pending_question = AsyncMock()
+    db.clear_session_pending_question = AsyncMock()
+    with (
+        patch("backend.copilot.tools.ask_question.chat_db", MagicMock(return_value=db)),
+        patch("backend.copilot.model.chat_db", MagicMock(return_value=db)),
+    ):
+        await tool._execute(
+            user_id=None,
+            session=session,
+            questions=[{"question": "Confirm choice?"}],
+        )
+        assert session.metadata.pending_question is not None
+
+        # Replying in the thread invokes clear_pending_question
+        await clear_pending_question(session)
+        assert session.metadata.pending_question is None
+        db.clear_session_pending_question.assert_awaited_once_with(
+            session.session_id, session.user_id
+        )
+


### PR DESCRIPTION
### Summary of Changes

In both the baseline (`backend/copilot/baseline/service.py`) and SDK (`backend/copilot/sdk/service.py`) streaming chat engines, `clear_pending_question(session)` was called *after* `build_expert_identity_suffix()`.

When an expert was archived, mismatched organization/team tenancy, or encountered origin-mismatch resume rejections, `build_expert_identity_suffix` raised before `clear_pending_question` ran. Because Home question cards carry no dismiss button, the question card remained permanently pinned on Home.

### Fix

1. **Reordered Clear Invocation**: Moved `clear_pending_question(session)` ahead of `build_expert_identity_suffix()` in both `stream_chat_completion_baseline` and `stream_chat_completion_sdk`. When a user replies to an open question in a thread, the pending question is resolved immediately upon message receipt, preventing orphan cards on Home regardless of downstream identity validation outcomes.
2. **Regression Test**: Added `test_clearing_pending_question_clears_metadata_and_persists` in `backend/copilot/tools/ask_question_test.py` to verify that replying to a pending question clears session metadata and invokes the DB cleanup.

Fixes #14118