### PR TITLE
hotfix(frontend/marketplace): show expert cards to signed-out visitors

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/__tests__/experts-section.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/__tests__/experts-section.test.tsx
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { MainMarkeplacePage } from "../components/MainMarketplacePage/MainMarketplacePage";
 
 const mockUseAuth = vi.hoisted(() => vi.fn());
+const hireExpertsFlag = vi.hoisted(() => ({ enabled: true }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -37,7 +38,9 @@ vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
   return {
     ...actual,
     useGetFlag: (flag: string) =>
-      flag === "hire-experts" ? true : actual.useGetFlag(flag as never),
+      flag === "hire-experts"
+        ? hireExpertsFlag.enabled
+        : actual.useGetFlag(flag as never),
   };
 });
 
@@ -71,6 +74,7 @@ const hiredMaria: Expert = {
 
 describe("Marketplace ExpertsSection", () => {
   beforeEach(() => {
+    hireExpertsFlag.enabled = true;
     mockUseAuth.mockReturnValue({
       user: { id: "user-1" },
       isLoggedIn: true,
@@ -100,8 +104,32 @@ describe("Marketplace ExpertsSection", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  test("stays hidden and fetches nothing for signed-out visitors", async () => {
+  test("shows the expert cards to signed-out visitors without account links", async () => {
     mockUseAuth.mockReturnValue({ user: null, isLoggedIn: false });
+    hireExpertsFlag.enabled = false;
+    let rosterRequested = false;
+    server.use(
+      getListExpertTemplatesMockHandler([mariaTemplate]),
+      getListExpertsMockHandler(() => {
+        rosterRequested = true;
+        return [];
+      }),
+    );
+
+    render(<MainMarkeplacePage />);
+
+    expect(await screen.findByText("Meet the AI Experts")).toBeDefined();
+    const card = await screen.findByRole("link", { name: /Maria/ });
+    expect(card.getAttribute("href")).toBe(
+      "/marketplace/experts/template-maria",
+    );
+    expect(screen.queryByText(/raise your own expert/i)).toBeNull();
+    expect(screen.queryByRole("link", { name: "View your team" })).toBeNull();
+    expect(rosterRequested).toBe(false);
+  });
+
+  test("stays hidden and fetches nothing for signed-in users outside the beta", async () => {
+    hireExpertsFlag.enabled = false;
     let templatesRequested = false;
     server.use(
       getListExpertTemplatesMockHandler(() => {

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/ExpertsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/ExpertsSection.tsx
@@ -11,13 +11,11 @@ export function ExpertsSection() {
   const { isLoggedIn, templates, hiredTemplateIds, isLoading, isError } =
     useExpertsSection();
 
-  if (!isLoggedIn) {
-    return null;
-  }
-
   if (isError || (!isLoading && templates.length === 0)) {
     // Raising an expert needs no roster templates, so the second door
     // stays open even when the template list is empty or failed to load.
+    // It needs an account, though, so visitors get nothing here.
+    if (!isLoggedIn) return null;
     return (
       <section id="experts" className="mb-20 scroll-mt-24">
         <RaiseLink standalone />
@@ -31,11 +29,15 @@ export function ExpertsSection() {
         titleIcon={<AITeamIcon size={30} />}
         title="Meet the AI Experts"
         subtitle="Hire a ready-made specialist — competent on day one, working for you in minutes."
-        action={{ label: "View your team", href: "/team" }}
+        action={
+          isLoggedIn ? { label: "View your team", href: "/team" } : undefined
+        }
       />
-      <div className="-mt-3 mb-6">
-        <RaiseLink />
-      </div>
+      {isLoggedIn ? (
+        <div className="-mt-3 mb-6">
+          <RaiseLink />
+        </div>
+      ) : null}
       {isLoading ? (
         <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
           {[0, 1, 2].map((i) => (

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/useExpertsSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/useExpertsSection.ts
@@ -5,11 +5,13 @@ import {
 import { Expert } from "@/app/api/__generated__/models/expert";
 import { useAuth } from "@/lib/auth/hooks/useAuth";
 
+/** Templates are public, so the section can show them to anyone; only the
+ *  hired roster (for the "Hired" state) needs a session. */
 export function useExpertsSection() {
   const { isLoggedIn } = useAuth();
 
   const templatesQuery = useListExpertTemplates({
-    query: { select: (x) => x.data as Expert[], enabled: isLoggedIn },
+    query: { select: (x) => x.data as Expert[] },
   });
   const expertsQuery = useListExperts({
     query: { select: (x) => x.data as Expert[], enabled: isLoggedIn },
@@ -26,7 +28,7 @@ export function useExpertsSection() {
     isLoggedIn,
     templates: templatesQuery.data ?? [],
     hiredTemplateIds,
-    isLoading: isLoggedIn && templatesQuery.isLoading,
+    isLoading: templatesQuery.isLoading,
     isError: templatesQuery.isError,
   };
 }

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/MainMarketplacePage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/MainMarketplacePage/MainMarketplacePage.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { ErrorCard } from "@/components/molecules/ErrorCard/ErrorCard";
+import { useAuth } from "@/lib/auth/hooks/useAuth";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { AICatalogIcon } from "../AICatalogIcon";
 import { AgentsSection } from "../AgentsSection/AgentsSection";
@@ -16,7 +17,12 @@ import { useMainMarketplacePage } from "./useMainMarketplacePage";
 export const MainMarkeplacePage = () => {
   const { featuredAgents, topAgents, featuredCreators, isLoading, hasError } =
     useMainMarketplacePage();
+  const { isLoggedIn, isUserLoading } = useAuth();
   const isHireExpertsEnabled = useGetFlag(Flag.HIRE_EXPERTS);
+  // Hiring is still behind the flag, but the expert pages are public: a
+  // visitor browsing the marketplace needs a way to reach them. Signed-in
+  // users keep the flag gate so the beta stays invisible to them.
+  const showExperts = !isUserLoading && (!isLoggedIn || isHireExpertsEnabled);
 
   if (isLoading) {
     return <MainMarketplacePageLoading />;
@@ -45,7 +51,7 @@ export const MainMarkeplacePage = () => {
     <div className="mx-auto w-full max-w-[1360px]">
       <main className="px-6 pb-16 md:px-10 lg:px-14">
         <HeroSection />
-        {isHireExpertsEnabled ? <ExpertsSection /> : null}
+        {showExperts ? <ExpertsSection /> : null}
         {topAgents && (
           <div className="mb-20" id={AGENTS_SECTION_ID}>
             <AgentsSection


### PR DESCRIPTION
### Why / What / How

**Why:** #14313 shipped public, shareable expert pages, but the marketplace only renders the "Meet the AI Experts" section when the `hire-experts` flag is on and the visitor is signed in. The flag is off in production while Experts are in beta, so nobody browsing the marketplace can see the cards, and the pages are reachable only by direct link.

**What:** The experts section now renders for signed-out visitors regardless of the flag. Signed-in users keep the flag gate, so the beta stays invisible to them. Visitors don't get the "View your team" and "raise your own expert" links, which need an account.

**How:** `MainMarketplacePage` shows the section when the visitor is signed out (once auth has resolved) or the flag is on. `useExpertsSection` fetches templates unconditionally, since `GET /api/experts/templates` is public as of #14313, and keeps the hired roster behind the session. `ExpertsSection` drops its signed-in early return and hides the two account links for visitors; the empty/error fallback (the raise link) still renders nothing for visitors. Each page already handles what comes next: "Get started" when signed out, "Coming soon" for signed-in users outside the beta.

### Changes 🏗️

- `MainMarketplacePage`: `showExperts = !isUserLoading && (!isLoggedIn || isHireExpertsEnabled)` replaces the flag-only gate.
- `useExpertsSection`: templates query no longer gated on `isLoggedIn`; roster query still is.
- `ExpertsSection`: no signed-out early return; "View your team" and the raise link only for signed-in users; empty/error state renders nothing for visitors.
- `experts-section.test.tsx`: the signed-out case now expects the cards without the account links and no roster request; new case checks the section stays hidden for signed-in users outside the beta.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan (`prettier`, `eslint` on the touched files and full `tsc` pass locally; `pnpm test:unit` left to CI):
  - [ ] Open /marketplace signed out with the flag off: "Meet the AI Experts" cards appear, without "View your team" or the raise link; a card opens `/marketplace/experts/<id>` with "Get started"
  - [ ] Open /marketplace signed in with the flag off: no experts section (unchanged)
  - [ ] Open /marketplace signed in with the flag on: section with team link, raise link and Hired states (unchanged)

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
