### PR TITLE
ci(platform): make Classic Python checks dispatch safe

### DIFF
--- a/.github/workflows/classic-python-checks.yml
+++ b/.github/workflows/classic-python-checks.yml
@@ -23,9 +23,13 @@ on:
       - 'classic/poetry.lock'
       - '**.py'
       - '!classic/forge/tests/vcr_cassettes'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
-  group: ${{ format('classic-python-checks-ci-{0}', github.head_ref && format('{0}-{1}', github.event_name, github.event.pull_request.number) || github.sha) }}
+  group: ${{ format('classic-python-checks-ci-{0}', github.event_name == 'workflow_dispatch' && github.run_id || (github.head_ref && format('{0}-{1}', github.event_name, github.event.pull_request.number) || github.sha)) }}
   cancel-in-progress: ${{ startsWith(github.event_name, 'pull_request') }}
 
 defaults:


### PR DESCRIPTION
### Why / What / How

Why: Allow the Classic Python checks to participate in manual CI waves without changing their checks.

What: This PR owns `.github/workflows/classic-python-checks.yml` and its directly relevant implementation/tests.

How: Restacked onto `dev@dbd1841f8da7d73754591ed1941fb9d89d551876` with one workflow per PR. Follow-up fixes have been folded into their owners instead of left in cross-workflow fix-up layers.

### Changes 🏗️

- Add input-free workflow dispatch and explicit read-only contents permission.
- Isolate dispatch concurrency by run ID; keep PR cancellation behavior.
- This PR now owns only classic-python-checks.yml. The original cross-workflow dispatch changes have moved to their workflow owners.

### Stack and provenance

- Layer 1/8; base branch: `dev`.
- Exact head: `2e2713658a985accfae928232add92705e5eec18`.
- Absorbed source: #14278.
- Original combined tip: `ca578975fffb99d9f41d06467dec41abf78ec109`; all old heads remain backed up locally and the superseded PR branches are retained.
- Reconciliation: all original stack files were preserved on current dev. The only additional changes are the two Codecov upload gates with regression tests and AST-identical overlap-test formatting.
- Historical CI, Fable feedback, and approvals are historical evidence only, not approval or validation of this new head. Nothing has been merged.

### Validation

Workflow YAML parsing, diff checks, and the one-workflow-per-layer/dependency audit passed.

The full local pre-commit invocation was attempted in the fresh Windows worktree. Schema export/type-check/frontend formatting hooks could not complete because that worktree lacks installed platform dependencies; the installed Poetry also rejects the existing hook's `-P` invocation. These are recorded limitations, not green checks. No frontend/backend application semantics were changed by this history rewrite. Fresh hosted CI remains the validation gate.

### Agents and large language models used

- Codex: model details unavailable (`unknown`); restacking and validation.
- Codex with `gpt-daybreak-blue-latest`: independent review of the earlier coverage/report/smoke fixes carried by the stack.
- Prior commits attribute Claude Opus 5; the originating platform was not recorded in those trailers. Human author/co-author attribution is preserved.
- Restack commits are unsigned.

### Checklist 📋

#### For code changes:

- [x] Changes and ownership are listed.
- [x] Test plan is described above.
- [x] Relevant local CI-helper checks and structural validation run.
- [ ] Current-head hosted workflow checks pass.
- [ ] Fresh review covers the redistributed diff.

#### For configuration changes:

- [x] Existing `.env.default` and compose configuration are preserved.
- [x] Configuration changes are listed above.
