### PR TITLE
fix(copilot): stop chat composer height flicker and placeholder flash on empty session

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
@@ -175,7 +175,6 @@ export const ChatContainer = ({
   // across renders — otherwise every consumer of `guardedOnSend` (the actions
   // provider, ChatInput, EmptySession, handleRetry) re-renders on each pass.
   const guardedOnSend = isSendLocked ? NO_OP_SEND : onSend;
-  const inputLayoutId = "copilot-2-chat-input";
 
   // Measure the usage-limit overlay so the messages scroll area can pad its
   // bottom — otherwise the last message would sit permanently behind the
@@ -355,7 +354,6 @@ export const ChatContainer = ({
               </div>
             ) : (
               <EmptySession
-                inputLayoutId={inputLayoutId}
                 isCreatingSession={isCreatingSession}
                 onCreateSession={onCreateSession}
                 onSend={guardedOnSend}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotHome/__tests__/flag-off.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotHome/__tests__/flag-off.test.tsx
@@ -24,7 +24,6 @@ vi.mock("@/services/feature-flags/use-get-flag", async (importActual) => {
 });
 
 const baseProps = {
-  inputLayoutId: "test-layout",
   isCreatingSession: false,
   onCreateSession: vi.fn(),
   onSend: vi.fn(),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotHome/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/CopilotHome/__tests__/main.test.tsx
@@ -27,7 +27,6 @@ vi.mock("@/services/feature-flags/use-get-flag", async (importActual) => {
 });
 
 const baseProps = {
-  inputLayoutId: "test-layout",
   isCreatingSession: false,
   onCreateSession: vi.fn(),
   onSend: vi.fn(),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { DotDistortionShader } from "@/components/ui/dot-distortion-shader";
 import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import {
   getGreetingName,
   getInputPlaceholder,
@@ -29,7 +29,6 @@ import { RecipientChip } from "../ChatInput/components/RecipientChip";
 import { useRecipientPicker } from "./useRecipientPicker";
 
 interface Props {
-  inputLayoutId: string;
   isCreatingSession: boolean;
   onCreateSession: () => void | Promise<string>;
   onSend: (
@@ -46,7 +45,6 @@ interface Props {
 }
 
 export function EmptySession({
-  inputLayoutId,
   isCreatingSession,
   onSend,
   isUploadingFiles,
@@ -81,7 +79,12 @@ export function EmptySession({
     getInputPlaceholder(),
   );
 
-  useEffect(() => {
+  // Layout effect (not a regular effect) so the width-dependent placeholder
+  // is swapped in before the browser paints — otherwise the shorter default
+  // string flashes on screen first and visibly reflows into the longer one,
+  // which is what caused the placeholder to jump between wrapping above the
+  // icons and sitting next to them.
+  useLayoutEffect(() => {
     function handleResize() {
       setInputPlaceholder(getInputPlaceholder(window.innerWidth));
     }
@@ -155,9 +158,7 @@ export function EmptySession({
               the greeting page instead of sitting under a bare hero. */}
           {!intro.isAwaitingGreeting && (
             <div className={cn("mb-6", intro.isVisible && "max-w-[48rem]")}>
-              <motion.div
-                layoutId={inputLayoutId}
-                transition={{ type: "spring", bounce: 0.2, duration: 0.65 }}
+              <div
                 className={cn(
                   isBrainDumpEnabled
                     ? "overflow-hidden rounded-xlarge border text-left transition-colors duration-300 ease-out"
@@ -204,7 +205,7 @@ export function EmptySession({
                     ) : undefined
                   }
                 />
-              </motion.div>
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
## Problem
On the empty CoPilot session (no chat history yet), the chat input box had a visible UI bug (SECRT-2590): the composer height kept increasing/decreasing as you typed, and the placeholder text sometimes wrapped above the icon row and sometimes sat next to it.

## Root causes
1. **Height flicker**: the composer's wrapping `motion.div` in `EmptySession.tsx` had `layoutId={inputLayoutId}` and a bouncy spring `transition`. This `layoutId` had no matching paired element anywhere else in the app (confirmed via a repo-wide search and by checking the docked/active-session composer, which uses a plain fade-in with no `layoutId`). Since `layoutId` alone enables Framer Motion's layout-animation tracking, every internal height change (the textarea auto-resizing on each keystroke) was animated through the spring transition instead of resizing instantly, causing the visible overshoot/settle flicker.
2. **Placeholder flash**: the width-dependent placeholder string was set in a `useEffect`, which runs after the browser paints. This caused the default (shorter) placeholder to render first and then visibly reflow into the longer, width-dependent one, which is what made the placeholder appear above the icons vs. next to them inconsistently.

## Fix
- Removed the vestigial `layoutId`/`transition` from the `EmptySession` composer wrapper (`motion.div` → plain `div`), and removed the now-dead `inputLayoutId` prop from `ChatContainer` and the related test mocks.
- Switched the placeholder-sizing effect from `useEffect` to `useLayoutEffect` so the correct placeholder is applied before paint, eliminating the flash/reflow.

## Testing
This sandbox environment only has 478MB RAM with no swap, which OOM-kills `pnpm install`'s linking phase for this monorepo, so I wasn't able to run the dev server, `tsc`, or `eslint` here. I verified all 4 changed files compile with no JS/TS syntax errors (`esbuild --bundle=false`), and manually traced the full `inputLayoutId` call chain to confirm it was safe to remove (no other element pairs with that `layoutId`, and the docked composer never used it). Would appreciate a maintainer or CI double-checking the visual behavior on a real dev server before merge.

Fixes SECRT-2590.