### PR TITLE
fix(backend): align pytest async loop scope

### DIFF
--- a/autogpt_platform/backend/backend/copilot/graphiti/conftest.py
+++ b/autogpt_platform/backend/backend/copilot/graphiti/conftest.py
@@ -34,6 +34,7 @@ import socket
 import uuid
 from collections.abc import Iterable
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
@@ -49,6 +50,19 @@ from pydantic import BaseModel
 from .client import _build_graphiti
 from .config import graphiti_config
 from .falkordb_driver import AutoGPTFalkorDriver
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    graphiti_dir = Path(__file__).parent
+    for item in items:
+        if not item.path.is_relative_to(graphiti_dir):
+            continue
+        if not pytest_asyncio.is_async_test(item):
+            continue
+        asyncio_marker = item.get_closest_marker("asyncio")
+        if asyncio_marker and "loop_scope" in asyncio_marker.kwargs:
+            continue
+        item.add_marker(pytest.mark.asyncio(loop_scope="function"), append=False)
 
 
 class ScriptedLLMClient(LLMClient):

--- a/autogpt_platform/backend/pyproject.toml
+++ b/autogpt_platform/backend/pyproject.toml
@@ -177,6 +177,7 @@ ignore_patterns = []
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 # Disable syrupy plugin to avoid conflict with pytest-snapshot
 # Both provide --snapshot-update argument causing ArgumentError
 addopts = "-p no:syrupy"


### PR DESCRIPTION
### Why / What / How

The full backend suite still reused process-global Prisma and async Redis pools across pytest event loops after #14259. The backend already ran session-scoped async fixtures, but unscoped async tests ran on function-scoped loops by default. Stack PR #14078 added enough async coverage to reproduce the mismatch consistently: later session-scoped Copilot tests saw Prisma and Redis connections created on loops that pytest had closed.

This aligns ordinary async backend tests with the existing session-scoped fixture loop. The Graphiti subtree keeps function-scoped loops for tests backed by its explicitly function-scoped FalkorDB fixtures and per-loop ingestion state. Tests that explicitly request another loop scope retain that behavior.

### Changes 🏗️

- Set `asyncio_default_test_loop_scope` to `session` in the backend pytest configuration.
- Preserve Graphiti's intentional function-loop isolation for unscoped async tests in its local `conftest.py`.
- Keep explicit test loop scopes and the existing session-scoped async fixture configuration unchanged.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verify with pytest-asyncio 1.3.0 that ordinary unscoped async tests share one session loop
  - [x] Verify Graphiti unscoped async tests retain separate function loops while explicit session-loop tests still share one loop
  - [x] Run the full backend suite on Python 3.11, 3.12, and 3.13 on this dev-based PR ([run 33587856499](https://github.com/Significant-Gravitas/AutoGPT/actions/runs/33587856499))
  - [x] Run the full backend suite on Python 3.11, 3.12, and 3.13 with this fix applied on top of #14078 ([run 33587937958](https://github.com/Significant-Gravitas/AutoGPT/actions/runs/33587937958))
  - [x] Build, smoke-test, and scan the single-container image on amd64 and arm64 ([run 33587856572](https://github.com/Significant-Gravitas/AutoGPT/actions/runs/33587856572))

#### For configuration changes:

- [x] `.env.default` is already compatible with my changes
- [x] `docker-compose.yml` is already compatible with my changes
- [x] The pytest configuration change is listed under **Changes**