### PR TITLE
docs: Publish new SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -212,4 +212,4 @@ We thank the following security researchers for contributing responsibly to impr
 - David Carliez ([@DavidCarliez](https://github.com/DavidCarliez)) – 1 advisory
 - [@long2809-exploi](https://github.com/long2809-exploi) – 1 advisory
 
-**Last updated: April 2026**
+**Last updated: September 2026**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,50 +1,215 @@
 # Security Policy
 
-## Reporting Security Issues
+## 1. Purpose
 
-We take the security of our project seriously. If you believe you have found a security vulnerability, please report it to us privately. **Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+This Security Policy sets out the process for reporting security vulnerabilities in the AutoGPT platform, the standards expected of security researchers, and the approach taken by us in investigating, remediating, and disclosing vulnerabilities.
 
-> **Important Note**: Any code within the `classic/` folder is considered legacy, unsupported, and out of scope for security reports. We will not address security vulnerabilities in this deprecated code.
+We are committed to maintaining the security and integrity of our systems and welcome responsible disclosure of vulnerabilities.
 
-> **Important Note**: The JWKS transport check (the startup warning when `JWT_JWKS_URL` is fetched over cleartext `http://` from a non-local host) is best-effort operator guidance, not a security boundary. It is a warning only, it never blocks startup, and it cannot tell a trusted private network from a hostile one. Securing the network path between the backend and the JWKS endpoint is the operator's responsibility — see the self-hosting security note in `docs/platform/getting-started.md`. Reports that the warning can be missed, silenced, or evaded are not eligible for a CVE.
+## 2. Reporting Security Vulnerabilities
 
-Instead, please report them via:
-- [GitHub Security Advisory](https://github.com/Significant-Gravitas/AutoGPT/security/advisories/new)
-<!--- [Huntr.dev](https://huntr.com/repos/significant-gravitas/autogpt) - where you may be eligible for a bounty-->
+If you believe you have identified a security vulnerability, you must report it confidentially and in accordance with this policy.
 
-### Reporting Process
-1. **Submit Report**: Use one of the above channels to submit your report
-2. **Response Time**: Our team will acknowledge receipt of your report within 14 business days.
-3. **Collaboration**: We will collaborate with you to understand and validate the issue
-4. **Resolution**: We will work on a fix and coordinate the release process
+**Do not disclose vulnerabilities publicly** (including via GitHub issues, discussions, pull requests, or social media) prior to coordinated disclosure.
 
-### Disclosure Policy
-- Please provide detailed reports with reproducible steps
-- Include the version/commit hash where you discovered the vulnerability
-- Allow us a 90-day security fix window before any public disclosure
-- After patch is released, allow 30 days for users to update before public disclosure (for a total of 120 days max between update time and fix time)
-- Share any potential mitigations or workarounds if known
+### 2.1 Reporting Channels
 
-## Supported Versions
-Only the following versions are eligible for security updates:
+- **GitHub Security Advisory (preferred):**\
+  <https://github.com/Significant-Gravitas/AutoGPT/security/advisories/new>
+- **Email:** <security@agpt.co>
 
-| Version | Supported |
-|---------|-----------|
-| Latest release on master branch | ✅ |
-| Development commits (pre-master) | ✅ |
-| Classic folder (deprecated) | ❌ |
-| All other versions | ❌ |
+Reports submitted through other channels may not be monitored or may result in delays.
 
-## Security Best Practices
-When using this project:
-1. Always use the latest stable version
-2. Review security advisories before updating
-3. Follow our security documentation and guidelines
-4. Keep your dependencies up to date
-5. Do not use code from the `classic/` folder as it is deprecated and unsupported
+## 3. Information to Include
 
-## Past Security Advisories
-For a list of past security advisories, please visit our [Security Advisory Page](https://github.com/Significant-Gravitas/AutoGPT/security/advisories) and [Huntr Disclosures Page](https://huntr.com/repos/significant-gravitas/autogpt).
+To enable effective triage and remediation, reports should include:
 
----
-Last updated: November 2024
+- A clear description of the vulnerability, including affected components
+- The potential impact (e.g. confidentiality, integrity, availability)
+- Step-by-step instructions to verify/exploit the vulnerability
+- Version number, commit hash, or environment details
+- Proof-of-concept code, scripts, or screenshots (where appropriate)
+- Any known mitigations or suggested fixes
+
+Incomplete reports may delay investigation.
+
+## 4. Response and Remediation Process
+
+We follow a coordinated vulnerability disclosure process.
+
+### 4.1 Target Timelines
+
+| Stage | Target |
+| --- | --- |
+| Initial acknowledgment | Within 5 business days |
+| Initial assessment / triage | Within 14 business days |
+| Remediation window | Up to 90 days |
+| Public disclosure | Typically within 120 days of report |
+
+These timelines are indicative and may be adjusted depending on:
+
+- Severity and exploitability
+- Complexity of remediation
+- Risk to users or infrastructure
+
+Where appropriate, we may accelerate disclosure for actively exploited vulnerabilities or extend timelines for complex fixes.
+
+### 4.2 Communication
+
+We will:
+
+- Keep reporters informed of status where reasonably practicable
+- Coordinate disclosure timing where possible
+- Notify users through appropriate channels (e.g. advisories, release notes)
+
+## 5. Coordinated Disclosure
+
+You agree to:
+
+- Refrain from public disclosure until:
+  - A fix has been released; or
+  - We have agreed on a disclosure timeline; or
+  - 120 days have elapsed from initial report (whichever is earlier, unless otherwise agreed)
+
+We reserve the right to disclose vulnerabilities earlier where necessary to protect users or systems.
+
+## 6. Safe Harbor
+
+We support good faith security research conducted in accordance with this policy.
+
+We will not initiate legal action against you for:
+
+- Accessing or testing systems within the defined scope
+- Conducting research in good faith and in compliance with this policy
+
+Provided that you:
+
+- Comply with all applicable laws and regulations
+- Do not exploit vulnerabilities for personal gain
+- Do not access, modify, or exfiltrate data beyond what is strictly necessary
+- Promptly report any discovered vulnerabilities
+
+### 6.1 Limitations
+
+This Safe Harbour:
+
+- Does not apply to activities outside the scope of this policy
+- Does not extend to third-party systems or services
+- Does not override applicable laws or regulatory obligations
+- Does not create any contractual relationship, employment relationship, or entitlement to compensation
+
+Where a third party initiates legal action, we may, at our discretion, confirm that the research was conducted in accordance with this policy.
+
+## 7. Testing Guidelines
+
+All testing must be conducted responsibly and proportionately.
+
+You must:
+
+- **Minimise impact**: only perform actions necessary to demonstrate the vulnerability
+- **Avoid data compromise:** do not access, download, or retain personal or confidential data unless strictly necessary and then only minimally
+- **Preserve system integrity:** do not alter, corrupt, or destroy data
+- **Protect availability**: do not conduct denial-of-service, stress, or load testing on production systems
+- **Use appropriate environments**: use test or staging environments where available
+- **Cease testing once validated**: stop testing once sufficient evidence is obtained
+
+Any activity that risks harm to users, systems, or the confidentiality, integrity or availability of data is strictly prohibited.
+
+Failure to comply with these guidelines may result in exclusion from Safe Harbor protections.
+
+## 8. Scope
+
+### 8.1 In Scope
+
+- Latest production release on the master branch
+- Active development code intended for future release
+
+### 8.2 Out of Scope
+
+- Code within the classic/ directory (unsupported)
+- Legacy or unsupported versions
+- Third-party dependencies (unless the issue arises directly from AutoGPT’s implementation)
+- Infrastructure or systems not owned or controlled by us
+
+We reserve the right to determine whether a reported issue falls within scope.
+
+## 9. Recognition
+
+We recognise the contribution of security researchers.
+
+Subject to your consent:
+
+- You will be credited in relevant security advisories; and
+- You may be listed in our Security Acknowledgments section
+
+We do not currently operate a paid bug bounty programme and no compensation is guaranteed.
+
+## 10. User Security Responsibilities
+
+Users of AutoGPT are responsible for maintaining secure deployments.
+
+We recommend that users:
+
+- Use the latest supported version
+- Monitor and apply security updates promptly
+- Review published security advisories
+- Maintain secure configuration and access controls
+- Avoid using default passwords and encryption keys
+- Keep dependencies up to date
+- Avoid use of deprecated components (including the classic/ folder)
+
+## 11. Security Advisories
+
+- GitHub Security Advisories:\
+  <https://github.com/Significant-Gravitas/AutoGPT/security/advisories>
+- Huntr disclosures:\
+  <https://huntr.com/repos/significant-gravitas/autogpt>
+
+## 12. Disclaimer
+
+This policy:
+
+- Does not grant permission to access systems outside its defined scope
+- Does not create any legal obligation to provide compensation
+- May be updated from time to time without prior notice
+
+## 13. Acknowledgments
+
+We thank the following security researchers for contributing responsibly to improving the security of AutoGPT:
+
+- [@lukas-eu](https://github.com/lukas-eu) – 3 advisories
+- [@AgentSec](https://github.com/AgentSec) – 11 advisories
+- Joshua Rogers ([@MegaManSec](https://github.com/MegaManSec)) – 2 advisories
+- Gecko Security ([@geckosecurity](https://github.com/geckosecurity)) – 1 advisory
+- JJ ([@jjjutla](https://github.com/jjjutla)) – 1 advisory
+- Artemiy ([@nkoorty](https://github.com/nkoorty)) – 1 advisory
+- [@rahulgovind](https://github.com/rahulgovind) – 1 advisory
+- Panuganti Siva Aditya ([@sivaadityacoder](https://github.com/sivaadityacoder)) – 1 advisory
+- Sunwoo Lee ([@programsurf](https://github.com/programsurf)) – 2 advisories
+- [@daeungdaeung](https://github.com/daeungdaeung) – 2 advisories
+- Seunghyun Yoon ([@yoonsh](https://github.com/yoonsh)) – 1 advisory
+- @lubroai – 2 advisories
+- [@ltduc147](https://github.com/ltduc147) – 1 advisory
+- [@222n5](https://github.com/222n5) – 3 advisories
+- [@ygboy777-alt](https://github.com/ygboy777-alt) – 1 advisory
+- [@S4nso](https://github.com/S4nso) – 1 advisory
+- [@CYC4D](https://github.com/CYC4D) – 1 advisory
+- [@Mirr2](https://github.com/Mirr2) – 1 advisory
+- Minjoon Gregorio Kim ([@Greg-Kim](https://github.com/Greg-Kim)) – 1 advisory
+- Dirstibone ([@1024wlsdud](https://github.com/1024wlsdud)) – 1 advisory
+- [@johnatzeropath](https://github.com/johnatzeropath) – 1 advisory
+- [@LeftenantZero](https://github.com/LeftenantZero) – 1 advisory
+- [@dxlerYT](https://github.com/dxlerYT) – 1 advisory
+- Jiaqi Luo ([@lhahah](https://github.com/lhahah)) – 1 advisory
+- Pavan Nallamothu ([@pavanchow](https://github.com/pavanchow)) – 1 advisory
+- Johnathan ([@TrebledJ](https://github.com/TrebledJ)) – 1 advisory
+- [@sai-sh](https://github.com/sai-sh) – 1 advisory
+- [@Acce1erator-R](https://github.com/Acce1erator-R) – 1 advisory
+- Edward-x ([@YLChen-007](https://github.com/YLChen-007)) – 1 advisory
+- 狗and猫 ([@Fushuling](https://github.com/Fushuling)) – 1 advisory
+- RacerZ ([@RacerZ-fighting](https://github.com/RacerZ-fighting)) – 1 advisory
+- Ace ([@Fried-Squid](https://github.com/Fried-Squid)) – 1 advisory
+- David Carliez ([@DavidCarliez](https://github.com/DavidCarliez)) – 1 advisory
+- [@long2809-exploi](https://github.com/long2809-exploi) – 1 advisory
+
+**Last updated: April 2026**


### PR DESCRIPTION
`SECURITY.md` is the repository's public security policy: how to report a vulnerability, what happens to a report, the safe-harbour terms for researchers, what is in scope, and who is credited. This replaces the November 2024 policy with the revised policy agreed in June 2026 and fills in its acknowledgments list from the published GitHub security advisories.

### Changes 🏗️

- Replaces the 2024 `SECURITY.md` with the June 2026 revision, converted from the agreed draft with its headings, lists, links, table and emphasis preserved and the wording unchanged. The draft's review comments are not carried over.
- Section 13 lists the 34 researchers who hold an accepted reporter, finder or analyst credit on at least one of the 40 published advisories, ordered by their first advisory, with a per-person advisory count and the GitHub display name where one is set.
- Maintainers credited in coordinator or remediation roles are not listed as researchers (Pwuts, ntindle, majdyz, kcze, Bentlybro, erik-megarad, Wladastic, Otto-AGPT), nor is lc0rp, whose only credit is typed "other".
- Credits the researcher has not yet accepted on GitHub are not listed, in line with the consent condition in section 9: five people across five advisories, plus one further credit for a researcher who is already listed once.
- Every published advisory carries credits; none had to be marked as uncredited.
- One credited account, `lubroai`, no longer resolves on GitHub, so it is listed without a profile link.

### Verified

Converted from ODT to Markdown by Claude, then manually text-verified against the original by @Pwuts.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Rendered `SECURITY.md` through the GitHub markdown API and inspected the structure
  - [x] Cross-checked the acknowledgments list against the advisory API output
