### PR TITLE
feat(platform): task spine phase 3 — overseer service, hire office, task outcome review

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/routes.py
+++ b/autogpt_platform/backend/backend/api/features/chat/routes.py
@@ -1466,6 +1466,8 @@ async def stream_chat_post(
     # cross-process / cross-restart idempotency. Same pattern as
     # graphiti/ingest.py's ensure_dream_system_scheduled registration.
     from backend.copilot.briefing.scheduling import ensure_morning_briefing_scheduled
+    from backend.copilot.overseer.scheduling import ensure_task_overseer_scheduled
+    from backend.copilot.task_spine import record_mid_task_instruction
 
     # Spawned through the shared helper: the loop only holds a weak
     # reference, so an unretained task can be GC'd mid-flight — leaving the
@@ -1475,6 +1477,18 @@ async def stream_chat_post(
         ensure_morning_briefing_scheduled(user_id),
         name=f"morning-briefing-register-{user_id[:12]}",
     )
+    spawn_background_task(
+        ensure_task_overseer_scheduled(user_id),
+        name=f"task-overseer-register-{user_id[:12]}",
+    )
+    if session.metadata.delegated_task_id:
+        # A user message into a session working a delegated task is a
+        # mid-task instruction: record it on the task's timeline so the
+        # next model turn (and the drawer) can see it.
+        spawn_background_task(
+            record_mid_task_instruction(user_id, session, request.message),
+            name=f"task-amendment-{session_id[:12]}",
+        )
 
     is_platform_route = session.metadata.llm_auth_provider == "platform"
     if is_platform_route:
@@ -1884,6 +1898,13 @@ async def queue_pending_message(
         raise HTTPException(
             status_code=409,
             detail="Session has no active turn. Start a new turn with POST /stream.",
+        )
+    if session.metadata.delegated_task_id:
+        from backend.copilot.task_spine import record_mid_task_instruction
+
+        spawn_background_task(
+            record_mid_task_instruction(user_id, session, request.message),
+            name=f"task-amendment-{session_id[:12]}",
         )
     return await queue_pending_for_http(
         session_id=session_id,

--- a/autogpt_platform/backend/backend/api/features/experts/errors.py
+++ b/autogpt_platform/backend/backend/api/features/experts/errors.py
@@ -23,6 +23,7 @@ __all__ = [
     "LIFETIME_RAISED_EXPERT_LIMIT",
     "ExpertHireUnavailableError",
     "ExpertLimitExceededError",
+    "ExpertPodLeadNotMemberError",
     "ExpertPodLimitReachedError",
     "ExpertPodNameTakenError",
     "ExpertPodNotFoundError",
@@ -52,3 +53,13 @@ class ExpertPodLimitReachedError(Exception):
     def __init__(self, limit: int):
         super().__init__(f"You can have at most {limit} pods")
         self.limit = limit
+
+
+class ExpertPodLeadNotMemberError(Exception):
+    def __init__(self, expert_id: str, pod_id: str):
+        super().__init__(
+            f"Expert {expert_id} is not a member of pod {pod_id}, "
+            "so they cannot lead it"
+        )
+        self.expert_id = expert_id
+        self.pod_id = pod_id

--- a/autogpt_platform/backend/backend/api/features/experts/experts_db.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db.py
@@ -22,6 +22,7 @@ from backend.api.features.experts.errors import (
     LIFETIME_RAISED_EXPERT_LIMIT,
     ExpertHireUnavailableError,
     ExpertLimitExceededError,
+    ExpertPodLeadNotMemberError,
     ExpertPodLimitReachedError,
     ExpertPodNameTakenError,
     ExpertPodNotFoundError,
@@ -45,6 +46,7 @@ from backend.api.features.experts.models import (
 )
 from backend.api.features.library import db as library_db
 from backend.api.features.orgs.db import get_user_default_team
+from backend.api.features.tasks import overseer_db
 from backend.blocks import get_output_block_ids
 from backend.copilot.briefing.outcome import DEFAULT_AGENT_NAME, run_link
 from backend.data.db import prisma as db_client
@@ -526,17 +528,15 @@ async def resolve_private_expert_tenancy(
     return organization_id, team_id
 
 
-async def hire_expert(user_id: str, template_id: str, name: str | None) -> HireResult:
-    template = await prisma.models.Expert.prisma().find_first(
-        where={"id": template_id, "isTemplate": True, "isArchived": False},
-        include=_WORKFLOW_INCLUDE,
-    )
-    if template is None:
-        raise ExpertTemplateNotFoundError(template_id)
+def hire_create_data(
+    user_id: str, template: prisma.models.Expert, name: str | None = None
+) -> prisma.types.ExpertCreateInput:
+    """The hired-copy row for *template*, shared by hire and hire-office.
 
-    # Copy the plain description, never the template's sample envelope: a hire
-    # that skips the voice pick must not leave raw JSON in the prompt, and the
-    # pick (when made) overwrites this via the soul PATCH anyway.
+    Copies the plain voice description, never the template's sample envelope:
+    a hire that skips the voice pick must not leave raw JSON in the prompt,
+    and the pick (when made) overwrites this via the soul PATCH anyway.
+    """
     template_voice, _ = decode_voice_preferences(template.voicePreferences)
     create_data: prisma.types.ExpertCreateInput = {
         "ownerUserId": user_id,
@@ -555,6 +555,18 @@ async def hire_expert(user_id: str, template_id: str, name: str | None) -> HireR
     }
     if template.toolProfile is not None:
         create_data["toolProfile"] = template.toolProfile
+    return create_data
+
+
+async def hire_expert(user_id: str, template_id: str, name: str | None) -> HireResult:
+    template = await prisma.models.Expert.prisma().find_first(
+        where={"id": template_id, "isTemplate": True, "isArchived": False},
+        include=_WORKFLOW_INCLUDE,
+    )
+    if template is None:
+        raise ExpertTemplateNotFoundError(template_id)
+
+    create_data = hire_create_data(user_id, template, name)
 
     try:
         expert, state = await _reserve_hired_expert(user_id, template_id, create_data)
@@ -592,35 +604,48 @@ async def _reserve_hired_expert(
     consume capacity, while reviving an archived hire does.
     """
     async with transaction() as tx:
-        await _lock_expert_creation(tx, user_id)
-        existing = await tx.expert.find_first(
-            where={"ownerUserId": user_id, "sourceTemplateId": template_id},
-            include=_WORKFLOW_INCLUDE,
-        )
-        if existing is not None:
-            # Fail closed on a hire that would resolve to a non-PRIVATE row:
-            # idempotent re-hire must never hand back an expert the rest of
-            # the API hides (mirrors get_expert's visibility filter).
-            if existing.visibility != ResourceVisibility.PRIVATE:
-                raise ExpertNotFoundError(existing.id)
-            if not existing.isArchived:
-                return existing, "existing"
-            await _ensure_active_expert_capacity(tx, user_id)
-            revived = await tx.expert.update(
-                where={"id": existing.id},
-                data={"isArchived": False},
-                include=_WORKFLOW_INCLUDE,
-            )
-            if revived is None:
-                raise ExpertNotFoundError(existing.id)
-            return revived, "revived"
+        await lock_expert_creation(tx, user_id)
+        return await reserve_hired_expert_locked(tx, user_id, template_id, create_data)
 
+
+async def reserve_hired_expert_locked(
+    tx: prisma.Prisma,
+    user_id: str,
+    template_id: str,
+    create_data: prisma.types.ExpertCreateInput,
+) -> tuple[prisma.models.Expert, Literal["existing", "revived", "created"]]:
+    """Get, revive, or create one hired expert inside the caller's
+    transaction. The caller must already hold the per-user creation lock
+    (:func:`lock_expert_creation`) — hire-office reserves several experts
+    under one lock and one transaction."""
+    existing = await tx.expert.find_first(
+        where={"ownerUserId": user_id, "sourceTemplateId": template_id},
+        include=_WORKFLOW_INCLUDE,
+    )
+    if existing is not None:
+        # Fail closed on a hire that would resolve to a non-PRIVATE row:
+        # idempotent re-hire must never hand back an expert the rest of
+        # the API hides (mirrors get_expert's visibility filter).
+        if existing.visibility != ResourceVisibility.PRIVATE:
+            raise ExpertNotFoundError(existing.id)
+        if not existing.isArchived:
+            return existing, "existing"
         await _ensure_active_expert_capacity(tx, user_id)
-        created = await tx.expert.create(
-            data=create_data,
+        revived = await tx.expert.update(
+            where={"id": existing.id},
+            data={"isArchived": False},
             include=_WORKFLOW_INCLUDE,
         )
-        return created, "created"
+        if revived is None:
+            raise ExpertNotFoundError(existing.id)
+        return revived, "revived"
+
+    await _ensure_active_expert_capacity(tx, user_id)
+    created = await tx.expert.create(
+        data=create_data,
+        include=_WORKFLOW_INCLUDE,
+    )
+    return created, "created"
 
 
 async def _resume_revived_hire(row: prisma.models.Expert) -> prisma.models.Expert:
@@ -672,7 +697,7 @@ async def _rollback_revive(owner_user_id: str, expert_id: str) -> None:
         logger.exception(f"Failed to restore archived state for expert #{expert_id}")
 
 
-async def _lock_expert_creation(tx: prisma.Prisma, user_id: str) -> None:
+async def lock_expert_creation(tx: prisma.Prisma, user_id: str) -> None:
     # execute_raw, not query_raw: pg_advisory_xact_lock returns void,
     # which Prisma cannot deserialize as a result column.
     await tx.execute_raw(
@@ -770,7 +795,7 @@ async def _create_raised_expert_row(
     skills: list[str] | None = None,
 ) -> prisma.models.Expert:
     async with transaction() as tx:
-        await _lock_expert_creation(tx, user_id)
+        await lock_expert_creation(tx, user_id)
         await _ensure_active_expert_capacity(tx, user_id)
         lifetime_raised_count = await tx.expert.count(
             where={
@@ -1182,6 +1207,14 @@ async def archive_expert(user_id: str, expert_id: str) -> None:
         logger.exception(
             f"Failed to detach triggers while archiving expert #{expert_id}"
         )
+    try:
+        # Open tasks must not die with their owner: hand them to Autopilot
+        # (null owner), with a handoff amendment on each task's timeline.
+        await overseer_db.reassign_open_tasks_to_autopilot(user_id, expert_id)
+    except Exception:
+        logger.exception(
+            f"Failed to reassign open tasks while archiving expert #{expert_id}"
+        )
 
 
 # ─── Pods (owner-scoped named groups) ──────────────────────────────────
@@ -1256,11 +1289,63 @@ async def assign_pod(user_id: str, expert_id: str, pod_id: str | None) -> Expert
     if updated == 0:
         raise ExpertNotFoundError(expert_id)
 
+    # A lead must stay a member of the pod they lead, so moving them out of a
+    # pod clears its leadership rather than leaving a stale lead behind.
+    where: prisma.types.ExpertPodWhereInput = {
+        "userId": user_id,
+        "leadExpertId": expert_id,
+    }
+    if pod_id is not None:
+        where["NOT"] = [{"id": pod_id}]
+    await prisma.models.ExpertPod.prisma().update_many(
+        where=where, data={"leadExpertId": None}
+    )
+
     expert = await get_expert(user_id, expert_id)
     if expert is None:
         raise ExpertNotFoundError(expert_id)
     return expert
 
 
+async def set_pod_lead(
+    user_id: str, pod_id: str, lead_expert_id: str | None
+) -> ExpertPod:
+    """Set (or clear, with ``None``) who fronts *pod_id*.
+
+    The lead must be a live hire of *user_id* who is a member of the pod:
+    routing sends the pod's work to them, so an outsider or archived expert
+    as lead would silently swallow delegations.
+    """
+    pod = await prisma.models.ExpertPod.prisma().find_first(
+        where={"id": pod_id, "userId": user_id}
+    )
+    if pod is None:
+        raise ExpertPodNotFoundError(pod_id)
+
+    if lead_expert_id is not None:
+        lead = await prisma.models.Expert.prisma().find_first(
+            where={
+                "id": lead_expert_id,
+                "ownerUserId": user_id,
+                "isTemplate": False,
+                "isArchived": False,
+            }
+        )
+        if lead is None:
+            raise ExpertNotFoundError(lead_expert_id)
+        if lead.podId != pod_id:
+            raise ExpertPodLeadNotMemberError(lead_expert_id, pod_id)
+
+    updated = await prisma.models.ExpertPod.prisma().update(
+        where={"id": pod_id}, data={"leadExpertId": lead_expert_id}
+    )
+    return _to_pod(updated or pod)
+
+
 def _to_pod(row: prisma.models.ExpertPod) -> ExpertPod:
-    return ExpertPod(id=row.id, name=row.name, created_at=row.createdAt)
+    return ExpertPod(
+        id=row.id,
+        name=row.name,
+        created_at=row.createdAt,
+        lead_expert_id=row.leadExpertId,
+    )

--- a/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
@@ -941,7 +941,7 @@ async def test_raise_expert_locks_are_independent_per_owner(server: SpinTestServ
     first_lock_acquired = asyncio.Event()
     second_lock_acquired = asyncio.Event()
     release_first = asyncio.Event()
-    lock_creation = experts_db._lock_expert_creation
+    lock_creation = experts_db.lock_expert_creation
 
     async def lock_and_hold_first(tx: prisma.Prisma, user_id: str) -> None:
         await lock_creation(tx, user_id)
@@ -951,7 +951,7 @@ async def test_raise_expert_locks_are_independent_per_owner(server: SpinTestServ
         elif user_id == second_owner.id:
             second_lock_acquired.set()
 
-    with patch.object(experts_db, "_lock_expert_creation", new=lock_and_hold_first):
+    with patch.object(experts_db, "lock_expert_creation", new=lock_and_hold_first):
         first = asyncio.create_task(
             experts_db.create_raised_expert(first_owner.id, "Alpha", None, None)
         )
@@ -3123,6 +3123,72 @@ async def test_assign_pod_none_detaches(server: SpinTestServer, test_user):
 
     detached = await experts_db.assign_pod(test_user.id, hired.expert.id, None)
     assert detached.pod_id is None
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_set_pod_lead_requires_membership(server: SpinTestServer, test_user):
+    member_template = await _seed_template(name="Maria", preload_listings=[])
+    outsider_template = await _seed_template(name="Omar", preload_listings=[])
+    member = await experts_db.hire_expert(test_user.id, member_template.id, "Member")
+    outsider = await experts_db.hire_expert(
+        test_user.id, outsider_template.id, "Outsider"
+    )
+    pod = await experts_db.create_pod(test_user.id, _pod_name("Growth"))
+    await experts_db.assign_pod(test_user.id, member.expert.id, pod.id)
+
+    with pytest.raises(experts_db.ExpertPodLeadNotMemberError):
+        await experts_db.set_pod_lead(test_user.id, pod.id, outsider.expert.id)
+
+    led = await experts_db.set_pod_lead(test_user.id, pod.id, member.expert.id)
+    assert led.lead_expert_id == member.expert.id
+
+    cleared = await experts_db.set_pod_lead(test_user.id, pod.id, None)
+    assert cleared.lead_expert_id is None
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_set_pod_lead_rejects_other_users_pod(
+    server: SpinTestServer, test_user, other_user
+):
+    foreign_pod = await experts_db.create_pod(other_user.id, _pod_name("Theirs"))
+
+    with pytest.raises(experts_db.ExpertPodNotFoundError):
+        await experts_db.set_pod_lead(test_user.id, foreign_pod.id, None)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_moving_the_lead_out_of_the_pod_clears_its_leadership(
+    server: SpinTestServer, test_user
+):
+    """A lead must stay a member of the pod they lead — leaving the pod must
+    not strand routing on an outsider."""
+    template = await _seed_template(name="Maria", preload_listings=[])
+    lead = await experts_db.hire_expert(test_user.id, template.id, "Lead")
+    pod = await experts_db.create_pod(test_user.id, _pod_name("Growth"))
+    other_pod = await experts_db.create_pod(test_user.id, _pod_name("Ops"))
+    await experts_db.assign_pod(test_user.id, lead.expert.id, pod.id)
+    await experts_db.set_pod_lead(test_user.id, pod.id, lead.expert.id)
+
+    await experts_db.assign_pod(test_user.id, lead.expert.id, other_pod.id)
+
+    pods = {p.id: p for p in await experts_db.list_pods(test_user.id)}
+    assert pods[pod.id].lead_expert_id is None
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_reassigning_the_lead_to_the_same_pod_keeps_leadership(
+    server: SpinTestServer, test_user
+):
+    template = await _seed_template(name="Maria", preload_listings=[])
+    lead = await experts_db.hire_expert(test_user.id, template.id, "Lead")
+    pod = await experts_db.create_pod(test_user.id, _pod_name("Growth"))
+    await experts_db.assign_pod(test_user.id, lead.expert.id, pod.id)
+    await experts_db.set_pod_lead(test_user.id, pod.id, lead.expert.id)
+
+    await experts_db.assign_pod(test_user.id, lead.expert.id, pod.id)
+
+    pods = {p.id: p for p in await experts_db.list_pods(test_user.id)}
+    assert pods[pod.id].lead_expert_id == lead.expert.id
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/autogpt_platform/backend/backend/api/features/experts/hire_office.py
+++ b/autogpt_platform/backend/backend/api/features/experts/hire_office.py
@@ -1,0 +1,315 @@
+"""Hire a whole office pack in one call.
+
+An OfficeTemplate's config lists expert templates plus an intro task per
+expert. Hiring the office reserves every expert copy AND opens every intro
+DelegatedTask inside ONE transaction — a failure on the Nth expert rolls
+the whole office back, so the user never ends up with half a team. Preload
+installs and scheduler registration stay outside the transaction: both are
+best-effort in the single-hire flow too, and the scheduler is an external
+service that must not hold a DB transaction open.
+"""
+
+import logging
+
+import prisma.enums
+import prisma.models
+from pydantic import BaseModel, Field
+
+from backend.api.features.experts import experts_db, scheduling
+from backend.api.features.experts.errors import ExpertTemplateNotFoundError
+from backend.api.features.experts.models import Expert
+from backend.api.features.tasks.models import (
+    TASK_SPEC_MAX_LENGTH,
+    TASK_TITLE_MAX_LENGTH,
+)
+from backend.data.db import transaction
+from backend.data.user import get_user_by_id
+from backend.util.exceptions import ExpertNotFoundError
+from backend.util.timezone_utils import get_user_timezone_or_utc
+
+logger = logging.getLogger(__name__)
+
+
+class OfficeTemplateNotFoundError(Exception):
+    def __init__(self, office_template_id: str):
+        super().__init__(f"Office template #{office_template_id} not found")
+
+
+class OfficeExpertEntry(BaseModel):
+    """One expert line in an OfficeTemplate config."""
+
+    template_id: str
+    schedule_cron: str | None = None
+    intro_task_title: str
+    intro_task_spec: str
+
+
+class OfficeConfig(BaseModel):
+    experts: list[OfficeExpertEntry] = Field(min_length=1)
+
+
+class OfficeTemplateExpert(BaseModel):
+    template_id: str
+    name: str
+    role: str
+    avatar_url: str | None
+    tagline: str | None
+    schedule_cron: str | None
+    intro_task_title: str
+
+
+class OfficeTemplateSummary(BaseModel):
+    id: str
+    name: str
+    description: str
+    experts: list[OfficeTemplateExpert]
+
+
+class HiredOfficeExpert(BaseModel):
+    expert: Expert
+    intro_task_id: str
+    intro_task_title: str
+    schedule_created: bool
+
+
+class HireOfficeResult(BaseModel):
+    office_template_id: str
+    office_name: str
+    hired: list[HiredOfficeExpert]
+
+
+async def list_office_templates() -> list[OfficeTemplateSummary]:
+    """Every office pack, with its expert lines joined to the template rows.
+
+    A pack whose config no longer validates, or whose expert templates are
+    gone, is skipped with a warning rather than failing the listing.
+    """
+    rows = await prisma.models.OfficeTemplate.prisma().find_many(order={"name": "asc"})
+    summaries = []
+    for row in rows:
+        config = _parse_config(row)
+        if config is None:
+            continue
+        templates = await _load_templates(config)
+        if templates is None:
+            logger.warning(f"Office template '{row.name}' references missing experts")
+            continue
+        summaries.append(
+            OfficeTemplateSummary(
+                id=row.id,
+                name=row.name,
+                description=row.description,
+                experts=[
+                    OfficeTemplateExpert(
+                        template_id=entry.template_id,
+                        name=templates[entry.template_id].name,
+                        role=templates[entry.template_id].role,
+                        avatar_url=templates[entry.template_id].avatarUrl,
+                        tagline=templates[entry.template_id].tagline,
+                        schedule_cron=entry.schedule_cron,
+                        intro_task_title=entry.intro_task_title,
+                    )
+                    for entry in config.experts
+                ],
+            )
+        )
+    return summaries
+
+
+async def hire_office(user_id: str, office_template_id: str) -> HireOfficeResult:
+    office = await prisma.models.OfficeTemplate.prisma().find_unique(
+        where={"id": office_template_id}
+    )
+    if office is None:
+        raise OfficeTemplateNotFoundError(office_template_id)
+    config = OfficeConfig.model_validate(office.config)
+    templates = await _load_templates(config)
+    if templates is None:
+        raise ExpertTemplateNotFoundError(office_template_id)
+
+    reserved = await _reserve_office(user_id, config, templates)
+
+    hired = []
+    for entry, expert_row, state, task_id in reserved:
+        await _finish_hire(user_id, expert_row, state, templates[entry.template_id])
+        schedule_created = False
+        if entry.schedule_cron:
+            schedule_created = await _create_office_schedule(
+                user_id, expert_row.id, entry.schedule_cron
+            )
+        hired.append(
+            HiredOfficeExpert(
+                expert=await _hydrated_expert(expert_row.id),
+                intro_task_id=task_id,
+                intro_task_title=entry.intro_task_title,
+                schedule_created=schedule_created,
+            )
+        )
+    return HireOfficeResult(
+        office_template_id=office.id,
+        office_name=office.name,
+        hired=hired,
+    )
+
+
+_ReservedEntry = tuple[OfficeExpertEntry, prisma.models.Expert, str, str]
+
+
+async def _reserve_office(
+    user_id: str,
+    config: OfficeConfig,
+    templates: dict[str, prisma.models.Expert],
+) -> list[_ReservedEntry]:
+    """All expert copies + intro tasks in ONE transaction, under the same
+    per-user creation lock the single-hire flow takes."""
+    reserved: list[_ReservedEntry] = []
+    async with transaction() as tx:
+        await experts_db.lock_expert_creation(tx, user_id)
+        for entry in config.experts:
+            template = templates[entry.template_id]
+            expert_row, state = await experts_db.reserve_hired_expert_locked(
+                tx,
+                user_id,
+                template.id,
+                experts_db.hire_create_data(user_id, template),
+            )
+            task = await _create_intro_task(tx, user_id, expert_row.id, entry)
+            reserved.append((entry, expert_row, state, task.id))
+    return reserved
+
+
+async def _create_intro_task(
+    tx: prisma.Prisma,
+    user_id: str,
+    expert_id: str,
+    entry: OfficeExpertEntry,
+) -> prisma.models.DelegatedTask:
+    """Open the expert's intro receipt inside the office transaction.
+
+    Mirrors ``tasks_db.create_delegated_task`` for a root task (self-stamped
+    ``rootTaskId``), but on the transaction client — the shared writer uses
+    the global client, whose writes would survive an office rollback.
+    """
+    row = await tx.delegatedtask.create(
+        data={
+            "userId": user_id,
+            "ownerId": expert_id,
+            "createdByType": prisma.enums.TaskCreatedByType.USER,
+            "createdById": user_id,
+            "title": entry.intro_task_title[:TASK_TITLE_MAX_LENGTH],
+            "spec": entry.intro_task_spec[:TASK_SPEC_MAX_LENGTH],
+            "status": prisma.enums.DelegatedTaskStatus.QUEUED,
+            "ancestorExpertIds": [expert_id],
+        }
+    )
+    stamped = await tx.delegatedtask.update(
+        where={"id": row.id}, data={"rootTaskId": row.id}
+    )
+    return stamped or row
+
+
+async def _finish_hire(
+    user_id: str,
+    expert_row: prisma.models.Expert,
+    state: str,
+    template: prisma.models.Expert,
+) -> None:
+    """Post-commit follow-ups, all best-effort like the single-hire flow:
+    a fresh hire installs the template's preloads, a revived hire resumes
+    its paused schedules."""
+    if state == "created":
+        failed = await experts_db._install_preloads(
+            expert_row.id, user_id, template.Workflows or []
+        )
+        if failed:
+            logger.warning(
+                f"Office hire: {len(failed)} preload(s) failed for expert "
+                f"#{expert_row.id}"
+            )
+        return
+    if state == "revived":
+        try:
+            await scheduling.resume_expert_schedules(user_id, expert_row.id)
+        except Exception:
+            logger.exception(
+                f"Office hire: failed to resume schedules for expert "
+                f"#{expert_row.id}"
+            )
+
+
+async def _create_office_schedule(user_id: str, expert_id: str, cron: str) -> bool:
+    """Attach the pack's cadence to the expert's first schedulable workflow.
+
+    Mirrors preload semantics: the cron is recorded on the row first, so a
+    scheduler failure leaves the workflow surfaced as "needs setup" instead
+    of silently dropping the pack's intent. False when the expert has no
+    installed workflow to schedule.
+    """
+    rows = await prisma.models.ExpertWorkflow.prisma().find_many(
+        where={"expertId": expert_id},
+        include={"LibraryAgent": True, "StoreListingVersion": True},
+        order={"createdAt": "asc"},
+    )
+    row = next(
+        (r for r in rows if r.LibraryAgent is not None and r.scheduleId is None),
+        None,
+    )
+    if row is None or row.LibraryAgent is None:
+        return False
+
+    await prisma.models.ExpertWorkflow.prisma().update(
+        where={"id": row.id}, data={"scheduleCron": cron}
+    )
+    user = await get_user_by_id(user_id)
+    return await scheduling.create_workflow_schedule(
+        workflow_row_id=row.id,
+        expert_id=expert_id,
+        user_id=user_id,
+        cron=cron,
+        graph_id=row.LibraryAgent.agentGraphId,
+        graph_version=row.LibraryAgent.agentGraphVersion,
+        name=(
+            row.StoreListingVersion.name
+            if row.StoreListingVersion
+            else "Expert workflow"
+        ),
+        user_timezone=get_user_timezone_or_utc(user.timezone if user else None),
+    )
+
+
+def _parse_config(row: prisma.models.OfficeTemplate) -> OfficeConfig | None:
+    try:
+        return OfficeConfig.model_validate(row.config)
+    except ValueError:
+        logger.warning(f"Office template '{row.name}' has an invalid config")
+        return None
+
+
+async def _load_templates(
+    config: OfficeConfig,
+) -> dict[str, prisma.models.Expert] | None:
+    """The live template rows for every expert line, or None when any is
+    missing/archived — an office must hire completely or not at all."""
+    ids = [entry.template_id for entry in config.experts]
+    rows = await prisma.models.Expert.prisma().find_many(
+        where={"id": {"in": ids}, "isTemplate": True, "isArchived": False},
+        include={"Workflows": {"include": {"StoreListingVersion": True}}},
+    )
+    templates = {row.id: row for row in rows}
+    if any(template_id not in templates for template_id in ids):
+        return None
+    return templates
+
+
+async def _hydrated_expert(expert_id: str) -> Expert:
+    row = await prisma.models.Expert.prisma().find_unique(
+        where={"id": expert_id},
+        include={
+            "Workflows": {
+                "include": {"LibraryAgent": True, "StoreListingVersion": True}
+            }
+        },
+    )
+    if row is None:
+        raise ExpertNotFoundError(expert_id)
+    return experts_db._to_model(row)

--- a/autogpt_platform/backend/backend/api/features/experts/hire_office_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/hire_office_test.py
@@ -1,0 +1,149 @@
+"""DB-level tests for the hire-office flow.
+
+Real-postgres tests via the session ``server`` fixture, mirroring
+``experts_db_test.py``: seed templates + an OfficeTemplate row, then drive
+:mod:`hire_office` directly. The rollback test is the point — every write
+of an office hire lands in ONE transaction, so a failure on the Nth expert
+must leave no Expert copies and no DelegatedTasks behind.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import prisma.enums
+import prisma.models
+import pytest
+
+from backend.api.features.experts import hire_office
+from backend.data.user import get_or_create_user
+from backend.util.json import SafeJson
+from backend.util.test import SpinTestServer
+
+# DB tests share the session loop so the Prisma pool stays bound to one loop
+# (mirrors experts_db_test.py / task_review_test.py).
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _create_seed_user():
+    suffix = uuid.uuid4().hex[:8]
+    return await get_or_create_user(
+        {
+            "sub": str(uuid.uuid4()),
+            "email": f"office-seed-{suffix}@example.com",
+            "name": "Office Owner",
+        }
+    )
+
+
+async def _seed_template(role: str) -> prisma.models.Expert:
+    return await prisma.models.Expert.prisma().create(
+        data={
+            "name": f"Office {role} {uuid.uuid4().hex[:8]}",
+            "role": role,
+            "identity": f"You are a {role} expert.",
+            "isTemplate": True,
+        }
+    )
+
+
+def _entry(template_id: str, *, cron: str | None = None) -> dict:
+    return {
+        "template_id": template_id,
+        "schedule_cron": cron,
+        "intro_task_title": f"Intro for {template_id[:8]}",
+        "intro_task_spec": "Introduce yourself and propose a first task.",
+    }
+
+
+async def _seed_office(entries: list[dict]) -> prisma.models.OfficeTemplate:
+    return await prisma.models.OfficeTemplate.prisma().create(
+        data={
+            "name": f"Office pack {uuid.uuid4().hex[:8]}",
+            "description": "Test pack",
+            "config": SafeJson({"experts": entries}),
+        }
+    )
+
+
+async def test_hire_office_hires_experts_and_opens_intro_tasks(
+    server: SpinTestServer,
+):
+    user = await _create_seed_user()
+    templates = [await _seed_template("Marketing"), await _seed_template("Sales")]
+    office = await _seed_office([_entry(t.id) for t in templates])
+
+    result = await hire_office.hire_office(user.id, office.id)
+
+    assert result.office_template_id == office.id
+    assert result.office_name == office.name
+    assert len(result.hired) == 2
+    for hired, template in zip(result.hired, templates):
+        assert hired.expert.source_template_id == template.id
+        assert hired.schedule_created is False
+
+        task = await prisma.models.DelegatedTask.prisma().find_unique(
+            where={"id": hired.intro_task_id}
+        )
+        assert task is not None
+        assert task.userId == user.id
+        assert task.ownerId == hired.expert.id
+        assert task.status == prisma.enums.DelegatedTaskStatus.QUEUED
+        assert task.createdByType == prisma.enums.TaskCreatedByType.USER
+        assert task.createdById == user.id
+        assert task.rootTaskId == task.id
+        assert task.originSessionId is None
+        assert task.title == hired.intro_task_title
+
+
+async def test_hire_office_rolls_back_all_writes_on_failure(
+    server: SpinTestServer,
+):
+    user = await _create_seed_user()
+    templates = [await _seed_template("Marketing"), await _seed_template("Sales")]
+    office = await _seed_office([_entry(t.id) for t in templates])
+
+    real_create_intro_task = hire_office._create_intro_task
+    calls = 0
+
+    async def fail_on_second(tx, user_id, expert_id, entry):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("second intro task exploded")
+        return await real_create_intro_task(tx, user_id, expert_id, entry)
+
+    with patch.object(hire_office, "_create_intro_task", new=fail_on_second):
+        with pytest.raises(RuntimeError, match="second intro task exploded"):
+            await hire_office.hire_office(user.id, office.id)
+
+    assert calls == 2
+    assert (
+        await prisma.models.Expert.prisma().count(where={"ownerUserId": user.id}) == 0
+    )
+    assert (
+        await prisma.models.DelegatedTask.prisma().count(where={"userId": user.id}) == 0
+    )
+
+
+async def test_hire_office_unknown_office_raises(server: SpinTestServer):
+    user = await _create_seed_user()
+    with pytest.raises(hire_office.OfficeTemplateNotFoundError):
+        await hire_office.hire_office(user.id, str(uuid.uuid4()))
+
+
+async def test_list_office_templates_joins_expert_rows(server: SpinTestServer):
+    template = await _seed_template("Ops")
+    office = await _seed_office([_entry(template.id, cron="0 9 * * 1")])
+
+    summaries = await hire_office.list_office_templates()
+    summary = next(s for s in summaries if s.id == office.id)
+
+    assert summary.name == office.name
+    assert summary.description == "Test pack"
+    assert len(summary.experts) == 1
+    line = summary.experts[0]
+    assert line.template_id == template.id
+    assert line.name == template.name
+    assert line.role == "Ops"
+    assert line.schedule_cron == "0 9 * * 1"
+    assert line.intro_task_title == f"Intro for {template.id[:8]}"

--- a/autogpt_platform/backend/backend/api/features/experts/models.py
+++ b/autogpt_platform/backend/backend/api/features/experts/models.py
@@ -162,6 +162,9 @@ class ExpertPod(BaseModel):
     id: str
     name: str
     created_at: datetime
+    # The member who fronts the pod: delegations aimed at the pod (or at a
+    # member, from outside it) are routed to the lead. None = no lead set.
+    lead_expert_id: str | None = None
 
 
 class ExpertRun(BaseModel):
@@ -186,6 +189,9 @@ class ExpertDetachPreview(BaseModel):
 
     schedule_names: list[str]
     trigger_names: list[str]
+    # Open delegated tasks the expert still holds; archiving reassigns them
+    # to Autopilot. Defaulted so stale clients keep validating.
+    open_task_count: int = 0
 
 
 class HireResult(BaseModel):

--- a/autogpt_platform/backend/backend/api/features/experts/office_seed.py
+++ b/autogpt_platform/backend/backend/api/features/experts/office_seed.py
@@ -1,0 +1,340 @@
+"""Dev seed for hireable "office" packs.
+
+Run with: poetry run python -m backend.api.features.experts.office_seed
+
+Upserts the three office packs (YouTuber, SaaS founder, Agency) by
+OfficeTemplate name, so repeated runs keep the same office ids. Each pack
+lists 2-3 expert templates plus an intro task per expert; template ids are
+resolved by template NAME at seed time. Roster templates (Maria, Max,
+Frankie — see ``seed.ROSTER``) are reused where they fit and must already
+be seeded; the office-only gaps (a video Scriptwriter, an Account manager)
+are upserted here as minimal templates with no preloads.
+"""
+
+import asyncio
+import logging
+from typing import TypedDict
+
+import prisma.models
+
+from backend.data import db as database
+from backend.util.json import SafeJson
+
+logger = logging.getLogger(__name__)
+
+
+class MinimalTemplateEntry(TypedDict):
+    name: str
+    role: str
+    tagline: str
+    identity: str
+    bio: str
+    skills: list[str]
+
+
+class OfficeExpertSeed(TypedDict):
+    # Resolved to a template id by name at seed time.
+    template_name: str
+    schedule_cron: str | None
+    intro_task_title: str
+    intro_task_spec: str
+
+
+class OfficePackSeed(TypedDict):
+    name: str
+    description: str
+    experts: list[OfficeExpertSeed]
+
+
+# Office-only templates. Deliberately minimal (no preloads, no voice
+# envelope): they exist so a pack can ship a persona the roster lacks.
+MINIMAL_TEMPLATES: list[MinimalTemplateEntry] = [
+    {
+        "name": "Sasha",
+        "role": "Scriptwriter",
+        "tagline": "Turns your video ideas into scripts with hooks that hold.",
+        "identity": (
+            "You are Sasha, a video scriptwriter who has written for creators "
+            "from 10k to 2M subscribers. You structure every script around a "
+            "hook in the first ten seconds, an open loop that earns the next "
+            "minute, and a payoff that matches the title's promise. You write "
+            "in spoken language — short sentences, contractions, no prose that "
+            "only works on paper. When given a topic you return a working "
+            "title, a hook, a beat outline, and a full script draft. You flag "
+            "claims that need a source and never invent statistics."
+        ),
+        "bio": (
+            "I'm a video scriptwriter — hooks, open loops, and payoffs that "
+            "match the title. Give me a topic and I'll hand back a working "
+            "title, a beat outline, and a full draft in spoken language."
+        ),
+        "skills": [
+            "Video scripts",
+            "Hooks",
+            "Story structure",
+            "Titles & thumbnails",
+        ],
+    },
+    {
+        "name": "Alex",
+        "role": "Account manager",
+        "tagline": "Keeps every client warm: updates, check-ins, and renewals.",
+        "identity": (
+            "You are Alex, an account manager who has kept churn low at two "
+            "agencies by treating every client like the only one. You keep a "
+            "running picture of each account: what was promised, what shipped, "
+            "what's next, and how the client feels about it. You draft status "
+            "updates, check-in emails, and renewal conversations in a warm, "
+            "professional voice. You never promise scope, dates, or discounts "
+            "on the agency's behalf — you draft them and flag them for "
+            "approval. When information about an account is missing, you list "
+            "exactly what you need."
+        ),
+        "bio": (
+            "I'm an account manager — I keep clients warm with status "
+            "updates, check-ins, and renewal prep, and I flag anything that "
+            "commits the agency before it goes out."
+        ),
+        "skills": [
+            "Client updates",
+            "Check-ins",
+            "Renewals",
+            "Account health",
+        ],
+    },
+]
+
+
+OFFICE_PACKS: list[OfficePackSeed] = [
+    {
+        "name": "YouTuber",
+        "description": (
+            "A creator's back office: a scriptwriter for your videos, a "
+            "marketer to grow the channel, and ops to keep you on schedule."
+        ),
+        "experts": [
+            {
+                "template_name": "Sasha",
+                "schedule_cron": None,
+                "intro_task_title": "Draft a script for your next video",
+                "intro_task_spec": (
+                    "Ask what the channel is about and what the next video "
+                    "should cover, then deliver a working title, a hook, a "
+                    "beat outline, and a full script draft."
+                ),
+            },
+            {
+                "template_name": "Maria",
+                "schedule_cron": "0 9 * * 1",
+                "intro_task_title": "Plan this week's channel promotion",
+                "intro_task_spec": (
+                    "Learn the channel's niche and audience, then draft a "
+                    "one-week promotion plan: three social posts and one "
+                    "community post that point at the latest video."
+                ),
+            },
+            {
+                "template_name": "Frankie",
+                "schedule_cron": None,
+                "intro_task_title": "Set up your publishing checklist",
+                "intro_task_spec": (
+                    "Build a repeatable pre-publish checklist (title, "
+                    "thumbnail, description, tags, end screen, community "
+                    "post) tailored to how this channel works."
+                ),
+            },
+        ],
+    },
+    {
+        "name": "SaaS founder",
+        "description": (
+            "A founder's first three hires: outbound sales, marketing copy, "
+            "and an ops brief that starts every day for you."
+        ),
+        "experts": [
+            {
+                "template_name": "Max",
+                "schedule_cron": "0 9 * * 1",
+                "intro_task_title": "Build your first prospect list",
+                "intro_task_spec": (
+                    "Sharpen the ideal customer profile (industry, size, "
+                    "trigger events), then assemble a first list of ten "
+                    "prospects with the decision-maker and a one-line reason "
+                    "each is a fit."
+                ),
+            },
+            {
+                "template_name": "Maria",
+                "schedule_cron": None,
+                "intro_task_title": "Sharpen your landing page copy",
+                "intro_task_spec": (
+                    "Review the current landing page, then propose a "
+                    "rewritten headline, subheadline, and three benefit "
+                    "bullets positioned against doing nothing."
+                ),
+            },
+            {
+                "template_name": "Frankie",
+                "schedule_cron": None,
+                "intro_task_title": "Set up your weekly ops rhythm",
+                "intro_task_spec": (
+                    "Draft a weekly operating checklist: metrics to glance "
+                    "at, follow-ups to send, and the one meeting brief that "
+                    "should never be skipped."
+                ),
+            },
+        ],
+    },
+    {
+        "name": "Agency",
+        "description": (
+            "An agency pod: an account manager who keeps clients warm, "
+            "sales to fill the pipeline, and marketing for your own brand."
+        ),
+        "experts": [
+            {
+                "template_name": "Alex",
+                "schedule_cron": None,
+                "intro_task_title": "Map your client accounts",
+                "intro_task_spec": (
+                    "List the agency's current clients and, for each, what "
+                    "was promised, what shipped last, and the next touchpoint "
+                    "— then flag the account most at risk of going quiet."
+                ),
+            },
+            {
+                "template_name": "Max",
+                "schedule_cron": None,
+                "intro_task_title": "Draft your new-business hit list",
+                "intro_task_spec": (
+                    "Define the agency's ideal client profile and assemble a "
+                    "short hit list of prospects with decision-makers and a "
+                    "personalised opening line for each."
+                ),
+            },
+            {
+                "template_name": "Maria",
+                "schedule_cron": "0 9 * * 1",
+                "intro_task_title": "Plan the agency's own marketing week",
+                "intro_task_spec": (
+                    "Agencies market everyone but themselves — draft one "
+                    "case-study outline and two social posts that show off "
+                    "recent client work."
+                ),
+            },
+        ],
+    },
+]
+
+
+async def seed_offices() -> list[str]:
+    """Upsert the office-only templates and the office packs. Returns the
+    OfficeTemplate ids."""
+    for entry in MINIMAL_TEMPLATES:
+        await _upsert_minimal_template(entry)
+
+    template_ids = {
+        name: await _resolve_template_id(name)
+        for name in sorted(
+            {e["template_name"] for pack in OFFICE_PACKS for e in pack["experts"]}
+        )
+    }
+
+    office_ids = []
+    for pack in OFFICE_PACKS:
+        office = await _upsert_office(pack, template_ids)
+        office_ids.append(office.id)
+        logger.info(f"Seeded office pack '{pack['name']}' (#{office.id})")
+    return office_ids
+
+
+async def _upsert_minimal_template(entry: MinimalTemplateEntry) -> None:
+    fields = {
+        "role": entry["role"],
+        "tagline": entry["tagline"],
+        "identity": entry["identity"],
+        "bio": entry["bio"],
+        "skills": entry["skills"],
+        "voicePreferences": "",
+        "boundaries": "",
+        "isArchived": False,
+    }
+    existing = await prisma.models.Expert.prisma().find_first(
+        where={"isTemplate": True, "name": entry["name"]},
+        order=[{"createdAt": "asc"}, {"id": "asc"}],
+    )
+    if existing is None:
+        await prisma.models.Expert.prisma().create(
+            data={"name": entry["name"], "isTemplate": True, **fields}
+        )
+        return
+    updated = await prisma.models.Expert.prisma().update(
+        where={"id": existing.id}, data=fields
+    )
+    if updated is None:
+        raise RuntimeError(f"Failed to update expert template '{entry['name']}'")
+
+
+async def _resolve_template_id(name: str) -> str:
+    """Template id for *name*. Roster names must be seeded first by
+    ``backend.api.features.experts.seed`` — this module never creates them,
+    or a minimal upsert would clobber the roster's full persona."""
+    template = await prisma.models.Expert.prisma().find_first(
+        where={"isTemplate": True, "name": name, "isArchived": False},
+        order=[{"createdAt": "asc"}, {"id": "asc"}],
+    )
+    if template is None:
+        raise RuntimeError(
+            f"Expert template '{name}' not found. Run "
+            "`poetry run python -m backend.api.features.experts.seed` first."
+        )
+    return template.id
+
+
+async def _upsert_office(
+    pack: OfficePackSeed, template_ids: dict[str, str]
+) -> prisma.models.OfficeTemplate:
+    config = SafeJson(
+        {
+            "experts": [
+                {
+                    "template_id": template_ids[entry["template_name"]],
+                    "schedule_cron": entry["schedule_cron"],
+                    "intro_task_title": entry["intro_task_title"],
+                    "intro_task_spec": entry["intro_task_spec"],
+                }
+                for entry in pack["experts"]
+            ]
+        }
+    )
+    existing = await prisma.models.OfficeTemplate.prisma().find_unique(
+        where={"name": pack["name"]}
+    )
+    if existing is None:
+        return await prisma.models.OfficeTemplate.prisma().create(
+            data={
+                "name": pack["name"],
+                "description": pack["description"],
+                "config": config,
+            }
+        )
+    updated = await prisma.models.OfficeTemplate.prisma().update(
+        where={"id": existing.id},
+        data={"description": pack["description"], "config": config},
+    )
+    if updated is None:
+        raise RuntimeError(f"Failed to update office template '{pack['name']}'")
+    return updated
+
+
+async def main() -> None:
+    await database.connect()
+    try:
+        await seed_offices()
+    finally:
+        await database.disconnect()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main())

--- a/autogpt_platform/backend/backend/api/features/experts/routes.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Security
 from pydantic import BaseModel, Field, field_validator
 
 from backend.api.features.experts import credentials as expert_credentials
-from backend.api.features.experts import experts_db, scheduling
+from backend.api.features.experts import experts_db, hire_office, scheduling
 from backend.api.features.experts.models import (
     EXPERT_AVATAR_URL_MAX_LENGTH,
     EXPERT_COLOR_MAX_LENGTH,
@@ -37,6 +37,10 @@ class HireRequest(BaseModel):
     name: str | None = Field(default=None, max_length=100)
 
 
+class HireOfficeRequest(BaseModel):
+    template_id: str
+
+
 class InstallWorkflowRequest(BaseModel):
     store_listing_version_id: str
 
@@ -58,6 +62,12 @@ class AssignPodRequest(BaseModel):
     # expert, while an omitted field is rejected rather than treated as
     # a silent detach.
     pod_id: str | None
+
+
+class UpdatePodRequest(BaseModel):
+    # Same required-but-nullable convention as AssignPodRequest: an explicit
+    # {"lead_expert_id": null} clears the lead.
+    lead_expert_id: str | None
 
 
 class CreateRaisedExpertRequest(BaseModel):
@@ -105,6 +115,38 @@ class CreateRaisedExpertRequest(BaseModel):
 @router.get("/templates", operation_id="list_expert_templates")
 async def list_expert_templates() -> list[Expert]:
     return await experts_db.list_templates()
+
+
+# Office routes are declared before "/{expert_id}" so "/experts/office-templates"
+# is not swallowed by the expert-detail path parameter.
+@router.get("/office-templates", operation_id="list_office_templates")
+async def list_office_templates() -> list[hire_office.OfficeTemplateSummary]:
+    return await hire_office.list_office_templates()
+
+
+@router.post(
+    "/hire-office",
+    operation_id="hire_office",
+    responses={
+        404: {"description": "Office template or expert template not found"},
+        409: {"description": "Active expert limit reached"},
+    },
+)
+async def hire_office_pack(
+    request: HireOfficeRequest,
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> hire_office.HireOfficeResult:
+    try:
+        return await hire_office.hire_office(user_id, request.template_id)
+    except hire_office.OfficeTemplateNotFoundError as e:
+        raise fastapi.HTTPException(status_code=404, detail=str(e))
+    except experts_db.ExpertTemplateNotFoundError as e:
+        raise fastapi.HTTPException(status_code=404, detail=str(e))
+    except experts_db.ExpertLimitExceededError as e:
+        raise fastapi.HTTPException(
+            status_code=409,
+            detail={"code": "active_expert_limit", "limit": e.limit},
+        )
 
 
 @router.post(
@@ -225,6 +267,32 @@ async def list_expert_pods(
     user_id: str = Security(autogpt_auth_lib.get_user_id),
 ) -> list[ExpertPod]:
     return await experts_db.list_pods(user_id)
+
+
+@router.patch(
+    "/pods/{pod_id}",
+    operation_id="update_expert_pod",
+    responses={
+        404: {"description": "Pod or lead expert not found"},
+        409: {"description": "The lead is not a member of the pod"},
+    },
+)
+async def update_expert_pod(
+    pod_id: str,
+    request: UpdatePodRequest,
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> ExpertPod:
+    """Set or clear the pod's lead. Delegations aimed at the pod (or at a
+    member from outside it) are routed to the lead."""
+    try:
+        return await experts_db.set_pod_lead(user_id, pod_id, request.lead_expert_id)
+    except (
+        experts_db.ExpertNotFoundError,
+        experts_db.ExpertPodNotFoundError,
+    ):
+        raise fastapi.HTTPException(status_code=404, detail="Expert or pod not found")
+    except experts_db.ExpertPodLeadNotMemberError as e:
+        raise fastapi.HTTPException(status_code=409, detail=str(e))
 
 
 @router.patch(

--- a/autogpt_platform/backend/backend/api/features/experts/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes_test.py
@@ -1218,6 +1218,84 @@ def test_list_pods_returns_user_pods(
     )
 
 
+def test_update_pod_sets_the_lead(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_set = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.set_pod_lead",
+        new_callable=AsyncMock,
+        return_value=_make_pod(lead_expert_id="expert-1"),
+    )
+
+    response = client.patch("/experts/pods/pod-1", json={"lead_expert_id": "expert-1"})
+
+    assert response.status_code == 200
+    assert response.json()["lead_expert_id"] == "expert-1"
+    mock_set.assert_awaited_once_with(test_user_id, "pod-1", "expert-1")
+
+
+def test_update_pod_clears_the_lead_with_explicit_null(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_set = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.set_pod_lead",
+        new_callable=AsyncMock,
+        return_value=_make_pod(),
+    )
+
+    response = client.patch("/experts/pods/pod-1", json={"lead_expert_id": None})
+
+    assert response.status_code == 200
+    assert response.json()["lead_expert_id"] is None
+    mock_set.assert_awaited_once_with(test_user_id, "pod-1", None)
+
+
+def test_update_pod_rejects_an_omitted_lead_field(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mock_set = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.set_pod_lead",
+        new_callable=AsyncMock,
+        return_value=_make_pod(),
+    )
+
+    response = client.patch("/experts/pods/pod-1", json={})
+
+    assert response.status_code == 422
+    mock_set.assert_not_awaited()
+
+
+def test_update_pod_unknown_pod_returns_404(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.experts.routes.experts_db.set_pod_lead",
+        new_callable=AsyncMock,
+        side_effect=experts_db.ExpertPodNotFoundError("pod-9"),
+    )
+
+    response = client.patch("/experts/pods/pod-9", json={"lead_expert_id": "expert-1"})
+
+    assert response.status_code == 404
+
+
+def test_update_pod_non_member_lead_returns_409(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.experts.routes.experts_db.set_pod_lead",
+        new_callable=AsyncMock,
+        side_effect=experts_db.ExpertPodLeadNotMemberError("expert-9", "pod-1"),
+    )
+
+    response = client.patch("/experts/pods/pod-1", json={"lead_expert_id": "expert-9"})
+
+    assert response.status_code == 409
+    assert "not a member" in response.json()["detail"]
+
+
 def test_pods_route_is_not_shadowed_by_expert_detail(
     mocker: pytest_mock.MockerFixture,
 ) -> None:

--- a/autogpt_platform/backend/backend/api/features/experts/scheduling.py
+++ b/autogpt_platform/backend/backend/api/features/experts/scheduling.py
@@ -15,6 +15,7 @@ import prisma.models
 from prisma.enums import ResourceVisibility
 
 from backend.api.features.experts.models import ExpertDetachPreview
+from backend.api.features.tasks import overseer_db
 from backend.copilot import db as chat_db
 from backend.data.expert_spend import get_weekly_spend, reset_weekly_spend
 from backend.util.clients import get_scheduler_client
@@ -147,6 +148,9 @@ async def get_detach_preview(user_id: str, expert_id: str) -> ExpertDetachPrevie
     return ExpertDetachPreview(
         schedule_names=[s.name or s.cron for s in schedules],
         trigger_names=[p.name for p in presets],
+        open_task_count=await overseer_db.count_open_tasks_for_expert(
+            user_id, expert_id
+        ),
     )
 
 

--- a/autogpt_platform/backend/backend/api/features/home/attention.py
+++ b/autogpt_platform/backend/backend/api/features/home/attention.py
@@ -25,6 +25,7 @@ def compose_attention_items(
     credits_balance: int | None,
     questions: list[ChatSessionInfo] | None = None,
     tasks: list[DelegatedTask] | None = None,
+    failed_tasks: list[DelegatedTask] | None = None,
 ) -> list[HomeAttentionItem]:
     expert_by_id = {expert.id: expert for expert in experts}
     items = [_review_attention(review, now) for review in reviews]
@@ -40,6 +41,12 @@ def compose_attention_items(
         _escalation_attention(task, escalation)
         for task, escalation in _open_escalations(tasks or [])
     )
+    items.extend(
+        _failed_task_attention(task)
+        for task in failed_tasks or []
+        if _failed_after_retry(task)
+    )
+    items.extend(_stale_task_attention(task) for task in tasks or [] if task.stale_at)
     if credits_balance is not None and credits_balance <= 0 and schedules:
         items.append(_credits_attention(len(schedules)))
     return sorted(items, key=_attention_sort_key)
@@ -202,6 +209,60 @@ def _escalation_attention(
         primary_action=HomeAction(
             label="View task", href=f"/team?task={quote(task.id)}"
         ),
+    )
+
+
+def _failed_after_retry(task: DelegatedTask) -> bool:
+    """Only the failures the overseer gave up on earn a card — a run the
+    user watched fail in chat already told them."""
+    return task.status == "FAILED" and any(a.kind == "retry" for a in task.amendments)
+
+
+def _failed_task_attention(task: DelegatedTask) -> HomeAttentionItem:
+    owner = task.owner.name if task.owner else "Autopilot"
+    return HomeAttentionItem(
+        id=f"task-failed-{task.id}",
+        kind="task_failed",
+        priority="high",
+        title=f"“{task.title}” failed after a retry",
+        description=_clip(task.outcome_summary or f"{owner} could not finish it."),
+        why_it_matters="The work stopped; restart it or hand it to someone else.",
+        expert=_task_expert(task),
+        created_at=as_utc(task.updated_at),
+        task_id=task.id,
+        primary_action=HomeAction(
+            label="View task", href=f"/team/tasks/{quote(task.id)}"
+        ),
+    )
+
+
+def _stale_task_attention(task: DelegatedTask) -> HomeAttentionItem:
+    owner = task.owner.name if task.owner else "Autopilot"
+    return HomeAttentionItem(
+        id=f"task-stale-{task.id}",
+        kind="task_stale",
+        priority="normal",
+        title=f"Still waiting on you: “{task.title}”",
+        description=f"{owner} asked over a week ago and is still waiting.",
+        why_it_matters="The task stays parked until you answer — it is never "
+        "cancelled for you.",
+        expert=_task_expert(task),
+        created_at=as_utc(task.stale_at) if task.stale_at else None,
+        task_id=task.id,
+        primary_action=HomeAction(
+            label="View task", href=f"/team/tasks/{quote(task.id)}"
+        ),
+    )
+
+
+def _task_expert(task: DelegatedTask) -> HomeExpert | None:
+    if task.owner is None:
+        return None
+    return HomeExpert(
+        id=task.owner.id,
+        name=task.owner.name,
+        role=task.owner.role,
+        avatar_url=task.owner.avatar_url,
     )
 
 

--- a/autogpt_platform/backend/backend/api/features/home/compose.py
+++ b/autogpt_platform/backend/backend/api/features/home/compose.py
@@ -37,6 +37,7 @@ def compose_home_dashboard(
     work_events: list[ActivityEvent] | None = None,
     session_titles: dict[str, str | None] | None = None,
     open_tasks: list[DelegatedTask] | None = None,
+    failed_tasks: list[DelegatedTask] | None = None,
 ) -> HomeDashboardResponse:
     hired = [
         expert
@@ -77,6 +78,7 @@ def compose_home_dashboard(
             credits_balance=credits_balance,
             questions=questions,
             tasks=open_tasks,
+            failed_tasks=failed_tasks,
         ),
         briefing=compose_briefing(
             now=now,

--- a/autogpt_platform/backend/backend/api/features/home/models.py
+++ b/autogpt_platform/backend/backend/api/features/home/models.py
@@ -21,7 +21,14 @@ class HomeAction(BaseModel):
 class HomeAttentionItem(BaseModel):
     id: str
     kind: Literal[
-        "approval", "setup", "paused", "credits", "question", "task_escalation"
+        "approval",
+        "setup",
+        "paused",
+        "credits",
+        "question",
+        "task_escalation",
+        "task_failed",
+        "task_stale",
     ]
     priority: Literal["high", "normal"]
     title: str

--- a/autogpt_platform/backend/backend/api/features/home/service.py
+++ b/autogpt_platform/backend/backend/api/features/home/service.py
@@ -13,7 +13,7 @@ from backend.api.features.executions.review.model import PendingHumanReviewModel
 from backend.api.features.experts import experts_db
 from backend.api.features.experts.models import Expert
 from backend.api.features.library import db as library_db
-from backend.api.features.tasks import tasks_db
+from backend.api.features.tasks import overseer_db, tasks_db
 from backend.api.features.tasks.models import DelegatedTask
 from backend.copilot import db as chat_db
 from backend.copilot.briefing.models import BriefingContent
@@ -59,6 +59,7 @@ class HomeSourceData(BaseModel):
     questions: list[ChatSessionInfo]
     work_events: list[activity_db.ActivityEvent]
     open_tasks: list[DelegatedTask]
+    failed_tasks: list[DelegatedTask]
     timezone_name: str
 
 
@@ -111,6 +112,7 @@ async def build_home_dashboard(
         work_events=data.work_events,
         session_titles=session_titles,
         open_tasks=data.open_tasks,
+        failed_tasks=data.failed_tasks,
     )
 
 
@@ -211,6 +213,7 @@ async def _load_home_source_data(
         _get_work_events(user_id=user_id, since=week_start)
     )
     open_tasks_task = asyncio.create_task(_get_open_tasks(user_id=user_id))
+    failed_tasks_task = asyncio.create_task(_get_failed_tasks(user_id=user_id, now=now))
     user_task = asyncio.create_task(user_db.get_user_by_id(user_id))
     # Gather rather than awaiting one by one: a failure in the first task would
     # otherwise leave the rest detached with their exceptions never retrieved.
@@ -224,6 +227,7 @@ async def _load_home_source_data(
         questions_task,
         work_events_task,
         open_tasks_task,
+        failed_tasks_task,
         user_task,
     ]
     await asyncio.gather(*started)
@@ -240,6 +244,7 @@ async def _load_home_source_data(
         questions=questions_task.result(),
         work_events=work_events_task.result(),
         open_tasks=open_tasks_task.result(),
+        failed_tasks=failed_tasks_task.result(),
         timezone_name=get_user_timezone_or_utc(user.timezone if user else None),
     )
 
@@ -269,6 +274,20 @@ async def _get_open_tasks(*, user_id: str) -> list[DelegatedTask]:
     except Exception:
         logger.warning(
             "Home could not load open tasks for user %s", user_id[:_LOG_ID_CHARS]
+        )
+        return []
+
+
+async def _get_failed_tasks(*, user_id: str, now: datetime) -> list[DelegatedTask]:
+    # Recently FAILED tasks feed the "failed after retry" attention card.
+    # Fail-soft like open tasks: losing them costs a card, not the page.
+    try:
+        return await overseer_db.list_recent_failed_tasks(
+            user_id, since=now - timedelta(days=3)
+        )
+    except Exception:
+        logger.warning(
+            "Home could not load failed tasks for user %s", user_id[:_LOG_ID_CHARS]
         )
         return []
 

--- a/autogpt_platform/backend/backend/api/features/tasks/mapping.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/mapping.py
@@ -1,0 +1,136 @@
+"""Row→model mapping shared by the task-spine query modules.
+
+A leaf module on purpose: ``tasks_db`` imports the executor (to stop runs on
+cancel) and the executor's import chain reaches back into this package via
+the experts feature, so anything the sibling query modules share must live
+where it imports neither.
+"""
+
+import logging
+from typing import cast
+
+import prisma.enums
+import prisma.models
+import prisma.types
+
+from backend.copilot.briefing.outcome import DEFAULT_AGENT_NAME, run_link
+
+from .models import (
+    DelegatedTask,
+    TaskAcceptance,
+    TaskAmendment,
+    TaskCreatedBy,
+    TaskExpertRef,
+    TaskRunRef,
+    TaskStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# The owner join is always needed (the card shows who did the work) and the
+# execution join is what makes a task a receipt rather than a label.
+TASK_INCLUDE: prisma.types.DelegatedTaskInclude = {
+    "Owner": True,
+    "Executions": {"include": {"AgentGraph": True}},
+}
+
+RUNNING_EXECUTION_STATUSES = [
+    prisma.enums.AgentExecutionStatus.QUEUED,
+    prisma.enums.AgentExecutionStatus.RUNNING,
+    prisma.enums.AgentExecutionStatus.INCOMPLETE,
+]
+
+
+async def library_agents_by_graph(
+    user_id: str, tasks: list[prisma.models.DelegatedTask]
+) -> dict[str, str]:
+    """Graph id → the caller's library agent id, for the run deep links.
+
+    One batched query for every graph across every listed task; without it a
+    Tasks tab with N runs would issue N lookups just to build hrefs.
+    """
+    graph_ids = {
+        execution.agentGraphId for task in tasks for execution in task.Executions or []
+    }
+    if not graph_ids:
+        return {}
+    rows = await prisma.models.LibraryAgent.prisma().find_many(
+        where={
+            "userId": user_id,
+            "agentGraphId": {"in": list(graph_ids)},
+            "isDeleted": False,
+        }
+    )
+    return {row.agentGraphId: row.id for row in rows}
+
+
+def to_model(
+    row: prisma.models.DelegatedTask, library_agents: dict[str, str]
+) -> DelegatedTask:
+    return DelegatedTask(
+        id=row.id,
+        title=row.title,
+        spec=row.spec,
+        # Prisma-client-py declares enum columns as its own generated enums
+        # but hands back plain strings at runtime, which the ``Literal``
+        # aliases in models.py already match value-for-value.
+        status=cast(TaskStatus, row.status),
+        acceptance=cast(TaskAcceptance, row.acceptance),
+        created_by_type=cast(TaskCreatedBy, row.createdByType),
+        created_by_id=row.createdById,
+        owner=_to_expert_ref(row.Owner),
+        parent_task_id=row.parentTaskId,
+        root_task_id=row.rootTaskId,
+        origin_session_id=row.originSessionId,
+        ancestor_expert_ids=row.ancestorExpertIds,
+        handoff_count=row.handoffCount,
+        revision_count=row.revisionCount,
+        spend_total=row.spendTotal,
+        outcome_summary=row.outcomeSummary,
+        amendments=to_amendments(row.amendments),
+        stale_at=row.staleAt,
+        created_at=row.createdAt,
+        updated_at=row.updatedAt,
+        runs=[
+            _to_run_ref(execution, library_agents.get(execution.agentGraphId))
+            for execution in row.Executions or []
+        ],
+    )
+
+
+def _to_expert_ref(row: prisma.models.Expert | None) -> TaskExpertRef | None:
+    if row is None:
+        return None
+    return TaskExpertRef(
+        id=row.id, name=row.name, avatar_url=row.avatarUrl, role=row.role
+    )
+
+
+def _to_run_ref(
+    row: prisma.models.AgentGraphExecution, library_agent_id: str | None
+) -> TaskRunRef:
+    graph = row.AgentGraph
+    return TaskRunRef(
+        execution_id=row.id,
+        graph_id=row.agentGraphId,
+        library_agent_id=library_agent_id,
+        agent_name=(graph.name if graph and graph.name else DEFAULT_AGENT_NAME),
+        status=row.executionStatus,
+        started_at=row.startedAt,
+        ended_at=row.endedAt,
+        link=run_link(library_agent_id, row.id),
+    )
+
+
+def to_amendments(value: object) -> list[TaskAmendment]:
+    """Amendments are stored as free Json, so a hand-edited or legacy blob
+    must degrade to an empty list rather than 500 the whole Tasks tab."""
+    if not isinstance(value, list):
+        return []
+    amendments = []
+    for entry in value:
+        try:
+            amendments.append(TaskAmendment.model_validate(entry))
+        except Exception:
+            logger.warning("Skipping malformed task amendment", exc_info=True)
+    return amendments

--- a/autogpt_platform/backend/backend/api/features/tasks/models.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/models.py
@@ -32,6 +32,10 @@ MAX_TASK_HANDOFFS = 5
 # is told to escalate to the user rather than delegate further.
 MAX_TASK_DEPTH = 3
 
+# How many revision rounds a rejected outcome may trigger before the reject
+# stops spawning subtasks and asks the user to clarify instead.
+MAX_TASK_REVISIONS = 2
+
 TASK_QUESTION_MAX_LENGTH = 1_000
 TASK_ANSWER_MAX_LENGTH = 4_000
 MAX_TASK_QUESTION_OPTIONS = 6
@@ -39,6 +43,10 @@ MAX_TASK_QUESTION_OPTIONS = 6
 # Bounds the list endpoint so one user's history can't turn into an unbounded
 # scan; the Tasks tab pages by nothing else today.
 MAX_TASKS_PER_PAGE = 50
+
+# Bounds one poll of the office view's events feed; the client polls again
+# with a fresh `since` rather than paging.
+MAX_TASK_EVENTS = 100
 
 
 class TaskExpertRef(BaseModel):
@@ -63,12 +71,15 @@ class TaskRunRef(BaseModel):
     link: str | None
 
 
-TaskAmendmentKind = Literal["note", "handoff", "escalation", "answer"]
+TaskAmendmentKind = Literal[
+    "note", "handoff", "escalation", "answer", "retry", "revision"
+]
 
 
 class TaskAmendment(BaseModel):
     """An event recorded against a live task: a scope note, a handoff
-    between experts, an escalation to the user, or the user's answer.
+    between experts, an escalation to the user, the user's answer, an
+    overseer stall retry, or a revision request on a rejected outcome.
     Stored in the append-only ``amendments`` Json column, so new kinds land
     without a migration; ``kind`` defaults to ``note`` for phase-1 rows."""
 
@@ -104,9 +115,27 @@ class DelegatedTask(BaseModel):
     spend_total: int
     outcome_summary: str | None
     amendments: list[TaskAmendment]
+    # Overseer stamp: a WAITING_USER task that sat unanswered for a week.
+    stale_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
     runs: list[TaskRunRef] = []
+
+
+class TaskEvent(BaseModel):
+    """One task's latest state change, for the office view's polling feed.
+    ``event`` is the task's lowercase status ("queued" / "working" /
+    "waiting_user" / "done" / "failed" / "cancelled"); ``ts`` is the row's
+    ``updatedAt`` in ISO 8601. This exact shape is the frontend contract."""
+
+    task_id: str
+    expert_id: str | None
+    event: str
+    ts: str
+
+
+class TaskEventsResponse(BaseModel):
+    events: list[TaskEvent]
 
 
 class DelegatedTaskDetail(BaseModel):
@@ -131,6 +160,33 @@ class AnswerTaskRequest(BaseModel):
         if not stripped:
             raise ValueError("Answer must not be blank")
         return stripped
+
+
+class RejectTaskRequest(BaseModel):
+    """The user's rejection of a task outcome, with what to change."""
+
+    note: str = Field(min_length=1, max_length=TASK_ANSWER_MAX_LENGTH)
+
+    @field_validator("note", mode="before")
+    @classmethod
+    def strip_note(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Rejection note must not be blank")
+        return stripped
+
+
+class TaskReviewResult(BaseModel):
+    """Outcome of an accept/reject action on a finished task. ``escalated``
+    is set when the revision cap was hit: no new subtask was opened and the
+    user is asked to clarify in chat instead."""
+
+    task: DelegatedTask
+    revision_task: "DelegatedTask | None" = None
+    escalated: bool = False
+    message: str
 
 
 class CreateTaskRequest(BaseModel):

--- a/autogpt_platform/backend/backend/api/features/tasks/overseer_db.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/overseer_db.py
@@ -1,0 +1,160 @@
+"""Prisma reads and writes the overseer pass and its surfaces lean on.
+
+Same tenancy rule as ``tasks_db``: every statement filters on ``userId``.
+The pass runs in the scheduler process (Prisma-less), so each function here
+is exposed over the DatabaseManager RPC — names must stay unique across
+that surface and match their registered attribute.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+import prisma.enums
+import prisma.models
+
+from backend.util.json import SafeJson
+
+from .mapping import RUNNING_EXECUTION_STATUSES, to_model
+from .models import MAX_TASKS_PER_PAGE, OPEN_TASK_STATUSES, DelegatedTask, TaskAmendment
+
+logger = logging.getLogger(__name__)
+
+_OPEN_STATUSES = [prisma.enums.DelegatedTaskStatus(s) for s in OPEN_TASK_STATUSES]
+
+
+async def has_running_executions(user_id: str, task_ids: list[str]) -> dict[str, bool]:
+    """Which of *task_ids* still have a live execution attached — the signal
+    that a WORKING task is progressing rather than stalled."""
+    if not task_ids:
+        return {}
+    rows = await prisma.models.AgentGraphExecution.prisma().find_many(
+        where={
+            "userId": user_id,
+            "delegatedTaskId": {"in": task_ids},
+            "executionStatus": {"in": RUNNING_EXECUTION_STATUSES},
+        }
+    )
+    running = {row.delegatedTaskId for row in rows if row.delegatedTaskId}
+    return {task_id: task_id in running for task_id in task_ids}
+
+
+async def mark_task_stale(user_id: str, task_id: str, stale_at: datetime) -> bool:
+    """Stamp ``staleAt`` on a still-waiting task. Never changes status —
+    stale is a nag, not a cancellation."""
+    updated = await prisma.models.DelegatedTask.prisma().update_many(
+        where={
+            "id": task_id,
+            "userId": user_id,
+            "status": prisma.enums.DelegatedTaskStatus.WAITING_USER,
+            "staleAt": None,
+        },
+        data={"staleAt": stale_at},
+    )
+    return updated > 0
+
+
+async def count_recent_failed_tasks_by_expert(
+    user_id: str, since: datetime
+) -> dict[str, int]:
+    """FAILED tasks per owning expert since *since* — the expert-health
+    signal that trips an automatic pause."""
+    rows = await prisma.models.DelegatedTask.prisma().find_many(
+        where={
+            "userId": user_id,
+            "status": prisma.enums.DelegatedTaskStatus.FAILED,
+            "updatedAt": {"gte": since},
+            "ownerId": {"not": None},
+        },
+        take=500,
+    )
+    counts: dict[str, int] = {}
+    for row in rows:
+        if row.ownerId:
+            counts[row.ownerId] = counts.get(row.ownerId, 0) + 1
+    return counts
+
+
+async def list_recent_failed_tasks(
+    user_id: str, since: datetime, limit: int = MAX_TASKS_PER_PAGE
+) -> list[DelegatedTask]:
+    """Recently FAILED tasks, newest first — Home's attention list shows the
+    ones the overseer gave up on after a retry."""
+    rows = await prisma.models.DelegatedTask.prisma().find_many(
+        where={
+            "userId": user_id,
+            "status": prisma.enums.DelegatedTaskStatus.FAILED,
+            "updatedAt": {"gte": since},
+        },
+        order={"updatedAt": "desc"},
+        take=min(limit, MAX_TASKS_PER_PAGE),
+    )
+    return [to_model(row, {}) for row in rows]
+
+
+async def list_recent_autopilot_tasks(
+    user_id: str, since: datetime, limit: int = 200
+) -> list[DelegatedTask]:
+    """Tasks Autopilot finished itself (no owning expert) — the recruiter's
+    raw material for spotting a category worth hiring for."""
+    rows = await prisma.models.DelegatedTask.prisma().find_many(
+        where={
+            "userId": user_id,
+            "ownerId": None,
+            "status": prisma.enums.DelegatedTaskStatus.DONE,
+            "createdAt": {"gte": since},
+        },
+        order={"createdAt": "desc"},
+        take=limit,
+    )
+    return [to_model(row, {}) for row in rows]
+
+
+async def count_open_tasks_for_expert(user_id: str, expert_id: str) -> int:
+    """Open tasks an expert still holds — the fire dialog warns these will
+    move to Autopilot."""
+    return await prisma.models.DelegatedTask.prisma().count(
+        where={
+            "userId": user_id,
+            "ownerId": expert_id,
+            "status": {"in": _OPEN_STATUSES},
+        }
+    )
+
+
+async def reassign_open_tasks_to_autopilot(user_id: str, expert_id: str) -> int:
+    """Move an archived expert's open tasks to Autopilot (null owner),
+    recording the swap on each task's timeline. Row-by-row because the
+    amendment append is per-task Json; open task counts are small."""
+    rows = await prisma.models.DelegatedTask.prisma().find_many(
+        where={
+            "userId": user_id,
+            "ownerId": expert_id,
+            "status": {"in": _OPEN_STATUSES},
+        }
+    )
+    reassigned = 0
+    for row in rows:
+        entry = TaskAmendment(
+            at=datetime.now(UTC),
+            by="system",
+            note="Owner was archived — reassigned to Autopilot.",
+            kind="handoff",
+            from_expert_id=expert_id,
+            to_expert_id=None,
+        )
+        existing = row.amendments if isinstance(row.amendments, list) else []
+        updated = await prisma.models.DelegatedTask.prisma().update_many(
+            where={"id": row.id, "userId": user_id, "ownerId": expert_id},
+            data={
+                "ownerId": None,
+                "amendments": SafeJson([*existing, entry.model_dump(mode="json")]),
+            },
+        )
+        reassigned += updated
+    if reassigned:
+        logger.info(
+            "Reassigned %d open task(s) from archived expert %s to Autopilot",
+            reassigned,
+            expert_id,
+        )
+    return reassigned

--- a/autogpt_platform/backend/backend/api/features/tasks/routes.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/routes.py
@@ -1,16 +1,20 @@
 import logging
+from datetime import datetime
 
 import autogpt_libs.auth as autogpt_auth_lib
 import fastapi
 from fastapi import APIRouter, Query, Security
 
-from backend.api.features.tasks import task_actions, tasks_db
+from backend.api.features.tasks import task_actions, task_review, tasks_db
 from backend.api.features.tasks.errors import DelegatedTaskNotFoundError
 from backend.api.features.tasks.models import (
     MAX_TASKS_PER_PAGE,
     AnswerTaskRequest,
     DelegatedTask,
     DelegatedTaskDetail,
+    RejectTaskRequest,
+    TaskEventsResponse,
+    TaskReviewResult,
     TaskStatus,
 )
 from backend.copilot.executor.utils import schedule_chat_turn
@@ -38,6 +42,23 @@ async def list_tasks(
     """The caller's delegated tasks, newest first."""
     return await tasks_db.list_tasks(
         user_id, expert_id=expert_id, status=status, limit=limit
+    )
+
+
+# Declared before "/{task_id}" so "/tasks/events" is not swallowed by the
+# task-detail path parameter.
+@router.get("/events", operation_id="list_task_events")
+async def list_task_events(
+    since: datetime | None = Query(
+        default=None,
+        description="Only events on tasks updated after this ISO 8601 instant",
+    ),
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> TaskEventsResponse:
+    """Lightweight polling feed for the office view: one event per task
+    updated since ``since``, carrying the task's current lowercase status."""
+    return TaskEventsResponse(
+        events=await tasks_db.list_task_events(user_id, since=since)
     )
 
 
@@ -127,6 +148,111 @@ async def _deliver_answer(
             "Failed to deliver escalation answer for task #%s to session #%s",
             task.id,
             worker_session_id,
+            exc_info=True,
+        )
+
+
+@router.post(
+    "/{task_id}/accept",
+    operation_id="accept_task",
+    responses={
+        404: {"description": "Task not found"},
+        409: {"description": "Task is not finished"},
+    },
+)
+async def accept_task(
+    task_id: str,
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> TaskReviewResult:
+    """Approve a finished task's outcome."""
+    try:
+        task = await task_review.accept_delegated_task(user_id, task_id)
+    except DelegatedTaskNotFoundError:
+        raise fastapi.HTTPException(status_code=404, detail="Task not found")
+    except (TaskDelegationRefusedError, TaskUpdateConflictError) as e:
+        raise fastapi.HTTPException(status_code=409, detail=str(e))
+    return TaskReviewResult(task=task, message="Outcome accepted.")
+
+
+@router.post(
+    "/{task_id}/reject",
+    operation_id="reject_task",
+    responses={
+        404: {"description": "Task not found"},
+        409: {"description": "Task is not finished"},
+    },
+)
+async def reject_task(
+    task_id: str,
+    request: RejectTaskRequest,
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> TaskReviewResult:
+    """Reject a finished task's outcome. Under the revision cap this opens a
+    revision subtask for the same owner and nudges their session; at the cap
+    it asks the user to clarify in chat instead of looping again."""
+    try:
+        task, revision = await task_review.reject_delegated_task(
+            user_id, task_id, note=request.note
+        )
+    except DelegatedTaskNotFoundError:
+        raise fastapi.HTTPException(status_code=404, detail="Task not found")
+    except (TaskDelegationRefusedError, TaskUpdateConflictError) as e:
+        raise fastapi.HTTPException(status_code=409, detail=str(e))
+
+    if revision is None:
+        return TaskReviewResult(
+            task=task,
+            escalated=True,
+            message=(
+                "We've iterated twice on this task already. Please clarify "
+                "what you need in chat so the next attempt lands."
+            ),
+        )
+
+    await _deliver_revision(user_id=user_id, task=task, revision=revision)
+    return TaskReviewResult(
+        task=task,
+        revision_task=revision,
+        message=f"Revision requested — {_owner_name(task)} is on it.",
+    )
+
+
+def _owner_name(task: DelegatedTask) -> str:
+    return task.owner.name if task.owner else "Autopilot"
+
+
+async def _deliver_revision(
+    *, user_id: str, task: DelegatedTask, revision: DelegatedTask
+) -> None:
+    """Nudge the owner's working session with the revision ask. Best-effort,
+    mirroring ``_deliver_answer`` — the revision subtask already exists, so a
+    failed delivery degrades to the owner finding it next turn."""
+    if revision.origin_session_id is None:
+        return
+    message = (
+        f"[Revision requested on task '{task.title}' (task_id: {task.id})]\n\n"
+        f"The user rejected the outcome and asked for changes:\n"
+        f"{revision.spec}\n\n"
+        f"Do the revision, then report the revision task done with "
+        f"report_task (task_id: {revision.id})."
+    )
+    try:
+        queued = await queue_user_message(
+            session_id=revision.origin_session_id,
+            message=message,
+            require_turn_in_flight=True,
+        )
+        if not queued.turn_in_flight:
+            await schedule_chat_turn(
+                session_id=revision.origin_session_id,
+                user_id=user_id,
+                message=message,
+            )
+    except Exception:
+        logger.warning(
+            "Failed to deliver revision ask for task #%s to session #%s",
+            task.id,
+            revision.origin_session_id,
             exc_info=True,
         )
 

--- a/autogpt_platform/backend/backend/api/features/tasks/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/routes_test.py
@@ -24,6 +24,7 @@ from backend.api.features.tasks.errors import DelegatedTaskNotFoundError
 from backend.api.features.tasks.models import (
     DelegatedTask,
     DelegatedTaskDetail,
+    TaskEvent,
     TaskExpertRef,
 )
 from backend.api.features.tasks.routes import router
@@ -129,6 +130,68 @@ def test_list_tasks_rejects_an_oversized_limit() -> None:
     """The cap exists so one user's history can't turn into an unbounded
     scan; a client asking past it must be refused, not silently clamped."""
     response = client.get("/tasks?limit=500")
+
+    assert response.status_code == 422
+
+
+# ─── events ────────────────────────────────────────────────────────────
+
+
+def test_list_task_events_returns_the_callers_events_in_the_fe_shape(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    """The exact snake_case shape is the office view's polling contract."""
+    mock_events = mocker.patch(
+        "backend.api.features.tasks.routes.tasks_db.list_task_events",
+        new_callable=AsyncMock,
+        return_value=[
+            TaskEvent(
+                task_id="task-1",
+                expert_id="expert-maria",
+                event="working",
+                ts="2026-08-30T09:00:00+00:00",
+            )
+        ],
+    )
+
+    response = client.get("/tasks/events")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "events": [
+            {
+                "task_id": "task-1",
+                "expert_id": "expert-maria",
+                "event": "working",
+                "ts": "2026-08-30T09:00:00+00:00",
+            }
+        ]
+    }
+    mock_events.assert_awaited_once_with(test_user_id, since=None)
+
+
+def test_list_task_events_forwards_since_as_a_datetime(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_events = mocker.patch(
+        "backend.api.features.tasks.routes.tasks_db.list_task_events",
+        new_callable=AsyncMock,
+        return_value=[],
+    )
+
+    response = client.get("/tasks/events?since=2026-08-30T09:00:00Z")
+
+    assert response.status_code == 200
+    assert response.json() == {"events": []}
+    mock_events.assert_awaited_once_with(
+        test_user_id, since=datetime(2026, 8, 30, 9, 0, tzinfo=timezone.utc)
+    )
+
+
+def test_list_task_events_rejects_a_malformed_since() -> None:
+    response = client.get("/tasks/events?since=not-a-date")
 
     assert response.status_code == 422
 
@@ -309,5 +372,110 @@ def test_answer_task_409s_when_the_task_is_not_waiting(
 
 def test_answer_task_rejects_a_blank_answer() -> None:
     response = client.post("/tasks/task-1/answer", json={"answer": "   "})
+
+    assert response.status_code == 422
+
+
+# ─── accept / reject ───────────────────────────────────────────────────
+
+
+def test_accept_task_forwards_the_callers_user_id(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_accept = mocker.patch(
+        "backend.api.features.tasks.routes.task_review.accept_delegated_task",
+        new_callable=AsyncMock,
+        return_value=_make_task(status="DONE", acceptance="ACCEPTED"),
+    )
+
+    response = client.post("/tasks/task-1/accept")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["task"]["acceptance"] == "ACCEPTED"
+    assert data["escalated"] is False
+    mock_accept.assert_awaited_once_with(test_user_id, "task-1")
+
+
+def test_accept_task_409s_when_the_task_is_open(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.tasks.routes.task_review.accept_delegated_task",
+        new_callable=AsyncMock,
+        side_effect=TaskDelegationRefusedError("Only a finished task…"),
+    )
+
+    response = client.post("/tasks/task-1/accept")
+
+    assert response.status_code == 409
+
+
+def test_reject_task_opens_a_revision_and_nudges_the_owner_session(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    parent = _make_task(status="DONE", acceptance="REJECTED", revision_count=1)
+    revision = _make_task(
+        id="task-2",
+        status="QUEUED",
+        parent_task_id="task-1",
+        origin_session_id="worker-session-1",
+        spec="Revise the outcome of task 'Draft the weekly report'.",
+    )
+    mock_reject = mocker.patch(
+        "backend.api.features.tasks.routes.task_review.reject_delegated_task",
+        new_callable=AsyncMock,
+        return_value=(parent, revision),
+    )
+    mocker.patch(
+        "backend.api.features.tasks.routes.queue_user_message",
+        new_callable=AsyncMock,
+        return_value=mocker.Mock(turn_in_flight=False),
+    )
+    mock_schedule = mocker.patch(
+        "backend.api.features.tasks.routes.schedule_chat_turn",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post("/tasks/task-1/reject", json={"note": "Use Q3 numbers"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["escalated"] is False
+    assert data["revision_task"]["id"] == "task-2"
+    mock_reject.assert_awaited_once_with(test_user_id, "task-1", note="Use Q3 numbers")
+    schedule_kwargs = mock_schedule.await_args.kwargs
+    assert schedule_kwargs["session_id"] == "worker-session-1"
+    assert "report_task" in schedule_kwargs["message"]
+
+
+def test_reject_task_at_the_cap_escalates_without_scheduling(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    parent = _make_task(status="DONE", acceptance="REJECTED", revision_count=2)
+    mocker.patch(
+        "backend.api.features.tasks.routes.task_review.reject_delegated_task",
+        new_callable=AsyncMock,
+        return_value=(parent, None),
+    )
+    mock_schedule = mocker.patch(
+        "backend.api.features.tasks.routes.schedule_chat_turn",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post("/tasks/task-1/reject", json={"note": "Still wrong"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["escalated"] is True
+    assert data["revision_task"] is None
+    assert "clarify" in data["message"]
+    mock_schedule.assert_not_awaited()
+
+
+def test_reject_task_rejects_a_blank_note() -> None:
+    response = client.post("/tasks/task-1/reject", json={"note": "  "})
 
     assert response.status_code == 422

--- a/autogpt_platform/backend/backend/api/features/tasks/task_actions.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/task_actions.py
@@ -18,6 +18,9 @@ from backend.util.exceptions import TaskDelegationRefusedError, TaskUpdateConfli
 from backend.util.json import SafeJson
 
 from .errors import DelegatedTaskNotFoundError
+from .mapping import TASK_INCLUDE as _TASK_INCLUDE
+from .mapping import library_agents_by_graph as _library_agents_by_graph
+from .mapping import to_model as _to_model
 from .models import (
     MAX_TASK_HANDOFFS,
     MAX_TASK_QUESTION_OPTIONS,
@@ -28,7 +31,6 @@ from .models import (
     DelegatedTask,
     TaskAmendment,
 )
-from .tasks_db import _TASK_INCLUDE, _library_agents_by_graph, _to_model
 
 logger = logging.getLogger(__name__)
 

--- a/autogpt_platform/backend/backend/api/features/tasks/task_review.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/task_review.py
@@ -1,0 +1,195 @@
+"""Phase-3 writers: outcome accept/reject with bounded revisions, plus the
+generic amendment append the mid-task instruction hook and the overseer use.
+
+Same tenancy rule as ``tasks_db``: every statement filters on ``userId``.
+``append_task_amendment`` crosses the DatabaseManager RPC (the copilot
+executor and scheduler are Prisma-less); the review writers are called from
+the REST API only.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+import prisma.enums
+import prisma.models
+
+from backend.util.exceptions import TaskDelegationRefusedError, TaskUpdateConflictError
+
+from .errors import DelegatedTaskNotFoundError
+from .models import (
+    MAX_TASK_REVISIONS,
+    TASK_ANSWER_MAX_LENGTH,
+    TASK_SPEC_MAX_LENGTH,
+    TASK_TITLE_MAX_LENGTH,
+    DelegatedTask,
+    TaskAmendment,
+    TaskAmendmentKind,
+)
+from .task_actions import _appended, _reload
+
+logger = logging.getLogger(__name__)
+
+
+async def append_task_amendment(
+    user_id: str,
+    task_id: str,
+    *,
+    note: str,
+    by: str,
+    kind: TaskAmendmentKind = "note",
+) -> DelegatedTask | None:
+    """Append one timeline entry to a still-open task. Returns the task, or
+    None when it is closed or missing — callers treat both as "nothing to
+    record". Last-write-wins on a concurrent append: this is a best-effort
+    log line, not a state transition, so it takes no optimistic lock."""
+    row = await prisma.models.DelegatedTask.prisma().find_first(
+        where={"id": task_id, "userId": user_id}
+    )
+    if row is None or row.status not in (
+        prisma.enums.DelegatedTaskStatus.QUEUED,
+        prisma.enums.DelegatedTaskStatus.WORKING,
+        prisma.enums.DelegatedTaskStatus.WAITING_USER,
+    ):
+        return None
+    amendments = _appended(
+        row,
+        TaskAmendment(
+            at=datetime.now(UTC),
+            by=by,
+            note=note[:TASK_ANSWER_MAX_LENGTH],
+            kind=kind,
+        ),
+    )
+    updated = await prisma.models.DelegatedTask.prisma().update_many(
+        where={"id": task_id, "userId": user_id},
+        data={"amendments": amendments},
+    )
+    if updated == 0:
+        return None
+    return await _reload(user_id, task_id)
+
+
+async def accept_delegated_task(user_id: str, task_id: str) -> DelegatedTask:
+    """Stamp the user's approval on a finished task's outcome."""
+    row = await _finished_task(user_id, task_id)
+    if row.acceptance == prisma.enums.DelegatedTaskAcceptance.ACCEPTED:
+        return await _reload(user_id, task_id)
+    updated = await prisma.models.DelegatedTask.prisma().update_many(
+        where={
+            "id": task_id,
+            "userId": user_id,
+            "status": prisma.enums.DelegatedTaskStatus.DONE,
+        },
+        data={"acceptance": prisma.enums.DelegatedTaskAcceptance.ACCEPTED},
+    )
+    if updated == 0:
+        raise TaskUpdateConflictError("The task changed while you were accepting it.")
+    return await _reload(user_id, task_id)
+
+
+async def reject_delegated_task(
+    user_id: str,
+    task_id: str,
+    *,
+    note: str,
+) -> tuple[DelegatedTask, DelegatedTask | None]:
+    """Reject a finished task's outcome with what to change.
+
+    Under the cap this opens a revision subtask beneath the task (same
+    owner) and bumps ``revisionCount``; the caller then nudges the owner's
+    session to work it. At the cap no subtask is opened — the task is marked
+    REJECTED and the caller tells the user to clarify in chat instead of
+    looping a third time. Returns ``(task, revision_task | None)``.
+    """
+    row = await _finished_task(user_id, task_id)
+    revision_note = note[:TASK_ANSWER_MAX_LENGTH]
+    amendments = _appended(
+        row,
+        TaskAmendment(
+            at=datetime.now(UTC),
+            by="user",
+            note=revision_note,
+            kind="revision",
+        ),
+    )
+
+    if row.revisionCount >= MAX_TASK_REVISIONS:
+        updated = await prisma.models.DelegatedTask.prisma().update_many(
+            where={
+                "id": task_id,
+                "userId": user_id,
+                "status": prisma.enums.DelegatedTaskStatus.DONE,
+                "revisionCount": row.revisionCount,
+            },
+            data={
+                "acceptance": prisma.enums.DelegatedTaskAcceptance.REJECTED,
+                "amendments": amendments,
+            },
+        )
+        if updated == 0:
+            raise TaskUpdateConflictError(
+                "The task changed while you were rejecting it. Try again."
+            )
+        return await _reload(user_id, task_id), None
+
+    updated = await prisma.models.DelegatedTask.prisma().update_many(
+        where={
+            "id": task_id,
+            "userId": user_id,
+            "status": prisma.enums.DelegatedTaskStatus.DONE,
+            "revisionCount": row.revisionCount,
+        },
+        data={
+            "acceptance": prisma.enums.DelegatedTaskAcceptance.REJECTED,
+            "revisionCount": row.revisionCount + 1,
+            "amendments": amendments,
+        },
+    )
+    if updated == 0:
+        raise TaskUpdateConflictError(
+            "The task changed while you were rejecting it. Try again."
+        )
+
+    # Deliberately NOT create_delegated_task: the revision keeps the same
+    # owner, which the delegation loop-check would refuse (the owner is on
+    # their own ancestor trail by construction).
+    revision_row = await prisma.models.DelegatedTask.prisma().create(
+        data={
+            "userId": user_id,
+            "ownerId": row.ownerId,
+            "originSessionId": row.originSessionId,
+            "createdByType": prisma.enums.TaskCreatedByType.USER,
+            "createdById": user_id,
+            "title": f"Revision {row.revisionCount + 1}: {row.title}"[
+                :TASK_TITLE_MAX_LENGTH
+            ],
+            "spec": _revision_spec(row, revision_note),
+            "status": prisma.enums.DelegatedTaskStatus.QUEUED,
+            "ancestorExpertIds": list(row.ancestorExpertIds),
+            "parentTaskId": row.id,
+            "rootTaskId": row.rootTaskId or row.id,
+        }
+    )
+    return await _reload(user_id, task_id), await _reload(user_id, revision_row.id)
+
+
+async def _finished_task(user_id: str, task_id: str) -> prisma.models.DelegatedTask:
+    row = await prisma.models.DelegatedTask.prisma().find_first(
+        where={"id": task_id, "userId": user_id}
+    )
+    if row is None:
+        raise DelegatedTaskNotFoundError(task_id)
+    if row.status != prisma.enums.DelegatedTaskStatus.DONE:
+        raise TaskDelegationRefusedError(
+            "Only a finished task's outcome can be accepted or rejected."
+        )
+    return row
+
+
+def _revision_spec(row: prisma.models.DelegatedTask, note: str) -> str:
+    outcome = " ".join((row.outcomeSummary or "").split())
+    return (
+        f"Revise the outcome of task '{row.title}'.\n"
+        f"Previous outcome: {outcome or 'not recorded.'}\n"
+        f"User feedback: {note}"
+    )[:TASK_SPEC_MAX_LENGTH]

--- a/autogpt_platform/backend/backend/api/features/tasks/task_review_test.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/task_review_test.py
@@ -1,0 +1,229 @@
+"""Real-Prisma tests for the phase-3 writers.
+
+Like ``tasks_db_test``, these need a live database: the revision-cap and
+acceptance flips are optimistic-concurrency writes whose predicates have to
+be *in the query*, and orphan reassignment appends per-row Json amendments.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import prisma.enums
+import prisma.models
+import pytest
+
+from backend.api.features.tasks import overseer_db, task_review
+from backend.data.user import get_or_create_user
+from backend.util.exceptions import TaskDelegationRefusedError
+from backend.util.test import SpinTestServer
+
+
+async def _create_seed_user():
+    suffix = uuid.uuid4().hex[:8]
+    return await get_or_create_user(
+        {
+            "sub": str(uuid.uuid4()),
+            "email": f"task-review-{suffix}@example.com",
+            "name": "Task Owner",
+        }
+    )
+
+
+async def _seed_task(
+    user_id: str,
+    *,
+    title: str = "Draft the weekly report",
+    status: prisma.enums.DelegatedTaskStatus = prisma.enums.DelegatedTaskStatus.DONE,
+    owner_id: str | None = None,
+    revision_count: int = 0,
+    outcome_summary: str | None = "Report drafted.",
+) -> prisma.models.DelegatedTask:
+    return await prisma.models.DelegatedTask.prisma().create(
+        data={
+            "userId": user_id,
+            "ownerId": owner_id,
+            "createdByType": prisma.enums.TaskCreatedByType.USER,
+            "title": title,
+            "spec": "spec",
+            "status": status,
+            "revisionCount": revision_count,
+            "outcomeSummary": outcome_summary,
+        }
+    )
+
+
+async def _seed_expert(user_id: str) -> prisma.models.Expert:
+    return await prisma.models.Expert.prisma().create(
+        data={
+            "ownerUserId": user_id,
+            "name": "Maria",
+            "role": "Marketing",
+            "identity": "Marketing strategist",
+            "visibility": prisma.enums.ResourceVisibility.PRIVATE,
+        }
+    )
+
+
+# ─── accept / reject ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_accept_stamps_acceptance(server: SpinTestServer):
+    user = await _create_seed_user()
+    row = await _seed_task(user.id)
+
+    task = await task_review.accept_delegated_task(user.id, row.id)
+
+    assert task.acceptance == "ACCEPTED"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_accept_refuses_an_open_task(server: SpinTestServer):
+    user = await _create_seed_user()
+    row = await _seed_task(user.id, status=prisma.enums.DelegatedTaskStatus.WORKING)
+
+    with pytest.raises(TaskDelegationRefusedError):
+        await task_review.accept_delegated_task(user.id, row.id)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_reject_opens_a_revision_subtask_with_the_same_owner(
+    server: SpinTestServer,
+):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id)
+    row = await _seed_task(user.id, owner_id=expert.id)
+
+    task, revision = await task_review.reject_delegated_task(
+        user.id, row.id, note="Wrong quarter — use Q3 numbers."
+    )
+
+    assert task.acceptance == "REJECTED"
+    assert task.revision_count == 1
+    assert task.amendments[-1].kind == "revision"
+    assert revision is not None
+    assert revision.parent_task_id == row.id
+    assert revision.owner is not None and revision.owner.id == expert.id
+    assert revision.status == "QUEUED"
+    assert "Q3" in revision.spec
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_reject_at_the_cap_escalates_instead_of_looping(
+    server: SpinTestServer,
+):
+    user = await _create_seed_user()
+    row = await _seed_task(user.id, revision_count=2)
+
+    task, revision = await task_review.reject_delegated_task(
+        user.id, row.id, note="Still wrong."
+    )
+
+    assert revision is None
+    assert task.acceptance == "REJECTED"
+    assert task.revision_count == 2
+    children = await prisma.models.DelegatedTask.prisma().find_many(
+        where={"parentTaskId": row.id}
+    )
+    assert children == []
+
+
+# ─── amendments ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_append_amendment_records_a_user_note_on_an_open_task(
+    server: SpinTestServer,
+):
+    user = await _create_seed_user()
+    row = await _seed_task(user.id, status=prisma.enums.DelegatedTaskStatus.WORKING)
+
+    task = await task_review.append_task_amendment(
+        user.id, row.id, note="Also include churn numbers.", by="user"
+    )
+
+    assert task is not None
+    assert task.amendments[-1].kind == "note"
+    assert task.amendments[-1].by == "user"
+    assert task.amendments[-1].note == "Also include churn numbers."
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_append_amendment_skips_a_closed_task(server: SpinTestServer):
+    user = await _create_seed_user()
+    row = await _seed_task(user.id, status=prisma.enums.DelegatedTaskStatus.DONE)
+
+    assert (
+        await task_review.append_task_amendment(
+            user.id, row.id, note="too late", by="user"
+        )
+        is None
+    )
+
+
+# ─── overseer writes ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_mark_task_stale_only_touches_waiting_rows(server: SpinTestServer):
+    user = await _create_seed_user()
+    waiting = await _seed_task(
+        user.id, status=prisma.enums.DelegatedTaskStatus.WAITING_USER
+    )
+    working = await _seed_task(user.id, status=prisma.enums.DelegatedTaskStatus.WORKING)
+    stamp = datetime.now(UTC)
+
+    assert await overseer_db.mark_task_stale(user.id, waiting.id, stamp) is True
+    assert await overseer_db.mark_task_stale(user.id, waiting.id, stamp) is False
+    assert await overseer_db.mark_task_stale(user.id, working.id, stamp) is False
+
+    refreshed = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": waiting.id}
+    )
+    assert refreshed is not None and refreshed.staleAt is not None
+    assert refreshed.status == prisma.enums.DelegatedTaskStatus.WAITING_USER
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_reassign_open_tasks_moves_them_to_autopilot(server: SpinTestServer):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id)
+    open_row = await _seed_task(
+        user.id,
+        owner_id=expert.id,
+        status=prisma.enums.DelegatedTaskStatus.WORKING,
+    )
+    done_row = await _seed_task(user.id, owner_id=expert.id)
+
+    assert await overseer_db.count_open_tasks_for_expert(user.id, expert.id) == 1
+    reassigned = await overseer_db.reassign_open_tasks_to_autopilot(user.id, expert.id)
+    assert reassigned == 1
+
+    moved = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": open_row.id}
+    )
+    kept = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": done_row.id}
+    )
+    assert moved is not None and moved.ownerId is None
+    assert isinstance(moved.amendments, list)
+    assert moved.amendments[-1]["kind"] == "handoff"
+    assert kept is not None and kept.ownerId == expert.id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_failed_task_counts_group_by_expert(server: SpinTestServer):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id)
+    for _ in range(3):
+        await _seed_task(
+            user.id,
+            owner_id=expert.id,
+            status=prisma.enums.DelegatedTaskStatus.FAILED,
+        )
+
+    counts = await overseer_db.count_recent_failed_tasks_by_expert(
+        user.id, since=datetime.now(UTC) - timedelta(days=7)
+    )
+
+    assert counts == {expert.id: 3}

--- a/autogpt_platform/backend/backend/api/features/tasks/tasks_db.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/tasks_db.py
@@ -6,20 +6,24 @@ expert's id stays readable and would otherwise leak its receipts.
 """
 
 import logging
-from typing import cast
+from datetime import datetime, timezone
 
 import prisma.enums
 import prisma.models
 import prisma.types
 
-from backend.copilot.briefing.outcome import DEFAULT_AGENT_NAME, run_link
 from backend.data.db import transaction
 from backend.executor import utils as execution_utils
 from backend.util.exceptions import TaskDelegationRefusedError
 
 from .errors import DelegatedTaskNotFoundError
+from .mapping import RUNNING_EXECUTION_STATUSES as _RUNNING_EXECUTION_STATUSES
+from .mapping import TASK_INCLUDE as _TASK_INCLUDE
+from .mapping import library_agents_by_graph as _library_agents_by_graph
+from .mapping import to_model as _to_model
 from .models import (
     MAX_TASK_DEPTH,
+    MAX_TASK_EVENTS,
     MAX_TASKS_PER_PAGE,
     OPEN_TASK_STATUSES,
     TASK_OUTCOME_MAX_LENGTH,
@@ -27,28 +31,12 @@ from .models import (
     TASK_TITLE_MAX_LENGTH,
     DelegatedTask,
     DelegatedTaskDetail,
-    TaskAcceptance,
-    TaskAmendment,
     TaskCreatedBy,
-    TaskExpertRef,
-    TaskRunRef,
+    TaskEvent,
     TaskStatus,
 )
 
 logger = logging.getLogger(__name__)
-
-# The owner join is always needed (the card shows who did the work) and the
-# execution join is what makes a task a receipt rather than a label.
-_TASK_INCLUDE: prisma.types.DelegatedTaskInclude = {
-    "Owner": True,
-    "Executions": {"include": {"AgentGraph": True}},
-}
-
-_RUNNING_EXECUTION_STATUSES = [
-    prisma.enums.AgentExecutionStatus.QUEUED,
-    prisma.enums.AgentExecutionStatus.RUNNING,
-    prisma.enums.AgentExecutionStatus.INCOMPLETE,
-]
 
 
 async def list_tasks(
@@ -95,6 +83,34 @@ async def list_open_tasks(
     )
     library_agents = await _library_agents_by_graph(user_id, rows)
     return [_to_model(row, library_agents) for row in rows]
+
+
+async def list_task_events(
+    user_id: str, *, since: datetime | None = None
+) -> list[TaskEvent]:
+    """The user's task state changes since *since*, oldest first — one event
+    per changed task, carrying its current status. Feeds the office view's
+    lightweight poll; the client passes the last event's ``ts`` back as the
+    next ``since``."""
+    where: prisma.types.DelegatedTaskWhereInput = {"userId": user_id}
+    if since is not None:
+        if since.tzinfo is None:
+            since = since.replace(tzinfo=timezone.utc)
+        where["updatedAt"] = {"gt": since}
+    rows = await prisma.models.DelegatedTask.prisma().find_many(
+        where=where,
+        order={"updatedAt": "asc"},
+        take=MAX_TASK_EVENTS,
+    )
+    return [
+        TaskEvent(
+            task_id=row.id,
+            expert_id=row.ownerId,
+            event=row.status.lower(),
+            ts=row.updatedAt.isoformat(),
+        )
+        for row in rows
+    ]
 
 
 async def get_task(user_id: str, task_id: str) -> DelegatedTaskDetail | None:
@@ -398,97 +414,3 @@ async def _stop_running_executions(user_id: str, task_ids: list[str]) -> None:
                 execution.id,
                 exc_info=True,
             )
-
-
-async def _library_agents_by_graph(
-    user_id: str, tasks: list[prisma.models.DelegatedTask]
-) -> dict[str, str]:
-    """Graph id → the caller's library agent id, for the run deep links.
-
-    One batched query for every graph across every listed task; without it a
-    Tasks tab with N runs would issue N lookups just to build hrefs.
-    """
-    graph_ids = {
-        execution.agentGraphId for task in tasks for execution in task.Executions or []
-    }
-    if not graph_ids:
-        return {}
-    rows = await prisma.models.LibraryAgent.prisma().find_many(
-        where={
-            "userId": user_id,
-            "agentGraphId": {"in": list(graph_ids)},
-            "isDeleted": False,
-        }
-    )
-    return {row.agentGraphId: row.id for row in rows}
-
-
-def _to_model(
-    row: prisma.models.DelegatedTask, library_agents: dict[str, str]
-) -> DelegatedTask:
-    return DelegatedTask(
-        id=row.id,
-        title=row.title,
-        spec=row.spec,
-        # Prisma-client-py declares enum columns as its own generated enums
-        # but hands back plain strings at runtime, which the ``Literal``
-        # aliases in models.py already match value-for-value.
-        status=cast(TaskStatus, row.status),
-        acceptance=cast(TaskAcceptance, row.acceptance),
-        created_by_type=cast(TaskCreatedBy, row.createdByType),
-        created_by_id=row.createdById,
-        owner=_to_expert_ref(row.Owner),
-        parent_task_id=row.parentTaskId,
-        root_task_id=row.rootTaskId,
-        origin_session_id=row.originSessionId,
-        ancestor_expert_ids=row.ancestorExpertIds,
-        handoff_count=row.handoffCount,
-        revision_count=row.revisionCount,
-        spend_total=row.spendTotal,
-        outcome_summary=row.outcomeSummary,
-        amendments=_to_amendments(row.amendments),
-        created_at=row.createdAt,
-        updated_at=row.updatedAt,
-        runs=[
-            _to_run_ref(execution, library_agents.get(execution.agentGraphId))
-            for execution in row.Executions or []
-        ],
-    )
-
-
-def _to_expert_ref(row: prisma.models.Expert | None) -> TaskExpertRef | None:
-    if row is None:
-        return None
-    return TaskExpertRef(
-        id=row.id, name=row.name, avatar_url=row.avatarUrl, role=row.role
-    )
-
-
-def _to_run_ref(
-    row: prisma.models.AgentGraphExecution, library_agent_id: str | None
-) -> TaskRunRef:
-    graph = row.AgentGraph
-    return TaskRunRef(
-        execution_id=row.id,
-        graph_id=row.agentGraphId,
-        library_agent_id=library_agent_id,
-        agent_name=(graph.name if graph and graph.name else DEFAULT_AGENT_NAME),
-        status=row.executionStatus,
-        started_at=row.startedAt,
-        ended_at=row.endedAt,
-        link=run_link(library_agent_id, row.id),
-    )
-
-
-def _to_amendments(value: object) -> list[TaskAmendment]:
-    """Amendments are stored as free Json, so a hand-edited or legacy blob
-    must degrade to an empty list rather than 500 the whole Tasks tab."""
-    if not isinstance(value, list):
-        return []
-    amendments = []
-    for entry in value:
-        try:
-            amendments.append(TaskAmendment.model_validate(entry))
-        except Exception:
-            logger.warning("Skipping malformed task amendment", exc_info=True)
-    return amendments

--- a/autogpt_platform/backend/backend/api/features/tasks/tasks_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/tasks/tasks_db_test.py
@@ -6,15 +6,19 @@ and the cancel cascade (which walks the tree with several statements).
 """
 
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
+import fastapi
+import httpx
 import prisma.enums
 import prisma.models
 import pytest
+from autogpt_libs.auth.jwt_utils import get_jwt_payload
 
 from backend.api.features.tasks import task_actions, tasks_db
 from backend.api.features.tasks.errors import DelegatedTaskNotFoundError
+from backend.api.features.tasks.routes import router as tasks_router
 from backend.data.user import get_or_create_user
 from backend.util.exceptions import TaskDelegationRefusedError, TaskUpdateConflictError
 from backend.util.test import SpinTestServer
@@ -490,3 +494,65 @@ async def test_escalate_then_answer_round_trip(server: SpinTestServer):
     assert worker_session_id == "worker-session-1"
     assert task.amendments[-1].kind == "answer"
     assert task.amendments[-1].note == "Staging"
+
+
+# ─── events feed ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_task_events_never_include_another_users_tasks(server: SpinTestServer):
+    owner = await _create_seed_user()
+    intruder = await _create_seed_user()
+    task = await _seed_task(owner.id)
+    await _seed_task(intruder.id, title="Intruder task")
+
+    events = await tasks_db.list_task_events(owner.id)
+
+    assert [e.task_id for e in events] == [task.id]
+    assert events[0].event == "working"
+    assert all(
+        e.task_id != task.id for e in await tasks_db.list_task_events(intruder.id)
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_task_events_since_filters_older_rows(server: SpinTestServer):
+    owner = await _create_seed_user()
+    await _seed_task(owner.id, title="Older")
+    cutoff = datetime.fromisoformat((await tasks_db.list_task_events(owner.id))[-1].ts)
+    newer_task = await _seed_task(owner.id, title="Newer")
+
+    events = await tasks_db.list_task_events(owner.id, since=cutoff)
+
+    assert [e.task_id for e in events] == [newer_task.id]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_events_endpoint_only_returns_the_callers_rows(server: SpinTestServer):
+    """End-to-end tenancy proof for GET /tasks/events: user A's poll must
+    never surface user B's task events, with the real query underneath."""
+    owner = await _create_seed_user()
+    intruder = await _create_seed_user()
+    owner_task = await _seed_task(owner.id, title="Owner task")
+    await _seed_task(intruder.id, title="Intruder task")
+
+    app = fastapi.FastAPI()
+    app.include_router(tasks_router)
+    app.dependency_overrides[get_jwt_payload] = lambda: {
+        "sub": owner.id,
+        "role": "user",
+        "email": owner.email,
+    }
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.get("/tasks/events")
+
+    assert response.status_code == 200
+    events = response.json()["events"]
+    assert [e["task_id"] for e in events] == [owner_task.id]
+    assert events[0] == {
+        "task_id": owner_task.id,
+        "expert_id": None,
+        "event": "working",
+        "ts": events[0]["ts"],
+    }

--- a/autogpt_platform/backend/backend/copilot/baseline/service.py
+++ b/autogpt_platform/backend/backend/copilot/baseline/service.py
@@ -28,7 +28,7 @@ from openai.types import CompletionUsage
 from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
 from opentelemetry import trace as otel_trace
 
-from backend.copilot import engine_switch
+from backend.copilot import engine_switch, task_spine
 from backend.copilot.anthropic_rate_card import (
     compute_anthropic_cost_usd,
     get_max_output_tokens,
@@ -1952,6 +1952,7 @@ async def stream_chat_completion_baseline(
             skills_ctx=skills_ctx,
             user_id=user_id,
             expert_id=session.expert_id,
+            task_ctx=await task_spine.build_task_context(user_id, session),
         )
         if prefixed is not None:
             # Reverse scan so we update the current turn's user message, not

--- a/autogpt_platform/backend/backend/copilot/briefing/generate.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/generate.py
@@ -12,6 +12,8 @@ from pydantic import ValidationError
 from backend.api.features.executions.review.model import PendingHumanReviewModel
 from backend.api.features.experts.models import Expert
 from backend.copilot.constants import COPILOT_SESSION_PREFIX
+from backend.copilot.overseer.cards import compose_merge_items, compose_nudge_items
+from backend.copilot.overseer.recruiter import RECRUITER_WINDOW, compose_hire_items
 from backend.data.db_accessors import (
     execution_db,
     experts_db,
@@ -235,8 +237,22 @@ async def _compose_fresh_briefing(
         generated_at=now_local,
         tz_name=tz_name,
     )
+    nudges, merges, hires = await _compose_task_cards(user_id, now_local, experts)
     if content is None:
-        return None
+        if not (nudges or merges or hires):
+            return None
+        # A day with nothing run but tasks worth nagging about still earns
+        # a briefing — otherwise a week-stale question never resurfaces.
+        content = BriefingContent(
+            generated_at=now_local,
+            timezone=tz_name,
+            zero_expert_fallback=not experts,
+            run_items=[],
+            decision_items=[],
+        )
+    content = content.model_copy(
+        update={"nudge_items": nudges, "merge_items": merges, "hire_items": hires}
+    )
     # Written here, once, rather than at render time: the thread post and the
     # home card must show the same paragraph, and home must not pay for an LLM
     # call on every poll. `None` on failure — the briefing ships either way.
@@ -250,6 +266,31 @@ async def _compose_fresh_briefing(
     return content.model_copy(
         update={"narrative": await compose_narrative(user_id, content, experts)}
     )
+
+
+async def _compose_task_cards(user_id: str, now: datetime, experts: list[Expert]):
+    """Overseer/recruiter cards for the briefing. Best-effort: a task-spine
+    hiccup must not sink the whole briefing."""
+    client = get_database_manager_async_client()
+    try:
+        open_tasks = await client.list_open_tasks(user_id)
+        nudges = compose_nudge_items(open_tasks, now)
+        merges = compose_merge_items(open_tasks)
+        hires = []
+        autopilot_tasks = await client.list_recent_autopilot_tasks(
+            user_id, since=now - RECRUITER_WINDOW
+        )
+        if autopilot_tasks:
+            templates = await client.list_templates()
+            hires = compose_hire_items(autopilot_tasks, templates, experts)
+        return nudges, merges, hires
+    except Exception:
+        logger.warning(
+            "Briefing task cards failed for user %s; shipping without them",
+            user_id[:12],
+            exc_info=True,
+        )
+        return [], [], []
 
 
 async def generate_and_deliver_briefing(user_id: str) -> BriefingResult:

--- a/autogpt_platform/backend/backend/copilot/briefing/models.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/models.py
@@ -36,6 +36,37 @@ class BriefingDecisionItem(BaseModel):
     link: str
 
 
+class BriefingNudgeItem(BaseModel):
+    """A WAITING_USER task the user has sat on for over a day."""
+
+    task_id: str
+    title: str
+    waiting_since: datetime
+    question: str | None = None
+    # Set when the overseer already stamped the task stale (a week without
+    # an answer) — the renderer nags harder.
+    is_stale: bool = False
+
+
+class BriefingMergeItem(BaseModel):
+    """Two open tasks that look like the same ask — a suggestion only,
+    nothing is merged automatically."""
+
+    task_ids: list[str]
+    titles: list[str]
+
+
+class BriefingHireItem(BaseModel):
+    """A recommendation to hire a specific expert template, made after
+    Autopilot self-handled several tasks in that template's lane."""
+
+    template_id: str
+    name: str
+    role: str
+    task_count: int
+    example_titles: list[str] = []
+
+
 class BriefingContent(BaseModel):
     generated_at: datetime
     timezone: str
@@ -58,3 +89,9 @@ class BriefingContent(BaseModel):
     # and any briefing whose narrative call failed, carry None and render as
     # template-only.
     narrative: str | None = None
+    # Overseer/recruiter cards (see `overseer/cards.py` and
+    # `overseer/recruiter.py`). All default so stored rows predating them
+    # still validate.
+    nudge_items: list[BriefingNudgeItem] = []
+    merge_items: list[BriefingMergeItem] = []
+    hire_items: list[BriefingHireItem] = []

--- a/autogpt_platform/backend/backend/copilot/briefing/render.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/render.py
@@ -49,6 +49,30 @@ def render_briefing_markdown(content: BriefingContent) -> str:
         remaining = total - len(content.decision_items)
         if remaining > 0:
             lines.append(f"- …and {remaining} more on your home page")
+        lines.append("")
+    if content.nudge_items:
+        lines.append("**Waiting on you**")
+        for nudge in content.nudge_items:
+            title = _md_link(_md(nudge.title), f"/team/tasks/{nudge.task_id}")
+            ask = f" — {_md(nudge.question)}" if nudge.question else ""
+            marker = " (stale for over a week)" if nudge.is_stale else ""
+            lines.append(f"- {title}{ask}{marker}")
+        lines.append("")
+    if content.merge_items:
+        lines.append("**Possible duplicates — merge?**")
+        for merge in content.merge_items:
+            titles = " / ".join(
+                _md_link(_md(title), f"/team/tasks/{task_id}")
+                for title, task_id in zip(merge.titles, merge.task_ids)
+            )
+            lines.append(f"- {titles} look like the same ask")
+        lines.append("")
+    for hire in content.hire_items:
+        lines.append(
+            f"**Worth a hire?** Autopilot handled {hire.task_count} "
+            f"{_md(hire.role.lower())} tasks itself recently — "
+            f"{_md(hire.name)} covers that lane. Hire them from the team page."
+        )
     return "\n".join(lines).strip()
 
 

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -369,6 +369,17 @@ class ChatConfig(BaseSettings):
         "0 means no spend allowed (will block); there is no unlimited tier.",
     )
 
+    # Hard per-task spend ceiling for tasks the dream proactive pass opens.
+    # Enforced by backend.copilot.dream.proactive: a DREAM-created task whose
+    # spendTotal reaches this cap is stopped and marked FAILED.
+    dream_task_budget_cap: int = Field(
+        default=25,
+        ge=0,
+        description="Per-task credit cap (100 credits = $1) for dream-created "
+        "proactive tasks. A task at or over the cap is failed rather than "
+        "allowed to keep spending.",
+    )
+
     # Cost (in credits / cents) to reset the daily rate limit using credits.
     # When a user hits their daily limit, they can spend this amount to reset
     # the daily counter and keep working.  Set to 0 to disable the feature.

--- a/autogpt_platform/backend/backend/copilot/dream/orchestrator.py
+++ b/autogpt_platform/backend/backend/copilot/dream/orchestrator.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from typing import TypeVar
 
 from backend.copilot.config import ChatConfig
+from backend.copilot.dream_events import EmitFn, emit_dream_operations_event
 from backend.copilot.graphiti.client import derive_memory_scope_key
 from backend.util.feature_flag import Flag, is_feature_enabled
 
@@ -52,6 +53,7 @@ from .locks import (
     dream_lock,
 )
 from .model_pricing import compute_cost_usd, execution_path_discount
+from .proactive import run_proactive_pass
 from .prompts import (
     MAX_DEMOTIONS_PER_PASS,
     MAX_PROPOSALS_PER_PASS,
@@ -744,6 +746,7 @@ async def _execute_dream_pass_async(
     transport_is_local: bool = False,
     config: ChatConfig | None = None,
     status_id: str | None = None,
+    emit: EmitFn | None = None,
 ) -> DreamPassResult:
     config = config or ChatConfig()
     pass_id = str(uuidlib.uuid4())
@@ -984,9 +987,18 @@ async def _execute_dream_pass_async(
                 user_id, input_bundle.window_end, expert_id
             )
 
+            # Proactive pass only after a completed sync apply — skipped and
+            # batch-submitted passes never reach here, so the mode gating
+            # lives with the rest of the state machine as dream_events.py
+            # prescribes. Best-effort: proposals must never fail the dream.
+            await _run_proactive_pass_safe(user_id, pass_id, config)
+
             completed_at = datetime.now(timezone.utc)
             snapshot = apply_stats.get("snapshot")
             raw_session_id = apply_stats.get("session_id")
+
+            if emit is not None and isinstance(snapshot, DreamOperationsSnapshot):
+                await emit_dream_operations_event(emit, snapshot, pass_id, user_id)
 
             def _as_int(key: str) -> int:
                 v = apply_stats.get(key, 0)
@@ -1067,11 +1079,33 @@ def _failure_result(
     )
 
 
+async def _run_proactive_pass_safe(
+    user_id: str, pass_id: str, config: ChatConfig
+) -> None:
+    """Run the idle-expert proactive pass; log-and-continue on failure."""
+    try:
+        result = await run_proactive_pass(user_id, dream_pass_id=pass_id, config=config)
+    except Exception:
+        logger.warning(
+            "Dream proactive pass failed for user %s", user_id[:12], exc_info=True
+        )
+        return
+    if result.created or result.budget_capped_task_count:
+        logger.info(
+            "Dream proactive pass %s: %d task(s) proposed, %d over-budget "
+            "task(s) stopped",
+            pass_id,
+            len(result.created),
+            result.budget_capped_task_count,
+        )
+
+
 async def execute_dream_pass(
     user_id: str,
     *,
     status_id: str | None = None,
     expert_id: str | None = None,
+    emit: EmitFn | None = None,
 ) -> DreamPassResult:
     """Public async entry point used by the scheduler + admin trigger.
 
@@ -1080,9 +1114,15 @@ async def execute_dream_pass(
     into the batch path so the BatchExecutor callbacks can update the
     user-visible status row as each phase lands. AgentProbe + other
     sync callers pass ``None`` and never hit the batch path.
+
+    ``emit`` is the caller's stream closure (same shape baseline / sdk
+    use for ``StreamStatus``); when provided, a completed sync pass
+    surfaces its operations snapshot inline via
+    :func:`emit_dream_operations_event`. ``None`` (scheduler, eval)
+    skips the event.
     """
     return await _execute_dream_pass_async(
-        user_id, status_id=status_id, expert_id=expert_id
+        user_id, status_id=status_id, expert_id=expert_id, emit=emit
     )
 
 

--- a/autogpt_platform/backend/backend/copilot/dream/proactive.py
+++ b/autogpt_platform/backend/backend/copilot/dream/proactive.py
@@ -1,0 +1,176 @@
+"""Dream proactive pass: propose one small task per idle expert.
+
+Runs after a dream pass applies (see ``orchestrator.py``). For every hired,
+non-archived, non-paused expert with no open DelegatedTask, it opens one
+DREAM-created task whose behaviour follows ``Expert.autonomyLevel``:
+
+* ``SUGGEST`` — proposal only. The task is QUEUED with acceptance PENDING
+  and the pass never starts any execution for it; it exists so the morning
+  briefing and Tasks tab can surface the suggestion for the user to accept.
+* ``ASK_FIRST`` / ``AUTONOMOUS`` — a real task (acceptance ACCEPTED),
+  bounded by the hard ``ChatConfig.dream_task_budget_cap``: any open
+  DREAM-created task whose ``spendTotal`` reaches the cap is failed here.
+
+``originSessionId`` stays null on every task this pass creates, so the
+outcome path (``executor.task_outcomes``) never posts into a chat session —
+outcomes reach the user through the briefing only.
+"""
+
+import logging
+
+import prisma.enums
+import prisma.models
+from pydantic import BaseModel
+
+from backend.api.features.tasks import tasks_db
+from backend.api.features.tasks.models import (
+    OPEN_TASK_STATUSES,
+    TASK_OUTCOME_MAX_LENGTH,
+)
+from backend.copilot.config import ChatConfig
+
+logger = logging.getLogger(__name__)
+
+_OPEN_STATUSES = [prisma.enums.DelegatedTaskStatus(s) for s in OPEN_TASK_STATUSES]
+
+# One pass never floods the board: at most this many proposals per run.
+MAX_PROACTIVE_TASKS_PER_PASS = 5
+
+
+class ProactiveTask(BaseModel):
+    task_id: str
+    expert_id: str
+    autonomy: str
+    # True for SUGGEST experts — the task is a proposal the user must accept.
+    proposal_only: bool
+
+
+class ProactivePassResult(BaseModel):
+    budget_capped_task_count: int = 0
+    created: list[ProactiveTask] = []
+
+
+async def run_proactive_pass(
+    user_id: str,
+    *,
+    dream_pass_id: str,
+    config: ChatConfig | None = None,
+) -> ProactivePassResult:
+    """One sweep: enforce the budget cap, then propose work for idle experts."""
+    config = config or ChatConfig()
+    capped = await enforce_task_budget_caps(user_id, config.dream_task_budget_cap)
+
+    created = [
+        await _propose_task(user_id, expert, dream_pass_id)
+        for expert in (await _idle_experts(user_id))[:MAX_PROACTIVE_TASKS_PER_PASS]
+    ]
+    return ProactivePassResult(budget_capped_task_count=capped, created=created)
+
+
+async def enforce_task_budget_caps(user_id: str, cap: int) -> int:
+    """Fail every open DREAM-created task whose spend reached *cap*.
+
+    ``spendTotal`` is reconciled when a task's run settles, so this sweep is
+    the hard stop that keeps a dream-created task from queueing further paid
+    work once its budget is gone. Returns the number of tasks stopped.
+    """
+    if cap <= 0:
+        return 0
+    stopped = await prisma.models.DelegatedTask.prisma().update_many(
+        where={
+            "userId": user_id,
+            "createdByType": prisma.enums.TaskCreatedByType.DREAM,
+            "status": {"in": _OPEN_STATUSES},
+            "spendTotal": {"gte": cap},
+        },
+        data={
+            "status": prisma.enums.DelegatedTaskStatus.FAILED,
+            "outcomeSummary": (
+                f"Stopped: spend reached the {cap}-credit cap for "
+                "dream-created tasks."
+            )[:TASK_OUTCOME_MAX_LENGTH],
+        },
+    )
+    if stopped:
+        logger.info(
+            "Dream proactive: stopped %d over-budget task(s) for user %s",
+            stopped,
+            user_id[:12],
+        )
+    return stopped
+
+
+async def _idle_experts(user_id: str) -> list[prisma.models.Expert]:
+    """Hired, non-archived, non-paused experts with no open task."""
+    experts = await prisma.models.Expert.prisma().find_many(
+        where={
+            "ownerUserId": user_id,
+            "isTemplate": False,
+            "isArchived": False,
+            "schedulesPausedAt": None,
+        },
+        order={"createdAt": "asc"},
+    )
+    if not experts:
+        return []
+    open_tasks = await prisma.models.DelegatedTask.prisma().find_many(
+        where={
+            "userId": user_id,
+            "ownerId": {"in": [expert.id for expert in experts]},
+            "status": {"in": _OPEN_STATUSES},
+        },
+        distinct=["ownerId"],
+    )
+    busy = {task.ownerId for task in open_tasks}
+    return [expert for expert in experts if expert.id not in busy]
+
+
+async def _propose_task(
+    user_id: str, expert: prisma.models.Expert, dream_pass_id: str
+) -> ProactiveTask:
+    proposal_only = expert.autonomyLevel == prisma.enums.ExpertAutonomyLevel.SUGGEST
+    task = await tasks_db.create_delegated_task(
+        user_id,
+        title=_task_title(expert),
+        spec=_task_spec(expert, proposal_only=proposal_only),
+        owner_id=expert.id,
+        origin_session_id=None,
+        created_by_type="DREAM",
+        created_by_id=dream_pass_id,
+    )
+    if not proposal_only:
+        # ASK_FIRST / AUTONOMOUS tasks are real work, not proposals — mark
+        # them accepted so the review flow doesn't hold them for a nod the
+        # autonomy level already granted.
+        await prisma.models.DelegatedTask.prisma().update_many(
+            where={"id": task.id, "userId": user_id},
+            data={"acceptance": prisma.enums.DelegatedTaskAcceptance.ACCEPTED},
+        )
+    return ProactiveTask(
+        task_id=task.id,
+        expert_id=expert.id,
+        autonomy=str(expert.autonomyLevel),
+        proposal_only=proposal_only,
+    )
+
+
+def _task_title(expert: prisma.models.Expert) -> str:
+    lane = expert.role or expert.name
+    return f"Proactive: one small {lane} win"
+
+
+def _task_spec(expert: prisma.models.Expert, *, proposal_only: bool) -> str:
+    lane = expert.role or "your lane"
+    lines = [
+        f"{expert.name} has no open work. Propose ONE small, concrete "
+        f"{lane} task that would help right now, sized to finish in a "
+        "single sitting.",
+        "Keep it cheap and reversible; skip anything that needs approvals "
+        "or external commitments.",
+    ]
+    if proposal_only:
+        lines.append(
+            "This is a suggestion only — do not start any work until the "
+            "user accepts it."
+        )
+    return "\n".join(lines)

--- a/autogpt_platform/backend/backend/copilot/dream/proactive_test.py
+++ b/autogpt_platform/backend/backend/copilot/dream/proactive_test.py
@@ -1,0 +1,170 @@
+"""DB-level tests for the dream proactive pass.
+
+Real-postgres tests via the session ``server`` fixture. The two invariants
+that matter: a SUGGEST expert's proposal never becomes running work, and a
+DREAM-created task at the budget cap is stopped dead.
+"""
+
+import uuid
+
+import prisma.enums
+import prisma.models
+import pytest
+
+from backend.copilot.config import ChatConfig
+from backend.copilot.dream.proactive import enforce_task_budget_caps, run_proactive_pass
+from backend.data.user import get_or_create_user
+from backend.util.test import SpinTestServer
+
+# DB tests share the session loop so the Prisma pool stays bound to one loop
+# (mirrors experts_db_test.py / task_review_test.py).
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+async def _create_seed_user():
+    suffix = uuid.uuid4().hex[:8]
+    return await get_or_create_user(
+        {
+            "sub": str(uuid.uuid4()),
+            "email": f"proactive-{suffix}@example.com",
+            "name": "Proactive Owner",
+        }
+    )
+
+
+async def _seed_expert(
+    user_id: str, autonomy: prisma.enums.ExpertAutonomyLevel
+) -> prisma.models.Expert:
+    return await prisma.models.Expert.prisma().create(
+        data={
+            "ownerUserId": user_id,
+            "name": f"Expert {uuid.uuid4().hex[:8]}",
+            "role": "Marketing",
+            "identity": "You are a marketing expert.",
+            "autonomyLevel": autonomy,
+        }
+    )
+
+
+async def _seed_dream_task(
+    user_id: str,
+    expert_id: str,
+    *,
+    spend: int,
+    status: prisma.enums.DelegatedTaskStatus = prisma.enums.DelegatedTaskStatus.WORKING,
+) -> prisma.models.DelegatedTask:
+    row = await prisma.models.DelegatedTask.prisma().create(
+        data={
+            "userId": user_id,
+            "ownerId": expert_id,
+            "createdByType": prisma.enums.TaskCreatedByType.DREAM,
+            "createdById": "pass-prior",
+            "title": "Prior dream task",
+            "spec": "Keep working.",
+            "status": status,
+            "spendTotal": spend,
+        }
+    )
+    stamped = await prisma.models.DelegatedTask.prisma().update(
+        where={"id": row.id}, data={"rootTaskId": row.id}
+    )
+    return stamped or row
+
+
+async def test_budget_cap_stops_over_budget_dream_task(server: SpinTestServer):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id, prisma.enums.ExpertAutonomyLevel.AUTONOMOUS)
+    over = await _seed_dream_task(user.id, expert.id, spend=30)
+    under = await _seed_dream_task(user.id, expert.id, spend=5)
+
+    stopped = await enforce_task_budget_caps(user.id, 25)
+
+    assert stopped == 1
+    over_row = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": over.id}
+    )
+    assert over_row is not None
+    assert over_row.status == prisma.enums.DelegatedTaskStatus.FAILED
+    assert over_row.outcomeSummary is not None
+    assert "25-credit cap" in over_row.outcomeSummary
+
+    under_row = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": under.id}
+    )
+    assert under_row is not None
+    assert under_row.status == prisma.enums.DelegatedTaskStatus.WORKING
+
+
+async def test_budget_cap_at_exact_cap_is_enforced(server: SpinTestServer):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id, prisma.enums.ExpertAutonomyLevel.ASK_FIRST)
+    task = await _seed_dream_task(user.id, expert.id, spend=25)
+
+    assert await enforce_task_budget_caps(user.id, 25) == 1
+    row = await prisma.models.DelegatedTask.prisma().find_unique(where={"id": task.id})
+    assert row is not None
+    assert row.status == prisma.enums.DelegatedTaskStatus.FAILED
+
+
+async def test_suggest_expert_gets_proposal_that_never_executes(
+    server: SpinTestServer,
+):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id, prisma.enums.ExpertAutonomyLevel.SUGGEST)
+
+    result = await run_proactive_pass(
+        user.id, dream_pass_id="pass-suggest", config=ChatConfig()
+    )
+
+    assert len(result.created) == 1
+    created = result.created[0]
+    assert created.expert_id == expert.id
+    assert created.proposal_only is True
+
+    task = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": created.task_id}
+    )
+    assert task is not None
+    assert task.status == prisma.enums.DelegatedTaskStatus.QUEUED
+    assert task.acceptance == prisma.enums.DelegatedTaskAcceptance.PENDING
+    assert task.createdByType == prisma.enums.TaskCreatedByType.DREAM
+    assert task.createdById == "pass-suggest"
+    assert task.originSessionId is None
+    assert "do not start any work" in task.spec
+
+    # The pass proposed only — nothing was executed for this user.
+    assert (
+        await prisma.models.AgentGraphExecution.prisma().count(
+            where={"userId": user.id}
+        )
+        == 0
+    )
+
+
+async def test_ask_first_expert_gets_accepted_task(server: SpinTestServer):
+    user = await _create_seed_user()
+    await _seed_expert(user.id, prisma.enums.ExpertAutonomyLevel.ASK_FIRST)
+
+    result = await run_proactive_pass(
+        user.id, dream_pass_id="pass-ask", config=ChatConfig()
+    )
+
+    assert len(result.created) == 1
+    assert result.created[0].proposal_only is False
+    task = await prisma.models.DelegatedTask.prisma().find_unique(
+        where={"id": result.created[0].task_id}
+    )
+    assert task is not None
+    assert task.status == prisma.enums.DelegatedTaskStatus.QUEUED
+    assert task.acceptance == prisma.enums.DelegatedTaskAcceptance.ACCEPTED
+
+
+async def test_busy_expert_is_skipped(server: SpinTestServer):
+    user = await _create_seed_user()
+    expert = await _seed_expert(user.id, prisma.enums.ExpertAutonomyLevel.AUTONOMOUS)
+    await _seed_dream_task(user.id, expert.id, spend=0)
+
+    result = await run_proactive_pass(
+        user.id, dream_pass_id="pass-busy", config=ChatConfig()
+    )
+    assert result.created == []

--- a/autogpt_platform/backend/backend/copilot/overseer/cards.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/cards.py
@@ -1,0 +1,83 @@
+"""Pure composers for the overseer's daily briefing cards.
+
+Called at briefing-generation time (`briefing/generate.py`) — these
+describe a day of task state, not a 15-minute window, so they live with
+the composer rather than the 15-minute pass. Pure functions over already-
+fetched tasks: no I/O, trivially testable with frozen time.
+"""
+
+from datetime import datetime, timedelta
+from difflib import SequenceMatcher
+from itertools import combinations
+
+from backend.api.features.tasks.models import DelegatedTask
+from backend.copilot.briefing.models import BriefingMergeItem, BriefingNudgeItem
+
+NUDGE_AFTER = timedelta(hours=24)
+
+# Normalized-title similarity at or above this reads as "probably the same
+# ask" — high enough that generic titles ("Run Agent") need a near-exact
+# match before we suggest merging.
+MERGE_SIMILARITY_THRESHOLD = 0.75
+
+_MAX_NUDGE_ITEMS = 5
+_MAX_MERGE_ITEMS = 3
+
+
+def compose_nudge_items(
+    tasks: list[DelegatedTask], now: datetime
+) -> list[BriefingNudgeItem]:
+    """WAITING_USER tasks the user has sat on for over a day, oldest first —
+    the briefing nudges rather than Home shouting immediately."""
+    waiting = sorted(
+        (
+            task
+            for task in tasks
+            if task.status == "WAITING_USER" and task.updated_at < now - NUDGE_AFTER
+        ),
+        key=lambda task: task.updated_at,
+    )
+    return [
+        BriefingNudgeItem(
+            task_id=task.id,
+            title=task.title,
+            waiting_since=task.updated_at,
+            question=_latest_question(task),
+            is_stale=task.stale_at is not None,
+        )
+        for task in waiting[:_MAX_NUDGE_ITEMS]
+    ]
+
+
+def compose_merge_items(tasks: list[DelegatedTask]) -> list[BriefingMergeItem]:
+    """Pairs of open root tasks whose titles look like the same ask — a
+    "merge?" suggestion only; nothing is ever merged automatically."""
+    roots = [task for task in tasks if task.parent_task_id is None]
+    suggested: set[str] = set()
+    items: list[BriefingMergeItem] = []
+    for a, b in combinations(roots, 2):
+        if len(items) >= _MAX_MERGE_ITEMS:
+            break
+        if a.id in suggested or b.id in suggested:
+            continue
+        if _title_similarity(a.title, b.title) >= MERGE_SIMILARITY_THRESHOLD:
+            suggested.update((a.id, b.id))
+            items.append(
+                BriefingMergeItem(task_ids=[a.id, b.id], titles=[a.title, b.title])
+            )
+    return items
+
+
+def _title_similarity(a: str, b: str) -> float:
+    return SequenceMatcher(None, _normalize(a), _normalize(b)).ratio()
+
+
+def _normalize(title: str) -> str:
+    return " ".join(title.lower().split())
+
+
+def _latest_question(task: DelegatedTask) -> str | None:
+    for amendment in reversed(task.amendments):
+        if amendment.kind == "escalation":
+            return amendment.question or amendment.note
+    return None

--- a/autogpt_platform/backend/backend/copilot/overseer/cards_test.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/cards_test.py
@@ -1,0 +1,97 @@
+"""Pure-function tests for the briefing nudge and merge composers."""
+
+from datetime import UTC, datetime, timedelta
+
+from backend.api.features.tasks.models import DelegatedTask, TaskAmendment
+from backend.copilot.overseer.cards import compose_merge_items, compose_nudge_items
+
+_NOW = datetime(2026, 8, 30, 9, 0, tzinfo=UTC)
+
+
+def _task(
+    *,
+    task_id: str,
+    title: str = "Draft the weekly report",
+    status: str = "WAITING_USER",
+    updated_hours_ago: float = 0,
+    amendments: list[TaskAmendment] | None = None,
+    stale_at: datetime | None = None,
+    parent_task_id: str | None = None,
+) -> DelegatedTask:
+    updated = _NOW - timedelta(hours=updated_hours_ago)
+    return DelegatedTask(
+        id=task_id,
+        title=title,
+        spec="spec",
+        status=status,  # type: ignore[arg-type]
+        acceptance="PENDING",
+        created_by_type="USER",
+        created_by_id="user-1",
+        owner=None,
+        parent_task_id=parent_task_id,
+        root_task_id=task_id,
+        origin_session_id=None,
+        ancestor_expert_ids=[],
+        handoff_count=0,
+        revision_count=0,
+        spend_total=0,
+        outcome_summary=None,
+        amendments=amendments or [],
+        stale_at=stale_at,
+        created_at=updated,
+        updated_at=updated,
+    )
+
+
+def test_nudges_only_tasks_waiting_over_a_day():
+    fresh = _task(task_id="fresh", updated_hours_ago=2)
+    old = _task(task_id="old", updated_hours_ago=30)
+    working = _task(task_id="working", status="WORKING", updated_hours_ago=48)
+
+    items = compose_nudge_items([fresh, old, working], _NOW)
+
+    assert [item.task_id for item in items] == ["old"]
+
+
+def test_nudge_carries_the_latest_escalation_question_and_stale_flag():
+    escalation = TaskAmendment(
+        at=_NOW - timedelta(days=2),
+        by="expert-1",
+        note="Which quarter?",
+        kind="escalation",
+        question="Which quarter should the report cover?",
+    )
+    task = _task(
+        task_id="old",
+        updated_hours_ago=10 * 24,
+        amendments=[escalation],
+        stale_at=_NOW - timedelta(days=1),
+    )
+
+    (item,) = compose_nudge_items([task], _NOW)
+
+    assert item.question == "Which quarter should the report cover?"
+    assert item.is_stale is True
+
+
+def test_similar_titles_suggest_a_merge_once():
+    a = _task(task_id="a", title="Write the launch blog post")
+    b = _task(task_id="b", title="Write the launch blog post!")
+    c = _task(task_id="c", title="Reconcile the Q3 invoices")
+
+    items = compose_merge_items([a, b, c])
+
+    assert len(items) == 1
+    assert set(items[0].task_ids) == {"a", "b"}
+
+
+def test_dissimilar_titles_and_subtasks_never_suggest_merges():
+    a = _task(task_id="a", title="Write the launch blog post")
+    b = _task(task_id="b", title="Reconcile the Q3 invoices")
+    dup_child = _task(
+        task_id="child",
+        title="Write the launch blog post",
+        parent_task_id="a",
+    )
+
+    assert compose_merge_items([a, b, dup_child]) == []

--- a/autogpt_platform/backend/backend/copilot/overseer/recruiter.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/recruiter.py
@@ -1,0 +1,70 @@
+"""The recruiter: spot a run of Autopilot-self-handled tasks that a hired
+expert template already covers, and recommend the hire.
+
+Pure keyword matching over template roles/skills — deterministic and
+cheap enough for briefing-compose time. A category here is simply the
+template whose vocabulary the task titles/specs keep hitting.
+"""
+
+from datetime import timedelta
+
+from backend.api.features.experts.models import Expert
+from backend.api.features.tasks.models import DelegatedTask
+from backend.copilot.briefing.models import BriefingHireItem
+
+RECRUITER_WINDOW = timedelta(days=14)
+
+# How many same-category self-handled tasks it takes before Autopilot
+# doing the work itself starts to look like a missing hire.
+RECRUITER_TASK_THRESHOLD = 3
+
+_MIN_TOKEN_LENGTH = 4
+
+
+def compose_hire_items(
+    autopilot_tasks: list[DelegatedTask],
+    templates: list[Expert],
+    hired: list[Expert],
+) -> list[BriefingHireItem]:
+    """At most one recommendation: the not-yet-hired template whose
+    vocabulary matched the most recent self-handled tasks, once it clears
+    the threshold."""
+    hired_template_ids = {
+        expert.source_template_id for expert in hired if expert.source_template_id
+    }
+    best: BriefingHireItem | None = None
+    for template in templates:
+        if template.id in hired_template_ids:
+            continue
+        vocabulary = _template_vocabulary(template)
+        if not vocabulary:
+            continue
+        matched = [task for task in autopilot_tasks if _matches(task, vocabulary)]
+        if len(matched) < RECRUITER_TASK_THRESHOLD:
+            continue
+        if best is None or len(matched) > best.task_count:
+            best = BriefingHireItem(
+                template_id=template.id,
+                name=template.name,
+                role=template.role,
+                task_count=len(matched),
+                example_titles=[task.title for task in matched[:3]],
+            )
+    return [best] if best else []
+
+
+def _template_vocabulary(template: Expert) -> set[str]:
+    tokens: set[str] = set()
+    for phrase in (template.role, *template.skills):
+        tokens.update(
+            token
+            for token in phrase.lower().replace("-", " ").split()
+            if len(token) >= _MIN_TOKEN_LENGTH
+        )
+    return tokens
+
+
+def _matches(task: DelegatedTask, vocabulary: set[str]) -> bool:
+    text = f"{task.title} {task.spec}".lower()
+    words = set(text.replace("-", " ").split())
+    return bool(words & vocabulary)

--- a/autogpt_platform/backend/backend/copilot/overseer/recruiter_test.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/recruiter_test.py
@@ -1,0 +1,115 @@
+"""Pure-function tests for the recruiter's hire recommendation."""
+
+from datetime import UTC, datetime
+
+from backend.api.features.experts.models import Expert
+from backend.api.features.tasks.models import DelegatedTask
+from backend.copilot.overseer.recruiter import compose_hire_items
+
+_NOW = datetime(2026, 8, 30, 9, 0, tzinfo=UTC)
+
+
+def _autopilot_task(task_id: str, title: str) -> DelegatedTask:
+    return DelegatedTask(
+        id=task_id,
+        title=title,
+        spec="spec",
+        status="DONE",
+        acceptance="PENDING",
+        created_by_type="USER",
+        created_by_id="user-1",
+        owner=None,
+        parent_task_id=None,
+        root_task_id=task_id,
+        origin_session_id=None,
+        ancestor_expert_ids=[],
+        handoff_count=0,
+        revision_count=0,
+        spend_total=0,
+        outcome_summary=None,
+        amendments=[],
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+def _expert(
+    *,
+    expert_id: str,
+    name: str = "Maria",
+    role: str = "Marketing",
+    skills: list[str] | None = None,
+    is_template: bool = True,
+    source_template_id: str | None = None,
+) -> Expert:
+    return Expert.model_construct(
+        id=expert_id,
+        name=name,
+        role=role,
+        skills=skills if skills is not None else ["Marketing campaigns"],
+        is_template=is_template,
+        source_template_id=source_template_id,
+    )
+
+
+def test_three_matching_tasks_recommend_the_template():
+    tasks = [
+        _autopilot_task("t1", "Plan the marketing campaign"),
+        _autopilot_task("t2", "Draft marketing email"),
+        _autopilot_task("t3", "Review marketing budget"),
+    ]
+    template = _expert(expert_id="tmpl-maria")
+
+    (item,) = compose_hire_items(tasks, [template], hired=[])
+
+    assert item.template_id == "tmpl-maria"
+    assert item.task_count == 3
+    assert len(item.example_titles) == 3
+
+
+def test_two_matching_tasks_are_not_enough():
+    tasks = [
+        _autopilot_task("t1", "Plan the marketing campaign"),
+        _autopilot_task("t2", "Draft marketing email"),
+    ]
+
+    assert compose_hire_items(tasks, [_expert(expert_id="tmpl")], hired=[]) == []
+
+
+def test_already_hired_template_is_never_recommended():
+    tasks = [
+        _autopilot_task("t1", "Plan the marketing campaign"),
+        _autopilot_task("t2", "Draft marketing email"),
+        _autopilot_task("t3", "Review marketing budget"),
+    ]
+    template = _expert(expert_id="tmpl-maria")
+    hired = [
+        _expert(
+            expert_id="maria-1",
+            is_template=False,
+            source_template_id="tmpl-maria",
+        )
+    ]
+
+    assert compose_hire_items(tasks, [template], hired=hired) == []
+
+
+def test_best_matching_template_wins():
+    tasks = [
+        _autopilot_task("t1", "Plan the marketing campaign"),
+        _autopilot_task("t2", "Draft marketing email"),
+        _autopilot_task("t3", "Review marketing budget"),
+        _autopilot_task("t4", "Chase overdue sales invoices"),
+        _autopilot_task("t5", "Prepare sales pipeline review"),
+        _autopilot_task("t6", "Summarise sales calls"),
+        _autopilot_task("t7", "Draft sales outreach sequence"),
+    ]
+    marketing = _expert(expert_id="tmpl-maria")
+    sales = _expert(
+        expert_id="tmpl-max", name="Max", role="Sales", skills=["Sales outreach"]
+    )
+
+    (item,) = compose_hire_items(tasks, [marketing, sales], hired=[])
+
+    assert item.template_id == "tmpl-max"
+    assert item.task_count == 4

--- a/autogpt_platform/backend/backend/copilot/overseer/scheduling.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/scheduling.py
@@ -1,0 +1,80 @@
+"""Lazy auto-registration of the per-user task-overseer cron.
+
+Mirrors ``backend/copilot/briefing/scheduling.py`` minus the timezone
+machinery: the overseer fires every 15 minutes, so local time is
+irrelevant and the Redis marker only has to bound out-of-band drift (an
+externally deleted cron). Fired via ``asyncio.create_task`` from the hot
+chat path — never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from backend.data.redis_client import get_redis_async
+from backend.util.feature_flag import Flag, is_feature_enabled
+
+logger = logging.getLogger(__name__)
+
+REGISTRATION_TTL_SECONDS = 7 * 24 * 3600
+
+OVERSEER_REGISTRATION_PREFIX = "task_overseer_registered"
+
+
+async def ensure_task_overseer_scheduled(user_id: str) -> None:
+    """Idempotently register the 15-minute overseer cron for a user.
+
+    The pass itself no-ops cheaply when the user has no open tasks, so
+    registration errs toward "on": any chat turn from a flagged user
+    keeps the cron alive.
+    """
+    try:
+        if not user_id:
+            return
+        if not await is_feature_enabled(Flag.HIRE_EXPERTS, user_id, default=False):
+            return
+        if await _marker_present(user_id):
+            return
+
+        from backend.util.clients import get_scheduler_client
+
+        await get_scheduler_client().add_task_overseer_schedule(user_id=user_id)
+        await _write_marker(user_id)
+        logger.info("Task overseer: registered cron for user %s", user_id[:12])
+    except Exception:
+        logger.warning(
+            "Task overseer: failed to register cron for user %s",
+            user_id[:12],
+            exc_info=True,
+        )
+
+
+async def _marker_present(user_id: str) -> bool:
+    try:
+        redis = await get_redis_async()
+        return await redis.get(f"{OVERSEER_REGISTRATION_PREFIX}:{user_id}") is not None
+    except Exception:
+        logger.debug(
+            "Redis read failed for %s:%s; treating as not-registered",
+            OVERSEER_REGISTRATION_PREFIX,
+            user_id[:12],
+            exc_info=True,
+        )
+        return False
+
+
+async def _write_marker(user_id: str) -> None:
+    try:
+        redis = await get_redis_async()
+        await redis.set(
+            f"{OVERSEER_REGISTRATION_PREFIX}:{user_id}",
+            "1",
+            ex=REGISTRATION_TTL_SECONDS,
+        )
+    except Exception:
+        logger.debug(
+            "Redis write failed for %s:%s; lazy path will re-register later",
+            OVERSEER_REGISTRATION_PREFIX,
+            user_id[:12],
+            exc_info=True,
+        )

--- a/autogpt_platform/backend/backend/copilot/overseer/service.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/service.py
@@ -44,6 +44,11 @@ _FAILED_OUTCOME = (
 )
 
 
+def _as_utc(value: datetime) -> datetime:
+    """Normalize a possibly naive DB timestamp to timezone-aware UTC."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
 async def run_overseer_pass(
     user_id: str, *, now: datetime | None = None
 ) -> dict[str, int]:
@@ -74,7 +79,7 @@ async def run_overseer_pass(
             if (
                 task.status == "WAITING_USER"
                 and task.stale_at is None
-                and task.updated_at < now - STALE_AFTER
+                and _as_utc(task.updated_at) < now - STALE_AFTER
             ):
                 if await client.mark_task_stale(user_id, task.id, stale_at=now):
                     summary["stale"] += 1
@@ -101,7 +106,7 @@ async def _find_stalled(
     candidates = [
         task
         for task in tasks
-        if task.status == "WORKING" and task.updated_at < now - STALL_AFTER
+        if task.status == "WORKING" and _as_utc(task.updated_at) < now - STALL_AFTER
     ]
     if not candidates:
         return []

--- a/autogpt_platform/backend/backend/copilot/overseer/service.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/service.py
@@ -1,0 +1,148 @@
+"""The overseer pass: a 15-minute per-user sweep over open delegated tasks.
+
+Runs in the scheduler process (Prisma-less), so every read and write goes
+through the DatabaseManager RPC. Three checks per pass:
+
+* **Stall** — a WORKING task with no live execution and no update for 15
+  minutes gets one retry (a nudge into its working session); a task that
+  stalls again after the retry is closed FAILED, which Home's attention
+  list then surfaces.
+* **Staleness** — a WAITING_USER task unanswered for 7 days gets ``staleAt``
+  stamped. Never auto-cancelled; Home nags instead.
+* **Expert health** — an expert with 3+ FAILED tasks inside 7 days is
+  paused through the existing ExpertPauseEvent flow, which Home's paused
+  attention card already surfaces.
+
+The daily briefing cards (24h nudges, merge suggestions, hire
+recommendations) are composed at briefing-generation time from
+``cards.py`` / ``recruiter.py`` — they describe a day, not a 15-minute
+window, so they live with the briefing composer rather than this pass.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from backend.api.features.tasks.models import DelegatedTask
+from backend.copilot.executor.utils import schedule_chat_turn
+from backend.copilot.pending_message_helpers import queue_user_message
+from backend.util.clients import get_database_manager_async_client
+from backend.util.feature_flag import Flag, is_feature_enabled
+
+logger = logging.getLogger(__name__)
+
+STALL_AFTER = timedelta(minutes=15)
+STALE_AFTER = timedelta(days=7)
+EXPERT_FAILURE_WINDOW = timedelta(days=7)
+EXPERT_FAILURE_THRESHOLD = 3
+
+_RETRY_NOTE = (
+    "No progress for 15 minutes with no run in flight — the overseer asked "
+    "the owner to pick this back up."
+)
+_FAILED_OUTCOME = (
+    "Stalled with no progress after a retry; marked failed by the overseer."
+)
+
+
+async def run_overseer_pass(
+    user_id: str, *, now: datetime | None = None
+) -> dict[str, int]:
+    """One sweep for one user. Returns per-check counters for the job log."""
+    summary = {"retried": 0, "failed": 0, "stale": 0, "paused_experts": 0}
+    if not await is_feature_enabled(Flag.HIRE_EXPERTS, user_id, default=False):
+        return summary
+    now = now or datetime.now(UTC)
+    client = get_database_manager_async_client()
+
+    tasks = await client.list_open_tasks(user_id)
+    if tasks:
+        stalled = await _find_stalled(client, user_id, tasks, now)
+        for task in stalled:
+            if any(a.kind == "retry" for a in task.amendments):
+                await client.close_delegated_task(
+                    user_id=user_id,
+                    task_id=task.id,
+                    succeeded=False,
+                    outcome_summary=_FAILED_OUTCOME,
+                )
+                summary["failed"] += 1
+            else:
+                await _retry_task(client, user_id, task)
+                summary["retried"] += 1
+
+        for task in tasks:
+            if (
+                task.status == "WAITING_USER"
+                and task.stale_at is None
+                and task.updated_at < now - STALE_AFTER
+            ):
+                if await client.mark_task_stale(user_id, task.id, stale_at=now):
+                    summary["stale"] += 1
+
+    counts = await client.count_recent_failed_tasks_by_expert(
+        user_id, since=now - EXPERT_FAILURE_WINDOW
+    )
+    for expert_id, failures in counts.items():
+        if failures >= EXPERT_FAILURE_THRESHOLD:
+            paused = await client.pause_expert_schedules(
+                user_id,
+                expert_id,
+                reason=f"{failures} failed tasks in the last 7 days",
+            )
+            if paused:
+                summary["paused_experts"] += 1
+
+    return summary
+
+
+async def _find_stalled(
+    client, user_id: str, tasks: list[DelegatedTask], now: datetime
+) -> list[DelegatedTask]:
+    candidates = [
+        task
+        for task in tasks
+        if task.status == "WORKING" and task.updated_at < now - STALL_AFTER
+    ]
+    if not candidates:
+        return []
+    running = await client.has_running_executions(
+        user_id, [task.id for task in candidates]
+    )
+    return [task for task in candidates if not running.get(task.id)]
+
+
+async def _retry_task(client, user_id: str, task: DelegatedTask) -> None:
+    """First stall: record the retry on the timeline, then nudge the working
+    session back into motion. The amendment write bumps ``updatedAt``, so
+    the next stall check measures from the retry — a second silent window
+    is what fails the task."""
+    await client.append_task_amendment(
+        user_id, task.id, note=_RETRY_NOTE, by="overseer", kind="retry"
+    )
+    if task.origin_session_id is None:
+        return
+    message = (
+        f"[Overseer] Task '{task.title}' (task_id: {task.id}) has stalled — "
+        "no progress for 15 minutes and no run in flight. Pick it back up "
+        "and finish it, or escalate to the user with escalate_task if you "
+        "are blocked."
+    )
+    try:
+        queued = await queue_user_message(
+            session_id=task.origin_session_id,
+            message=message,
+            require_turn_in_flight=True,
+        )
+        if not queued.turn_in_flight:
+            await schedule_chat_turn(
+                session_id=task.origin_session_id,
+                user_id=user_id,
+                message=message,
+            )
+    except Exception:
+        logger.warning(
+            "Overseer could not nudge session #%s for task #%s",
+            task.origin_session_id,
+            task.id,
+            exc_info=True,
+        )

--- a/autogpt_platform/backend/backend/copilot/overseer/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/service_test.py
@@ -1,0 +1,225 @@
+"""Unit tests for the overseer pass — no DB, frozen clock via ``now=``."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.api.features.tasks.models import DelegatedTask, TaskAmendment
+from backend.copilot.overseer.service import run_overseer_pass
+
+_MODULE = "backend.copilot.overseer.service"
+
+_NOW = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+
+
+def _task(
+    *,
+    task_id: str = "task-1",
+    status: str = "WORKING",
+    updated_minutes_ago: float = 0,
+    amendments: list[TaskAmendment] | None = None,
+    stale_at: datetime | None = None,
+    origin_session_id: str | None = "sess-1",
+) -> DelegatedTask:
+    updated = _NOW - timedelta(minutes=updated_minutes_ago)
+    return DelegatedTask(
+        id=task_id,
+        title="Draft the weekly report",
+        spec="spec",
+        status=status,  # type: ignore[arg-type]
+        acceptance="PENDING",
+        created_by_type="USER",
+        created_by_id="user-1",
+        owner=None,
+        parent_task_id=None,
+        root_task_id=task_id,
+        origin_session_id=origin_session_id,
+        ancestor_expert_ids=[],
+        handoff_count=0,
+        revision_count=0,
+        spend_total=0,
+        outcome_summary=None,
+        amendments=amendments or [],
+        stale_at=stale_at,
+        created_at=updated,
+        updated_at=updated,
+    )
+
+
+def _retry_amendment() -> TaskAmendment:
+    return TaskAmendment(
+        at=_NOW - timedelta(minutes=20), by="overseer", note="retried", kind="retry"
+    )
+
+
+def _client(
+    tasks: list[DelegatedTask],
+    *,
+    running: dict[str, bool] | None = None,
+    failed_counts: dict[str, int] | None = None,
+) -> MagicMock:
+    client = MagicMock()
+    client.list_open_tasks = AsyncMock(return_value=tasks)
+    client.has_running_executions = AsyncMock(return_value=running or {})
+    client.close_delegated_task = AsyncMock()
+    client.append_task_amendment = AsyncMock()
+    client.mark_task_stale = AsyncMock(return_value=True)
+    client.count_recent_failed_tasks_by_expert = AsyncMock(
+        return_value=failed_counts or {}
+    )
+    client.pause_expert_schedules = AsyncMock(return_value=True)
+    return client
+
+
+def _run(client: MagicMock, *, flag: bool = True):
+    queued = MagicMock(turn_in_flight=False)
+    patches = {
+        "get_database_manager_async_client": patch(
+            f"{_MODULE}.get_database_manager_async_client", return_value=client
+        ),
+        "flag": patch(f"{_MODULE}.is_feature_enabled", AsyncMock(return_value=flag)),
+        "queue": patch(f"{_MODULE}.queue_user_message", AsyncMock(return_value=queued)),
+        "schedule": patch(f"{_MODULE}.schedule_chat_turn", AsyncMock()),
+    }
+    return patches
+
+
+@pytest.mark.asyncio
+async def test_flag_off_does_nothing():
+    client = _client([_task(updated_minutes_ago=60)])
+    patches = _run(client, flag=False)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary == {"retried": 0, "failed": 0, "stale": 0, "paused_experts": 0}
+    client.list_open_tasks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_first_stall_records_retry_and_nudges_the_session():
+    client = _client([_task(updated_minutes_ago=20)], running={"task-1": False})
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"] as schedule:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["retried"] == 1
+    kwargs = client.append_task_amendment.call_args.kwargs
+    assert kwargs["kind"] == "retry"
+    assert kwargs["by"] == "overseer"
+    client.close_delegated_task.assert_not_awaited()
+    # queue reported no turn in flight, so the nudge schedules a fresh turn.
+    schedule.assert_awaited_once()
+    assert schedule.call_args.kwargs["session_id"] == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_second_stall_fails_the_task():
+    client = _client(
+        [_task(updated_minutes_ago=20, amendments=[_retry_amendment()])],
+        running={"task-1": False},
+    )
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["failed"] == 1
+    kwargs = client.close_delegated_task.call_args.kwargs
+    assert kwargs["succeeded"] is False
+    client.append_task_amendment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recently_updated_working_task_is_left_alone():
+    client = _client([_task(updated_minutes_ago=5)])
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["retried"] == 0
+    client.has_running_executions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stalled_task_with_live_execution_is_not_retried():
+    client = _client([_task(updated_minutes_ago=45)], running={"task-1": True})
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["retried"] == 0
+    client.append_task_amendment.assert_not_awaited()
+    client.close_delegated_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_week_old_waiting_task_is_stamped_stale():
+    client = _client([_task(status="WAITING_USER", updated_minutes_ago=8 * 24 * 60)])
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["stale"] == 1
+    client.mark_task_stale.assert_awaited_once_with("user-1", "task-1", stale_at=_NOW)
+
+
+@pytest.mark.asyncio
+async def test_day_old_waiting_task_is_not_stale_and_never_cancelled():
+    client = _client([_task(status="WAITING_USER", updated_minutes_ago=25 * 60)])
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["stale"] == 0
+    client.mark_task_stale.assert_not_awaited()
+    client.close_delegated_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_already_stale_task_is_not_restamped():
+    client = _client(
+        [
+            _task(
+                status="WAITING_USER",
+                updated_minutes_ago=9 * 24 * 60,
+                stale_at=_NOW - timedelta(days=1),
+            )
+        ]
+    )
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["stale"] == 0
+    client.mark_task_stale.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_three_failures_in_a_week_pause_the_expert():
+    client = _client([], failed_counts={"expert-1": 3, "expert-2": 2})
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["paused_experts"] == 1
+    client.pause_expert_schedules.assert_awaited_once()
+    args = client.pause_expert_schedules.call_args.args
+    assert args[:2] == ("user-1", "expert-1")

--- a/autogpt_platform/backend/backend/copilot/overseer/service_test.py
+++ b/autogpt_platform/backend/backend/copilot/overseer/service_test.py
@@ -21,8 +21,11 @@ def _task(
     amendments: list[TaskAmendment] | None = None,
     stale_at: datetime | None = None,
     origin_session_id: str | None = "sess-1",
+    naive_updated: bool = False,
 ) -> DelegatedTask:
     updated = _NOW - timedelta(minutes=updated_minutes_ago)
+    if naive_updated:
+        updated = updated.replace(tzinfo=None)
     return DelegatedTask(
         id=task_id,
         title="Draft the weekly report",
@@ -173,6 +176,32 @@ async def test_week_old_waiting_task_is_stamped_stale():
 
     assert summary["stale"] == 1
     client.mark_task_stale.assert_awaited_once_with("user-1", "task-1", stale_at=_NOW)
+
+
+@pytest.mark.asyncio
+async def test_naive_updated_at_does_not_crash_the_pass():
+    # Prisma can hand back a timezone-naive ``updated_at``; the pass must
+    # normalize it rather than raise TypeError on the comparison.
+    client = _client(
+        [
+            _task(updated_minutes_ago=20, naive_updated=True),
+            _task(
+                task_id="task-2",
+                status="WAITING_USER",
+                updated_minutes_ago=8 * 24 * 60,
+                naive_updated=True,
+            ),
+        ],
+        running={"task-1": False},
+    )
+    patches = _run(client)
+    with patches["get_database_manager_async_client"], patches["flag"], patches[
+        "queue"
+    ], patches["schedule"]:
+        summary = await run_overseer_pass("user-1", now=_NOW)
+
+    assert summary["retried"] == 1
+    assert summary["stale"] == 1
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/sdk/service.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/service.py
@@ -47,6 +47,7 @@ from backend.copilot.model_router import (
     resolve_codex_model_route,
     resolve_model_route,
 )
+from backend.copilot import task_spine
 from backend.copilot.graphiti.context import fetch_warm_context
 from backend.copilot.graphiti.ingest import enqueue_conversation_turn
 from backend.copilot.sdk.codex_compat_gateway import CodexAnthropicGateway
@@ -5123,6 +5124,7 @@ async def stream_chat_completion_sdk(  # pyright: ignore[reportGeneralTypeIssues
                 skills_ctx=skills_ctx_content,
                 user_id=user_id,
                 expert_id=session.expert_id,
+                task_ctx=await task_spine.build_task_context(user_id, session),
             )
             if prefixed_message is not None:
                 current_message = prefixed_message

--- a/autogpt_platform/backend/backend/copilot/service.py
+++ b/autogpt_platform/backend/backend/copilot/service.py
@@ -342,6 +342,15 @@ _TEAM_CONTEXT_PREFIX_RE = re.compile(
     r"^<team_context>.*?</team_context>\n\n", re.DOTALL
 )
 
+CURRENT_TASK_TAG = "current_task"
+_CURRENT_TASK_ANYWHERE_RE = re.compile(
+    r"<current_task>.*?</current_task>\s*", re.DOTALL
+)
+_CURRENT_TASK_LONE_TAG_RE = re.compile(r"</?current_task>", re.IGNORECASE)
+_CURRENT_TASK_PREFIX_RE = re.compile(
+    r"^<current_task>.*?</current_task>\n\n", re.DOTALL
+)
+
 
 def _sanitize_user_context_field(value: str) -> str:
     """Escape any characters that would let user-controlled text break out of
@@ -422,7 +431,12 @@ def strip_server_injected_tags(text: str) -> str:
     without_expert = _EXPERT_WORKFLOWS_ANYWHERE_RE.sub("", without_expert)
     without_expert = _EXPERT_WORKFLOWS_LONE_TAG_RE.sub("", without_expert)
     without_expert = _TEAM_CONTEXT_ANYWHERE_RE.sub("", without_expert)
-    return _TEAM_CONTEXT_LONE_TAG_RE.sub("", without_expert)
+    without_expert = _TEAM_CONTEXT_LONE_TAG_RE.sub("", without_expert)
+    # Strip <current_task> blocks and lone tags — prevents spoofing of the
+    # server-injected delegated-task briefing (a forged block could point
+    # report_task/escalate_task at a task the session doesn't own).
+    without_task = _CURRENT_TASK_ANYWHERE_RE.sub("", without_expert)
+    return _CURRENT_TASK_LONE_TAG_RE.sub("", without_task)
 
 
 def sanitize_user_supplied_context(message: str) -> str:
@@ -478,6 +492,7 @@ def strip_injected_context_for_display(message: str) -> str:
         result = _EXPERT_IDENTITY_PREFIX_RE.sub("", result)
         result = _EXPERT_WORKFLOWS_PREFIX_RE.sub("", result)
         result = _TEAM_CONTEXT_PREFIX_RE.sub("", result)
+        result = _CURRENT_TASK_PREFIX_RE.sub("", result)
     return result
 
 
@@ -574,6 +589,7 @@ async def inject_user_context(
     skills_ctx: str = "",
     user_id: str | None = None,
     expert_id: str | None = None,
+    task_ctx: str = "",
 ) -> str | None:
     """Prepend trusted context blocks to the first user message.
 
@@ -713,6 +729,16 @@ async def inject_user_context(
     expert_ctx = await build_expert_context(user_id, expert_id)
     if expert_ctx:
         final_message = expert_ctx + final_message
+    # Prepend the delegated-task briefing for worker sessions.  Trusted
+    # server-built string (see ``task_spine.build_task_context``) carrying
+    # the task's spec plus any mid-task user instructions, prepended AFTER
+    # sanitisation like every other trusted block.  Per-turn dynamic, so it
+    # sits below the cached <available_skills> prefix.
+    if task_ctx:
+        final_message = (
+            f"<{CURRENT_TASK_TAG}>\n{task_ctx}\n</{CURRENT_TASK_TAG}>\n\n"
+            + final_message
+        )
     # Prepend Graphiti warm context as a <memory_context> block AFTER
     # sanitization so the trusted server-injected block is never stripped by
     # ``sanitize_user_supplied_context``.  Memory must land BELOW

--- a/autogpt_platform/backend/backend/copilot/task_spine.py
+++ b/autogpt_platform/backend/backend/copilot/task_spine.py
@@ -8,7 +8,7 @@ simply lands without a task, exactly as it did before the spine existed.
 
 import logging
 
-from backend.copilot.model import ChatSession, get_chat_session
+from backend.copilot.model import ChatSession, ChatSessionInfo, get_chat_session
 from backend.util.clients import get_database_manager_async_client
 from backend.util.exceptions import TaskDelegationRefusedError
 
@@ -133,6 +133,65 @@ async def _final_answer(session: ChatSession, user_id: str) -> str:
         if message.role == "assistant" and message.content and message.content.strip():
             return " ".join(message.content.split())
     return "The delegated work finished."
+
+
+async def record_mid_task_instruction(
+    user_id: str, session: ChatSession | ChatSessionInfo, text: str
+) -> None:
+    """A user message into a session working a delegated task is a mid-task
+    instruction — append it to the task's timeline so the next model turn
+    (via ``build_task_context``) and the task drawer both see it.
+    Best-effort; the message itself still reaches the model either way."""
+    task_id = session.metadata.delegated_task_id
+    note = " ".join(text.split()) if text else ""
+    if not task_id or not note:
+        return
+    try:
+        await get_database_manager_async_client().append_task_amendment(
+            user_id, task_id, note=note, by="user", kind="note"
+        )
+    except Exception:
+        logger.warning(
+            "Failed to record mid-task instruction on task #%s",
+            task_id,
+            exc_info=True,
+        )
+
+
+async def build_task_context(user_id: str | None, session: ChatSession) -> str:
+    """The delegated-task briefing injected as ``<current_task>`` into a
+    worker session's turn. Empty string when the session has no open task —
+    the block is simply omitted."""
+    task_id = session.metadata.delegated_task_id
+    if not task_id or user_id is None:
+        return ""
+    try:
+        detail = await get_database_manager_async_client().get_delegated_task(
+            user_id, task_id
+        )
+    except Exception:
+        logger.warning(
+            "Failed to load task #%s for context injection", task_id, exc_info=True
+        )
+        return ""
+    task = detail.task if detail else None
+    if task is None or task.status not in ("QUEUED", "WORKING"):
+        return ""
+    lines = [
+        f"You are working delegated task '{task.title}' "
+        f"(task_id: {task.id}, status: {task.status}).",
+        f"Spec: {task.spec}",
+    ]
+    instructions = [a for a in task.amendments if a.kind == "note" and a.by == "user"]
+    if instructions:
+        lines.append("The user added instructions mid-task:")
+        lines.extend(
+            f"- [{a.at.isoformat(timespec='minutes')}] {a.note}" for a in instructions
+        )
+        lines.append(
+            "Fold these into the work in progress — they refine the spec above."
+        )
+    return "\n".join(lines)
 
 
 def _describe_run(agent_name: str, inputs: dict) -> str:

--- a/autogpt_platform/backend/backend/copilot/task_spine_test.py
+++ b/autogpt_platform/backend/backend/copilot/task_spine_test.py
@@ -9,9 +9,11 @@ import pytest
 from backend.copilot.model import ChatMessage, ChatSession, ChatSessionMetadata
 from backend.copilot.task_spine import (
     _describe_run,
+    build_task_context,
     fail_task,
     mark_task_working,
     open_task_for_run,
+    record_mid_task_instruction,
     settle_task_for_turn,
 )
 
@@ -230,3 +232,119 @@ def test_describe_run_lists_inputs_and_truncates():
     assert "Run Brief with:" in described
     assert "- topic: 'news'" in described
     assert len(_describe_run("Brief", {"blob": "x" * 10_000})) <= 4_000
+
+
+# ─── phase 3: mid-task instructions + task context ─────────────────────
+
+
+def _amendment_client(task: object) -> MagicMock:
+    client = MagicMock()
+    client.append_task_amendment = AsyncMock()
+    client.get_delegated_task = AsyncMock(
+        return_value=MagicMock(task=task) if task is not None else None
+    )
+    return client
+
+
+def _context_task(
+    *,
+    status: str = "WORKING",
+    amendments: list | None = None,
+):
+    from backend.api.features.tasks.models import TaskAmendment
+
+    task = MagicMock(status=status)
+    task.id = "task-1"
+    task.title = "Draft the weekly report"
+    task.spec = "Cover revenue and churn."
+    task.amendments = [
+        TaskAmendment.model_validate(a) if isinstance(a, dict) else a
+        for a in (amendments or [])
+    ]
+    return task
+
+
+@pytest.mark.asyncio
+async def test_mid_task_instruction_is_appended_as_a_user_note():
+    client = _amendment_client(None)
+
+    with patch(f"{_MODULE}.get_database_manager_async_client", return_value=client):
+        await record_mid_task_instruction(
+            "user-1", _worker_session(), "Also include churn numbers.\n"
+        )
+
+    kwargs = client.append_task_amendment.call_args.kwargs
+    args = client.append_task_amendment.call_args.args
+    assert args == ("user-1", "task-1")
+    assert kwargs["note"] == "Also include churn numbers."
+    assert kwargs["by"] == "user"
+    assert kwargs["kind"] == "note"
+
+
+@pytest.mark.asyncio
+async def test_mid_task_instruction_skips_sessions_without_a_task():
+    client = _amendment_client(None)
+
+    with patch(f"{_MODULE}.get_database_manager_async_client", return_value=client):
+        await record_mid_task_instruction("user-1", _session(), "hello")
+
+    client.append_task_amendment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mid_task_instruction_swallows_rpc_failure():
+    client = _amendment_client(None)
+    client.append_task_amendment.side_effect = RuntimeError("rpc down")
+
+    with patch(f"{_MODULE}.get_database_manager_async_client", return_value=client):
+        await record_mid_task_instruction("user-1", _worker_session(), "note")
+
+
+@pytest.mark.asyncio
+async def test_task_context_carries_spec_and_mid_task_instructions():
+    from datetime import UTC as _UTC
+    from datetime import datetime as _dt
+
+    task = _context_task(
+        amendments=[
+            {
+                "at": _dt(2026, 8, 30, 9, 30, tzinfo=_UTC),
+                "by": "user",
+                "note": "Also include churn numbers.",
+                "kind": "note",
+            },
+            {
+                "at": _dt(2026, 8, 30, 9, 0, tzinfo=_UTC),
+                "by": "overseer",
+                "note": "retried",
+                "kind": "retry",
+            },
+        ]
+    )
+    client = _amendment_client(task)
+
+    with patch(f"{_MODULE}.get_database_manager_async_client", return_value=client):
+        context = await build_task_context("user-1", _worker_session())
+
+    assert "task_id: task-1" in context
+    assert "Cover revenue and churn." in context
+    assert "added instructions mid-task" in context
+    assert "Also include churn numbers." in context
+    assert "retried" not in context
+
+
+@pytest.mark.asyncio
+async def test_task_context_is_empty_for_closed_or_missing_tasks():
+    with patch(
+        f"{_MODULE}.get_database_manager_async_client",
+        return_value=_amendment_client(_context_task(status="DONE")),
+    ):
+        assert await build_task_context("user-1", _worker_session()) == ""
+
+    with patch(
+        f"{_MODULE}.get_database_manager_async_client",
+        return_value=_amendment_client(None),
+    ):
+        assert await build_task_context("user-1", _worker_session()) == ""
+
+    assert await build_task_context("user-1", _session()) == ""

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert.py
@@ -50,6 +50,7 @@ from .base import BaseTool
 from .expert_delegation import (
     chain_refusal,
     resolve_target_expert,
+    route_to_pod_lead,
     safe_caller_name,
     unknown_target_message,
 )
@@ -187,6 +188,10 @@ class DelegateToExpertTool(BaseTool):
                 "run_sub_session to isolate it in a fresh context.",
                 session,
             )
+
+        # Work aimed at a pod member from outside the pod lands on the pod's
+        # lead, who then delegates within the members.
+        target = await route_to_pod_lead(user_id, session.expert_id, target)
 
         refusal = await chain_refusal(user_id, session, target)
         if refusal is not None:

--- a/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/delegate_to_expert_test.py
@@ -72,9 +72,13 @@ def roster(monkeypatch):
     async def fake_list_experts(user_id, *, with_metrics=True, **_):
         return list(experts.values())
 
+    async def fake_list_pods(user_id):
+        return []
+
     db = MagicMock()
     db.get_expert = fake_get_expert
     db.list_experts = fake_list_experts
+    db.list_pods = fake_list_pods
     for module in (
         "delegate_to_expert",
         "get_sub_session_result",

--- a/autogpt_platform/backend/backend/copilot/tools/expert_delegation.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_delegation.py
@@ -14,7 +14,7 @@ just passes the task on with the other tool.
 
 import logging
 
-from backend.api.features.experts.models import Expert
+from backend.api.features.experts.models import Expert, ExpertPod
 from backend.copilot.model import ChatSession, get_chat_session
 from backend.data.db_accessors import experts_db
 
@@ -58,6 +58,10 @@ async def resolve_target_expert(user_id: str, reference: str) -> Expert | None:
     rather than raising — which leaves any exception meaning a real database
     failure. Those propagate to the caller, whose handler says "try again"
     instead of the flat lie that the teammate does not exist.
+
+    A reference matching no expert is finally tried as a pod name: an ask
+    aimed at "the growth pod" resolves to that pod's lead expert, who then
+    delegates within the members.
     """
     expert = await experts_db().get_expert(user_id, reference, include_workflows=False)
     if expert is not None:
@@ -70,7 +74,83 @@ async def resolve_target_expert(user_id: str, reference: str) -> Expert | None:
         for e in await experts_db().list_experts(user_id, with_metrics=False)
         if not e.is_archived and e.name.strip().casefold() == wanted
     ]
-    return matches[0] if len(matches) == 1 else None
+    if len(matches) == 1:
+        return matches[0]
+    if matches:
+        return None
+    return await _lead_of_pod_named(user_id, wanted)
+
+
+async def _lead_of_pod_named(user_id: str, wanted: str) -> Expert | None:
+    """The lead expert of the uniquely-named pod matching *wanted*, if any."""
+    pods = [
+        p
+        for p in await experts_db().list_pods(user_id)
+        if p.name.strip().casefold() == wanted
+    ]
+    if len(pods) != 1 or pods[0].lead_expert_id is None:
+        return None
+    lead = await experts_db().get_expert(
+        user_id, pods[0].lead_expert_id, include_workflows=False
+    )
+    if lead is None or lead.is_archived:
+        return None
+    return lead
+
+
+async def route_to_pod_lead(
+    user_id: str, caller_expert_id: str | None, target: Expert
+) -> Expert:
+    """Who should actually receive work aimed at *target*.
+
+    A delegation aimed at a pod member from outside the pod lands on the
+    pod's lead, who then delegates within the members with the same tools.
+    Calls from inside the pod (the lead included) keep their direct target so
+    the lead can actually distribute work; a lead who cannot take work
+    (missing, archived, paused, or the caller themself) falls back to the
+    direct target rather than blocking the delegation.
+    """
+    if target.pod_id is None:
+        return target
+    try:
+        pod = await _pod_by_id(user_id, target.pod_id)
+        if pod is None or pod.lead_expert_id is None or pod.lead_expert_id == target.id:
+            return target
+        if caller_expert_id is not None:
+            if caller_expert_id == pod.lead_expert_id:
+                return target
+            caller = await experts_db().get_expert(
+                user_id, caller_expert_id, include_workflows=False
+            )
+            if caller is not None and caller.pod_id == target.pod_id:
+                return target
+        lead = await experts_db().get_expert(
+            user_id, pod.lead_expert_id, include_workflows=False
+        )
+    except Exception as e:
+        # Routing is an optimisation on top of a valid direct target; a pod
+        # lookup hiccup must not fail the delegation itself.
+        logger.warning(f"Pod-lead routing lookup failed: {e}")
+        return target
+    if (
+        lead is None
+        or lead.is_archived
+        or lead.schedules_paused_at is not None
+        or lead.id == caller_expert_id
+    ):
+        return target
+    logger.info(
+        "Routing: delegation aimed at expert %s rerouted to pod lead %s (pod %s)",
+        target.id,
+        lead.id,
+        target.pod_id,
+    )
+    return lead
+
+
+async def _pod_by_id(user_id: str, pod_id: str) -> ExpertPod | None:
+    pods = await experts_db().list_pods(user_id)
+    return next((p for p in pods if p.id == pod_id), None)
 
 
 async def unknown_target_message(

--- a/autogpt_platform/backend/backend/copilot/tools/handoff_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/handoff_to_expert_test.py
@@ -78,9 +78,13 @@ def roster(monkeypatch):
     async def fake_list_experts(user_id, *, with_metrics=True, **_):
         return list(experts.values())
 
+    async def fake_list_pods(user_id):
+        return []
+
     db = MagicMock()
     db.get_expert = fake_get_expert
     db.list_experts = fake_list_experts
+    db.list_pods = fake_list_pods
     for module in ("handoff_to_expert", "expert_delegation"):
         monkeypatch.setattr(
             f"backend.copilot.tools.{module}.experts_db",

--- a/autogpt_platform/backend/backend/copilot/tools/pod_lead_routing_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/pod_lead_routing_test.py
@@ -1,0 +1,252 @@
+"""Tests for pod-lead routing on delegate_to_expert.
+
+A delegation aimed at a pod member from outside the pod must land on the
+pod's lead — who then distributes the work within the members with the same
+tools — while intra-pod delegation keeps its direct target. The harness
+mirrors ``delegate_to_expert_test``: an in-memory roster plus pods, faked
+session CRUD, and a mocked queue turn.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.copilot.sdk.session_waiter import SessionResult
+
+from .delegate_to_expert import DelegateToExpertTool
+from .models import ErrorResponse
+
+
+def _session(
+    user_id: str = "alice",
+    session_id: str = "s1",
+    expert_id: str | None = "expert-out",
+) -> MagicMock:
+    sess = MagicMock()
+    sess.session_id = session_id
+    sess.user_id = user_id
+    sess.dry_run = False
+    sess.metadata.llm_auth_provider = "platform"
+    sess.metadata.llm_credential_id = None
+    sess.metadata.delegated_by_session_id = None
+    sess.metadata.origin = "interactive"
+    sess.expert_id = expert_id
+    return sess
+
+
+def _expert(expert_id: str, name: str, *, pod_id: str | None = None) -> MagicMock:
+    expert = MagicMock()
+    expert.id = expert_id
+    expert.name = name
+    expert.role = "Specialist"
+    expert.avatar_url = None
+    expert.color = "violet"
+    expert.is_archived = False
+    expert.schedules_paused_at = None
+    expert.pod_id = pod_id
+    return expert
+
+
+def _pod(pod_id: str, name: str, lead_expert_id: str | None) -> MagicMock:
+    pod = MagicMock()
+    pod.id = pod_id
+    pod.name = name
+    pod.lead_expert_id = lead_expert_id
+    return pod
+
+
+@pytest.fixture
+def team(monkeypatch):
+    """A pod with a lead and two members, plus an outsider."""
+    experts = {
+        "expert-lead": _expert("expert-lead", "Lena", pod_id="pod-growth"),
+        "expert-m1": _expert("expert-m1", "Mia", pod_id="pod-growth"),
+        "expert-m2": _expert("expert-m2", "Moe", pod_id="pod-growth"),
+        "expert-out": _expert("expert-out", "Omar"),
+    }
+    pods = [_pod("pod-growth", "Growth", "expert-lead")]
+
+    async def fake_get_expert(user_id, expert_id, *, include_workflows=True, **_):
+        return experts.get(expert_id)
+
+    async def fake_list_experts(user_id, *, with_metrics=True, **_):
+        return list(experts.values())
+
+    async def fake_list_pods(user_id):
+        return list(pods)
+
+    db = MagicMock()
+    db.get_expert = fake_get_expert
+    db.list_experts = fake_list_experts
+    db.list_pods = fake_list_pods
+    for module in ("delegate_to_expert", "expert_delegation"):
+        monkeypatch.setattr(
+            f"backend.copilot.tools.{module}.experts_db", lambda: db, raising=True
+        )
+    return experts
+
+
+@pytest.fixture
+def mock_turn(monkeypatch):
+    turn = AsyncMock(return_value=("running", SessionResult()))
+    monkeypatch.setattr(
+        "backend.copilot.tools.delegate_to_expert.run_copilot_turn_via_queue", turn
+    )
+    monkeypatch.setattr(
+        "backend.copilot.tools.delegate_to_expert.list_sub_workspace_files",
+        AsyncMock(return_value=None),
+    )
+    return turn
+
+
+@pytest.fixture
+def mock_sessions(monkeypatch):
+    created: list[MagicMock] = []
+
+    async def fake_create(user_id, **kwargs):
+        sess = _session(user_id, f"inner-{len(created) + 1}", kwargs.get("expert_id"))
+        sess.metadata.delegated_by_expert_id = kwargs.get("delegated_by_expert_id")
+        sess.metadata.delegated_by_session_id = kwargs.get("delegated_by_session_id")
+        sess.metadata.origin = kwargs.get("origin")
+        sess.metadata.handed_off_from_expert_id = None
+        created.append(sess)
+        return sess
+
+    async def fake_get(session_id, user_id=None):
+        return next((s for s in created if s.session_id == session_id), None)
+
+    monkeypatch.setattr(
+        "backend.copilot.tools.delegate_to_expert.create_chat_session", fake_create
+    )
+    monkeypatch.setattr(
+        "backend.copilot.tools.delegate_to_expert.get_chat_session", fake_get
+    )
+    monkeypatch.setattr(
+        "backend.copilot.tools.expert_delegation.get_chat_session", fake_get
+    )
+    return created
+
+
+async def _delegate(session: MagicMock, expert_id: str):
+    return await DelegateToExpertTool()._execute(
+        user_id="alice",
+        session=session,
+        expert_id=expert_id,
+        prompt="grow the newsletter",
+        wait_for_result=0,
+    )
+
+
+class TestPodLeadRouting:
+    @pytest.mark.asyncio
+    async def test_outside_delegation_to_a_pod_member_lands_on_the_lead(
+        self, team, mock_turn, mock_sessions
+    ):
+        r = await _delegate(_session(expert_id="expert-out"), "expert-m1")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-lead"
+
+    @pytest.mark.asyncio
+    async def test_autopilot_delegation_to_a_pod_member_lands_on_the_lead(
+        self, team, mock_turn, mock_sessions
+    ):
+        r = await _delegate(_session(expert_id=None), "expert-m1")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-lead"
+
+    @pytest.mark.asyncio
+    async def test_an_ask_naming_the_pod_lands_on_the_lead(
+        self, team, mock_turn, mock_sessions
+    ):
+        r = await _delegate(_session(expert_id="expert-out"), "growth")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-lead"
+
+    @pytest.mark.asyncio
+    async def test_the_lead_delegates_directly_to_members(
+        self, team, mock_turn, mock_sessions
+    ):
+        r = await _delegate(_session(expert_id="expert-lead"), "expert-m1")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-m1"
+
+    @pytest.mark.asyncio
+    async def test_intra_pod_delegation_keeps_its_direct_target(
+        self, team, mock_turn, mock_sessions
+    ):
+        r = await _delegate(_session(expert_id="expert-m1"), "expert-m2")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-m2"
+
+    @pytest.mark.asyncio
+    async def test_a_paused_lead_falls_back_to_the_direct_target(
+        self, team, mock_turn, mock_sessions
+    ):
+        team["expert-lead"].schedules_paused_at = "2026-01-01T00:00:00Z"
+
+        r = await _delegate(_session(expert_id="expert-out"), "expert-m1")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-m1"
+
+    @pytest.mark.asyncio
+    async def test_a_delegation_to_a_member_of_a_leadless_pod_is_direct(
+        self, team, mock_turn, mock_sessions
+    ):
+        team["expert-m1"].pod_id = "pod-leadless"
+
+        r = await _delegate(_session(expert_id="expert-out"), "expert-m1")
+
+        assert not isinstance(r, ErrorResponse)
+        assert mock_sessions[0].expert_id == "expert-m1"
+
+
+class TestPodChainGuards:
+    """The routed hop rides the same provenance chain as any delegation, so
+    the depth bound and the loop check must still hold around it."""
+
+    def _chain(self, mock_sessions, expert_ids: list[str | None]) -> MagicMock:
+        parent_id = None
+        for depth, expert_id in enumerate(expert_ids):
+            sess = _session(session_id=f"chain-{depth}", expert_id=expert_id)
+            sess.metadata.delegated_by_session_id = parent_id
+            mock_sessions.append(sess)
+            parent_id = sess.session_id
+        return mock_sessions[-1]
+
+    @pytest.mark.asyncio
+    async def test_router_to_lead_to_member_chain_clears_the_depth_guard(
+        self, team, mock_turn, mock_sessions
+    ):
+        """Autopilot delegated to the lead; the lead now delegates to a
+        member. Two hops sit well inside MAX_DELEGATION_DEPTH, so the extra
+        pod hop must not trip the guard."""
+        lead_session = self._chain(mock_sessions, [None, "expert-lead"])
+
+        r = await _delegate(lead_session, "expert-m1")
+
+        assert not isinstance(r, ErrorResponse)
+        mock_turn.assert_awaited_once()
+        assert mock_sessions[-1].expert_id == "expert-m1"
+
+    @pytest.mark.asyncio
+    async def test_a_member_handing_back_to_the_lead_is_refused_as_a_loop(
+        self, team, mock_turn, mock_sessions
+    ):
+        """The lead delegated to a member; the member delegating back to the
+        lead must still be refused by the chain walk — pod routing does not
+        open a way around the ``seen`` guard."""
+        member_session = self._chain(mock_sessions, ["expert-lead", "expert-m1"])
+
+        r = await _delegate(member_session, "expert-lead")
+
+        assert isinstance(r, ErrorResponse)
+        assert "loop" in r.message
+        mock_turn.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -48,7 +48,7 @@ from backend.api.features.store.db import (
     get_store_agents,
 )
 from backend.api.features.store.embeddings import backfill_missing_embeddings
-from backend.api.features.tasks import task_actions, tasks_db
+from backend.api.features.tasks import overseer_db, task_actions, task_review, tasks_db
 from backend.copilot import db as chat_db
 from backend.copilot.sharing.db import link_new_execution_to_chat_share
 from backend.data import bot_analytics as bot_analytics_db
@@ -520,6 +520,8 @@ class DatabaseManager(AppService):
     expert_row_exists = _(experts_db.expert_row_exists)
     resolve_attributable_expert = _(experts_db.resolve_attributable_expert)
     list_experts = _(experts_db.list_experts)
+    # Pod-lead routing: the delegation tools resolve pod membership and leads.
+    list_pods = _(experts_db.list_pods)
     resolve_private_expert_tenancy = _(experts_db.resolve_private_expert_tenancy)
     enforce_expert_run_budget = _(experts_scheduling.enforce_expert_run_budget)
     expert_allowed_credential_ids = _(expert_credentials.expert_allowed_credential_ids)
@@ -547,6 +549,17 @@ class DatabaseManager(AppService):
     handoff_delegated_task = _(task_actions.handoff_delegated_task)
     escalate_delegated_task = _(task_actions.escalate_delegated_task)
     report_delegated_task = _(task_actions.report_delegated_task)
+    # Phase 3: the overseer pass (scheduler process) and the mid-task
+    # instruction hook, plus the pause writer its expert-health check uses.
+    list_open_tasks = _(tasks_db.list_open_tasks)
+    append_task_amendment = _(task_review.append_task_amendment)
+    has_running_executions = _(overseer_db.has_running_executions)
+    mark_task_stale = _(overseer_db.mark_task_stale)
+    count_recent_failed_tasks_by_expert = _(
+        overseer_db.count_recent_failed_tasks_by_expert
+    )
+    list_recent_autopilot_tasks = _(overseer_db.list_recent_autopilot_tasks)
+    pause_expert_schedules = _(experts_scheduling.pause_expert_schedules)
 
     # ============ CoPilot Chat Sessions ============ #
     # NOTE: no eager-load `get_chat_session` here — callers go through
@@ -918,6 +931,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     expert_row_exists = d.expert_row_exists
     resolve_attributable_expert = d.resolve_attributable_expert
     list_experts = d.list_experts
+    list_pods = d.list_pods
     resolve_private_expert_tenancy = d.resolve_private_expert_tenancy
     enforce_expert_run_budget = d.enforce_expert_run_budget
     expert_allowed_credential_ids = d.expert_allowed_credential_ids
@@ -950,6 +964,13 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     handoff_delegated_task = d.handoff_delegated_task
     escalate_delegated_task = d.escalate_delegated_task
     report_delegated_task = d.report_delegated_task
+    list_open_tasks = d.list_open_tasks
+    append_task_amendment = d.append_task_amendment
+    has_running_executions = d.has_running_executions
+    mark_task_stale = d.mark_task_stale
+    count_recent_failed_tasks_by_expert = d.count_recent_failed_tasks_by_expert
+    list_recent_autopilot_tasks = d.list_recent_autopilot_tasks
+    pause_expert_schedules = d.pause_expert_schedules
     get_user_chat_sessions = d.get_user_chat_sessions
     set_session_pending_question = d.set_session_pending_question
     clear_session_pending_question = d.clear_session_pending_question

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -805,6 +805,33 @@ def execute_morning_briefing(user_id: str) -> None:
         logger.error("Morning briefing failed for user %s: %s", user_id[:12], e)
 
 
+def _task_overseer_crontab(user_id: str) -> str:
+    """Every-15-minutes cron, with the offset spread across the window.
+
+    Same sha256 spreading rationale as ``_morning_briefing_crontab``: a
+    fixed ``*/15`` fires every user at the same instant.
+    """
+    offset = int(hashlib.sha256(user_id.encode("utf-8")).hexdigest(), 16) % 15
+    return f"{offset}-59/15 * * * *"
+
+
+def execute_task_overseer(user_id: str) -> None:
+    """Per-user task-overseer cron body. Same sync-wrapper shape as
+    ``execute_morning_briefing`` — one user's sweep must never affect
+    scheduler health."""
+    from backend.copilot.overseer.service import run_overseer_pass
+
+    try:
+        result = run_async(
+            run_overseer_pass(user_id),
+            timeout=SCHEDULER_OPERATION_TIMEOUT_SECONDS,
+        )
+        if any(result.values()):
+            logger.info("Task overseer for user %s: %s", user_id[:12], result)
+    except Exception as e:
+        logger.error("Task overseer failed for user %s: %s", user_id[:12], e)
+
+
 def execute_nightly_batch_sync(user_id: str):
     """Per-user nightly batch-family fan-out cron body.
 
@@ -2486,6 +2513,50 @@ class Scheduler(AppService):
             ),
         }
 
+    @expose
+    def add_task_overseer_schedule(self, user_id: str) -> dict:
+        """Register the 15-minute task-overseer sweep for one user.
+
+        UTC and interval-shaped, so unlike the briefing there is no
+        timezone to compare — an existing job is simply left alone
+        (re-adding would reset a pending ``next_run_time``).
+        """
+        job_id = f"task_overseer_{user_id}"
+        existing = self.scheduler.get_job(job_id, jobstore=Jobstores.EXECUTION.value)
+        if existing is not None:
+            return {
+                "id": existing.id,
+                "user_id": user_id,
+                "next_run_time": (
+                    existing.next_run_time.isoformat()
+                    if existing.next_run_time
+                    else None
+                ),
+                "skipped": True,
+                "reason": "already_registered",
+            }
+
+        job = self.scheduler.add_job(
+            execute_task_overseer,
+            kwargs={"user_id": user_id},
+            trigger=CronTrigger.from_crontab(
+                _task_overseer_crontab(user_id), timezone="UTC"
+            ),
+            id=job_id,
+            name=f"Task overseer for {user_id[:12]}",
+            jobstore=Jobstores.EXECUTION.value,
+            replace_existing=True,
+            max_instances=1,
+        )
+        logger.info("Registered task overseer job %s for user %s", job.id, user_id[:12])
+        return {
+            "id": job.id,
+            "user_id": user_id,
+            "next_run_time": (
+                job.next_run_time.isoformat() if job.next_run_time else None
+            ),
+        }
+
     # --- Dream nightly batch (P-0.2 + P-0.4 consolidated) ---
     #
     # ONE per-user cron at user-local 03:00 fans out all batch-family
@@ -2709,6 +2780,7 @@ class SchedulerClient(AppServiceClient):
     add_morning_briefing_schedule = endpoint_to_async(
         Scheduler.add_morning_briefing_schedule
     )
+    add_task_overseer_schedule = endpoint_to_async(Scheduler.add_task_overseer_schedule)
 
     add_nightly_batch_schedule = endpoint_to_async(Scheduler.add_nightly_batch_schedule)
     delete_nightly_batch_schedule = endpoint_to_async(

--- a/autogpt_platform/backend/migrations/20260831120000_add_delegated_task_stale_at/migration.sql
+++ b/autogpt_platform/backend/migrations/20260831120000_add_delegated_task_stale_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "DelegatedTask" ADD COLUMN "staleAt" TIMESTAMP(3);

--- a/autogpt_platform/backend/migrations/20260831120000_add_office_templates_and_pod_lead/migration.sql
+++ b/autogpt_platform/backend/migrations/20260831120000_add_office_templates_and_pod_lead/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "ExpertAutonomyLevel" AS ENUM ('SUGGEST', 'ASK_FIRST', 'AUTONOMOUS');
+
+-- AlterTable
+ALTER TABLE "Expert" ADD COLUMN "autonomyLevel" "ExpertAutonomyLevel" NOT NULL DEFAULT 'SUGGEST';
+
+-- AlterTable
+ALTER TABLE "ExpertPod" ADD COLUMN "leadExpertId" TEXT;
+
+-- CreateTable
+CREATE TABLE "OfficeTemplate" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "config" JSONB NOT NULL,
+
+    CONSTRAINT "OfficeTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OfficeTemplate_name_key" ON "OfficeTemplate"("name");
+
+-- AddForeignKey
+ALTER TABLE "ExpertPod" ADD CONSTRAINT "ExpertPod_leadExpertId_fkey" FOREIGN KEY ("leadExpertId") REFERENCES "Expert"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -1029,6 +1029,12 @@ model Expert {
   podId String?
   Pod   ExpertPod? @relation(fields: [podId], references: [id], onDelete: SetNull)
 
+  LeadOfPods ExpertPod[] @relation("PodLead")
+
+  // How far the proactive (dream) pass may go on this expert's behalf:
+  // SUGGEST = briefing proposal only, ASK_FIRST/AUTONOMOUS = run a capped task.
+  autonomyLevel ExpertAutonomyLevel @default(SUGGEST)
+
   // Tenancy
   organizationId String?
   teamId         String?
@@ -1129,8 +1135,32 @@ model ExpertPod {
 
   Experts Expert[]
 
+  // Optional lead: pod-domain asks route to the lead, who delegates within
+  // members via the existing subtask tools. SetNull keeps the pod on archive.
+  leadExpertId String?
+  Lead         Expert? @relation("PodLead", fields: [leadExpertId], references: [id], onDelete: SetNull)
+
   // Doubles as the userId lookup index for list_pods.
   @@unique([userId, name])
+}
+
+enum ExpertAutonomyLevel {
+  SUGGEST
+  ASK_FIRST
+  AUTONOMOUS
+}
+
+// A hireable "office pack": config lists expert template ids plus per-expert
+// {scheduleCron?, introTaskTitle, introTaskSpec}. Hiring an office hires every
+// expert, creates schedules, and opens one intro DelegatedTask per expert.
+model OfficeTemplate {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  name        String @unique
+  description String
+  config      Json
 }
 
 // Who asked for the work. USER = a person typed it into a chat, EXPERT =
@@ -1204,6 +1234,10 @@ model DelegatedTask {
   status         DelegatedTaskStatus     @default(QUEUED)
   outcomeSummary String?
   acceptance     DelegatedTaskAcceptance @default(PENDING)
+
+  // Stamped by the overseer when a WAITING_USER task passes a week without
+  // an answer. Never auto-cancelled — the stale section on Home nags instead.
+  staleAt DateTime?
 
   // Every expert the task passed through, oldest first. Lets the UI show a
   // handoff trail and lets cycle detection run without walking the tree.

--- a/autogpt_platform/backend/snapshots/expert_pod_create
+++ b/autogpt_platform/backend/snapshots/expert_pod_create
@@ -1,5 +1,6 @@
 {
   "created_at": "2026-08-14T00:00:00Z",
   "id": "pod-1",
+  "lead_expert_id": null,
   "name": "Growth"
 }

--- a/autogpt_platform/backend/snapshots/expert_pods_list
+++ b/autogpt_platform/backend/snapshots/expert_pods_list
@@ -2,6 +2,7 @@
   {
     "created_at": "2026-08-14T00:00:00Z",
     "id": "pod-1",
+    "lead_expert_id": null,
     "name": "Growth"
   }
 ]

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TaskUpdateCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/TaskUpdateCard.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  getGetTaskQueryKey,
+  getListTasksQueryKey,
+  useAcceptTask,
+  useRejectTask,
+} from "@/app/api/__generated__/endpoints/tasks/tasks";
+import { okData } from "@/app/api/helpers";
+import { Button } from "@/components/atoms/Button/Button";
+import { Input } from "@/components/atoms/Input/Input";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { cn } from "@/lib/utils";
+import { CARD } from "./ResultCards";
+import { str } from "./resultHelpers";
+
+interface Props {
+  output: Record<string, unknown>;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  handoff: "Handed off",
+  escalation: "Escalated to you",
+  report: "Outcome reported",
+};
+
+/** An expert-side task action (report / escalate / handoff) surfaced in the
+ *  chain: what happened, the task it touched, and the door into its Team
+ *  detail. A reported outcome also gets Accept / Request-changes controls. */
+export function TaskUpdateCard({ output }: Props) {
+  const taskId = str(output, "task_id");
+  const action = str(output, "action") ?? "report";
+  const title = str(output, "task_title");
+  if (!taskId) return null;
+
+  return (
+    <div className={cn(CARD, "w-full rounded-2xl p-2.5")}>
+      <div className="flex items-center gap-2.5">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-[13px] font-medium text-zinc-800">
+            {ACTION_LABELS[action] ?? "Task updated"}
+          </p>
+          <p className="truncate text-xs text-zinc-500">{title ?? "Task"}</p>
+        </div>
+        <Link
+          href={`/team/tasks/${encodeURIComponent(taskId)}`}
+          className="shrink-0 text-xs text-zinc-500 transition-colors hover:text-zinc-800"
+        >
+          View task
+        </Link>
+      </div>
+      {action === "report" ? <ReportReview taskId={taskId} /> : null}
+    </div>
+  );
+}
+
+function ReportReview({ taskId }: { taskId: string }) {
+  const queryClient = useQueryClient();
+  const [isReviewed, setIsReviewed] = useState(false);
+  const [isRequestingChanges, setIsRequestingChanges] = useState(false);
+  const [note, setNote] = useState("");
+
+  async function refreshTask() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) }),
+      queryClient.invalidateQueries({ queryKey: getListTasksQueryKey() }),
+    ]);
+  }
+
+  const { mutate: accept, isPending: isAccepting } = useAcceptTask({
+    mutation: {
+      onSuccess: async (res) => {
+        toast({ title: okData(res)?.message ?? "Outcome accepted" });
+        setIsReviewed(true);
+        await refreshTask();
+      },
+      onError: () =>
+        toast({
+          title: "Could not accept the outcome",
+          description: "Please try again.",
+          variant: "destructive",
+        }),
+    },
+  });
+
+  const { mutate: reject, isPending: isRejecting } = useRejectTask({
+    mutation: {
+      onSuccess: async (res) => {
+        toast({ title: okData(res)?.message ?? "Changes requested" });
+        setIsReviewed(true);
+        await refreshTask();
+      },
+      onError: () =>
+        toast({
+          title: "Could not send your changes",
+          description: "Please try again.",
+          variant: "destructive",
+        }),
+    },
+  });
+
+  function submitChanges() {
+    const trimmed = note.trim();
+    if (!trimmed || isRejecting) return;
+    reject({ taskId, data: { note: trimmed } });
+  }
+
+  if (isReviewed) return null;
+
+  if (isRequestingChanges) {
+    return (
+      <form
+        className="mt-2 flex flex-col gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitChanges();
+        }}
+      >
+        <Input
+          id={`task-update-note-${taskId}`}
+          label="What should change?"
+          hideLabel
+          size="small"
+          placeholder="What should change?"
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          disabled={isRejecting}
+          wrapperClassName="mb-0"
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            loading={isRejecting}
+            disabled={!note.trim()}
+          >
+            Send changes
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            disabled={isRejecting}
+            onClick={() => {
+              setIsRequestingChanges(false);
+              setNote("");
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <Button
+        variant="primary"
+        size="small"
+        loading={isAccepting}
+        onClick={() => accept({ taskId })}
+      >
+        Accept
+      </Button>
+      <Button
+        variant="secondary"
+        size="small"
+        disabled={isAccepting}
+        onClick={() => setIsRequestingChanges(true)}
+      >
+        Request changes
+      </Button>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolResult.tsx
@@ -16,6 +16,7 @@ import { BlockListCard, BlockOutputCard } from "./BlockCards";
 import { ExecutionCard } from "./ExecutionCard";
 import { ExpertChangeCard, ExpertChangeCardSkeleton } from "./ExpertCards";
 import { RoutingCard, RoutingConfirmCard } from "./RoutingCard";
+import { TaskUpdateCard } from "./TaskUpdateCard";
 import { FileDiff } from "./FileDiff";
 import { isDiffText } from "./fileDiffHelpers";
 import type { ChainRow } from "./helpers";
@@ -202,6 +203,11 @@ function toolCard(row: ChainRow, output: Record<string, unknown> | null) {
     if (setupCard) return setupCard;
     const questions = asItems(output.questions);
     if (questions) return <QuestionsCard questions={questions} />;
+    // A task action tool (report / escalate / handoff) reports back on the
+    // task it touched — distinct from the delegation cards below, which sniff
+    // on status + task_id rather than this explicit type tag.
+    if (str(output, "type") === "task_update")
+      return <TaskUpdateCard output={output} />;
   }
 
   switch (row.tool) {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkspaceFileCards/components/SessionActivityContent.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkspaceFileCards/components/SessionActivityContent.tsx
@@ -136,7 +136,11 @@ const TASK_STATUS: Record<
 > = {
   completed: RUN_STATUS.COMPLETED,
   error: RUN_STATUS.FAILED,
-  cancelled: { icon: CancelCircleIcon, className: "text-zinc-400", spin: false },
+  cancelled: {
+    icon: CancelCircleIcon,
+    className: "text-zinc-400",
+    spin: false,
+  },
   running: RUN_STATUS.RUNNING,
   queued: RUN_STATUS.QUEUED,
 };

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkspaceFileCards/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/WorkspaceFileCards/helpers.test.ts
@@ -18,19 +18,31 @@ function messageOf(...parts: Record<string, unknown>[]): UIMessage[] {
 
 describe("getSessionActivity", () => {
   it("returns nothing for an empty transcript", () => {
-    expect(getSessionActivity([])).toEqual({ runs: [], schedules: [], tasks: [] });
+    expect(getSessionActivity([])).toEqual({
+      runs: [],
+      schedules: [],
+      tasks: [],
+    });
   });
 
   it("ignores non-tool message parts", () => {
     const messages = messageOf({ type: "text", text: "hello" });
-    expect(getSessionActivity(messages)).toEqual({ runs: [], schedules: [], tasks: [] });
+    expect(getSessionActivity(messages)).toEqual({
+      runs: [],
+      schedules: [],
+      tasks: [],
+    });
   });
 
   it("ignores tool parts with no output that aren't run tools", () => {
     const messages = messageOf(
       toolPart({ type: "tool-something_else", output: undefined }),
     );
-    expect(getSessionActivity(messages)).toEqual({ runs: [], schedules: [], tasks: [] });
+    expect(getSessionActivity(messages)).toEqual({
+      runs: [],
+      schedules: [],
+      tasks: [],
+    });
   });
 
   it("surfaces an in-flight run from the tool input, deslugifying the name", () => {
@@ -93,7 +105,11 @@ describe("getSessionActivity", () => {
         state: "input-available",
       }),
     );
-    expect(getSessionActivity(messages)).toEqual({ runs: [], schedules: [], tasks: [] });
+    expect(getSessionActivity(messages)).toEqual({
+      runs: [],
+      schedules: [],
+      tasks: [],
+    });
   });
 
   it("records a completed async run from a top-level execution_started envelope", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/AgentTeam.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/AgentTeam.tsx
@@ -11,6 +11,8 @@ import { formatWeeklySpend } from "../../helpers";
 import { HomeTileEmpty } from "../HomeTileEmpty/HomeTileEmpty";
 import { HomeTile } from "../HomeTile/HomeTile";
 import { AgentRow } from "./components/AgentRow";
+import { PodRollupRow } from "./components/PodRollupRow";
+import { useAgentTeam } from "./useAgentTeam";
 
 interface Props {
   dashboard: HomeDashboardResponse;
@@ -19,6 +21,8 @@ interface Props {
 
 export function AgentTeam({ dashboard, className }: Props) {
   const { team, agents } = dashboard;
+  const { showRollups, rollups, expandedPodIds, togglePod } =
+    useAgentTeam(agents);
   const readyCount = team.ready + team.working;
   const teamSpend = formatWeeklySpend(team.spend_cents);
   const statusLine =
@@ -64,6 +68,17 @@ export function AgentTeam({ dashboard, className }: Props) {
           description="Hire an expert to start delegating work."
           action={{ href: "/marketplace", label: "Browse experts" }}
         />
+      ) : showRollups ? (
+        <div className="divide-y divide-zinc-100">
+          {rollups.map((rollup) => (
+            <PodRollupRow
+              key={rollup.id}
+              rollup={rollup}
+              expanded={expandedPodIds.includes(rollup.id)}
+              onToggle={() => togglePod(rollup.id)}
+            />
+          ))}
+        </div>
       ) : (
         <div className="divide-y divide-zinc-100">
           {agents.slice(0, 3).map((agent) => (

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/__tests__/pod-rollups.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/__tests__/pod-rollups.test.tsx
@@ -1,0 +1,186 @@
+import {
+  getListExpertPodsMockHandler,
+  getListExpertsMockHandler,
+} from "@/app/api/__generated__/endpoints/experts/experts.msw";
+import { getGetHomeDashboardResponseMock } from "@/app/api/__generated__/endpoints/home/home.msw";
+import { getListTasksMockHandler } from "@/app/api/__generated__/endpoints/tasks/tasks.msw";
+import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import { DelegatedTaskStatus } from "@/app/api/__generated__/models/delegatedTaskStatus";
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { ExpertPod } from "@/app/api/__generated__/models/expertPod";
+import { HomeAgentStatus } from "@/app/api/__generated__/models/homeAgentStatus";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import { AgentTeam } from "../AgentTeam";
+
+function makeAgent(
+  id: string,
+  name: string,
+  spendCents: number,
+): HomeAgentStatus {
+  return {
+    expert: { id, name, role: "Specialist", avatar_url: null },
+    status: "ready",
+    detail: "Ready for work",
+    spend_cents: spendCents,
+  };
+}
+
+function makeExpert(id: string, name: string, podId: string | null): Expert {
+  return {
+    id,
+    name,
+    avatar_url: null,
+    role: "Specialist",
+    tagline: null,
+    bio: null,
+    skills: [],
+    identity: "",
+    voice_preferences: "",
+    boundaries: "",
+    protected_soul_rules: [],
+    is_template: false,
+    source_template_id: null,
+    is_archived: false,
+    workflows: [],
+    pod_id: podId,
+  };
+}
+
+function makeTask(
+  id: string,
+  ownerId: string,
+  ownerName: string,
+  status: DelegatedTaskStatus,
+): DelegatedTask {
+  return {
+    id,
+    title: `Task ${id}`,
+    spec: "Do the thing",
+    status,
+    acceptance: "ACCEPTED",
+    created_by_type: "USER",
+    created_by_id: null,
+    owner: {
+      id: ownerId,
+      name: ownerName,
+      avatar_url: null,
+      role: "Specialist",
+    },
+    parent_task_id: null,
+    root_task_id: null,
+    origin_session_id: null,
+    ancestor_expert_ids: [],
+    handoff_count: 0,
+    revision_count: 0,
+    spend_total: 0,
+    outcome_summary: null,
+    amendments: [],
+    created_at: new Date("2026-08-30T10:00:00Z"),
+    updated_at: new Date("2026-08-30T10:00:00Z"),
+  };
+}
+
+const pods: ExpertPod[] = [
+  { id: "pod-growth", name: "Growth", created_at: new Date("2026-08-01") },
+  { id: "pod-ops", name: "Ops", created_at: new Date("2026-08-01") },
+];
+
+const sixAgents = [
+  makeAgent("e1", "Expert One", 100),
+  makeAgent("e2", "Expert Two", 200),
+  makeAgent("e3", "Expert Three", 300),
+  makeAgent("e4", "Expert Four", 0),
+  makeAgent("e5", "Expert Five", 0),
+  makeAgent("e6", "Expert Six", 0),
+];
+
+const sixExperts = [
+  makeExpert("e1", "Expert One", "pod-growth"),
+  makeExpert("e2", "Expert Two", "pod-growth"),
+  makeExpert("e3", "Expert Three", "pod-growth"),
+  makeExpert("e4", "Expert Four", "pod-ops"),
+  makeExpert("e5", "Expert Five", "pod-ops"),
+  makeExpert("e6", "Expert Six", null),
+];
+
+const tasks = [
+  makeTask("t1", "e1", "Expert One", "WORKING"),
+  makeTask("t2", "e2", "Expert Two", "QUEUED"),
+  makeTask("t3", "e3", "Expert Three", "WAITING_USER"),
+  makeTask("t4", "e4", "Expert Four", "WORKING"),
+  makeTask("t5", "e5", "Expert Five", "DONE"),
+];
+
+function dashboardWith(agents: HomeAgentStatus[]) {
+  return getGetHomeDashboardResponseMock({
+    agents,
+    team: {
+      total: agents.length,
+      ready: agents.length,
+      working: 0,
+      needs_attention: 0,
+      spend_cents: 0,
+    },
+  });
+}
+
+describe("AgentTeam pod rollups", () => {
+  test("collapses more than five experts into pod rollups", async () => {
+    server.use(
+      getListExpertsMockHandler(sixExperts),
+      getListExpertPodsMockHandler(pods),
+      getListTasksMockHandler(tasks),
+    );
+
+    render(<AgentTeam dashboard={dashboardWith(sixAgents)} />);
+
+    const growthRow = await screen.findByRole("button", { name: /Growth/ });
+    expect(growthRow.textContent).toContain("2 active");
+    expect(growthRow.textContent).toContain("1 need you");
+    expect(growthRow.textContent).toContain("$6.00 this week");
+
+    const opsRow = screen.getByRole("button", { name: /Ops/ });
+    expect(opsRow.textContent).toContain("1 active");
+
+    expect(screen.getByRole("button", { name: /Unassigned/ })).toBeDefined();
+    expect(screen.queryByText("Expert One")).toBeNull();
+    expect(screen.queryByText("Expert Six")).toBeNull();
+  });
+
+  test("expands a pod rollup to reveal its expert rows", async () => {
+    const user = userEvent.setup();
+    server.use(
+      getListExpertsMockHandler(sixExperts),
+      getListExpertPodsMockHandler(pods),
+      getListTasksMockHandler(tasks),
+    );
+
+    render(<AgentTeam dashboard={dashboardWith(sixAgents)} />);
+
+    const growthRow = await screen.findByRole("button", { name: /Growth/ });
+    expect(growthRow.getAttribute("aria-expanded")).toBe("false");
+    await user.click(growthRow);
+
+    expect(growthRow.getAttribute("aria-expanded")).toBe("true");
+    expect(await screen.findByText("Expert One")).toBeDefined();
+    expect(screen.getByText("Expert Two")).toBeDefined();
+    expect(screen.getByText("Expert Three")).toBeDefined();
+    expect(screen.queryByText("Expert Four")).toBeNull();
+
+    await user.click(growthRow);
+    expect(screen.queryByText("Expert One")).toBeNull();
+  });
+
+  test("keeps plain expert rows with five or fewer experts", async () => {
+    render(<AgentTeam dashboard={dashboardWith(sixAgents.slice(0, 5))} />);
+
+    expect(await screen.findByText("Expert One")).toBeDefined();
+    expect(screen.getByText("Expert Two")).toBeDefined();
+    expect(screen.getByText("Expert Three")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Growth/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Unassigned/ })).toBeNull();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/components/PodRollupRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/components/PodRollupRow.tsx
@@ -1,0 +1,65 @@
+import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import { cn } from "@/lib/utils";
+import { formatWeeklySpend } from "../../../helpers";
+import type { PodRollup } from "../helpers";
+import { AgentRow } from "./AgentRow";
+
+interface Props {
+  rollup: PodRollup;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function PodRollupRow({ rollup, expanded, onToggle }: Props) {
+  const spend = formatWeeklySpend(rollup.spendCents);
+  const summary = [
+    `${rollup.activeCount} active`,
+    rollup.needsYouCount > 0 ? `${rollup.needsYouCount} need you` : null,
+    spend,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={onToggle}
+        className="group -mx-2 flex w-[calc(100%+16px)] min-w-0 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Text variant="body-medium" className="truncate text-zinc-900">
+              {rollup.name}
+            </Text>
+            <span className="shrink-0 rounded-md bg-zinc-100 px-1.5 py-0.5 text-xs font-medium tabular-nums text-zinc-600">
+              {rollup.agents.length}
+            </span>
+          </div>
+          <Text variant="small" className="min-w-0 truncate text-zinc-500">
+            {summary}
+          </Text>
+        </div>
+        <Icon
+          icon={ArrowDown01Icon}
+          size={15}
+          className={cn(
+            "shrink-0 text-zinc-300 transition-transform group-hover:text-zinc-600",
+            expanded && "rotate-180",
+          )}
+          aria-hidden="true"
+        />
+      </button>
+      {expanded ? (
+        <div className="divide-y divide-zinc-100 pl-3">
+          {rollup.agents.map((agent) => (
+            <AgentRow key={agent.expert.id} agent={agent} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/helpers.ts
@@ -1,0 +1,71 @@
+import type { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import type { Expert } from "@/app/api/__generated__/models/expert";
+import type { ExpertPod } from "@/app/api/__generated__/models/expertPod";
+import type { HomeAgentStatus } from "@/app/api/__generated__/models/homeAgentStatus";
+
+export const POD_ROLLUP_THRESHOLD = 5;
+export const UNASSIGNED_POD_ID = "unassigned";
+
+export interface PodRollup {
+  id: string;
+  name: string;
+  agents: HomeAgentStatus[];
+  activeCount: number;
+  needsYouCount: number;
+  spendCents: number;
+}
+
+interface Args {
+  agents: HomeAgentStatus[];
+  experts: Expert[];
+  pods: ExpertPod[];
+  tasks: DelegatedTask[];
+}
+
+export function buildPodRollups({ agents, experts, pods, tasks }: Args) {
+  const podIdByExpert = new Map(
+    experts.map((expert) => [expert.id, expert.pod_id ?? UNASSIGNED_POD_ID]),
+  );
+  const rollups = new Map<string, PodRollup>(
+    [...pods, { id: UNASSIGNED_POD_ID, name: "Unassigned" }].map((pod) => [
+      pod.id,
+      {
+        id: pod.id,
+        name: pod.name,
+        agents: [],
+        activeCount: 0,
+        needsYouCount: 0,
+        spendCents: 0,
+      },
+    ]),
+  );
+
+  for (const agent of agents) {
+    const rollup = rollupFor(rollups, podIdByExpert.get(agent.expert.id));
+    rollup.agents.push(agent);
+    rollup.spendCents += agent.spend_cents ?? 0;
+  }
+
+  for (const task of tasks) {
+    if (!task.owner) continue;
+    const podId = podIdByExpert.get(task.owner.id);
+    if (podId === undefined) continue;
+    const rollup = rollupFor(rollups, podId);
+    if (task.status === "WAITING_USER") rollup.needsYouCount += 1;
+    else if (task.status === "WORKING" || task.status === "QUEUED") {
+      rollup.activeCount += 1;
+    }
+  }
+
+  return [...rollups.values()].filter((rollup) => rollup.agents.length > 0);
+}
+
+function rollupFor(
+  rollups: Map<string, PodRollup>,
+  podId: string | undefined,
+): PodRollup {
+  return (
+    rollups.get(podId ?? UNASSIGNED_POD_ID) ??
+    (rollups.get(UNASSIGNED_POD_ID) as PodRollup)
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/useAgentTeam.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/AgentTeam/useAgentTeam.ts
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import {
+  useListExpertPods,
+  useListExperts,
+} from "@/app/api/__generated__/endpoints/experts/experts";
+import { useListTasks } from "@/app/api/__generated__/endpoints/tasks/tasks";
+import type { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import type { Expert } from "@/app/api/__generated__/models/expert";
+import type { ExpertPod } from "@/app/api/__generated__/models/expertPod";
+import type { HomeAgentStatus } from "@/app/api/__generated__/models/homeAgentStatus";
+import { okData } from "@/app/api/helpers";
+import { buildPodRollups, POD_ROLLUP_THRESHOLD } from "./helpers";
+
+export function useAgentTeam(agents: HomeAgentStatus[]) {
+  const [expandedPodIds, setExpandedPodIds] = useState<string[]>([]);
+  const shouldCollapse = agents.length > POD_ROLLUP_THRESHOLD;
+
+  const expertsQuery = useListExperts({
+    query: {
+      enabled: shouldCollapse,
+      select: (response) => (okData(response) ?? []) as Expert[],
+    },
+  });
+  const podsQuery = useListExpertPods({
+    query: {
+      enabled: shouldCollapse,
+      select: (response) => (okData(response) ?? []) as ExpertPod[],
+    },
+  });
+  const tasksQuery = useListTasks(undefined, {
+    query: {
+      enabled: shouldCollapse,
+      select: (response) => (okData(response) ?? []) as DelegatedTask[],
+    },
+  });
+
+  const showRollups =
+    shouldCollapse &&
+    expertsQuery.data !== undefined &&
+    podsQuery.data !== undefined &&
+    tasksQuery.data !== undefined;
+
+  const rollups = showRollups
+    ? buildPodRollups({
+        agents,
+        experts: expertsQuery.data,
+        pods: podsQuery.data,
+        tasks: tasksQuery.data,
+      })
+    : [];
+
+  function togglePod(podId: string) {
+    setExpandedPodIds((current) =>
+      current.includes(podId)
+        ? current.filter((id) => id !== podId)
+        : [...current, podId],
+    );
+  }
+
+  return { showRollups, rollups, expandedPodIds, togglePod };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/MorningBriefing.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/MorningBriefing.tsx
@@ -13,6 +13,7 @@ import { HomeTileEmpty } from "../HomeTileEmpty/HomeTileEmpty";
 import { HomeTileFilter } from "../HomeTileFilter/HomeTileFilter";
 import { HomeTile } from "../HomeTile/HomeTile";
 import { OutcomeRow } from "./components/OutcomeRow";
+import { ProactiveSection } from "./components/ProactiveSection/ProactiveSection";
 import { type BriefingFilter, useMorningBriefing } from "./useMorningBriefing";
 
 interface Props {
@@ -98,6 +99,8 @@ export function MorningBriefing({ dashboard, className }: Props) {
           ))}
         </div>
       )}
+
+      <ProactiveSection />
 
       {briefing.routine_count > 0 ? (
         <div className="inline-flex items-center gap-1.5 self-end rounded-full border border-purple-500 bg-purple-100 px-2.5 py-1 text-sm font-medium text-purple-600">

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/__tests__/proactive-section.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/__tests__/proactive-section.test.tsx
@@ -1,0 +1,76 @@
+import { getListTasksMockHandler } from "@/app/api/__generated__/endpoints/tasks/tasks.msw";
+import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import { expect, test } from "vitest";
+import { ProactiveSection } from "../components/ProactiveSection/ProactiveSection";
+
+function makeTask(overrides: Partial<DelegatedTask> = {}): DelegatedTask {
+  return {
+    id: "task-dream-1",
+    title: "Refresh the competitor pricing sheet",
+    spec: "Compare pricing pages and update the sheet.",
+    status: "QUEUED",
+    acceptance: "PENDING",
+    created_by_type: "DREAM",
+    created_by_id: null,
+    owner: null,
+    parent_task_id: null,
+    root_task_id: "task-dream-1",
+    origin_session_id: null,
+    ancestor_expert_ids: [],
+    handoff_count: 0,
+    revision_count: 0,
+    spend_total: 0,
+    outcome_summary: null,
+    amendments: [],
+    created_at: new Date("2026-08-30T09:00:00Z"),
+    updated_at: new Date("2026-08-30T09:00:00Z"),
+    runs: [],
+    ...overrides,
+  };
+}
+
+test("renders dream proposals and outcomes, hiding other origins", async () => {
+  server.use(
+    getListTasksMockHandler([
+      makeTask(),
+      makeTask({
+        id: "task-dream-2",
+        title: "Weekly traffic digest",
+        status: "DONE",
+        outcome_summary: "Digest posted to your inbox.",
+      }),
+      makeTask({
+        id: "task-user",
+        title: "A user-created task",
+        created_by_type: "USER",
+      }),
+    ]),
+  );
+
+  render(<ProactiveSection />);
+
+  expect(await screen.findByText("Proactive")).toBeTruthy();
+
+  const proposal = screen.getByRole("link", {
+    name: /Refresh the competitor pricing sheet/,
+  });
+  expect(proposal.getAttribute("href")).toBe("/team/tasks/task-dream-1");
+  expect(screen.getByText(/Suggested by your team/)).toBeTruthy();
+
+  const outcome = screen.getByRole("link", { name: /Weekly traffic digest/ });
+  expect(outcome.getAttribute("href")).toBe("/team/tasks/task-dream-2");
+  expect(screen.getByText("Digest posted to your inbox.")).toBeTruthy();
+
+  expect(screen.queryByText("A user-created task")).toBeNull();
+});
+
+test("renders nothing when no dream tasks exist", async () => {
+  server.use(getListTasksMockHandler([makeTask({ created_by_type: "USER" })]));
+
+  const { container } = render(<ProactiveSection />);
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  expect(container.textContent).toBe("");
+});

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/ProactiveSection/ProactiveSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/ProactiveSection/ProactiveSection.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import {
+  AiIdeaIcon,
+  ArrowUpRight01Icon,
+  CheckmarkCircle02Icon,
+} from "@hugeicons/core-free-icons";
+import Link from "next/link";
+import { useProactiveSection } from "./useProactiveSection";
+
+export function ProactiveSection() {
+  const { proposals, outcomes } = useProactiveSection();
+
+  if (proposals.length === 0 && outcomes.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Proactive"
+      className="flex flex-col gap-1 border-t border-zinc-100 pt-3"
+    >
+      <div className="flex items-center gap-1.5 pb-1">
+        <Icon icon={AiIdeaIcon} size={15} className="text-fuchsia-600" />
+        <Text variant="small" className="font-medium text-zinc-900">
+          Proactive
+        </Text>
+      </div>
+      {proposals.map((task) => (
+        <ProactiveRow key={task.id} task={task} kind="proposal" />
+      ))}
+      {outcomes.map((task) => (
+        <ProactiveRow key={task.id} task={task} kind="outcome" />
+      ))}
+    </section>
+  );
+}
+
+function ProactiveRow({
+  task,
+  kind,
+}: {
+  task: DelegatedTask;
+  kind: "proposal" | "outcome";
+}) {
+  return (
+    <Link
+      href={`/team/tasks/${task.id}`}
+      className="group -mx-2 flex items-center gap-2.5 rounded-xl px-2 py-1.5 hover:bg-zinc-50"
+    >
+      {kind === "outcome" ? (
+        <Icon
+          icon={CheckmarkCircle02Icon}
+          size={15}
+          className="shrink-0 text-emerald-500"
+        />
+      ) : (
+        <span className="mx-[3px] size-2 shrink-0 rounded-full bg-fuchsia-400" />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm text-zinc-800">
+          {task.title}
+        </span>
+        <span className="block truncate text-xs text-zinc-500">
+          {kind === "outcome"
+            ? (task.outcome_summary ?? "Done — open to see the outcome.")
+            : "Suggested by your team — open to review."}
+        </span>
+      </span>
+      <Icon
+        icon={ArrowUpRight01Icon}
+        size={14}
+        className="shrink-0 text-zinc-300 transition-colors group-hover:text-zinc-600"
+      />
+    </Link>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/ProactiveSection/useProactiveSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/MorningBriefing/components/ProactiveSection/useProactiveSection.ts
@@ -1,0 +1,25 @@
+import { useListTasks } from "@/app/api/__generated__/endpoints/tasks/tasks";
+import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import { DelegatedTaskStatus } from "@/app/api/__generated__/models/delegatedTaskStatus";
+import { okData } from "@/app/api/helpers";
+
+const OPEN_STATUSES: DelegatedTaskStatus[] = [
+  "QUEUED",
+  "WORKING",
+  "WAITING_USER",
+];
+
+export function useProactiveSection() {
+  const tasksQuery = useListTasks(undefined, {
+    query: { select: (res) => okData(res) ?? [] },
+  });
+
+  const dreamTasks: DelegatedTask[] = (tasksQuery.data ?? []).filter(
+    (task) => task.created_by_type === "DREAM",
+  );
+
+  return {
+    proposals: dreamTasks.filter((task) => OPEN_STATUSES.includes(task.status)),
+    outcomes: dreamTasks.filter((task) => task.status === "DONE"),
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/NeedsYou/components/AttentionRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/NeedsYou/components/AttentionRow.tsx
@@ -1,5 +1,7 @@
 import {
   AlertCircleIcon,
+  CancelCircleIcon,
+  Clock01Icon,
   CoinsDollarIcon,
   MessageQuestionIcon,
   PauseIcon,
@@ -12,6 +14,7 @@ import type { HomeAttentionItem } from "@/app/api/__generated__/models/homeAtten
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import { cn } from "@/lib/utils";
 import { AttentionRowActions } from "./AttentionRowActions";
 import { EscalationAnswer } from "./EscalationAnswer";
 
@@ -28,6 +31,8 @@ const ICONS: Record<HomeAttentionItem["kind"], IconSvgElement> = {
   credits: CoinsDollarIcon,
   question: MessageQuestionIcon,
   task_escalation: Task01Icon,
+  task_failed: CancelCircleIcon,
+  task_stale: Clock01Icon,
 };
 
 const KIND_LABELS: Record<HomeAttentionItem["kind"], string> = {
@@ -37,7 +42,18 @@ const KIND_LABELS: Record<HomeAttentionItem["kind"], string> = {
   credits: "Credits",
   question: "Question",
   task_escalation: "Task question",
+  task_failed: "Failed",
+  task_stale: "Stale",
 };
+
+// Failed and stale tasks carry their own alarm color on the fallback glyph;
+// every other kind keeps the neutral chip.
+const KIND_ICON_CLASSES: Partial<Record<HomeAttentionItem["kind"], string>> = {
+  task_failed: "bg-red-50 text-red-600 ring-red-200",
+  task_stale: "bg-amber-50 text-amber-600 ring-amber-200",
+};
+
+const DEFAULT_ICON_CLASS = "bg-zinc-50 text-zinc-500 ring-zinc-200";
 
 export function AttentionRow({ item, isProcessing, onDecision }: Props) {
   const [confirmDecline, setConfirmDecline] = useState(false);
@@ -61,7 +77,12 @@ export function AttentionRow({ item, isProcessing, onDecision }: Props) {
               avatarUrl={item.expert.avatar_url}
             />
           ) : (
-            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-zinc-50 text-zinc-500 ring-1 ring-inset ring-zinc-200">
+            <span
+              className={cn(
+                "flex size-9 shrink-0 items-center justify-center rounded-lg ring-1 ring-inset",
+                KIND_ICON_CLASSES[item.kind] ?? DEFAULT_ICON_CLASS,
+              )}
+            >
               <Icon icon={ICONS[item.kind]} size={17} aria-hidden="true" />
             </span>
           )}

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/NeedsYou/useNeedsYou.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/NeedsYou/useNeedsYou.ts
@@ -16,6 +16,8 @@ const FILTER_LABELS: Partial<Record<AttentionFilter, string>> = {
   credits: "Credits",
   question: "Questions",
   task_escalation: "Task questions",
+  task_failed: "Failed",
+  task_stale: "Stale",
 };
 
 export function useNeedsYou({ items }: Args) {

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertTasksSection/components/TaskRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertTasksSection/components/TaskRow.tsx
@@ -4,6 +4,7 @@ import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
 import { Badge } from "@/components/atoms/Badge/Badge";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
+import { OriginBadge } from "../../../../components/OriginBadge/OriginBadge";
 import {
   formatElapsed,
   formatSpend,
@@ -26,6 +27,7 @@ export function TaskRow({ task }: Props) {
           <Badge variant={getStatusVariant(task.status)} size="small">
             {getStatusLabel(task.status)}
           </Badge>
+          <OriginBadge createdByType={task.created_by_type} />
           <Text variant="small" className="text-zinc-500">
             {formatElapsed(task)}
           </Text>

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/AllTasksSection/components/DelegatedTasksBoard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/AllTasksSection/components/DelegatedTasksBoard.tsx
@@ -23,6 +23,7 @@ import {
   getTaskFilterKey,
   getTaskOrbVariant,
 } from "../../../task-helpers";
+import { OriginBadge } from "../../OriginBadge/OriginBadge";
 import { RefreshButton } from "../../RefreshButton";
 import { TaskStatusChip } from "../../TaskStatusChip/TaskStatusChip";
 import { useDelegatedTasksBoard } from "./useDelegatedTasksBoard";
@@ -130,7 +131,10 @@ function OwnerCell({ owner }: { owner: DelegatedTask["owner"] }) {
 function buildCells(task: DelegatedTask) {
   return {
     task: (
-      <span className="truncate font-medium text-zinc-900">{task.title}</span>
+      <span className="flex min-w-0 items-center gap-2">
+        <span className="truncate font-medium text-zinc-900">{task.title}</span>
+        <OriginBadge createdByType={task.created_by_type} />
+      </span>
     ),
     owner: <OwnerCell owner={task.owner} />,
     status: (

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/FireExpertDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/FireExpertDialog.tsx
@@ -58,6 +58,7 @@ export function FireExpertDialog({
           <FireExpertPreview
             expertName={expertName}
             automationLine={summary.automationLine}
+            reassignLine={summary.reassignLine}
             items={summary.items}
             isLoading={isPreviewLoading}
             isError={isPreviewError}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/FireExpertDialogSections.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/FireExpertDialogSections.tsx
@@ -7,6 +7,7 @@ import type { PauseItem } from "./helpers";
 type PreviewProps = {
   expertName: string;
   automationLine: string;
+  reassignLine: string | null;
   items: PauseItem[];
   isLoading: boolean;
   isError: boolean;
@@ -33,6 +34,7 @@ type FireLineProps = {
 export function FireExpertPreview({
   expertName,
   automationLine,
+  reassignLine,
   items,
   isLoading,
   isError,
@@ -58,6 +60,7 @@ export function FireExpertPreview({
       <ul className="flex flex-col gap-2.5">
         <FireLine>Installed workflows stay in your library.</FireLine>
         <FireLine>{getAutomationLineText()}</FireLine>
+        {reassignLine ? <FireLine>{reassignLine}</FireLine> : null}
         <FireLine>Any chat history stays available but read-only.</FireLine>
         <FireLine>Their work stays yours.</FireLine>
       </ul>

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/helpers.test.ts
@@ -60,6 +60,7 @@ describe("getFireSummary", () => {
     expect(getFireSummary(null)).toEqual({
       items: [],
       automationLine: "No automations will pause.",
+      reassignLine: null,
     });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/FireExpertDialog/helpers.ts
@@ -28,7 +28,16 @@ export function getAutomationLine(count: number) {
   return `${count} ${count === 1 ? "automation" : "automations"} will pause.`;
 }
 
+export function getReassignLine(count: number): string | null {
+  if (count <= 0) return null;
+  return `${count} open ${count === 1 ? "task" : "tasks"} will be reassigned to Autopilot.`;
+}
+
 export function getFireSummary(preview: ExpertDetachPreview | null) {
   const items = getPauseItems(preview);
-  return { items, automationLine: getAutomationLine(items.length) };
+  return {
+    items,
+    automationLine: getAutomationLine(items.length),
+    reassignLine: getReassignLine(preview?.open_task_count ?? 0),
+  };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/HireOfficeGallery.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/HireOfficeGallery.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
+import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { Building06Icon } from "@hugeicons/core-free-icons";
+import { OfficeDialog } from "./components/OfficeDialog";
+import { OfficePackCard } from "./components/OfficePackCard";
+import { useHireOfficeGallery } from "./useHireOfficeGallery";
+
+export function HireOfficeGallery() {
+  const {
+    templates,
+    isLoading,
+    isError,
+    refetch,
+    selectedTemplate,
+    openPreview,
+    closePreview,
+    hire,
+    isHiring,
+    hireResult,
+  } = useHireOfficeGallery();
+
+  if (isError) {
+    return (
+      <ErrorCard
+        context="office packs"
+        hint="We could not load the offices you can hire."
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  if (!isLoading && templates.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Hire an office" className="space-y-4">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Icon icon={Building06Icon} size={18} className="text-zinc-950" />
+          <Text variant="h5">Hire an office</Text>
+        </div>
+        <Text variant="body" className="max-w-prose text-zinc-600">
+          Bring on a ready-made team of experts in one go — schedules and first
+          tasks included.
+        </Text>
+      </div>
+
+      {isLoading ? (
+        <div className="grid gap-4 sm:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-44 rounded-3xl" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-3">
+          {templates.map((template) => (
+            <OfficePackCard
+              key={template.id}
+              template={template}
+              onSelect={openPreview}
+            />
+          ))}
+        </div>
+      )}
+
+      <OfficeDialog
+        template={selectedTemplate}
+        hireResult={hireResult}
+        isHiring={isHiring}
+        onHire={hire}
+        onClose={closePreview}
+      />
+    </section>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/__tests__/hire-office-gallery.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/__tests__/hire-office-gallery.test.tsx
@@ -1,0 +1,173 @@
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { server } from "@/mocks/mock-server";
+import { render, screen } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { beforeEach, expect, test, vi } from "vitest";
+import { HireOfficeGallery } from "../HireOfficeGallery";
+import type { HireOfficeResponse, OfficeTemplate } from "../api";
+
+// Strip Radix portals — happy-dom doesn't render them. The mock keeps the
+// Dialog tree visible while ignoring controlled/forceOpen props.
+function MockDialog({ children }: { children: React.ReactNode }) {
+  return <div role="dialog">{children}</div>;
+}
+function MockDialogContent({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>;
+}
+MockDialog.Content = MockDialogContent;
+vi.mock("@/components/molecules/Dialog/Dialog", () => ({
+  Dialog: MockDialog,
+}));
+
+const templates: OfficeTemplate[] = [
+  {
+    id: "office-growth",
+    name: "Growth Office",
+    description: "Marketing and outreach experts that grow your audience.",
+    experts: [
+      {
+        template_id: "template-maria",
+        name: "Maria",
+        role: "Marketing Strategist",
+        avatar_url: null,
+        tagline: "Grows your brand while you sleep",
+        schedule_cron: "0 9 * * 1",
+        intro_task_title: "Audit your current marketing channels",
+      },
+      {
+        template_id: "template-leo",
+        name: "Leo",
+        role: "Outreach Specialist",
+        avatar_url: null,
+        tagline: null,
+        schedule_cron: null,
+        intro_task_title: null,
+      },
+    ],
+  },
+  {
+    id: "office-support",
+    name: "Support Office",
+    description: "Keeps your customers answered around the clock.",
+    experts: [
+      {
+        template_id: "template-sam",
+        name: "Sam",
+        role: "Support Lead",
+        avatar_url: null,
+        tagline: null,
+        schedule_cron: null,
+        intro_task_title: null,
+      },
+    ],
+  },
+  {
+    id: "office-ops",
+    name: "Ops Office",
+    description: "Back-office experts that keep operations humming.",
+    experts: [
+      {
+        template_id: "template-ada",
+        name: "Ada",
+        role: "Operations Manager",
+        avatar_url: null,
+        tagline: null,
+        schedule_cron: null,
+        intro_task_title: null,
+      },
+    ],
+  },
+];
+
+const hiredExpert = {
+  id: "expert-maria",
+  name: "Maria",
+  avatar_url: null,
+  role: "Marketing Strategist",
+  tagline: "Grows your brand while you sleep",
+  bio: null,
+  skills: [],
+  identity: "You are Maria.",
+  voice_preferences: "",
+  boundaries: "",
+  protected_soul_rules: [],
+  is_template: false,
+  source_template_id: "template-maria",
+  is_archived: false,
+  workflows: [],
+} as unknown as Expert;
+
+const hireResponse: HireOfficeResponse = {
+  office_template_id: "office-growth",
+  office_name: "Growth Office",
+  hired: [
+    {
+      expert: hiredExpert,
+      intro_task_id: "task-1",
+      intro_task_title: "Audit your current marketing channels",
+      schedule_created: true,
+    },
+  ],
+};
+
+beforeEach(() => {
+  server.use(
+    http.get("/api/proxy/api/experts/office-templates", () =>
+      HttpResponse.json(templates),
+    ),
+    http.post("/api/proxy/api/experts/hire-office", () =>
+      HttpResponse.json(hireResponse),
+    ),
+  );
+});
+
+test("renders the three office packs with expert counts", async () => {
+  render(<HireOfficeGallery />);
+
+  expect(await screen.findByText("Growth Office")).toBeTruthy();
+  expect(screen.getByText("Support Office")).toBeTruthy();
+  expect(screen.getByText("Ops Office")).toBeTruthy();
+  expect(screen.getByText("2 experts")).toBeTruthy();
+});
+
+test("clicking a pack previews its experts", async () => {
+  const user = userEvent.setup();
+  render(<HireOfficeGallery />);
+
+  await user.click(
+    await screen.findByRole("button", { name: /Growth Office/ }),
+  );
+
+  const list = await screen.findByRole("list", {
+    name: "Experts in this office",
+  });
+  expect(list).toBeTruthy();
+  expect(screen.getByText("Maria")).toBeTruthy();
+  expect(screen.getByText("Marketing Strategist")).toBeTruthy();
+  expect(screen.getByText("Grows your brand while you sleep")).toBeTruthy();
+  expect(screen.getByText("Scheduled")).toBeTruthy();
+  expect(
+    screen.getByText(/First task: Audit your current marketing channels/),
+  ).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Hire office" })).toBeTruthy();
+});
+
+test("hiring shows the roster success state", async () => {
+  const user = userEvent.setup();
+  render(<HireOfficeGallery />);
+
+  await user.click(
+    await screen.findByRole("button", { name: /Growth Office/ }),
+  );
+  await user.click(screen.getByRole("button", { name: "Hire office" }));
+
+  expect(await screen.findByText(/1 expert joined your team/)).toBeTruthy();
+  const roster = screen.getByRole("list", { name: "Hired experts" });
+  expect(roster).toBeTruthy();
+  expect(
+    screen.getByText("Audit your current marketing channels"),
+  ).toBeTruthy();
+  expect(screen.getByText("Queued")).toBeTruthy();
+  expect(screen.getByText("Schedule created")).toBeTruthy();
+});

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/api.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/api.ts
@@ -1,0 +1,73 @@
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { customMutator } from "@/app/api/mutators/custom-mutator";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+export interface OfficeTemplateExpert {
+  template_id: string;
+  name: string;
+  role: string;
+  avatar_url: string | null;
+  tagline: string | null;
+  schedule_cron: string | null;
+  intro_task_title: string | null;
+}
+
+export interface OfficeTemplate {
+  id: string;
+  name: string;
+  description: string;
+  experts: OfficeTemplateExpert[];
+}
+
+export interface HiredOfficeExpert {
+  expert: Expert;
+  intro_task_id: string | null;
+  intro_task_title: string | null;
+  schedule_created: boolean;
+}
+
+export interface HireOfficeResponse {
+  office_template_id: string;
+  office_name: string;
+  hired: HiredOfficeExpert[];
+}
+
+interface ApiResponse<T> {
+  data: T;
+  status: number;
+  headers: Headers;
+}
+
+export const OFFICE_TEMPLATES_URL = "/api/experts/office-templates";
+export const HIRE_OFFICE_URL = "/api/experts/hire-office";
+
+// Seam: replace these two hooks with the orval-generated ones once the
+// client is regenerated; call sites stay unchanged.
+export function useOfficeTemplatesQuery() {
+  return useQuery({
+    queryKey: [OFFICE_TEMPLATES_URL],
+    queryFn: async () => {
+      const res = await customMutator<ApiResponse<OfficeTemplate[]>>(
+        OFFICE_TEMPLATES_URL,
+        { method: "GET" },
+      );
+      return res.data;
+    },
+  });
+}
+
+export function useHireOfficeMutation(options?: {
+  onSuccess?: (result: HireOfficeResponse) => void;
+  onError?: (error: unknown) => void;
+}) {
+  return useMutation({
+    mutationFn: async (body: { template_id: string }) => {
+      const res = await customMutator<ApiResponse<HireOfficeResponse>>(
+        HIRE_OFFICE_URL,
+        { method: "POST", body: JSON.stringify(body) },
+      );
+      return res.data;
+    },
+    ...options,
+  });
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/HiredRoster.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/HiredRoster.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@/components/atoms/Button/Button";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import {
+  CalendarCheckIcon,
+  CheckmarkCircle02Icon,
+  Clock01Icon,
+} from "@hugeicons/core-free-icons";
+import { HireOfficeResponse } from "../api";
+
+interface Props {
+  result: HireOfficeResponse;
+  onDone: () => void;
+}
+
+export function HiredRoster({ result, onDone }: Props) {
+  const count = result.hired.length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2 rounded-2xl bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+        <Icon icon={CheckmarkCircle02Icon} size={16} />
+        {count} expert{count === 1 ? "" : "s"} joined your team and got to work.
+      </div>
+
+      <ul
+        className="flex flex-col divide-y divide-zinc-100"
+        aria-label="Hired experts"
+      >
+        {result.hired.map((entry) => (
+          <li key={entry.expert.id} className="flex items-start gap-3 py-3">
+            <ExpertAvatar
+              name={entry.expert.name}
+              avatarUrl={entry.expert.avatar_url}
+              size={36}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <Text variant="body-medium" className="text-zinc-900">
+                  {entry.expert.name}
+                </Text>
+                <span className="text-xs text-zinc-500">
+                  {entry.expert.role}
+                </span>
+              </div>
+              {entry.intro_task_title ? (
+                <span className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-zinc-600">
+                  <Icon
+                    icon={Clock01Icon}
+                    size={13}
+                    className="shrink-0 text-zinc-400"
+                  />
+                  {entry.intro_task_title}
+                  <span className="rounded-full bg-sky-50 px-2 py-0.5 text-[11px] font-medium text-sky-700 ring-1 ring-inset ring-sky-200">
+                    {entry.intro_task_id ? "Queued" : "Starting"}
+                  </span>
+                </span>
+              ) : null}
+              {entry.schedule_created ? (
+                <span className="mt-1 flex items-center gap-1.5 text-xs text-zinc-500">
+                  <Icon
+                    icon={CalendarCheckIcon}
+                    size={13}
+                    className="shrink-0 text-zinc-400"
+                  />
+                  Schedule created
+                </span>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex justify-end">
+        <Button type="button" variant="primary" onClick={onDone}>
+          Done
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/OfficeDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/OfficeDialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { Dialog } from "@/components/molecules/Dialog/Dialog";
+import { HireOfficeResponse, OfficeTemplate } from "../api";
+import { HiredRoster } from "./HiredRoster";
+import { OfficePreviewList } from "./OfficePreviewList";
+
+interface Props {
+  template: OfficeTemplate | null;
+  hireResult: HireOfficeResponse | null;
+  isHiring: boolean;
+  onHire: (template: OfficeTemplate) => void;
+  onClose: () => void;
+}
+
+export function OfficeDialog({
+  template,
+  hireResult,
+  isHiring,
+  onHire,
+  onClose,
+}: Props) {
+  if (!template) return null;
+
+  return (
+    <Dialog
+      title={
+        hireResult ? `${hireResult.office_name} is on board` : template.name
+      }
+      styling={{ maxWidth: "32rem" }}
+      controlled={{
+        isOpen: true,
+        set: (next) => {
+          if (!next) onClose();
+        },
+      }}
+    >
+      <Dialog.Content>
+        {hireResult ? (
+          <HiredRoster result={hireResult} onDone={onClose} />
+        ) : (
+          <div className="flex flex-col gap-4">
+            <Text variant="body" className="text-zinc-600">
+              {template.description}
+            </Text>
+            <OfficePreviewList experts={template.experts} />
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                loading={isHiring}
+                disabled={isHiring}
+                onClick={() => onHire(template)}
+              >
+                Hire office
+              </Button>
+            </div>
+          </div>
+        )}
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/OfficePackCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/OfficePackCard.tsx
@@ -1,0 +1,32 @@
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import { UserGroupIcon } from "@hugeicons/core-free-icons";
+import { OfficeTemplate } from "../api";
+
+interface Props {
+  template: OfficeTemplate;
+  onSelect: (templateId: string) => void;
+}
+
+export function OfficePackCard({ template, onSelect }: Props) {
+  const count = template.experts.length;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(template.id)}
+      className="group flex flex-col items-start gap-2 rounded-3xl border border-zinc-200 bg-white p-5 text-left transition-colors hover:border-zinc-300 hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+    >
+      <Text variant="large-medium" className="text-zinc-900">
+        {template.name}
+      </Text>
+      <Text variant="body" className="line-clamp-2 text-zinc-600">
+        {template.description}
+      </Text>
+      <span className="mt-auto inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-600">
+        <Icon icon={UserGroupIcon} size={14} />
+        {count} expert{count === 1 ? "" : "s"}
+      </span>
+    </button>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/OfficePreviewList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/components/OfficePreviewList.tsx
@@ -1,0 +1,57 @@
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import { CalendarCheckIcon, Task01Icon } from "@hugeicons/core-free-icons";
+import { OfficeTemplateExpert } from "../api";
+
+interface Props {
+  experts: OfficeTemplateExpert[];
+}
+
+export function OfficePreviewList({ experts }: Props) {
+  return (
+    <ul
+      className="flex flex-col divide-y divide-zinc-100"
+      aria-label="Experts in this office"
+    >
+      {experts.map((expert) => (
+        <li key={expert.template_id} className="flex items-start gap-3 py-3">
+          <ExpertAvatar
+            name={expert.name}
+            avatarUrl={expert.avatar_url}
+            size={36}
+          />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <Text variant="body-medium" className="text-zinc-900">
+                {expert.name}
+              </Text>
+              <span className="text-xs text-zinc-500">{expert.role}</span>
+              {expert.schedule_cron ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700 ring-1 ring-inset ring-violet-200">
+                  <Icon icon={CalendarCheckIcon} size={12} />
+                  Scheduled
+                </span>
+              ) : null}
+            </div>
+            {expert.tagline ? (
+              <Text variant="small" className="mt-0.5 text-zinc-500">
+                {expert.tagline}
+              </Text>
+            ) : null}
+            {expert.intro_task_title ? (
+              <span className="mt-1.5 flex items-center gap-1.5 text-xs text-zinc-500">
+                <Icon
+                  icon={Task01Icon}
+                  size={13}
+                  className="shrink-0 text-zinc-400"
+                />
+                First task: {expert.intro_task_title}
+              </span>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/useHireOfficeGallery.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/HireOfficeGallery/useHireOfficeGallery.ts
@@ -1,0 +1,65 @@
+import { getListExpertsQueryKey } from "@/app/api/__generated__/endpoints/experts/experts";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  HireOfficeResponse,
+  OfficeTemplate,
+  useHireOfficeMutation,
+  useOfficeTemplatesQuery,
+} from "./api";
+
+export function useHireOfficeGallery() {
+  const queryClient = useQueryClient();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hireResult, setHireResult] = useState<HireOfficeResponse | null>(null);
+
+  const templatesQuery = useOfficeTemplatesQuery();
+  const templates = Array.isArray(templatesQuery.data)
+    ? templatesQuery.data
+    : [];
+
+  const hireMutation = useHireOfficeMutation({
+    onSuccess: (result) => {
+      setHireResult(result);
+      void queryClient.invalidateQueries({
+        queryKey: getListExpertsQueryKey(),
+      });
+    },
+    onError: (error) => {
+      toast({
+        title: "Could not hire this office",
+        description: error instanceof Error ? error.message : undefined,
+        variant: "destructive",
+      });
+    },
+  });
+
+  function openPreview(templateId: string) {
+    setHireResult(null);
+    setSelectedId(templateId);
+  }
+
+  function closePreview() {
+    setSelectedId(null);
+    setHireResult(null);
+  }
+
+  function hire(template: OfficeTemplate) {
+    hireMutation.mutate({ template_id: template.id });
+  }
+
+  return {
+    templates,
+    isLoading: templatesQuery.isLoading,
+    isError: templatesQuery.isError,
+    refetch: () => templatesQuery.refetch(),
+    selectedTemplate:
+      templates.find((template) => template.id === selectedId) ?? null,
+    openPreview,
+    closePreview,
+    hire,
+    isHiring: hireMutation.isPending,
+    hireResult,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/OriginBadge/OriginBadge.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/OriginBadge/OriginBadge.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+
+const ORIGIN_STYLES: Record<string, { label: string; className: string }> = {
+  USER: { label: "You", className: "bg-sky-50 text-sky-700 ring-sky-200" },
+  SCHEDULE: {
+    label: "Schedule",
+    className: "bg-violet-50 text-violet-700 ring-violet-200",
+  },
+  DREAM: {
+    label: "Proactive",
+    className: "bg-fuchsia-50 text-fuchsia-700 ring-fuchsia-200",
+  },
+  EXPERT: {
+    label: "Expert",
+    className: "bg-teal-50 text-teal-700 ring-teal-200",
+  },
+};
+
+interface Props {
+  createdByType: string | null | undefined;
+  className?: string;
+}
+
+export function OriginBadge({ createdByType, className }: Props) {
+  const style = createdByType ? ORIGIN_STYLES[createdByType] : undefined;
+  if (!style) return null;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ring-inset",
+        style.className,
+        className,
+      )}
+    >
+      {style.label}
+    </span>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/OriginBadge/__tests__/origin-badge.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/OriginBadge/__tests__/origin-badge.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@/tests/integrations/test-utils";
+import { expect, test } from "vitest";
+import { OriginBadge } from "../OriginBadge";
+
+test.each([
+  ["USER", "You"],
+  ["SCHEDULE", "Schedule"],
+  ["DREAM", "Proactive"],
+  ["EXPERT", "Expert"],
+])("renders %s as %s", (type, label) => {
+  render(<OriginBadge createdByType={type} />);
+  expect(screen.getByText(label)).toBeTruthy();
+});
+
+test("renders nothing for a missing or unknown origin", () => {
+  const { container } = render(<OriginBadge createdByType={undefined} />);
+  expect(container.textContent).toBe("");
+
+  const unknown = render(<OriginBadge createdByType="SOMETHING_NEW" />);
+  expect(unknown.container.textContent).toBe("");
+});

--- a/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
@@ -21,6 +21,7 @@ import { notFound } from "next/navigation";
 import { AllTasksSection } from "./components/AllTasksSection/AllTasksSection";
 import { EmptyTeamState } from "./components/EmptyTeamState";
 import { ExpertTeamCard } from "./components/ExpertTeamCard/ExpertTeamCard";
+import { HireOfficeGallery } from "./components/HireOfficeGallery/HireOfficeGallery";
 import { ExpertTeamCardSkeleton } from "./components/ExpertTeamCardSkeleton";
 import { NewPodDialog } from "./components/NewPodDialog/NewPodDialog";
 import { PodBoard } from "./components/PodBoard/PodBoard";
@@ -149,6 +150,8 @@ export default function TeamPage() {
           {!isLoading && !isError && hiredExperts.length === 0 ? (
             <EmptyTeamState />
           ) : null}
+
+          <HireOfficeGallery />
         </TabsLineContent>
 
         <TabsLineContent value="pods">

--- a/autogpt_platform/frontend/src/app/(platform)/team/task-helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/task-helpers.ts
@@ -206,7 +206,9 @@ export function buildTaskTree(
 
 export function getTimelineEvents(task: DelegatedTask) {
   return (task.amendments ?? []).filter((amendment) =>
-    ["handoff", "escalation", "answer"].includes(amendment.kind ?? "note"),
+    ["handoff", "escalation", "answer", "note", "retry", "revision"].includes(
+      amendment.kind ?? "note",
+    ),
   );
 }
 
@@ -214,6 +216,9 @@ export function getTimelineLabel(kind: string | undefined): string {
   if (kind === "handoff") return "Handed off";
   if (kind === "escalation") return "Asked you";
   if (kind === "answer") return "You answered";
+  if (kind === "note") return "User note";
+  if (kind === "retry") return "Overseer retried";
+  if (kind === "revision") return "Revision requested";
   return "Note";
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/components/TaskOutcomeReview/TaskOutcomeReview.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/components/TaskOutcomeReview/TaskOutcomeReview.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
+import { Button } from "@/components/atoms/Button/Button";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Input } from "@/components/atoms/Input/Input";
+import { Text } from "@/components/atoms/Text/Text";
+import { useTaskOutcomeReview } from "./useTaskOutcomeReview";
+
+interface Props {
+  task: DelegatedTask;
+}
+
+const MAX_REVISIONS = 2;
+
+export function TaskOutcomeReview({ task }: Props) {
+  const {
+    isRequestingChanges,
+    note,
+    setNote,
+    handleAccept,
+    revealNote,
+    cancelNote,
+    submitChanges,
+    isAccepting,
+    isRejecting,
+  } = useTaskOutcomeReview(task.id);
+
+  if (task.status !== "DONE") return null;
+
+  if (task.acceptance === "ACCEPTED") {
+    return (
+      <div className="flex items-center gap-1.5 text-emerald-600">
+        <Icon icon={CheckmarkCircle02Icon} size={16} />
+        <Text variant="small" className="text-emerald-700">
+          Outcome accepted
+        </Text>
+      </div>
+    );
+  }
+
+  if (task.acceptance === "REJECTED" && task.revision_count >= MAX_REVISIONS) {
+    return (
+      <Text variant="small" className="text-zinc-500">
+        You have asked for changes twice — Autopilot escalated this to a chat so
+        you can clarify what you need.
+      </Text>
+    );
+  }
+
+  if (task.acceptance === "REJECTED") {
+    return (
+      <Text variant="small" className="text-zinc-500">
+        Changes requested — a revision is on the way.
+      </Text>
+    );
+  }
+
+  if (isRequestingChanges) {
+    return (
+      <form
+        className="flex flex-col gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitChanges();
+        }}
+      >
+        <Input
+          id={`task-outcome-note-${task.id}`}
+          label="What should change?"
+          hideLabel
+          size="small"
+          placeholder="What should change?"
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          disabled={isRejecting}
+          wrapperClassName="mb-0"
+        />
+        <div className="flex items-center gap-2">
+          <Button
+            type="submit"
+            variant="primary"
+            size="small"
+            loading={isRejecting}
+            disabled={!note.trim()}
+          >
+            Send changes
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="small"
+            disabled={isRejecting}
+            onClick={cancelNote}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="primary"
+        size="small"
+        loading={isAccepting}
+        onClick={handleAccept}
+      >
+        Accept
+      </Button>
+      <Button
+        variant="secondary"
+        size="small"
+        disabled={isAccepting}
+        onClick={revealNote}
+      >
+        Request changes
+      </Button>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/components/TaskOutcomeReview/useTaskOutcomeReview.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/components/TaskOutcomeReview/useTaskOutcomeReview.ts
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  getGetTaskQueryKey,
+  getListTasksQueryKey,
+  useAcceptTask,
+  useRejectTask,
+} from "@/app/api/__generated__/endpoints/tasks/tasks";
+import { okData } from "@/app/api/helpers";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+
+export function useTaskOutcomeReview(taskId: string) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [isRequestingChanges, setIsRequestingChanges] = useState(false);
+  const [note, setNote] = useState("");
+
+  async function refreshTask() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: getGetTaskQueryKey(taskId) }),
+      queryClient.invalidateQueries({ queryKey: getListTasksQueryKey() }),
+    ]);
+  }
+
+  const { mutate: accept, isPending: isAccepting } = useAcceptTask({
+    mutation: {
+      onSuccess: async (res) => {
+        toast({ title: okData(res)?.message ?? "Outcome accepted" });
+        await refreshTask();
+      },
+      onError: () =>
+        toast({
+          title: "Could not accept the outcome",
+          description: "Please try again.",
+          variant: "destructive",
+        }),
+    },
+  });
+
+  const { mutate: reject, isPending: isRejecting } = useRejectTask({
+    mutation: {
+      onSuccess: async (res) => {
+        toast({ title: okData(res)?.message ?? "Changes requested" });
+        setIsRequestingChanges(false);
+        setNote("");
+        await refreshTask();
+      },
+      onError: () =>
+        toast({
+          title: "Could not send your changes",
+          description: "Please try again.",
+          variant: "destructive",
+        }),
+    },
+  });
+
+  function handleAccept() {
+    accept({ taskId });
+  }
+
+  function revealNote() {
+    setIsRequestingChanges(true);
+  }
+
+  function cancelNote() {
+    setIsRequestingChanges(false);
+    setNote("");
+  }
+
+  function submitChanges() {
+    const trimmed = note.trim();
+    if (!trimmed || isRejecting) return;
+    reject({ taskId, data: { note: trimmed } });
+  }
+
+  return {
+    isRequestingChanges,
+    note,
+    setNote,
+    handleAccept,
+    revealNote,
+    cancelNote,
+    submitChanges,
+    isAccepting,
+    isRejecting,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/components/TaskProperties.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/components/TaskProperties.tsx
@@ -3,6 +3,7 @@
 import { DelegatedTask } from "@/app/api/__generated__/models/delegatedTask";
 import { TaskRunRef } from "@/app/api/__generated__/models/taskRunRef";
 import { AutoGPTLogo } from "@/components/atoms/AutoGPTLogo/AutoGPTLogo";
+import { Badge } from "@/components/atoms/Badge/Badge";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
@@ -11,10 +12,12 @@ import { RunStatusBadge } from "@/components/molecules/RunStatusBadge/RunStatusB
 import {
   Clock01Icon,
   DollarCircleIcon,
+  Flag01Icon,
   PlayCircleIcon,
   Progress02Icon,
   UserIcon,
 } from "@hugeicons/core-free-icons";
+import { OriginBadge } from "../../../components/OriginBadge/OriginBadge";
 import type { IconSvgElement } from "@hugeicons/react";
 import Link from "next/link";
 import { ACTION_BUTTON_CLASS } from "../../../helpers";
@@ -39,13 +42,23 @@ export function TaskProperties({ task, onCancel, isCancelling }: Props) {
     <aside className="flex flex-col gap-3 lg:sticky lg:top-20 lg:max-h-[calc(100vh-6rem)] lg:self-start lg:overflow-y-auto">
       <Card title="Properties">
         <Row label="Status" icon={Progress02Icon}>
-          <TaskStatusChip
-            status={task.status}
-            orbVariant={getTaskOrbVariant(task.id)}
-          />
+          <span className="inline-flex items-center gap-1.5">
+            <TaskStatusChip
+              status={task.status}
+              orbVariant={getTaskOrbVariant(task.id)}
+            />
+            {task.stale_at && isOpenTask(task) ? (
+              <Badge variant="warning" size="small">
+                Stale
+              </Badge>
+            ) : null}
+          </span>
         </Row>
         <Row label="Owner" icon={UserIcon}>
           <TaskOwner owner={task.owner} />
+        </Row>
+        <Row label="Origin" icon={Flag01Icon}>
+          <OriginBadge createdByType={task.created_by_type} />
         </Row>
         <Row label="Spend" icon={DollarCircleIcon}>
           <span className="text-zinc-700">{formatSpend(task.spend_total)}</span>

--- a/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/tasks/[taskId]/page.tsx
@@ -7,6 +7,7 @@ import { Flag, useFlagStatus } from "@/services/feature-flags/use-get-flag";
 import { notFound, useParams } from "next/navigation";
 import Link from "next/link";
 import { TaskActivity } from "./components/TaskActivity";
+import { TaskOutcomeReview } from "./components/TaskOutcomeReview/TaskOutcomeReview";
 import { TaskProperties } from "./components/TaskProperties";
 import { TaskSpec } from "./components/TaskSpec";
 import { TaskSubtasks } from "./components/TaskSubtasks";
@@ -83,6 +84,7 @@ export default function TaskDetailPage() {
               <p className="whitespace-pre-line text-sm leading-6 text-zinc-600">
                 {task.outcome_summary}
               </p>
+              <TaskOutcomeReview task={task} />
             </section>
           ) : null}
 

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -5958,6 +5958,47 @@
         "security": [{ "HTTPBearerJWT": [] }]
       }
     },
+    "/api/experts/hire-office": {
+      "post": {
+        "tags": ["v2", "experts", "experts", "private"],
+        "summary": "Hire Office Pack",
+        "operationId": "hire_office",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/HireOfficeRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HireOfficeResult" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "404": {
+            "description": "Office template or expert template not found"
+          },
+          "409": { "description": "Active expert limit reached" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
     "/api/experts/identities": {
       "get": {
         "tags": ["v2", "experts", "experts", "private"],
@@ -5973,6 +6014,33 @@
                   "items": { "$ref": "#/components/schemas/ExpertIdentity" },
                   "type": "array",
                   "title": "Response List Expert Identities"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          }
+        },
+        "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
+    "/api/experts/office-templates": {
+      "get": {
+        "tags": ["v2", "experts", "experts", "private"],
+        "summary": "List Office Templates",
+        "operationId": "list_office_templates",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OfficeTemplateSummary"
+                  },
+                  "type": "array",
+                  "title": "Response List Office Templates"
                 }
               }
             }
@@ -6045,6 +6113,54 @@
           }
         },
         "security": [{ "HTTPBearerJWT": [] }]
+      }
+    },
+    "/api/experts/pods/{pod_id}": {
+      "patch": {
+        "tags": ["v2", "experts", "experts", "private"],
+        "summary": "Update Expert Pod",
+        "description": "Set or clear the pod's lead. Delegations aimed at the pod (or at a\nmember from outside it) are routed to the lead.",
+        "operationId": "update_expert_pod",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "pod_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Pod Id" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdatePodRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ExpertPod" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "404": { "description": "Pod or lead expert not found" },
+          "409": { "description": "The lead is not a member of the pod" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
       }
     },
     "/api/experts/raise": {
@@ -14355,6 +14471,52 @@
         }
       }
     },
+    "/api/tasks/events": {
+      "get": {
+        "tags": ["v2", "tasks", "tasks", "private"],
+        "summary": "List Task Events",
+        "description": "Lightweight polling feed for the office view: one event per task\nupdated since ``since``, carrying the task's current lowercase status.",
+        "operationId": "list_task_events",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "format": "date-time" },
+                { "type": "null" }
+              ],
+              "description": "Only events on tasks updated after this ISO 8601 instant",
+              "title": "Since"
+            },
+            "description": "Only events on tasks updated after this ISO 8601 instant"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskEventsResponse" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/tasks/{task_id}": {
       "get": {
         "tags": ["v2", "tasks", "tasks", "private"],
@@ -14383,6 +14545,46 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
           "404": { "description": "Task not found" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/{task_id}/accept": {
+      "post": {
+        "tags": ["v2", "tasks", "tasks", "private"],
+        "summary": "Accept Task",
+        "description": "Approve a finished task's outcome.",
+        "operationId": "accept_task",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Task Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskReviewResult" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "404": { "description": "Task not found" },
+          "409": { "description": "Task is not finished" },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -14470,6 +14672,54 @@
             "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
           },
           "404": { "description": "Task not found" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/{task_id}/reject": {
+      "post": {
+        "tags": ["v2", "tasks", "tasks", "private"],
+        "summary": "Reject Task",
+        "description": "Reject a finished task's outcome. Under the revision cap this opens a\nrevision subtask for the same owner and nudges their session; at the cap\nit asks the user to clarify in chat instead of looping again.",
+        "operationId": "reject_task",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Task Id" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RejectTaskRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskReviewResult" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "404": { "description": "Task not found" },
+          "409": { "description": "Task is not finished" },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -16892,6 +17142,24 @@
           "narrative": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Narrative"
+          },
+          "nudge_items": {
+            "items": { "$ref": "#/components/schemas/BriefingNudgeItem" },
+            "type": "array",
+            "title": "Nudge Items",
+            "default": []
+          },
+          "merge_items": {
+            "items": { "$ref": "#/components/schemas/BriefingMergeItem" },
+            "type": "array",
+            "title": "Merge Items",
+            "default": []
+          },
+          "hire_items": {
+            "items": { "$ref": "#/components/schemas/BriefingHireItem" },
+            "type": "array",
+            "title": "Hire Items",
+            "default": []
           }
         },
         "type": "object",
@@ -16939,6 +17207,66 @@
         "type": "string",
         "enum": ["DAILY", "WEEKLY", "MONTHLY", "OFF"],
         "title": "BriefingFrequency"
+      },
+      "BriefingHireItem": {
+        "properties": {
+          "template_id": { "type": "string", "title": "Template Id" },
+          "name": { "type": "string", "title": "Name" },
+          "role": { "type": "string", "title": "Role" },
+          "task_count": { "type": "integer", "title": "Task Count" },
+          "example_titles": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Example Titles",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["template_id", "name", "role", "task_count"],
+        "title": "BriefingHireItem",
+        "description": "A recommendation to hire a specific expert template, made after\nAutopilot self-handled several tasks in that template's lane."
+      },
+      "BriefingMergeItem": {
+        "properties": {
+          "task_ids": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Task Ids"
+          },
+          "titles": {
+            "items": { "type": "string" },
+            "type": "array",
+            "title": "Titles"
+          }
+        },
+        "type": "object",
+        "required": ["task_ids", "titles"],
+        "title": "BriefingMergeItem",
+        "description": "Two open tasks that look like the same ask — a suggestion only,\nnothing is merged automatically."
+      },
+      "BriefingNudgeItem": {
+        "properties": {
+          "task_id": { "type": "string", "title": "Task Id" },
+          "title": { "type": "string", "title": "Title" },
+          "waiting_since": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Waiting Since"
+          },
+          "question": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Question"
+          },
+          "is_stale": {
+            "type": "boolean",
+            "title": "Is Stale",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["task_id", "title", "waiting_since"],
+        "title": "BriefingNudgeItem",
+        "description": "A WAITING_USER task the user has sat on for over a day."
       },
       "BriefingResponse": {
         "properties": {
@@ -18502,6 +18830,13 @@
             "type": "array",
             "title": "Amendments"
           },
+          "stale_at": {
+            "anyOf": [
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
+            ],
+            "title": "Stale At"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -19613,6 +19948,11 @@
             "items": { "type": "string" },
             "type": "array",
             "title": "Trigger Names"
+          },
+          "open_task_count": {
+            "type": "integer",
+            "title": "Open Task Count",
+            "default": 0
           }
         },
         "type": "object",
@@ -19643,6 +19983,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At"
+          },
+          "lead_expert_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Lead Expert Id"
           }
         },
         "type": "object",
@@ -21010,6 +21354,31 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "HireOfficeRequest": {
+        "properties": {
+          "template_id": { "type": "string", "title": "Template Id" }
+        },
+        "type": "object",
+        "required": ["template_id"],
+        "title": "HireOfficeRequest"
+      },
+      "HireOfficeResult": {
+        "properties": {
+          "office_template_id": {
+            "type": "string",
+            "title": "Office Template Id"
+          },
+          "office_name": { "type": "string", "title": "Office Name" },
+          "hired": {
+            "items": { "$ref": "#/components/schemas/HiredOfficeExpert" },
+            "type": "array",
+            "title": "Hired"
+          }
+        },
+        "type": "object",
+        "required": ["office_template_id", "office_name", "hired"],
+        "title": "HireOfficeResult"
+      },
       "HireRequest": {
         "properties": {
           "template_id": { "type": "string", "title": "Template Id" },
@@ -21037,6 +21406,22 @@
         "type": "object",
         "required": ["expert", "failed_preloads"],
         "title": "HireResult"
+      },
+      "HiredOfficeExpert": {
+        "properties": {
+          "expert": { "$ref": "#/components/schemas/Expert" },
+          "intro_task_id": { "type": "string", "title": "Intro Task Id" },
+          "intro_task_title": { "type": "string", "title": "Intro Task Title" },
+          "schedule_created": { "type": "boolean", "title": "Schedule Created" }
+        },
+        "type": "object",
+        "required": [
+          "expert",
+          "intro_task_id",
+          "intro_task_title",
+          "schedule_created"
+        ],
+        "title": "HiredOfficeExpert"
       },
       "HomeAction": {
         "properties": {
@@ -21115,7 +21500,9 @@
               "paused",
               "credits",
               "question",
-              "task_escalation"
+              "task_escalation",
+              "task_failed",
+              "task_stale"
             ],
             "title": "Kind"
           },
@@ -23393,6 +23780,52 @@
         "title": "OAuthApplicationPublicInfo",
         "description": "Public information about an OAuth application (for consent screen)"
       },
+      "OfficeTemplateExpert": {
+        "properties": {
+          "template_id": { "type": "string", "title": "Template Id" },
+          "name": { "type": "string", "title": "Name" },
+          "role": { "type": "string", "title": "Role" },
+          "avatar_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Avatar Url"
+          },
+          "tagline": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Tagline"
+          },
+          "schedule_cron": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Schedule Cron"
+          },
+          "intro_task_title": { "type": "string", "title": "Intro Task Title" }
+        },
+        "type": "object",
+        "required": [
+          "template_id",
+          "name",
+          "role",
+          "avatar_url",
+          "tagline",
+          "schedule_cron",
+          "intro_task_title"
+        ],
+        "title": "OfficeTemplateExpert"
+      },
+      "OfficeTemplateSummary": {
+        "properties": {
+          "id": { "type": "string", "title": "Id" },
+          "name": { "type": "string", "title": "Name" },
+          "description": { "type": "string", "title": "Description" },
+          "experts": {
+            "items": { "$ref": "#/components/schemas/OfficeTemplateExpert" },
+            "type": "array",
+            "title": "Experts"
+          }
+        },
+        "type": "object",
+        "required": ["id", "name", "description", "experts"],
+        "title": "OfficeTemplateSummary"
+      },
       "OnboardingProfileRequest": {
         "properties": {
           "user_name": {
@@ -25019,6 +25452,20 @@
           "updated_at"
         ],
         "title": "RefundRequest"
+      },
+      "RejectTaskRequest": {
+        "properties": {
+          "note": {
+            "type": "string",
+            "maxLength": 4000,
+            "minLength": 1,
+            "title": "Note"
+          }
+        },
+        "type": "object",
+        "required": ["note"],
+        "title": "RejectTaskRequest",
+        "description": "The user's rejection of a task outcome, with what to change."
       },
       "RequestTopUp": {
         "properties": {
@@ -27060,7 +27507,14 @@
           "note": { "type": "string", "title": "Note" },
           "kind": {
             "type": "string",
-            "enum": ["note", "handoff", "escalation", "answer"],
+            "enum": [
+              "note",
+              "handoff",
+              "escalation",
+              "answer",
+              "retry",
+              "revision"
+            ],
             "title": "Kind",
             "default": "note"
           },
@@ -27090,7 +27544,7 @@
         "type": "object",
         "required": ["at", "by", "note"],
         "title": "TaskAmendment",
-        "description": "An event recorded against a live task: a scope note, a handoff\nbetween experts, an escalation to the user, or the user's answer.\nStored in the append-only ``amendments`` Json column, so new kinds land\nwithout a migration; ``kind`` defaults to ``note`` for phase-1 rows."
+        "description": "An event recorded against a live task: a scope note, a handoff\nbetween experts, an escalation to the user, the user's answer, an\noverseer stall retry, or a revision request on a rejected outcome.\nStored in the append-only ``amendments`` Json column, so new kinds land\nwithout a migration; ``kind`` defaults to ``note`` for phase-1 rows."
       },
       "TaskDecompositionResponse": {
         "properties": {
@@ -27125,6 +27579,33 @@
         "title": "TaskDecompositionResponse",
         "description": "Response for decompose_goal tool — shows the plan to the user."
       },
+      "TaskEvent": {
+        "properties": {
+          "task_id": { "type": "string", "title": "Task Id" },
+          "expert_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Expert Id"
+          },
+          "event": { "type": "string", "title": "Event" },
+          "ts": { "type": "string", "title": "Ts" }
+        },
+        "type": "object",
+        "required": ["task_id", "expert_id", "event", "ts"],
+        "title": "TaskEvent",
+        "description": "One task's latest state change, for the office view's polling feed.\n``event`` is the task's lowercase status (\"queued\" / \"working\" /\n\"waiting_user\" / \"done\" / \"failed\" / \"cancelled\"); ``ts`` is the row's\n``updatedAt`` in ISO 8601. This exact shape is the frontend contract."
+      },
+      "TaskEventsResponse": {
+        "properties": {
+          "events": {
+            "items": { "$ref": "#/components/schemas/TaskEvent" },
+            "type": "array",
+            "title": "Events"
+          }
+        },
+        "type": "object",
+        "required": ["events"],
+        "title": "TaskEventsResponse"
+      },
       "TaskExpertRef": {
         "properties": {
           "id": { "type": "string", "title": "Id" },
@@ -27139,6 +27620,27 @@
         "required": ["id", "name", "avatar_url", "role"],
         "title": "TaskExpertRef",
         "description": "The expert a task is owned by. Null owner = Autopilot."
+      },
+      "TaskReviewResult": {
+        "properties": {
+          "task": { "$ref": "#/components/schemas/DelegatedTask" },
+          "revision_task": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/DelegatedTask" },
+              { "type": "null" }
+            ]
+          },
+          "escalated": {
+            "type": "boolean",
+            "title": "Escalated",
+            "default": false
+          },
+          "message": { "type": "string", "title": "Message" }
+        },
+        "type": "object",
+        "required": ["task", "message"],
+        "title": "TaskReviewResult",
+        "description": "Outcome of an accept/reject action on a finished task. ``escalated``\nis set when the revision cap was hit: no new subtask was opened and the\nuser is asked to clarify in chat instead."
       },
       "TaskRunRef": {
         "properties": {
@@ -28335,6 +28837,17 @@
         "type": "object",
         "required": ["permissions"],
         "title": "UpdatePermissionsRequest"
+      },
+      "UpdatePodRequest": {
+        "properties": {
+          "lead_expert_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Lead Expert Id"
+          }
+        },
+        "type": "object",
+        "required": ["lead_expert_id"],
+        "title": "UpdatePodRequest"
       },
       "UpdateSessionPinnedRequest": {
         "properties": {

--- a/autogpt_platform/frontend/src/components/organisms/BriefingCard/BriefingCard.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/BriefingCard/BriefingCard.tsx
@@ -11,6 +11,7 @@ import type { BriefingResponse } from "@/app/api/__generated__/models/briefingRe
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
+import { BriefingExtras } from "./components/BriefingExtras";
 import { RunRow } from "./components/RunRow";
 import { COLLAPSED_ROWS, formatBriefingDate, hasRecapContent } from "./helpers";
 import { useBriefingCard } from "./useBriefingCard";
@@ -60,70 +61,74 @@ export function BriefingCard({ briefing, className }: Props) {
         </Text>
       </div>
 
-      <div className="overflow-hidden rounded-3xl bg-white shadow-zinc-950 smooth-shadow-ring-sm">
-        <motion.div
-          // Real height, not a layout transform: the page below has to reflow
-          // with the card, and a transform would scale the rows' text.
-          initial={false}
-          animate={{ height: height ?? "auto" }}
-          transition={heightTransition}
-          className="relative"
-        >
-          <ul
-            ref={listRef}
-            className={cn(
-              "h-full divide-y divide-zinc-100",
-              isShowingAll
-                ? "overflow-y-auto scrollbar-none"
-                : "overflow-hidden",
-            )}
+      {run_items.length > 0 ? (
+        <div className="overflow-hidden rounded-3xl bg-white shadow-zinc-950 smooth-shadow-ring-sm">
+          <motion.div
+            // Real height, not a layout transform: the page below has to reflow
+            // with the card, and a transform would scale the rows' text.
+            initial={false}
+            animate={{ height: height ?? "auto" }}
+            transition={heightTransition}
+            className="relative"
           >
-            {run_items.map((item, index) => (
-              <RunRow
-                key={item.execution_id}
-                item={item}
-                isHidden={!isShowingAll && index >= COLLAPSED_ROWS}
-              />
-            ))}
-          </ul>
+            <ul
+              ref={listRef}
+              className={cn(
+                "h-full divide-y divide-zinc-100",
+                isShowingAll
+                  ? "overflow-y-auto scrollbar-none"
+                  : "overflow-hidden",
+              )}
+            >
+              {run_items.map((item, index) => (
+                <RunRow
+                  key={item.execution_id}
+                  item={item}
+                  isHidden={!isShowingAll && index >= COLLAPSED_ROWS}
+                />
+              ))}
+            </ul>
 
-          {/* Inside the card, over the scrolling rows: the scrollbar is
+            {/* Inside the card, over the scrolling rows: the scrollbar is
               hidden, so these are the only affordance once the list runs past
               its window. */}
-          <ScrollArrow
-            direction="up"
-            isVisible={canScrollUp}
-            onScroll={() => scrollByStep(-1)}
-          />
-          <ScrollArrow
-            direction="down"
-            isVisible={canScrollDown}
-            onScroll={() => scrollByStep(1)}
-          />
-        </motion.div>
-
-        {hasMore ? (
-          <button
-            type="button"
-            onClick={toggleShowAll}
-            className="flex w-full items-center justify-center gap-1.5 border-t border-zinc-100 px-4 py-3 text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-900"
-          >
-            <Text variant="small-medium" className="text-inherit">
-              {isShowingAll
-                ? "Show less"
-                : `Show all results (${run_items.length})`}
-            </Text>
-            <Icon
-              icon={ArrowDown01Icon}
-              size={14}
-              className={cn(
-                "transition-transform",
-                isShowingAll && "rotate-180",
-              )}
+            <ScrollArrow
+              direction="up"
+              isVisible={canScrollUp}
+              onScroll={() => scrollByStep(-1)}
             />
-          </button>
-        ) : null}
-      </div>
+            <ScrollArrow
+              direction="down"
+              isVisible={canScrollDown}
+              onScroll={() => scrollByStep(1)}
+            />
+          </motion.div>
+
+          {hasMore ? (
+            <button
+              type="button"
+              onClick={toggleShowAll}
+              className="flex w-full items-center justify-center gap-1.5 border-t border-zinc-100 px-4 py-3 text-zinc-500 transition-colors hover:bg-zinc-50 hover:text-zinc-900"
+            >
+              <Text variant="small-medium" className="text-inherit">
+                {isShowingAll
+                  ? "Show less"
+                  : `Show all results (${run_items.length})`}
+              </Text>
+              <Icon
+                icon={ArrowDown01Icon}
+                size={14}
+                className={cn(
+                  "transition-transform",
+                  isShowingAll && "rotate-180",
+                )}
+              />
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      <BriefingExtras content={briefing.content} />
     </section>
   );
 }

--- a/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/BriefingExtras.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/BriefingExtras.tsx
@@ -1,0 +1,81 @@
+import {
+  Clock01Icon,
+  Copy01Icon,
+  UserAdd01Icon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+import type { BriefingContent } from "@/app/api/__generated__/models/briefingContent";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import { HireRow } from "./HireRow";
+import { MergeRow } from "./MergeRow";
+import { NudgeRow } from "./NudgeRow";
+
+interface Props {
+  content: BriefingContent;
+}
+
+// The recap's follow-ups: what the user is holding up, likely duplicates, and
+// a hire Autopilot's workload suggests. Each section only earns its space when
+// the backend actually sent items for it.
+export function BriefingExtras({ content }: Props) {
+  const nudges = content.nudge_items ?? [];
+  const merges = content.merge_items ?? [];
+  const hires = content.hire_items ?? [];
+
+  if (nudges.length === 0 && merges.length === 0 && hires.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 flex flex-col gap-4">
+      {nudges.length > 0 ? (
+        <Section title="Waiting on you" icon={Clock01Icon}>
+          {nudges.map((item) => (
+            <NudgeRow key={item.task_id} item={item} />
+          ))}
+        </Section>
+      ) : null}
+
+      {merges.length > 0 ? (
+        <Section title="Possible duplicates" icon={Copy01Icon}>
+          {merges.map((item, index) => (
+            <MergeRow key={item.task_ids.join("-") || index} item={item} />
+          ))}
+        </Section>
+      ) : null}
+
+      {hires.length > 0 ? (
+        <Section title="Hire recommendation" icon={UserAdd01Icon}>
+          {hires.map((item) => (
+            <HireRow key={item.template_id} item={item} />
+          ))}
+        </Section>
+      ) : null}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: IconSvgElement;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2 px-2">
+        <Icon icon={icon} size={16} className="text-zinc-400" />
+        <Text variant="body" className="text-zinc-700">
+          {title}
+        </Text>
+      </div>
+      <div className="overflow-hidden rounded-3xl bg-white shadow-zinc-950 smooth-shadow-ring-sm">
+        <ul className="divide-y divide-zinc-100">{children}</ul>
+      </div>
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/HireRow.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/HireRow.tsx
@@ -1,0 +1,53 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useHireExpert } from "@/app/api/__generated__/endpoints/experts/experts";
+import type { BriefingHireItem } from "@/app/api/__generated__/models/briefingHireItem";
+import { Button } from "@/components/atoms/Button/Button";
+import { Text } from "@/components/atoms/Text/Text";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { invalidateExpertRosterQueries } from "@/services/experts/invalidate-experts";
+
+interface Props {
+  item: BriefingHireItem;
+}
+
+// A recommendation to hire a template Autopilot has been covering: one-tap
+// hire, with the roster refreshed so the new teammate shows up right away.
+export function HireRow({ item }: Props) {
+  const queryClient = useQueryClient();
+  const { mutate: hire, isPending } = useHireExpert({
+    mutation: {
+      onSuccess: async () => {
+        toast({ title: `${item.name} joined your team` });
+        await invalidateExpertRosterQueries(queryClient);
+      },
+      onError: () =>
+        toast({
+          title: `Couldn't hire ${item.name}`,
+          description: "Please try again.",
+          variant: "destructive",
+        }),
+    },
+  });
+
+  return (
+    <li className="flex items-center gap-3 px-5 py-4">
+      <div className="min-w-0 flex-1">
+        <Text variant="body-medium" className="truncate text-zinc-900">
+          {item.name} — {item.role}
+        </Text>
+        <Text variant="body" className="text-zinc-500">
+          Autopilot handled {item.task_count} similar{" "}
+          {item.task_count === 1 ? "task" : "tasks"}
+        </Text>
+      </div>
+      <Button
+        variant="primary"
+        size="small"
+        loading={isPending}
+        onClick={() => hire({ data: { template_id: item.template_id } })}
+      >
+        Hire
+      </Button>
+    </li>
+  );
+}

--- a/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/MergeRow.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/MergeRow.tsx
@@ -1,0 +1,50 @@
+import { Fragment } from "react";
+import Link from "next/link";
+import type { BriefingMergeItem } from "@/app/api/__generated__/models/briefingMergeItem";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Props {
+  item: BriefingMergeItem;
+}
+
+// Two open tasks that look like the same ask — a suggestion only, so both
+// titles link to their tasks and nothing is merged automatically.
+export function MergeRow({ item }: Props) {
+  return (
+    <li className="px-5 py-4">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+        {item.titles.map((title, index) => {
+          const taskId = item.task_ids[index];
+          return (
+            <Fragment key={taskId ?? index}>
+              {index > 0 ? (
+                <span aria-hidden className="text-zinc-300">
+                  ·
+                </span>
+              ) : null}
+              {taskId ? (
+                <Link
+                  href={`/team/tasks/${taskId}`}
+                  className="truncate text-[0.9375rem] font-medium text-zinc-900 hover:underline"
+                >
+                  {title}
+                </Link>
+              ) : (
+                <Text
+                  variant="body-medium"
+                  unmask={false}
+                  className="truncate text-zinc-900"
+                >
+                  {title}
+                </Text>
+              )}
+            </Fragment>
+          );
+        })}
+      </div>
+      <Text variant="body" className="mt-0.5 text-zinc-500">
+        look like the same ask — merge?
+      </Text>
+    </li>
+  );
+}

--- a/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/NudgeRow.tsx
+++ b/autogpt_platform/frontend/src/components/organisms/BriefingCard/components/NudgeRow.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import type { BriefingNudgeItem } from "@/app/api/__generated__/models/briefingNudgeItem";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+
+interface Props {
+  item: BriefingNudgeItem;
+}
+
+// A WAITING_USER task the user has sat on: the question doubles as the row's
+// subtitle, mirroring RunRow's single-line title + detail.
+export function NudgeRow({ item }: Props) {
+  return (
+    <li>
+      <Link
+        href={`/team/tasks/${item.task_id}`}
+        className="group flex items-start gap-3 px-5 py-4 transition-colors hover:bg-zinc-50"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Text
+              variant="body-medium"
+              unmask={false}
+              className="truncate text-zinc-900"
+            >
+              {item.title}
+            </Text>
+            {item.is_stale ? (
+              <span className="shrink-0 rounded-full bg-amber-50 px-2 py-0.5 text-[0.6875rem] font-medium text-amber-700">
+                Stale
+              </span>
+            ) : null}
+          </div>
+          {item.question ? (
+            <Text
+              variant="body"
+              unmask={false}
+              className="line-clamp-2 text-zinc-500"
+            >
+              {item.question}
+            </Text>
+          ) : null}
+        </div>
+        <Icon
+          icon={ArrowRight01Icon}
+          size={16}
+          className="shrink-0 self-center text-zinc-300 transition-colors group-hover:text-zinc-500"
+        />
+      </Link>
+    </li>
+  );
+}

--- a/autogpt_platform/frontend/src/components/organisms/BriefingCard/helpers.ts
+++ b/autogpt_platform/frontend/src/components/organisms/BriefingCard/helpers.ts
@@ -9,7 +9,14 @@ import type { BriefingRunItem } from "@/app/api/__generated__/models/briefingRun
 export function hasRecapContent(
   briefing: BriefingResponse | null | undefined,
 ): briefing is BriefingResponse {
-  return Boolean(briefing && briefing.content.run_items.length > 0);
+  if (!briefing) return false;
+  const { run_items, nudge_items, merge_items, hire_items } = briefing.content;
+  return (
+    run_items.length > 0 ||
+    (nudge_items?.length ?? 0) > 0 ||
+    (merge_items?.length ?? 0) > 0 ||
+    (hire_items?.length ?? 0) > 0
+  );
 }
 
 export const COLLAPSED_ROWS = 3;

--- a/autogpt_platform/frontend/src/mocks/mock-handlers.ts
+++ b/autogpt_platform/frontend/src/mocks/mock-handlers.ts
@@ -29,7 +29,9 @@ import { getSchedulesMock } from "@/app/api/__generated__/endpoints/schedules/sc
 import { getSearchMock } from "@/app/api/__generated__/endpoints/search/search.msw";
 import { getSkillsMock } from "@/app/api/__generated__/endpoints/skills/skills.msw";
 import { getStoreMock } from "@/app/api/__generated__/endpoints/store/store.msw";
+import { getListTasksMockHandler } from "@/app/api/__generated__/endpoints/tasks/tasks.msw";
 import { getWorkspaceMock } from "@/app/api/__generated__/endpoints/workspace/workspace.msw";
+import { HttpResponse, http } from "msw";
 
 // Pass hard-coded data to individual handler functions to override faker-generated data.
 export const mockHandlers = [
@@ -59,6 +61,13 @@ export const mockHandlers = [
   ...getDefaultMock(),
   ...getEmailMock(),
   ...getExecutionsMock(),
+  // Hand-written until the office endpoints land in the OpenAPI spec; swap
+  // for the generated experts.msw handlers after `pnpm generate:api`. Must
+  // sit before getExpertsMock so `GET /api/experts/:expertId` doesn't
+  // swallow the office-templates path.
+  http.get("/api/proxy/api/experts/office-templates", () =>
+    HttpResponse.json([]),
+  ),
   ...getExpertsMock(),
   ...getFilesMock(),
   ...getGraphsMock(),
@@ -74,5 +83,8 @@ export const mockHandlers = [
   ...getSearchMock(),
   ...getSkillsMock(),
   ...getStoreMock(),
+  // Empty by default so surfaces that read the task spine stay quiet in
+  // unrelated tests; task tests override with their own fixtures.
+  getListTasksMockHandler([]),
   ...getWorkspaceMock(),
 ];


### PR DESCRIPTION
## Changes 🏗️

Stack 5/6, on top of #14254.

- Overseer service (`copilot/overseer/`): cron scheduling, recruiter, cards
- Hire office + office seed templates + pod lead
- Task outcome review (`task_review.py`) + amendments/revisions
- Briefing extras: proactive section, pod rollups on home
- Migrations: `delegated_task_stale_at`, `office_templates_and_pod_lead`

## Checklist 📋
- [x] Migrations validated
- [x] User ID checks in data layer