### PR TITLE
docs(platform): add sign-up and tour CTAs to platform overview page

### DIFF
--- a/docs/platform/what-is-autogpt-platform.md
+++ b/docs/platform/what-is-autogpt-platform.md
@@ -2,6 +2,10 @@
 
 The AutoGPT Platform is a groundbreaking system that revolutionizes AI utilization for businesses and individuals. It enables the creation, deployment, and management of continuous agents that work tirelessly on your behalf, bringing unprecedented efficiency and innovation to your workflows.
 
+{% hint style="success" %}
+**See it in action:** [**Sign up free →**](https://platform.agpt.co/signup?utm_source=docs_platform_overview) no install required, or [**take the interactive tour →**](https://platform.agpt.co/tour/chat?utm_source=docs_platform_overview) to watch AutoPilot build and run an agent in your browser.
+{% endhint %}
+
 ## Key Features
 
 * **Seamless Integration and Low-Code Workflows**: Rapidly create complex workflows without extensive coding knowledge.
@@ -78,5 +82,6 @@ This strategy allows us to share previously closed-source components, fostering 
 
 ## Ready to Get Started?
 
-* **Cloud:** Read the [Getting Started (Cloud)](getting-started-cloud.md) guide to start using the hosted platform immediately.
+* **Just want to try it?** [**Sign up free**](https://platform.agpt.co/signup?utm_source=docs_platform_getstarted) and start building in your browser — no install required. Prefer to watch first? [**Take the interactive tour**](https://platform.agpt.co/tour/chat?utm_source=docs_platform_getstarted).
+* **Cloud:** Read the [Getting Started (Cloud)](getting-started-cloud.md) guide for a full walkthrough of the hosted platform.
 * **Self-Host:** Read the [Self-Hosting Guide](getting-started.md) to run the platform on your own infrastructure.


### PR DESCRIPTION
## What
Adds prominent calls-to-action to the `/docs/platform/` landing page (`what-is-autogpt-platform.md`):
- A success-styled callout right after the intro linking to **Sign up free** (`platform.agpt.co/signup`) and the **interactive tour** (`platform.agpt.co/tour/chat`)
- The bottom **Ready to Get Started?** section now leads with the same sign-up/tour links (previously only linked to internal doc pages)

Both links carry `utm_source=docs_platform_overview` / `utm_source=docs_platform_getstarted` for attribution, consistent with the UTM convention already used on the marketing site.

## Why
Requested by Toran/Nick: readers hitting https://agpt.co/docs/platform/ had no direct path into the product — only more documentation. This gets people from 'reading about the platform' to 'signed up or watching the tour' in one click.

## Notes
- Left `getting-started-cloud.md` untouched — it already walks through signup step-by-step for people who click through from here.
- No touched files outside the single docs page.