### PR TITLE
fix(backend): make async Redis clients loop-safe

### DIFF
--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -183,15 +183,12 @@ def _get_async_client_lock(loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
 async def disconnect_async():
     loop = asyncio.get_running_loop()
     async with _get_async_client_lock(loop):
-        client = _async_clients.get(loop)
-        finalizer = _async_client_finalizers.get(loop)
-        if client is not None:
-            await client.close()
-            if _async_clients.get(loop) is client:
-                _async_clients.pop(loop, None)
-        if finalizer is not None and _async_client_finalizers.get(loop) is finalizer:
-            _async_client_finalizers.pop(loop, None)
+        client = _async_clients.pop(loop, None)
+        finalizer = _async_client_finalizers.pop(loop, None)
+        if finalizer is not None:
             await finalizer.aclose()
+        elif client is not None:
+            await client.close()
 
 
 async def get_redis_async() -> AsyncRedisClient:
@@ -216,10 +213,9 @@ async def _close_async_client_on_loop_shutdown(
     finally:
         loop = asyncio.get_running_loop()
         if _async_clients.get(loop) is client:
-            await client.close()
-            if _async_clients.get(loop) is client:
-                _async_clients.pop(loop, None)
-                _async_client_finalizers.pop(loop, None)
+            _async_clients.pop(loop, None)
+            _async_client_finalizers.pop(loop, None)
+        await client.close()
 
 
 # Sharded pub/sub only delivers on the keyslot-owning shard; subscribers

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -183,12 +183,15 @@ def _get_async_client_lock(loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
 async def disconnect_async():
     loop = asyncio.get_running_loop()
     async with _get_async_client_lock(loop):
-        client = _async_clients.pop(loop, None)
-        finalizer = _async_client_finalizers.pop(loop, None)
-        if finalizer is not None:
-            await finalizer.aclose()
-        elif client is not None:
+        client = _async_clients.get(loop)
+        finalizer = _async_client_finalizers.get(loop)
+        if client is not None:
             await client.close()
+            if _async_clients.get(loop) is client:
+                _async_clients.pop(loop, None)
+        if finalizer is not None and _async_client_finalizers.get(loop) is finalizer:
+            _async_client_finalizers.pop(loop, None)
+            await finalizer.aclose()
 
 
 async def get_redis_async() -> AsyncRedisClient:
@@ -213,9 +216,10 @@ async def _close_async_client_on_loop_shutdown(
     finally:
         loop = asyncio.get_running_loop()
         if _async_clients.get(loop) is client:
-            _async_clients.pop(loop, None)
-            _async_client_finalizers.pop(loop, None)
-        await client.close()
+            await client.close()
+            if _async_clients.get(loop) is client:
+                _async_clients.pop(loop, None)
+                _async_client_finalizers.pop(loop, None)
 
 
 # Sharded pub/sub only delivers on the keyslot-owning shard; subscribers

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import os
+from collections.abc import AsyncGenerator
+from weakref import WeakKeyDictionary
 
 from dotenv import load_dotenv
 from redis import Redis
@@ -156,26 +158,50 @@ async def connect_async() -> AsyncRedisClient:
     return c
 
 
-# One AsyncRedisCluster per event loop: the client binds to the loop it was
-# first awaited on, so a module-level singleton breaks across test loops.
-_async_clients: dict[int, AsyncRedisCluster] = {}
+# Async Redis connections bind to the loop where they are first used.
+_async_clients: WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncRedisClient] = (
+    WeakKeyDictionary()
+)
+_async_client_finalizers: WeakKeyDictionary[
+    asyncio.AbstractEventLoop, AsyncGenerator[None, None]
+] = WeakKeyDictionary()
 
 
 @conn_retry("AsyncRedis", "Releasing connection")
 async def disconnect_async():
     loop = asyncio.get_running_loop()
-    c = _async_clients.pop(id(loop), None)
-    if c is not None:
-        await c.close()
+    client = _async_clients.pop(loop, None)
+    finalizer = _async_client_finalizers.pop(loop, None)
+    if finalizer is not None:
+        await finalizer.aclose()
+    elif client is not None:
+        await client.close()
 
 
 async def get_redis_async() -> AsyncRedisClient:
     loop = asyncio.get_running_loop()
-    client = _async_clients.get(id(loop))
+    client = _async_clients.get(loop)
     if client is None:
         client = await connect_async()
-        _async_clients[id(loop)] = client
+        finalizer = _close_async_client_on_loop_shutdown(client)
+        await anext(finalizer)
+        _async_clients[loop] = client
+        _async_client_finalizers[loop] = finalizer
     return client
+
+
+async def _close_async_client_on_loop_shutdown(
+    client: AsyncRedisClient,
+) -> AsyncGenerator[None, None]:
+    """Close a loop-owned client during ``loop.shutdown_asyncgens()``."""
+    try:
+        yield
+    finally:
+        loop = asyncio.get_running_loop()
+        if _async_clients.get(loop) is client:
+            _async_clients.pop(loop, None)
+        _async_client_finalizers.pop(loop, None)
+        await client.close()
 
 
 # Sharded pub/sub only delivers on the keyslot-owning shard; subscribers

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 from collections.abc import AsyncGenerator
-from weakref import WeakKeyDictionary
+from weakref import ReferenceType, WeakKeyDictionary, ref
 
 from dotenv import load_dotenv
 from redis import Redis
@@ -165,29 +165,43 @@ _async_clients: WeakKeyDictionary[asyncio.AbstractEventLoop, AsyncRedisClient] =
 _async_client_finalizers: WeakKeyDictionary[
     asyncio.AbstractEventLoop, AsyncGenerator[None, None]
 ] = WeakKeyDictionary()
+_async_client_locks: WeakKeyDictionary[
+    asyncio.AbstractEventLoop, ReferenceType[asyncio.Lock]
+] = WeakKeyDictionary()
+
+
+def _get_async_client_lock(loop: asyncio.AbstractEventLoop) -> asyncio.Lock:
+    lock_ref = _async_client_locks.get(loop)
+    lock = lock_ref() if lock_ref is not None else None
+    if lock is None:
+        lock = asyncio.Lock()
+        _async_client_locks[loop] = ref(lock)
+    return lock
 
 
 @conn_retry("AsyncRedis", "Releasing connection")
 async def disconnect_async():
     loop = asyncio.get_running_loop()
-    client = _async_clients.pop(loop, None)
-    finalizer = _async_client_finalizers.pop(loop, None)
-    if finalizer is not None:
-        await finalizer.aclose()
-    elif client is not None:
-        await client.close()
+    async with _get_async_client_lock(loop):
+        client = _async_clients.pop(loop, None)
+        finalizer = _async_client_finalizers.pop(loop, None)
+        if finalizer is not None:
+            await finalizer.aclose()
+        elif client is not None:
+            await client.close()
 
 
 async def get_redis_async() -> AsyncRedisClient:
     loop = asyncio.get_running_loop()
-    client = _async_clients.get(loop)
-    if client is None:
-        client = await connect_async()
-        finalizer = _close_async_client_on_loop_shutdown(client)
-        await anext(finalizer)
-        _async_clients[loop] = client
-        _async_client_finalizers[loop] = finalizer
-    return client
+    async with _get_async_client_lock(loop):
+        client = _async_clients.get(loop)
+        if client is None:
+            client = await connect_async()
+            finalizer = _close_async_client_on_loop_shutdown(client)
+            await anext(finalizer)
+            _async_clients[loop] = client
+            _async_client_finalizers[loop] = finalizer
+        return client
 
 
 async def _close_async_client_on_loop_shutdown(
@@ -200,7 +214,7 @@ async def _close_async_client_on_loop_shutdown(
         loop = asyncio.get_running_loop()
         if _async_clients.get(loop) is client:
             _async_clients.pop(loop, None)
-        _async_client_finalizers.pop(loop, None)
+            _async_client_finalizers.pop(loop, None)
         await client.close()
 
 

--- a/autogpt_platform/backend/backend/data/redis_client_test.py
+++ b/autogpt_platform/backend/backend/data/redis_client_test.py
@@ -3,6 +3,7 @@
 Patches the redis-py constructors + ``ping()`` so no real Redis is needed.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +23,7 @@ def _reset_module_caches() -> None:
     """Flush cached singletons between tests so each test sees a fresh connect."""
     redis_client.get_redis.cache_clear()
     redis_client._async_clients.clear()
+    redis_client._async_client_finalizers.clear()
 
 
 def test_connect_builds_redis_cluster() -> None:
@@ -151,6 +153,25 @@ async def test_get_redis_async_caches_connect() -> None:
     mock_conn.assert_called_once()
 
 
+def test_get_redis_async_closes_client_when_owning_loop_shuts_down() -> None:
+    fake = MagicMock(spec=AsyncRedisCluster)
+    fake.close = AsyncMock()
+
+    with patch.object(redis_client, "connect_async", new=AsyncMock(return_value=fake)):
+        loop = asyncio.new_event_loop()
+        try:
+            client = loop.run_until_complete(redis_client.get_redis_async())
+            assert client is fake
+            assert redis_client._async_clients[loop] is fake
+        finally:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+    fake.close.assert_awaited_once()
+    assert not redis_client._async_clients
+    assert not redis_client._async_client_finalizers
+
+
 def test_disconnect_closes_cached_client() -> None:
     with patch.object(redis_client, "connect", autospec=True) as mock_connect:
         fake = MagicMock(spec=RedisCluster)
@@ -171,7 +192,8 @@ async def test_disconnect_async_closes_cached_client() -> None:
         await redis_client.disconnect_async()
 
     fake.close.assert_awaited_once()
-    assert redis_client._async_clients == {}
+    assert not redis_client._async_clients
+    assert not redis_client._async_client_finalizers
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/data/redis_client_test.py
+++ b/autogpt_platform/backend/backend/data/redis_client_test.py
@@ -24,6 +24,7 @@ def _reset_module_caches() -> None:
     redis_client.get_redis.cache_clear()
     redis_client._async_clients.clear()
     redis_client._async_client_finalizers.clear()
+    redis_client._async_client_locks.clear()
 
 
 def test_connect_builds_redis_cluster() -> None:
@@ -151,6 +152,40 @@ async def test_get_redis_async_caches_connect() -> None:
 
     assert a is b
     mock_conn.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_redis_async_serializes_concurrent_connects() -> None:
+    connect_started = asyncio.Event()
+    allow_connect = asyncio.Event()
+    fake = MagicMock(spec=AsyncRedisCluster)
+    fake.close = AsyncMock()
+
+    async def delayed_connect() -> AsyncRedisCluster:
+        connect_started.set()
+        await allow_connect.wait()
+        return fake
+
+    with patch.object(
+        redis_client,
+        "connect_async",
+        new=AsyncMock(side_effect=delayed_connect),
+    ) as mock_connect:
+        first = asyncio.create_task(redis_client.get_redis_async())
+        second = asyncio.create_task(redis_client.get_redis_async())
+        await connect_started.wait()
+        await asyncio.sleep(0)
+
+        assert mock_connect.await_count == 1
+
+        allow_connect.set()
+        first_client, second_client = await asyncio.gather(first, second)
+        await redis_client.disconnect_async()
+
+    assert first_client is fake
+    assert second_client is fake
+    mock_connect.assert_awaited_once()
+    fake.close.assert_awaited_once()
 
 
 def test_get_redis_async_closes_client_when_owning_loop_shuts_down() -> None:

--- a/autogpt_platform/backend/backend/data/redis_client_test.py
+++ b/autogpt_platform/backend/backend/data/redis_client_test.py
@@ -22,9 +22,6 @@ import backend.data.redis_client as redis_client
 def _reset_module_caches() -> None:
     """Flush cached singletons between tests so each test sees a fresh connect."""
     redis_client.get_redis.cache_clear()
-    redis_client._async_clients.clear()
-    redis_client._async_client_finalizers.clear()
-    redis_client._async_client_locks.clear()
 
 
 def test_connect_builds_redis_cluster() -> None:
@@ -146,12 +143,15 @@ def test_get_redis_caches_connect() -> None:
 async def test_get_redis_async_caches_connect() -> None:
     with patch.object(redis_client, "connect_async", autospec=True) as mock_conn:
         fake = MagicMock(spec=AsyncRedisCluster)
+        fake.close = AsyncMock()
         mock_conn.return_value = fake
         a = await redis_client.get_redis_async()
         b = await redis_client.get_redis_async()
+        await redis_client.disconnect_async()
 
     assert a is b
     mock_conn.assert_called_once()
+    fake.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -232,6 +232,33 @@ async def test_disconnect_async_closes_cached_client() -> None:
 
 
 @pytest.mark.asyncio
+async def test_disconnect_async_preserves_client_when_close_fails() -> None:
+    fake = MagicMock(spec=AsyncRedisCluster)
+    fake.close = AsyncMock(side_effect=[RedisConnectionError("close failed"), None])
+
+    with patch.object(
+        redis_client,
+        "connect_async",
+        new=AsyncMock(return_value=fake),
+    ):
+        await redis_client.get_redis_async()
+        disconnect_once = redis_client.disconnect_async.__wrapped__
+
+        with pytest.raises(RedisConnectionError, match="close failed"):
+            await disconnect_once()
+
+        loop = asyncio.get_running_loop()
+        assert redis_client._async_clients[loop] is fake
+        assert loop in redis_client._async_client_finalizers
+
+        await disconnect_once()
+
+    assert fake.close.await_count == 2
+    assert not redis_client._async_clients
+    assert not redis_client._async_client_finalizers
+
+
+@pytest.mark.asyncio
 async def test_disconnect_async_no_cached_client_is_noop() -> None:
     with patch.object(redis_client, "connect_async", autospec=True) as mock_connect:
         await redis_client.disconnect_async()
@@ -297,7 +324,6 @@ def test_sharded_pubsub_end_to_end_sync() -> None:
 async def test_sharded_spublish_end_to_end_async() -> None:
     """Async cluster client routes SPUBLISH via ``execute_command``
     because redis-py 6.x has no async ``spublish()`` wrapper."""
-    redis_client._async_clients.clear()
     cluster = await redis_client.get_redis_async()
     try:
         res = await cluster.execute_command(

--- a/autogpt_platform/backend/backend/data/redis_client_test.py
+++ b/autogpt_platform/backend/backend/data/redis_client_test.py
@@ -22,6 +22,9 @@ import backend.data.redis_client as redis_client
 def _reset_module_caches() -> None:
     """Flush cached singletons between tests so each test sees a fresh connect."""
     redis_client.get_redis.cache_clear()
+    redis_client._async_clients.clear()
+    redis_client._async_client_finalizers.clear()
+    redis_client._async_client_locks.clear()
 
 
 def test_connect_builds_redis_cluster() -> None:
@@ -143,15 +146,12 @@ def test_get_redis_caches_connect() -> None:
 async def test_get_redis_async_caches_connect() -> None:
     with patch.object(redis_client, "connect_async", autospec=True) as mock_conn:
         fake = MagicMock(spec=AsyncRedisCluster)
-        fake.close = AsyncMock()
         mock_conn.return_value = fake
         a = await redis_client.get_redis_async()
         b = await redis_client.get_redis_async()
-        await redis_client.disconnect_async()
 
     assert a is b
     mock_conn.assert_called_once()
-    fake.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -232,33 +232,6 @@ async def test_disconnect_async_closes_cached_client() -> None:
 
 
 @pytest.mark.asyncio
-async def test_disconnect_async_preserves_client_when_close_fails() -> None:
-    fake = MagicMock(spec=AsyncRedisCluster)
-    fake.close = AsyncMock(side_effect=[RedisConnectionError("close failed"), None])
-
-    with patch.object(
-        redis_client,
-        "connect_async",
-        new=AsyncMock(return_value=fake),
-    ):
-        await redis_client.get_redis_async()
-        disconnect_once = redis_client.disconnect_async.__wrapped__
-
-        with pytest.raises(RedisConnectionError, match="close failed"):
-            await disconnect_once()
-
-        loop = asyncio.get_running_loop()
-        assert redis_client._async_clients[loop] is fake
-        assert loop in redis_client._async_client_finalizers
-
-        await disconnect_once()
-
-    assert fake.close.await_count == 2
-    assert not redis_client._async_clients
-    assert not redis_client._async_client_finalizers
-
-
-@pytest.mark.asyncio
 async def test_disconnect_async_no_cached_client_is_noop() -> None:
     with patch.object(redis_client, "connect_async", autospec=True) as mock_connect:
         await redis_client.disconnect_async()
@@ -324,6 +297,7 @@ def test_sharded_pubsub_end_to_end_sync() -> None:
 async def test_sharded_spublish_end_to_end_async() -> None:
     """Async cluster client routes SPUBLISH via ``execute_command``
     because redis-py 6.x has no async ``spublish()`` wrapper."""
+    redis_client._async_clients.clear()
     cluster = await redis_client.get_redis_async()
     try:
         res = await cluster.execute_command(

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -53,8 +53,10 @@ class SpinTestServer:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await redis_client.disconnect_async()
-        await db.disconnect()
+        try:
+            await redis_client.disconnect_async()
+        finally:
+            await db.disconnect()
 
         self.scheduler.__exit__(exc_type, exc_val, exc_tb)
         self.exec_manager.__exit__(exc_type, exc_val, exc_tb)

--- a/autogpt_platform/backend/backend/util/test.py
+++ b/autogpt_platform/backend/backend/util/test.py
@@ -9,7 +9,7 @@ from autogpt_libs.auth import get_user_id
 
 from backend.api.rest_api import AgentServer
 from backend.blocks._base import Block, BlockSchema
-from backend.data import db
+from backend.data import db, redis_client
 from backend.data.block import initialize_blocks
 from backend.data.db_manager import DatabaseManager
 from backend.data.execution import (
@@ -53,6 +53,7 @@ class SpinTestServer:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await redis_client.disconnect_async()
         await db.disconnect()
 
         self.scheduler.__exit__(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
### Why / What / How

Backend tests can run async Redis calls on multiple pytest event loops in one process. The shared Redis cache keyed clients by `id(loop)` and retained them after loop shutdown, so Python could reuse an integer loop ID and return a client whose connection pool was bound to a closed loop. This surfaced late in the full suite as `RuntimeError: Event loop is closed` from unrelated Copilot session tests.

This PR makes async Redis client ownership follow the actual event-loop object. It registers loop-shutdown cleanup through an async-generator finalizer, so `shutdown_asyncgens()` closes the client and clears both registries before the loop closes. Explicit application shutdown continues to use `disconnect_async()`, and the shared `SpinTestServer` now invokes it during teardown.

### Changes 🏗️

- Key async Redis clients by event-loop object using a weak mapping instead of integer loop IDs.
- Register per-loop finalizers that close clients and clear lifecycle state during loop shutdown.
- Close the shared async Redis client during `SpinTestServer` teardown.
- Add regression coverage proving loop shutdown closes the client and empties both registries.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Redis client module: 22 passed, 6 live-cluster tests skipped locally
  - [x] 500 repeated event-loop lifecycles, alternating implicit loop shutdown and explicit disconnect
  - [x] Focused Ruff, isort, Black, and Pyright checks
  - [x] Full backend suite on Python 3.11, 3.12, and 3.13 passed twice on final commit 0ae95fdcd5
    - An earlier 3.13 repeat hit an unrelated 0.2-second Codex transport timeout; its replacement full suite passed

#### For configuration changes:

- [x] `.env.default` is already compatible with my changes
- [x] `docker-compose.yml` is already compatible with my changes
- [x] No configuration changes are included


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared async Redis lifecycle used across the backend; incorrect teardown could leak connections or close clients on the wrong loop, though scope is test-harness and client caching only.
> 
> **Overview**
> Fixes flaky **`RuntimeError: Event loop is closed`** in tests by tying async Redis client lifetime to the **event loop object**, not recycled `id(loop)` integers.
> 
> **`redis_client`:** Per-loop caches now use **`WeakKeyDictionary`** keyed by the loop, with a **per-loop `asyncio.Lock`** so concurrent `get_redis_async()` calls share one connect. Each client registers an **async-generator finalizer** that runs on `loop.shutdown_asyncgens()` to close the client and clear client/finalizer registries. **`disconnect_async()`** acquires the same lock and tears down via the finalizer (or direct `close()` as fallback).
> 
> **Tests / harness:** New coverage for serialized concurrent connects and automatic close on loop shutdown; **`SpinTestServer`** teardown now calls **`redis_client.disconnect_async()`** before DB disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e944a523eca2d7633f216b619a5189e35e1278a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


