### PR TITLE
fix: add AllQuiet to camelCase search exceptions

### DIFF
--- a/autogpt_platform/backend/backend/api/features/store/text_utils_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/text_utils_test.py
@@ -43,6 +43,7 @@ from backend.util.text import split_camelcase
         ("AutoGPTAgent", "AutoGPT Agent"),
         ("GitHubIntegration", "GitHub Integration"),
         ("LinkedInBlock", "LinkedIn Block"),
+        ("AllQuietGetOnCallBlock", "AllQuiet Get On Call Block"),
     ],
 )
 def test_split_camelcase(input_text: str, expected: str):

--- a/autogpt_platform/backend/backend/util/text.py
+++ b/autogpt_platform/backend/backend/util/text.py
@@ -140,6 +140,7 @@ _CAMELCASE_EXCEPTIONS: dict[str, str] = {
     "You Tube": "YouTube",
     "Git Hub": "GitHub",
     "Linked In": "LinkedIn",
+    "All Quiet": "AllQuiet",
 }
 
 _CAMELCASE_EXCEPTION_RE = re.compile(

--- a/autogpt_platform/frontend/src/lib/utils.ts
+++ b/autogpt_platform/frontend/src/lib/utils.ts
@@ -166,6 +166,7 @@ const exceptionMap: Record<string, string> = {
   Json: "JSON",
   Ai: "AI",
   "You Tube": "YouTube",
+  "All Quiet": "AllQuiet",
 };
 
 const applyExceptions = (str: string): string => {


### PR DESCRIPTION
## Problem

Block search (`find_block`) for `allquiet` returned no results, while `all quiet` (with a space) did.

Block search indexes each block's display name via `split_camelcase()` (`backend/util/text.py`), which splits `AllQuietGetOnCallBlock` into `All Quiet Get On Call Block` — two separate word tokens — because `AllQuiet` wasn't in the `_CAMELCASE_EXCEPTIONS` merge list (unlike `AutoGPT`, `OpenAI`, `YouTube`, `GitHub`, `LinkedIn`, which are already merged back into single tokens). A single-word query like `allquiet` can't match two separate indexed tokens.

## Fix

Add `"All Quiet": "AllQuiet"` to the exception list in both:
- `autogpt_platform/backend/backend/util/text.py` (`_CAMELCASE_EXCEPTIONS`) — used for block search indexing
- `autogpt_platform/frontend/src/lib/utils.ts` (`exceptionMap`) — the mirrored frontend list, per the existing docstring

Added a test case in `text_utils_test.py` confirming `AllQuietGetOnCallBlock` → `AllQuiet Get On Call Block`.

## Verified

```
>>> split_camelcase("AllQuietGetOnCallBlock")
'AllQuiet Get On Call Block'
```
