### PR TITLE
fix(backend): invalidate the copilot integration-token cache across processes

### DIFF
--- a/autogpt_platform/backend/backend/copilot/integration_creds.py
+++ b/autogpt_platform/backend/backend/copilot/integration_creds.py
@@ -211,13 +211,11 @@ async def get_provider_token(user_id: str, provider: str) -> str | None:
 
 
 def _ensure_cache_invalidation_listener() -> None:
-    """Start this process's subscription to credential changes, once.
+    """Subscribe this process to credential changes, once.
 
-    Started from the cache read path rather than from a service's startup: a
-    subscription wired up somewhere else is the defect this fixes — the
-    in-process hook was registered by a module the writing process never
-    imported, so it silently invalidated nothing.  Anything that reads the
-    cache now also subscribes to it.
+    Started from the cache read path so the subscription cannot be wired up
+    separately from the cache, and then silently forgotten — which is exactly
+    how the in-process hook came to invalidate nothing.
     """
     global _listener_thread
     with _listener_start_lock:

--- a/autogpt_platform/backend/backend/copilot/integration_creds.py
+++ b/autogpt_platform/backend/backend/copilot/integration_creds.py
@@ -5,7 +5,7 @@ Provides token retrieval for connected integrations so that copilot tools
 hitting the database on every command.
 
 Cache semantics (handled automatically by TTLCache):
-- Token found → cached for _TOKEN_CACHE_TTL (5 min).  Avoids repeated DB hits
+- Token found → cached for _TOKEN_CACHE_TTL (60 s).  Avoids repeated DB hits
   for users who have credentials and are running many bash commands.
 - No credentials found → cached for _NULL_CACHE_TTL (60 s).  Avoids a DB hit
   on every E2B command for users who haven't connected an account yet, while
@@ -14,24 +14,27 @@ Cache semantics (handled automatically by TTLCache):
 Both caches are bounded to _CACHE_MAX_SIZE entries; cachetools evicts the
 least-recently-used entry when the limit is reached.
 
-Multi-worker note: both caches are in-process only.  Each worker/replica
-maintains its own independent cache, so a credential fetch may be duplicated
-across processes.  This is acceptable for the current goal (reduce DB hits per
-session per-process), but if cache efficiency across replicas becomes important
-a shared cache (e.g. Redis) should be used instead.
+Multi-worker note: the cached values are per-process, but invalidation is not.
+Credential writes happen in the API process while this cache lives in the
+copilot executor, so a subscription to the Redis creds-changed bus drops the
+affected entry wherever it is held.  See ``_ensure_cache_invalidation_listener``.
 """
 
+import asyncio
 import logging
+import threading
 from typing import cast
 
 from cachetools import TTLCache
 
 from backend.copilot.providers import SUPPORTED_PROVIDERS
 from backend.data.model import APIKeyCredentials, OAuth2Credentials
+from backend.integrations.creds_events import listen_creds_changed
 from backend.integrations.creds_manager import (
     IntegrationCredentialsManager,
     register_creds_changed_hook,
 )
+from backend.util.retry import continuous_retry
 
 logger = logging.getLogger(__name__)
 
@@ -40,32 +43,60 @@ PROVIDER_ENV_VARS: dict[str, list[str]] = {
     slug: entry["env_vars"] for slug, entry in SUPPORTED_PROVIDERS.items()
 }
 
-_TOKEN_CACHE_TTL = 300.0  # seconds — for found tokens
+# 60 s, not the original 300 s: the pub/sub invalidation below is best-effort
+# (a Redis blip drops the message), so the TTL is the floor on how long a stale
+# token can survive when it fails.  Five minutes was long enough for AutoPilot
+# to verify a re-authorization against the provider and report it as failed.
+_TOKEN_CACHE_TTL = 60.0  # seconds — for found tokens
 _NULL_CACHE_TTL = 60.0  # seconds — for "not connected" results
 _CACHE_MAX_SIZE = 10_000
 
+
+class _LockedTTLCache(TTLCache):
+    """TTLCache with a lock: the invalidation listener evicts entries from its
+    own thread while copilot workers read them from theirs."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._lock = threading.RLock()
+
+    def __getitem__(self, key):
+        with self._lock:
+            return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        with self._lock:
+            super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        with self._lock:
+            super().__delitem__(key)
+
+    def __contains__(self, key):
+        with self._lock:
+            return super().__contains__(key)
+
+    def pop(self, key, default=None):
+        with self._lock:
+            return super().pop(key, default)
+
+
 # (user_id, provider) → token string.  TTLCache handles expiry + eviction.
-# Thread-safety note: TTLCache is NOT thread-safe, but that is acceptable here
-# because all callers (get_provider_token, invalidate_user_provider_cache) run
-# exclusively on the asyncio event loop.  There are no await points between a
-# cache read and its corresponding write within any function, so no concurrent
-# coroutine can interleave.  If ThreadPoolExecutor workers are ever added to
-# this path, a threading.RLock should be wrapped around these caches.
-_token_cache: TTLCache[tuple[str, str], str] = TTLCache(
+_token_cache: TTLCache[tuple[str, str], str] = _LockedTTLCache(
     maxsize=_CACHE_MAX_SIZE, ttl=_TOKEN_CACHE_TTL
 )
 # Separate cache for "no credentials" results with a shorter TTL.
-_null_cache: TTLCache[tuple[str, str], bool] = TTLCache(
+_null_cache: TTLCache[tuple[str, str], bool] = _LockedTTLCache(
     maxsize=_CACHE_MAX_SIZE, ttl=_NULL_CACHE_TTL
 )
 
 # GitHub user identity caches (keyed by user_id only, not provider tuple).
 # Declared here so invalidate_user_provider_cache() can reference them.
 _GH_IDENTITY_CACHE_TTL = 600.0  # 10 min — profile data rarely changes
-_gh_identity_cache: TTLCache[str, dict[str, str]] = TTLCache(
+_gh_identity_cache: TTLCache[str, dict[str, str]] = _LockedTTLCache(
     maxsize=_CACHE_MAX_SIZE, ttl=_GH_IDENTITY_CACHE_TTL
 )
-_gh_identity_null_cache: TTLCache[str, bool] = TTLCache(
+_gh_identity_null_cache: TTLCache[str, bool] = _LockedTTLCache(
     maxsize=_CACHE_MAX_SIZE, ttl=_NULL_CACHE_TTL
 )
 
@@ -90,10 +121,9 @@ def invalidate_user_provider_cache(user_id: str, provider: str) -> None:
         _gh_identity_null_cache.pop(user_id, None)
 
 
-# Register this module's cache-bust function with the credentials manager so
-# that any create/update/delete operation immediately evicts stale cache
-# entries.  This avoids a lazy import inside creds_manager and eliminates the
-# circular-import risk.
+# Same-process writes (a token refresh performed by this process) invalidate
+# through the hook, without a Redis round trip.  Writes in other processes
+# arrive over the bus instead.
 try:
     register_creds_changed_hook(invalidate_user_provider_cache)
 except RuntimeError:
@@ -109,11 +139,10 @@ async def get_provider_token(user_id: str, provider: str) -> str | None:
     """Return the user's access token for *provider*, or ``None`` if not connected.
 
     OAuth2 tokens are preferred (refreshed if needed); API keys are the fallback.
-    Found tokens are cached for _TOKEN_CACHE_TTL (5 min).  "Not connected" results
-    are cached for _NULL_CACHE_TTL (60 s) to avoid a DB hit on every bash_exec
-    command for users who haven't connected yet, while still picking up a
-    newly-connected account within one minute.
+    Both found tokens and "not connected" results are cached for 60 s, and a
+    credential write in any process evicts the entry before that lapses.
     """
+    _ensure_cache_invalidation_listener()
     cache_key = (user_id, provider)
 
     if cache_key in _null_cache:
@@ -179,6 +208,38 @@ async def get_provider_token(user_id: str, provider: str) -> str | None:
     if not refresh_failed:
         _null_cache[cache_key] = True
     return None
+
+
+def _ensure_cache_invalidation_listener() -> None:
+    """Start this process's subscription to credential changes, once.
+
+    Started from the cache read path rather than from a service's startup: a
+    subscription wired up somewhere else is the defect this fixes — the
+    in-process hook was registered by a module the writing process never
+    imported, so it silently invalidated nothing.  Anything that reads the
+    cache now also subscribes to it.
+    """
+    global _listener_thread
+    with _listener_start_lock:
+        if _listener_thread is not None:
+            return
+        _listener_thread = threading.Thread(
+            target=lambda: asyncio.run(_consume_creds_changed_events()),
+            name="creds-cache-invalidation",
+            daemon=True,
+        )
+        _listener_thread.start()
+
+
+@continuous_retry(retry_delay=5.0)
+async def _consume_creds_changed_events() -> None:
+    async for event in listen_creds_changed():
+        invalidate_user_provider_cache(event.user_id, event.provider)
+    raise RuntimeError("creds-changed subscription ended; resubscribing")
+
+
+_listener_start_lock = threading.Lock()
+_listener_thread: threading.Thread | None = None
 
 
 async def get_integration_env_vars(user_id: str) -> dict[str, str]:

--- a/autogpt_platform/backend/backend/copilot/integration_creds.py
+++ b/autogpt_platform/backend/backend/copilot/integration_creds.py
@@ -15,9 +15,9 @@ Both caches are bounded to _CACHE_MAX_SIZE entries; cachetools evicts the
 least-recently-used entry when the limit is reached.
 
 Multi-worker note: the cached values are per-process, but invalidation is not.
-Credential writes happen in the API process while this cache lives in the
-copilot executor, so a subscription to the Redis creds-changed bus drops the
-affected entry wherever it is held.  See ``_ensure_cache_invalidation_listener``.
+The API server and the copilot executor each hold their own copy of these
+caches, so a write in one cannot evict the other's; a subscription to the Redis
+creds-changed bus does.  See ``_ensure_cache_invalidation_listener``.
 """
 
 import asyncio
@@ -52,6 +52,10 @@ _NULL_CACHE_TTL = 60.0  # seconds — for "not connected" results
 _CACHE_MAX_SIZE = 10_000
 
 
+# Sentinel so ``pop`` keeps ``Cache.pop``'s "raise without a default" contract.
+_MISSING = object()
+
+
 class _LockedTTLCache(TTLCache):
     """TTLCache with a lock: the invalidation listener evicts entries from its
     own thread while copilot workers read them from theirs."""
@@ -76,9 +80,15 @@ class _LockedTTLCache(TTLCache):
         with self._lock:
             return super().__contains__(key)
 
-    def pop(self, key, default=None):
+    def pop(self, key, default=_MISSING):
         with self._lock:
+            if default is _MISSING:
+                return super().pop(key)
             return super().pop(key, default)
+
+    def popitem(self):
+        with self._lock:
+            return super().popitem()
 
 
 # (user_id, provider) → token string.  TTLCache handles expiry + eviction.
@@ -191,6 +201,8 @@ async def get_provider_token(user_id: str, provider: str) -> str | None:
                 # preventing the LLM from receiving a non-functional token.
                 refresh_failed = True
                 continue
+            # A refresh here publishes, and this process's own listener may evict
+            # the entry just written; the cost is one extra lookup, not a leak.
             _token_cache[cache_key] = token
             return token
 
@@ -213,9 +225,9 @@ async def get_provider_token(user_id: str, provider: str) -> str | None:
 def _ensure_cache_invalidation_listener() -> None:
     """Subscribe this process to credential changes, once.
 
-    Started from the cache read path so the subscription cannot be wired up
-    separately from the cache, and then silently forgotten — which is exactly
-    how the in-process hook came to invalidate nothing.
+    Started from the cache read path so that every process holding a cache
+    subscribes, and only those do — the in-process hook covers a write served
+    by this process, and this covers the ones served elsewhere.
     """
     global _listener_thread
     with _listener_start_lock:

--- a/autogpt_platform/backend/backend/copilot/integration_creds_test.py
+++ b/autogpt_platform/backend/backend/copilot/integration_creds_test.py
@@ -1,5 +1,7 @@
 """Tests for integration_creds — TTL cache and token lookup paths."""
 
+import asyncio
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,6 +11,7 @@ from backend.copilot.integration_creds import (
     _NULL_CACHE_TTL,
     _TOKEN_CACHE_TTL,
     PROVIDER_ENV_VARS,
+    _consume_creds_changed_events,
     _gh_identity_cache,
     _gh_identity_null_cache,
     _null_cache,
@@ -18,6 +21,12 @@ from backend.copilot.integration_creds import (
     invalidate_user_provider_cache,
 )
 from backend.data.model import APIKeyCredentials, OAuth2Credentials
+from backend.integrations.creds_events import CredentialsChangedEvent
+from backend.integrations.creds_manager import (
+    IntegrationCredentialsManager,
+    register_creds_changed_hook,
+    unregister_creds_changed_hook,
+)
 
 _USER = "user-integration-creds-test"
 _PROVIDER = "github"
@@ -44,6 +53,13 @@ def _make_oauth2_creds(token: str = "test-oauth-token") -> OAuth2Credentials:
         refresh_token_expires_at=None,
         scopes=[],
     )
+
+
+@pytest.fixture(autouse=True)
+def no_listener_thread():
+    """Keep the lazy subscription from spawning a Redis-connecting thread."""
+    with patch("backend.copilot.integration_creds._ensure_cache_invalidation_listener"):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -212,11 +228,11 @@ class TestGetProviderToken:
         assert (_USER, _PROVIDER) not in _null_cache
 
     @pytest.mark.asyncio(loop_scope="session")
-    async def test_null_cache_has_shorter_ttl_than_token_cache(self):
-        """Verify the TTL constants are set correctly for each cache."""
+    async def test_token_cache_ttl_is_the_stale_token_ceiling(self):
+        """The TTL is the fallback when a pub/sub invalidation is lost."""
         assert _null_cache.ttl == _NULL_CACHE_TTL
         assert _token_cache.ttl == _TOKEN_CACHE_TTL
-        assert _NULL_CACHE_TTL < _TOKEN_CACHE_TTL
+        assert _TOKEN_CACHE_TTL <= 60.0
 
 
 class TestThreadSafetyLocks:
@@ -327,3 +343,97 @@ class TestGetIntegrationEnvVars:
         result = await get_integration_env_vars(_USER)
 
         assert result == {}
+
+
+class TestCacheInvalidationListener:
+    """The cross-process half: a write elsewhere reaches this process's cache."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_drops_exactly_the_affected_entry(self):
+        _token_cache[(_USER, "github")] = "stale"
+        _token_cache[(_USER, "notion")] = "untouched"
+        _token_cache[("other-user", "github")] = "untouched"
+
+        await _consume(CredentialsChangedEvent(user_id=_USER, provider="github"))
+
+        assert (_USER, "github") not in _token_cache
+        assert _token_cache[(_USER, "notion")] == "untouched"
+        assert _token_cache[("other-user", "github")] == "untouched"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_resubscribes_when_the_stream_ends(self):
+        """A closed subscription must not leave the cache unwatched."""
+        streams = 0
+
+        async def stream():
+            nonlocal streams
+            streams += 1
+            if streams > 1:
+                raise asyncio.CancelledError
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        with patch("backend.copilot.integration_creds.listen_creds_changed", stream):
+            with pytest.raises(asyncio.CancelledError):
+                await _consume_creds_changed_events()
+
+        assert streams == 2
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_upgrade_after_fetch_is_visible_without_waiting_for_the_ttl(self):
+        """OPEN-3472: a token fetched at T, upgraded at T+60s, was still served
+        from cache until the 300 s TTL lapsed at T+300s."""
+        manager = MagicMock()
+        manager.store.get_creds_by_provider = AsyncMock(
+            return_value=[_make_api_key_creds("old-scopes-token")]
+        )
+        with patch("backend.copilot.integration_creds._manager", manager):
+            assert await get_provider_token(_USER, _PROVIDER) == "old-scopes-token"
+
+        published = await _write_credential_as_another_process()
+        assert _token_cache[(_USER, _PROVIDER)] == "old-scopes-token"
+
+        for event in published:
+            await _consume(event)
+
+        manager.store.get_creds_by_provider = AsyncMock(
+            return_value=[_make_api_key_creds("new-scopes-token")]
+        )
+        with patch("backend.copilot.integration_creds._manager", manager):
+            assert await get_provider_token(_USER, _PROVIDER) == "new-scopes-token"
+
+
+async def _consume(*events: CredentialsChangedEvent) -> None:
+    """Run the listener over *events*, then stop it."""
+
+    async def stream():
+        for event in events:
+            yield event
+        raise asyncio.CancelledError
+
+    with patch("backend.copilot.integration_creds.listen_creds_changed", stream):
+        with pytest.raises(asyncio.CancelledError):
+            await _consume_creds_changed_events()
+
+
+async def _write_credential_as_another_process() -> list[CredentialsChangedEvent]:
+    """Perform a credential write with no in-process hook — the API process's
+    shape — and return what it broadcast."""
+    published: list[CredentialsChangedEvent] = []
+
+    async def capture(user_id: str, provider: str) -> None:
+        published.append(CredentialsChangedEvent(user_id=user_id, provider=provider))
+
+    manager = IntegrationCredentialsManager()
+    manager.store = MagicMock()
+    manager.store.update_creds = AsyncMock()
+    manager._locked = lambda *args, **kwargs: contextlib.nullcontext()
+
+    unregister_creds_changed_hook()
+    try:
+        with patch("backend.integrations.creds_manager.publish_creds_changed", capture):
+            await manager.update(_USER, _make_oauth2_creds("new-scopes-token"))
+    finally:
+        register_creds_changed_hook(invalidate_user_provider_cache)
+
+    return published

--- a/autogpt_platform/backend/backend/integrations/creds_events.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events.py
@@ -1,10 +1,9 @@
 """Cross-process broadcast of credential changes.
 
-A credential write happens in whichever process serves the request — the API
-process for an OAuth callback — while the caches holding the stale token live
-in other processes, such as the copilot executor.  An in-process callback
-cannot cross that boundary, so every write is also published here and picked
-up by subscribers wherever they run.
+The API server and the copilot executor are separate processes and each holds
+its own credential caches.  A write serves one request in one of them, so an
+in-process callback only ever reaches that process's copy; every write is also
+published here so the other processes drop theirs.
 """
 
 from collections.abc import AsyncGenerator

--- a/autogpt_platform/backend/backend/integrations/creds_events.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events.py
@@ -7,18 +7,14 @@ cannot cross that boundary, so every write is also published here and picked
 up by subscribers wherever they run.
 """
 
-import logging
 from collections.abc import AsyncGenerator
 
 from pydantic import BaseModel
 
 from backend.data.event_bus import AsyncRedisEventBus
 
-logger = logging.getLogger(__name__)
-
-# Sharded pub/sub has no pattern-subscribe and a subscriber cannot enumerate
-# the users whose tokens it may be holding, so every change goes on one
-# broadcast channel and subscribers filter locally.
+# Sharded pub/sub has no pattern-subscribe, and a subscriber cannot know which
+# users it holds tokens for — so everything goes on one channel.
 CREDS_CHANGED_CHANNEL = "all"
 
 

--- a/autogpt_platform/backend/backend/integrations/creds_events.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events.py
@@ -1,0 +1,52 @@
+"""Cross-process broadcast of credential changes.
+
+A credential write happens in whichever process serves the request — the API
+process for an OAuth callback — while the caches holding the stale token live
+in other processes, such as the copilot executor.  An in-process callback
+cannot cross that boundary, so every write is also published here and picked
+up by subscribers wherever they run.
+"""
+
+import logging
+from collections.abc import AsyncGenerator
+
+from pydantic import BaseModel
+
+from backend.data.event_bus import AsyncRedisEventBus
+
+logger = logging.getLogger(__name__)
+
+# Sharded pub/sub has no pattern-subscribe and a subscriber cannot enumerate
+# the users whose tokens it may be holding, so every change goes on one
+# broadcast channel and subscribers filter locally.
+CREDS_CHANGED_CHANNEL = "all"
+
+
+class CredentialsChangedEvent(BaseModel):
+    user_id: str
+    provider: str
+
+
+async def publish_creds_changed(user_id: str, provider: str) -> None:
+    """Announce that *user_id*'s *provider* credentials were written."""
+    await _bus.publish_event(
+        CredentialsChangedEvent(user_id=user_id, provider=provider),
+        CREDS_CHANGED_CHANNEL,
+    )
+
+
+async def listen_creds_changed() -> AsyncGenerator[CredentialsChangedEvent, None]:
+    """Yield credential-change events published by any process."""
+    async for event in _bus.listen_events(CREDS_CHANGED_CHANNEL):
+        yield event
+
+
+class CredentialsChangedEventBus(AsyncRedisEventBus[CredentialsChangedEvent]):
+    Model = CredentialsChangedEvent
+
+    @property
+    def event_bus_name(self) -> str:
+        return "creds_changed"
+
+
+_bus = CredentialsChangedEventBus()

--- a/autogpt_platform/backend/backend/integrations/creds_events_test.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events_test.py
@@ -1,6 +1,7 @@
 """Tests for the credentials-changed bus — the cross-process half of invalidation."""
 
 import contextlib
+import socket
 import subprocess
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -51,28 +52,32 @@ async def test_credential_write_publishes_creds_changed():
     publish.assert_awaited_once_with(_USER, "github")
 
 
-def test_write_publishes_in_a_process_that_has_no_in_process_hook():
-    """The regression: the OAuth callback runs in the API process, which never
-    imports the copilot cache, so its in-process hook is None."""
+@pytest.mark.parametrize(
+    "module", ["backend.api.rest_api", "backend.copilot.executor.manager"]
+)
+def test_every_process_holding_the_cache_broadcasts_its_writes(module: str):
+    """The regression: the API server and the copilot executor each hold their
+    own copy of the token cache, so the in-process hook only ever evicts the
+    writer's copy and the OAuth callback could not reach the executor's."""
     result = subprocess.run(
-        [sys.executable, "-c", _API_PROCESS_SCRIPT],
+        [sys.executable, "-c", _PROCESS_PROBE.replace("__MODULE__", module)],
         capture_output=True,
         text=True,
         timeout=300,
     )
     assert result.returncode == 0, result.stderr
-    assert "hook=None published=('user-1', 'github')" in result.stdout
+    assert "cache=True hook=True published=('user-1', 'github')" in result.stdout
 
 
 def _has_live_cluster() -> bool:
+    """Probe the socket, not ``redis_client.connect()``: this runs at collection
+    time and that helper retries a dead host for ~45 minutes before giving up."""
     from backend.data import redis_client
 
     try:
-        client = redis_client.connect()
-    except Exception:
+        socket.create_connection((redis_client.HOST, redis_client.PORT), 1).close()
+    except OSError:
         return False
-    with contextlib.suppress(Exception):
-        client.close()
     return True
 
 
@@ -123,15 +128,21 @@ def _oauth_creds(token: str = "tok") -> OAuth2Credentials:
     )
 
 
-_API_PROCESS_SCRIPT = """
+_PROCESS_PROBE = """
 import asyncio
+import sys
 from unittest.mock import AsyncMock, patch
 
-import backend.api.features.integrations.router  # noqa: F401 - API process import set
+import __MODULE__  # noqa: F401 - the process under test loads this
 import backend.integrations.creds_manager as cm
 
 with patch.object(cm, "publish_creds_changed", new_callable=AsyncMock) as publish:
     asyncio.run(cm._invoke_creds_changed_hook("user-1", "github"))
 
-print(f"hook={cm._on_creds_changed} published={publish.await_args[0]}")
+cached = "backend.copilot.integration_creds" in sys.modules
+print(
+    "cache=" + str(cached)
+    + " hook=" + str(cm._on_creds_changed is not None)
+    + " published=" + str(publish.await_args[0])
+)
 """

--- a/autogpt_platform/backend/backend/integrations/creds_events_test.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events_test.py
@@ -17,10 +17,7 @@ from backend.integrations.creds_events import (
     listen_creds_changed,
     publish_creds_changed,
 )
-from backend.integrations.creds_manager import (
-    IntegrationCredentialsManager,
-    _invoke_creds_changed_hook,
-)
+from backend.integrations.creds_manager import IntegrationCredentialsManager
 
 _USER = "user-creds-events-test"
 
@@ -41,8 +38,13 @@ async def test_publish_spublishes_on_the_broadcast_channel():
 
 @pytest.mark.asyncio
 async def test_a_dead_redis_does_not_fail_the_credential_write():
-    """The write is already durable by the time we publish, so a broadcast
-    failure must stay non-fatal — loudly, since the fallback is the 60 s TTL."""
+    """A write is durable before it is announced, so a broadcast failure must
+    stay non-fatal — loudly, since the fallback is then the 60 s TTL."""
+    manager = IntegrationCredentialsManager()
+    manager.store = MagicMock()
+    manager.store.update_creds = AsyncMock()
+    manager._locked = lambda *args, **kwargs: contextlib.nullcontext()
+
     records: list[logging.LogRecord] = []
     handler = logging.Handler()
     handler.emit = records.append
@@ -53,10 +55,11 @@ async def test_a_dead_redis_does_not_fail_the_credential_write():
             "backend.data.event_bus.redis.get_redis_async",
             side_effect=ConnectionError("redis down"),
         ):
-            await _invoke_creds_changed_hook(_USER, "github")
+            await manager.update(_USER, _oauth_creds())
     finally:
         bus_logger.removeHandler(handler)
 
+    manager.store.update_creds.assert_awaited_once()
     assert [r for r in records if r.levelno >= logging.ERROR and r.exc_info]
 
 

--- a/autogpt_platform/backend/backend/integrations/creds_events_test.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events_test.py
@@ -1,0 +1,137 @@
+"""Tests for the credentials-changed bus — the cross-process half of invalidation."""
+
+import contextlib
+import subprocess
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from backend.data.model import OAuth2Credentials
+from backend.integrations.creds_events import (
+    CREDS_CHANGED_CHANNEL,
+    CredentialsChangedEvent,
+    listen_creds_changed,
+    publish_creds_changed,
+)
+from backend.integrations.creds_manager import IntegrationCredentialsManager
+
+_USER = "user-creds-events-test"
+
+
+@pytest.mark.asyncio
+async def test_publish_spublishes_on_the_broadcast_channel():
+    cluster = MagicMock()
+    cluster.execute_command = AsyncMock()
+
+    with patch("backend.data.event_bus.redis.get_redis_async", return_value=cluster):
+        await publish_creds_changed(_USER, "github")
+
+    command, channel, message = cluster.execute_command.await_args[0]
+    assert command == "SPUBLISH"
+    assert channel == f"creds_changed/{CREDS_CHANGED_CHANNEL}"
+    assert _USER in message and "github" in message
+
+
+@pytest.mark.asyncio
+async def test_credential_write_publishes_creds_changed():
+    """Every write through the manager announces itself, hook or no hook."""
+    manager = IntegrationCredentialsManager()
+    manager.store = MagicMock()
+    manager.store.update_creds = AsyncMock()
+    manager._locked = lambda *args, **kwargs: contextlib.nullcontext()
+
+    with patch(
+        "backend.integrations.creds_manager.publish_creds_changed",
+        new_callable=AsyncMock,
+    ) as publish:
+        await manager.update(_USER, _oauth_creds())
+
+    publish.assert_awaited_once_with(_USER, "github")
+
+
+def test_write_publishes_in_a_process_that_has_no_in_process_hook():
+    """The regression: the OAuth callback runs in the API process, which never
+    imports the copilot cache, so its in-process hook is None."""
+    result = subprocess.run(
+        [sys.executable, "-c", _API_PROCESS_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "hook=None published=('user-1', 'github')" in result.stdout
+
+
+def _has_live_cluster() -> bool:
+    from backend.data import redis_client
+
+    try:
+        client = redis_client.connect()
+    except Exception:
+        return False
+    with contextlib.suppress(Exception):
+        client.close()
+    return True
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _has_live_cluster(),
+    reason="local redis cluster not reachable; skip creds-changed round trip",
+)
+async def test_publish_reaches_a_subscriber_in_another_event_loop():
+    import asyncio
+
+    from backend.data import redis_client
+
+    redis_client.get_redis.cache_clear()
+    redis_client._async_clients.clear()
+
+    received: list[CredentialsChangedEvent] = []
+
+    async def consume() -> None:
+        async for event in listen_creds_changed():
+            received.append(event)
+            return
+
+    task = asyncio.create_task(consume())
+    # Let SSUBSCRIBE settle; races drop the publish otherwise.
+    await asyncio.sleep(0.3)
+    try:
+        await publish_creds_changed(_USER, "github")
+        await asyncio.wait_for(task, timeout=5.0)
+    finally:
+        if not task.done():
+            task.cancel()
+        await redis_client.disconnect_async()
+
+    assert received and received[0].user_id == _USER
+
+
+def _oauth_creds(token: str = "tok") -> OAuth2Credentials:
+    return OAuth2Credentials(
+        id="creds-oauth2",
+        provider="github",
+        title="Test OAuth",
+        access_token=SecretStr(token),
+        refresh_token=SecretStr("test-refresh"),
+        access_token_expires_at=None,
+        refresh_token_expires_at=None,
+        scopes=[],
+    )
+
+
+_API_PROCESS_SCRIPT = """
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import backend.api.features.integrations.router  # noqa: F401 - API process import set
+import backend.integrations.creds_manager as cm
+
+with patch.object(cm, "publish_creds_changed", new_callable=AsyncMock) as publish:
+    asyncio.run(cm._invoke_creds_changed_hook("user-1", "github"))
+
+print(f"hook={cm._on_creds_changed} published={publish.await_args[0]}")
+"""

--- a/autogpt_platform/backend/backend/integrations/creds_events_test.py
+++ b/autogpt_platform/backend/backend/integrations/creds_events_test.py
@@ -1,6 +1,7 @@
 """Tests for the credentials-changed bus — the cross-process half of invalidation."""
 
 import contextlib
+import logging
 import socket
 import subprocess
 import sys
@@ -16,7 +17,10 @@ from backend.integrations.creds_events import (
     listen_creds_changed,
     publish_creds_changed,
 )
-from backend.integrations.creds_manager import IntegrationCredentialsManager
+from backend.integrations.creds_manager import (
+    IntegrationCredentialsManager,
+    _invoke_creds_changed_hook,
+)
 
 _USER = "user-creds-events-test"
 
@@ -33,6 +37,27 @@ async def test_publish_spublishes_on_the_broadcast_channel():
     assert command == "SPUBLISH"
     assert channel == f"creds_changed/{CREDS_CHANGED_CHANNEL}"
     assert _USER in message and "github" in message
+
+
+@pytest.mark.asyncio
+async def test_a_dead_redis_does_not_fail_the_credential_write():
+    """The write is already durable by the time we publish, so a broadcast
+    failure must stay non-fatal — loudly, since the fallback is the 60 s TTL."""
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = records.append
+    bus_logger = logging.getLogger("backend.data.event_bus")
+    bus_logger.addHandler(handler)
+    try:
+        with patch(
+            "backend.data.event_bus.redis.get_redis_async",
+            side_effect=ConnectionError("redis down"),
+        ):
+            await _invoke_creds_changed_hook(_USER, "github")
+    finally:
+        bus_logger.removeHandler(handler)
+
+    assert [r for r in records if r.levelno >= logging.ERROR and r.exc_info]
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/integrations/creds_manager.py
+++ b/autogpt_platform/backend/backend/integrations/creds_manager.py
@@ -15,6 +15,7 @@ from backend.integrations.credentials_store import (
     IntegrationCredentialsStore,
     provider_matches,
 )
+from backend.integrations.creds_events import publish_creds_changed
 from backend.integrations.oauth import (
     CREDENTIALS_BY_PROVIDER,
     DEVICE_HANDLERS_BY_NAME,
@@ -43,6 +44,10 @@ def register_creds_changed_hook(hook: Callable[[str, str], None]) -> None:
     application startup (e.g. by the copilot module) without creating an
     import cycle.
 
+    In-process only.  Cross-process invalidation rides on
+    :func:`~backend.integrations.creds_events.publish_creds_changed`, which
+    :func:`_invoke_creds_changed_hook` calls alongside this hook.
+
     Raises:
         RuntimeError: If a hook is already registered.  Call
             :func:`unregister_creds_changed_hook` first if replacement is needed.
@@ -65,8 +70,13 @@ def unregister_creds_changed_hook() -> None:
     _on_creds_changed = None
 
 
-def _invoke_creds_changed_hook(user_id: str, provider: str) -> None:
-    """Invoke the registered creds-changed hook (if any)."""
+async def _invoke_creds_changed_hook(user_id: str, provider: str) -> None:
+    """Notify this process's hook, then every other process over Redis.
+
+    The hook alone is not enough: it is registered by the module owning the
+    cache (copilot), while writes happen in the API process, where the global
+    is never set. The broadcast is what actually reaches the stale cache.
+    """
     if _on_creds_changed is not None:
         try:
             _on_creds_changed(user_id, provider)
@@ -77,6 +87,7 @@ def _invoke_creds_changed_hook(user_id: str, provider: str) -> None:
                 provider,
                 exc_info=True,
             )
+    await publish_creds_changed(user_id, provider)
 
 
 class IntegrationCredentialsManager:
@@ -124,7 +135,7 @@ class IntegrationCredentialsManager:
     async def create(self, user_id: str, credentials: Credentials) -> None:
         result = await self.store.add_creds(user_id, credentials)
         # Notify listeners so downstream caches are invalidated immediately.
-        _invoke_creds_changed_hook(user_id, credentials.provider)
+        await _invoke_creds_changed_hook(user_id, credentials.provider)
         return result
 
     async def exists(self, user_id: str, credentials_id: str) -> bool:
@@ -310,7 +321,9 @@ class IntegrationCredentialsManager:
                 try:
                     fresh_credentials = await oauth_handler.refresh_tokens(credentials)
                     await self.store.update_creds(user_id, fresh_credentials)
-                    _invoke_creds_changed_hook(user_id, fresh_credentials.provider)
+                    await _invoke_creds_changed_hook(
+                        user_id, fresh_credentials.provider
+                    )
                     credentials = fresh_credentials
                 finally:
                     if (await _lock.locked()) and (await _lock.owned()):
@@ -346,7 +359,7 @@ class IntegrationCredentialsManager:
             )
             fresh_credentials = await oauth_handler.refresh_tokens(credentials)
             await self.store.update_creds(user_id, fresh_credentials)
-            _invoke_creds_changed_hook(user_id, fresh_credentials.provider)
+            await _invoke_creds_changed_hook(user_id, fresh_credentials.provider)
             credentials = fresh_credentials
         return credentials
 
@@ -354,7 +367,7 @@ class IntegrationCredentialsManager:
         async with self._locked(user_id, updated.id):
             await self.store.update_creds(user_id, updated)
         # Notify listeners so the updated credential is picked up immediately.
-        _invoke_creds_changed_hook(user_id, updated.provider)
+        await _invoke_creds_changed_hook(user_id, updated.provider)
 
     async def upsert_single_provider(
         self,
@@ -386,7 +399,7 @@ class IntegrationCredentialsManager:
         credentials: Credentials,
     ) -> Credentials:
         stored = await self.store.upsert_single_provider_creds(user_id, credentials)
-        _invoke_creds_changed_hook(user_id, stored.provider)
+        await _invoke_creds_changed_hook(user_id, stored.provider)
         return stored
 
     async def update_acquired(
@@ -426,7 +439,7 @@ class IntegrationCredentialsManager:
         ):
             raise RuntimeError("Provider-runtime credential identity changed")
         await self.store.update_creds(user_id, updated)
-        _invoke_creds_changed_hook(user_id, updated.provider)
+        await _invoke_creds_changed_hook(user_id, updated.provider)
 
     async def delete_acquired(
         self,
@@ -453,7 +466,7 @@ class IntegrationCredentialsManager:
         ):
             raise RuntimeError("Credential identity changed before deletion")
         await self.store.delete_creds_by_id(user_id, credentials.id)
-        _invoke_creds_changed_hook(user_id, credentials.provider)
+        await _invoke_creds_changed_hook(user_id, credentials.provider)
 
     async def delete(self, user_id: str, credentials_id: str) -> None:
         async with self._locked(user_id, credentials_id):
@@ -462,7 +475,7 @@ class IntegrationCredentialsManager:
             creds = await self.store.get_creds_by_id(user_id, credentials_id)
             await self.store.delete_creds_by_id(user_id, credentials_id)
         if creds:
-            _invoke_creds_changed_hook(user_id, creds.provider)
+            await _invoke_creds_changed_hook(user_id, creds.provider)
 
     # -- Locking utilities -- #
 

--- a/autogpt_platform/backend/backend/integrations/creds_manager.py
+++ b/autogpt_platform/backend/backend/integrations/creds_manager.py
@@ -73,9 +73,8 @@ def unregister_creds_changed_hook() -> None:
 async def _invoke_creds_changed_hook(user_id: str, provider: str) -> None:
     """Notify this process's hook, then every other process over Redis.
 
-    The hook alone is not enough: it is registered by the module owning the
-    cache (copilot), while writes happen in the API process, where the global
-    is never set. The broadcast is what actually reaches the stale cache.
+    The hook alone is not enough: it evicts only the writing process's caches,
+    and the copilot executor holds its own in a different process.
     """
     if _on_creds_changed is not None:
         try:

--- a/autogpt_platform/backend/backend/integrations/creds_manager_test.py
+++ b/autogpt_platform/backend/backend/integrations/creds_manager_test.py
@@ -1,6 +1,6 @@
 """Tests for credential hooks and provider-runtime credential leases."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
@@ -18,16 +18,22 @@ from backend.integrations.creds_manager import (
 def _reset_hook():
     """Ensure global hook state is clean before and after every test."""
     unregister_creds_changed_hook()
-    yield
+    # The broadcast half is covered in creds_events_test; keep these tests off Redis.
+    with patch(
+        "backend.integrations.creds_manager.publish_creds_changed",
+        new_callable=AsyncMock,
+    ):
+        yield
     unregister_creds_changed_hook()
 
 
 class TestRegisterCredsChangedHook:
-    def test_register_and_invoke(self):
+    @pytest.mark.asyncio
+    async def test_register_and_invoke(self):
         calls: list[tuple[str, str]] = []
         register_creds_changed_hook(lambda u, p: calls.append((u, p)))
 
-        _invoke_creds_changed_hook("user-1", "github")
+        await _invoke_creds_changed_hook("user-1", "github")
         assert calls == [("user-1", "github")]
 
     def test_double_register_raises(self):
@@ -43,24 +49,39 @@ class TestRegisterCredsChangedHook:
 
 
 class TestInvokeCredsChangedHook:
-    def test_noop_when_no_hook_registered(self):
+    @pytest.mark.asyncio
+    async def test_noop_when_no_hook_registered(self):
         # Must not raise even when no hook is registered.
-        _invoke_creds_changed_hook("user-1", "github")
+        await _invoke_creds_changed_hook("user-1", "github")
 
-    def test_hook_exception_is_swallowed(self):
+    @pytest.mark.asyncio
+    async def test_hook_exception_is_swallowed(self):
         def bad_hook(user_id: str, provider: str) -> None:
             raise ValueError("boom")
 
         register_creds_changed_hook(bad_hook)
         # Must not propagate the exception.
-        _invoke_creds_changed_hook("user-1", "github")
+        await _invoke_creds_changed_hook("user-1", "github")
 
-    def test_hook_receives_correct_args(self):
+    @pytest.mark.asyncio
+    async def test_broadcast_happens_even_when_the_hook_raises(self):
+        register_creds_changed_hook(MagicMock(side_effect=ValueError("boom")))
+
+        with patch(
+            "backend.integrations.creds_manager.publish_creds_changed",
+            new_callable=AsyncMock,
+        ) as publish:
+            await _invoke_creds_changed_hook("user-1", "github")
+
+        publish.assert_awaited_once_with("user-1", "github")
+
+    @pytest.mark.asyncio
+    async def test_hook_receives_correct_args(self):
         calls: list[tuple[str, str]] = []
         register_creds_changed_hook(lambda u, p: calls.append((u, p)))
 
-        _invoke_creds_changed_hook("user-a", "github")
-        _invoke_creds_changed_hook("user-b", "slack")
+        await _invoke_creds_changed_hook("user-a", "github")
+        await _invoke_creds_changed_hook("user-b", "slack")
 
         assert calls == [("user-a", "github"), ("user-b", "slack")]
 


### PR DESCRIPTION
### Why / What / How

Makes AutoPilot pick up a re-authorized integration token immediately instead of up to five minutes later, by broadcasting every credential write on Redis and having the copilot's token cache drop the affected entry when it hears one. Fixes #14318.

**Why.** When AutoPilot runs a shell command it injects your connected accounts' tokens into the sandbox — `GH_TOKEN` for GitHub, and so on — and caches them in memory to avoid a database read per command. Nothing evicted that cache when a credential changed, so for up to five minutes after re-authorizing an account AutoPilot kept using the old token, and therefore the old permissions. In the reported session it then verified the upgrade against the GitHub API *with the stale token*, and reported the re-authorization as having failed — four minutes before concluding it had landed all along.

The cache does have an invalidation hook, and it could not help. `AgentServer` (the REST API) and `CoPilotExecutor` are separate processes, and both import `backend.copilot.integration_creds`, so each registers the hook and each holds its own copy of the cache. The OAuth callback runs in the API server: it evicted the API server's copy, which nothing was reading. `bash_exec` runs in the executor, whose copy nothing touched. A same-process callback cannot cross a process boundary, so recovery was the TTL lapsing, nothing else.

**What.**
- Every credential write through `IntegrationCredentialsManager` publishes a `creds_changed` event on the existing Redis event bus.
- Every process holding the token cache subscribes to that bus and evicts exactly the `(user_id, provider)` entry named by the event, wherever the write happened.
- The in-process hook stays, so a write served by the process that also holds the cache invalidates without a Redis round trip.
- The token cache TTL drops from 300 s to 60 s.

**How.** `backend/integrations/creds_events.py` adds a `CredentialsChangedEvent` bus on top of `AsyncRedisEventBus` — the same sharded pub/sub the execution and notification buses use. Sharded pub/sub has no pattern-subscribe and a subscriber cannot know which users it holds tokens for, so all events go on one broadcast channel and subscribers filter locally. The payload is `{user_id, provider}`: no token, no scopes, no credential id. `_invoke_creds_changed_hook` became `async` and now calls the in-process hook *and* publishes; all eight of its call sites were already in async methods.

On the copilot side, the subscription starts lazily from the cache read path rather than from a service's startup hook, so exactly the processes that hold a cache subscribe and no others. The listener runs on a daemon thread with its own event loop (copilot turns run on pool threads, each with its own loop, so there is no single long-lived loop to attach to) and re-subscribes if the stream ends. Because that thread now evicts entries concurrently with worker-thread reads, the four `TTLCache` instances are wrapped in a small locked subclass — the file's existing comment already anticipated needing this.

The TTL change is belt-and-braces, not the fix: publishing is best-effort, so a Redis blip drops the message and the TTL becomes the ceiling on how long a stale token survives. 300 s was long enough for AutoPilot to draw and report a wrong conclusion; 60 s matches the TTL already used for "not connected" results. It costs one extra credential lookup per user per process per minute, and `SUPPORTED_PROVIDERS` is `{"github"}`, so that is one lookup, not one per provider.

**The other options in the ticket, and why not.**
- *Register the hook where the write happens.* It already is registered there — that is what the sweep on this PR established, and it changes nothing, because the process that reads the cache is a different one.
- *Drop the TTL sharply / skip the cache after a recent change.* Bounds the damage without removing it, and buys freshness with a DB read per bash command. Taken as the secondary measure, not the primary one.
- *Re-read the token when a tool call fails on a permission error.* Only recovers from failures the provider actually reports as errors. In the reported session GitHub returned 200 on the public org endpoints, so there was no error to trigger it. Worth doing separately; it does not close this hole.

### Changes 🏗️

- **New** `backend/integrations/creds_events.py`: `CredentialsChangedEvent`, `publish_creds_changed`, `listen_creds_changed` on a `creds_changed` bus.
- `backend/integrations/creds_manager.py`: `_invoke_creds_changed_hook` is now `async` and publishes to the bus after invoking the in-process hook; its eight call sites are awaited.
- `backend/copilot/integration_creds.py`: lazy subscription to the bus that evicts `(user_id, provider)`; `_TOKEN_CACHE_TTL` 300 s → 60 s; caches wrapped in a lock-guarded `TTLCache` subclass.
- Tests: `backend/integrations/creds_events_test.py` (new), plus additions to `backend/copilot/integration_creds_test.py` and `backend/integrations/creds_manager_test.py`.

No configuration changes: the platform already runs Redis, and this uses the bus that the execution and notification paths use.

### Known residuals, not fixed here

- **Read-then-invalidate race.** `get_provider_token` reads the database, then writes the cache. An eviction arriving between those two steps is lost and the stale value it just read gets inserted for the full TTL. Pre-existing — the same race existed against the in-process hook — and the TTL cut shrinks its cost fivefold. Closing it properly needs a per-key generation counter checked before the write.
- **A refresh in the reading process evicts the entry it is about to write.** `get_provider_token` refreshes with `lock=False`, which now publishes; this process's own listener consumes that and may evict the entry a moment after it lands. Self-limiting — the next call finds the token fresh and publishes nothing — so the cost is one extra lookup per real token refresh. Noted in a comment at the write site.
- **Three write sites bypass the chokepoint.** `api/features/mcp/routes.py:374` and `:468` and `data/graph.py:2069` write through `store.*` directly, so they neither fire the hook nor publish. No impact today: the cache only holds providers in `SUPPORTED_PROVIDERS`, which is `{"github"}`, and these write `mcp`, `openai`, `anthropic` or `groq`. Latent for the day a second provider is added.

### Verified

I executed all of the touched suites with `pytest.sh` against the local stack, including a live-Redis round trip proving a publish from one event loop reaches a subscriber in another, and a subprocess test that imports each of the two real process modules (`backend.api.rest_api`, `backend.copilot.executor.manager`) and confirms each holds its own cache, registers the hook, and broadcasts its writes anyway. I confirmed the regression tests earn their keep by breaking the fix — with the eviction removed, both the "drops exactly the affected entry" and the timeline test fail, and both pass with it restored. I also pinned the best-effort guarantee: with Redis unreachable, a credential write still returns normally and the failure is logged at ERROR — removing the `try/except` from `AsyncRedisEventBus.publish_event` makes that test fail. I did **not** drive this end to end through a real OAuth re-authorization in a browser; the cross-process delivery it depends on is covered by the live-Redis test instead. Evidence is in a comment below.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Both real process modules hold their own cache, register the hook, and still broadcast on write
  - [x] A published event reaches a subscriber over real Redis
  - [x] The subscriber evicts exactly the affected `(user, provider)` entry and leaves neighbours alone
  - [x] Timeline regression: token fetched, credential upgraded elsewhere, next fetch returns the new token with no TTL wait
  - [x] The listener re-subscribes when the stream ends
  - [x] A Redis publish failure leaves the credential write successful and logs at ERROR
  - [x] Existing `integrations` and `copilot` suites pass

