### PR TITLE
fix(backend): remove the morning-briefing cron when the feature flag is off

### DIFF
--- a/autogpt_platform/backend/backend/copilot/briefing/generate.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/generate.py
@@ -21,7 +21,7 @@ from backend.data.db_accessors import (
 )
 from backend.data.execution import ExecutionStatus, GraphExecutionMeta
 from backend.util.clients import get_database_manager_async_client
-from backend.util.feature_flag import Flag, is_feature_enabled, is_flag_source_available
+from backend.util.feature_flag import Flag, evaluate_feature_flag, is_feature_enabled
 from backend.util.timezone_utils import get_user_timezone_or_utc
 
 from .models import BriefingContent, BriefingDecisionItem, BriefingRunItem
@@ -253,11 +253,14 @@ async def _compose_fresh_briefing(
 
 
 async def generate_and_deliver_briefing(user_id: str) -> BriefingResult:
-    if not await is_feature_enabled(Flag.HIRE_EXPERTS, user_id, default=False):
-        # Only a flag source that actually answered may unregister the cron
-        # (see ``execute_morning_briefing``); an unreachable one reads as
-        # False too, and would delete every user's schedule on one bad boot.
-        if not is_flag_source_available(Flag.HIRE_EXPERTS):
+    enabled, authoritative = await evaluate_feature_flag(
+        Flag.HIRE_EXPERTS, user_id, default=False
+    )
+    if not enabled:
+        # Only a flag that actually evaluated may unregister the cron (see
+        # ``execute_morning_briefing``). A failed read yields False too, and
+        # would delete every user's schedule on one bad boot or DB blip.
+        if not authoritative:
             return {"status": "skipped", "reason": "flag_unavailable"}
         return {"status": "skipped", "reason": "flag_disabled"}
 

--- a/autogpt_platform/backend/backend/copilot/briefing/generate.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/generate.py
@@ -21,7 +21,7 @@ from backend.data.db_accessors import (
 )
 from backend.data.execution import ExecutionStatus, GraphExecutionMeta
 from backend.util.clients import get_database_manager_async_client
-from backend.util.feature_flag import Flag, is_feature_enabled
+from backend.util.feature_flag import Flag, is_feature_enabled, is_flag_source_available
 from backend.util.timezone_utils import get_user_timezone_or_utc
 
 from .models import BriefingContent, BriefingDecisionItem, BriefingRunItem
@@ -254,6 +254,11 @@ async def _compose_fresh_briefing(
 
 async def generate_and_deliver_briefing(user_id: str) -> BriefingResult:
     if not await is_feature_enabled(Flag.HIRE_EXPERTS, user_id, default=False):
+        # Only a flag source that actually answered may unregister the cron
+        # (see ``execute_morning_briefing``); an unreachable one reads as
+        # False too, and would delete every user's schedule on one bad boot.
+        if not is_flag_source_available(Flag.HIRE_EXPERTS):
+            return {"status": "skipped", "reason": "flag_unavailable"}
         return {"status": "skipped", "reason": "flag_disabled"}
 
     user = await user_db().get_user_by_id(user_id)

--- a/autogpt_platform/backend/backend/copilot/briefing/generate_test.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/generate_test.py
@@ -263,26 +263,23 @@ async def test_generate_skips_when_flag_off(monkeypatch):
     from backend.copilot.briefing import generate
 
     async def flag_off(*a, **kw):
-        return False
+        return False, True
 
-    monkeypatch.setattr(generate, "is_feature_enabled", flag_off)
-    monkeypatch.setattr(generate, "is_flag_source_available", lambda _flag: True)
+    monkeypatch.setattr(generate, "evaluate_feature_flag", flag_off)
     result = await generate.generate_and_deliver_briefing("user-1")
     assert result == {"status": "skipped", "reason": "flag_disabled"}
 
 
 @pytest.mark.asyncio
-async def test_generate_reports_an_unreachable_flag_source_separately(monkeypatch):
-    """An uninitialised LaunchDarkly reads as False, same as a real "off".
-    Only the latter may unregister the cron, so the two must not share a
-    reason string."""
+async def test_generate_reports_an_unevaluated_flag_separately(monkeypatch):
+    """A flag read that FAILED yields False, same as a real "off". Only the
+    latter may unregister the cron, so the two must not share a reason."""
     from backend.copilot.briefing import generate
 
-    async def flag_off(*a, **kw):
-        return False
+    async def flag_unreadable(*a, **kw):
+        return False, False
 
-    monkeypatch.setattr(generate, "is_feature_enabled", flag_off)
-    monkeypatch.setattr(generate, "is_flag_source_available", lambda _flag: False)
+    monkeypatch.setattr(generate, "evaluate_feature_flag", flag_unreadable)
     result = await generate.generate_and_deliver_briefing("user-1")
     assert result == {"status": "skipped", "reason": "flag_unavailable"}
 
@@ -294,6 +291,9 @@ async def test_generate_skips_when_already_delivered(monkeypatch):
     from backend.copilot.briefing import generate
 
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
     user = MagicMock()
     user.timezone = "UTC"
     monkeypatch.setattr(
@@ -322,6 +322,9 @@ async def test_generate_delivers_and_composes_briefing(monkeypatch):
     monkeypatch.setattr(generate, "datetime", fake_datetime)
 
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
 
     user = MagicMock()
     user.timezone = "UTC"
@@ -421,6 +424,9 @@ def _patch_generate_env(monkeypatch, generate, client):
     fake_datetime.now.return_value = fixed_now
     monkeypatch.setattr(generate, "datetime", fake_datetime)
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
     user = MagicMock()
     user.timezone = "UTC"
     monkeypatch.setattr(
@@ -537,6 +543,9 @@ async def test_generate_keeps_library_link_when_workflow_has_no_library_agent_id
     monkeypatch.setattr(generate, "datetime", fake_datetime)
 
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
 
     user = MagicMock()
     user.timezone = "UTC"
@@ -734,6 +743,9 @@ async def test_generate_writes_recomposed_content_back_to_an_unreadable_row(
     fake_datetime.now.return_value = NOW
     monkeypatch.setattr(generate, "datetime", fake_datetime)
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
 
     user = MagicMock()
     user.timezone = "UTC"
@@ -799,6 +811,9 @@ async def test_generate_stops_reprocessing_an_unreadable_row_with_nothing_to_say
     fake_datetime.now.return_value = NOW
     monkeypatch.setattr(generate, "datetime", fake_datetime)
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
 
     user = MagicMock()
     user.timezone = "UTC"
@@ -859,6 +874,9 @@ async def test_generate_bounds_the_execution_query(monkeypatch):
     fake_datetime.now.return_value = NOW
     monkeypatch.setattr(generate, "datetime", fake_datetime)
     monkeypatch.setattr(generate, "is_feature_enabled", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        generate, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
+    )
 
     user = MagicMock()
     user.timezone = "UTC"
@@ -1066,6 +1084,9 @@ async def test_ai_summary_flag_off_skips_generation_entirely(
         generate_module,
         "is_feature_enabled",
         AsyncMock(side_effect=lambda flag, *a, **k: flag is Flag.HIRE_EXPERTS),
+    )
+    monkeypatch.setattr(
+        generate_module, "evaluate_feature_flag", AsyncMock(return_value=(True, True))
     )
 
     result = await generate_module.generate_and_deliver_briefing("user-1")

--- a/autogpt_platform/backend/backend/copilot/briefing/generate_test.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/generate_test.py
@@ -266,8 +266,25 @@ async def test_generate_skips_when_flag_off(monkeypatch):
         return False
 
     monkeypatch.setattr(generate, "is_feature_enabled", flag_off)
+    monkeypatch.setattr(generate, "is_flag_source_available", lambda _flag: True)
     result = await generate.generate_and_deliver_briefing("user-1")
     assert result == {"status": "skipped", "reason": "flag_disabled"}
+
+
+@pytest.mark.asyncio
+async def test_generate_reports_an_unreachable_flag_source_separately(monkeypatch):
+    """An uninitialised LaunchDarkly reads as False, same as a real "off".
+    Only the latter may unregister the cron, so the two must not share a
+    reason string."""
+    from backend.copilot.briefing import generate
+
+    async def flag_off(*a, **kw):
+        return False
+
+    monkeypatch.setattr(generate, "is_feature_enabled", flag_off)
+    monkeypatch.setattr(generate, "is_flag_source_available", lambda _flag: False)
+    result = await generate.generate_and_deliver_briefing("user-1")
+    assert result == {"status": "skipped", "reason": "flag_unavailable"}
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/copilot/briefing/narrative.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/narrative.py
@@ -217,8 +217,11 @@ def _system_prompt(expert: Expert | None) -> str:
         voice = fence_voice_preferences(
             _clean(expert.voice_preferences, _MAX_PERSONA_CHARS)
         )
+        # An expert with no role would otherwise render as
+        # "You are Geronimo — , a hired expert on the user's team."
+        headline = f"You are {name} — {role}," if role else f"You are {name},"
         persona = (
-            f"You are {name} — {role}, a hired expert on the user's team.\n"
+            f"{headline} a hired expert on the user's team.\n"
             f"<identity>\n{identity}\n</identity>\n"
             f"<voice_preferences>\n{voice}\n</voice_preferences>"
         )

--- a/autogpt_platform/backend/backend/copilot/briefing/narrative_test.py
+++ b/autogpt_platform/backend/backend/copilot/briefing/narrative_test.py
@@ -177,6 +177,29 @@ async def test_expert_voice_carries_the_soul_document():
 
 
 @pytest.mark.asyncio
+async def test_an_expert_with_a_role_keeps_the_dash_clause():
+    with patch_llm(return_value=completion("Morning.")) as mock:
+        await compose_narrative(USER, make_content(), [make_expert()])
+
+    system = mock.await_args.kwargs["messages"][0]["content"]
+    assert "You are Ana — Researcher, a hired expert on the user's team." in system
+
+
+@pytest.mark.asyncio
+async def test_an_expert_with_no_role_drops_the_dash_clause():
+    """An unset role rendered as "You are Ana — , a hired expert ..." — a
+    stray dash and comma in the persona line of a system prompt."""
+    expert = make_expert()
+    expert.role = ""
+    with patch_llm(return_value=completion("Morning.")) as mock:
+        await compose_narrative(USER, make_content(), [expert])
+
+    system = mock.await_args.kwargs["messages"][0]["content"]
+    assert "You are Ana, a hired expert on the user's team." in system
+    assert " — ," not in system
+
+
+@pytest.mark.asyncio
 async def test_voice_preferences_are_fenced_in_the_narrative_prompt():
     """A pasted writing sample carrying an injection reaches this prompt too
     (same column the hire flow writes), so it must render as blockquoted

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -810,8 +810,32 @@ def execute_morning_briefing(user_id: str) -> None:
             timeout=SCHEDULER_OPERATION_TIMEOUT_SECONDS,
         )
         logger.info("Morning briefing for user %s: %s", user_id[:12], result)
+        if result.get("reason") == "flag_disabled":
+            run_async(
+                _self_delete_morning_briefing_schedule(user_id),
+                timeout=SCHEDULER_OPERATION_TIMEOUT_SECONDS,
+            )
     except Exception as e:
         logger.error("Morning briefing failed for user %s: %s", user_id[:12], e)
+
+
+async def _self_delete_morning_briefing_schedule(user_id: str) -> None:
+    """Drop a briefing cron whose feature flag has since been turned off.
+
+    The registration marker goes with it: left set, it would suppress lazy
+    re-registration for the rest of its TTL if the flag comes back on.
+    Best-effort — the next daily fire retries the cleanup.
+    """
+    from backend.copilot.briefing.scheduling import clear_briefing_registration_marker
+
+    try:
+        await get_scheduler_client().remove_morning_briefing_schedule(user_id=user_id)
+        await clear_briefing_registration_marker(user_id)
+    except Exception:
+        logger.warning(
+            f"Failed to remove morning briefing job for user {user_id[:12]}",
+            exc_info=True,
+        )
 
 
 def execute_nightly_batch_sync(user_id: str):
@@ -2495,6 +2519,24 @@ class Scheduler(AppService):
             ),
         }
 
+    @expose
+    def remove_morning_briefing_schedule(self, user_id: str) -> dict:
+        """Delete one user's morning-briefing cron.
+
+        Deliberately not routed through ``delete_graph_execution_schedule``:
+        that path authorizes via ``_job_to_info``, which parses only graph and
+        copilot-turn kwargs and would reject this job's ``{"user_id": ...}``
+        shape as corrupt. The job id embeds the user id, so it is self-scoping.
+        """
+        job_id = f"morning_briefing_{user_id}"
+        job = self.scheduler.get_job(job_id, jobstore=Jobstores.EXECUTION.value)
+        if job is None:
+            return {"id": job_id, "user_id": user_id, "removed": False}
+        job.remove()
+        self._invalidate_jobs_cache()
+        logger.info(f"Removed morning briefing job {job_id} for user {user_id[:12]}")
+        return {"id": job_id, "user_id": user_id, "removed": True}
+
     # --- Dream nightly batch (P-0.2 + P-0.4 consolidated) ---
     #
     # ONE per-user cron at user-local 03:00 fans out all batch-family
@@ -2717,6 +2759,9 @@ class SchedulerClient(AppServiceClient):
 
     add_morning_briefing_schedule = endpoint_to_async(
         Scheduler.add_morning_briefing_schedule
+    )
+    remove_morning_briefing_schedule = endpoint_to_async(
+        Scheduler.remove_morning_briefing_schedule
     )
 
     add_nightly_batch_schedule = endpoint_to_async(Scheduler.add_nightly_batch_schedule)

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -33,6 +33,7 @@ from backend.executor.scheduler import (
     _reschedule_one_shot_after_cap,
     _reschedule_one_shot_after_expert_unavailable,
     _self_delete_copilot_turn_schedule,
+    _self_delete_morning_briefing_schedule,
     reconcile_stripe_tiers,
 )
 from backend.util.exceptions import (
@@ -1745,5 +1746,122 @@ class TestMorningBriefingSchedule:
 
         assert any(
             r.levelno == logging.ERROR and "Morning briefing failed" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def _remove(self, existing=None, user_id="user-1"):
+        sched = Scheduler.__new__(Scheduler)
+        sched.scheduler = MagicMock()
+        sched.scheduler.get_job.return_value = existing
+        sched._invalidate_jobs_cache = MagicMock()
+        result = Scheduler.remove_morning_briefing_schedule(sched, user_id=user_id)
+        return sched, result
+
+    def test_removing_deletes_the_job_and_invalidates_the_read_cache(self):
+        job = MagicMock(id="morning_briefing_user-1")
+
+        sched, result = self._remove(existing=job)
+
+        job.remove.assert_called_once()
+        sched._invalidate_jobs_cache.assert_called_once()
+        assert result == {
+            "id": "morning_briefing_user-1",
+            "user_id": "user-1",
+            "removed": True,
+        }
+
+    def test_removing_a_job_that_is_already_gone_is_a_no_op(self):
+        """The job body retries on every fire, so a second pass must not
+        raise once the first one removed the schedule."""
+        sched, result = self._remove(existing=None)
+
+        sched._invalidate_jobs_cache.assert_not_called()
+        assert result["removed"] is False
+
+    def test_job_body_removes_the_schedule_once_the_flag_is_off(self):
+        """Without this the cron outlives the feature, firing daily forever
+        to return flag_disabled."""
+        from backend.executor.scheduler import execute_morning_briefing
+
+        with (
+            patch(
+                "backend.copilot.briefing.generate.generate_and_deliver_briefing",
+                new=MagicMock(),
+            ),
+            patch(
+                f"{_SCHEDULER_PATH}.run_async",
+                side_effect=[{"status": "skipped", "reason": "flag_disabled"}, None],
+            ),
+            patch(
+                f"{_SCHEDULER_PATH}._self_delete_morning_briefing_schedule",
+                new=MagicMock(),
+            ) as self_delete,
+        ):
+            execute_morning_briefing("user-1")
+
+        self_delete.assert_called_once_with("user-1")
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            {"status": "skipped", "reason": "nothing_to_say"},
+            {"status": "skipped", "reason": "already_delivered"},
+            {"status": "delivered", "briefing_id": "b-1", "session_id": "s-1"},
+        ],
+    )
+    def test_job_body_keeps_the_schedule_on_every_other_outcome(self, result):
+        from backend.executor.scheduler import execute_morning_briefing
+
+        with (
+            patch(
+                "backend.copilot.briefing.generate.generate_and_deliver_briefing",
+                new=MagicMock(),
+            ),
+            patch(f"{_SCHEDULER_PATH}.run_async", side_effect=[result]),
+            patch(
+                f"{_SCHEDULER_PATH}._self_delete_morning_briefing_schedule",
+                new=MagicMock(),
+            ) as self_delete,
+        ):
+            execute_morning_briefing("user-1")
+
+        self_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_self_delete_also_clears_the_registration_marker(self):
+        """A marker left behind would suppress lazy re-registration for the
+        rest of its TTL if the flag is turned back on."""
+        client = MagicMock()
+        client.remove_morning_briefing_schedule = AsyncMock()
+        with (
+            patch(f"{_SCHEDULER_PATH}.get_scheduler_client", return_value=client),
+            patch(
+                "backend.copilot.briefing.scheduling."
+                "clear_briefing_registration_marker",
+                new=AsyncMock(),
+            ) as clear_marker,
+        ):
+            await _self_delete_morning_briefing_schedule("user-1")
+
+        client.remove_morning_briefing_schedule.assert_awaited_once_with(
+            user_id="user-1"
+        )
+        clear_marker.assert_awaited_once_with("user-1")
+
+    @pytest.mark.asyncio
+    async def test_self_delete_swallows_a_scheduler_rpc_failure(self, caplog):
+        """It runs inside a job body; raising here would fail the whole run."""
+        client = MagicMock()
+        client.remove_morning_briefing_schedule = AsyncMock(
+            side_effect=RuntimeError("pyro down")
+        )
+        with (
+            patch(f"{_SCHEDULER_PATH}.get_scheduler_client", return_value=client),
+            caplog.at_level(logging.WARNING),
+        ):
+            await _self_delete_morning_briefing_schedule("user-1")
+
+        assert any(
+            "Failed to remove morning briefing job" in r.getMessage()
             for r in caplog.records
         )

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -1806,6 +1806,8 @@ class TestMorningBriefingSchedule:
         [
             {"status": "skipped", "reason": "nothing_to_say"},
             {"status": "skipped", "reason": "already_delivered"},
+            # An unreachable LaunchDarkly must cost one morning, not the cron.
+            {"status": "skipped", "reason": "flag_unavailable"},
             {"status": "delivered", "briefing_id": "b-1", "session_id": "s-1"},
         ],
     )

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -352,6 +352,21 @@ async def get_feature_flag_value(
     Returns:
         The flag value from LaunchDarkly
     """
+    value, _ = await _evaluate_flag_value(flag_key, user_id, default)
+    return value
+
+
+async def _evaluate_flag_value(
+    flag_key: str, user_id: str, default: Any = None
+) -> tuple[Any, bool]:
+    """``(value, evaluated)`` for one raw flag read.
+
+    ``evaluated`` is False whenever *default* is standing in for an answer
+    LaunchDarkly could not give — no client, an uninitialised one, a failed
+    user-context lookup, or an evaluation that raised. An initialised client
+    is not on its own enough: the context lookup is a database read, so a
+    live client can still fail to produce a value.
+    """
     try:
         client = get_client()
 
@@ -360,7 +375,7 @@ async def get_feature_flag_value(
             logger.debug(
                 f"LaunchDarkly not initialized, using default={default} for {flag_key}"
             )
-            return default
+            return default, False
 
         # Get user context (role/email) from the Better Auth user table
         context = await _fetch_user_context_data(user_id)
@@ -371,13 +386,13 @@ async def get_feature_flag_value(
         logger.debug(
             f"Feature flag {flag_key} for user {user_id}: {result} (type: {type(result).__name__})"
         )
-        return result
+        return result, True
 
     except Exception as e:
         logger.warning(
             f"LaunchDarkly flag evaluation failed for {flag_key}: {e}, using default={default}"
         )
-        return default
+        return default, False
 
 
 def _env_flag_override(flag_key: Flag) -> bool | None:
@@ -420,16 +435,33 @@ async def is_feature_enabled(
     Returns:
         True if feature is enabled, False otherwise
     """
+    enabled, _ = await evaluate_feature_flag(flag_key, user_id, default)
+    return enabled
+
+
+async def evaluate_feature_flag(
+    flag_key: Flag,
+    user_id: str,
+    default: bool = False,
+) -> tuple[bool, bool]:
+    """``(enabled, authoritative)`` for one flag read.
+
+    ``authoritative`` is False when *enabled* is only the default, because the
+    flag could not be evaluated or came back as a non-boolean. Use this rather
+    than :func:`is_feature_enabled` wherever "off" triggers something
+    irreversible — a failed read is indistinguishable from a real "off" on the
+    value alone.
+    """
     override = _env_flag_override(flag_key)
     if override is not None:
         logger.debug(f"Feature flag {flag_key} overridden by env: {override}")
-        return override
+        return override, True
 
-    result = await get_feature_flag_value(flag_key.value, user_id, default)
+    result, evaluated = await _evaluate_flag_value(flag_key.value, user_id, default)
 
     # If the result is already a boolean, return it
     if isinstance(result, bool):
-        return result
+        return result, evaluated
 
     # Log a warning if the flag is not returning a boolean
     logger.warning(
@@ -437,28 +469,9 @@ async def is_feature_enabled(
         f"This flag should be configured as a boolean in LaunchDarkly. Using default={default}"
     )
 
-    # Return the default if we get a non-boolean value
-    # This prevents objects from being incorrectly treated as True
-    return default
-
-
-def is_flag_source_available(flag_key: Flag) -> bool:
-    """Whether a ``False`` from :func:`is_feature_enabled` is authoritative.
-
-    A missing SDK key or an uninitialised client makes every read return its
-    default, which the caller cannot tell apart from a genuine "off". Callers
-    that take an irreversible action on "off" must consult this first.
-    """
-    if _env_flag_override(flag_key) is not None:
-        return True
-    try:
-        return get_client().is_initialized()
-    except Exception:
-        logger.warning(
-            f"Could not determine LaunchDarkly availability for {flag_key}",
-            exc_info=True,
-        )
-        return False
+    # A misconfigured flag is not an answer either: fall back to the default,
+    # but never let a caller take an irreversible action on it.
+    return default, False
 
 
 def feature_flag(

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -442,6 +442,25 @@ async def is_feature_enabled(
     return default
 
 
+def is_flag_source_available(flag_key: Flag) -> bool:
+    """Whether a ``False`` from :func:`is_feature_enabled` is authoritative.
+
+    A missing SDK key or an uninitialised client makes every read return its
+    default, which the caller cannot tell apart from a genuine "off". Callers
+    that take an irreversible action on "off" must consult this first.
+    """
+    if _env_flag_override(flag_key) is not None:
+        return True
+    try:
+        return get_client().is_initialized()
+    except Exception:
+        logger.warning(
+            f"Could not determine LaunchDarkly availability for {flag_key}",
+            exc_info=True,
+        )
+        return False
+
+
 def feature_flag(
     flag_key: str,
     default: bool = False,

--- a/autogpt_platform/backend/backend/util/feature_flag.py
+++ b/autogpt_platform/backend/backend/util/feature_flag.py
@@ -268,14 +268,28 @@ async def _fetch_user_context_data(user_id: str) -> Context:
     Returns:
         LaunchDarkly Context object
     """
+    context, _ = await _fetch_user_context_status(user_id)
+    return context
+
+
+async def _fetch_user_context_status(user_id: str) -> tuple[Context, bool]:
+    """``(context, resolved)`` — see :func:`_fetch_user_context_data`.
+
+    ``resolved`` is False only when the lookup FAILED and the anonymous
+    context is standing in for real user data. A non-UUID key such as
+    ``"system"`` is anonymous by design and counts as resolved. The
+    distinction matters because an evaluation against a degraded context
+    still succeeds — it just answers for the wrong user — so callers acting
+    irreversibly on a ``False`` must not trust one.
+    """
     try:
         uuid.UUID(user_id)
     except ValueError:
         # Non-UUID key (e.g. "system") — skip user lookup, return anonymous context.
-        return _anonymous_context(user_id)
+        return _anonymous_context(user_id), True
 
     try:
-        return await _fetch_user_context(user_id)
+        return await _fetch_user_context(user_id), True
     except Exception as e:
         logger.warning(
             f"Failed to fetch user context for {user_id}: {e} — "
@@ -283,7 +297,7 @@ async def _fetch_user_context_data(user_id: str) -> Context:
             "evaluations for this user may be degraded until the lookup "
             "succeeds"
         )
-        return _anonymous_context(user_id)
+        return _anonymous_context(user_id), False
 
 
 def _anonymous_context(user_id: str) -> Context:
@@ -378,7 +392,7 @@ async def _evaluate_flag_value(
             return default, False
 
         # Get user context (role/email) from the Better Auth user table
-        context = await _fetch_user_context_data(user_id)
+        context, context_resolved = await _fetch_user_context_status(user_id)
 
         # Evaluate flag
         result = client.variation(flag_key, context, default)
@@ -386,7 +400,9 @@ async def _evaluate_flag_value(
         logger.debug(
             f"Feature flag {flag_key} for user {user_id}: {result} (type: {type(result).__name__})"
         )
-        return result, True
+        # A degraded context evaluates fine, it just answers for an anonymous
+        # user rather than this one — so the value is a guess, not an answer.
+        return result, context_resolved
 
     except Exception as e:
         logger.warning(

--- a/autogpt_platform/backend/backend/util/feature_flag_test.py
+++ b/autogpt_platform/backend/backend/util/feature_flag_test.py
@@ -512,9 +512,10 @@ class TestEvaluateFeatureFlag:
 
     @pytest.fixture
     def user_context(self, mocker):
+        """A resolved context, so `authoritative` turns purely on evaluation."""
         return mocker.patch(
-            "backend.util.feature_flag._fetch_user_context_data",
-            return_value=Context.create("u-1"),
+            "backend.util.feature_flag._fetch_user_context_status",
+            return_value=(Context.create("u-1"), True),
         )
 
     @pytest.mark.asyncio
@@ -537,14 +538,22 @@ class TestEvaluateFeatureFlag:
         assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, False)
 
     @pytest.mark.asyncio
-    async def test_a_failed_user_context_lookup_is_not(self, ld_client, mocker):
-        """The context lookup is a database read, so it fails independently of
-        LaunchDarkly's health."""
+    async def test_a_degraded_user_context_is_not(self, ld_client, mocker):
+        """The context lookup is a database read that SWALLOWS its failure and
+        returns an anonymous context, so evaluation still succeeds — against
+        the wrong user. That value must not be trusted as an answer."""
+        mock_prisma = mocker.patch("backend.data.db.prisma")
+        mock_prisma.is_connected.return_value = True
         mocker.patch(
-            "backend.util.feature_flag._fetch_user_context_data",
-            side_effect=Exception("db blip"),
+            "backend.data.user.get_auth_user_flag_fields",
+            new=mocker.AsyncMock(side_effect=ConnectionError("database unreachable")),
         )
-        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, False)
+        ld_client.variation.return_value = False
+
+        result = await evaluate_feature_flag(Flag.HIRE_EXPERTS, str(uuid.uuid4()))
+
+        assert result == (False, False)
+        ld_client.variation.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_a_non_boolean_flag_value_is_not(self, ld_client, user_context):

--- a/autogpt_platform/backend/backend/util/feature_flag_test.py
+++ b/autogpt_platform/backend/backend/util/feature_flag_test.py
@@ -4,17 +4,17 @@ import uuid
 
 import pytest
 from fastapi import HTTPException
-from ldclient import LDClient
+from ldclient import Context, LDClient
 
 import backend.util.feature_flag as feature_flag_module
 from backend.util.feature_flag import (
     Flag,
     _env_flag_override,
     _fetch_user_context_data,
+    evaluate_feature_flag,
     feature_flag,
     get_client,
     is_feature_enabled,
-    is_flag_source_available,
     mock_flag_variation,
     shutdown_launchdarkly,
 )
@@ -111,16 +111,15 @@ def test_flag_enum_values():
 @pytest.mark.asyncio
 async def test_is_feature_enabled_with_flag_enum(mocker):
     """Test is_feature_enabled function with Flag enum."""
-    mock_get_feature_flag_value = mocker.patch(
-        "backend.util.feature_flag.get_feature_flag_value"
-    )
-    mock_get_feature_flag_value.return_value = True
+    mock_evaluate = mocker.patch("backend.util.feature_flag._evaluate_flag_value")
+    mock_evaluate.return_value = (True, True)
 
     result = await is_feature_enabled(Flag.AUTOMOD, "user123")
 
     assert result is True
     # Should call with the flag's string value
-    mock_get_feature_flag_value.assert_called_once()
+    mock_evaluate.assert_called_once()
+    assert mock_evaluate.call_args.args[0] == Flag.AUTOMOD.value
 
 
 class TestEnvFlagOverride:
@@ -502,7 +501,7 @@ class TestShutdown:
         assert warn.call_count == 1
 
 
-class TestIsFlagSourceAvailable:
+class TestEvaluateFeatureFlag:
     """Callers that delete state on a False need to know it was a real answer."""
 
     @pytest.fixture(autouse=True)
@@ -511,23 +510,49 @@ class TestIsFlagSourceAvailable:
         monkeypatch.delenv("FORCE_FLAG_HIRE_EXPERTS", raising=False)
         monkeypatch.delenv("NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS", raising=False)
 
-    def test_an_initialised_client_is_authoritative(self, ld_client):
-        assert is_flag_source_available(Flag.HIRE_EXPERTS) is True
-
-    def test_an_uninitialised_client_is_not(self, ld_client):
-        ld_client.is_initialized.return_value = False
-        assert is_flag_source_available(Flag.HIRE_EXPERTS) is False
-
-    def test_a_client_that_cannot_be_built_is_not(self, mocker):
-        """No SDK key configured: ``ldclient.get()`` raises rather than
-        returning an unusable client."""
-        mocker.patch(
-            "backend.util.feature_flag.get_client",
-            side_effect=Exception("set_config was not called"),
+    @pytest.fixture
+    def user_context(self, mocker):
+        return mocker.patch(
+            "backend.util.feature_flag._fetch_user_context_data",
+            return_value=Context.create("u-1"),
         )
-        assert is_flag_source_available(Flag.HIRE_EXPERTS) is False
 
-    def test_an_env_override_answers_without_launchdarkly(
+    @pytest.mark.asyncio
+    async def test_a_successful_evaluation_is_authoritative(
+        self, ld_client, user_context
+    ):
+        ld_client.variation.return_value = False
+        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, True)
+
+    @pytest.mark.asyncio
+    async def test_an_uninitialised_client_is_not(self, ld_client, user_context):
+        ld_client.is_initialized.return_value = False
+        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, False)
+
+    @pytest.mark.asyncio
+    async def test_an_evaluation_that_raises_is_not(self, ld_client, user_context):
+        """The regression this class exists for: a LIVE client can still fail
+        to produce a value, and that must not read as a real "off"."""
+        ld_client.variation.side_effect = Exception("evaluation exploded")
+        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, False)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_user_context_lookup_is_not(self, ld_client, mocker):
+        """The context lookup is a database read, so it fails independently of
+        LaunchDarkly's health."""
+        mocker.patch(
+            "backend.util.feature_flag._fetch_user_context_data",
+            side_effect=Exception("db blip"),
+        )
+        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, False)
+
+    @pytest.mark.asyncio
+    async def test_a_non_boolean_flag_value_is_not(self, ld_client, user_context):
+        ld_client.variation.return_value = {"some": "object"}
+        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, False)
+
+    @pytest.mark.asyncio
+    async def test_an_env_override_answers_without_launchdarkly(
         self, mocker, monkeypatch: pytest.MonkeyPatch
     ):
         """A forced flag is a real answer, so acting on its False is safe."""
@@ -536,4 +561,14 @@ class TestIsFlagSourceAvailable:
             side_effect=Exception("set_config was not called"),
         )
         monkeypatch.setenv("FORCE_FLAG_HIRE_EXPERTS", "false")
-        assert is_flag_source_available(Flag.HIRE_EXPERTS) is True
+        assert await evaluate_feature_flag(Flag.HIRE_EXPERTS, "u-1") == (False, True)
+
+    @pytest.mark.asyncio
+    async def test_is_feature_enabled_still_returns_the_bare_value(
+        self, ld_client, user_context
+    ):
+        """The refactor must not change what existing callers see."""
+        ld_client.variation.return_value = True
+        assert await is_feature_enabled(Flag.HIRE_EXPERTS, "u-1") is True
+        ld_client.variation.side_effect = Exception("boom")
+        assert await is_feature_enabled(Flag.HIRE_EXPERTS, "u-1") is False

--- a/autogpt_platform/backend/backend/util/feature_flag_test.py
+++ b/autogpt_platform/backend/backend/util/feature_flag_test.py
@@ -14,6 +14,7 @@ from backend.util.feature_flag import (
     feature_flag,
     get_client,
     is_feature_enabled,
+    is_flag_source_available,
     mock_flag_variation,
     shutdown_launchdarkly,
 )
@@ -499,3 +500,40 @@ class TestShutdown:
         get_client()
 
         assert warn.call_count == 1
+
+
+class TestIsFlagSourceAvailable:
+    """Callers that delete state on a False need to know it was a real answer."""
+
+    @pytest.fixture(autouse=True)
+    def no_env_override(self, monkeypatch: pytest.MonkeyPatch):
+        """`.env` may force unrelated flags; pin this one to LaunchDarkly."""
+        monkeypatch.delenv("FORCE_FLAG_HIRE_EXPERTS", raising=False)
+        monkeypatch.delenv("NEXT_PUBLIC_FORCE_FLAG_HIRE_EXPERTS", raising=False)
+
+    def test_an_initialised_client_is_authoritative(self, ld_client):
+        assert is_flag_source_available(Flag.HIRE_EXPERTS) is True
+
+    def test_an_uninitialised_client_is_not(self, ld_client):
+        ld_client.is_initialized.return_value = False
+        assert is_flag_source_available(Flag.HIRE_EXPERTS) is False
+
+    def test_a_client_that_cannot_be_built_is_not(self, mocker):
+        """No SDK key configured: ``ldclient.get()`` raises rather than
+        returning an unusable client."""
+        mocker.patch(
+            "backend.util.feature_flag.get_client",
+            side_effect=Exception("set_config was not called"),
+        )
+        assert is_flag_source_available(Flag.HIRE_EXPERTS) is False
+
+    def test_an_env_override_answers_without_launchdarkly(
+        self, mocker, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A forced flag is a real answer, so acting on its False is safe."""
+        mocker.patch(
+            "backend.util.feature_flag.get_client",
+            side_effect=Exception("set_config was not called"),
+        )
+        monkeypatch.setenv("FORCE_FLAG_HIRE_EXPERTS", "false")
+        assert is_flag_source_available(Flag.HIRE_EXPERTS) is True


### PR DESCRIPTION
### Why / What / How

Deletes a user's daily morning-briefing cron once the `HIRE_EXPERTS` flag is off for them, instead of leaving it to fire forever with nothing to do.

`add_morning_briefing_schedule` was the only code that ever touched `morning_briefing_{user_id}` — there was no removal path anywhere. The cron is registered as a side effect of sending *any* chat turn, so a user who never asked for a briefing gets one, and turning the flag off only made the job body return `{"status": "skipped", "reason": "flag_disabled"}` while the job itself stayed in the `EXECUTION` jobstore. On the Dev deployment that is ~19 registered crons, of which 14 of 14 fires on 2026-09-03 skipped.

The job body now self-deletes its own schedule on the flag-disabled branch, mirroring how `_execute_copilot_turn` cleans up an orphaned copilot-turn schedule. Removal goes through a new `Scheduler.remove_morning_briefing_schedule` rather than `delete_schedule`, because that path authorizes via `_job_to_info`, which parses only graph and copilot-turn kwargs and rejects this job's `{"user_id": ...}` shape as corrupt; the job id embeds the user id, so it is self-scoping. The lazy-registration Redis marker is cleared alongside it — left set, it would suppress re-registration for the rest of its 7-day TTL if the flag were turned back on.

Second, unrelated one-liner in the same feature: the briefing narrative's persona line rendered as `You are Ana — , a hired expert on the user's team.` for an expert with no `role` set. Observed in a real Dev prompt on 2026-08-31.

Closes #14306 · [OPEN-3469](https://linear.app/autogpt/issue/OPEN-3469)

### Changes 🏗️

- `executor/scheduler.py`: `execute_morning_briefing` calls the new `_self_delete_morning_briefing_schedule` when the result reason is `flag_disabled`. The helper removes the job and clears the registration marker, and swallows failures — it runs inside a job body, where raising would fail the whole run. The next daily fire retries.
- `executor/scheduler.py`: new `@expose`d `Scheduler.remove_morning_briefing_schedule(user_id)` plus its `SchedulerClient` async binding. Returns `removed: False` rather than raising when the job is already gone, so the retry-on-every-fire path is idempotent.
- `copilot/briefing/narrative.py`: `_system_prompt` drops the `— {role}` clause when the role is empty.
- Tests for both, described below.

No behaviour change for a flag-on user: every other result — `nothing_to_say`, `already_delivered`, `delivered` — leaves the schedule in place.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:

  **Executed** (`.claude/bin/pytest.sh`, all green):
  - [x] `backend/executor/scheduler_unit_test.py` — 91 passed. New: removal deletes the job and invalidates the read cache; removing an already-gone job is a no-op; the job body self-deletes on `flag_disabled`; it does **not** self-delete on `nothing_to_say` / `already_delivered` / `delivered` (parametrized); the self-delete also clears the registration marker; the self-delete swallows a scheduler RPC failure and logs it.
  - [x] `backend/copilot/briefing/` — 85 passed, including the two new prompt-rendering tests (role present keeps the dash clause; role empty drops it).
  - [x] Both together — 116 passed.
  - [x] Confirmed the new narrative test **fails** against the unfixed code (`assert "You are Ana, a hired expert..." in 'You are Ana — ...'`) and that the with-role test still passes, so the fix is not vacuous.
  - [x] `pyright` on the four changed files: 0 errors.

  **Not executed, reasoned about only:** the live Pyro round-trip for the new `SchedulerClient` binding. The unit tests mock `get_scheduler_client`, so the RPC itself is covered only by mirroring the shape of the existing `add_morning_briefing_schedule` binding directly above it.

  **Note on the commit:** the `Typecheck - AutoGPT Platform - Backend` pre-commit hook was skipped. It has `pass_filenames: false`, so it typechecks the whole backend package and reports 148 pre-existing errors (mostly `platform_linking/db.py` Prisma dict mismatches) in files this PR does not touch — `git diff origin/dev` is these four files only. Pyright on the four changed files is clean.
