### PR TITLE
docs(dx): refresh pr-test skill for Better Auth, env setup, and billing-test trap

### DIFF
--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -384,7 +384,10 @@ miss because nothing fails loudly without them, it just 401s later:
   rest of the stack actually uses.
 
 ```bash
-grep -q '^JWT_JWKS_URL=' $BACKEND_DIR/.env || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env  # native mode only — see note above
+# [ -n ... ], not grep -q alone — a present-but-empty JWT_JWKS_URL= would
+# otherwise be treated as "already set" and skip the fallback, leaving the
+# backend without a JWKS endpoint to verify tokens against.
+[ -n "$(grep '^JWT_JWKS_URL=' $BACKEND_DIR/.env | cut -d= -f2-)" ] || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env  # native mode only — see note above
 
 if [ -n "$(grep '^DATABASE_URL=' $FRONTEND_DIR/.env | cut -d= -f2-)" ]; then
   # grep -q alone matches a present-but-empty DATABASE_URL= too, which would
@@ -606,15 +609,17 @@ AUTH_PAYLOAD=$(PR_TEST_USER_EMAIL="$PR_TEST_USER_EMAIL" PR_TEST_USER_PASSWORD="$
 # check; -d passes the payload as an argument, which leaks the password into
 # process listings, so pipe it through stdin with --data-binary @- instead.
 # --noproxy guards against an inherited proxy env var routing the password
-# through a proxy).
-SIGNUP_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s --noproxy localhost,127.0.0.1,::1 -X POST 'http://localhost:3000/api/auth/sign-up/email' \
+# through a proxy. --max-time bounds it — without one, a server that accepts
+# the connection but never responds hangs setup indefinitely instead of
+# reaching the empty-$TOKEN failure check below).
+SIGNUP_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s --max-time 15 --noproxy localhost,127.0.0.1,::1 -X POST 'http://localhost:3000/api/auth/sign-up/email' \
   -H 'Content-Type: application/json' --data-binary @-)
 echo "$SIGNUP_RESULT" | grep -qi '"code"' && echo "Signup: $SIGNUP_RESULT"  # log it — "already exists" and "password too short" look identical downstream otherwise
 
 # Sign in — sets the better-auth.session_token cookie in $COOKIE_JAR.
 # Capture the body: a failure here (e.g. account exists with a different
 # password) otherwise only shows up as an empty $TOKEN with no explanation.
-SIGNIN_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s --noproxy localhost,127.0.0.1,::1 -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
+SIGNIN_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s --max-time 15 --noproxy localhost,127.0.0.1,::1 -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
   -H 'Content-Type: application/json' --data-binary @-)
 echo "$SIGNIN_RESULT" | grep -qi '"code"' && echo "Sign-in: $SIGNIN_RESULT"
 

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -182,7 +182,7 @@ fi
 : "${PR_TEST_USER_PASSWORD:?PR_TEST_USER_PASSWORD is empty after env+prompt — supply a value before re-running}"
 ```
 
-For **local docker-compose** runs, a fresh dev user is created on first call to the signup snippet below. For **dev-preview** runs, the test user lives in the project's Supabase — ask the user for the current valid credentials each session (the previously-shared `test@test.com` test account was disabled on 2026-05-23 after its credentials leaked into this very SKILL — do NOT re-introduce a default).
+For **local docker-compose** runs, a fresh dev user is created on first call to the signup snippet below. For **dev-preview** runs, the test user lives in the project's hosted auth backend — ask the user for the current valid credentials each session (the previously-shared `test@test.com` test account was disabled on 2026-05-23 after its credentials leaked into this very SKILL — do NOT re-introduce a default). **`PR_TEST_USER_PASSWORD` should always be a throwaway/test-only credential, never a real account's password** — the auth requests in 3h go over plain HTTP on `localhost:3000` for local runs, which has no transport encryption. If a dev-preview run's target isn't on `localhost`, confirm it's HTTPS before sending credentials to it.
 
 ## Step 1: Understand the PR
 
@@ -386,7 +386,9 @@ miss because nothing fails loudly without them, it just 401s later:
 ```bash
 grep -q '^JWT_JWKS_URL=' $BACKEND_DIR/.env || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env  # native mode only — see note above
 
-if grep -q '^DATABASE_URL=' $FRONTEND_DIR/.env; then
+if [ -n "$(grep '^DATABASE_URL=' $FRONTEND_DIR/.env | cut -d= -f2-)" ]; then
+  # grep -q alone matches a present-but-empty DATABASE_URL= too, which would
+  # otherwise skip derivation and leave Better Auth pointed at nothing.
   echo "Frontend DATABASE_URL: already set (not touching it)"
 else
   # cut -f2 (not -f2-) truncates any value containing '=' (base64 secrets do); -f2- keeps the rest.
@@ -397,8 +399,9 @@ else
   : "${DB_USER:?}" "${DB_PASS:?}" "${DB_PORT:?}" "${DB_NAME:?}"  # fail loudly, not with a silently-empty URL
   # Percent-encode user/pass — a raw '@', '#', '?', '%', or ':' in either would
   # otherwise be misparsed as URL structure instead of credential content.
-  DB_USER_ENC=$(jq -rn --arg s "$DB_USER" '$s|@uri')
-  DB_PASS_ENC=$(jq -rn --arg s "$DB_PASS" '$s|@uri')
+  # Via env vars, not `jq --arg`, which would put DB_PASS in the process arglist.
+  DB_USER_ENC=$(DB_USER_VAL="$DB_USER" jq -rn '$ENV.DB_USER_VAL|@uri')
+  DB_PASS_ENC=$(DB_PASS_VAL="$DB_PASS" jq -rn '$ENV.DB_PASS_VAL|@uri')
   echo "DATABASE_URL=postgresql://${DB_USER_ENC}:${DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}" >> $FRONTEND_DIR/.env
   # Reconstructed, not regex-redacted — a password containing '@' would otherwise
   # leak its tail past a naive "redact up to the first @" pattern.
@@ -595,19 +598,23 @@ silently into an empty token unless you check for it.
 ```bash
 COOKIE_JAR=$(mktemp)
 trap 'rm -f "$COOKIE_JAR"' EXIT  # cleans up on early exit too, not just the happy path
-AUTH_PAYLOAD=$(jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p,name:"PR Test User"}')
+# Via env vars, not `jq --arg`, which would put the password in the process arglist.
+AUTH_PAYLOAD=$(PR_TEST_USER_EMAIL="$PR_TEST_USER_EMAIL" PR_TEST_USER_PASSWORD="$PR_TEST_USER_PASSWORD" \
+  jq -nc '{email:$ENV.PR_TEST_USER_EMAIL,password:$ENV.PR_TEST_USER_PASSWORD,name:"PR Test User"}')
 
 # Signup (idempotent — a real error body means "already exists" only if you
 # check; -d passes the payload as an argument, which leaks the password into
-# process listings, so pipe it through stdin with --data-binary @- instead).
-SIGNUP_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s -X POST 'http://localhost:3000/api/auth/sign-up/email' \
+# process listings, so pipe it through stdin with --data-binary @- instead.
+# --noproxy guards against an inherited proxy env var routing the password
+# through a proxy).
+SIGNUP_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s --noproxy localhost,127.0.0.1,::1 -X POST 'http://localhost:3000/api/auth/sign-up/email' \
   -H 'Content-Type: application/json' --data-binary @-)
 echo "$SIGNUP_RESULT" | grep -qi '"code"' && echo "Signup: $SIGNUP_RESULT"  # log it — "already exists" and "password too short" look identical downstream otherwise
 
 # Sign in — sets the better-auth.session_token cookie in $COOKIE_JAR.
 # Capture the body: a failure here (e.g. account exists with a different
 # password) otherwise only shows up as an empty $TOKEN with no explanation.
-SIGNIN_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
+SIGNIN_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s --noproxy localhost,127.0.0.1,::1 -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
   -H 'Content-Type: application/json' --data-binary @-)
 echo "$SIGNIN_RESULT" | grep -qi '"code"' && echo "Sign-in: $SIGNIN_RESULT"
 
@@ -802,7 +809,11 @@ fails looking for an executable, then use it for finer control over timing
 
 ```bash
 cd $FRONTEND_DIR  # required — @playwright/test is only declared here, not at the repo root
-pnpm exec playwright install chromium 2>&1 | grep -v "^$"  # no-op if already installed
+# Check the installer's own exit status, not grep's — piping through grep to
+# drop blank lines would otherwise swallow a real install failure and let
+# chromium.launch() below fail later with a much less clear error.
+pnpm exec playwright install chromium
+[ $? -eq 0 ] || { echo "ERROR: playwright install chromium failed"; exit 1; }
 
 node -e "
 const { chromium } = require('@playwright/test');

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -5,12 +5,19 @@ user-invocable: true
 argument-hint: "[worktree path or PR number] — tests the PR in the given worktree. Optional flags: --fix (auto-fix issues found)"
 metadata:
   author: autogpt-team
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 # Manual E2E Test
 
 Test a PR/branch end-to-end by building the full platform, interacting via browser and API, capturing screenshots, and reporting results.
+
+**Changelog 2.2.0** — auth flow updated for Better Auth (Supabase signup is
+gone), env-setup gaps closed, a proven Playwright fallback for agent-browser,
+a billing-test trap that produces false passes, safer process cleanup, and a
+mock-provider pattern for deterministic $0 testing. Learned on
+[#14206](https://github.com/Significant-Gravitas/AutoGPT/pull/14206) — see the
+[evidence comment](https://github.com/Significant-Gravitas/AutoGPT/pull/14206#issuecomment-5511429524).
 
 ## Critical Requirements
 
@@ -48,6 +55,16 @@ Each test scenario in the report MUST have:
 - **Screenshot Evidence**: Before/after screenshots with explanations
 
 ## State Manipulation for Realistic Testing
+
+**Billing-test trap — this one produces a false pass, not a visible failure.**
+LLM block cost filters key on the *platform-owned* credential id. A run made
+with the test user's own API key bills nothing by design, so a credits
+before/after assertion silently passes on zero deltas either way. Any test
+that verifies credit reconciliation MUST use the system credential, not a
+user-supplied key. Related: Ollama models have `MODEL_COST` set but
+`TOKEN_COST=None`, so pre/post-flight cost deltas are always 0 for them
+regardless of credential — never use an Ollama model to test credit
+reconciliation, pick any hosted model billed through the system credential.
 
 When testing features that depend on specific states (rate limits, credits, quotas):
 
@@ -337,6 +354,22 @@ cp $REPO_ROOT/autogpt_platform/backend/.env $BACKEND_DIR/.env
 cp $REPO_ROOT/autogpt_platform/frontend/.env $FRONTEND_DIR/.env
 ```
 
+**A copy from the root worktree is no longer sufficient on a recent `dev`** —
+auth moved from Supabase to Better Auth (see 3h) and two vars are easy to
+miss because nothing fails loudly without them, it just 401s later:
+
+- `$BACKEND_DIR/.env` needs `JWT_JWKS_URL` — the Better Auth JWKS endpoint the
+  backend verifies tokens against. Value shape: `backend/.env.default:42`
+  (`http://localhost:3000/api/auth/jwks` for native/local runs).
+- `$FRONTEND_DIR/.env` needs its **own** `DATABASE_URL` — Better Auth runs
+  inside the Next.js app and talks to Postgres directly, it does not go
+  through the backend. See `frontend/.env.default` for the local shape.
+
+```bash
+grep -q '^JWT_JWKS_URL=' $BACKEND_DIR/.env || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env
+grep -q '^DATABASE_URL=' $FRONTEND_DIR/.env || grep '^DATABASE_URL=' $FRONTEND_DIR/.env.default >> $FRONTEND_DIR/.env
+```
+
 ### 3b. Configure copilot authentication
 
 The copilot needs an LLM API to function. Two approaches (try subscription first):
@@ -394,17 +427,24 @@ done
 
 **Native mode also:** when running the app natively (see 3e-native), kill any stray host processes and free the app ports before starting — otherwise `poetry run app` and `pnpm dev` will fail to bind.
 
-```bash
-# Kill stray native app processes from prior runs
-pkill -9 -f "python.*backend" 2>/dev/null || true
-pkill -9 -f "poetry run app" 2>/dev/null || true
-pkill -9 -f "next-server|next dev" 2>/dev/null || true
+**Kill by port, not by broad process pattern.** A pattern-based
+`pkill -f "python.*backend"` (or anything matching by worktree cwd) is too
+coarse on a host running several worktrees — it has taken out the frontend
+and a mock server sitting on other ports along with the intended backend
+process. Target the pid actually holding each port instead:
 
-# Free app ports (errors per port are ignored — port may simply be unused)
+```bash
+# Free app ports one at a time — errors per port are ignored (port may simply
+# be unused). This only kills the process holding that specific port, so it
+# can't collide with an unrelated sibling worktree's processes.
 for port in 3000 8006 8001 8002 8005 8008; do
   lsof -ti :$port -sTCP:LISTEN | xargs -r kill -9 2>/dev/null || true
 done
 ```
+
+Killing the process on :3000 restarts the frontend and therefore rotates the
+Better Auth JWKS keypair (see 3h) — re-fetch `$TOKEN` after this step, not
+just after starting services back up.
 
 ### 3e-native. Run the app natively (PREFERRED for iterative dev)
 
@@ -504,38 +544,42 @@ done
 
 ### 3h. Create test user and get auth token
 
+The platform moved off Supabase auth to Better Auth, embedded in the
+Next.js app at `/api/auth/*`. Signup and sign-in both go through the frontend
+now, not Kong on :8000 — and `/api/auth/token` mints a backend-API JWT from a
+**session cookie**, it does not accept credentials directly, so sign-in has to
+happen first to get that cookie.
+
 ```bash
-ANON_KEY=$(grep "NEXT_PUBLIC_SUPABASE_ANON_KEY=" $FRONTEND_DIR/.env | sed 's/.*NEXT_PUBLIC_SUPABASE_ANON_KEY=//' | tr -d '[:space:]')
+COOKIE_JAR=$(mktemp)
+SIGNUP_PAYLOAD=$(jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p,name:"PR Test User"}')
 
-# Signup (idempotent — returns "User already registered" if exists)
-SIGNUP_PAYLOAD=$(jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p}')
-RESULT=$(curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
-  -H "apikey: $ANON_KEY" \
+# Signup (idempotent — returns an error body if the account already exists;
+# treat that as success and fall through to sign-in)
+curl -s -X POST 'http://localhost:3000/api/auth/sign-up/email' \
   -H 'Content-Type: application/json' \
-  -d "$SIGNUP_PAYLOAD")
+  -d "$SIGNUP_PAYLOAD" > /dev/null
 
-# If "Database error finding user", restart supabase-auth and retry —
-# capture the retry result back into $RESULT so the token step below
-# reads the post-retry state, not the original failure.
-if echo "$RESULT" | grep -q "Database error"; then
-  docker restart supabase-auth && sleep 5
-  RESULT=$(curl -s -X POST 'http://localhost:8000/auth/v1/signup' \
-    -H "apikey: $ANON_KEY" \
-    -H 'Content-Type: application/json' \
-    -d "$SIGNUP_PAYLOAD")
-fi
-
-# Get auth token
-TOKEN=$(curl -s -X POST 'http://localhost:8000/auth/v1/token?grant_type=password' \
-  -H "apikey: $ANON_KEY" \
+# Sign in — sets the better-auth.session_token cookie in $COOKIE_JAR
+curl -s -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
   -H 'Content-Type: application/json' \
-  -d "$SIGNUP_PAYLOAD" | jq -r '.access_token // ""')
+  -d "$SIGNUP_PAYLOAD" > /dev/null
+
+# Mint a backend-API JWT from the session cookie
+TOKEN=$(curl -s -b "$COOKIE_JAR" 'http://localhost:3000/api/auth/token' | jq -r '.token // ""')
+rm -f "$COOKIE_JAR"
 ```
 
 **Use this token for ALL API calls:**
 ```bash
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8006/api/...
 ```
+
+**Restarting the frontend mid-run rotates the Better Auth JWKS keypair and
+invalidates every JWT already issued** — the backend verifies tokens against
+whatever `JWT_JWKS_URL` currently serves (see 3a), so a stale `$TOKEN` starts
+401ing right after a frontend restart with no other symptom. Re-run the token
+fetch above after any frontend restart, not just after a backend one.
 
 ### 3i. Disable onboarding for test user
 
@@ -621,7 +665,46 @@ echo "After: $AFTER_STATE"
 echo "Expected change: {describe what should have changed}"
 ```
 
+### Mock-provider pattern (deterministic, $0)
+
+For timeout/latency/error-handling behavior that would otherwise need a real
+LLM call, point the OpenAI SDK at a local mock instead — it honours
+`OPENAI_BASE_URL`, so a small local Responses-API server can stand in for the
+provider while everything downstream (executor, credentials, billing) still
+runs for real. This proved out 4/4 test items at $0 in this run.
+
+```bash
+# In $BACKEND_DIR/.env, point the OpenAI provider at a local mock server
+# that implements the subset of the Responses API you need (e.g. delayed
+# responses to test timeout handling, or a 500 to test error surfacing):
+OPENAI_BASE_URL=http://localhost:{mock_port}/v1
+```
+
+Only the transport is faked — the credential lookup, execution graph, and
+billing path are exercised unmodified, so this is safe to use for anything
+that isn't itself testing model *output* quality.
+
 ### Browser testing with agent-browser
+
+**If `agent-browser` isn't installed on the host, don't let `npx` download it.**
+Use `@playwright/test` against the Chromium already installed in the
+frontend's `node_modules` instead — zero downloads, and it gives finer
+control over timing (`waitForSelector`, explicit timeouts) than agent-browser's
+CLI. Keep agent-browser as the primary tool wherever it's already present;
+this is a proven fallback, not a replacement:
+
+```bash
+cd $FRONTEND_DIR && node -e "
+const { chromium } = require('@playwright/test');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:3000/login');
+  await page.screenshot({ path: '$RESULTS_DIR/01-login.png' });
+  await browser.close();
+})();
+"
+```
 
 ```bash
 # Close any existing session

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -386,15 +386,24 @@ miss because nothing fails loudly without them, it just 401s later:
 ```bash
 grep -q '^JWT_JWKS_URL=' $BACKEND_DIR/.env || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env  # native mode only — see note above
 
-if ! grep -q '^DATABASE_URL=' $FRONTEND_DIR/.env; then
-  DB_USER=$(grep '^DB_USER=' $BACKEND_DIR/.env | cut -d= -f2)
-  DB_PASS=$(grep '^DB_PASS=' $BACKEND_DIR/.env | cut -d= -f2)
-  DB_PORT=$(grep '^DB_PORT=' $BACKEND_DIR/.env | cut -d= -f2)
-  DB_NAME=$(grep '^DB_NAME=' $BACKEND_DIR/.env | cut -d= -f2)
+if grep -q '^DATABASE_URL=' $FRONTEND_DIR/.env; then
+  echo "Frontend DATABASE_URL: already set (not touching it)"
+else
+  # cut -f2 (not -f2-) truncates any value containing '=' (base64 secrets do); -f2- keeps the rest.
+  DB_USER=$(grep '^DB_USER=' $BACKEND_DIR/.env | cut -d= -f2-)
+  DB_PASS=$(grep '^DB_PASS=' $BACKEND_DIR/.env | cut -d= -f2-)
+  DB_PORT=$(grep '^DB_PORT=' $BACKEND_DIR/.env | cut -d= -f2-)
+  DB_NAME=$(grep '^DB_NAME=' $BACKEND_DIR/.env | cut -d= -f2-)
   : "${DB_USER:?}" "${DB_PASS:?}" "${DB_PORT:?}" "${DB_NAME:?}"  # fail loudly, not with a silently-empty URL
-  echo "DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}" >> $FRONTEND_DIR/.env
+  # Percent-encode user/pass — a raw '@', '#', '?', '%', or ':' in either would
+  # otherwise be misparsed as URL structure instead of credential content.
+  DB_USER_ENC=$(jq -rn --arg s "$DB_USER" '$s|@uri')
+  DB_PASS_ENC=$(jq -rn --arg s "$DB_PASS" '$s|@uri')
+  echo "DATABASE_URL=postgresql://${DB_USER_ENC}:${DB_PASS_ENC}@localhost:${DB_PORT}/${DB_NAME}" >> $FRONTEND_DIR/.env
+  # Reconstructed, not regex-redacted — a password containing '@' would otherwise
+  # leak its tail past a naive "redact up to the first @" pattern.
+  echo "Frontend DATABASE_URL: postgresql://${DB_USER_ENC}:***@localhost:${DB_PORT}/${DB_NAME}"
 fi
-echo "Frontend DATABASE_URL: $(grep '^DATABASE_URL=' $FRONTEND_DIR/.env | sed -E 's#(://[^:]+:)[^@]+#\1***#')"  # redacted — a bad host/port/db should be obvious here without echoing the password into the run log
 ```
 
 ### 3b. Configure copilot authentication
@@ -595,9 +604,12 @@ SIGNUP_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s -X POST 'http://localhost:
   -H 'Content-Type: application/json' --data-binary @-)
 echo "$SIGNUP_RESULT" | grep -qi '"code"' && echo "Signup: $SIGNUP_RESULT"  # log it — "already exists" and "password too short" look identical downstream otherwise
 
-# Sign in — sets the better-auth.session_token cookie in $COOKIE_JAR
-printf '%s' "$AUTH_PAYLOAD" | curl -s -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
-  -H 'Content-Type: application/json' --data-binary @- > /dev/null
+# Sign in — sets the better-auth.session_token cookie in $COOKIE_JAR.
+# Capture the body: a failure here (e.g. account exists with a different
+# password) otherwise only shows up as an empty $TOKEN with no explanation.
+SIGNIN_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
+  -H 'Content-Type: application/json' --data-binary @-)
+echo "$SIGNIN_RESULT" | grep -qi '"code"' && echo "Sign-in: $SIGNIN_RESULT"
 
 # Mint a backend-API JWT from the session cookie
 TOKEN=$(curl -s -b "$COOKIE_JAR" 'http://localhost:3000/api/auth/token' | jq -r '.token // ""')
@@ -789,9 +801,10 @@ fails looking for an executable, then use it for finer control over timing
 (`waitForSelector`, explicit timeouts) than agent-browser's CLI gives you:
 
 ```bash
+cd $FRONTEND_DIR  # required — @playwright/test is only declared here, not at the repo root
 pnpm exec playwright install chromium 2>&1 | grep -v "^$"  # no-op if already installed
 
-cd $FRONTEND_DIR && node -e "
+node -e "
 const { chromium } = require('@playwright/test');
 (async () => {
   const browser = await chromium.launch();

--- a/.claude/skills/pr-test/SKILL.md
+++ b/.claude/skills/pr-test/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 argument-hint: "[worktree path or PR number] — tests the PR in the given worktree. Optional flags: --fix (auto-fix issues found)"
 metadata:
   author: autogpt-team
-  version: "2.2.0"
+  version: "2.2.1"
 ---
 
 # Manual E2E Test
@@ -18,6 +18,11 @@ a billing-test trap that produces false passes, safer process cleanup, and a
 mock-provider pattern for deterministic $0 testing. Learned on
 [#14206](https://github.com/Significant-Gravitas/AutoGPT/pull/14206) — see the
 [evidence comment](https://github.com/Significant-Gravitas/AutoGPT/pull/14206#issuecomment-5511429524).
+**2.2.1** — corrects two claims from 2.2.0 that didn't survive live-stack
+verification (JWKS does **not** rotate on a frontend restart; the local
+Postgres port is `5432`, not `54322`) and hardens the auth setup (explicit
+password-length/allowlist/rate-limit failure modes, fail-fast on an empty
+token, password kept out of process args).
 
 ## Critical Requirements
 
@@ -61,10 +66,12 @@ LLM block cost filters key on the *platform-owned* credential id. A run made
 with the test user's own API key bills nothing by design, so a credits
 before/after assertion silently passes on zero deltas either way. Any test
 that verifies credit reconciliation MUST use the system credential, not a
-user-supplied key. Related: Ollama models have `MODEL_COST` set but
-`TOKEN_COST=None`, so pre/post-flight cost deltas are always 0 for them
-regardless of credential — never use an Ollama model to test credit
-reconciliation, pick any hosted model billed through the system credential.
+user-supplied key. Related: Ollama block entries are configured with an
+explicit `$0` run-based cost (`BlockCostType.RUN, cost_amount=0` in
+`block_cost_config.py`), not a token-metered one — so pre/post-flight cost
+deltas are always 0 for them regardless of credential. Never use an Ollama
+model to test credit reconciliation; pick any hosted model billed through the
+system credential instead.
 
 When testing features that depend on specific states (rate limits, credits, quotas):
 
@@ -359,15 +366,35 @@ auth moved from Supabase to Better Auth (see 3h) and two vars are easy to
 miss because nothing fails loudly without them, it just 401s later:
 
 - `$BACKEND_DIR/.env` needs `JWT_JWKS_URL` — the Better Auth JWKS endpoint the
-  backend verifies tokens against. Value shape: `backend/.env.default:42`
-  (`http://localhost:3000/api/auth/jwks` for native/local runs).
+  backend verifies tokens against. The `localhost:3000` value below is for
+  **native mode only**. In docker mode it's harmless to have it in `.env`
+  because `docker-compose.platform.yml` overrides it with the
+  Compose-reachable `http://frontend:3000/api/auth/jwks` — but if you ever run
+  the backend against this `.env` value directly (bypassing Compose), a
+  `localhost` value inside a container resolves to itself, not the frontend,
+  and every call 401s with no other symptom.
 - `$FRONTEND_DIR/.env` needs its **own** `DATABASE_URL` — Better Auth runs
   inside the Next.js app and talks to Postgres directly, it does not go
-  through the backend. See `frontend/.env.default` for the local shape.
+  through the backend. **Derive it from `$BACKEND_DIR/.env`'s `DB_USER` /
+  `DB_PASS` / `DB_PORT` / `DB_NAME` rather than copying
+  `frontend/.env.default`'s placeholder verbatim** — the placeholder happens
+  to match the stock local defaults, but if `backend/.env`'s `DB_PASS` was
+  ever customized (rotated secret, non-default port), copying the placeholder
+  silently points Better Auth at the wrong database instead of the one the
+  rest of the stack actually uses.
 
 ```bash
-grep -q '^JWT_JWKS_URL=' $BACKEND_DIR/.env || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env
-grep -q '^DATABASE_URL=' $FRONTEND_DIR/.env || grep '^DATABASE_URL=' $FRONTEND_DIR/.env.default >> $FRONTEND_DIR/.env
+grep -q '^JWT_JWKS_URL=' $BACKEND_DIR/.env || echo "JWT_JWKS_URL=http://localhost:3000/api/auth/jwks" >> $BACKEND_DIR/.env  # native mode only — see note above
+
+if ! grep -q '^DATABASE_URL=' $FRONTEND_DIR/.env; then
+  DB_USER=$(grep '^DB_USER=' $BACKEND_DIR/.env | cut -d= -f2)
+  DB_PASS=$(grep '^DB_PASS=' $BACKEND_DIR/.env | cut -d= -f2)
+  DB_PORT=$(grep '^DB_PORT=' $BACKEND_DIR/.env | cut -d= -f2)
+  DB_NAME=$(grep '^DB_NAME=' $BACKEND_DIR/.env | cut -d= -f2)
+  : "${DB_USER:?}" "${DB_PASS:?}" "${DB_PORT:?}" "${DB_NAME:?}"  # fail loudly, not with a silently-empty URL
+  echo "DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}" >> $FRONTEND_DIR/.env
+fi
+echo "Frontend DATABASE_URL: $(grep '^DATABASE_URL=' $FRONTEND_DIR/.env | sed -E 's#(://[^:]+:)[^@]+#\1***#')"  # redacted — a bad host/port/db should be obvious here without echoing the password into the run log
 ```
 
 ### 3b. Configure copilot authentication
@@ -431,20 +458,22 @@ done
 `pkill -f "python.*backend"` (or anything matching by worktree cwd) is too
 coarse on a host running several worktrees — it has taken out the frontend
 and a mock server sitting on other ports along with the intended backend
-process. Target the pid actually holding each port instead:
+process. Target the pid actually holding each port instead — this only kills
+whoever is bound to that specific port, which is narrower than a pattern
+match, but **it is not worktree isolation**: if a sibling worktree's own dev
+server happens to be using one of these ports (e.g. its frontend also on
+:3000), this kills that too. `lsof` tells you who holds the port, not who
+owns it — a `docker-proxy` pid there means a compose stack owns it.
 
 ```bash
 # Free app ports one at a time — errors per port are ignored (port may simply
-# be unused). This only kills the process holding that specific port, so it
-# can't collide with an unrelated sibling worktree's processes.
+# be unused). `xargs -r` is GNU-only (macOS xargs rejects -r); the `[ -n ]`
+# guard below is the portable equivalent.
 for port in 3000 8006 8001 8002 8005 8008; do
-  lsof -ti :$port -sTCP:LISTEN | xargs -r kill -9 2>/dev/null || true
+  pids=$(lsof -ti :$port -sTCP:LISTEN 2>/dev/null)
+  [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
 done
 ```
-
-Killing the process on :3000 restarts the frontend and therefore rotates the
-Better Auth JWKS keypair (see 3h) — re-fetch `$TOKEN` after this step, not
-just after starting services back up.
 
 ### 3e-native. Run the app natively (PREFERRED for iterative dev)
 
@@ -550,36 +579,35 @@ now, not Kong on :8000 — and `/api/auth/token` mints a backend-API JWT from a
 **session cookie**, it does not accept credentials directly, so sign-in has to
 happen first to get that cookie.
 
+Better Auth's default minimum password length is **12 characters** — shorter
+values fail signup with `PASSWORD_TOO_SHORT` and every step below degrades
+silently into an empty token unless you check for it.
+
 ```bash
 COOKIE_JAR=$(mktemp)
-SIGNUP_PAYLOAD=$(jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p,name:"PR Test User"}')
+trap 'rm -f "$COOKIE_JAR"' EXIT  # cleans up on early exit too, not just the happy path
+AUTH_PAYLOAD=$(jq -nc --arg e "$PR_TEST_USER_EMAIL" --arg p "$PR_TEST_USER_PASSWORD" '{email:$e,password:$p,name:"PR Test User"}')
 
-# Signup (idempotent — returns an error body if the account already exists;
-# treat that as success and fall through to sign-in)
-curl -s -X POST 'http://localhost:3000/api/auth/sign-up/email' \
-  -H 'Content-Type: application/json' \
-  -d "$SIGNUP_PAYLOAD" > /dev/null
+# Signup (idempotent — a real error body means "already exists" only if you
+# check; -d passes the payload as an argument, which leaks the password into
+# process listings, so pipe it through stdin with --data-binary @- instead).
+SIGNUP_RESULT=$(printf '%s' "$AUTH_PAYLOAD" | curl -s -X POST 'http://localhost:3000/api/auth/sign-up/email' \
+  -H 'Content-Type: application/json' --data-binary @-)
+echo "$SIGNUP_RESULT" | grep -qi '"code"' && echo "Signup: $SIGNUP_RESULT"  # log it — "already exists" and "password too short" look identical downstream otherwise
 
 # Sign in — sets the better-auth.session_token cookie in $COOKIE_JAR
-curl -s -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
-  -H 'Content-Type: application/json' \
-  -d "$SIGNUP_PAYLOAD" > /dev/null
+printf '%s' "$AUTH_PAYLOAD" | curl -s -c "$COOKIE_JAR" -X POST 'http://localhost:3000/api/auth/sign-in/email' \
+  -H 'Content-Type: application/json' --data-binary @- > /dev/null
 
 # Mint a backend-API JWT from the session cookie
 TOKEN=$(curl -s -b "$COOKIE_JAR" 'http://localhost:3000/api/auth/token' | jq -r '.token // ""')
-rm -f "$COOKIE_JAR"
+[ -n "$TOKEN" ] || { echo "ERROR: auth setup failed — TOKEN is empty. Check password length (min 12 chars), AUTH_ALLOW_NEW_ACCOUNTS, AUTH_SIGNUP_ALLOWLIST, and rate limiting on /api/auth/*."; exit 1; }
 ```
 
 **Use this token for ALL API calls:**
 ```bash
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8006/api/...
 ```
-
-**Restarting the frontend mid-run rotates the Better Auth JWKS keypair and
-invalidates every JWT already issued** — the backend verifies tokens against
-whatever `JWT_JWKS_URL` currently serves (see 3a), so a stale `$TOKEN` starts
-401ing right after a frontend restart with no other symptom. Re-run the token
-fetch above after any frontend restart, not just after a backend one.
 
 ### 3i. Disable onboarding for test user
 
@@ -671,40 +699,41 @@ For timeout/latency/error-handling behavior that would otherwise need a real
 LLM call, point the OpenAI SDK at a local mock instead — it honours
 `OPENAI_BASE_URL`, so a small local Responses-API server can stand in for the
 provider while everything downstream (executor, credentials, billing) still
-runs for real. This proved out 4/4 test items at $0 in this run.
+runs for real. This proved out 4/4 test items at $0 in this run. **This
+covers LLM blocks (`providers.py`) and the Codex block** — the copilot's own
+LLM calls go through `backend/util/clients.py`, which passes `base_url`
+explicitly and does not read `OPENAI_BASE_URL`, so this trick doesn't reach
+copilot chat.
 
 ```bash
 # In $BACKEND_DIR/.env, point the OpenAI provider at a local mock server
 # that implements the subset of the Responses API you need (e.g. delayed
-# responses to test timeout handling, or a 500 to test error surfacing):
+# responses to test timeout handling, or a 500 to test error surfacing).
+# Restart the backend after changing this — it's read at startup.
 OPENAI_BASE_URL=http://localhost:{mock_port}/v1
 ```
 
-Only the transport is faked — the credential lookup, execution graph, and
-billing path are exercised unmodified, so this is safe to use for anything
-that isn't itself testing model *output* quality.
+**Use a throwaway/dummy provider credential with the mock, never the system
+credential** — only the transport is faked, so the credential lookup still
+runs for real and whatever key you configure gets sent as a header to your
+local mock server. A dummy key also means the mock server's logs (which may
+end up pasted into a PR comment) can't leak a real one. Aside from the
+credential, this is safe to use for anything that isn't itself testing model
+*output* quality.
+
+In **docker mode**, `localhost` inside the backend container isn't reachable
+from your host-side mock server — point `OPENAI_BASE_URL` at a
+Compose-reachable hostname instead (or `host.docker.internal` with a
+`host-gateway` entry), and set it before `docker compose up` or restart the
+affected services after changing `$BACKEND_DIR/.env`.
+
+Keep the mock server's own response timeout short — the OpenAI SDK's default
+client timeout is 600s, so a hung mock stalls every LLM-backed block for that
+long instead of failing fast.
 
 ### Browser testing with agent-browser
 
-**If `agent-browser` isn't installed on the host, don't let `npx` download it.**
-Use `@playwright/test` against the Chromium already installed in the
-frontend's `node_modules` instead — zero downloads, and it gives finer
-control over timing (`waitForSelector`, explicit timeouts) than agent-browser's
-CLI. Keep agent-browser as the primary tool wherever it's already present;
-this is a proven fallback, not a replacement:
-
-```bash
-cd $FRONTEND_DIR && node -e "
-const { chromium } = require('@playwright/test');
-(async () => {
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  await page.goto('http://localhost:3000/login');
-  await page.screenshot({ path: '$RESULTS_DIR/01-login.png' });
-  await browser.close();
-})();
-"
-```
+Primary tool — use this wherever `agent-browser` is installed:
 
 ```bash
 # Close any existing session
@@ -749,6 +778,33 @@ agent-browser --session-name pr-test snapshot | grep "text:"
 - `/library` — Agent library (for testing listing/import features)
 - `/library/agents/{id}` — Agent detail with run history
 - `/marketplace` — Marketplace
+
+**Fallback — if `agent-browser` isn't installed on the host, don't let `npx`
+download it.** Use `@playwright/test` instead — the package is already in the
+frontend's `node_modules`, but **the Chromium binary itself is not**;
+Playwright caches browser binaries separately (`~/.cache/ms-playwright/` by
+default) and nothing installs them automatically. Run
+`pnpm exec playwright install chromium` once per host if `chromium.launch()`
+fails looking for an executable, then use it for finer control over timing
+(`waitForSelector`, explicit timeouts) than agent-browser's CLI gives you:
+
+```bash
+pnpm exec playwright install chromium 2>&1 | grep -v "^$"  # no-op if already installed
+
+cd $FRONTEND_DIR && node -e "
+const { chromium } = require('@playwright/test');
+(async () => {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto('http://localhost:3000/login');
+    await page.screenshot({ path: '$RESULTS_DIR/01-login.png' });
+  } finally {
+    await browser.close();  // otherwise a goto timeout leaks a headless Chromium process
+  }
+})();
+"
+```
 
 ### Checking logs
 
@@ -1196,9 +1252,14 @@ test scenario → find issue (bug OR UX problem) → screenshot broken state
 
 ## Known issues and workarounds
 
-### Problem: "Database error finding user" on signup
-**Cause:** Supabase auth service schema cache is stale after migration.
-**Fix:** `docker restart supabase-auth && sleep 5` then retry signup.
+### Problem: Signup/sign-in fails with no useful error
+**Cause:** Better Auth's default minimum password length is 12 characters, or
+`AUTH_ALLOW_NEW_ACCOUNTS=false` / `AUTH_SIGNUP_ALLOWLIST` is blocking new
+accounts, or you're rate-limited after repeated signup attempts (`429 Too many
+requests`) — all three degrade into an empty `$TOKEN` further down if you
+don't check the raw response (see 3h).
+**Fix:** Log the raw signup/sign-in response body before minting the token,
+not just the token itself.
 
 ### Problem: Copilot returns auth errors in subscription mode
 **Cause:** `CHAT_USE_CLAUDE_CODE_SUBSCRIPTION=true` but `CLAUDE_CODE_OAUTH_TOKEN` is not set or expired.
@@ -1226,7 +1287,7 @@ test scenario → find issue (bug OR UX problem) → screenshot broken state
 **Fix:** `pkill -9 -f "agent-browser|chromium|Chrome for Testing" && sleep 2`, then reopen the browser with a fresh `--session-name`. If still failing, verify via `agent-browser eval` + `agent-browser snapshot` (DOM state) instead of relying on PNGs — the feature under test is the same.
 
 ### Problem: Services not starting after `docker compose up`
-**Fix:** Wait and check health: `docker compose ps`. Common cause: migration hasn't finished. Check: `docker logs autogpt_platform-migrate-1 2>&1 | tail -5`. If supabase-db isn't healthy: `docker restart supabase-db && sleep 10`.
+**Fix:** Wait and check health: `docker compose ps`. Common cause: migration hasn't finished. Check: `docker logs autogpt_platform-migrate-1 2>&1 | tail -5`. If the `db` container isn't healthy: `docker restart autogpt_platform-db-1 && sleep 10`.
 
 ### Problem: Docker uses cached layers with old code (PR changes not visible)
 **Cause:** `docker compose up --build` reuses cached `COPY` layers from previous builds. If the PR branch changes Python files but the previous build already cached that layer from `dev`, the container runs `dev` code.
@@ -1235,7 +1296,3 @@ test scenario → find issue (bug OR UX problem) → screenshot broken state
 ### Problem: `agent-browser open` loses login session
 **Cause:** Without session persistence, `agent-browser open` starts fresh.
 **Fix:** Use `--session-name pr-test` on ALL agent-browser commands. This auto-saves/restores cookies and localStorage across navigations. Alternatively, use `agent-browser eval "window.location.href = '...'"` to navigate within the same context.
-
-### Problem: Supabase auth returns "Database error querying schema"
-**Cause:** The database schema changed (migration ran) but supabase-auth has a stale schema cache.
-**Fix:** `docker restart supabase-db && sleep 10 && docker restart supabase-auth && sleep 8`. If user data was lost, re-signup.

--- a/autogpt_platform/frontend/.env.default
+++ b/autogpt_platform/frontend/.env.default
@@ -3,10 +3,10 @@
 BETTER_AUTH_SECRET=dev-only-better-auth-secret-9f4e8c2a71b6d05e3a8f12c4b7d9e6a1
 BETTER_AUTH_URL=http://localhost:3000
 # Postgres connection for Better Auth; tables live in the platform schema
-# (created by the backend's Prisma migrations). Local supabase-db listens on
-# 54322, not the default 5432 — and the password must match backend/.env's
-# DB_PASS, not this placeholder.
-DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:54322/postgres
+# (created by the backend's Prisma migrations). This matches the local `db`
+# service's default port and password (docker-compose.yml, backend/.env.default)
+# — if you've changed DB_PASS in backend/.env, update this to match.
+DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:5432/postgres
 AUTH_DB_SCHEMA=platform
 # Set to true to block sign-in until the email is verified. There is no SMTP
 # setting here: auth emails are sent by the backend's Postmark mailer (see the

--- a/autogpt_platform/frontend/.env.default
+++ b/autogpt_platform/frontend/.env.default
@@ -3,8 +3,10 @@
 BETTER_AUTH_SECRET=dev-only-better-auth-secret-9f4e8c2a71b6d05e3a8f12c4b7d9e6a1
 BETTER_AUTH_URL=http://localhost:3000
 # Postgres connection for Better Auth; tables live in the platform schema
-# (created by the backend's Prisma migrations).
-DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:5432/postgres
+# (created by the backend's Prisma migrations). Local supabase-db listens on
+# 54322, not the default 5432 — and the password must match backend/.env's
+# DB_PASS, not this placeholder.
+DATABASE_URL=postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:54322/postgres
 AUTH_DB_SCHEMA=platform
 # Set to true to block sign-in until the email is verified. There is no SMTP
 # setting here: auth emails are sent by the backend's Postmark mailer (see the

--- a/autogpt_platform/frontend/.prettierignore
+++ b/autogpt_platform/frontend/.prettierignore
@@ -5,3 +5,4 @@ pnpm-lock.yaml
 public
 Dockerfile
 .prettierignore
+.env*


### PR DESCRIPTION
Updates the `pr-test` skill (`.claude/skills/pr-test/SKILL.md`) so the next agent that runs `/pr-test` doesn't re-pay the discovery cost this run paid — the auth flow, env setup, and a billing-test trap it documented had all gone stale or were undocumented gaps.

### Why / What / How

**Why:** `/pr-test`'s setup steps were pointing at Supabase auth endpoints the platform no longer has, and two other gaps (env vars, a billing false-pass trap) cost a full E2E run to rediscover. Left undocumented, the next agent pays the same cost again.
**What:** Rewrites the auth setup (Better Auth sign-up/sign-in/token), documents two env vars a plain `.env` copy now misses, adds a proven Playwright fallback for `agent-browser`, documents a billing-test false-pass trap, replaces broad process-kill guidance with port-targeted kill, and adds a mock-provider pattern for deterministic $0 testing. A follow-up commit then corrects two claims from the first pass that an automated review's live-stack QA disproved (see below).
**How:** Direct edits to the skill doc plus one line in `frontend/.env.default` and one in `frontend/.prettierignore` (see Second file).

## Source

All items were verified during a real E2E run of `/pr-test` against [#14206](https://github.com/Significant-Gravitas/AutoGPT/pull/14206) — see the [evidence comment](https://github.com/Significant-Gravitas/AutoGPT/pull/14206#issuecomment-5511429524) for the specifics behind each finding.

## Changes 🏗️

### What changed in the skill (2.1.0 → 2.2.1)

- **Auth was stale**: the skill assumed Supabase (`/auth/v1/signup`); the platform moved to Better Auth. Step 3h now signs up + signs in against `/api/auth/*` and mints a backend JWT from the resulting session cookie via `/api/auth/token`. Documents Better Auth's 12-char password minimum and fails loudly on an empty token instead of silently 401ing every subsequent call.
- **Env setup was stale**: "copy `.env` from the root worktree" no longer boots a recent `dev` worktree — documents the two additions needed (`backend/.env` needs `JWT_JWKS_URL`, `frontend/.env` needs its own `DATABASE_URL` for Better Auth, now derived from the backend's actual `DB_PASS` rather than copied from a placeholder).
- **Browser fallback**: documents the proven fallback when `agent-browser` isn't installed on the host — `@playwright/test`, with the correct prerequisite (`playwright install chromium` — the binary isn't in `node_modules`, only the package is).
- **Billing-test trap** (this one produces a false pass, not a visible failure): LLM block cost filters key on the platform-owned credential id, so a run on the test user's own API key bills nothing by design — a credits assertion silently passes vacuous. Documents that billing verification must use the system credential, and that Ollama blocks are configured with an explicit `$0` run-based cost so they always yield a zero delta regardless.
- **Process hygiene**: replaces broad pattern-based `pkill` guidance (which took out the frontend and a mock server along with the intended backend process in this run) with port-targeted kill — portable, and honest about not being full worktree isolation.
- **Mock-provider pattern**: new section — the OpenAI SDK honours `OPENAI_BASE_URL`, so timeout/latency/error-path behavior can be tested deterministically and free against a local mock Responses-API server while everything from executor to billing stays real. This run proved 4/4 items this way at $0. Mandates a throwaway credential, not the system one.

### Corrections from automated review (2.2.0 → 2.2.1)

`autogpt-pr-reviewer` and CodeRabbit reviewed this PR and ran live-stack QA against the actual claims. Two didn't survive:
- **JWKS does not rotate on a frontend restart.** The first pass claimed a frontend restart rotates the Better Auth keypair and invalidates issued JWTs. QA restarted the frontend twice and found the keypair persists in Postgres (`platform."UserAuthJwks"`) and a pre-restart JWT still authenticated. This claim is removed — it would have sent future agents chasing a phantom cause for unrelated 401s.
- **The local Postgres port is `5432`, not `54322`.** The first pass "corrected" `frontend/.env.default`'s `DATABASE_URL` to port `54322`, reasoning from a Supabase CLI convention that doesn't apply to this repo's docker-compose stack (`db` service listens on `5432`, no `supabase-db` container exists). Reverted, and the comment above it (which had the correctness backwards) is fixed.

Full triage of the review's findings is in the PR comment below.

## Second file

`autogpt_platform/frontend/.env.default` — its documented `DATABASE_URL` example is `postgresql://postgres:your-super-secret-and-long-postgres-password@localhost:5432/postgres`, matching the local `db` service's default port and password (unchanged after the 2.2.1 correction above).

Also added `.env*` to the frontend's `.prettierignore` — Prettier has no parser for that extension, so the pre-commit hook failed on any edit to `.env.default` regardless of content; fixing this was required to commit the required second file.

### Configuration changes
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes (no compose changes needed)
- [x] I have included a list of my configuration changes in the PR description (see Second file, above)

## Testing

Docs-only change — no application code paths to run.

### Checklist 📋
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified the corrected Better Auth signup/sign-in/token endpoints against `frontend/src/lib/autogpt-server-api/helpers.ts` (confirmed `/api/auth/token` requires a session cookie, not credentials directly)
  - [x] `prettier --check` and `tsc --noEmit` pass locally after regenerating the frontend API client (`orval`) and `pnpm install`
  - [x] CI green on the PR (docs/config-only diff; frontend lint/types/unit-tests/build all pass)
  - [x] Addressed the automated review's backlog (`autogpt-pr-reviewer` + CodeRabbit) per `~/code/agpt/.claude/playbooks/review-backlog.md` — corrected the two claims their live-stack QA disproved, fixed the remaining confirmed defects (portable port-kill, fail-fast token check, password off the `curl` command line, dummy mock credential, docker-mode reachability notes), replied+resolved every addressed thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KHsYkbLKR1updaEEnuD1e
