### PR TITLE
fix(backend): stop block docs generator overwriting prose on a rename

### DIFF
--- a/.github/workflows/docs-block-sync.yml
+++ b/.github/workflows/docs-block-sync.yml
@@ -7,6 +7,8 @@ on:
       - "autogpt_platform/backend/backend/blocks/**"
       - "docs/integrations/**"
       - "autogpt_platform/backend/scripts/generate_block_docs.py"
+      # Block display names come from _CAMELCASE_EXCEPTIONS here; editing it renames blocks.
+      - "autogpt_platform/backend/backend/util/text.py"
       - ".github/workflows/docs-block-sync.yml"
   pull_request:
     branches: [master, dev]
@@ -14,6 +16,8 @@ on:
       - "autogpt_platform/backend/backend/blocks/**"
       - "docs/integrations/**"
       - "autogpt_platform/backend/scripts/generate_block_docs.py"
+      # Block display names come from _CAMELCASE_EXCEPTIONS here; editing it renames blocks.
+      - "autogpt_platform/backend/backend/util/text.py"
       - ".github/workflows/docs-block-sync.yml"
 
 jobs:

--- a/autogpt_platform/backend/scripts/generate_block_docs.py
+++ b/autogpt_platform/backend/scripts/generate_block_docs.py
@@ -385,110 +385,6 @@ def extract_manual_content(existing_content: str) -> dict[str, str]:
     return manual_sections
 
 
-class OrphanedManualContentError(Exception):
-    """Manual prose exists under a heading no block claims; regenerating would drop it."""
-
-    def __init__(self, orphans: dict[str, list[tuple[str, list[str]]]]):
-        self.orphans = orphans
-        super().__init__(format_orphan_report(orphans))
-
-
-def find_block_manual_content(
-    existing_content: str,
-    block_name: str,
-    rename_map: dict[str, str] | None = None,
-) -> dict[str, str]:
-    """Manual sections written under this block's heading, or under a --rekey'd old one."""
-    headings = [block_name] + [
-        old for old, new in (rename_map or {}).items() if new == block_name
-    ]
-    for heading in headings:
-        pattern = rf"(?:^|\n)## {re.escape(heading)}\s*\n(.*?)(?=\n---|\Z)"
-        match = re.search(pattern, existing_content, re.DOTALL)
-        if match:
-            return extract_manual_content(match.group(1))
-    return {}
-
-
-def find_orphaned_manual_sections(
-    existing_content: str,
-    block_names: Iterable[str],
-    rename_map: dict[str, str] | None = None,
-) -> list[tuple[str, list[str]]]:
-    """
-    Hand-written prose under headings that no current block claims.
-
-    A block rename changes its generated heading, so the prose written under the old
-    one would otherwise be replaced by a placeholder without anyone being told.
-    Returns [(heading, [manual keys])].
-    """
-    rename_map = rename_map or {}
-    claimed = set(block_names)
-    orphans: list[tuple[str, list[str]]] = []
-
-    for match in re.finditer(
-        r"(?:^|\n)## ([^\n]+?)[ \t]*\n(.*?)(?=\n## |\Z)", existing_content, re.DOTALL
-    ):
-        heading = match.group(1)
-        if heading in claimed or rename_map.get(heading) in claimed:
-            continue
-        written = sorted(
-            key
-            for key, content in extract_manual_content(match.group(2)).items()
-            if key not in FILE_LEVEL_MANUAL_KEYS
-            and content
-            and content not in PLACEHOLDER_TEXTS
-        )
-        if written:
-            orphans.append((heading, written))
-
-    return orphans
-
-
-def collect_orphaned_manual_sections(
-    output_dir: Path,
-    file_mapping: dict[str, list[BlockDoc]],
-    rename_map: dict[str, str] | None = None,
-) -> dict[str, list[tuple[str, list[str]]]]:
-    """Orphaned manual sections across every file the generator is about to rewrite."""
-    orphans = {}
-    for file_path, file_blocks in file_mapping.items():
-        full_path = output_dir / file_path
-        if not full_path.exists():
-            continue
-        file_orphans = find_orphaned_manual_sections(
-            full_path.read_text(), [b.name for b in file_blocks], rename_map
-        )
-        if file_orphans:
-            orphans[str(file_path)] = file_orphans
-    return orphans
-
-
-def format_orphan_report(orphans: dict[str, list[tuple[str, list[str]]]]) -> str:
-    lines = [
-        "Refusing to write: hand-written documentation would be lost.",
-        "",
-        "These headings carry manual content but match no current block —",
-        "most likely a block was renamed and the docs still use its old name:",
-        "",
-    ]
-    for file_path, file_orphans in sorted(orphans.items()):
-        lines.append(f"  {file_path}")
-        for heading, keys in file_orphans:
-            lines.append(f"    ## {heading}  ({', '.join(keys)})")
-    lines += [
-        "",
-        "Carry the prose over to the new name:",
-        "",
-        '    poetry run python scripts/generate_block_docs.py --rekey "OLD NAME=NEW NAME"',
-        "",
-        "Or, if the block really was deleted and the prose should go with it:",
-        "",
-        "    poetry run python scripts/generate_block_docs.py --allow-orphaned-manual",
-    ]
-    return "\n".join(lines)
-
-
 def generate_block_markdown(
     block: BlockDoc,
     manual_content: dict[str, str] | None = None,
@@ -1169,6 +1065,110 @@ def parse_rekey_args(rekey_args: list[str]) -> dict[str, str]:
             raise ValueError(f"--rekey expects OLD=NEW, got {arg!r}")
         rename_map[old.strip()] = new.strip()
     return rename_map
+
+
+def find_block_manual_content(
+    existing_content: str,
+    block_name: str,
+    rename_map: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Manual sections written under this block's heading, or under a --rekey'd old one."""
+    headings = [block_name] + [
+        old for old, new in (rename_map or {}).items() if new == block_name
+    ]
+    for heading in headings:
+        pattern = rf"(?:^|\n)## {re.escape(heading)}\s*\n(.*?)(?=\n---|\Z)"
+        match = re.search(pattern, existing_content, re.DOTALL)
+        if match:
+            return extract_manual_content(match.group(1))
+    return {}
+
+
+def collect_orphaned_manual_sections(
+    output_dir: Path,
+    file_mapping: dict[str, list[BlockDoc]],
+    rename_map: dict[str, str] | None = None,
+) -> dict[str, list[tuple[str, list[str]]]]:
+    """Orphaned manual sections across every file the generator is about to rewrite."""
+    orphans = {}
+    for file_path, file_blocks in file_mapping.items():
+        full_path = output_dir / file_path
+        if not full_path.exists():
+            continue
+        file_orphans = find_orphaned_manual_sections(
+            full_path.read_text(), [b.name for b in file_blocks], rename_map
+        )
+        if file_orphans:
+            orphans[str(file_path)] = file_orphans
+    return orphans
+
+
+def find_orphaned_manual_sections(
+    existing_content: str,
+    block_names: Iterable[str],
+    rename_map: dict[str, str] | None = None,
+) -> list[tuple[str, list[str]]]:
+    """
+    Hand-written prose under headings that no current block claims.
+
+    A block rename changes its generated heading, so the prose written under the old
+    one would otherwise be replaced by a placeholder without anyone being told.
+    Returns [(heading, [manual keys])].
+    """
+    rename_map = rename_map or {}
+    claimed = set(block_names)
+    orphans: list[tuple[str, list[str]]] = []
+
+    for match in re.finditer(
+        r"(?:^|\n)## ([^\n]+?)[ \t]*\n(.*?)(?=\n## |\Z)", existing_content, re.DOTALL
+    ):
+        heading = match.group(1)
+        if heading in claimed or rename_map.get(heading) in claimed:
+            continue
+        written = sorted(
+            key
+            for key, content in extract_manual_content(match.group(2)).items()
+            if key not in FILE_LEVEL_MANUAL_KEYS
+            and content
+            and content not in PLACEHOLDER_TEXTS
+        )
+        if written:
+            orphans.append((heading, written))
+
+    return orphans
+
+
+class OrphanedManualContentError(Exception):
+    """Manual prose exists under a heading no block claims; regenerating would drop it."""
+
+    def __init__(self, orphans: dict[str, list[tuple[str, list[str]]]]):
+        self.orphans = orphans
+        super().__init__(format_orphan_report(orphans))
+
+
+def format_orphan_report(orphans: dict[str, list[tuple[str, list[str]]]]) -> str:
+    lines = [
+        "Refusing to write: hand-written documentation would be lost.",
+        "",
+        "These headings carry manual content but match no current block —",
+        "most likely a block was renamed and the docs still use its old name:",
+        "",
+    ]
+    for file_path, file_orphans in sorted(orphans.items()):
+        lines.append(f"  {file_path}")
+        for heading, keys in file_orphans:
+            lines.append(f"    ## {heading}  ({', '.join(keys)})")
+    lines += [
+        "",
+        "Carry the prose over to the new name:",
+        "",
+        '    poetry run python scripts/generate_block_docs.py --rekey "OLD NAME=NEW NAME"',
+        "",
+        "Or, if the block really was deleted and the prose should go with it:",
+        "",
+        "    poetry run python scripts/generate_block_docs.py --allow-orphaned-manual",
+    ]
+    return "\n".join(lines)
 
 
 if __name__ == "__main__":

--- a/autogpt_platform/backend/scripts/generate_block_docs.py
+++ b/autogpt_platform/backend/scripts/generate_block_docs.py
@@ -14,6 +14,10 @@ Usage:
 
     # Verbose output
     poetry run python scripts/generate_block_docs.py -v
+
+    # Carry hand-written prose over to a renamed block
+    poetry run python scripts/generate_block_docs.py \\
+        --rekey "All Quiet Incident Trigger=AllQuiet Incident Trigger"
 """
 
 import argparse
@@ -24,7 +28,7 @@ import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Type
+from typing import TYPE_CHECKING, Any, Iterable, Type
 
 if TYPE_CHECKING:
     from backend.blocks._base import AnyBlockSchema
@@ -45,6 +49,16 @@ DEFAULT_OUTPUT_DIR = (
     / "integrations"
     / "block-integrations"
 )
+
+HOW_IT_WORKS_PLACEHOLDER = "_Add technical explanation here._"
+USE_CASE_PLACEHOLDER = "_Add practical use case examples here._"
+FILE_DESCRIPTION_PLACEHOLDER = "_Add a description of this category of blocks._"
+PLACEHOLDER_TEXTS = frozenset(
+    {HOW_IT_WORKS_PLACEHOLDER, USE_CASE_PLACEHOLDER, FILE_DESCRIPTION_PLACEHOLDER}
+)
+
+# Manual keys owned by the file as a whole rather than by a single block heading.
+FILE_LEVEL_MANUAL_KEYS = frozenset({"file_description", "additional_content"})
 
 
 @dataclass
@@ -371,6 +385,110 @@ def extract_manual_content(existing_content: str) -> dict[str, str]:
     return manual_sections
 
 
+class OrphanedManualContentError(Exception):
+    """Manual prose exists under a heading no block claims; regenerating would drop it."""
+
+    def __init__(self, orphans: dict[str, list[tuple[str, list[str]]]]):
+        self.orphans = orphans
+        super().__init__(format_orphan_report(orphans))
+
+
+def find_block_manual_content(
+    existing_content: str,
+    block_name: str,
+    rename_map: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Manual sections written under this block's heading, or under a --rekey'd old one."""
+    headings = [block_name] + [
+        old for old, new in (rename_map or {}).items() if new == block_name
+    ]
+    for heading in headings:
+        pattern = rf"(?:^|\n)## {re.escape(heading)}\s*\n(.*?)(?=\n---|\Z)"
+        match = re.search(pattern, existing_content, re.DOTALL)
+        if match:
+            return extract_manual_content(match.group(1))
+    return {}
+
+
+def find_orphaned_manual_sections(
+    existing_content: str,
+    block_names: Iterable[str],
+    rename_map: dict[str, str] | None = None,
+) -> list[tuple[str, list[str]]]:
+    """
+    Hand-written prose under headings that no current block claims.
+
+    A block rename changes its generated heading, so the prose written under the old
+    one would otherwise be replaced by a placeholder without anyone being told.
+    Returns [(heading, [manual keys])].
+    """
+    rename_map = rename_map or {}
+    claimed = set(block_names)
+    orphans: list[tuple[str, list[str]]] = []
+
+    for match in re.finditer(
+        r"(?:^|\n)## ([^\n]+?)[ \t]*\n(.*?)(?=\n## |\Z)", existing_content, re.DOTALL
+    ):
+        heading = match.group(1)
+        if heading in claimed or rename_map.get(heading) in claimed:
+            continue
+        written = sorted(
+            key
+            for key, content in extract_manual_content(match.group(2)).items()
+            if key not in FILE_LEVEL_MANUAL_KEYS
+            and content
+            and content not in PLACEHOLDER_TEXTS
+        )
+        if written:
+            orphans.append((heading, written))
+
+    return orphans
+
+
+def collect_orphaned_manual_sections(
+    output_dir: Path,
+    file_mapping: dict[str, list[BlockDoc]],
+    rename_map: dict[str, str] | None = None,
+) -> dict[str, list[tuple[str, list[str]]]]:
+    """Orphaned manual sections across every file the generator is about to rewrite."""
+    orphans = {}
+    for file_path, file_blocks in file_mapping.items():
+        full_path = output_dir / file_path
+        if not full_path.exists():
+            continue
+        file_orphans = find_orphaned_manual_sections(
+            full_path.read_text(), [b.name for b in file_blocks], rename_map
+        )
+        if file_orphans:
+            orphans[str(file_path)] = file_orphans
+    return orphans
+
+
+def format_orphan_report(orphans: dict[str, list[tuple[str, list[str]]]]) -> str:
+    lines = [
+        "Refusing to write: hand-written documentation would be lost.",
+        "",
+        "These headings carry manual content but match no current block —",
+        "most likely a block was renamed and the docs still use its old name:",
+        "",
+    ]
+    for file_path, file_orphans in sorted(orphans.items()):
+        lines.append(f"  {file_path}")
+        for heading, keys in file_orphans:
+            lines.append(f"    ## {heading}  ({', '.join(keys)})")
+    lines += [
+        "",
+        "Carry the prose over to the new name:",
+        "",
+        '    poetry run python scripts/generate_block_docs.py --rekey "OLD NAME=NEW NAME"',
+        "",
+        "Or, if the block really was deleted and the prose should go with it:",
+        "",
+        "    poetry run python scripts/generate_block_docs.py --allow-orphaned-manual",
+    ]
+    return "\n".join(lines)
+
+
 def generate_block_markdown(
     block: BlockDoc,
     manual_content: dict[str, str] | None = None,
@@ -390,9 +508,7 @@ def generate_block_markdown(
 
     # How it works (manual section)
     lines.append("### How it works")
-    how_it_works = manual_content.get(
-        "how_it_works", "_Add technical explanation here._"
-    )
+    how_it_works = manual_content.get("how_it_works", HOW_IT_WORKS_PLACEHOLDER)
     lines.append("<!-- MANUAL: how_it_works -->")
     lines.append(how_it_works)
     lines.append("<!-- END MANUAL -->")
@@ -433,7 +549,7 @@ def generate_block_markdown(
 
     # Possible use case (manual section)
     lines.append("### Possible use case")
-    use_case = manual_content.get("use_case", "_Add practical use case examples here._")
+    use_case = manual_content.get("use_case", USE_CASE_PLACEHOLDER)
     lines.append("<!-- MANUAL: use_case -->")
     lines.append(use_case)
     lines.append("<!-- END MANUAL -->")
@@ -689,9 +805,14 @@ def write_block_docs(
     output_dir: Path,
     blocks: list[BlockDoc],
     verbose: bool = False,
+    rename_map: dict[str, str] | None = None,
+    allow_orphaned_manual: bool = False,
 ) -> dict[str, str]:
     """
     Write block documentation files.
+
+    Raises OrphanedManualContentError if any file holds manual prose that no block
+    claims, so a rename cannot silently overwrite it.
 
     Returns dict of {file_path: content} for all generated files.
     """
@@ -699,6 +820,12 @@ def write_block_docs(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     file_mapping = get_block_file_mapping(blocks)
+
+    # Checked across every file before writing any, so a refusal leaves the docs intact.
+    orphans = collect_orphaned_manual_sections(output_dir, file_mapping, rename_map)
+    if orphans and not allow_orphaned_manual:
+        raise OrphanedManualContentError(orphans)
+
     generated_files = {}
 
     for file_path, file_blocks in file_mapping.items():
@@ -724,7 +851,7 @@ def write_block_docs(
         if file_header_match:
             file_description = file_header_match.group(1)
         else:
-            file_description = "_Add a description of this category of blocks._"
+            file_description = FILE_DESCRIPTION_PLACEHOLDER
 
         # Generate file header
         file_header = f"# {file_title}\n"
@@ -735,15 +862,9 @@ def write_block_docs(
         # Generate content for each block
         content_parts = []
         for block in sorted(file_blocks, key=lambda b: b.name):
-            # Extract manual content specific to this block
-            # Match block heading (h2) and capture until --- separator
-            block_pattern = rf"(?:^|\n)## {re.escape(block.name)}\s*\n(.*?)(?=\n---|\Z)"
-            block_match = re.search(block_pattern, existing_content, re.DOTALL)
-            if block_match:
-                manual_content = extract_manual_content(block_match.group(1))
-            else:
-                manual_content = {}
-
+            manual_content = find_block_manual_content(
+                existing_content, block.name, rename_map
+            )
             content_parts.append(
                 generate_block_markdown(
                     block,
@@ -795,7 +916,11 @@ def write_block_docs(
     return generated_files
 
 
-def check_docs_in_sync(output_dir: Path, blocks: list[BlockDoc]) -> bool:
+def check_docs_in_sync(
+    output_dir: Path,
+    blocks: list[BlockDoc],
+    rename_map: dict[str, str] | None = None,
+) -> bool:
     """
     Check if generated docs match existing docs.
 
@@ -806,6 +931,7 @@ def check_docs_in_sync(output_dir: Path, blocks: list[BlockDoc]) -> bool:
 
     all_match = True
     out_of_sync_details: list[tuple[str, list[str]]] = []
+    orphans = collect_orphaned_manual_sections(output_dir, file_mapping, rename_map)
 
     for file_path, file_blocks in file_mapping.items():
         full_path = output_dir / file_path
@@ -832,7 +958,7 @@ def check_docs_in_sync(output_dir: Path, blocks: list[BlockDoc]) -> bool:
         if file_header_match:
             file_description = file_header_match.group(1)
         else:
-            file_description = "_Add a description of this category of blocks._"
+            file_description = FILE_DESCRIPTION_PLACEHOLDER
 
         # Generate expected file header
         file_header = f"# {file_title}\n"
@@ -841,14 +967,12 @@ def check_docs_in_sync(output_dir: Path, blocks: list[BlockDoc]) -> bool:
         file_header += "<!-- END MANUAL -->\n"
 
         # Extract manual content from existing file
-        manual_sections_by_block = {}
-        for block in file_blocks:
-            block_pattern = rf"(?:^|\n)## {re.escape(block.name)}\s*\n(.*?)(?=\n---|\Z)"
-            block_match = re.search(block_pattern, existing_content, re.DOTALL)
-            if block_match:
-                manual_sections_by_block[block.name] = extract_manual_content(
-                    block_match.group(1)
-                )
+        manual_sections_by_block = {
+            block.name: find_block_manual_content(
+                existing_content, block.name, rename_map
+            )
+            for block in file_blocks
+        }
 
         # Generate expected content and check each block individually
         content_parts = []
@@ -923,28 +1047,29 @@ def check_docs_in_sync(output_dir: Path, blocks: list[BlockDoc]) -> bool:
         out_of_sync_details.append(("SUMMARY.md", ["navigation"]))
         all_match = False
 
-    # Check for unfilled manual sections
-    unfilled_patterns = [
-        "_Add a description of this category of blocks._",
-        "_Add technical explanation here._",
-        "_Add practical use case examples here._",
-    ]
+    # Unfilled sections fail the check: the state left behind by a wipe is otherwise
+    # indistinguishable from "in sync", which is how one passed CI.
     files_with_unfilled = []
     for file_path in file_mapping.keys():
         full_path = output_dir / file_path
         if full_path.exists():
             content = full_path.read_text()
-            unfilled_count = sum(1 for p in unfilled_patterns if p in content)
+            unfilled_count = sum(1 for p in PLACEHOLDER_TEXTS if p in content)
             if unfilled_count > 0:
                 files_with_unfilled.append((file_path, unfilled_count))
 
     if files_with_unfilled:
-        print("\nWARNING: Files with unfilled manual sections:")
+        print("\nUNFILLED: files with placeholder manual sections:")
         for file_path, count in sorted(files_with_unfilled):
             print(f"  {file_path}: {count} unfilled section(s)")
         print(
             f"\nTotal: {len(files_with_unfilled)} files with unfilled manual sections"
         )
+        all_match = False
+
+    if orphans:
+        print("\n" + format_orphan_report(orphans))
+        all_match = False
 
     return all_match
 
@@ -970,8 +1095,26 @@ def main():
         action="store_true",
         help="Verbose output",
     )
+    parser.add_argument(
+        "--rekey",
+        action="append",
+        default=[],
+        metavar="OLD=NEW",
+        help="Carry manual prose from an old block heading over to its new name "
+        "(repeatable)",
+    )
+    parser.add_argument(
+        "--allow-orphaned-manual",
+        action="store_true",
+        help="Overwrite manual prose that no block claims, e.g. after a real deletion",
+    )
 
     args = parser.parse_args()
+
+    try:
+        rename_map = parse_rekey_args(args.rekey)
+    except ValueError as e:
+        parser.error(str(e))
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -984,7 +1127,7 @@ def main():
 
     if args.check:
         print(f"Checking docs in {args.output_dir}...")
-        in_sync = check_docs_in_sync(args.output_dir, blocks)
+        in_sync = check_docs_in_sync(args.output_dir, blocks, rename_map)
         if in_sync:
             print("All documentation is in sync!")
             sys.exit(0)
@@ -1003,12 +1146,29 @@ def main():
             sys.exit(1)
     else:
         print(f"Generating docs to {args.output_dir}...")
-        write_block_docs(
-            args.output_dir,
-            blocks,
-            verbose=args.verbose,
-        )
+        try:
+            write_block_docs(
+                args.output_dir,
+                blocks,
+                verbose=args.verbose,
+                rename_map=rename_map,
+                allow_orphaned_manual=args.allow_orphaned_manual,
+            )
+        except OrphanedManualContentError as e:
+            print("\n" + str(e), file=sys.stderr)
+            sys.exit(1)
         print("Done!")
+
+
+def parse_rekey_args(rekey_args: list[str]) -> dict[str, str]:
+    """Parse repeated --rekey "OLD=NEW" arguments into {old heading: new heading}."""
+    rename_map = {}
+    for arg in rekey_args:
+        old, sep, new = arg.partition("=")
+        if not sep or not old.strip() or not new.strip():
+            raise ValueError(f"--rekey expects OLD=NEW, got {arg!r}")
+        rename_map[old.strip()] = new.strip()
+    return rename_map
 
 
 if __name__ == "__main__":

--- a/autogpt_platform/backend/scripts/test_generate_block_docs.py
+++ b/autogpt_platform/backend/scripts/test_generate_block_docs.py
@@ -4,12 +4,19 @@
 import pytest
 
 from scripts.generate_block_docs import (
+    BlockDoc,
+    OrphanedManualContentError,
     class_name_to_display_name,
+    collect_orphaned_manual_sections,
     extract_manual_content,
     file_path_to_title,
+    find_block_manual_content,
+    find_orphaned_manual_sections,
     generate_anchor,
     generate_overview_table,
+    parse_rekey_args,
     type_to_readable,
+    write_block_docs,
 )
 
 
@@ -233,6 +240,175 @@ class TestOverviewGuideLinks:
         overview = generate_overview_table([])
         assert "(https://agpt.co/docs/platform/new-blocks)" in overview
         assert "(https://agpt.co/docs/platform/block-sdk-guide)" in overview
+
+
+class TestOrphanedManualSections:
+    """A block rename must not let the generator overwrite prose (OPEN-3458)."""
+
+    def test_renamed_block_orphans_its_prose(self):
+        orphans = find_orphaned_manual_sections(
+            RENAMED_DOC, ["AllQuiet Create Incident"]
+        )
+        assert orphans == [("All Quiet Create Incident", ["how_it_works", "use_case"])]
+
+    def test_matching_heading_is_not_orphaned(self):
+        orphans = find_orphaned_manual_sections(
+            RENAMED_DOC, ["All Quiet Create Incident"]
+        )
+        assert orphans == []
+
+    def test_rekey_rescues_the_prose(self):
+        orphans = find_orphaned_manual_sections(
+            RENAMED_DOC,
+            ["AllQuiet Create Incident"],
+            {"All Quiet Create Incident": "AllQuiet Create Incident"},
+        )
+        assert orphans == []
+
+    def test_placeholders_are_not_worth_saving(self):
+        doc = RENAMED_DOC.replace(
+            "Posts to the incident endpoint.", "_Add technical explanation here._"
+        ).replace(
+            "A triage agent pages the responder.",
+            "_Add practical use case examples here._",
+        )
+        assert find_orphaned_manual_sections(doc, ["AllQuiet Create Incident"]) == []
+
+    def test_file_level_sections_belong_to_no_block(self):
+        doc = RENAMED_DOC + (
+            "\n<!-- MANUAL: additional_content -->\nFile-level notes.\n<!-- END MANUAL -->\n"
+        )
+        orphans = find_orphaned_manual_sections(doc, ["AllQuiet Create Incident"])
+        assert orphans == [("All Quiet Create Incident", ["how_it_works", "use_case"])]
+
+    def test_collect_reports_the_file(self, tmp_path):
+        doc_path = tmp_path / "allquiet" / "incidents.md"
+        doc_path.parent.mkdir()
+        doc_path.write_text(RENAMED_DOC)
+
+        orphans = collect_orphaned_manual_sections(
+            tmp_path,
+            {"allquiet/incidents.md": [make_block("AllQuiet Create Incident")]},
+        )
+        assert orphans == {
+            "allquiet/incidents.md": [
+                ("All Quiet Create Incident", ["how_it_works", "use_case"])
+            ]
+        }
+
+
+class TestFindBlockManualContent:
+    def test_reads_prose_under_the_current_heading(self):
+        manual = find_block_manual_content(RENAMED_DOC, "All Quiet Create Incident")
+        assert manual["how_it_works"] == "Posts to the incident endpoint."
+
+    def test_falls_back_to_a_rekeyed_heading(self):
+        manual = find_block_manual_content(
+            RENAMED_DOC,
+            "AllQuiet Create Incident",
+            {"All Quiet Create Incident": "AllQuiet Create Incident"},
+        )
+        assert manual["how_it_works"] == "Posts to the incident endpoint."
+
+    def test_unknown_heading_yields_nothing(self):
+        assert find_block_manual_content(RENAMED_DOC, "AllQuiet Create Incident") == {}
+
+
+class TestWriteRefusesToDropProse:
+    def test_raises_and_leaves_the_file_untouched(self, tmp_path):
+        doc_path = tmp_path / "allquiet" / "incidents.md"
+        doc_path.parent.mkdir()
+        doc_path.write_text(RENAMED_DOC)
+
+        with pytest.raises(OrphanedManualContentError) as excinfo:
+            write_block_docs(tmp_path, [make_block("AllQuiet Create Incident")])
+
+        assert "All Quiet Create Incident" in str(excinfo.value)
+        assert "--rekey" in str(excinfo.value)
+        assert doc_path.read_text() == RENAMED_DOC
+
+    def test_rekey_carries_the_prose_over(self, tmp_path):
+        doc_path = tmp_path / "allquiet" / "incidents.md"
+        doc_path.parent.mkdir()
+        doc_path.write_text(RENAMED_DOC)
+
+        write_block_docs(
+            tmp_path,
+            [make_block("AllQuiet Create Incident")],
+            rename_map={"All Quiet Create Incident": "AllQuiet Create Incident"},
+        )
+
+        written = doc_path.read_text()
+        assert "## AllQuiet Create Incident" in written
+        assert "Posts to the incident endpoint." in written
+        assert "_Add technical explanation here._" not in written
+
+    def test_allow_orphaned_manual_is_an_explicit_opt_in(self, tmp_path):
+        doc_path = tmp_path / "allquiet" / "incidents.md"
+        doc_path.parent.mkdir()
+        doc_path.write_text(RENAMED_DOC)
+
+        write_block_docs(
+            tmp_path,
+            [make_block("AllQuiet Create Incident")],
+            allow_orphaned_manual=True,
+        )
+
+        assert "_Add technical explanation here._" in doc_path.read_text()
+
+
+class TestParseRekeyArgs:
+    def test_parses_pairs(self):
+        assert parse_rekey_args(["All Quiet Foo=AllQuiet Foo"]) == {
+            "All Quiet Foo": "AllQuiet Foo"
+        }
+
+    def test_strips_surrounding_whitespace(self):
+        assert parse_rekey_args([" Old Name = New Name "]) == {"Old Name": "New Name"}
+
+    @pytest.mark.parametrize("arg", ["no separator", "=New Name", "Old Name="])
+    def test_rejects_malformed_pairs(self, arg: str):
+        with pytest.raises(ValueError):
+            parse_rekey_args([arg])
+
+
+RENAMED_DOC = """# All Quiet Incidents
+<!-- MANUAL: file_description -->
+Blocks that create All Quiet incidents.
+<!-- END MANUAL -->
+
+## All Quiet Create Incident
+
+### What it is
+Creates an incident.
+
+### How it works
+<!-- MANUAL: how_it_works -->
+Posts to the incident endpoint.
+<!-- END MANUAL -->
+
+### Possible use case
+<!-- MANUAL: use_case -->
+A triage agent pages the responder.
+<!-- END MANUAL -->
+
+---
+"""
+
+
+def make_block(name: str) -> BlockDoc:
+    return BlockDoc(
+        id="test-block-id",
+        name=name,
+        class_name="AllQuietCreateIncidentBlock",
+        description="Creates an incident.",
+        categories=["COMMUNICATION"],
+        category_descriptions={},
+        inputs=[],
+        outputs=[],
+        block_type="Standard",
+        source_file="blocks/allquiet/incidents.py",
+    )
 
 
 if __name__ == "__main__":

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -494,13 +494,13 @@ Below is a comprehensive list of all available blocks, categorized by their prim
 
 | Block Name | Description |
 |------------|-------------|
-| [All Quiet Create Incident](block-integrations/allquiet/incidents.md#all-quiet-create-incident) | Creates an incident in All Quiet and pages the on-call responder |
-| [All Quiet Get Incident](block-integrations/allquiet/incident_search.md#all-quiet-get-incident) | Fetches a single All Quiet incident by ID |
-| [All Quiet Get On Call](block-integrations/allquiet/on_call.md#all-quiet-get-on-call) | Looks up who is on call in All Quiet, now or at a given time |
-| [All Quiet Incident Trigger](block-integrations/allquiet/triggers.md#all-quiet-incident-trigger) | Triggers a graph when All Quiet posts an incident to this webhook |
-| [All Quiet List Incidents](block-integrations/allquiet/incident_search.md#all-quiet-list-incidents) | Searches All Quiet incidents by status, severity, team or text |
-| [All Quiet List Teams](block-integrations/allquiet/teams.md#all-quiet-list-teams) | Lists All Quiet teams and their IDs |
-| [All Quiet Update Incident](block-integrations/allquiet/incidents.md#all-quiet-update-incident) | Investigates, resolves, escalates or comments on an All Quiet incident |
+| [AllQuiet Create Incident](block-integrations/allquiet/incidents.md#allquiet-create-incident) | Creates an incident in All Quiet and pages the on-call responder |
+| [AllQuiet Get Incident](block-integrations/allquiet/incident_search.md#allquiet-get-incident) | Fetches a single All Quiet incident by ID |
+| [AllQuiet Get On Call](block-integrations/allquiet/on_call.md#allquiet-get-on-call) | Looks up who is on call in All Quiet, now or at a given time |
+| [AllQuiet Incident Trigger](block-integrations/allquiet/triggers.md#allquiet-incident-trigger) | Triggers a graph when All Quiet posts an incident to this webhook |
+| [AllQuiet List Incidents](block-integrations/allquiet/incident_search.md#allquiet-list-incidents) | Searches All Quiet incidents by status, severity, team or text |
+| [AllQuiet List Teams](block-integrations/allquiet/teams.md#allquiet-list-teams) | Lists All Quiet teams and their IDs |
+| [AllQuiet Update Incident](block-integrations/allquiet/incidents.md#allquiet-update-incident) | Investigates, resolves, escalates or comments on an All Quiet incident |
 | [Exa Code Context](block-integrations/exa/code_context.md#exa-code-context) | Search billions of GitHub repos, docs, and Stack Overflow for relevant code examples |
 | [Execute Code](block-integrations/misc.md#execute-code) | Executes code in a sandbox environment with internet access |
 | [Execute Code Step](block-integrations/misc.md#execute-code-step) | Execute code in a previously instantiated sandbox |

--- a/docs/integrations/block-integrations/allquiet/incident_search.md
+++ b/docs/integrations/block-integrations/allquiet/incident_search.md
@@ -3,7 +3,7 @@
 Blocks that read All Quiet incidents — fetching a single incident by ID, or searching the incident list by status, severity, team, text or time range.
 <!-- END MANUAL -->
 
-## All Quiet Get Incident
+## AllQuiet Get Incident
 
 ### What it is
 Fetches a single All Quiet incident by ID
@@ -39,7 +39,7 @@ A triage agent receives an incident ID from the trigger block, fetches it with `
 
 ---
 
-## All Quiet List Incidents
+## AllQuiet List Incidents
 
 ### What it is
 Searches All Quiet incidents by status, severity, team or text

--- a/docs/integrations/block-integrations/allquiet/incidents.md
+++ b/docs/integrations/block-integrations/allquiet/incidents.md
@@ -3,7 +3,7 @@
 Blocks that create All Quiet incidents and move them through their lifecycle. Use these when an agent needs to raise an alert that reaches a human, or to acknowledge, resolve, escalate or comment on one it already raised.
 <!-- END MANUAL -->
 
-## All Quiet Create Incident
+## AllQuiet Create Incident
 
 ### What it is
 Creates an incident in All Quiet and pages the on-call responder
@@ -44,7 +44,7 @@ An agent monitoring error rates notices checkout failures spiking. Rather than p
 
 ---
 
-## All Quiet Update Incident
+## AllQuiet Update Incident
 
 ### What it is
 Investigates, resolves, escalates or comments on an All Quiet incident

--- a/docs/integrations/block-integrations/allquiet/on_call.md
+++ b/docs/integrations/block-integrations/allquiet/on_call.md
@@ -3,7 +3,7 @@
 A block for reading All Quiet's on-call rotation: who is responsible right now, or who was (or will be) at any other point in time.
 <!-- END MANUAL -->
 
-## All Quiet Get On Call
+## AllQuiet Get On Call
 
 ### What it is
 Looks up who is on call in All Quiet, now or at a given time

--- a/docs/integrations/block-integrations/allquiet/teams.md
+++ b/docs/integrations/block-integrations/allquiet/teams.md
@@ -3,7 +3,7 @@
 A block for listing All Quiet teams. Mainly used to resolve the team IDs that the incident and on-call blocks accept as inputs.
 <!-- END MANUAL -->
 
-## All Quiet List Teams
+## AllQuiet List Teams
 
 ### What it is
 Lists All Quiet teams and their IDs

--- a/docs/integrations/block-integrations/allquiet/triggers.md
+++ b/docs/integrations/block-integrations/allquiet/triggers.md
@@ -3,7 +3,7 @@
 A webhook trigger that starts a graph when All Quiet posts an incident to it, so agents can react to incidents rather than only create them.
 <!-- END MANUAL -->
 
-## All Quiet Incident Trigger
+## AllQuiet Incident Trigger
 
 ### What it is
 Triggers a graph when All Quiet posts an incident to this webhook


### PR DESCRIPTION
### Why / What / How

**Why.** Block docs carry hand-written prose in `<!-- MANUAL: ... -->` regions, matched to a block by its `## Heading`. Rename a block in code and the generated heading changes, so the generator finds no match, treats it as "this block never had prose", and writes `_Add technical explanation here._` over it. Silently, and for whoever next runs the generator rather than whoever did the rename.

#14258 renamed the AllQuiet blocks (`All Quiet X` → `AllQuiet X`). The next agent to run the generator, on unrelated work, destroyed **14 hand-written paragraphs across 5 files** under a 28-line diffstat. Caught by eye before merge.

Two things made it worse: `check-docs-sync` goes red after a rename and the obvious remedy — run the generator, commit the result — is exactly the destructive action; and `check_docs_in_sync` printed `WARNING: Files with unfilled manual sections` and then returned success, so `--check` exited 0 over a fresh wipe.

Exposure today: **1299 hand-written MANUAL blocks across 161 files**, any of which a block rename reaches.

**What/How.** The generator now refuses to discard manual content it cannot match, and `--check` can no longer report a wipe as healthy.

Resolves #14261

### Changes 🏗️

**`scripts/generate_block_docs.py`**
- `write_block_docs` scans every file for orphaned manual sections **before writing any of them**, and raises `OrphanedManualContentError` naming each orphaned heading, its file, and its manual keys. A refusal leaves the docs completely untouched.
- `--rekey "OLD NAME=NEW NAME"` (repeatable) carries prose from an old heading over to the renamed block — the migration path, and what the error message points you at.
- `--allow-orphaned-manual` opts back into overwriting, for a genuine block deletion.
- `check_docs_in_sync` reports orphans too, and now returns `False` on placeholder sections instead of warning and exiting 0.
- Placeholder strings lifted to module constants; two copies of the block-section lookup collapsed into `find_block_manual_content`.

**`.github/workflows/docs-block-sync.yml`** — added `backend/backend/util/text.py` to both path filters. The generator imports `_CAMELCASE_EXCEPTIONS` from it, so #14258's edit renamed blocks without ever triggering the docs check.

**`docs/integrations/.../allquiet/*`** — re-keyed with the new flag, so all 14 paragraphs move to the new headings intact. This is what makes `--check` green again on dev; it is a heading + overview-table change only, zero prose lines touched.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] **Reproduced the bug before the change.** `dev` already carries the live rename, so no synthetic setup was needed. Running the generator against a copy of `docs/integrations` replaced 14 prose paragraphs with placeholders across the 5 AllQuiet files and **exited 0**.
  - [x] **Same run after the change** exits **1** with the report below, and `diff -rq` against the original tree shows **no files modified** — the refusal is checked before anything is written.
  - [x] `--check` on the unfixed docs exits 1 and prints the same orphan report, instead of pointing only at the destructive remedy.
  - [x] **Migration path:** the 7-flag `--rekey` run preserves every paragraph — the whole diff is 7 headings plus their overview-table links, 0 placeholder lines introduced.
  - [x] **Normal path unaffected:** after re-keying, a plain run is byte-idempotent (docs tree hash unchanged by a second run) and `--check` exits 0 **with the prose in place**.
  - [x] `poetry run pytest scripts/test_generate_block_docs.py` — **51 passed** (17 new, covering orphan detection, placeholder-only sections being ignored, file-level keys not being attributed to a block, `--rekey` rescue, the write refusal leaving the file untouched, `--allow-orphaned-manual`, and `--rekey` arg parsing).

<details>
<summary>Guard firing on the real case</summary>

```
$ poetry run python scripts/generate_block_docs.py

Refusing to write: hand-written documentation would be lost.

These headings carry manual content but match no current block —
most likely a block was renamed and the docs still use its old name:

  allquiet/incident_search.md
    ## All Quiet Get Incident  (how_it_works, use_case)
    ## All Quiet List Incidents  (how_it_works, use_case)
  allquiet/incidents.md
    ## All Quiet Create Incident  (how_it_works, use_case)
    ## All Quiet Update Incident  (how_it_works, use_case)
  allquiet/on_call.md
    ## All Quiet Get On Call  (how_it_works, use_case)
  allquiet/teams.md
    ## All Quiet List Teams  (how_it_works, use_case)
  allquiet/triggers.md
    ## All Quiet Incident Trigger  (how_it_works, use_case)

Carry the prose over to the new name:

    poetry run python scripts/generate_block_docs.py --rekey "OLD NAME=NEW NAME"

Or, if the block really was deleted and the prose should go with it:

    poetry run python scripts/generate_block_docs.py --allow-orphaned-manual

exit=1
```

14 orphaned manual keys across 7 headings and 5 files — exactly the 14 paragraphs the incident lost.
</details>

#### Note on the stricter `--check`

Placeholder sections now fail the check. There are currently **zero** placeholders anywhere under `docs/`, so this is green on `dev` today; the cost is that a newly added block needs its two manual sections written before CI passes. That is the point — the state immediately after a wipe is otherwise indistinguishable from "in sync".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3hUw1N1Hais4W9VNihxbQ
