### PR TITLE
fix(backend/executor): skip scheduled runs for paywalled users quietly

### DIFF
--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -65,6 +65,7 @@ from backend.util.exceptions import (
     GraphValidationError,
     NotAuthorizedError,
     NotFoundError,
+    UserPaywalledError,
 )
 from backend.util.feature_flag import initialize_launchdarkly, shutdown_launchdarkly
 from backend.util.logging import PrefixFilter
@@ -232,6 +233,11 @@ async def _execute_graph(**kwargs):
     except ExpertRunPausedError as e:
         # Expected while an expert is paused (budget/archive): skip quietly;
         # the schedule stays registered for one-click resume.
+        logger.info(f"Skipping scheduled run for graph #{args.graph_id}: {e}")
+    except UserPaywalledError as e:
+        # Expected while the owner has no subscription: skip quietly. The
+        # schedule stays registered so it resumes on its own once they
+        # subscribe, and a recurring tick is not an error worth paging on.
         logger.info(f"Skipping scheduled run for graph #{args.graph_id}: {e}")
     except ExpertPrivateTenancyNotFoundError:
         # Graph schedules are recurring, so the next cron tick is the retry.

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -39,6 +39,7 @@ from backend.executor.scheduler import (
 from backend.util.exceptions import (
     ExpertNotFoundError,
     ExpertPrivateTenancyNotFoundError,
+    UserPaywalledError,
 )
 
 _SCHEDULER_PATH = "backend.executor.scheduler"
@@ -1087,6 +1088,38 @@ async def test_execute_graph_forwards_expert_id():
         await _execute_graph(**args.model_dump(mode="json"))
 
     assert mock_add.call_args.kwargs["expert_id"] == "expert-1"
+
+
+@pytest.mark.asyncio
+async def test_execute_graph_quietly_skips_paywalled_user(caplog):
+    args = GraphExecutionJobArgs(
+        schedule_id="sched-1",
+        user_id="user-1",
+        graph_id="graph-1",
+        graph_version=3,
+        cron="* * * * *",
+        input_data={},
+        input_credentials={},
+    )
+    mock_add = AsyncMock(
+        side_effect=UserPaywalledError("A subscription is required to run agents.")
+    )
+    mock_db = MagicMock()
+    mock_db.increment_onboarding_runs = AsyncMock()
+
+    with (
+        patch(f"{_SCHEDULER_PATH}.execution_utils.add_graph_execution", new=mock_add),
+        patch(
+            f"{_SCHEDULER_PATH}.get_database_manager_async_client",
+            return_value=mock_db,
+        ),
+        caplog.at_level(logging.INFO, logger=_SCHEDULER_PATH),
+    ):
+        await _execute_graph(**args.model_dump(mode="json"))
+
+    mock_db.increment_onboarding_runs.assert_not_awaited()
+    assert "Skipping scheduled run for graph #graph-1" in caplog.text
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -1118,7 +1118,11 @@ async def test_execute_graph_quietly_skips_paywalled_user(caplog):
         await _execute_graph(**args.model_dump(mode="json"))
 
     mock_db.increment_onboarding_runs.assert_not_awaited()
-    assert "Skipping scheduled run for graph #graph-1" in caplog.text
+    assert any(
+        record.levelno == logging.INFO
+        and "Skipping scheduled run for graph #graph-1" in record.getMessage()
+        for record in caplog.records
+    )
     assert not any(record.levelno >= logging.ERROR for record in caplog.records)
 
 


### PR DESCRIPTION
### Why / What / How

**Why.** The scheduler fires saved schedules on their cron regardless of whether the owner still has a subscription. `add_graph_execution` correctly rejects those with `UserPaywalledError`, but `_execute_graph` only knows how to skip paused, missing, or unavailable experts quietly; everything else lands in the catch-all and is logged at error level. A handful of one-minute schedules owned by users without a subscription therefore log an error every tick: Sentry issue `AUTOGPT-SERVER-96T` is at roughly 138k events in 30 days and still climbing, the single noisiest issue in prod, drowning out real scheduler failures.

**What.** Handle `UserPaywalledError` the same way `ExpertRunPausedError` already is: log at info and move on. The schedule stays registered, so it resumes on its own the moment the user subscribes; nothing is deleted or paused.

**How.** One `except` branch placed next to the existing paused-expert branch, plus a unit test mirroring `test_execute_graph_quietly_skips_unavailable_expert`: the onboarding-run counter is not touched and no record at error level is emitted.

Pausing or unregistering schedules when a subscription lapses is a product decision (SECRT-2376) and is deliberately out of scope here; this only stops the noise.

### Changes 🏗️

- `backend/executor/scheduler.py`: import `UserPaywalledError`; skip quietly in `_execute_graph`
- `backend/executor/scheduler_unit_test.py`: `test_execute_graph_quietly_skips_paywalled_user`

No API surface change, no configuration changes, no `data/*.py` changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `scheduler_unit_test.py`: 93 passed, 0 failed (test VM backend container, tree synced)
  - [x] pyright: 0 errors on `scheduler.py`
  - [x] black, isort, ruff clean on both files
  - [ ] After deploy: `AUTOGPT-SERVER-96T` stops receiving events and the scheduler log shows `Skipping scheduled run` at info for the same graph IDs

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
