### PR TITLE
docs(platform): add OPENAI_API_BASE_URL and CHAT_BASE_URL config examples

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,6 @@
+# ==========================================
+# Custom LLM Endpoint Configuration (PZERO)
+# ==========================================
+# Set custom base URLs if you are using custom gateways, proxies, or local models.
+# OPENAI_API_BASE_URL=https://your-custom-endpoint.com/v1
+# CHAT_BASE_URL=https://your-custom-endpoint.com/v1


### PR DESCRIPTION
## Summary
Adds documentation and commented-out environment variable examples for custom LLM endpoints (`OPENAI_API_BASE_URL` and `CHAT_BASE_URL`) to `.env.default`. 

This helps users easily configure local models, alternative providers, or custom API gateways when setting up the platform.

## Changes
- Updated `.env.default` with standard configuration placeholders for custom base URLs.