### PR TITLE
fix(frontend/copilot): stop managed, stale and trigger credentials breaking the Connect card

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ChainActionCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ChainActionCard.tsx
@@ -22,6 +22,9 @@ interface Props {
   mcp: McpConnectorRequest[];
   inputs: InputsRequest[];
   questions: QuestionRequest[];
+  /** A card opted out of auto-sending, so the stack needs a Proceed even with
+   *  no inputs of its own. */
+  manualProceed: boolean;
   isReady: boolean;
   onProceed: () => void;
 }
@@ -36,6 +39,7 @@ export function ChainActionCard({
   mcp,
   inputs,
   questions,
+  manualProceed,
   isReady,
   onProceed,
 }: Props) {
@@ -114,7 +118,7 @@ export function ChainActionCard({
         </div>
       )}
 
-      {hasInputs && !hasQuestions && (
+      {(hasInputs || manualProceed) && !hasQuestions && (
         <Button
           variant="primary"
           size="small"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
@@ -38,8 +38,10 @@ export function ConnectorRow({ row }: Props) {
     // Cards stream in one commit at a time, so a row's schema can widen after
     // it auto-selected: a selection that no longer satisfies it must go, or
     // the row reads Connected while Proceed sends a credential missing the
-    // scopes the later card asked for.
-    if (row.selected && !savedCredential) {
+    // scopes the later card asked for. `null` is the provider context's
+    // "still loading" sentinel, where every lookup misses — clearing then
+    // would drop a good selection on every mount.
+    if (allProviders && row.selected && !savedCredential) {
       row.select(undefined);
       return;
     }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
@@ -53,7 +53,7 @@ export function ConnectorRow({ row }: Props) {
       title: savedCredential.title ?? undefined,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- row.select is rebuilt each render by the card
-  }, [savedCredential?.id, row.selected]);
+  }, [savedCredential?.id, row.selected, allProviders]);
 
   return (
     <div className="flex items-center gap-3 px-4 py-3">

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
@@ -35,6 +35,14 @@ export function ConnectorRow({ row }: Props) {
   );
 
   useEffect(() => {
+    // Cards stream in one commit at a time, so a row's schema can widen after
+    // it auto-selected: a selection that no longer satisfies it must go, or
+    // the row reads Connected while Proceed sends a credential missing the
+    // scopes the later card asked for.
+    if (row.selected && !savedCredential) {
+      row.select(undefined);
+      return;
+    }
     if (row.selected || !savedCredential) return;
     row.select({
       id: savedCredential.id,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ConnectorRow.tsx
@@ -94,13 +94,17 @@ export function ConnectorRow({ row }: Props) {
 /** The account a re-auth should upgrade in place. Signing in without it can
  *  grant narrower scopes than the user already had and leave a second row for
  *  the same provider, which no ConnectorRow can ever resolve. Only safe when
- *  exactly one account exists — otherwise picking one would be a guess. */
+ *  exactly one account exists — otherwise picking one would be a guess.
+ *  Managed and system credentials are excluded: the backend refuses to upgrade
+ *  either, so offering one turns every Connect click into a 400. */
 function upgradableCredentialID(
   provider: string,
   allProviders: CredentialsProvidersContextType | null,
 ) {
   const oauthCredentials = filterSystemCredentials(
     allProviders?.[provider]?.savedCredentials ?? [],
-  ).filter((credential) => credential.type === "oauth2");
+  ).filter(
+    (credential) => credential.type === "oauth2" && !credential.is_managed,
+  );
   return oauthCredentials.length === 1 ? oauthCredentials[0].id : undefined;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -202,6 +202,34 @@ describe("ChainActionCard", () => {
       expect(screen.queryByText("Connect")).toBeNull();
     });
 
+    it("keeps a selection while the providers context is still loading", async () => {
+      const selected = {
+        id: "saved-1",
+        provider: "github",
+        type: "api_key" as const,
+      };
+      const request = connectorRequest({ selected: { credentials: selected } });
+
+      render(
+        // `null` is the provider context's "still loading" sentinel, so every
+        // credential lookup misses — clearing then drops a good selection.
+        <CredentialsProvidersContext.Provider value={null}>
+          <ChainActionCard
+            connectors={[request]}
+            mcp={[]}
+            inputs={[]}
+            questions={[]}
+            manualProceed={false}
+            isReady
+            onProceed={vi.fn()}
+          />
+        </CredentialsProvidersContext.Provider>,
+      );
+
+      await screen.findByText("GitHub");
+      expect(request.onChange).not.toHaveBeenCalled();
+    });
+
     it("auto-selects a saved credential from the providers context", async () => {
       const request = connectorRequest();
       const providers = {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -230,6 +230,53 @@ describe("ChainActionCard", () => {
       expect(request.onChange).not.toHaveBeenCalled();
     });
 
+    it("clears the selection once loading reveals no matching credential", async () => {
+      const selected = {
+        id: "saved-1",
+        provider: "github",
+        type: "api_key" as const,
+      };
+      const request = connectorRequest({ selected: { credentials: selected } });
+      const loadedWithNoMatch = {
+        github: { savedCredentials: [] },
+      } as unknown as CredentialsProvidersContextType;
+
+      const { rerender } = render(
+        <CredentialsProvidersContext.Provider value={null}>
+          <ChainActionCard
+            connectors={[request]}
+            mcp={[]}
+            inputs={[]}
+            questions={[]}
+            manualProceed={false}
+            isReady
+            onProceed={vi.fn()}
+          />
+        </CredentialsProvidersContext.Provider>,
+      );
+      expect(request.onChange).not.toHaveBeenCalled();
+
+      rerender(
+        <CredentialsProvidersContext.Provider value={loadedWithNoMatch}>
+          <ChainActionCard
+            connectors={[request]}
+            mcp={[]}
+            inputs={[]}
+            questions={[]}
+            manualProceed={false}
+            isReady
+            onProceed={vi.fn()}
+          />
+        </CredentialsProvidersContext.Provider>,
+      );
+
+      // Neither the credential nor the selection changed across this
+      // transition, so only `allProviders` can re-run the effect.
+      await waitFor(() =>
+        expect(request.onChange).toHaveBeenCalledWith("credentials", undefined),
+      );
+    });
+
     it("auto-selects a saved credential from the providers context", async () => {
       const request = connectorRequest();
       const providers = {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -138,6 +138,7 @@ function renderCard(
       mcp={[]}
       inputs={[]}
       questions={[]}
+      manualProceed={false}
       isReady
       onProceed={onProceed}
       {...overrides}
@@ -223,6 +224,7 @@ describe("ChainActionCard", () => {
             mcp={[]}
             inputs={[]}
             questions={[]}
+            manualProceed={false}
             isReady
             onProceed={vi.fn()}
           />
@@ -378,6 +380,7 @@ describe("ChainActionCard", () => {
           mcp={[]}
           inputs={[inputsRequest()]}
           questions={[]}
+          manualProceed={false}
           isReady
           onProceed={onProceed}
         />,
@@ -975,6 +978,7 @@ describe("ChainActionCard", () => {
           mcp={[]}
           inputs={[]}
           questions={[{ ...request, answers: { region: "Europe" } }]}
+          manualProceed={false}
           isReady
           onProceed={onProceed}
         />,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/helpers.test.ts
@@ -60,6 +60,50 @@ describe("toConnectorRows", () => {
     expect(rows[0].provider).toBe("github");
   });
 
+  it("asks for the union of the scopes every card needs", () => {
+    const first = connectorRequest({
+      id: "req-1",
+      fields: [
+        [
+          "credentials",
+          {
+            credentials_provider: ["github"],
+            credentials_types: ["oauth2"],
+            credentials_scopes: ["repo"],
+          },
+        ],
+      ],
+    });
+    const second = connectorRequest({
+      id: "req-2",
+      fields: [
+        [
+          "credentials",
+          {
+            credentials_provider: ["github"],
+            credentials_types: ["oauth2"],
+            credentials_scopes: ["repo", "workflow"],
+          },
+        ],
+      ],
+    });
+
+    const [row] = toConnectorRows([first, second], []);
+
+    // Keeping only the first card's scopes leaves the second permanently
+    // unsatisfiable, and with auto-proceed it never sends.
+    expect(row.schema.credentials_scopes).toEqual(["repo", "workflow"]);
+  });
+
+  it("leaves the schema alone when no card asks for scopes", () => {
+    const first = connectorRequest({ id: "req-1" });
+    const second = connectorRequest({ id: "req-2" });
+
+    const [row] = toConnectorRows([first, second], []);
+
+    expect(row.schema.credentials_scopes).toBeUndefined();
+  });
+
   it("fans a selection out to every request asking for the provider", () => {
     const first = connectorRequest({ id: "req-1" });
     const second = connectorRequest({ id: "req-2" });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/helpers.ts
@@ -98,10 +98,21 @@ export function toConnectorRows(
     for (const [key, schema] of request.fields) {
       const provider = schema.credentials_provider?.[0];
       if (!provider) continue;
-      const row = rows.get(provider) ?? { schema, targets: [] };
+      const row = rows.get(provider);
+      if (!row) {
+        rows.set(provider, {
+          schema,
+          targets: [{ request, key }],
+          selected: request.selected[key],
+        });
+        continue;
+      }
+      // One row answers every card that asked for this provider, so it must
+      // request the union of their scopes — keeping only the first card's
+      // leaves the others permanently unsatisfiable.
+      row.schema = withUnionedScopes(row.schema, schema);
       row.targets.push({ request, key });
       row.selected = row.selected ?? request.selected[key];
-      rows.set(provider, row);
     }
   }
 
@@ -117,4 +128,17 @@ export function toConnectorRows(
     onConnected: () =>
       row.targets.forEach(({ request }) => request.onConnected()),
   }));
+}
+
+function withUnionedScopes(
+  kept: CredentialField[1],
+  incoming: CredentialField[1],
+): CredentialField[1] {
+  const scopes = [
+    ...new Set([
+      ...(kept.credentials_scopes ?? []),
+      ...(incoming.credentials_scopes ?? []),
+    ]),
+  ];
+  return scopes.length > 0 ? { ...kept, credentials_scopes: scopes } : kept;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/helpers.ts
@@ -109,7 +109,9 @@ export function toConnectorRows(
       }
       // One row answers every card that asked for this provider, so it must
       // request the union of their scopes — keeping only the first card's
-      // leaves the others permanently unsatisfiable.
+      // leaves the others permanently unsatisfiable. Scopes only: merging
+      // `credentials_types` would offer a method some cards cannot accept, and
+      // that needs a per-card row rather than a wider one.
       row.schema = withUnionedScopes(row.schema, schema);
       row.targets.push({ request, key });
       row.selected = row.selected ?? request.selected[key];
@@ -130,6 +132,8 @@ export function toConnectorRows(
   }));
 }
 
+/** Merges `incoming`'s scopes into `kept`, leaving every other schema field
+ *  as the first card set it. */
 function withUnionedScopes(
   kept: CredentialField[1],
   incoming: CredentialField[1],

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/SetupRequirementsCard/SetupRequirementsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/SetupRequirementsCard/SetupRequirementsCard.tsx
@@ -154,11 +154,15 @@ export function SetupRequirementsCard({
   // signal; without this the chain stalls after the user connects. It must be
   // the sign-in and not merely a satisfied credential: every card in the chat
   // history re-mounts on load with its credential already in place.
+  // Trigger cards are excluded: `hasUserActionableInputs` is edit-mode only, and
+  // a trigger's message carries the account the webhook registers under, which
+  // the user is meant to choose rather than have auto-picked.
   const canAutoProceed =
     Boolean(chainActions) &&
     justConnected &&
     isAllCredsComplete &&
-    !hasUserActionableInputs;
+    !hasUserActionableInputs &&
+    inputsMode !== "trigger";
 
   // Auto-send when dismissing so the AI receives the run message and the
   // chat doesn't hang waiting for a confirmation that the user can no longer

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/SetupRequirementsCard/SetupRequirementsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/SetupRequirementsCard/SetupRequirementsCard.tsx
@@ -101,6 +101,7 @@ export function SetupRequirementsCard({
   }, [initialValuesKey]);
 
   const isEditMode = inputsMode === "edit";
+  const isTriggerMode = inputsMode === "trigger";
 
   const hasAdvancedFields =
     isEditMode && expectedInputs.some((i) => i.advanced);
@@ -150,7 +151,7 @@ export function SetupRequirementsCard({
   // A trigger card's message carries the account its webhook registers under,
   // which the backend requires the user to have picked — so neither auto path
   // may send it, and the chain gives it a Proceed instead.
-  const needsManualPick = inputsMode === "trigger";
+  const needsManualPick = isTriggerMode;
   const canAutoDismiss =
     needsCredentials &&
     alreadyConnected &&
@@ -258,7 +259,7 @@ export function SetupRequirementsCard({
   }
 
   function buildProceedMessage() {
-    return inputsMode === "trigger"
+    return isTriggerMode
       ? buildTriggerSetupMessage(inputCredentials)
       : isEditMode
         ? buildRunMessage(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/SetupRequirementsCard/SetupRequirementsCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/SetupRequirementsCard/SetupRequirementsCard.tsx
@@ -147,22 +147,26 @@ export function SetupRequirementsCard({
   const requestedProviders = getRequestedProviders(credentialFields);
   const alreadyConnected = useAreAllConnected(sessionID, requestedProviders);
   const hasUserActionableInputs = isEditMode && needsInputs;
+  // A trigger card's message carries the account its webhook registers under,
+  // which the backend requires the user to have picked — so neither auto path
+  // may send it, and the chain gives it a Proceed instead.
+  const needsManualPick = inputsMode === "trigger";
   const canAutoDismiss =
-    needsCredentials && alreadyConnected && !hasUserActionableInputs;
+    needsCredentials &&
+    alreadyConnected &&
+    !hasUserActionableInputs &&
+    !needsManualPick;
   // Inside a chain this card renders no Proceed of its own — the chain only
   // renders one for inputs/questions — so a completed sign-in is the sole "go"
   // signal; without this the chain stalls after the user connects. It must be
   // the sign-in and not merely a satisfied credential: every card in the chat
   // history re-mounts on load with its credential already in place.
-  // Trigger cards are excluded: `hasUserActionableInputs` is edit-mode only, and
-  // a trigger's message carries the account the webhook registers under, which
-  // the user is meant to choose rather than have auto-picked.
   const canAutoProceed =
     Boolean(chainActions) &&
     justConnected &&
     isAllCredsComplete &&
     !hasUserActionableInputs &&
-    inputsMode !== "trigger";
+    !needsManualPick;
 
   // Auto-send when dismissing so the AI receives the run message and the
   // chat doesn't hang waiting for a confirmation that the user can no longer
@@ -205,6 +209,7 @@ export function SetupRequirementsCard({
     chainActions.register({
       id: actionId,
       ready: canRun,
+      manualProceed: needsManualPick,
       buildMessage: () => buildProceedMessage(),
       onSent: markSent,
       connectors: needsCredentials

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -165,9 +165,7 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
   const questionRequests = pendingActions
     .map((entry) => entry.questions)
     .filter((request) => request !== undefined);
-  const needsManualProceed = pendingActions.some(
-    (entry) => entry.manualProceed,
-  );
+  const manualProceed = pendingActions.some((entry) => entry.manualProceed);
   const hasCardWork =
     connectorRequests.length > 0 ||
     mcpRequests.length > 0 ||
@@ -346,7 +344,7 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
             mcp={mcpRequests}
             inputs={inputRequests}
             questions={questionRequests}
-            manualProceed={needsManualProceed}
+            manualProceed={manualProceed}
             isReady={allActionsReady}
             onProceed={handleProceed}
           />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -165,6 +165,9 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
   const questionRequests = pendingActions
     .map((entry) => entry.questions)
     .filter((request) => request !== undefined);
+  const needsManualProceed = pendingActions.some(
+    (entry) => entry.manualProceed,
+  );
   const hasCardWork =
     connectorRequests.length > 0 ||
     mcpRequests.length > 0 ||
@@ -343,6 +346,7 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
             mcp={mcpRequests}
             inputs={inputRequests}
             questions={questionRequests}
+            manualProceed={needsManualProceed}
             isReady={allActionsReady}
             onProceed={handleProceed}
           />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/connect-card-flow.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/connect-card-flow.test.tsx
@@ -117,13 +117,7 @@ describe("copilot Connect card", () => {
     );
   });
 
-  afterEach(() => {
-    cleanup();
-    useCopilotUIStore.setState({ initialPrompt: null, sentMessageCount: 0 });
-    // The auto-send claim is a module singleton keyed by session id, so a
-    // later test reusing SESSION_ID would silently dismiss its own card.
-    useConnectedProvidersStore.getState().clearSession(SESSION_ID);
-  });
+  afterEach(resetStores);
 
   it("asks the consent screen for the scopes the block requires", async () => {
     renderChain();
@@ -196,8 +190,8 @@ describe("copilot Connect card, cards that owe more than a credential", () => {
       http.get("*/api/integrations/credentials", () =>
         HttpResponse.json(savedCredentials),
       ),
-      http.get("*/api/integrations/github/login", () => {
-        requestedScopes = REQUIRED_SCOPE;
+      http.get("*/api/integrations/github/login", ({ request }) => {
+        requestedScopes = new URL(request.url).searchParams.get("scopes") ?? "";
         return HttpResponse.json({
           login_url: "https://github.com/login/oauth/authorize",
           state_token: "state-token",
@@ -225,8 +219,10 @@ describe("copilot Connect card, cards that owe more than a credential", () => {
     await completeConnectFlow();
 
     // Auto-sending here would run the block with the inputs the user has not
-    // filled in yet, discarding them.
-    await waitFor(() => expect(savedCredentials).toHaveLength(1));
+    // filled in yet, discarding them. Wait on the row resolving, not on the
+    // MSW handler: `savedCredentials` is set inside the handler, before the
+    // query invalidates or the auto-send effect could run.
+    await screen.findByText("Connected");
     expect(onSend).not.toHaveBeenCalled();
   });
 
@@ -246,9 +242,10 @@ describe("copilot Connect card, cards that owe more than a credential", () => {
     // under, so the account must be chosen rather than auto-picked — but
     // excluding the auto-send without adding a button leaves the card with no
     // way forward at all, which is worse than sending the wrong account.
-    await waitFor(() => expect(savedCredentials).toHaveLength(1));
-    expect(onSend).not.toHaveBeenCalled();
+    // The Proceed button is the positive signal that the card has finished
+    // reacting, so it has to come before the negative assertion.
     await screen.findByRole("button", { name: "Proceed" });
+    expect(onSend).not.toHaveBeenCalled();
   });
 
   it("gives a trigger card a Proceed when a sibling already connected its provider", async () => {
@@ -274,10 +271,62 @@ describe("copilot Connect card, cards that owe more than a credential", () => {
   });
 });
 
+describe("copilot Connect card, a row whose schema widens mid-stream", () => {
+  beforeEach(() => {
+    requestedScopes = null;
+    upgradedCredentialID = null;
+    // Satisfies the first card's `repo` but not the second card's `workflow`.
+    savedCredentials = [oauthCredential("cred-repo", [REQUIRED_SCOPE])];
+    server.use(
+      http.get("*/api/integrations/providers", () =>
+        HttpResponse.json([{ name: "github", description: "Repositories" }]),
+      ),
+      http.get("*/api/integrations/providers/system", () =>
+        HttpResponse.json([]),
+      ),
+      http.get("*/api/integrations/credentials", () =>
+        HttpResponse.json(savedCredentials),
+      ),
+    );
+  });
+
+  afterEach(resetStores);
+
+  it("drops a selection the widened schema no longer satisfies", async () => {
+    const onSend = vi.fn();
+    const { rerender } = render(
+      <CredentialsProvider>
+        <CopilotChatActionsProvider onSend={onSend}>
+          <ToolChain parts={[setupRequirementsPart()]} isStreaming={true} />
+        </CopilotChatActionsProvider>
+      </CredentialsProvider>,
+    );
+    await screen.findByText("Connected");
+
+    rerender(
+      <CredentialsProvider>
+        <CopilotChatActionsProvider onSend={onSend}>
+          <ToolChain
+            parts={[setupRequirementsPart(), widerScopePart()]}
+            isStreaming={false}
+          />
+        </CopilotChatActionsProvider>
+      </CredentialsProvider>,
+    );
+
+    // Cards stream in one commit at a time. Leaving the stale selection in
+    // place renders "Connected" and lets Proceed send a credential missing
+    // the scope the second card asked for.
+    await screen.findByRole("button", { name: "Connect" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
 describe("copilot Connect card, upgrade-target selection", () => {
   beforeEach(() => {
     requestedScopes = null;
     upgradedCredentialID = null;
+    savedCredentials = [];
     server.use(
       http.get("*/api/integrations/providers", () =>
         HttpResponse.json([{ name: "github", description: "Repositories" }]),
@@ -378,11 +427,7 @@ describe("copilot Connect card, API-key provider", () => {
     );
   });
 
-  afterEach(() => {
-    cleanup();
-    useCopilotUIStore.setState({ initialPrompt: null, sentMessageCount: 0 });
-    useConnectedProvidersStore.getState().clearSession(SESSION_ID);
-  });
+  afterEach(resetStores);
 
   it("continues the chat after an API key is saved", async () => {
     const onSend = vi.fn();
@@ -448,16 +493,12 @@ describe("copilot Connect card, already satisfied", () => {
     );
   });
 
-  afterEach(() => {
-    cleanup();
-    useCopilotUIStore.setState({ initialPrompt: null, sentMessageCount: 0 });
-    useConnectedProvidersStore.getState().clearSession(SESSION_ID);
-  });
+  afterEach(resetStores);
 
   it("stays silent when a finished card re-mounts from chat history", async () => {
     const { onSend } = renderChain();
 
-    await settle(1);
+    await settle({ connectedRows: 1 });
 
     expect(onSend).not.toHaveBeenCalled();
   });
@@ -475,7 +516,7 @@ describe("copilot Connect card, already satisfied", () => {
       </CredentialsProvider>,
     );
 
-    await settle(2);
+    await settle({ connectedRows: 2 });
 
     // The auto-send claim is keyed by provider set, so two cards are two
     // claims — each would fire its own message on mount.
@@ -535,10 +576,8 @@ function setupRequirementsPart(): MessagePart {
 
 /** Waits on a positive signal — every row resolved against the refreshed
  *  credential list — so a "nothing was sent" assertion cannot pass merely
- *  because nothing has mounted yet. The old form waited on
- *  `queryByText(...)).toBeDefined()`, which accepts the `null` of a miss and
- *  resolved on the first tick, leaving a bare sleep as the only barrier. */
-async function settle(connectedRows: number) {
+ *  because nothing has mounted yet. */
+async function settle({ connectedRows }: { connectedRows: number }) {
   await screen.findByText("Plug in what this needs");
   await waitFor(() =>
     expect(screen.getAllByText("Connected")).toHaveLength(connectedRows),
@@ -627,5 +666,30 @@ function triggerPart(): MessagePart {
     ...base,
     type: "tool-setup_agent_webhook_trigger",
     toolCallId: "call-setup_agent_webhook_trigger",
+  } as unknown as MessagePart;
+}
+function widerScopePart(): MessagePart {
+  const base = setupRequirementsPart() as unknown as Record<string, unknown>;
+  const output = base.output as Record<string, unknown>;
+  const setup = output.setup_info as Record<string, unknown>;
+  return {
+    ...base,
+    toolCallId: "call-run_block-wider",
+    output: {
+      ...output,
+      setup_info: {
+        ...setup,
+        user_readiness: {
+          has_all_credentials: false,
+          missing_credentials: {
+            credentials: {
+              provider: "github",
+              types: ["oauth2"],
+              scopes: [REQUIRED_SCOPE, "workflow"],
+            },
+          },
+        },
+      },
+    },
   } as unknown as MessagePart;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/connect-card-flow.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/connect-card-flow.test.tsx
@@ -146,7 +146,7 @@ describe("copilot Connect card", () => {
     expect(onSend.mock.calls[0][0]).toContain(
       "I've configured the required credentials.",
     );
-    expect(await screen.findByText("Connected. Continuing…")).toBeDefined();
+    await screen.findByText("Connected. Continuing…");
   });
 
   it("offers the existing account for upgrade instead of a fresh grant", async () => {
@@ -176,15 +176,159 @@ describe("copilot Connect card", () => {
     await completeConnectFlow();
 
     await waitFor(() => expect(savedCredentials).toHaveLength(2));
-    expect(
-      await screen.findByRole("button", { name: "Connect" }),
-    ).toBeDefined();
+    await screen.findByRole("button", { name: "Connect" });
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("copilot Connect card, cards that owe more than a credential", () => {
+  beforeEach(() => {
+    requestedScopes = null;
+    upgradedCredentialID = null;
+    savedCredentials = [];
+    server.use(
+      http.get("*/api/integrations/providers", () =>
+        HttpResponse.json([{ name: "github", description: "Repositories" }]),
+      ),
+      http.get("*/api/integrations/providers/system", () =>
+        HttpResponse.json([]),
+      ),
+      http.get("*/api/integrations/credentials", () =>
+        HttpResponse.json(savedCredentials),
+      ),
+      http.get("*/api/integrations/github/login", () => {
+        requestedScopes = REQUIRED_SCOPE;
+        return HttpResponse.json({
+          login_url: "https://github.com/login/oauth/authorize",
+          state_token: "state-token",
+        });
+      }),
+      http.post("*/api/integrations/github/callback", () => {
+        savedCredentials = [oauthCredential("cred-new", [REQUIRED_SCOPE])];
+        return HttpResponse.json(savedCredentials[0]);
+      }),
+    );
+  });
+
+  afterEach(resetStores);
+
+  it("waits for the user when the card also collects run inputs", async () => {
+    const onSend = vi.fn();
+    render(
+      <CredentialsProvider>
+        <CopilotChatActionsProvider onSend={onSend}>
+          <ToolChain parts={[partWithInputs()]} isStreaming={false} />
+        </CopilotChatActionsProvider>
+      </CredentialsProvider>,
+    );
+
+    await completeConnectFlow();
+
+    // Auto-sending here would run the block with the inputs the user has not
+    // filled in yet, discarding them.
+    await waitFor(() => expect(savedCredentials).toHaveLength(1));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("waits for the user on a trigger card, whose account they must pick", async () => {
+    const onSend = vi.fn();
+    render(
+      <CredentialsProvider>
+        <CopilotChatActionsProvider onSend={onSend}>
+          <ToolChain parts={[triggerPart()]} isStreaming={false} />
+        </CopilotChatActionsProvider>
+      </CredentialsProvider>,
+    );
+
+    await completeConnectFlow();
+
+    // buildTriggerSetupMessage carries the credential the webhook registers
+    // under, so the account must be chosen rather than auto-picked.
+    await waitFor(() => expect(savedCredentials).toHaveLength(1));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("copilot Connect card, upgrade-target selection", () => {
+  beforeEach(() => {
+    requestedScopes = null;
+    upgradedCredentialID = null;
+    server.use(
+      http.get("*/api/integrations/providers", () =>
+        HttpResponse.json([{ name: "github", description: "Repositories" }]),
+      ),
+      http.get("*/api/integrations/providers/system", () =>
+        HttpResponse.json([]),
+      ),
+      http.get("*/api/integrations/credentials", () =>
+        HttpResponse.json(savedCredentials),
+      ),
+      http.get("*/api/integrations/github/login", ({ request }) => {
+        const query = new URL(request.url).searchParams;
+        requestedScopes = query.get("scopes") ?? "";
+        upgradedCredentialID = query.get("credential_id");
+        return HttpResponse.json({
+          login_url: "https://github.com/login/oauth/authorize",
+          state_token: "state-token",
+        });
+      }),
+      http.post("*/api/integrations/github/callback", () =>
+        HttpResponse.json({ id: "cred-new", provider: "github" }),
+      ),
+    );
+  });
+
+  afterEach(resetStores);
+
+  it("picks no upgrade target when two accounts could be the one", async () => {
+    savedCredentials = [
+      oauthCredential("cred-a", ["notifications"]),
+      oauthCredential("cred-b", ["read:user"]),
+    ];
+
+    renderChain();
+    await completeConnectFlow();
+
+    // Choosing between them would be a guess; the backend upgrades in place,
+    // so guessing wrong silently broadens the wrong account.
+    await waitFor(() => expect(requestedScopes).toBe(REQUIRED_SCOPE));
+    expect(upgradedCredentialID).toBeNull();
+  });
+
+  it("does not offer a managed account, which the backend refuses to upgrade", async () => {
+    savedCredentials = [
+      {
+        ...oauthCredential("cred-managed", ["notifications"]),
+        is_managed: true,
+      },
+    ];
+
+    renderChain();
+    await completeConnectFlow();
+
+    // _prepare_scope_upgrade 400s a managed credential, so offering one makes
+    // every Connect click fail and the row permanently unconnectable.
+    await waitFor(() => expect(requestedScopes).toBe(REQUIRED_SCOPE));
+    expect(upgradedCredentialID).toBeNull();
+  });
+
+  it("does not offer an API-key account for an OAuth upgrade", async () => {
+    savedCredentials = [
+      { id: "cred-key", provider: "github", type: "api_key", title: "GitHub" },
+    ];
+
+    renderChain();
+    await completeConnectFlow();
+
+    await waitFor(() => expect(requestedScopes).toBe(REQUIRED_SCOPE));
+    expect(upgradedCredentialID).toBeNull();
   });
 });
 
 describe("copilot Connect card, API-key provider", () => {
   beforeEach(() => {
+    requestedScopes = null;
+    upgradedCredentialID = null;
     savedCredentials = [];
     server.use(
       http.get("*/api/integrations/providers", () =>
@@ -243,6 +387,8 @@ describe("copilot Connect card, API-key provider", () => {
 
 describe("copilot Connect card, already satisfied", () => {
   beforeEach(() => {
+    requestedScopes = null;
+    upgradedCredentialID = null;
     // The state a chat is in after the user connected and later reopened it:
     // every card in the history re-mounts with its credential already there.
     savedCredentials = [
@@ -286,7 +432,7 @@ describe("copilot Connect card, already satisfied", () => {
   it("stays silent when a finished card re-mounts from chat history", async () => {
     const { onSend } = renderChain();
 
-    await settle();
+    await settle(1);
 
     expect(onSend).not.toHaveBeenCalled();
   });
@@ -304,7 +450,7 @@ describe("copilot Connect card, already satisfied", () => {
       </CredentialsProvider>,
     );
 
-    await settle();
+    await settle(2);
 
     // The auto-send claim is keyed by provider set, so two cards are two
     // claims — each would fire its own message on mount.
@@ -362,11 +508,16 @@ function setupRequirementsPart(): MessagePart {
   } as unknown as MessagePart;
 }
 
-/** Long enough for the credential list, the row's auto-select and the
- *  auto-send effect to have all run had they been going to. */
-async function settle() {
-  await waitFor(() => expect(screen.queryByText("Connect")).toBeDefined());
-  await new Promise((resolve) => setTimeout(resolve, 800));
+/** Waits on a positive signal — every row resolved against the refreshed
+ *  credential list — so a "nothing was sent" assertion cannot pass merely
+ *  because nothing has mounted yet. The old form waited on
+ *  `queryByText(...)).toBeDefined()`, which accepts the `null` of a miss and
+ *  resolved on the first tick, leaving a bare sleep as the only barrier. */
+async function settle(connectedRows: number) {
+  await screen.findByText("Plug in what this needs");
+  await waitFor(() =>
+    expect(screen.getAllByText("Connected")).toHaveLength(connectedRows),
+  );
 }
 
 function slackRequirementsPart(): MessagePart {
@@ -413,5 +564,43 @@ function apiKeyRequirementsPart(): MessagePart {
         },
       },
     },
+  } as unknown as MessagePart;
+}
+function oauthCredential(id: string, scopes: string[]) {
+  return { id, provider: "github", type: "oauth2", title: "GitHub", scopes };
+}
+function resetStores() {
+  cleanup();
+  useCopilotUIStore.setState({ initialPrompt: null, sentMessageCount: 0 });
+  // The auto-send claim is a module singleton keyed by session id, so a later
+  // test reusing SESSION_ID would silently dismiss its own card.
+  useConnectedProvidersStore.getState().clearSession(SESSION_ID);
+}
+function partWithInputs(): MessagePart {
+  const base = setupRequirementsPart() as unknown as Record<string, unknown>;
+  const output = base.output as Record<string, unknown>;
+  const setup = output.setup_info as Record<string, unknown>;
+  return {
+    ...base,
+    output: {
+      ...output,
+      setup_info: {
+        ...setup,
+        requirements: {
+          inputs: [
+            { name: "url", title: "URL", type: "string", required: true },
+          ],
+        },
+      },
+    },
+  } as unknown as MessagePart;
+}
+
+function triggerPart(): MessagePart {
+  const base = setupRequirementsPart() as unknown as Record<string, unknown>;
+  return {
+    ...base,
+    type: "tool-setup_agent_webhook_trigger",
+    toolCallId: "call-setup_agent_webhook_trigger",
   } as unknown as MessagePart;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/connect-card-flow.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/connect-card-flow.test.tsx
@@ -230,7 +230,7 @@ describe("copilot Connect card, cards that owe more than a credential", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("waits for the user on a trigger card, whose account they must pick", async () => {
+  it("gives a trigger card a Proceed instead of auto-sending it", async () => {
     const onSend = vi.fn();
     render(
       <CredentialsProvider>
@@ -243,8 +243,33 @@ describe("copilot Connect card, cards that owe more than a credential", () => {
     await completeConnectFlow();
 
     // buildTriggerSetupMessage carries the credential the webhook registers
-    // under, so the account must be chosen rather than auto-picked.
+    // under, so the account must be chosen rather than auto-picked — but
+    // excluding the auto-send without adding a button leaves the card with no
+    // way forward at all, which is worse than sending the wrong account.
     await waitFor(() => expect(savedCredentials).toHaveLength(1));
+    expect(onSend).not.toHaveBeenCalled();
+    await screen.findByRole("button", { name: "Proceed" });
+  });
+
+  it("gives a trigger card a Proceed when a sibling already connected its provider", async () => {
+    // The auto-dismiss path fires before any account is selected and sends
+    // `credentials={}`; the backend then re-issues the card, the re-issued one
+    // has already lost the dedupe claim, and the chat waits forever.
+    savedCredentials = [oauthCredential("cred-existing", [REQUIRED_SCOPE])];
+    useConnectedProvidersStore
+      .getState()
+      .markConnected({ sessionID: SESSION_ID, providers: ["github"] });
+
+    const onSend = vi.fn();
+    render(
+      <CredentialsProvider>
+        <CopilotChatActionsProvider onSend={onSend}>
+          <ToolChain parts={[triggerPart()]} isStreaming={false} />
+        </CopilotChatActionsProvider>
+      </CredentialsProvider>,
+    );
+
+    await screen.findByRole("button", { name: "Proceed" });
     expect(onSend).not.toHaveBeenCalled();
   });
 });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/chainActions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/chainActions.ts
@@ -17,6 +17,9 @@ export interface ChainActionEntry {
   ready: boolean;
   buildMessage: () => string | null;
   onSent?: () => void;
+  /** This card's reply must be reviewed before it is sent, so the chain owes
+   *  it a Proceed even when it asks for nothing but credentials. */
+  manualProceed?: boolean;
   /** Credentials this card needs. The chain merges every entry's request
    *  into the single connectors table it renders underneath itself. */
   connectors?: ConnectorRequest;

--- a/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/ConnectCredentialDialog/ConnectCredentialDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/ConnectCredentialDialog/ConnectCredentialDialog.tsx
@@ -63,13 +63,14 @@ export function ConnectCredentialDialog({
     onClose();
   }
 
-  // The hook resets before calling this; device auth completes inside
-  // ConnectMethodView and never passes through the hook, so it resets here.
+  // The hook has already reset by the time it calls this.
   function handleConnected() {
     onConnected?.();
     onClose();
   }
 
+  // Device auth completes inside ConnectMethodView, bypassing the hook, so
+  // this is the only place its reset can happen.
   function handleDeviceAuthSuccess() {
     reset();
     handleConnected();

--- a/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/ConnectCredentialDialog/ConnectCredentialDialog.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/CredentialsInput/components/ConnectCredentialDialog/ConnectCredentialDialog.tsx
@@ -53,10 +53,7 @@ export function ConnectCredentialDialog({
     reset,
   } = useConnectCredentialDialog({
     provider,
-    onConnected: () => {
-      onConnected?.();
-      onClose();
-    },
+    onConnected: handleConnected,
     scopes: schema.credentials_scopes,
     credentialID,
   });
@@ -66,12 +63,16 @@ export function ConnectCredentialDialog({
     onClose();
   }
 
-  // Device auth completes inside ConnectMethodView, so it never passes through
-  // the hook's success path and has to report the connection itself.
-  function handleDeviceAuthSuccess() {
-    reset();
+  // The hook resets before calling this; device auth completes inside
+  // ConnectMethodView and never passes through the hook, so it resets here.
+  function handleConnected() {
     onConnected?.();
     onClose();
+  }
+
+  function handleDeviceAuthSuccess() {
+    reset();
+    handleConnected();
   }
 
   const connectable: ConnectableProvider = {

--- a/autogpt_platform/frontend/src/components/contextual/DeviceAuth/useDeviceAuthConnect.ts
+++ b/autogpt_platform/frontend/src/components/contextual/DeviceAuth/useDeviceAuthConnect.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -10,6 +10,7 @@ import {
 import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/credentialsMetaResponse";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
+import { CredentialsActionsContext } from "@/providers/agent-credentials/credentials-provider";
 
 interface Args {
   provider: string;
@@ -26,6 +27,7 @@ type Phase = "idle" | "awaiting_user" | "polling" | "done" | "error";
 const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
 export function useDeviceAuthConnect({ provider, onSuccess }: Args) {
+  const credentialsActions = useContext(CredentialsActionsContext);
   const queryClient = useQueryClient();
   const [phase, setPhase] = useState<Phase>("idle");
   const [userCode, setUserCode] = useState("");
@@ -83,6 +85,9 @@ export function useDeviceAuthConnect({ provider, onSuccess }: Args) {
           stopPolling();
           toast({ title: "Connected via device auth", variant: "success" });
           await invalidateConnectionQueries(queryClient);
+          // Invalidation emits no cache event unless something already
+          // subscribed to the credentials query.
+          credentialsActions?.reload();
           onSuccess(credentials ?? undefined);
           return;
         }

--- a/autogpt_platform/frontend/src/components/contextual/DeviceAuth/useDeviceAuthConnect.ts
+++ b/autogpt_platform/frontend/src/components/contextual/DeviceAuth/useDeviceAuthConnect.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -10,7 +10,6 @@ import {
 import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/credentialsMetaResponse";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { invalidateConnectionQueries } from "@/lib/react-query/invalidateConnections";
-import { CredentialsActionsContext } from "@/providers/agent-credentials/credentials-provider";
 
 interface Args {
   provider: string;
@@ -27,7 +26,6 @@ type Phase = "idle" | "awaiting_user" | "polling" | "done" | "error";
 const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
 export function useDeviceAuthConnect({ provider, onSuccess }: Args) {
-  const credentialsActions = useContext(CredentialsActionsContext);
   const queryClient = useQueryClient();
   const [phase, setPhase] = useState<Phase>("idle");
   const [userCode, setUserCode] = useState("");
@@ -85,9 +83,6 @@ export function useDeviceAuthConnect({ provider, onSuccess }: Args) {
           stopPolling();
           toast({ title: "Connected via device auth", variant: "success" });
           await invalidateConnectionQueries(queryClient);
-          // Invalidation emits no cache event unless something already
-          // subscribed to the credentials query.
-          credentialsActions?.reload();
           onSuccess(credentials ?? undefined);
           return;
         }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/useOAuthConnect.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/useOAuthConnect.test.ts
@@ -409,3 +409,93 @@ describe("useOAuthConnect — popup window lifecycle", () => {
     await first;
   });
 });
+
+describe("useOAuthConnect — login request shape", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  async function connectWith(args: {
+    scopes?: string[];
+    credentialID?: string;
+  }) {
+    await setupSuccessfulPopup();
+    await mockInitiateOk();
+    const { postV1ExchangeOauthCodeForTokens } = await import(
+      "@/app/api/__generated__/endpoints/integrations/integrations"
+    );
+    vi.mocked(postV1ExchangeOauthCodeForTokens).mockResolvedValue({
+      status: 200,
+      data: { id: "cred-1" },
+    } as never);
+
+    const { result } = renderHook(() =>
+      useOAuthConnect({ provider: "github", onSuccess: vi.fn(), ...args }),
+    );
+    await result.current.connect();
+
+    const { getV1InitiateOauthFlow } = await import(
+      "@/app/api/__generated__/endpoints/integrations/integrations"
+    );
+    return vi.mocked(getV1InitiateOauthFlow).mock.calls[0];
+  }
+
+  it("sends no query at all for a provider-level connect", async () => {
+    // The four existing callers pass no scopes; they must be unaffected.
+    expect(await connectWith({})).toEqual(["github", undefined]);
+  });
+
+  it("omits the query for an empty scope list", async () => {
+    expect(await connectWith({ scopes: [] })).toEqual(["github", undefined]);
+  });
+
+  it("joins scopes with commas, as the endpoint parses them", async () => {
+    expect(await connectWith({ scopes: ["repo", "read:org"] })).toEqual([
+      "github",
+      { scopes: "repo,read:org" },
+    ]);
+  });
+
+  it("carries the upgrade target alongside the scopes", async () => {
+    expect(
+      await connectWith({ scopes: ["repo"], credentialID: "cred-old" }),
+    ).toEqual(["github", { scopes: "repo", credential_id: "cred-old" }]);
+  });
+
+  it("retries without the upgrade target when the backend 404s it", async () => {
+    await setupSuccessfulPopup();
+    const { getV1InitiateOauthFlow, postV1ExchangeOauthCodeForTokens } =
+      await import(
+        "@/app/api/__generated__/endpoints/integrations/integrations"
+      );
+    vi.mocked(getV1InitiateOauthFlow)
+      .mockRejectedValueOnce(
+        makeApiError(404, { detail: "Credential to upgrade not found" }),
+      )
+      .mockResolvedValueOnce({
+        status: 200,
+        data: {
+          login_url: "https://github.com/login/oauth",
+          state_token: "state-token",
+        },
+      } as never);
+    vi.mocked(postV1ExchangeOauthCodeForTokens).mockResolvedValue({
+      status: 200,
+      data: { id: "cred-1" },
+    } as never);
+
+    const { result } = renderHook(() =>
+      useOAuthConnect({
+        provider: "github",
+        onSuccess: vi.fn(),
+        scopes: ["repo"],
+        credentialID: "deleted-in-another-tab",
+      }),
+    );
+    await result.current.connect();
+
+    // A stale id must degrade to a fresh grant, not a dead Connect button.
+    expect(vi.mocked(getV1InitiateOauthFlow).mock.calls).toEqual([
+      ["github", { scopes: "repo", credential_id: "deleted-in-another-tab" }],
+      ["github", { scopes: "repo" }],
+    ]);
+  });
+});

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/useOAuthConnect.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/__tests__/useOAuthConnect.test.ts
@@ -460,6 +460,30 @@ describe("useOAuthConnect — login request shape", () => {
     ).toEqual(["github", { scopes: "repo", credential_id: "cred-old" }]);
   });
 
+  it("does not retry a 404 that is not about the upgrade target", async () => {
+    await setupSuccessfulPopup();
+    const { getV1InitiateOauthFlow } = await import(
+      "@/app/api/__generated__/endpoints/integrations/integrations"
+    );
+    vi.mocked(getV1InitiateOauthFlow).mockRejectedValue(
+      makeApiError(404, { detail: "Provider 'foo' does not support OAuth" }),
+    );
+
+    const { result } = renderHook(() =>
+      useOAuthConnect({
+        provider: "foo",
+        onSuccess: vi.fn(),
+        scopes: ["repo"],
+        credentialID: "cred-1",
+      }),
+    );
+    await result.current.connect();
+
+    // That 404 is raised before the endpoint reads the upgrade target, so
+    // re-sending without it fails identically.
+    expect(vi.mocked(getV1InitiateOauthFlow)).toHaveBeenCalledTimes(1);
+  });
+
   it("retries without the upgrade target when the backend 404s it", async () => {
     await setupSuccessfulPopup();
     const { getV1InitiateOauthFlow, postV1ExchangeOauthCodeForTokens } =

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useApiKeyConnectForm.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useApiKeyConnectForm.ts
@@ -53,8 +53,8 @@ export function useApiKeyConnectForm({ provider, onSuccess }: Args) {
 
       toast({ title: "API key saved", variant: "success" });
       await invalidateConnectionQueries(queryClient);
-      // Same reason as the OAuth branch: invalidation emits no cache event
-      // unless something already subscribed to the credentials query.
+      // Invalidation emits no cache event unless something already
+      // subscribed to the credentials query.
       credentialsActions?.reload();
       // Narrow by shape rather than by status code: the comment above keeps
       // this flow indifferent to a 201 ↔ 200 swap, and only the success

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useApiKeyConnectForm.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useApiKeyConnectForm.ts
@@ -56,9 +56,8 @@ export function useApiKeyConnectForm({ provider, onSuccess }: Args) {
       // Invalidation emits no cache event unless something already
       // subscribed to the credentials query.
       credentialsActions?.reload();
-      // Narrow by shape rather than by status code: the comment above keeps
-      // this flow indifferent to a 201 ↔ 200 swap, and only the success
-      // payload carries an id.
+      // Narrow by shape, not status code, so a 201 ↔ 200 swap cannot break
+      // this; only the success payload carries an id.
       onSuccess("id" in created.data ? created.data : undefined);
     } catch (error) {
       toast({

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect.ts
@@ -84,6 +84,9 @@ export function useOAuthConnect({
         provider,
         scopes,
         credentialID,
+        // The list that produced the dead id is stale; refresh it now so a
+        // cancelled popup does not make every later click pay the retry too.
+        () => credentialsActions?.reload(),
       );
       // customMutator rejects non-2xx, so this branch is unreachable at
       // runtime — it exists only to narrow the discriminated union so the
@@ -177,11 +180,15 @@ function buildLoginParams(scopes?: string[], credentialID?: string) {
 
 /** The upgrade target comes from an in-memory list that can be stale — the
  *  very staleness this flow exists to survive — and the backend 404s an id it
- *  cannot find. Fall back to a fresh grant rather than leaving a dead button. */
+ *  cannot find. Fall back to a fresh grant rather than leaving a dead button.
+ *  Only that 404 retries: the endpoint also 404s a provider without OAuth
+ *  support, before it ever reads the upgrade target, and re-sending that
+ *  fails identically. */
 async function initiateLogin(
   provider: string,
   scopes?: string[],
   credentialID?: string,
+  onStaleCredential?: () => void,
 ) {
   try {
     return await getV1InitiateOauthFlow(
@@ -189,9 +196,23 @@ async function initiateLogin(
       buildLoginParams(scopes, credentialID),
     );
   } catch (error) {
-    if (!credentialID || (error as { status?: number })?.status !== 404) {
-      throw error;
-    }
+    if (!credentialID || !isMissingUpgradeTarget(error)) throw error;
+    onStaleCredential?.();
     return getV1InitiateOauthFlow(provider, buildLoginParams(scopes));
   }
+}
+
+/** Matches only `_prepare_scope_upgrade`'s "Credential to upgrade not found".
+ *  If the backend rewords it the retry stops happening and the original 404
+ *  surfaces — the behaviour before the retry existed. */
+function isMissingUpgradeTarget(error: unknown) {
+  const { status, response } = (error ?? {}) as {
+    status?: number;
+    response?: { detail?: unknown };
+  };
+  return (
+    status === 404 &&
+    typeof response?.detail === "string" &&
+    response.detail.toLowerCase().includes("upgrade")
+  );
 }

--- a/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect.ts
+++ b/autogpt_platform/frontend/src/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/components/DetailView/useOAuthConnect.ts
@@ -80,9 +80,10 @@ export function useOAuthConnect({
     try {
       // Without the scopes the consent screen grants provider defaults, and
       // a credential missing a required scope never satisfies the caller.
-      const initiateResponse = await getV1InitiateOauthFlow(
+      const initiateResponse = await initiateLogin(
         provider,
-        buildLoginParams(scopes, credentialID),
+        scopes,
+        credentialID,
       );
       // customMutator rejects non-2xx, so this branch is unreachable at
       // runtime — it exists only to narrow the discriminated union so the
@@ -172,4 +173,25 @@ function buildLoginParams(scopes?: string[], credentialID?: string) {
   if (scopes?.length) params.scopes = scopes.join(",");
   if (credentialID) params.credential_id = credentialID;
   return Object.keys(params).length > 0 ? params : undefined;
+}
+
+/** The upgrade target comes from an in-memory list that can be stale — the
+ *  very staleness this flow exists to survive — and the backend 404s an id it
+ *  cannot find. Fall back to a fresh grant rather than leaving a dead button. */
+async function initiateLogin(
+  provider: string,
+  scopes?: string[],
+  credentialID?: string,
+) {
+  try {
+    return await getV1InitiateOauthFlow(
+      provider,
+      buildLoginParams(scopes, credentialID),
+    );
+  } catch (error) {
+    if (!credentialID || (error as { status?: number })?.status !== 404) {
+      throw error;
+    }
+    return getV1InitiateOauthFlow(provider, buildLoginParams(scopes));
+  }
 }


### PR DESCRIPTION
### Why / What / How

**Why:** Three of these are failure modes #14316 introduced, each reproducing the "clicking Connect does nothing" symptom that PR exists to remove. They were found by the automated review after the PR was already queued for merge, so they land separately.

**What:** Fixes four connect-card defects and one test that could pass without executing.

**How:**

- **A managed credential was offered as the scope-upgrade target.** `upgradableCredentialID` filtered system credentials but not AutoGPT-managed ones, and `_prepare_scope_upgrade` rejects a managed credential with a 400 (`router.py:1366`). A user whose only OAuth2 account for a provider is managed got a Connect button that failed on every click and a row that could never be satisfied. Now excluded.
- **A stale `credential_id` turned a recoverable connect into a dead button.** The upgrade target comes from the in-memory credentials list — the very list whose staleness #14316 exists to survive — and the backend returns `404 {"detail":"Credential to upgrade not found"}` for an id it cannot find, with no fallback. The sign-in now retries once without the upgrade target.
- **Trigger cards auto-sent an account the user never picked, and excluding them alone left a dead end.** `hasUserActionableInputs` is edit-mode only, so it is always false for `inputsMode="trigger"`, which `ToolResult.tsx:169` renders inside a chain, and `buildTriggerSetupMessage` carries the credential its webhook registers under. Excluding those cards from the auto-send is not sufficient on its own: the chain renders Proceed only for inputs or questions, and every tool result goes through the chain, so the standalone card with its own picker is unreachable — connecting produced no button, no draft and no send. A card can now declare `manualProceed`, which the chain treats like having inputs, so a trigger card gets the chain's Proceed and drafts its message with the account the user picked. The auto-dismiss path is excluded the same way: it fired for a trigger card whose provider an earlier card had connected, sent `credentials={}` before any account was selected, and left the chat hanging on a re-issued card that had already lost the dedupe claim.
- **A provider row dropped every card's scopes but the first.** `toConnectorRows` collapses N requests per provider keeping only the first schema. Harmless while scopes were dropped uniformly; load-bearing once they drive both the sign-in and the satisfaction check. The row now requests the union of the scopes — and only the scopes: merging `credentials_types` would offer a method some cards cannot accept, which needs a per-card row rather than a wider one. A row whose schema widens mid-stream also drops a selection the new scopes no longer satisfy, so it cannot read "Connected" on a credential a later card cannot use.
- **The 404 fallback retried too much and refreshed too little.** The retry fired on any 404, including the one raised for a provider without OAuth support before the endpoint reads the upgrade target, so a permanent failure was sent twice; it now matches only the missing-upgrade-target case and rethrows otherwise. It also refreshes the credentials list when it finds the dead id, so cancelling the popup does not leave every later click paying the extra round-trip.
- **`useDeviceAuthConnect.ts`**: the `reload()` this PR briefly added there is removed, for the reason below.

The dialog's success paths reset symmetrically. Device auth is deliberately left alone: #14177 fixes that path with an upsert plus a load-generation guard, which a reload cannot substitute for — where the credentials query is mounted the provider already runs two unordered loads per connect, so a third can still lose to a response that predates the credential.

### Test fix

`settle()` waited on `expect(screen.queryByText(...)).toBeDefined()`. `queryBy*` returns `null` on a miss and `toBeDefined()` accepts `null`, so the wait resolved on the first tick and the only real barrier was a fixed 800 ms sleep — against measured runtimes of 822 ms and 833 ms. On a loaded runner both "stays silent" assertions could pass without anything having rendered. It now waits on every row resolving against the refreshed credential list.

### Verified

Executed locally. Each of the five guards that survived mutation testing on #14316 now has a case that fails without it — verified by reverting each in turn: dropping the `is_managed` filter, the `length === 1` guard, the `type === "oauth2"` filter, `!hasUserActionableInputs`, or the trigger exclusion each fails exactly one test. The tightened `settle()` still fails both "stays silent" cases when the auto-send gate is reverted, so it remains a real regression guard. `useOAuthConnect.test.ts` gains the login-request shape (no query for a provider-level connect, comma-joined scopes, the upgrade target, and the 404 retry), which pins #14316's claim that its four existing callers are unaffected. 2734 of 2736 tests pass across copilot, CredentialsInput, IntegrationsPanel, DeviceAuth and onboarding; the two failures (`AgentCards` "links marketplace agents by creator and slug", `ToolResult` "renders found library agents with stats") also fail with these changes reverted and are pre-existing on `dev`. `pnpm types` is clean.

Reasoned but not executed: the managed-credential and stale-id paths against a live backend. Both rejections are the backend's documented behaviour and the QA specialist verified the 404 live on #14316; the tests here pin the frontend side, which is where both bugs are.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] A managed account is not offered for upgrade
  - [x] Two candidate accounts pick none
  - [x] An API-key account is not offered for an OAuth upgrade
  - [x] A card that also collects inputs waits for the user
  - [x] A trigger card gets a Proceed rather than auto-sending or dead-ending
  - [x] A trigger card whose provider a sibling connected also gets a Proceed
  - [x] A stale upgrade target retries without it
  - [x] Two cards sharing a provider ask for the union of their scopes
  - [x] A row drops a selection its widened schema no longer satisfies
  - [x] A 404 that is not about the upgrade target does not retry
  - [x] Every guard fails a test when reverted — checked one at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)


