### PR TITLE
fix(backend): route every Stripe SDK call through one async helper

### DIFF
--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -128,6 +128,7 @@ from backend.data.onboarding import (
 )
 from backend.data.redis_client import get_redis_async
 from backend.data.sharing.tokens import SHARE_TOKEN_PATTERN, generate_share_token
+from backend.data.stripe_client import stripe_call
 from backend.data.tally import extract_business_understanding
 from backend.data.tenancy import get_user_team_ids
 from backend.data.understanding import (
@@ -991,7 +992,7 @@ async def _get_stripe_price_amount(price_id: str) -> int | None:
     every GET /credits/subscription page load and reduces quota consumption.
     """
     try:
-        price = await run_in_threadpool(stripe.Price.retrieve, price_id)
+        price = await stripe_call(stripe.Price.retrieve_async, price_id)
         return price.unit_amount or 0
     except stripe.StripeError:
         logger.warning(
@@ -1640,7 +1641,7 @@ async def stripe_webhook(request: Request):
         if event_type in ("invoice_payment.paid", "invoice_payment.payment_failed"):
             invoice_id = data_object.get("invoice")
             if invoice_id:
-                invoice = await run_in_threadpool(stripe.Invoice.retrieve, invoice_id)
+                invoice = await stripe_call(stripe.Invoice.retrieve_async, invoice_id)
                 invoice_payload = cast(dict, invoice)
                 if event_type == "invoice_payment.paid":
                     await handle_subscription_payment_success(invoice_payload)

--- a/autogpt_platform/backend/backend/api/features/v1_stripe_webhook_test.py
+++ b/autogpt_platform/backend/backend/api/features/v1_stripe_webhook_test.py
@@ -265,7 +265,7 @@ def test_stripe_webhook_releases_dedup_on_invoice_retrieve_failure(
         new_callable=AsyncMock,
     )
     mocker.patch(
-        "backend.api.features.v1.stripe.Invoice.retrieve",
+        "backend.api.features.v1.stripe.Invoice.retrieve_async",
         side_effect=stripe.StripeError("stripe down"),
     )
 

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import posthog
 import stripe
-from fastapi.concurrency import run_in_threadpool
 from prisma.enums import (
     CreditRefundRequestStatus,
     CreditTransactionType,
@@ -38,6 +37,7 @@ from backend.data.model import (
 from backend.data.model import User as AppUser
 from backend.data.model import UserTransaction
 from backend.data.notifications import NotificationEventModel, OpsData
+from backend.data.stripe_client import stripe_call
 from backend.data.user import get_user_by_id, get_user_email_by_id
 from backend.notifications.queue import queue_notification_async
 from backend.util.cache import cached
@@ -910,7 +910,11 @@ class UserCredit(UserCreditBase):
             return 0  # Register the refund request for manual approval.
 
         # Auto refund the top-up.
-        refund = stripe.Refund.create(payment_intent=transaction_key, metadata=metadata)
+        refund = await stripe_call(
+            stripe.Refund.create_async,
+            payment_intent=transaction_key,
+            metadata=metadata,
+        )
         return refund.amount
 
     async def deduct_credits(self, request: stripe.Refund | stripe.Dispute):
@@ -1032,7 +1036,7 @@ class UserCredit(UserCreditBase):
             "customer_email_address": user.email,
             "uncategorized_text": evidence_text[:20000],
         }
-        stripe.Dispute.modify(dispute.id, evidence=evidence)
+        await stripe_call(stripe.Dispute.modify_async, dispute.id, evidence=evidence)
 
     async def _top_up_credits(
         self,
@@ -1085,7 +1089,9 @@ class UserCredit(UserCreditBase):
 
         customer_id = await get_stripe_customer_id(user_id)
 
-        payment_methods = stripe.PaymentMethod.list(customer=customer_id, type="card")
+        payment_methods = await stripe_call(
+            stripe.PaymentMethod.list_async, customer=customer_id, type="card"
+        )
         if not payment_methods:
             raise ValueError("No payment method found, please add it on the platform.")
 
@@ -1093,7 +1099,8 @@ class UserCredit(UserCreditBase):
         new_transaction_key = None
         for payment_method in payment_methods:
             if transaction_type == CreditTransactionType.CARD_CHECK:
-                setup_intent = stripe.SetupIntent.create(
+                setup_intent = await stripe_call(
+                    stripe.SetupIntent.create_async,
                     customer=customer_id,
                     usage="off_session",
                     confirm=True,
@@ -1108,7 +1115,8 @@ class UserCredit(UserCreditBase):
                     new_transaction_key = setup_intent.id
                     break
             else:
-                payment_intent = stripe.PaymentIntent.create(
+                payment_intent = await stripe_call(
+                    stripe.PaymentIntent.create_async,
                     amount=amount,
                     currency="usd",
                     description="AutoGPT Platform Credits",
@@ -1200,7 +1208,8 @@ class UserCredit(UserCreditBase):
         # https://docs.stripe.com/checkout/quickstart?client=react
         # unit_amount param is always in the smallest currency unit (so cents for usd)
         # which is equal to amount of credits
-        checkout_session = stripe.checkout.Session.create(
+        checkout_session = await stripe_call(
+            stripe.checkout.Session.create_async,
             customer=await get_stripe_customer_id(user_id),
             line_items=line_items,
             mode="payment",
@@ -1263,7 +1272,8 @@ class UserCredit(UserCreditBase):
             return
 
         # Retrieve the Checkout Session from the API
-        checkout_session = stripe.checkout.Session.retrieve(
+        checkout_session = await stripe_call(
+            stripe.checkout.Session.retrieve_async,
             credit_transaction.transactionKey,
             expand=["payment_intent"],
         )
@@ -1399,8 +1409,8 @@ class UserCredit(UserCreditBase):
         limit = max(1, min(limit, 100))
 
         try:
-            invoices = await run_in_threadpool(
-                stripe.Invoice.list,
+            invoices = await stripe_call(
+                stripe.Invoice.list_async,
                 customer=user.stripe_customer_id,
                 limit=limit,
             )
@@ -1524,8 +1534,8 @@ async def get_stripe_customer_id(user_id: str) -> str:
     # Pass an idempotency_key so Stripe collapses concurrent + retried calls
     # into the same Customer object server-side. The 24h Stripe idempotency
     # window comfortably covers any realistic in-flight retry scenario.
-    customer = await run_in_threadpool(
-        stripe.Customer.create,
+    customer = await stripe_call(
+        stripe.Customer.create_async,
         name=user.name or "",
         email=user.email,
         metadata={"user_id": user_id},
@@ -1596,8 +1606,11 @@ async def _cancel_customer_subscriptions(
     # past_due subs rather than filter them out client-side via status="all".
     seen_ids: set[str] = set()
     for status in ("active", "trialing"):
-        subscriptions = await run_in_threadpool(
-            stripe.Subscription.list, customer=customer_id, status=status, limit=10
+        subscriptions = await stripe_call(
+            stripe.Subscription.list_async,
+            customer=customer_id,
+            status=status,
+            limit=10,
         )
         # Iterate only the first page (up to 10); avoid auto_paging_iter which would
         # trigger additional sync HTTP calls inside the event loop.
@@ -1632,11 +1645,11 @@ async def _cancel_customer_subscriptions(
                     await _release_schedule_ignoring_terminal(
                         schedule_id, "_cancel_customer_subscriptions"
                     )
-                await run_in_threadpool(
-                    stripe.Subscription.modify, sub_id, cancel_at_period_end=True
+                await stripe_call(
+                    stripe.Subscription.modify_async, sub_id, cancel_at_period_end=True
                 )
             else:
-                await run_in_threadpool(stripe.Subscription.cancel, sub_id)
+                await stripe_call(stripe.Subscription.cancel_async, sub_id)
     return len(seen_ids)
 
 
@@ -1758,8 +1771,8 @@ class PendingChangeUnknown(Exception):
 async def _get_active_subscription(customer_id: str) -> stripe.Subscription | None:
     """Return the customer's active or trialing subscription, or None."""
     for status in ("active", "trialing"):
-        subs = await stripe.Subscription.list_async(
-            customer=customer_id, status=status, limit=1
+        subs = await stripe_call(
+            stripe.Subscription.list_async, customer=customer_id, status=status, limit=1
         )
         if subs.data:
             return subs.data[0]
@@ -1895,7 +1908,7 @@ async def _release_schedule_ignoring_terminal(
     silently masking a bug.
     """
     try:
-        await stripe.SubscriptionSchedule.release_async(schedule_id)
+        await stripe_call(stripe.SubscriptionSchedule.release_async, schedule_id)
         return True
     except stripe.InvalidRequestError as e:
         message = getattr(e, "user_message", None) or str(e)
@@ -1955,7 +1968,9 @@ async def _schedule_downgrade_at_period_end(
     period_end: int = sub["current_period_end"]
 
     if sub.cancel_at_period_end:
-        await stripe.Subscription.modify_async(sub_id, cancel_at_period_end=False)
+        await stripe_call(
+            stripe.Subscription.modify_async, sub_id, cancel_at_period_end=False
+        )
         logger.info(
             "_schedule_downgrade_at_period_end: cleared cancel_at_period_end"
             " on sub %s for user %s before scheduling downgrade",
@@ -1975,9 +1990,12 @@ async def _schedule_downgrade_at_period_end(
     # subscription, which blocks any future Stripe-side change until manually
     # released. Roll back by releasing the orphan, then re-raise so the caller
     # sees the original failure.
-    schedule = await stripe.SubscriptionSchedule.create_async(from_subscription=sub_id)
+    schedule = await stripe_call(
+        stripe.SubscriptionSchedule.create_async, from_subscription=sub_id
+    )
     try:
-        await stripe.SubscriptionSchedule.modify_async(
+        await stripe_call(
+            stripe.SubscriptionSchedule.modify_async,
             schedule.id,
             phases=[
                 {
@@ -2128,7 +2146,7 @@ async def modify_stripe_subscription_for_tier(
         if sub.cancel_at_period_end:
             modify_kwargs["cancel_at_period_end"] = False
 
-        await stripe.Subscription.modify_async(sub_id, **modify_kwargs)
+        await stripe_call(stripe.Subscription.modify_async, sub_id, **modify_kwargs)
         # Flip the DB tier immediately. The customer.subscription.updated webhook
         # will also fire and set it again — idempotent. Without this synchronous
         # update, the UI refetches before the webhook lands and shows the old
@@ -2222,8 +2240,8 @@ async def release_pending_subscription_schedule(user_id: str) -> bool:
                 did_anything = True
         if sub.cancel_at_period_end:
             try:
-                await stripe.Subscription.modify_async(
-                    sub_id, cancel_at_period_end=False
+                await stripe_call(
+                    stripe.Subscription.modify_async, sub_id, cancel_at_period_end=False
                 )
             except stripe.StripeError:
                 if schedule_released:
@@ -2332,7 +2350,9 @@ async def get_pending_subscription_change(
     if not sub.schedule:
         return None
     schedule_id = sub.schedule if isinstance(sub.schedule, str) else sub.schedule.id
-    schedule = await stripe.SubscriptionSchedule.retrieve_async(schedule_id)
+    schedule = await stripe_call(
+        stripe.SubscriptionSchedule.retrieve_async, schedule_id
+    )
     return _next_phase_tier_and_start(schedule, price_to_tier, price_to_cycle)
 
 
@@ -2502,7 +2522,9 @@ async def _expire_open_subscription_sessions(customer_id: str) -> None:
             }
             if starting_after:
                 list_kwargs["starting_after"] = starting_after
-            sessions = await stripe.checkout.Session.list_async(**list_kwargs)
+            sessions = await stripe_call(
+                stripe.checkout.Session.list_async, **list_kwargs
+            )
             for s in sessions.data:
                 if s.mode == "subscription":
                     try:
@@ -2604,7 +2626,7 @@ async def sync_tier_from_checkout_session(data_object: dict) -> None:
     sub_id = data_object.get("subscription")
     if not sub_id:
         return
-    sub = await stripe.Subscription.retrieve_async(sub_id)
+    sub = await stripe_call(stripe.Subscription.retrieve_async, sub_id)
     await sync_subscription_from_stripe(dict(sub))
 
 
@@ -2624,8 +2646,8 @@ async def create_subscription_checkout(
     customer_id = await get_stripe_customer_id(user_id)
     await _expire_open_subscription_sessions(customer_id)
     datafast = _datafast_metadata(datafast_visitor_id, datafast_session_id)
-    session = await run_in_threadpool(
-        stripe.checkout.Session.create,
+    session = await stripe_call(
+        stripe.checkout.Session.create_async,
         customer=customer_id,
         mode="subscription",
         line_items=[{"price": price_id, "quantity": 1}],
@@ -2780,14 +2802,14 @@ async def sync_subscription_from_stripe(stripe_subscription: dict) -> None:
         # own event will/has already set the correct tier).
         try:
             other_subs_active, other_subs_trialing = await asyncio.gather(
-                run_in_threadpool(
-                    stripe.Subscription.list,
+                stripe_call(
+                    stripe.Subscription.list_async,
                     customer=customer_id,
                     status="active",
                     limit=10,
                 ),
-                run_in_threadpool(
-                    stripe.Subscription.list,
+                stripe_call(
+                    stripe.Subscription.list_async,
                     customer=customer_id,
                     status="trialing",
                     limit=10,
@@ -2904,7 +2926,7 @@ async def sync_subscription_schedule_from_stripe(stripe_schedule: dict) -> None:
         )
         return
     try:
-        sub = await stripe.Subscription.retrieve_async(sub_id)
+        sub = await stripe_call(stripe.Subscription.retrieve_async, sub_id)
     except stripe.StripeError:
         logger.warning(
             "sync_subscription_schedule_from_stripe: failed to retrieve sub %s",
@@ -3136,8 +3158,8 @@ async def handle_subscription_payment_failure(invoice: dict) -> None:
         # balance debit isn't reversed if the credit-grant flag is on.
         if invoice_id:
             try:
-                await run_in_threadpool(
-                    stripe.Invoice.pay, invoice_id, paid_out_of_band=True
+                await stripe_call(
+                    stripe.Invoice.pay_async, invoice_id, paid_out_of_band=True
                 )
             except stripe.StripeError:
                 logger.warning(

--- a/autogpt_platform/backend/backend/data/credit.py
+++ b/autogpt_platform/backend/backend/data/credit.py
@@ -361,7 +361,8 @@ class UserCreditBase(ABC):
 
     @staticmethod
     async def create_billing_portal_session(user_id: str) -> str:
-        session = stripe.billing_portal.Session.create(
+        session = await stripe_call(
+            stripe.billing_portal.Session.create_async,
             customer=await get_stripe_customer_id(user_id),
             return_url=base_url + "/settings/billing",
         )
@@ -2528,7 +2529,7 @@ async def _expire_open_subscription_sessions(customer_id: str) -> None:
             for s in sessions.data:
                 if s.mode == "subscription":
                     try:
-                        await stripe.checkout.Session.expire_async(s.id)
+                        await stripe_call(stripe.checkout.Session.expire_async, s.id)
                     except stripe.StripeError:
                         logger.warning(
                             "create_subscription_checkout: could not expire session %s",

--- a/autogpt_platform/backend/backend/data/credit_invoices_test.py
+++ b/autogpt_platform/backend/backend/data/credit_invoices_test.py
@@ -64,7 +64,9 @@ class TestListInvoices:
                 "get_user_by_id",
                 AsyncMock(return_value=_make_user(None)),
             ),
-            patch.object(credit_module.stripe.Invoice, "list") as mock_list,
+            patch.object(
+                credit_module.stripe.Invoice, "list_async", new_callable=AsyncMock
+            ) as mock_list,
         ):
             result = await user_credit.list_invoices("user-1")
 
@@ -82,7 +84,8 @@ class TestListInvoices:
             ),
             patch.object(
                 credit_module.stripe.Invoice,
-                "list",
+                "list_async",
+                new_callable=AsyncMock,
                 side_effect=stripe.StripeError("boom"),
             ),
         ):
@@ -120,7 +123,8 @@ class TestListInvoices:
             ),
             patch.object(
                 credit_module.stripe.Invoice,
-                "list",
+                "list_async",
+                new_callable=AsyncMock,
                 return_value=stripe_response,
             ) as mock_list,
         ):
@@ -166,7 +170,8 @@ class TestListInvoices:
             ),
             patch.object(
                 credit_module.stripe.Invoice,
-                "list",
+                "list_async",
+                new_callable=AsyncMock,
                 return_value=stripe_response,
             ) as mock_list,
         ):

--- a/autogpt_platform/backend/backend/data/credit_metadata_test.py
+++ b/autogpt_platform/backend/backend/data/credit_metadata_test.py
@@ -176,7 +176,7 @@ async def test_top_up_intent_attaches_datafast_metadata():
     mock_session = MagicMock()
     mock_session.id = "cs_test_topup"
     mock_session.url = "https://checkout.stripe.com/c/cs_test_topup"
-    create_mock = MagicMock(return_value=mock_session)
+    create_mock = AsyncMock(return_value=mock_session)
     credit_system = UserCredit()
     with (
         patch(
@@ -190,7 +190,7 @@ async def test_top_up_intent_attaches_datafast_metadata():
             return_value=None,
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.create",
+            "backend.data.credit.stripe.checkout.Session.create_async",
             new=create_mock,
         ),
         patch.object(credit_system, "_add_transaction", new_callable=AsyncMock),
@@ -214,7 +214,7 @@ async def test_create_subscription_checkout_attaches_datafast_metadata():
     metadata and the subscription_data metadata while keeping user_id."""
     mock_session = MagicMock()
     mock_session.url = "https://checkout.stripe.com/pay/cs_test_sub"
-    create_mock = MagicMock(return_value=mock_session)
+    create_mock = AsyncMock(return_value=mock_session)
     with (
         patch(
             "backend.data.credit.get_subscription_price_id",
@@ -231,7 +231,7 @@ async def test_create_subscription_checkout_attaches_datafast_metadata():
             new_callable=AsyncMock,
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.create",
+            "backend.data.credit.stripe.checkout.Session.create_async",
             new=create_mock,
         ),
     ):

--- a/autogpt_platform/backend/backend/data/credit_refund_test.py
+++ b/autogpt_platform/backend/backend/data/credit_refund_test.py
@@ -162,7 +162,7 @@ async def test_deduct_credits_user_not_found(server: SpinTestServer):
 
 @pytest.mark.asyncio(loop_scope="session")
 @patch("backend.data.credit.settings")
-@patch("stripe.Dispute.modify")
+@patch("stripe.Dispute.modify_async")
 @patch("backend.data.credit.get_user_by_id")
 async def test_handle_dispute_with_sufficient_balance(
     mock_get_user, mock_stripe_modify, mock_settings, server: SpinTestServer
@@ -215,7 +215,7 @@ async def test_handle_dispute_with_sufficient_balance(
 
 @pytest.mark.asyncio(loop_scope="session")
 @patch("backend.data.credit.settings")
-@patch("stripe.Dispute.modify")
+@patch("stripe.Dispute.modify_async")
 @patch("backend.data.credit.get_user_by_id")
 async def test_handle_dispute_with_insufficient_balance(
     mock_get_user, mock_stripe_modify, mock_settings, server: SpinTestServer

--- a/autogpt_platform/backend/backend/data/credit_subscription_test.py
+++ b/autogpt_platform/backend/backend/data/credit_subscription_test.py
@@ -130,7 +130,7 @@ async def test_sync_subscription_from_stripe_active():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -224,7 +224,7 @@ async def test_sync_subscription_from_stripe_yearly_pro_maps_to_pro():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -271,7 +271,7 @@ async def test_sync_subscription_from_stripe_idempotent_no_write_if_unchanged():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -325,7 +325,7 @@ async def test_sync_subscription_from_stripe_cancelled():
             return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -359,7 +359,7 @@ async def test_sync_subscription_from_stripe_past_due_downgrades_to_no_tier():
             return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -398,7 +398,7 @@ async def test_sync_subscription_from_stripe_cancelled_applies_no_tier_storage_l
             return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -470,7 +470,7 @@ async def test_sync_subscription_from_stripe_cancelled_but_other_active_sub_exis
             return_value=MagicMock(find_first=AsyncMock(return_value=mock_user)),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             side_effect=list_side_effect,
         ),
         patch(
@@ -516,7 +516,7 @@ async def test_sync_subscription_from_stripe_trialing():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -566,10 +566,10 @@ async def test_cancel_stripe_subscription_cancels_active():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=mock_subscriptions,
         ),
-        patch("backend.data.credit.stripe.Subscription.modify") as mock_modify,
+        patch("backend.data.credit.stripe.Subscription.modify_async") as mock_modify,
     ):
         await cancel_stripe_subscription("user-1")
         mock_modify.assert_called_once_with("sub_abc123", cancel_at_period_end=True)
@@ -640,11 +640,11 @@ async def test_cancel_stripe_subscription_multi_partial_failure():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=mock_subscriptions,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.modify",
+            "backend.data.credit.stripe.Subscription.modify_async",
             side_effect=stripe.StripeError("first modify failed"),
         ) as mock_modify,
         patch(
@@ -678,10 +678,10 @@ async def test_cancel_stripe_subscription_no_active():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=mock_subscriptions,
         ),
-        patch("backend.data.credit.stripe.Subscription.cancel") as mock_cancel,
+        patch("backend.data.credit.stripe.Subscription.cancel_async") as mock_cancel,
     ):
         await cancel_stripe_subscription("user-1")
         mock_cancel.assert_not_called()
@@ -697,7 +697,7 @@ async def test_cancel_stripe_subscription_raises_on_list_failure():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             side_effect=stripe.StripeError("network error"),
         ),
     ):
@@ -729,10 +729,10 @@ async def test_cancel_stripe_subscription_cancels_trialing():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             side_effect=list_side_effect,
         ),
-        patch("backend.data.credit.stripe.Subscription.modify") as mock_modify,
+        patch("backend.data.credit.stripe.Subscription.modify_async") as mock_modify,
     ):
         await cancel_stripe_subscription("user-1")
         mock_modify.assert_called_once_with("sub_trial_123", cancel_at_period_end=True)
@@ -766,10 +766,10 @@ async def test_cancel_stripe_subscription_cancels_active_and_trialing():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             side_effect=list_side_effect,
         ),
-        patch("backend.data.credit.stripe.Subscription.modify") as mock_modify,
+        patch("backend.data.credit.stripe.Subscription.modify_async") as mock_modify,
     ):
         await cancel_stripe_subscription("user-1")
         modified_ids = {call.args[0] for call in mock_modify.call_args_list}
@@ -808,7 +808,7 @@ async def test_cancel_stripe_subscription_releases_attached_schedule_first():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=mock_subscriptions,
         ),
         patch(
@@ -817,7 +817,7 @@ async def test_cancel_stripe_subscription_releases_attached_schedule_first():
             side_effect=record_release,
         ) as mock_release,
         patch(
-            "backend.data.credit.stripe.Subscription.modify",
+            "backend.data.credit.stripe.Subscription.modify_async",
             side_effect=record_modify,
         ) as mock_modify,
     ):
@@ -945,7 +945,7 @@ async def test_create_subscription_checkout_returns_url():
             return_value="cus_123",
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.create",
+            "backend.data.credit.stripe.checkout.Session.create_async",
             return_value=mock_session,
         ),
     ):
@@ -985,7 +985,7 @@ async def test_create_subscription_checkout_offers_saved_payment_methods():
             new_callable=AsyncMock,
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.create",
+            "backend.data.credit.stripe.checkout.Session.create_async",
             return_value=mock_session,
         ) as mock_create,
     ):
@@ -1135,7 +1135,7 @@ async def test_sync_subscription_from_stripe_business_tier():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -1187,7 +1187,7 @@ async def test_sync_subscription_from_stripe_basic_tier_via_ld_price():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -1237,11 +1237,13 @@ async def test_sync_subscription_from_stripe_cancels_stale_subs():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
+            new_callable=AsyncMock,
             return_value=existing,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.cancel",
+            "backend.data.credit.stripe.Subscription.cancel_async",
+            new_callable=AsyncMock,
         ) as mock_cancel,
         patch(
             "backend.data.credit.set_subscription_tier", new_callable=AsyncMock
@@ -1289,11 +1291,11 @@ async def test_sync_subscription_from_stripe_stale_cancel_errors_swallowed():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=existing,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.cancel",
+            "backend.data.credit.stripe.Subscription.cancel_async",
             side_effect=stripe_mod.StripeError("cancel failed"),
         ),
         patch(
@@ -1590,11 +1592,11 @@ async def test_cancel_stripe_subscription_raises_on_cancel_error():
             return_value=_make_user_with_stripe("cus_123"),
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=mock_subscriptions,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.modify",
+            "backend.data.credit.stripe.Subscription.modify_async",
             side_effect=stripe_mod.StripeError("network error"),
         ),
     ):
@@ -1633,7 +1635,7 @@ async def test_sync_subscription_from_stripe_metadata_user_id_matches():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -1705,7 +1707,7 @@ async def test_sync_subscription_from_stripe_no_metadata_user_id_skips_check():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(
@@ -1740,7 +1742,9 @@ async def test_handle_subscription_payment_failure_balance_covers_pays_invoice()
             "backend.data.credit.UserCredit._add_transaction",
             new_callable=AsyncMock,
         ),
-        patch("backend.data.credit.stripe.Invoice.pay") as mock_pay,
+        patch(
+            "backend.data.credit.stripe.Invoice.pay_async", new_callable=AsyncMock
+        ) as mock_pay,
     ):
         await handle_subscription_payment_failure(invoice)
         mock_pay.assert_called_once_with("in_abc123", paid_out_of_band=True)
@@ -1769,7 +1773,7 @@ async def test_handle_subscription_payment_failure_invoice_pay_error_does_not_ra
             new_callable=AsyncMock,
         ),
         patch(
-            "backend.data.credit.stripe.Invoice.pay",
+            "backend.data.credit.stripe.Invoice.pay_async",
             side_effect=stripe_mod.StripeError("network error"),
         ),
     ):
@@ -1797,7 +1801,7 @@ async def test_handle_subscription_payment_failure_passes_invoice_id_as_transact
             "backend.data.credit.UserCredit._add_transaction",
             new_callable=AsyncMock,
         ) as mock_add_tx,
-        patch("backend.data.credit.stripe.Invoice.pay"),
+        patch("backend.data.credit.stripe.Invoice.pay_async", new_callable=AsyncMock),
     ):
         await handle_subscription_payment_failure(invoice)
         mock_add_tx.assert_called_once()
@@ -2317,7 +2321,7 @@ async def test_top_up_intent_uses_inline_product_data_when_flag_unset():
     mock_session = MagicMock()
     mock_session.id = "cs_test_topup"
     mock_session.url = "https://checkout.stripe.com/c/cs_test_topup"
-    create_mock = MagicMock(return_value=mock_session)
+    create_mock = AsyncMock(return_value=mock_session)
     credit_system = UserCredit()
     with (
         patch(
@@ -2331,7 +2335,7 @@ async def test_top_up_intent_uses_inline_product_data_when_flag_unset():
             return_value=None,
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.create",
+            "backend.data.credit.stripe.checkout.Session.create_async",
             new=create_mock,
         ),
         patch.object(credit_system, "_add_transaction", new_callable=AsyncMock),
@@ -2356,7 +2360,7 @@ async def test_top_up_intent_references_product_id_when_flag_set():
     mock_session = MagicMock()
     mock_session.id = "cs_test_topup"
     mock_session.url = "https://checkout.stripe.com/c/cs_test_topup"
-    create_mock = MagicMock(return_value=mock_session)
+    create_mock = AsyncMock(return_value=mock_session)
     credit_system = UserCredit()
     with (
         patch(
@@ -2370,7 +2374,7 @@ async def test_top_up_intent_references_product_id_when_flag_set():
             return_value="prod_abc123",
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.create",
+            "backend.data.credit.stripe.checkout.Session.create_async",
             new=create_mock,
         ),
         patch.object(credit_system, "_add_transaction", new_callable=AsyncMock),
@@ -2416,11 +2420,11 @@ async def test_top_up_credits_tracks_success():
             return_value="cus_123",
         ),
         patch(
-            "backend.data.credit.stripe.PaymentMethod.list",
+            "backend.data.credit.stripe.PaymentMethod.list_async",
             return_value=[payment_method],
         ),
         patch(
-            "backend.data.credit.stripe.PaymentIntent.create",
+            "backend.data.credit.stripe.PaymentIntent.create_async",
             return_value=payment_intent,
         ),
         patch("backend.data.credit.settings.secrets.posthog_api_key", new="phc_test"),
@@ -2463,7 +2467,7 @@ async def test_fulfill_checkout_tracks_credit_topup_success():
             return_value=MagicMock(find_first=AsyncMock(return_value=transaction)),
         ),
         patch(
-            "backend.data.credit.stripe.checkout.Session.retrieve",
+            "backend.data.credit.stripe.checkout.Session.retrieve_async",
             return_value=checkout_session,
         ),
         patch.object(
@@ -3731,7 +3735,7 @@ async def test_sync_subscription_from_stripe_phase_transition_updates_tier():
             side_effect=mock_price_id,
         ),
         patch(
-            "backend.data.credit.stripe.Subscription.list",
+            "backend.data.credit.stripe.Subscription.list_async",
             return_value=empty_list,
         ),
         patch(

--- a/autogpt_platform/backend/backend/data/org_credit.py
+++ b/autogpt_platform/backend/backend/data/org_credit.py
@@ -22,6 +22,7 @@ from backend.data.credit import (
 from backend.data.db import prisma
 from backend.data.model import RefundRequest, TransactionHistory
 from backend.data.onboarding_steps import OnboardingStep
+from backend.data.stripe_client import stripe_call
 from backend.util.cache import cached
 from backend.util.exceptions import InsufficientBalanceError
 from backend.util.json import SafeJson
@@ -454,12 +455,10 @@ class OrgCreditModel(UserCreditBase):
         if not org or not org.stripeCustomerId:
             return []
 
-        from fastapi.concurrency import run_in_threadpool
-
         limit = max(1, min(limit, 100))
         try:
-            invoices = await run_in_threadpool(
-                stripe.Invoice.list,
+            invoices = await stripe_call(
+                stripe.Invoice.list_async,
                 customer=org.stripeCustomerId,
                 limit=limit,
             )

--- a/autogpt_platform/backend/backend/data/stripe_client.py
+++ b/autogpt_platform/backend/backend/data/stripe_client.py
@@ -36,24 +36,6 @@ T = TypeVar("T")
 DEFAULT_TIMEOUT_SECONDS = 30.0
 
 
-def _labels(fn: Callable[..., object]) -> tuple[str, str]:
-    """``stripe.Subscription.list_async`` -> ("Subscription", "list")."""
-    qual = getattr(fn, "__qualname__", "") or ""
-    resource, _, method = qual.rpartition(".")
-    resource = resource.rsplit(".", 1)[-1] or "unknown"
-    return resource, method.removesuffix("_async") or "unknown"
-
-
-def _outcome(exc: BaseException) -> str:
-    if isinstance(exc, stripe.RateLimitError):
-        return "rate_limited"
-    if isinstance(exc, stripe.APIConnectionError):
-        return "connection_error"
-    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
-        return "timeout"
-    return "api_error"
-
-
 async def stripe_call(
     fn: Callable[P, Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs
 ) -> T:
@@ -92,10 +74,7 @@ async def _call(
             resource, method, "timeout", time.perf_counter() - started
         )
         logger.error(
-            "Stripe %s.%s exceeded %ss and was cancelled",
-            resource,
-            method,
-            timeout_seconds,
+            f"Stripe {resource}.{method} exceeded {timeout_seconds}s and was cancelled"
         )
         raise TimeoutError(
             f"Stripe {resource}.{method} exceeded {timeout_seconds}s and was cancelled."
@@ -107,3 +86,23 @@ async def _call(
         raise
     record_stripe_request(resource, method, "ok", time.perf_counter() - started)
     return result
+
+
+def _labels(fn: Callable[..., object]) -> tuple[str, str]:
+    """``stripe.Subscription.list_async`` -> ("Subscription", "list")."""
+    # Test doubles (AsyncMock) refuse to synthesise dunder attributes, so a
+    # default is needed here; this is a label lookup, not type dispatch.
+    qual = getattr(fn, "__qualname__", "") or ""
+    resource, _, method = qual.rpartition(".")
+    resource = resource.rsplit(".", 1)[-1] or "unknown"
+    return resource, method.removesuffix("_async") or "unknown"
+
+
+def _outcome(exc: BaseException) -> str:
+    if isinstance(exc, stripe.RateLimitError):
+        return "rate_limited"
+    if isinstance(exc, stripe.APIConnectionError):
+        return "connection_error"
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        return "timeout"
+    return "api_error"

--- a/autogpt_platform/backend/backend/data/stripe_client.py
+++ b/autogpt_platform/backend/backend/data/stripe_client.py
@@ -1,0 +1,109 @@
+"""One door for every Stripe SDK call.
+
+The SDK's native ``*_async`` methods are used directly (no thread pool), a
+timeout well under the SDK's 80s default is applied, and every call is
+counted by resource, method and outcome. Nothing about Stripe semantics is
+changed: the original exception is always re-raised unchanged, so callers
+that branch on ``stripe.InvalidRequestError`` etc. keep working.
+
+Retries are deliberately left to the SDK (``stripe.max_network_retries``),
+which only retries with idempotency keys. Wrapping this in our own retry
+decorator would re-issue non-idempotent writes such as PaymentIntent.create.
+
+On timeout the coroutine is cancelled on our side. For a write that Stripe may
+already have applied (a charge, a refund) that leaves the caller unsure, which
+is inherent to any client-side timeout on a non-idempotent call; the outcome is
+recorded as ``timeout`` and logged at error level so it is never silent.
+"""
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import ParamSpec, TypeVar
+
+import stripe
+
+from backend.monitoring.instrumentation import record_stripe_request
+
+logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+# Stripe's own p99 is low single-digit seconds; 80s (the SDK default) only
+# ever means a stalled socket, and holding a request that long serves nobody.
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+def _labels(fn: Callable[..., object]) -> tuple[str, str]:
+    """``stripe.Subscription.list_async`` -> ("Subscription", "list")."""
+    qual = getattr(fn, "__qualname__", "") or ""
+    resource, _, method = qual.rpartition(".")
+    resource = resource.rsplit(".", 1)[-1] or "unknown"
+    return resource, method.removesuffix("_async") or "unknown"
+
+
+def _outcome(exc: BaseException) -> str:
+    if isinstance(exc, stripe.RateLimitError):
+        return "rate_limited"
+    if isinstance(exc, stripe.APIConnectionError):
+        return "connection_error"
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        return "timeout"
+    return "api_error"
+
+
+async def stripe_call(
+    fn: Callable[P, Awaitable[T]], /, *args: P.args, **kwargs: P.kwargs
+) -> T:
+    """Await ``fn(*args, **kwargs)`` with the default timeout, recording the outcome.
+
+    ``fn`` must be one of the SDK's ``*_async`` methods, e.g.
+    ``stripe.Subscription.list_async``. The original exception is re-raised.
+    """
+    return await _call(DEFAULT_TIMEOUT_SECONDS, fn, *args, **kwargs)
+
+
+async def stripe_call_timeout(
+    timeout_seconds: float,
+    fn: Callable[P, Awaitable[T]],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> T:
+    """As :func:`stripe_call`, with an explicit timeout. Rarely needed."""
+    return await _call(timeout_seconds, fn, *args, **kwargs)
+
+
+async def _call(
+    timeout_seconds: float,
+    fn: Callable[P, Awaitable[T]],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> T:
+    resource, method = _labels(fn)
+    started = time.perf_counter()
+    try:
+        result = await asyncio.wait_for(fn(*args, **kwargs), timeout=timeout_seconds)
+    except asyncio.TimeoutError as exc:
+        record_stripe_request(
+            resource, method, "timeout", time.perf_counter() - started
+        )
+        logger.error(
+            "Stripe %s.%s exceeded %ss and was cancelled",
+            resource,
+            method,
+            timeout_seconds,
+        )
+        raise TimeoutError(
+            f"Stripe {resource}.{method} exceeded {timeout_seconds}s and was cancelled."
+        ) from exc
+    except Exception as exc:
+        record_stripe_request(
+            resource, method, _outcome(exc), time.perf_counter() - started
+        )
+        raise
+    record_stripe_request(resource, method, "ok", time.perf_counter() - started)
+    return result

--- a/autogpt_platform/backend/backend/data/stripe_client.py
+++ b/autogpt_platform/backend/backend/data/stripe_client.py
@@ -10,7 +10,10 @@ Retries are deliberately left to the SDK (``stripe.max_network_retries``),
 which only retries with idempotency keys. Wrapping this in our own retry
 decorator would re-issue non-idempotent writes such as PaymentIntent.create.
 
-On timeout the coroutine is cancelled on our side. For a write that Stripe may
+On timeout the coroutine is cancelled on our side and a
+``stripe.APIConnectionError`` is raised, the same type the SDK uses for its own
+network timeouts, so existing ``except stripe.StripeError`` handling keeps
+working. For a write that Stripe may
 already have applied (a charge, a refund) that leaves the caller unsure, which
 is inherent to any client-side timeout on a non-idempotent call; the outcome is
 recorded as ``timeout`` and logged at error level so it is never silent.
@@ -76,8 +79,9 @@ async def _call(
         logger.error(
             f"Stripe {resource}.{method} exceeded {timeout_seconds}s and was cancelled"
         )
-        raise TimeoutError(
-            f"Stripe {resource}.{method} exceeded {timeout_seconds}s and was cancelled."
+        raise stripe.APIConnectionError(
+            f"Stripe {resource}.{method} exceeded {timeout_seconds}s and was cancelled.",
+            should_retry=False,
         ) from exc
     except Exception as exc:
         record_stripe_request(
@@ -103,6 +107,4 @@ def _outcome(exc: BaseException) -> str:
         return "rate_limited"
     if isinstance(exc, stripe.APIConnectionError):
         return "connection_error"
-    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
-        return "timeout"
     return "api_error"

--- a/autogpt_platform/backend/backend/data/stripe_client_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_client_test.py
@@ -4,13 +4,12 @@ import asyncio
 
 import pytest
 import stripe
+from prometheus_client import REGISTRY
 
 from backend.data.stripe_client import stripe_call, stripe_call_timeout
 
 
 def _n(resource: str, method: str, outcome: str) -> float:
-    from prometheus_client import REGISTRY
-
     return (
         REGISTRY.get_sample_value(
             "autogpt_stripe_requests_total",

--- a/autogpt_platform/backend/backend/data/stripe_client_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_client_test.py
@@ -77,6 +77,8 @@ async def test_other_stripe_errors_keep_their_type():
 @pytest.mark.asyncio
 async def test_timeout_is_bounded_and_counted():
     before = _n("Subscription", "retrieve", "timeout")
-    with pytest.raises(TimeoutError):
+    with pytest.raises(stripe.APIConnectionError) as info:
         await stripe_call_timeout(0.05, _Fake.retrieve_async, "sub_1")
+    assert isinstance(info.value, stripe.StripeError)
+    assert "exceeded 0.05s" in str(info.value)
     assert _n("Subscription", "retrieve", "timeout") == before + 1

--- a/autogpt_platform/backend/backend/data/stripe_client_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_client_test.py
@@ -81,4 +81,5 @@ async def test_timeout_is_bounded_and_counted():
         await stripe_call_timeout(0.05, _Fake.retrieve_async, "sub_1")
     assert isinstance(info.value, stripe.StripeError)
     assert "exceeded 0.05s" in str(info.value)
+    assert info.value.should_retry is False
     assert _n("Subscription", "retrieve", "timeout") == before + 1

--- a/autogpt_platform/backend/backend/data/stripe_client_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_client_test.py
@@ -1,0 +1,83 @@
+"""Tests for the single-door Stripe helper."""
+
+import asyncio
+
+import pytest
+import stripe
+
+from backend.data.stripe_client import stripe_call, stripe_call_timeout
+
+
+def _n(resource: str, method: str, outcome: str) -> float:
+    from prometheus_client import REGISTRY
+
+    return (
+        REGISTRY.get_sample_value(
+            "autogpt_stripe_requests_total",
+            {"resource": resource, "method": method, "outcome": outcome},
+        )
+        or 0.0
+    )
+
+
+class _Fake:
+    """Stands in for a stripe resource class; __qualname__ drives the labels."""
+
+    @staticmethod
+    async def list_async(*, customer: str):
+        return {"customer": customer}
+
+    @staticmethod
+    async def create_async(**_):
+        raise stripe.RateLimitError("slow down")
+
+    @staticmethod
+    async def modify_async(*_a, **_k):
+        raise stripe.InvalidRequestError("bad", "param")
+
+    @staticmethod
+    async def retrieve_async(*_a, **_k):
+        await asyncio.sleep(10)
+
+
+for _f in (
+    _Fake.list_async,
+    _Fake.create_async,
+    _Fake.modify_async,
+    _Fake.retrieve_async,
+):
+    _f.__qualname__ = f"Subscription.{_f.__name__}"
+
+
+@pytest.mark.asyncio
+async def test_ok_returns_result_and_counts():
+    before = _n("Subscription", "list", "ok")
+    assert await stripe_call(_Fake.list_async, customer="cus_1") == {
+        "customer": "cus_1"
+    }
+    assert _n("Subscription", "list", "ok") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_its_own_outcome_and_reraised_unchanged():
+    before = _n("Subscription", "create", "rate_limited")
+    with pytest.raises(stripe.RateLimitError):
+        await stripe_call(_Fake.create_async, customer="cus_1")
+    assert _n("Subscription", "create", "rate_limited") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_other_stripe_errors_keep_their_type():
+    """Callers branch on stripe.InvalidRequestError; the wrapper must not mask it."""
+    before = _n("Subscription", "modify", "api_error")
+    with pytest.raises(stripe.InvalidRequestError):
+        await stripe_call(_Fake.modify_async, "sub_1", cancel_at_period_end=True)
+    assert _n("Subscription", "modify", "api_error") == before + 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_bounded_and_counted():
+    before = _n("Subscription", "retrieve", "timeout")
+    with pytest.raises(TimeoutError):
+        await stripe_call_timeout(0.05, _Fake.retrieve_async, "sub_1")
+    assert _n("Subscription", "retrieve", "timeout") == before + 1

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation.py
@@ -15,7 +15,6 @@ in ``_reconcile_one``), so a steady-state run does no DB writes.
 import logging
 
 import stripe
-from fastapi.concurrency import run_in_threadpool
 from prisma.enums import SubscriptionTier
 from prisma.models import User
 from pydantic import BaseModel
@@ -26,6 +25,7 @@ from backend.data.credit import (
     log_tier_reconciliation_discrepancy,
     set_subscription_tier,
 )
+from backend.data.stripe_client import stripe_call
 
 logger = logging.getLogger(__name__)
 
@@ -220,7 +220,7 @@ async def _collect_status_page(
         if starting_after:
             list_kwargs["starting_after"] = starting_after
         try:
-            subs = await run_in_threadpool(stripe.Subscription.list, **list_kwargs)
+            subs = await stripe_call(stripe.Subscription.list_async, **list_kwargs)
         except stripe.StripeError:
             # A Stripe outage/rate-limit must not abort the whole sweep. Stop
             # this status and flag the run incomplete so we don't downgrade users

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
@@ -59,7 +59,7 @@ def _patch_stripe_pages(
         return page
 
     mocker.patch(
-        "backend.data.stripe_reconciliation.stripe.Subscription.list",
+        "backend.data.stripe_reconciliation.stripe.Subscription.list_async",
         side_effect=_list,
     )
 
@@ -237,7 +237,7 @@ async def test_sweep_incomplete_map_skips_downgrades(
     )
     # Stripe list fails -> _collect_status_page returns capped -> map incomplete.
     mocker.patch(
-        "backend.data.stripe_reconciliation.stripe.Subscription.list",
+        "backend.data.stripe_reconciliation.stripe.Subscription.list_async",
         side_effect=stripe.StripeError("rate limited"),
     )
     candidates = [_candidate("u_down", "cus_gone", SubscriptionTier.PRO)]
@@ -387,7 +387,7 @@ async def test_collect_status_page_follows_pagination(
         return pages.pop(0)
 
     mocker.patch(
-        "backend.data.stripe_reconciliation.stripe.Subscription.list",
+        "backend.data.stripe_reconciliation.stripe.Subscription.list_async",
         side_effect=_list,
     )
     price_to_tier = {
@@ -428,7 +428,7 @@ async def test_collect_status_page_highest_tier_wins_across_pages(
     for first, second in (("price_basic", "price_pro"), ("price_pro", "price_basic")):
         pages = _run(first, second)
         mocker.patch(
-            "backend.data.stripe_reconciliation.stripe.Subscription.list",
+            "backend.data.stripe_reconciliation.stripe.Subscription.list_async",
             side_effect=lambda *, status, limit, starting_after=None: pages.pop(0),
         )
         tiers: dict[str, SubscriptionTier] = {}
@@ -450,7 +450,7 @@ async def test_collect_status_page_stops_at_cap(
         return _page([_sub(f"cus_{call_count['n']}", "price_pro")], has_more=True)
 
     mocker.patch(
-        "backend.data.stripe_reconciliation.stripe.Subscription.list",
+        "backend.data.stripe_reconciliation.stripe.Subscription.list_async",
         side_effect=_list,
     )
     tiers: dict[str, SubscriptionTier] = {}

--- a/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
+++ b/autogpt_platform/backend/backend/data/stripe_reconciliation_test.py
@@ -1,12 +1,14 @@
 """Tests for the periodic Stripe → DB tier reconciliation sweep."""
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_mock
 import stripe
 from prisma.enums import SubscriptionTier
 
+from backend.data import stripe_client
 from backend.data.stripe_reconciliation import (
     ReconciliationSummary,
     _collect_status_page,
@@ -476,3 +478,20 @@ def test_summary_defaults_to_zero() -> None:
         "pagination_capped": False,
         "discrepancies": [],
     }
+
+
+@pytest.mark.asyncio
+async def test_collect_status_page_timeout_marks_run_incomplete():
+    """A stripe_call timeout is a StripeError like any other outage: the sweep
+    stops this status and reports capped=True instead of raising."""
+
+    async def stalled(**_kwargs):
+        await asyncio.sleep(1)
+
+    with (
+        patch.object(stripe_client, "DEFAULT_TIMEOUT_SECONDS", 0.05),
+        patch.object(stripe.Subscription, "list_async", side_effect=stalled),
+    ):
+        capped = await _collect_status_page("active", {}, {})
+
+    assert capped is True

--- a/autogpt_platform/backend/backend/monitoring/instrumentation.py
+++ b/autogpt_platform/backend/backend/monitoring/instrumentation.py
@@ -54,6 +54,21 @@ SCHEDULER_JOBS = Gauge(
     labelnames=["job_type", "status"],
 )
 
+# Every Stripe SDK call, by resource/method and how it ended. Stripe applies
+# its rate limit per account rather than per endpoint, so the rate_limited
+# outcome is worth alerting on regardless of which call path produced it.
+STRIPE_REQUESTS = Counter(
+    "autogpt_stripe_requests_total",
+    "Stripe API requests by resource, method and outcome",
+    labelnames=["resource", "method", "outcome"],
+)
+
+STRIPE_REQUEST_DURATION = Histogram(
+    "autogpt_stripe_request_duration_seconds",
+    "Stripe API request duration in seconds",
+    labelnames=["resource", "method"],
+)
+
 DATABASE_QUERIES = Histogram(
     "autogpt_database_query_duration_seconds",
     "Duration of database queries in seconds",
@@ -248,6 +263,13 @@ def update_websocket_connections(user_id: str, delta: int):
         WEBSOCKET_CONNECTIONS.inc(delta)
     else:
         WEBSOCKET_CONNECTIONS.dec(abs(delta))
+
+
+def record_stripe_request(resource: str, method: str, outcome: str, duration: float):
+    """Record one Stripe API call. ``outcome`` is one of ok / rate_limited /
+    connection_error / timeout / api_error (see backend.data.stripe_client)."""
+    STRIPE_REQUESTS.labels(resource=resource, method=method, outcome=outcome).inc()
+    STRIPE_REQUEST_DURATION.labels(resource=resource, method=method).observe(duration)
 
 
 def record_database_query(operation: str, table: str, duration: float):

--- a/autogpt_platform/backend/backend/notifications/lifecycle.py
+++ b/autogpt_platform/backend/backend/notifications/lifecycle.py
@@ -26,6 +26,7 @@ from backend.data.notifications import (
     SubscriptionResumedData,
     SubscriptionWelcomeData,
 )
+from backend.data.stripe_client import stripe_call
 from backend.data.user import BillingEmailRecipient
 from backend.notifications.dedupe import claim_once, release_claim
 from backend.notifications.lifecycle_plan import (
@@ -82,12 +83,16 @@ async def send_welcome_for_session(session_id: str) -> None:
     Raises on failure so the consumer retries; `on_checkout_completed` is
     idempotent via the `welcomeEmailSentAt` claim.
     """
-    session = dict(await stripe.checkout.Session.retrieve_async(session_id))
+    session = dict(
+        await stripe_call(stripe.checkout.Session.retrieve_async, session_id)
+    )
     subscription_id = session.get("subscription")
     if not subscription_id:
         logger.info(f"Checkout {session_id} has no subscription; nothing to welcome")
         return
-    subscription = dict(await stripe.Subscription.retrieve_async(str(subscription_id)))
+    subscription = dict(
+        await stripe_call(stripe.Subscription.retrieve_async, str(subscription_id))
+    )
     await on_checkout_completed(session, subscription)
 
 


### PR DESCRIPTION
### Why / What / How

**Why.** Stripe calls were made three different ways across five files: via `run_in_threadpool`, via the SDK's native `_async` methods, and as bare synchronous calls inside `async` functions. That last group, on the top-up, refund and dispute paths, blocks the event loop for the entire Stripe round-trip, up to the SDK's 80-second default timeout, so every other request on that worker stalls while one user's card payment completes. No call had a shorter timeout, a metric, or a consistent error path (14 ad-hoc `except stripe.StripeError` sites).

**What.** One helper, `backend/data/stripe_client.py`, and every Stripe SDK call goes through it:

```python
sub = await stripe_call(stripe.Subscription.retrieve_async, sub_id)
```

**How.** `stripe_call` awaits one of the SDK's `_async` methods under a 30s timeout and records `autogpt_stripe_requests_total{resource, method, outcome}` plus a duration histogram, in the existing `instrumentation.py` recorder style. The original exception is always re-raised unchanged, so the caller that branches on `stripe.InvalidRequestError` keeps working. Retries are deliberately left to the SDK: its retries use idempotency keys, and wrapping this in our own retry decorator would re-issue non-idempotent writes such as `PaymentIntent.create`. The timeout pattern mirrors `call_provider` in `util/llm/providers.py`.

### Changes 🏗️

- New `backend/data/stripe_client.py` (`stripe_call`, `stripe_call_timeout`) with tests
- `STRIPE_REQUESTS` counter, `STRIPE_REQUEST_DURATION` histogram and `record_stripe_request` in `monitoring/instrumentation.py`
- 35 call sites migrated in `data/credit.py`, `api/features/v1.py`, `data/org_credit.py`, `data/stripe_reconciliation.py`, `notifications/lifecycle.py`; four `run_in_threadpool` imports removed
- `Webhook.construct_event` intentionally untouched: it is a local HMAC check, not a network call
- Test mocks retargeted to the `_async` names and made awaitable (`AsyncMock`)

No API surface change (no route or response-model edits), so no OpenAPI regeneration. No configuration changes.

**`data/*.py` note:** `credit.py` and `org_credit.py` are touched, but only the Stripe call expressions change; no user-ID lookups, ownership checks or query filters are altered.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] All 20 test modules touching Stripe, credits, subscriptions, refunds or webhooks: **332 passed, 0 failed** (run in the test VM's backend container with the tree synced and the Prisma client regenerated)
  - [x] New `stripe_client_test.py`: ok result and count; `RateLimitError` recorded as `rate_limited` and re-raised unchanged; other `StripeError` subclasses keep their type; timeout is bounded and counted
  - [x] pyright: 0 errors on all 7 source files
  - [x] black, isort, ruff: clean on all 14 touched files
  - [ ] Post-merge on dev: one test-mode top-up and one refund, then confirm `autogpt_stripe_requests_total` shows the calls in Prometheus. Nothing here has hit real Stripe yet.

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

### Worth knowing

A client-side timeout on a non-idempotent write (a charge, a refund) can cancel our side after Stripe has applied it. That is inherent to any timeout on such calls; here it is logged at error level and counted as `outcome="timeout"`, so it is never silent. The helper's docstring says so.

