### PR TITLE
fix(frontend/builder): show error toast when a requested graph fails to load

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/build/__tests__/useFlow.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/__tests__/useFlow.test.ts
@@ -15,6 +15,16 @@ vi.mock("@xyflow/react", async () => {
   };
 });
 
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
 const mockSetQueryStates = vi.fn();
 let mockQueryStateValues: {
   flowID: string | null;
@@ -34,11 +44,14 @@ vi.mock("nuqs", () => ({
 
 let mockGraphLoading = false;
 let mockBlocksLoading = false;
+let mockGraphError: unknown = undefined;
 
 vi.mock("@/app/api/__generated__/endpoints/graphs/graphs", () => ({
   useGetV1GetSpecificGraph: vi.fn(() => ({
     data: undefined,
     isLoading: mockGraphLoading,
+    isError: !!mockGraphError,
+    error: mockGraphError,
   })),
   useGetV1GetExecutionDetails: vi.fn(() => ({
     data: undefined,
@@ -80,6 +93,7 @@ describe("useFlow", () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     mockGraphLoading = false;
     mockBlocksLoading = false;
+    mockGraphError = undefined;
     mockIsReadOnly = false;
     mockQueryStateValues = {
       flowID: null,
@@ -173,6 +187,54 @@ describe("useFlow", () => {
       });
 
       expect(result.current.isLocked).toBe(true);
+    });
+  });
+
+  describe("graph load failure", () => {
+    it("toasts the reason and redirects to the library when the fetch fails", async () => {
+      mockGraphError = new Error("not found");
+      mockQueryStateValues = {
+        flowID: "test-flow",
+        flowVersion: 1,
+        flowExecutionID: null,
+      };
+
+      const { useFlow } = await import("../components/FlowEditor/Flow/useFlow");
+      renderHook(() => useFlow());
+
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "destructive" }),
+      );
+      expect(mockPush).toHaveBeenCalledWith("/library");
+    });
+
+    it("does nothing when there is no flowID to load", async () => {
+      mockGraphError = new Error("not found");
+      mockQueryStateValues = {
+        flowID: null,
+        flowVersion: null,
+        flowExecutionID: null,
+      };
+
+      const { useFlow } = await import("../components/FlowEditor/Flow/useFlow");
+      renderHook(() => useFlow());
+
+      expect(mockToast).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("does not toast or redirect when the graph loads successfully", async () => {
+      mockQueryStateValues = {
+        flowID: "test-flow",
+        flowVersion: 1,
+        flowExecutionID: null,
+      };
+
+      const { useFlow } = await import("../components/FlowEditor/Flow/useFlow");
+      renderHook(() => useFlow());
+
+      expect(mockToast).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/build/__tests__/useIsReadOnlyGraph.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/__tests__/useIsReadOnlyGraph.test.tsx
@@ -17,8 +17,12 @@ vi.mock("nuqs", () => ({
 }));
 
 let mockGraph: { id: string; user_id: string } | undefined;
+let mockIsGraphError = false;
 vi.mock("@/app/api/__generated__/endpoints/graphs/graphs", () => ({
-  useGetV1GetSpecificGraph: vi.fn(() => ({ data: mockGraph })),
+  useGetV1GetSpecificGraph: vi.fn(() => ({
+    data: mockGraph,
+    isError: mockIsGraphError,
+  })),
 }));
 
 import { useIsReadOnlyGraph } from "../hooks/useIsReadOnlyGraph";
@@ -29,6 +33,7 @@ describe("useIsReadOnlyGraph", () => {
     mockUser = { id: "user-1" };
     mockIsUserLoading = false;
     mockGraph = { id: "graph-1", user_id: "user-1" };
+    mockIsGraphError = false;
   });
 
   afterEach(() => {
@@ -73,6 +78,15 @@ describe("useIsReadOnlyGraph", () => {
     mockUser = null;
     mockIsUserLoading = false;
     mockGraph = { id: "graph-1", user_id: "other-user" };
+
+    const { result } = renderHook(() => useIsReadOnlyGraph());
+
+    expect(result.current.isReadOnly).toBe(true);
+  });
+
+  it("is read-only when the graph fetch fails for a requested flowID", () => {
+    mockGraph = undefined;
+    mockIsGraphError = true;
 
     const { result } = renderHook(() => useIsReadOnlyGraph());
 

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/useBuilderChatPanel.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/useBuilderChatPanel.ts
@@ -22,6 +22,7 @@ import { convertChatSessionMessagesToUiMessages } from "@/app/(platform)/copilot
 import { useCopilotStream } from "@/app/(platform)/copilot/useCopilotStream";
 import { useCopilotPendingChips } from "@/app/(platform)/copilot/useCopilotPendingChips";
 import { useGetV2GetSession } from "@/app/api/__generated__/endpoints/chat/chat";
+import { retryUnlessClientError } from "../../helpers/graphLoadError";
 
 interface UseBuilderChatPanelArgs {
   panelRef?: React.RefObject<HTMLElement | null>;
@@ -90,6 +91,7 @@ export function useBuilderChatPanel({
       query: {
         select: okData,
         enabled: !!flowID,
+        retry: retryUnlessClientError,
       },
     },
   );

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/Flow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/Flow.tsx
@@ -22,6 +22,7 @@ import { CustomControls } from "./components/CustomControl";
 import { GraphLoadingBox } from "./components/GraphLoadingBox";
 import { RunningBackground } from "./components/RunningBackground";
 import { TriggerAgentBanner } from "./components/TriggerAgentBanner";
+import { retryUnlessClientError } from "../../../helpers/graphLoadError";
 import { resolveCollisions } from "./helpers/resolve-collision";
 import { useCopyPaste } from "./useCopyPaste";
 import { useFlow } from "./useFlow";
@@ -43,6 +44,7 @@ export const Flow = () => {
       query: {
         select: okData,
         enabled: !!flowID,
+        retry: retryUnlessClientError,
       },
     },
   );

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/useFlow.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/FlowEditor/Flow/useFlow.ts
@@ -19,10 +19,18 @@ import { useControlPanelStore } from "../../../stores/controlPanelStore";
 import { useHistoryStore } from "../../../stores/historyStore";
 import { AgentExecutionStatus } from "@/app/api/__generated__/models/agentExecutionStatus";
 import { okData } from "@/app/api/helpers";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { useRouter } from "next/navigation";
 import { useIsReadOnlyGraph } from "../../../hooks/useIsReadOnlyGraph";
+import {
+  getGraphLoadErrorToast,
+  retryUnlessClientError,
+} from "../../../helpers/graphLoadError";
 
 export const useFlow = () => {
   const { isReadOnly } = useIsReadOnlyGraph();
+  const { toast } = useToast();
+  const router = useRouter();
   const [isLockedState, setIsLockedState] = useState(false);
   const [hasAutoFramed, setHasAutoFramed] = useState(false);
   const [isInitialLoadComplete, setIsInitialLoadComplete] = useState(false);
@@ -83,16 +91,32 @@ export const useFlow = () => {
     query: { select: okData },
   });
 
-  const { data: graph, isLoading: isGraphLoading } = useGetV1GetSpecificGraph(
+  const {
+    data: graph,
+    isLoading: isGraphLoading,
+    isError: isGraphError,
+    error: graphError,
+  } = useGetV1GetSpecificGraph(
     flowID ?? "",
     flowVersion !== null ? { version: flowVersion } : {},
     {
       query: {
         select: (res) => res.data as GraphModel,
         enabled: !!flowID,
+        retry: retryUnlessClientError,
       },
     },
   );
+
+  // The graph couldn't load — bail out of the builder instead of falling into
+  // the fully-editable "new agent" state, which would look like a wiped agent
+  // and risk an empty save over the real flowID.
+  useEffect(() => {
+    if (!flowID || !isGraphError) return;
+    const { title, description } = getGraphLoadErrorToast(graphError);
+    toast({ title, description, variant: "destructive" });
+    router.push("/library");
+  }, [flowID, isGraphError, graphError, toast, router]);
 
   const nodes = graph?.nodes;
   const blockIds = nodes

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewSaveControl/useNewSaveControl.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/NewControlPanel/NewSaveControl/useNewSaveControl.ts
@@ -7,6 +7,7 @@ import { useGetV1GetSpecificGraph } from "@/app/api/__generated__/endpoints/grap
 import { GraphModel } from "@/app/api/__generated__/models/graphModel";
 import { useControlPanelStore } from "../../../stores/controlPanelStore";
 import { useSaveGraph } from "../../../hooks/useSaveGraph";
+import { retryUnlessClientError } from "../../../helpers/graphLoadError";
 
 const formSchema = z.object({
   name: z.string().min(1, "Name is required").max(100),
@@ -43,6 +44,7 @@ export const useNewSaveControl = () => {
       query: {
         select: (res) => res.data as GraphModel,
         enabled: !!flowID,
+        retry: retryUnlessClientError,
       },
     },
   );

--- a/autogpt_platform/frontend/src/app/(platform)/build/helpers/__tests__/graphLoadError.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/helpers/__tests__/graphLoadError.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
+import {
+  getGraphLoadErrorToast,
+  retryUnlessClientError,
+} from "../graphLoadError";
+
+describe("getGraphLoadErrorToast", () => {
+  it("labels a 404 as not found and surfaces the backend message", () => {
+    const error = new ApiError("Graph not found", 404, { detail: "..." });
+    const toast = getGraphLoadErrorToast(error);
+    expect(toast.title).toBe("Agent not found");
+    expect(toast.description).toBe("Graph not found");
+  });
+
+  it("labels a 401/403 as unauthorized and surfaces the backend message", () => {
+    for (const status of [401, 403]) {
+      const error = new ApiError("Not authorized", status, {});
+      const toast = getGraphLoadErrorToast(error);
+      expect(toast.title).toBe("Not authorized to view this agent");
+      expect(toast.description).toBe("Not authorized");
+    }
+  });
+
+  it("falls back to a generic failure title for other statuses", () => {
+    const error = new ApiError("Internal server error", 500, {});
+    const toast = getGraphLoadErrorToast(error);
+    expect(toast.title).toBe("Failed to load agent");
+    expect(toast.description).toBe("Internal server error");
+  });
+
+  it("falls back to a generic description for a non-ApiError", () => {
+    const toast = getGraphLoadErrorToast(new Error());
+    expect(toast.title).toBe("Failed to load agent");
+    expect(toast.description).toBe("An unexpected error occurred.");
+  });
+
+  it("falls back to a generic description for a non-Error value", () => {
+    const toast = getGraphLoadErrorToast("boom");
+    expect(toast.title).toBe("Failed to load agent");
+    expect(toast.description).toBe("An unexpected error occurred.");
+  });
+});
+
+describe("retryUnlessClientError", () => {
+  it("does not retry a 404", () => {
+    expect(retryUnlessClientError(0, new ApiError("nope", 404, {}))).toBe(
+      false,
+    );
+  });
+
+  it("does not retry a 401", () => {
+    expect(retryUnlessClientError(0, new ApiError("nope", 401, {}))).toBe(
+      false,
+    );
+  });
+
+  it("retries a 500 up to 3 attempts", () => {
+    const error = new ApiError("boom", 500, {});
+    expect(retryUnlessClientError(0, error)).toBe(true);
+    expect(retryUnlessClientError(2, error)).toBe(true);
+    expect(retryUnlessClientError(3, error)).toBe(false);
+  });
+
+  it("retries a non-ApiError up to 3 attempts", () => {
+    expect(retryUnlessClientError(0, new Error("boom"))).toBe(true);
+    expect(retryUnlessClientError(3, new Error("boom"))).toBe(false);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/build/helpers/graphLoadError.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/helpers/graphLoadError.ts
@@ -1,0 +1,31 @@
+import { ApiError } from "@/lib/autogpt-server-api/helpers";
+
+/** A 4xx won't heal on retry — fail fast instead of stalling ~7s in backoff. */
+export function retryUnlessClientError(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  const status = error instanceof ApiError ? error.status : undefined;
+  return (
+    failureCount < 3 && !(status !== undefined && status >= 400 && status < 500)
+  );
+}
+
+export function getGraphLoadErrorToast(error: unknown): {
+  title: string;
+  description: string;
+} {
+  const status = error instanceof ApiError ? error.status : undefined;
+  const description =
+    error instanceof Error && error.message
+      ? error.message
+      : "An unexpected error occurred.";
+
+  if (status === 404) {
+    return { title: "Agent not found", description };
+  }
+  if (status === 401 || status === 403) {
+    return { title: "Not authorized to view this agent", description };
+  }
+  return { title: "Failed to load agent", description };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/build/hooks/useIsReadOnlyGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/hooks/useIsReadOnlyGraph.ts
@@ -2,6 +2,7 @@ import { useGetV1GetSpecificGraph } from "@/app/api/__generated__/endpoints/grap
 import { GraphModel } from "@/app/api/__generated__/models/graphModel";
 import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { retryUnlessClientError } from "../helpers/graphLoadError";
 
 // Read-only detection is a UX affordance only — the backend is the security
 // boundary and already rejects mutations (save, etc.) from non-owners. This
@@ -17,13 +18,14 @@ export function useIsReadOnlyGraph() {
   // Mirror useFlow's query (same key incl. version) so React Query serves both
   // from one cache entry and ownership reflects the version actually being
   // viewed, not just the latest.
-  const { data: graph } = useGetV1GetSpecificGraph(
+  const { data: graph, isError: isGraphError } = useGetV1GetSpecificGraph(
     flowID ?? "",
     flowVersion !== null ? { version: flowVersion } : {},
     {
       query: {
         select: (res) => res.data as GraphModel,
         enabled: !!flowID,
+        retry: retryUnlessClientError,
       },
     },
   );
@@ -31,9 +33,12 @@ export function useIsReadOnlyGraph() {
   // Wait for both the graph and the auth state to resolve before deciding, so
   // the banner doesn't flicker for owners during initial mount. Once resolved,
   // anyone who isn't the confirmed owner (including a logged-out viewer) is
-  // read-only — failing safe toward read-only rather than toward editable.
+  // read-only — failing safe toward read-only rather than toward editable. A
+  // fetch failure also fails safe to read-only, so a graph that couldn't load
+  // never falls into the fully-editable "new agent" state.
   const isReadOnly =
-    !!graph && !isUserLoading && (!user || graph.user_id !== user.id);
+    (!!flowID && isGraphError) ||
+    (!!graph && !isUserLoading && (!user || graph.user_id !== user.id));
 
   return { isReadOnly };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/build/hooks/useSaveGraph.ts
@@ -22,6 +22,7 @@ import {
   clearTempFlowId,
   getTempFlowId,
 } from "@/services/builder-draft/draft-service";
+import { retryUnlessClientError } from "../helpers/graphLoadError";
 
 export type SaveGraphOptions = {
   showToast?: boolean;
@@ -52,6 +53,7 @@ export const useSaveGraph = ({
       query: {
         select: (res) => res.data as GraphModel,
         enabled: !!flowID,
+        retry: retryUnlessClientError,
       },
     },
   );


### PR DESCRIPTION
This PR shows a destructive toast naming the actual failure reason and locks the canvas read-only when a requested graph fails to load in the builder, instead of silently rendering a blank, fully-editable canvas that looked exactly like the agent's contents had been wiped — with nothing stopping the user from saving that empty canvas back over the real `flowID`.

### Why / What / How

**Why.** Follow-up to [#14205](https://github.com/Significant-Gravitas/AutoGPT/pull/14205), which widens graph read denials and newly routes marketplace agents into the builder, growing the population that can hit this failure once it deploys. This PR does not resolve #14205 itself.

**What.** When the graph fetch for a requested `flowID` fails, the builder now shows a toast naming the reason (not-found/no-access, unauthorized, or a generic failure with the backend's message), locks the canvas read-only, and redirects to `/library`. A successful load or opening `/build` with no `flowID` (new-agent flow) is unchanged.

**How.** The library agent detail page (`useNewAgentLibraryView.ts` / `NewAgentLibraryView.tsx`) already handles this identical fetch-failure shape correctly, so this reuses its pattern:
- New `build/helpers/graphLoadError.ts`:
  - `getGraphLoadErrorToast(error)` — reads `ApiError.status`/`.message` (the same `ApiError` class and status/message shape the library page's `ApiError`/`getErrorStatus` helpers use) to build a toast `{ title, description }`, distinguishing 404 / 401·403 / other.
  - `retryUnlessClientError` — same "don't retry a 4xx" retry function as the library page's `retryUnlessClientError`, so a bad `flowID` fails fast instead of stalling through react-query's default 3x exponential backoff.
- `useFlow.ts`: reads `isError`/`error` from the existing `useGetV1GetSpecificGraph` call, and on error toasts the reason and `router.push("/library")`.
- `useIsReadOnlyGraph.ts`: already fails safe to read-only for a graph it can't confirm ownership of ("failing safe toward read-only rather than toward editable" — see its existing comment); extended the same fail-safe to a fetch error, so the canvas is locked (no save/run controls) for the moment before the redirect fires, not just after.
- `Flow.tsx`'s own (separate, pre-existing) `useGetV1GetSpecificGraph` call gets the same `retry` option so retry behavior doesn't depend on which of the three call sites reacts first (react-query dedupes the query but the first-mounted observer's options drive the actual fetch).

### Changes 🏗️

- `build/helpers/graphLoadError.ts` (new) — `getGraphLoadErrorToast`, `retryUnlessClientError`
- `build/components/FlowEditor/Flow/useFlow.ts` — toast + redirect to `/library` on graph load failure
- `build/hooks/useIsReadOnlyGraph.ts` — fail-safe read-only on fetch error
- `build/components/FlowEditor/Flow/Flow.tsx` — align retry option on its own graph query call
- Tests: `build/helpers/__tests__/graphLoadError.test.ts` (new), plus extended `useFlow.test.ts` and `useIsReadOnlyGraph.test.tsx`

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unit tests for `getGraphLoadErrorToast`/`retryUnlessClientError` covering 404 / 401 / 403 / 500 / non-`ApiError` errors — `pnpm vitest run build/helpers/__tests__/graphLoadError.test.ts`
  - [x] `useIsReadOnlyGraph` test: fails safe to read-only when the graph fetch errors for a requested `flowID` — extended `useIsReadOnlyGraph.test.tsx`
  - [x] `useFlow` tests: toasts + redirects to `/library` on error; no-op with no `flowID`; no-op on a successful load — extended `useFlow.test.ts`
  - [x] Existing `Flow.tsx` read-only-gating tests (unchanged) still cover that the locked/error state hides save/run controls and shows the read-only banner
  - [x] `pnpm types`, `pnpm lint` — clean
  - [x] Ran the 4 touched/added test files directly with `vitest run` (27/27 passing); a full `pnpm test:unit` run has 18 pre-existing failures, all locale-formatting (`toLocaleDateString` under the sandbox's non-`en` system locale) in unrelated files (`RecentChats/helpers.test.ts`, `CostsBreakdown/helpers.test.ts`), confirmed present on `dev` before this change and untouched by it
  - Not run: no manual end-to-end pass in a live app instance (no dev stack available in this environment) — the failure path was verified through the unit/hook tests above instead

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
