### PR TITLE
fix(backend/copilot-bot): read the post a Discord thread was created from

### DIFF
--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter.py
@@ -678,7 +678,7 @@ class DiscordAdapter(SocketAdapter):
         if not isinstance(message.channel, discord.Thread):
             return ()
         try:
-            return await self._budgeted_history(
+            history = await self._budgeted_history(
                 message.channel.history(
                     limit=THREAD_HISTORY_LIMIT,
                     before=message,
@@ -688,7 +688,42 @@ class DiscordAdapter(SocketAdapter):
             )
         except (discord.Forbidden, discord.HTTPException):
             logger.warning("Could not fetch Discord thread history", exc_info=True)
-            return ()
+            history = ()
+        starter = await self._thread_starter_entry(message.channel)
+        return (starter, *history) if starter else history
+
+    async def _thread_starter_entry(
+        self, thread: discord.Thread
+    ) -> Optional[MessageHistoryEntry]:
+        """The message a thread was opened from, as its oldest history entry.
+
+        A thread created from a channel post shares that post's id, but the
+        post itself lives in the parent channel and never appears in
+        ``thread.history()``. Without it the bot sees a thread whose first
+        line is "make this happen" and has no idea what "this" is. Threads
+        opened without an origin message have no starter and return None.
+        Kept outside the character budget so it is never truncated away.
+        """
+        starter = thread.starter_message
+        if not isinstance(starter, discord.Message):
+            parent = thread.parent
+            if not isinstance(parent, discord.abc.Messageable):
+                return None
+            try:
+                starter = await parent.fetch_message(thread.id)
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                return None
+        bot_user_id = self._client.user.id if self._client.user else None
+        if bot_user_id is not None and starter.author.id == bot_user_id:
+            return None
+        text = self._strip_mentions(starter)
+        if not text:
+            return None
+        return MessageHistoryEntry(
+            username=starter.author.display_name,
+            user_id=str(starter.author.id),
+            text=text,
+        )
 
     async def _budgeted_history(
         self, history, char_budget: int

--- a/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
+++ b/autogpt_platform/backend/backend/copilot/bot/adapters/discord/adapter_test.py
@@ -481,6 +481,69 @@ class TestRenameThread:
 
 class TestThreadHistory:
     @pytest.mark.asyncio
+    async def test_thread_started_from_a_post_includes_that_post_first(self):
+        # Toran turns Nick's channel post into a thread and @mentions the bot.
+        # Nick's post is the thread's starter message: it lives in the parent
+        # channel, not in thread.history(), so it must be fetched separately.
+        adapter, _ = _bare_adapter(bot_id=1000)
+        bot = _mention(1000, "AutoGPT")
+
+        starter = MagicMock(spec=discord.Message)
+        starter.content = "docs should link to platform sign up"
+        starter.mentions = []
+        starter.role_mentions = []
+        starter.author = MagicMock(bot=False, id=2000, display_name="Nick")
+
+        channel = MagicMock(spec=discord.Thread)
+        channel.id = 555
+        channel.starter_message = None
+        channel.parent = MagicMock(spec=discord.TextChannel)
+        channel.parent.fetch_message = AsyncMock(return_value=starter)
+        channel.history.return_value = _AsyncHistory([])
+        message = _message("<@1000> make this happen please", [bot])
+        message.channel = channel
+
+        history = await adapter._thread_history(message)
+
+        channel.parent.fetch_message.assert_awaited_once_with(555)
+        assert [entry.username for entry in history] == ["Nick"]
+        assert history[0].text == "docs should link to platform sign up"
+
+    async def test_thread_without_origin_message_has_no_starter_entry(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        bot = _mention(1000, "AutoGPT")
+        channel = MagicMock(spec=discord.Thread)
+        channel.id = 555
+        channel.starter_message = None
+        channel.parent = MagicMock(spec=discord.TextChannel)
+        channel.parent.fetch_message = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(status=404), "gone")
+        )
+        channel.history.return_value = _AsyncHistory([])
+        message = _message("<@1000> hi", [bot])
+        message.channel = channel
+
+        assert await adapter._thread_history(message) == ()
+
+    async def test_cached_starter_is_used_and_bot_authored_starter_is_skipped(self):
+        adapter, _ = _bare_adapter(bot_id=1000)
+        bot = _mention(1000, "AutoGPT")
+        starter = MagicMock(spec=discord.Message)
+        starter.content = "old bot output"
+        starter.mentions = []
+        starter.role_mentions = []
+        starter.author = MagicMock(bot=True, id=1000, display_name="AutoGPT")
+        channel = MagicMock(spec=discord.Thread)
+        channel.starter_message = starter
+        channel.parent = MagicMock(spec=discord.TextChannel)
+        channel.parent.fetch_message = AsyncMock()
+        channel.history.return_value = _AsyncHistory([])
+        message = _message("<@1000> hi", [bot])
+        message.channel = channel
+
+        assert await adapter._thread_history(message) == ()
+        channel.parent.fetch_message.assert_not_awaited()
+
     async def test_fetches_user_thread_history_chronological(self):
         # Discord returns history newest-first; the adapter reverses it back to
         # chronological order, dropping its own outputs.


### PR DESCRIPTION
### Why / What / How

**Why.** When someone turns a channel post into a thread and @mentions the bot with "make this happen", the bot answers that it has no idea what "this" refers to. A thread created from a post shares that post's id, but the post itself stays in the parent channel and never appears in `thread.history()`. The adapter only ever read the thread's own history, so for a freshly created thread it saw nothing at all. #13323 widened the history read to the full thread; it still never included the origin message, which is why this kept happening.

**What.** `_thread_history` now fetches the thread's starter message and prepends it as the oldest entry, so the bot reads the post the thread was opened from before anything said inside the thread.

**How.** `_thread_starter_entry` uses the cached `thread.starter_message` when discord.py has it, otherwise fetches message `thread.id` from the parent channel. Threads opened without an origin message (`create_thread` with a name only) get `NotFound` and contribute nothing. A starter authored by the bot is skipped, matching how its own messages are already dropped from history. The entry sits outside the history character budget so a long thread can never truncate its own origin away. A failure to read the thread's history no longer discards the starter either.

### Changes 🏗️

- `copilot/bot/adapters/discord/adapter.py`: `_thread_starter_entry`, wired into `_thread_history`
- `adapter_test.py`: starter fetched from the parent and listed first; thread without an origin message has no starter entry; cached starter used and bot-authored starter skipped

No API surface change, no configuration changes, no `data/*.py` changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Discord adapter suite plus shared `text_test.py`: 177 passed, 0 failed (test VM backend container, tree synced)
  - [x] pyright: 0 errors on `adapter.py`
  - [x] black, isort, ruff clean on both files
  - [ ] On dev: post in a channel, create a thread from that post, @mention the bot with "do this"; the bot should act on the post's content without asking what "this" is

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
