### PR TITLE
dx(platform): add the /process-vulnerability-report skill

### DIFF
--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -21,6 +21,9 @@ backlog is processed by running this skill per item, not by a separate tool.
 
 `REPO=Significant-Gravitas/AutoGPT` throughout.
 
+Corpus figures quoted below are as of 2026-09-04. They move; re-derive any you are about
+to act on rather than trusting the number here.
+
 ## Stages
 
 | # | Stage | Input | Artefact | Decides |
@@ -137,9 +140,9 @@ done
 
 #### Step 1 — is this a duplicate set at all?
 
-A same-reporter listing is **not** a duplicate set. Researchers file batches: 13 reporters
-have more than one report in the queue and 42 of the 59 sit in such a batch. This is one
-reporter's, minutes apart, and every row is a different bug:
+A same-reporter listing is **not** a duplicate set. Researchers file batches — most
+multi-report reporters in the queue are filing several different bugs at once, not
+resubmitting one. This is one reporter's, minutes apart, and every row is a different bug:
 
 ```
 GHSA-8vm4-8gj4-crrv  10:59:27  high      PATH_TRAVERSAL in data.py
@@ -150,22 +153,29 @@ GHSA-7353-x5vf-fr3c  11:05:14  medium    XSS in text.py
 GHSA-96rm-9gw4-8qvx  11:06:03  high      SSRF in manager.py
 ```
 
-Two reports are the same bug only when **both** hold:
+**The test is: would one fix fix both?** Same file is not enough, and neither is the
+reporter calling it "the same pattern" — a systematic auditor's batch is the same class of
+bug in the same file at different call sites. Two live examples that pass a same-file test
+and fail this one: two token-reuse races in one OAuth module, at the authorization-code
+path and the refresh path; and two hardcoded defaults in one `.env` file, a JWT signing
+key and a Fernet key. Each pair needs two fixes, so each is two bugs.
 
-- **same component** — the same module, file or `file:line`; and
-- **same effect** — the same class of impact through the same code path.
-
-**If the batch spans different components, it is not a duplicate set. Close nothing and
-work each report on its own.** Two criticals in that listing are RCEs in different files;
-a rule that keeps the earliest would close them both.
-
-List the reporter's batch and read it against those two tests:
+Summaries are not enough evidence for that call — they name behaviours, not lines. Fetch
+the batch and read the descriptions:
 
 ```bash
 gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
-  | jq -r --arg who "$REPORTER" '.[] | select(.author.login == $who)
-      | [.ghsa_id, .created_at, .summary] | @tsv' | sort -k2
+  | jq -r --arg who "$REPORTER" '.[] | select(.author.login == $who) | .ghsa_id' \
+  | while read -r g; do gh api "/repos/$REPO/security-advisories/$g" > "$WORK/$g.json"; done
+
+jq -r '[.ghsa_id, .created_at, .severity, .summary] | @tsv' "$WORK"/GHSA-*.json | sort -k2
 ```
+
+**If the batch is a mix, it is not a duplicate set: close nothing and work each report on
+its own.** Two criticals in the listing above are RCEs in different files; a rule that
+keeps the earliest would close them both. That stop is about the batch as a whole — a
+genuine duplicate *pair* inside a mixed batch is still a duplicate, and the one-fix test
+governs it.
 
 #### Step 2 — within a confirmed duplicate set, the earliest survives
 
@@ -183,8 +193,8 @@ bug, and must never decide *which copy* survives. Two traps, both nearly paid fo
   means the duplicate was handled correctly and the OPEN one is the report still needing
   work — four of the queue's untouched items are survivors sitting in exactly that state.
 
-`submission.accepted` looks like a second signal and is not: it is `false` on all 59
-queued reports and only flips at acceptance or publication. Do not read it here.
+`submission.accepted` looks like a second signal and is not: it only flips at acceptance
+or publication, so every copy still in the queue reads `false`. Do not read it here.
 
 **Only close within one reporter.** Every cross-reporter pair in this corpus was left
 open: closing one costs an outside researcher their credit and their place in the
@@ -227,30 +237,46 @@ Use `--input` — nested arrays do not survive `-f`. GitHub derives `severity` f
 vector, so the vector is the field that matters; send `severity` only when you have no
 vector.
 
+**`credits` REPLACES the list — it does not append.** GitHub's reference for this
+endpoint: *"To add a credit to an advisory, send the whole array of values."* A payload
+naming one reporter erases every co-reporter, silently and with nothing to restore from.
+Twelve queued reports credit two to five researchers each, including two of the criticals
+this skill's own ranking puts near the top of the backlog. So back the record up on this
+path too, and build the array from what is already there:
+
 ```bash
+gh api "/repos/$REPO/security-advisories/$GHSA" > "$WORK/before.json"
+jq '[.credits[] | {login, type}]' "$WORK/before.json" > "$WORK/credits.json"
+
 cat > "$WORK/advisory.json" <<'JSON'
 {
   "summary": "One line, under 100 chars, naming the component and the effect",
-  "severity": "high",
   "cvss_vector_string": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
   "cwe_ids": ["CWE-862"],
   "vulnerabilities": [{
     "package": { "ecosystem": "other", "name": "autogpt-platform-backend" },
     "vulnerable_version_range": ">= 0.7.0, < 0.7.4",
     "patched_versions": "0.7.4"
-  }],
-  "credits": [{ "login": "REPORTER_LOGIN", "type": "reporter" }]
+  }]
 }
 JSON
-gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/advisory.json"
+jq --slurpfile cur "$WORK/credits.json" \
+   '.credits = ($cur[0] + [{login: "REPORTER_LOGIN", type: "reporter"}] | unique_by(.login))' \
+   "$WORK/advisory.json" > "$WORK/patch.json"
+
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/patch.json"
+gh api "/repos/$REPO/security-advisories/$GHSA" --jq '[.credits[].login] | join(",")'
 ```
+
+Read the credits back and compare with `$WORK/credits.json`. A shorter list means the
+merge dropped someone.
 
 Three rules the corpus breaks constantly:
 
 - **One package spelling.** `autogpt-platform-backend` in ecosystem `other` for the
   platform; `autogpt-classic` in `pip` for classic (which is out of scope, so you should
-  not be filing one). The repo currently carries 32 distinct spellings, including a
-  trailing space and a missing leading letter.
+  not be filing one). The repo carries roughly 30 distinct spellings, including a trailing
+  space and a missing leading letter.
 - **Bounded ranges only.** Bare semver taken from the `autogpt-platform-beta-vX.Y.Z`
   tag, always two-sided, upper bound equal to `patched_versions`. `>= 0.6.34` with no
   upper bound reads to a scanner as "every version including today's". Four published
@@ -311,9 +337,10 @@ Only two verdicts continue:
   fixed still earns its advisory, its CVE and the reporter's credit; dropping it is the
   failure this skill exists to stop.
 
-Every other verdict produces a **recommendation to close, handed to a human with the
-evidence** — never a `PATCH`, and never a message to the reporter, which is a human call
-in any case.
+Every other verdict **except `could not run`** produces a recommendation to close, handed
+to a human with the evidence — never a `PATCH`, and never a message to the reporter, which
+is a human call in any case. `could not run` recommends nothing: fix the rig, or hand the
+report to someone who can run it.
 
 ---
 
@@ -413,8 +440,8 @@ gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/body-pat
 
 **Input:** everything above. **Artefact:** a published advisory. **Human decides.**
 
-Hand over: the GHSA id, the fix PR, your CVSS vector next to the reporter's, and the
-drafted body. The maintainer reviews the body, merges the fix, and publishes.
+Hand over: the GHSA id, the fix PR — or, on the `already fixed` route, the commit and the
+release that carried it — your CVSS vector next to the reporter's, and the drafted body. The maintainer reviews the body, merges the fix, and publishes.
 
 **Publication is per-advisory now, triggered by the fix landing in a release** — not the
 every-few-weeks batch sweep that produced a median 82-day created→published time and two
@@ -439,7 +466,7 @@ Every one of these is a failure the corpus actually contains. Run them all.
 | Body is ours | not the reporter's submission republished |
 | Credits accepted | `gh api "/repos/$REPO/security-advisories/$GHSA" --jq '.credits_detailed[] \| [.user.login, .state] \| @tsv'` — 87 pending repo-wide, 17 on already-published advisories, so a named researcher never reaches the acknowledgments list. Ask once and wait; publish without them only at the 120-day backstop, and say so in the reply. |
 | CVE requested | **STOP** — prepare `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"` for `high` and above; a human runs it. Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
-| Duplicate cluster resolved | this advisory is the survivor, and every later resubmission of it is closed **with the reason in its description** — no other copy left in `triage` |
+| Duplicate cluster resolved | this advisory is the survivor of *its own* duplicate set — every later resubmission of **this bug** closed with the reason in its description. The reporter's other open reports are other bugs and stay open; see step 1 |
 
 ### Publish, then close the loop
 
@@ -499,7 +526,7 @@ gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
 
 The second query is what carries the day-105 escalation and the 120-day backstop. It must
 not filter on `updated_at`: an advisory leaves the untouched set the moment stage 1 writes
-its metadata, and 30 of the 59 queued reports are already outside it.
+its metadata, and about half the queue is already outside it.
 
 **What the sweep needs that this skill cannot give it:**
 

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -341,7 +341,8 @@ Three rules the corpus breaks constantly:
   repo carries roughly 30 distinct spellings, including a trailing space and a missing
   leading letter.
 - **Bounded ranges only.** `>= 0.6.34` with no upper bound reads to a scanner as "every
-  version including today's". Four published advisories say exactly that.
+  version including today's". Six published advisories say exactly that, and five name no
+  package at all.
 - **Version strings collide.** `0.4.3` is both classic Auto-GPT v0.4.3 (2023) and
   `autogpt-platform-beta-v0.4.3` (2025). Say which in the body.
 

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: process-vulnerability-report
+description: Take one reported vulnerability from the triage queue to a published GitHub security advisory — triage, verify, fix, author the advisory body, hand to a maintainer to publish. TRIGGER when the user asks to process a security report, work the advisory backlog, triage a GHSA, or write/publish a security advisory.
+user-invocable: true
+argument-hint: "[GHSA id] — if omitted, takes the highest-ranked item from the triage queue."
+metadata:
+  author: autogpt-team
+  version: "1.0.0"
+---
+
+# Process a vulnerability report
+
+A **GitHub security advisory** is a private record on the repo. Outside researchers
+open one through a web form; it sits in state `triage` until a maintainer works it.
+Publishing makes it public and pushes it into GitHub's vulnerability database, so
+downstream users get alerted.
+
+This skill takes **one advisory** from `triage` to `published`. It works the same on a
+report filed five minutes ago and on one that has sat untouched for 126 days — the
+backlog is processed by running this skill per item, not by a separate tool.
+
+`REPO=Significant-Gravitas/AutoGPT` throughout.
+
+## Stages
+
+| # | Stage | Input | Artefact | Decides |
+|---|---|---|---|---|
+| 1 | Triage | a GHSA id, or the queue | acknowledgment + dedup verdict + CVSS vector + metadata block | agent proposes, **human confirms severity and sends the acknowledgment** |
+| 2 | Verify | the triaged report | reproduction note: proved-live vs read-in-source | agent (**runs on Fable**) |
+| 3 | Fix | the reproduction note | fix PR with tests, GHSA id in the commit body | agent |
+| 4 | Author | fix PR + reproduction note | the advisory body, in the template below | agent drafts |
+| 5 | Raise | body + fix PR + metadata | published advisory, refreshed SECURITY.md §13 | **human** reviews, merges, publishes |
+
+Human calls, always: severity when it drives the embargo, the decision to disclose,
+the CVE request, merge approval, publication, and anything sent to a reporter.
+
+---
+
+## Stage 1 — Triage
+
+**Input:** a GHSA id, or nothing (take the queue's top item).
+**Artefact:** an acknowledgment drafted for a human to send, a dedup verdict naming
+the ids compared, and a completed metadata block on the advisory.
+**Meets:** SECURITY.md §4.1 acknowledgment (5 business days) and triage (14 business
+days), both measured **from `created_at`** — receipt, not from when we picked it up.
+
+### Pick an item
+
+```bash
+gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
+  | jq -r 'map(. + {untouched: (.updated_at == .created_at)})
+           | sort_by((.severity as $s | ["critical","high","medium","low"] | index($s)) // 9, .created_at)
+           | .[] | [.ghsa_id, .severity, .created_at[:10], (if .untouched then "UNTOUCHED" else "-" end), .summary] | @tsv'
+```
+
+Rank untouched criticals first, then by age. A named GHSA id skips this.
+
+```bash
+gh api "/repos/$REPO/security-advisories/$GHSA"
+```
+
+### Close it out instead, if any of these hold
+
+- The code is in `classic/` — out of scope per SECURITY.md, close.
+- It is the JWKS cleartext-transport warning — explicitly not eligible, close.
+- It is spam or a test submission (`Hack`, `pvr-test`, empty bodies) — close.
+- It duplicates another advisory — close **and see the twin check below**.
+
+```bash
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" -f state=closed
+```
+
+### Dedup, and the twin check
+
+Compare the summary and the affected file against every state, not just published:
+
+```bash
+for s in triage draft published closed; do
+  gh api "/repos/$REPO/security-advisories?state=$s&per_page=100" --paginate \
+    | jq -r --arg s "$s" '.[] | [$s, .ghsa_id, .created_at[:10], .author.login, .summary] | @tsv'
+done
+```
+
+**Failure mode with four live cases:** one reporter submitted five findings twice; for
+four of them a copy was closed and its identical twin was left in `triage`, where it
+still sits. After closing any duplicate, list that reporter's remaining triage items and
+close every copy:
+
+```bash
+gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
+  | jq -r --arg who "$REPORTER" '.[] | select(.author.login == $who) | [.ghsa_id, .created_at[:10], .summary] | @tsv'
+```
+
+### Acknowledge
+
+**GitHub exposes no REST endpoint for advisory comments.** The acknowledgment is posted
+by a human in the advisory's web UI (`.html_url`). Draft it — one paragraph: received,
+the date received, that we are reproducing it, and the next date they will hear from us
+— and hand it over. Do not let stage 2 start before this is drafted; the 5-business-day
+promise is the cheapest one to keep and the most visibly broken today.
+
+### Score it — a CVSS vector is required
+
+Reporters supply a vector or a severity, and **they overstate**. Derive your own,
+independently, and compare. Draft it here from the report; finalise it after stage 2
+against what was actually proved. Use CVSS v3.1 (`CVSS:3.1/…`) — it is what the corpus
+uses and what `cvss_vector_string` takes.
+
+Anchors for this codebase:
+
+| Metric | Rule |
+|---|---|
+| `PR` | Nearly every platform endpoint requires auth. If the PoC carries a token, it is `PR:L`. `PR:N` only for a route that genuinely serves anonymous callers. |
+| `AV` | A self-hosted-only default, or something reachable only from localhost, is `AV:L` — often not a vulnerability at all. |
+| `S` | `S:C` only across a real trust boundary: tenant→tenant, container→host. Block code doing what its graph author asked is not scope change. |
+| `C`/`I` | Scope to one tenant's data unless cross-tenant access is demonstrated. |
+| `A` | `A:H` needs a demonstrated sustained outage, not one slow request. |
+
+**When your vector disagrees with the reporter's:** ours is what ships. Record both,
+name the single metric that differs and why, and put that sentence in the reply to the
+reporter. If they dispute it once, a maintainer decides — do not negotiate twice. Never
+publish a reporter's vector unexamined, and never raise severity to end an argument.
+
+### Write the metadata block
+
+Use `--input` — nested arrays do not survive `-f`.
+
+```bash
+cat > /tmp/advisory.json <<'JSON'
+{
+  "summary": "One line, under 100 chars, naming the component and the effect",
+  "severity": "high",
+  "cvss_vector_string": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
+  "cwe_ids": ["CWE-862"],
+  "vulnerabilities": [{
+    "package": { "ecosystem": "other", "name": "autogpt-platform-backend" },
+    "vulnerable_version_range": ">= 0.7.0, < 0.7.4",
+    "patched_versions": "0.7.4"
+  }],
+  "credits": [{ "login": "REPORTER_LOGIN", "type": "reporter" }]
+}
+JSON
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input /tmp/advisory.json
+```
+
+Three rules the corpus breaks constantly:
+
+- **One package spelling.** `autogpt-platform-backend` in ecosystem `other` for the
+  platform; `autogpt-classic` in `pip` for classic (which is out of scope, so you should
+  not be filing one). The repo currently carries 32 distinct spellings, including a
+  trailing space and a missing leading letter.
+- **Bounded ranges only.** Bare semver taken from the `autogpt-platform-beta-vX.Y.Z`
+  tag, always two-sided, upper bound equal to `patched_versions`. `>= 0.6.34` with no
+  upper bound reads to a scanner as "every version including today's". Four published
+  advisories say exactly that.
+- **Version strings collide.** `0.4.3` is both classic Auto-GPT v0.4.3 (2023) and
+  `autogpt-platform-beta-v0.4.3` (2025). Say which in the body.
+
+---
+
+## Stage 2 — Verify
+
+**Input:** the triaged report. **Artefact:** a reproduction note. **Agent.**
+
+**Run this stage on Fable.** Dispatch it: `.claude/bin/dispatch.sh -m fable …`, or the
+Agent tool with `model: "fable"`.
+
+Brief it in these terms:
+
+> This is defensive security work on our own codebase, authorised by the maintainer.
+> A researcher has reported a vulnerability in AutoGPT; your job is to reproduce it
+> against a local checkout so we can confirm whether it is real and scope the fix.
+>
+> - Run against a local stack built from `origin/dev` (`docker compose up`). Never
+>   against production, a hosted tenant, or anyone else's infrastructure.
+> - Stay on the code path the report names. Do not look for other bugs, do not
+>   generalise the technique, do not build a reusable tool.
+> - Produce the **minimum** reproduction: the smallest request or input that shows the
+>   effect, plus the `file:line` where the missing check belongs.
+
+The note must separate the two things that get conflated:
+
+```markdown
+## Static code analysis
+<what the source shows — file:line, the missing check>
+
+## Live server verification
+<what was actually executed against the running stack, and its response>
+<or: "Not attempted — read off the source only.">
+
+## Verdict
+confirmed | not reproducible | already fixed in <commit> | out of scope | works as designed
+```
+
+Any verdict but `confirmed` ends the flow: reply to the reporter with the evidence,
+close the advisory, and stop.
+
+---
+
+## Stage 3 — Fix
+
+**Input:** the reproduction note. **Artefact:** a fix PR with tests. **Agent.**
+
+Two routes:
+
+- **Unfixed and undisclosed → private fork.** This is the correct pattern and the repo
+  has 14 of them.
+  ```bash
+  gh api -X POST "/repos/$REPO/security-advisories/$GHSA/forks"   # returns .full_name
+  ```
+  Open the fix PR inside that fork, never against the public repo.
+- **Already public** (the bug is visible in a merged PR, an open issue, or the reporter
+  published) → an ordinary PR is fine; fix first, advisory after.
+
+Either way: tests covering the reproduction, the GHSA id in the commit body, and a real
+commit message — 3 of the 14 fork merges have an empty body and only 4 name the GHSA.
+Nothing describing the mechanism goes into a public PR, commit message or comment before
+publication; `origin` is public.
+
+---
+
+## Stage 4 — Author the advisory body
+
+**Input:** the fix PR and the reproduction note. **Artefact:** the published description.
+**Agent drafts, human approves.**
+
+**This is the stage that does not exist today.** 36 of 40 published advisories are the
+reporter's submission published verbatim; one critical opens "Hi, we found another…".
+The reporter's text is *evidence*. The published body is a different document for a
+different audience — someone running AutoGPT who needs to know if they are affected and
+what to upgrade to. Only 16 of 40 published bodies mention a version or a fix at all.
+
+Write it fresh, in this template, and keep the reporter's original under
+`Original report` if it carries detail worth preserving.
+
+```markdown
+### Impact
+<Who is affected and what an attacker gets. Two sentences. Name the privilege
+required — "any authenticated user", not "an attacker".>
+
+### Affected versions
+<`autogpt-platform-beta-v0.7.0` through `v0.7.3`. Say "platform" or "classic"
+explicitly — the bare version numbers collide.>
+
+### Patches
+<Fixed in `autogpt-platform-beta-v0.7.4`. Upgrade to that release or later.>
+
+### Workarounds
+<A concrete mitigation for someone who cannot upgrade today, or "None." Two
+advisories in the whole corpus offer one.>
+
+### Details
+<Root cause, in our own words. `file:line` and the missing check. Pre-empt the
+scope question the way the best advisory in the corpus does: say plainly whether
+this is `classic/` or supported platform code.>
+
+### Proof of concept
+<The minimum reproduction from stage 2. Nothing weaponised.>
+
+### References
+<Fix PR, commit, related advisories, CWE. GitHub's repository-advisory API has no
+`references` field — these live here or nowhere, and today 4 of 40 have any.>
+
+### Credit
+<Reported by @login. Or "Found internally during review.">
+
+### Timeline
+<Reported YYYY-MM-DD · Triaged YYYY-MM-DD · Fixed YYYY-MM-DD · Published YYYY-MM-DD.
+No advisory in the corpus has one.>
+```
+
+```bash
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" \
+  -f description="$(cat advisory-body.md)"
+```
+
+---
+
+## Stage 5 — Raise to a maintainer
+
+**Input:** everything above. **Artefact:** a published advisory. **Human decides.**
+
+Hand over: the GHSA id, the fix PR, your CVSS vector next to the reporter's, and the
+drafted body. The maintainer reviews the body, merges the fix, and publishes.
+
+**Publication is per-advisory now, triggered by the fix landing in a release** — not the
+every-few-weeks batch sweep that produced a median 82-day created→published time and two
+cases where the fix had shipped 200+ days earlier. As soon as the patched version is a
+real release tag, this advisory is ready.
+
+The 120-day clock in SECURITY.md §4.1 runs from **receipt**. Escalate to the maintainer
+at day 105 with either a publication date or a reason; it is a backstop that fires with
+or without a release.
+
+### Pre-publication checks
+
+Every one of these is a failure the corpus actually contains. Run them all.
+
+| Check | Command / rule |
+|---|---|
+| Fix is in a release | `gh release view "autogpt-platform-beta-v$PATCHED"` — 40/40 got this right; do not be the first to break it |
+| Range is bounded | upper bound present, and equal to `patched_versions` |
+| Package spelling | exactly one canonical string (above) |
+| References present | `### References` non-empty, or explicitly "none" |
+| Body is ours | not the reporter's submission republished |
+| Credits accepted | `gh api "/repos/$REPO/security-advisories/$GHSA" --jq '.credits_detailed[] \| [.user.login, .state] \| @tsv'` — 87 pending repo-wide, 17 on already-published advisories, so a named researcher never reaches the acknowledgments list. Ask once and wait; publish without them only at the 120-day backstop, and say so in the reply. |
+| CVE requested | `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"` for `high` and above. Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
+| Twins closed | no copy of this report left in `triage` |
+
+### Publish, then close the loop
+
+```bash
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" -f state=published
+.claude/bin/regen-security-credits.sh          # rewrites SECURITY.md §13 from the API
+```
+
+Regenerate the acknowledgments on **every** publication. That section is the one part of
+this process with a clean record — 34 researchers, all counts exact — and it stays clean
+by being generated, not hand-edited. (The script is written separately; in the local
+agent setup it lives in `~/code/agpt/.claude/bin/`.) Commit the regenerated SECURITY.md
+in an ordinary PR.
+
+Then: tell the reporter it is published, and close the Linear ticket if one exists.
+
+---
+
+## What SECURITY.md promises, and where this skill keeps it
+
+| Promise | Kept at |
+|---|---|
+| §4.1 Acknowledgment within **5 business days** of receipt | Stage 1, drafted before verification starts |
+| §4.1 Triage within **14 business days** of receipt | Stage 1 complete: dedup verdict, CVSS vector, metadata block |
+| §4.1 Remediation within **90 days** | Stage 3 |
+| §4.1 Disclosure typically within **120 days of report** | Stage 5, per-advisory on fix-released; escalation at day 105 |
+| §4.2 Keep reporters informed | Stage 1 acknowledgment, stage 2 verdict reply, stage 5 publication notice |
+| §5 Coordinated disclosure — fix before publish | Stage 5 pre-publication check |
+| §9 Credit, subject to consent | Stage 1 sets credits; stage 5 verifies acceptance and regenerates §13 |
+
+Both clocks start at `created_at`. For a backlog item that means the deadline has often
+already passed — record the real dates in the Timeline section anyway.
+
+---
+
+## Running as a daily sweep
+
+A scheduled run enumerates the queue and works items in rank order:
+
+```bash
+gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
+  | jq -r --argjson now "$(date +%s)" '
+      .[] | select(.updated_at == .created_at)
+      | [.ghsa_id, .severity, (($now - (.created_at|fromdate))/86400|floor), .summary] | @tsv'
+```
+
+**What the sweep needs that this skill cannot give it:**
+
+- **A durable per-advisory ledger.** GitHub records no "acknowledged" or "triaged" state,
+  and `updated_at` moves on any edit — so a sweep cannot distinguish a report we replied
+  to from one nobody has read. It needs its own store keyed by GHSA id (ack sent, triage
+  verdict, owner, next action). Nothing writes one today.
+- **A way to send the acknowledgment.** There is no advisory-comments API. Until a human
+  posts in the UI, the sweep can only queue the draft.
+- **A maintainer on duty.** Severity confirmation, disclosure, CVE, merge and publication
+  are human. An unattended 03:00 run finishes at the end of stage 4 and no further.
+- **The other intake channels.** The sweep sees GitHub advisories only.
+  `security@agpt.co` is advertised in §2.1 but SECRT-2020 says the mailing list was never
+  set up; Huntr reports arrive with no advisory record at all.
+- **Business-day arithmetic.** The 5- and 14-day promises are business days, holidays
+  included.
+
+Alerting is the point: the queue held 59 reports at a median age of 67 days, 29 never
+touched by anyone, six of those critical and the oldest 126 days old. Nothing was
+counting. A sweep that only counts is already worth more than the current state.

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -32,7 +32,8 @@ backlog is processed by running this skill per item, not by a separate tool.
 | 5 | Raise | body + fix PR + metadata | published advisory, refreshed SECURITY.md §13 | **human** reviews, merges, publishes |
 
 Human calls, always: severity when it drives the embargo, the decision to disclose,
-the CVE request, merge approval, publication, and anything sent to a reporter.
+the CVE request, merge approval, publication, a duplicate spanning two reporters, and
+anything sent to a reporter.
 
 ---
 
@@ -61,16 +62,43 @@ gh api "/repos/$REPO/security-advisories/$GHSA"
 
 ### Close it out instead, if any of these hold
 
-- The code is in `classic/` — out of scope per SECURITY.md, close.
-- It is the JWKS cleartext-transport warning — explicitly not eligible, close.
-- It is spam or a test submission (`Hack`, `pvr-test`, empty bodies) — close.
-- It duplicates another advisory — close **and see the twin check below**.
+- The code is in `classic/` — out of scope per SECURITY.md.
+- It is the JWKS cleartext-transport warning — explicitly not eligible.
+- It is spam or a test submission (`Hack`, `pvr-test`, empty bodies).
+- It is a later resubmission of an earlier report by the same reporter — see below.
+
+There is no advisory-comments API, so `description` is the **only** API-writable place
+for a closure reason. Write it there in the *same* `PATCH` that sets the state, so a
+failed call leaves the advisory untouched rather than closed without explanation. Back
+the record up first: `state` accepts only `published`, `closed` and `draft` — `triage`
+returns 422, so a closure cannot be undone through the API.
 
 ```bash
-gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" -f state=closed
+gh api "/repos/$REPO/security-advisories/$GHSA" > "$GHSA.backup.json"
+jq -n --rawfile d body.md '{description: $d, state: "closed"}' > close.json
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input close.json
+gh api "/repos/$REPO/security-advisories/$GHSA" \
+  --jq '[.state, .closed_at, (.description|length)] | @tsv'    # read back and confirm
 ```
 
-### Dedup, and the twin check
+`body.md` is the original description, unchanged, followed by the block below — swap the heading for the reason that applies (`Closed as out of scope`, `Closed as spam`):
+
+```markdown
+---
+
+## 🤖 Closed as duplicate
+
+Duplicate of [GHSA-SURVIVOR](https://github.com/Significant-Gravitas/AutoGPT/security/advisories/GHSA-SURVIVOR)
+— <one-line reason>. Triage, credit and any resulting fix stay on GHSA-SURVIVOR, which
+remains open. No action is needed from the reporter.
+
+_Closed by an automated duplicate-triage pass run with @Pwuts's account._
+```
+
+The 🤖 marker goes **inside** the heading; `🤖 ## Title` renders as literal hashes.
+Descriptions are public once published and these closures post under Reinier's account.
+
+### Dedup — decide which copy survives
 
 Compare the summary and the affected file against every state, not just published:
 
@@ -81,20 +109,37 @@ for s in triage draft published closed; do
 done
 ```
 
-**Failure mode with four live cases:** one reporter submitted five findings twice; for
-four of them a copy was closed and its identical twin was left in `triage`, where it
-still sits. After closing any duplicate, list that reporter's remaining triage items and
-close every copy:
+Then list the reporter's whole cluster, oldest first, before deciding anything:
 
 ```bash
 gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
-  | jq -r --arg who "$REPORTER" '.[] | select(.author.login == $who) | [.ghsa_id, .created_at[:10], .summary] | @tsv'
+  | jq -r --arg who "$REPORTER" '.[] | select(.author.login == $who)
+      | [.ghsa_id, .created_at, .submission.accepted, .summary] | @tsv' | sort -k2
 ```
+
+**Two fields decide the survivor — `created_at` and `submission.accepted`, never the
+text.** Keep the earliest, or the one carrying `submission.accepted: true` if any does,
+and close the later resubmissions. That is the pattern the maintainers applied across
+five pairs on 2026-05-16, and the copy that reached publication with a CVE was the
+earlier one.
+
+Two traps, both nearly paid for:
+
+- **Identical titles and byte-identical descriptions tell you nothing.** An earlier pass
+  read four pairs backwards on exactly that evidence; acting on it would have closed four
+  canonical unresolved reports, two of them critical.
+- **Never infer the survivor from which copy is already closed.** A closed copy usually
+  means the duplicate was handled correctly and the OPEN one is the report still needing
+  work — four of the queue's untouched items are survivors sitting in exactly that state.
+
+**Only close within one reporter.** Every cross-reporter pair in this corpus was left
+open: closing one costs an outside researcher their credit and their place in
+SECURITY.md §13. That is a maintainer's decision, not a triage call.
 
 ### Acknowledge
 
-**GitHub exposes no REST endpoint for advisory comments.** The acknowledgment is posted
-by a human in the advisory's web UI (`.html_url`). Draft it — one paragraph: received,
+With no advisory-comments API, the acknowledgment is posted by a human in the
+advisory's web UI (`.html_url`). Draft it — one paragraph: received,
 the date received, that we are reproducing it, and the next date they will hear from us
 — and hand it over. Do not let stage 2 start before this is drafted; the 5-business-day
 promise is the cheapest one to keep and the most visibly broken today.
@@ -305,7 +350,7 @@ Every one of these is a failure the corpus actually contains. Run them all.
 | Body is ours | not the reporter's submission republished |
 | Credits accepted | `gh api "/repos/$REPO/security-advisories/$GHSA" --jq '.credits_detailed[] \| [.user.login, .state] \| @tsv'` — 87 pending repo-wide, 17 on already-published advisories, so a named researcher never reaches the acknowledgments list. Ask once and wait; publish without them only at the 120-day backstop, and say so in the reply. |
 | CVE requested | `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"` for `high` and above. Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
-| Twins closed | no copy of this report left in `triage` |
+| Duplicate cluster resolved | this advisory is the survivor, and every later resubmission of it is closed **with the reason in its description** — no other copy left in `triage` |
 
 ### Publish, then close the loop
 

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -46,7 +46,8 @@ anything sent to a reporter.
 
 **Input:** a GHSA id, or nothing (take the queue's top item).
 **Artefact:** an acknowledgment drafted for a human to send, a dedup verdict naming
-the ids compared, and a completed metadata block on the advisory.
+the ids compared, and a completed metadata block on the advisory — including an affected
+version range derived from git history, never the reporter's.
 **Meets:** SECURITY.md *Target Timelines* — acknowledgment (5 business days) and triage
 (14 business days), both measured **from `created_at`**: receipt, not from when we picked
 it up. **Read the policy before quoting a number at a reporter.** The September 2026
@@ -231,6 +232,69 @@ name the single metric that differs and why, and put that sentence in the reply 
 reporter. If they dispute it once, a maintainer decides — do not negotiate twice. Never
 publish a reporter's vector unexamined, and never raise severity to end an argument.
 
+### Derive the affected versions from git history
+
+**Never carry the reporter's range forward.** Reporters almost never get it right, and
+the corpus wears it: `>= 0.1.0` with no upper bound, `>= 0.6.34` with none either, a
+package field reading `lautogpt-platform-beta-v0.6.45`, a range reading
+`Commit 57a06f7 <= autogpt-platform-beta-v0.6.33 <= `. The range is derived from git
+history every time, and the derivation is recorded in the triage note so the next reader
+can re-run it.
+
+Derive it here against the `file:line` the report names, and redo it after stage 2 —
+verification is what establishes the *actually* vulnerable line. Release tags sit on the
+`dev` line, so `git tag --contains` resolves against `origin/dev`; `git fetch --tags`
+first.
+
+1. **Locate the vulnerable code on `origin/dev`** — `file:line` from the reproduction
+   note, not from the report's prose.
+2. **Find the introducing commit**, two reads cross-checked:
+   ```bash
+   git log -S'<distinctive token from the vulnerable line>' --reverse \
+       --format='%H %ci %s' -- <path> | head -3
+   git blame -L <line>,<line> --porcelain <path> | head -1
+   ```
+   Record the sha and its author date. `-S` reports the commit that changed that token's
+   *count*, so a rename or a file move surfaces as the introduction; when the two reads
+   disagree, the older one is the lead — follow it with `git log --follow -M -C`.
+3. **First affected release** — the first platform tag containing that sha:
+   ```bash
+   git tag --contains <sha> --list 'autogpt-platform-beta-v*' | sort -V | head -1
+   ```
+   Empty output means the commit is in no release yet: nothing shipped is affected, and
+   the report is against unreleased code — say so and stop. An answer of
+   `autogpt-platform-beta-v0.2.1`, the first platform tag (2024-11-07), does **not** mean
+   the bug arrived in 0.2.1 — every earlier commit reports it too. Compare the commit's
+   date with the tag's; if it is older, the code predates every release and the range is
+   one-sided.
+4. **Fix release** — the same `--contains` on the fixing commit. With no fix yet,
+   `patched_versions` is left for publication and the range's upper bound is the current
+   release: `git tag --list 'autogpt-platform-beta-v*' | sort -V | tail -1`.
+5. **Write the result into the advisory's `vulnerabilities` field** in the notation below
+   — in the metadata `PATCH` under *Write the metadata block*, or on its own with
+   `advisory.sh edit <GHSA> --vulnerabilities-file <json>` (`--dry-run` first; it refuses
+   an empty array and a nameless package) — and into the triage note with both shas and
+   their dates. Where derivation was impossible, name the step that failed; never fall
+   back to the reporter's range.
+6. **A report against CI workflows or repo tooling ships in no release.** Record the
+   introducing and removing commits with their dates instead of a version range, and say
+   in the body that the affected artefact is the repository, not a release.
+
+**Three notations, one per case — do not invent a fourth:**
+
+| Case | `package.ecosystem` / `.name` | `vulnerable_version_range` | `patched_versions` |
+|---|---|---|---|
+| Platform, first affected release derived | `other` / `autogpt-platform-backend` | `>= 0.6.14, <= 0.6.67` | `0.6.68` |
+| Platform, introduction predates the first tag or step 2 failed | `other` / `Significant-Gravitas/AutoGPT autogpt_platform` | `< autogpt-platform-beta-v0.6.70` | `autogpt-platform-beta-v0.6.70` |
+| Classic — out of scope for new reports | `pip` / `autogpt-classic` | `< 0.6.66` | `0.6.66` |
+
+Reference records: GHSA-4m2w-qfr5-9f3v, GHSA-349p-3c3r-8mjr, and the six classic
+advisories published 2026-07-14. Bare semver and tag-named strings never mix inside one
+entry — the two-sided form is bare throughout, the one-sided form tag-named throughout.
+The two-sided upper bound is the **last affected** release (`<=`), not the patched one.
+GHSA-4m2w's record leaves `ecosystem` empty; that is the field's default, not a fourth
+convention.
+
 ### Write the metadata block
 
 Use `--input` — nested arrays do not survive `-f`. GitHub derives `severity` from the
@@ -255,7 +319,7 @@ cat > "$WORK/advisory.json" <<'JSON'
   "cwe_ids": ["CWE-862"],
   "vulnerabilities": [{
     "package": { "ecosystem": "other", "name": "autogpt-platform-backend" },
-    "vulnerable_version_range": ">= 0.7.0, < 0.7.4",
+    "vulnerable_version_range": ">= 0.7.0, <= 0.7.3",
     "patched_versions": "0.7.4"
   }]
 }
@@ -273,14 +337,11 @@ merge dropped someone.
 
 Three rules the corpus breaks constantly:
 
-- **One package spelling.** `autogpt-platform-backend` in ecosystem `other` for the
-  platform; `autogpt-classic` in `pip` for classic (which is out of scope, so you should
-  not be filing one). The repo carries roughly 30 distinct spellings, including a trailing
-  space and a missing leading letter.
-- **Bounded ranges only.** Bare semver taken from the `autogpt-platform-beta-vX.Y.Z`
-  tag, always two-sided, upper bound equal to `patched_versions`. `>= 0.6.34` with no
-  upper bound reads to a scanner as "every version including today's". Four published
-  advisories say exactly that.
+- **Package spelling and range come from the table above**, derived, never retyped. The
+  repo carries roughly 30 distinct spellings, including a trailing space and a missing
+  leading letter.
+- **Bounded ranges only.** `>= 0.6.34` with no upper bound reads to a scanner as "every
+  version including today's". Four published advisories say exactly that.
 - **Version strings collide.** `0.4.3` is both classic Auto-GPT v0.4.3 (2023) and
   `autogpt-platform-beta-v0.4.3` (2025). Say which in the body.
 
@@ -460,8 +521,8 @@ Every one of these is a failure the corpus actually contains. Run them all.
 | Check | Command / rule |
 |---|---|
 | Fix is in a release | `gh release view "autogpt-platform-beta-v$PATCHED"` — 40/40 got this right; do not be the first to break it |
-| Range is bounded | upper bound present, and equal to `patched_versions` |
-| Package spelling | exactly one canonical string (above) |
+| Range is derived and bounded | the two shas and dates are in the triage note (stage 1, *Derive the affected versions from git history*), and the upper bound is either `<= <last affected release>` or `< <patched>` — never absent, never the reporter's |
+| Package spelling | one of the three notations in stage 1, matching the case — not a fourth |
 | References present | `### References` non-empty, or explicitly "none" |
 | Body is ours | not the reporter's submission republished |
 | Credits accepted | `gh api "/repos/$REPO/security-advisories/$GHSA" --jq '.credits_detailed[] \| [.user.login, .state] \| @tsv'` — 87 pending repo-wide, 17 on already-published advisories, so a named researcher never reaches the acknowledgments list. Ask once and wait; publish without them only at the 120-day backstop, and say so in the reply. |

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -465,7 +465,7 @@ Every one of these is a failure the corpus actually contains. Run them all.
 | References present | `### References` non-empty, or explicitly "none" |
 | Body is ours | not the reporter's submission republished |
 | Credits accepted | `gh api "/repos/$REPO/security-advisories/$GHSA" --jq '.credits_detailed[] \| [.user.login, .state] \| @tsv'` — 87 pending repo-wide, 17 on already-published advisories, so a named researcher never reaches the acknowledgments list. Ask once and wait; publish without them only at the 120-day backstop, and say so in the reply. |
-| CVE requested | **STOP** — prepare `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"` for `high` and above; a human runs it. Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
+| CVE requested | **STOP** — prepare `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"`; a human runs it. **Every confirmed in-scope vulnerability gets one, whatever the severity** (Reinier, 2026-09-04). Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
 | Duplicate cluster resolved | this advisory is the survivor of *its own* duplicate set — every later resubmission of **this bug** closed with the reason in its description. The reporter's other open reports are other bugs and stay open; see step 1 |
 
 ### Publish, then close the loop
@@ -484,6 +484,70 @@ this process with a clean record — 34 researchers, all counts exact — and it
 by being generated, not hand-edited. Commit the regenerated SECURITY.md in an ordinary PR.
 
 Then: tell the reporter it is published, and close the Linear ticket if one exists.
+
+---
+
+## Endings off the main path
+
+Four cases the stages above do not reach. Each has an ending, because an advisory with no
+ending is where an agent improvises.
+
+### The twin is a `draft`, not a queued report
+
+Drafts are maintainer-created — all five current ones are — so a draft twin usually means
+we found the bug ourselves and are already fixing it. The batch query is `state=triage`
+only, so search drafts explicitly:
+
+```bash
+gh api "/repos/$REPO/security-advisories?state=draft&per_page=100" --paginate \
+  | jq -r '.[] | [.ghsa_id, .created_at[:10], (.summary // "")] | @tsv'
+```
+
+The draft is the survivor and the queued copy closes — **but add the reporter to the
+draft's credits first**, using the merge above. Do not close a researcher's report against
+our own draft while that draft has no credits entry for them: it is the one path that
+removes an outside reporter from the record entirely.
+
+### The reporter withdrew
+
+`withdrawn_at` is read-only and has never been set on this repo, so a withdrawal arrives
+as a comment in the advisory UI rather than as a field. Read the thread, and check the
+field before starting work:
+
+```bash
+gh api "/repos/$REPO/security-advisories/$GHSA" --jq '[.state, (.withdrawn_at // "-")] | @tsv'
+```
+
+Close it with the withdrawal as the reason. Never publish it, never request a CVE for it,
+and never credit the reporter without asking them first. If the bug is real, it is a
+finding of ours — open a draft; do not publish theirs.
+
+### Published, but no CVE was requested
+
+Publication is not the end of the queue. Eight published advisories carry no CVE, seven
+of them from the 2026-07-14 and 07-21 batches, and every confirmed in-scope vulnerability
+is meant to have one:
+
+```bash
+gh api "/repos/$REPO/security-advisories?state=published&per_page=100" --paginate \
+  | jq -r '.[] | select(.cve_id == null) | [.ghsa_id, .published_at[:10], .severity] | @tsv'
+```
+
+**STOP** — prepare the `POST …/cve` and hand it over. GitHub documents no state
+precondition for the request, but if it returns 400 or 422 on an already-published
+advisory, that is the answer: it goes to GitHub Support, not into a retry loop.
+
+### The fix turns out not to fix it
+
+**Stop. None of this is an agent action.** Publication cannot be undone — `withdrawn_at`
+is read-only and `withdrawn` is not a writable `state`, so only GitHub Support can retract
+an advisory. Tell Reinier and the advisory's publisher the same hour, treat the
+vulnerability as live and unfixed, and take the new fix back through stage 3 on a private
+fork. Update the **existing** advisory — corrected version range, new patched version, a
+Timeline entry — rather than opening a second one.
+
+**Open question, for Reinier and not for this file:** whether an incomplete fix warrants a
+second CVE. Common practice issues one; we have never had the case. Ask.
 
 ---
 
@@ -524,8 +588,9 @@ gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
       | [.ghsa_id, .severity, $age, .summary] | @tsv' | sort -k3 -rn
 ```
 
-The second query is what carries the day-105 escalation and the 120-day backstop. It must
-not filter on `updated_at`: an advisory leaves the untouched set the moment stage 1 writes
+A third pass belongs in the same run: the published advisories with no CVE, under
+*Endings off the main path*. The second query is what carries the day-105 escalation and
+the 120-day backstop. It must not filter on `updated_at`: an advisory leaves the untouched set the moment stage 1 writes
 its metadata, and about half the queue is already outside it.
 
 **What the sweep needs that this skill cannot give it:**

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -29,10 +29,12 @@ backlog is processed by running this skill per item, not by a separate tool.
 | 2 | Verify | the triaged report | reproduction note: proved-live vs read-in-source | agent (**runs on Fable**) |
 | 3 | Fix | the reproduction note | fix PR with tests, GHSA id in the commit body | agent |
 | 4 | Author | fix PR + reproduction note | the advisory body, in the template below | agent drafts |
-| 5 | Raise | body + fix PR + metadata | published advisory, refreshed SECURITY.md §13 | **human** reviews, merges, publishes |
+| 5 | Raise | body + fix PR + metadata | published advisory, regenerated SECURITY.md acknowledgments | **human** reviews, merges, publishes |
 
-Human calls, always: severity when it drives the embargo, the decision to disclose,
-the CVE request, merge approval, publication, a duplicate spanning two reporters, and
+**Three writes are irreversible and the agent never runs them: `state=closed`,
+`state=published`, and the CVE request.** The skill prepares each payload and stops; a
+human executes it. Also human, always: severity when it drives the embargo, merge
+approval, a duplicate spanning two reporters, choosing the public-PR fix route, and
 anything sent to a reporter.
 
 ---
@@ -42,8 +44,13 @@ anything sent to a reporter.
 **Input:** a GHSA id, or nothing (take the queue's top item).
 **Artefact:** an acknowledgment drafted for a human to send, a dedup verdict naming
 the ids compared, and a completed metadata block on the advisory.
-**Meets:** SECURITY.md §4.1 acknowledgment (5 business days) and triage (14 business
-days), both measured **from `created_at`** — receipt, not from when we picked it up.
+**Meets:** SECURITY.md *Target Timelines* — acknowledgment (5 business days) and triage
+(14 business days), both measured **from `created_at`**: receipt, not from when we picked
+it up. **Read the policy before quoting a number at a reporter.** The September 2026
+rewrite is on `master`; `dev` still carries the November 2024 policy, which promises 14
+business days to acknowledge and a different clock (90-day fix window, then 30 days for
+users to update). Sections are cited by title here because only the `master` version is
+numbered.
 
 ### Pick an item
 
@@ -60,23 +67,39 @@ Rank untouched criticals first, then by age. A named GHSA id skips this.
 gh api "/repos/$REPO/security-advisories/$GHSA"
 ```
 
+### Working files never live in a checkout
+
+An advisory's `description` is an unpublished vulnerability report. Keep every scratch
+file out of the repo tree, in one directory named once and used throughout:
+
+```bash
+WORK=~/code/agpt/.claude/vuln/$GHSA && mkdir -p "$WORK"
+```
+
 ### Close it out instead, if any of these hold
 
 - The code is in `classic/` — out of scope per SECURITY.md.
 - It is the JWKS cleartext-transport warning — explicitly not eligible.
-- It is spam or a test submission (`Hack`, `pvr-test`, empty bodies).
-- It is a later resubmission of an earlier report by the same reporter — see below.
+- It is spam or a test submission (`Hack`, `pvr-check`, `Matthew`, empty bodies — the
+  corpus has more shapes than any list here; judge it).
+- It is a later resubmission of an earlier report by the same reporter — and the duplicate
+  test below passed.
 
 There is no advisory-comments API, so `description` is the **only** API-writable place
-for a closure reason. Write it there in the *same* `PATCH` that sets the state, so a
-failed call leaves the advisory untouched rather than closed without explanation. Back
-the record up first: `state` accepts only `published`, `closed` and `draft` — `triage`
-returns 422, so a closure cannot be undone through the API.
+for a closure reason. It goes in the *same* `PATCH` that sets the state, so a failed call
+leaves the advisory untouched rather than closed without explanation.
+
+> **STOP — prepare this, do not run it.** `state` accepts only `published`, `closed` and
+> `draft`; `triage` returns 422, so a closure can never be undone through the API. Build
+> the payload, back the record up, and hand both to a human with your reason. The `PATCH`
+> is theirs to run.
 
 ```bash
-gh api "/repos/$REPO/security-advisories/$GHSA" > "$GHSA.backup.json"
-jq -n --rawfile d body.md '{description: $d, state: "closed"}' > close.json
-gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input close.json
+gh api "/repos/$REPO/security-advisories/$GHSA" > "$WORK/before.json"    # agent
+jq -n --rawfile d "$WORK/body.md" '{description: $d, state: "closed"}' > "$WORK/close.json"
+
+# human runs these two:
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/close.json"
 gh api "/repos/$REPO/security-advisories/$GHSA" \
   --jq '[.state, .closed_at, (.description|length)] | @tsv'    # read back and confirm
 ```
@@ -92,13 +115,16 @@ Duplicate of [GHSA-SURVIVOR](https://github.com/Significant-Gravitas/AutoGPT/sec
 — <one-line reason>. Triage, credit and any resulting fix stay on GHSA-SURVIVOR, which
 remains open. No action is needed from the reporter.
 
-_Closed by an automated duplicate-triage pass run with @Pwuts's account._
+_Closed by a maintainer after an automated duplicate-triage pass, using @Pwuts's account._
 ```
 
 The 🤖 marker goes **inside** the heading; `🤖 ## Title` renders as literal hashes.
 Descriptions are public once published and these closures post under Reinier's account.
 
-### Dedup — decide which copy survives
+### Dedup — two steps, in this order
+
+**Step 1 establishes that two reports are the same bug. Step 2 decides which copy
+survives. Never run step 2 on the output of the reporter listing alone.**
 
 Compare the summary and the affected file against every state, not just published:
 
@@ -109,32 +135,61 @@ for s in triage draft published closed; do
 done
 ```
 
-Then list the reporter's whole cluster, oldest first, before deciding anything:
+#### Step 1 — is this a duplicate set at all?
+
+A same-reporter listing is **not** a duplicate set. Researchers file batches: 13 reporters
+have more than one report in the queue and 42 of the 59 sit in such a batch. This is one
+reporter's, minutes apart, and every row is a different bug:
+
+```
+GHSA-8vm4-8gj4-crrv  10:59:27  high      PATH_TRAVERSAL in data.py
+GHSA-r7xf-m4q6-qpc9  10:59:37  high      SSRF in client.py
+GHSA-f4vx-7gff-9c6c  11:00:38  critical  RCE in _utils.py
+GHSA-rm96-587h-qhg6  11:02:28  critical  RCE in linter.py
+GHSA-7353-x5vf-fr3c  11:05:14  medium    XSS in text.py
+GHSA-96rm-9gw4-8qvx  11:06:03  high      SSRF in manager.py
+```
+
+Two reports are the same bug only when **both** hold:
+
+- **same component** — the same module, file or `file:line`; and
+- **same effect** — the same class of impact through the same code path.
+
+**If the batch spans different components, it is not a duplicate set. Close nothing and
+work each report on its own.** Two criticals in that listing are RCEs in different files;
+a rule that keeps the earliest would close them both.
+
+List the reporter's batch and read it against those two tests:
 
 ```bash
 gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
   | jq -r --arg who "$REPORTER" '.[] | select(.author.login == $who)
-      | [.ghsa_id, .created_at, .submission.accepted, .summary] | @tsv' | sort -k2
+      | [.ghsa_id, .created_at, .summary] | @tsv' | sort -k2
 ```
 
-**Two fields decide the survivor — `created_at` and `submission.accepted`, never the
-text.** Keep the earliest, or the one carrying `submission.accepted: true` if any does,
-and close the later resubmissions. That is the pattern the maintainers applied across
-five pairs on 2026-05-16, and the copy that reached publication with a CVE was the
-earlier one.
+#### Step 2 — within a confirmed duplicate set, the earliest survives
 
-Two traps, both nearly paid for:
+`created_at` decides, and nothing else: keep the earliest, close the later
+resubmissions. That is the pattern the maintainers applied across five pairs on
+2026-05-16, and the copy that reached publication with a CVE was the earlier one.
 
-- **Identical titles and byte-identical descriptions tell you nothing.** An earlier pass
-  read four pairs backwards on exactly that evidence; acting on it would have closed four
-  canonical unresolved reports, two of them critical.
+Text similarity belongs to step 1 only — it establishes *that* two reports are the same
+bug, and must never decide *which copy* survives. Two traps, both nearly paid for:
+
+- **Identical titles and byte-identical descriptions do not identify the survivor.** An
+  earlier pass read four pairs backwards on exactly that evidence; acting on it would
+  have closed four canonical unresolved reports, two of them critical.
 - **Never infer the survivor from which copy is already closed.** A closed copy usually
   means the duplicate was handled correctly and the OPEN one is the report still needing
   work — four of the queue's untouched items are survivors sitting in exactly that state.
 
+`submission.accepted` looks like a second signal and is not: it is `false` on all 59
+queued reports and only flips at acceptance or publication. Do not read it here.
+
 **Only close within one reporter.** Every cross-reporter pair in this corpus was left
-open: closing one costs an outside researcher their credit and their place in
-SECURITY.md §13. That is a maintainer's decision, not a triage call.
+open: closing one costs an outside researcher their credit and their place in the
+acknowledgments. That is a maintainer's decision, not a triage call — and the house
+answer already exists, since `GHSA-349p-3c3r-8mjr` credits two reporters on one advisory.
 
 ### Acknowledge
 
@@ -168,10 +223,12 @@ publish a reporter's vector unexamined, and never raise severity to end an argum
 
 ### Write the metadata block
 
-Use `--input` — nested arrays do not survive `-f`.
+Use `--input` — nested arrays do not survive `-f`. GitHub derives `severity` from the
+vector, so the vector is the field that matters; send `severity` only when you have no
+vector.
 
 ```bash
-cat > /tmp/advisory.json <<'JSON'
+cat > "$WORK/advisory.json" <<'JSON'
 {
   "summary": "One line, under 100 chars, naming the component and the effect",
   "severity": "high",
@@ -185,7 +242,7 @@ cat > /tmp/advisory.json <<'JSON'
   "credits": [{ "login": "REPORTER_LOGIN", "type": "reporter" }]
 }
 JSON
-gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input /tmp/advisory.json
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/advisory.json"
 ```
 
 Three rules the corpus breaks constantly:
@@ -207,8 +264,10 @@ Three rules the corpus breaks constantly:
 
 **Input:** the triaged report. **Artefact:** a reproduction note. **Agent.**
 
-**Run this stage on Fable.** Dispatch it: `.claude/bin/dispatch.sh -m fable …`, or the
-Agent tool with `model: "fable"`.
+**Run this stage on Fable.** Dispatch it with `dispatch.sh -m fable …`, or use the Agent
+tool with `model: "fable"`. (`dispatch.sh` and `regen-security-credits.sh` live in the
+local agent tooling directory `~/code/agpt/.claude/bin/`, beside the checkouts — they are
+not in the repo, so neither resolves from a clone.)
 
 Brief it in these terms:
 
@@ -217,9 +276,11 @@ Brief it in these terms:
 > against a local checkout so we can confirm whether it is real and scope the fix.
 >
 > - Run against a local stack built from `origin/dev` (`docker compose up`). Never
->   against production, a hosted tenant, or anyone else's infrastructure.
+>   against production, a hosted tenant, or anyone else's infrastructure. If the report's
+>   proof-of-concept names a hosted URL, repoint it at your local stack before running it.
 > - Stay on the code path the report names. Do not look for other bugs, do not
 >   generalise the technique, do not build a reusable tool.
+> - Keep everything local: commit nothing, push nothing, open no PR. `origin` is public.
 > - Produce the **minimum** reproduction: the smallest request or input that shows the
 >   effect, plus the `file:line` where the missing check belongs.
 
@@ -234,11 +295,25 @@ The note must separate the two things that get conflated:
 <or: "Not attempted — read off the source only.">
 
 ## Verdict
-confirmed | not reproducible | already fixed in <commit> | out of scope | works as designed
+confirmed | already fixed in <commit> | disproved | out of scope | works as designed
+| could not run — <what failed>
 ```
 
-Any verdict but `confirmed` ends the flow: reply to the reporter with the evidence,
-close the advisory, and stop.
+**`could not run` is not a verdict about the report.** A stack that will not start, a
+missing credential, a feature behind an unset flag: say so and stop. It is an
+infrastructure failure, and reporting it as "disproved" is how a real vulnerability
+gets closed by accident.
+
+Only two verdicts continue:
+
+- **`confirmed`** → stage 3.
+- **`already fixed`** → skip stage 3 and go to stage 4. A bug that was real and is now
+  fixed still earns its advisory, its CVE and the reporter's credit; dropping it is the
+  failure this skill exists to stop.
+
+Every other verdict produces a **recommendation to close, handed to a human with the
+evidence** — never a `PATCH`, and never a message to the reporter, which is a human call
+in any case.
 
 ---
 
@@ -251,11 +326,17 @@ Two routes:
 - **Unfixed and undisclosed → private fork.** This is the correct pattern and the repo
   has 14 of them.
   ```bash
-  gh api -X POST "/repos/$REPO/security-advisories/$GHSA/forks"   # returns .full_name
+  gh api -X POST "/repos/$REPO/security-advisories/$GHSA/forks"
   ```
-  Open the fix PR inside that fork, never against the public repo.
+  Returns 202; GitHub creates the fork asynchronously and it can take up to five minutes,
+  so poll for it rather than cloning straight away. Open the fix PR inside that fork,
+  never against the public repo.
 - **Already public** (the bug is visible in a merged PR, an open issue, or the reporter
-  published) → an ordinary PR is fine; fix first, advisory after.
+  published) → an ordinary PR is fine; fix first, advisory after. **This route needs
+  Reinier's explicit approval, by name, every time.** `CLAUDE.md`: *"Never open a public
+  PR that discloses an active, unfixed vulnerability without Reinier's explicit
+  approval."* Establishing that a bug is already public is exactly the judgement that
+  rule reserves; default to the private fork.
 
 Either way: tests covering the reproduction, the GHSA id in the commit body, and a real
 commit message — 3 of the 14 fork merges have an empty body and only 4 name the GHSA.
@@ -266,7 +347,8 @@ publication; `origin` is public.
 
 ## Stage 4 — Author the advisory body
 
-**Input:** the fix PR and the reproduction note. **Artefact:** the published description.
+**Input:** the reproduction note, plus the fix PR — or, for an `already fixed` verdict,
+the commit and release that fixed it. **Artefact:** the published description.
 **Agent drafts, human approves.**
 
 **This is the stage that does not exist today.** 36 of 40 published advisories are the
@@ -275,8 +357,14 @@ The reporter's text is *evidence*. The published body is a different document fo
 different audience — someone running AutoGPT who needs to know if they are affected and
 what to upgrade to. Only 16 of 40 published bodies mention a version or a fix at all.
 
-Write it fresh, in this template, and keep the reporter's original under
-`Original report` if it carries detail worth preserving.
+Write it fresh, in this template. **The reporter's submission is evidence: back it up and
+keep it.** This `PATCH` overwrites `description`, the only copy, and the API exposes no
+version history. Append the original verbatim under an `### Original report` heading — not
+conditionally, always.
+
+```bash
+gh api "/repos/$REPO/security-advisories/$GHSA" --jq .description > "$WORK/original.md"
+```
 
 ```markdown
 ### Impact
@@ -315,8 +403,8 @@ No advisory in the corpus has one.>
 ```
 
 ```bash
-gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" \
-  -f description="$(cat advisory-body.md)"
+jq -n --rawfile d "$WORK/advisory-body.md" '{description: $d}' > "$WORK/body-patch.json"
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/body-patch.json"
 ```
 
 ---
@@ -333,9 +421,10 @@ every-few-weeks batch sweep that produced a median 82-day created→published ti
 cases where the fix had shipped 200+ days earlier. As soon as the patched version is a
 real release tag, this advisory is ready.
 
-The 120-day clock in SECURITY.md §4.1 runs from **receipt**. Escalate to the maintainer
-at day 105 with either a publication date or a reason; it is a backstop that fires with
-or without a release.
+The 120-day clock in the policy's *Target Timelines* runs from **receipt**. Escalate to
+the maintainer at day 105 with either a publication date or a reason; it is a backstop
+that fires with or without a release. Nothing computes that date inside a single run —
+the daily sweep's deadline query is what surfaces it.
 
 ### Pre-publication checks
 
@@ -349,21 +438,23 @@ Every one of these is a failure the corpus actually contains. Run them all.
 | References present | `### References` non-empty, or explicitly "none" |
 | Body is ours | not the reporter's submission republished |
 | Credits accepted | `gh api "/repos/$REPO/security-advisories/$GHSA" --jq '.credits_detailed[] \| [.user.login, .state] \| @tsv'` — 87 pending repo-wide, 17 on already-published advisories, so a named researcher never reaches the acknowledgments list. Ask once and wait; publish without them only at the 120-day backstop, and say so in the reply. |
-| CVE requested | `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"` for `high` and above. Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
+| CVE requested | **STOP** — prepare `gh api -X POST "/repos/$REPO/security-advisories/$GHSA/cve"` for `high` and above; a human runs it. Requested consistently until July 2026, then dropped for two batches — 6 of the 8 published advisories with no CVE come from those two days. |
 | Duplicate cluster resolved | this advisory is the survivor, and every later resubmission of it is closed **with the reason in its description** — no other copy left in `triage` |
 
 ### Publish, then close the loop
 
+> **STOP — a human runs both of these.** Publication is irreversible and public: it
+> pushes the advisory into GitHub's vulnerability database. Hand over the checklist
+> results and the drafted body; do not run the `PATCH`.
+
 ```bash
 gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" -f state=published
-.claude/bin/regen-security-credits.sh          # rewrites SECURITY.md §13 from the API
+regen-security-credits.sh          # rewrites the SECURITY.md acknowledgments from the API
 ```
 
 Regenerate the acknowledgments on **every** publication. That section is the one part of
 this process with a clean record — 34 researchers, all counts exact — and it stays clean
-by being generated, not hand-edited. (The script is written separately; in the local
-agent setup it lives in `~/code/agpt/.claude/bin/`.) Commit the regenerated SECURITY.md
-in an ordinary PR.
+by being generated, not hand-edited. Commit the regenerated SECURITY.md in an ordinary PR.
 
 Then: tell the reporter it is published, and close the Linear ticket if one exists.
 
@@ -371,18 +462,22 @@ Then: tell the reporter it is published, and close the Linear ticket if one exis
 
 ## What SECURITY.md promises, and where this skill keeps it
 
-| Promise | Kept at |
-|---|---|
-| §4.1 Acknowledgment within **5 business days** of receipt | Stage 1, drafted before verification starts |
-| §4.1 Triage within **14 business days** of receipt | Stage 1 complete: dedup verdict, CVSS vector, metadata block |
-| §4.1 Remediation within **90 days** | Stage 3 |
-| §4.1 Disclosure typically within **120 days of report** | Stage 5, per-advisory on fix-released; escalation at day 105 |
-| §4.2 Keep reporters informed | Stage 1 acknowledgment, stage 2 verdict reply, stage 5 publication notice |
-| §5 Coordinated disclosure — fix before publish | Stage 5 pre-publication check |
-| §9 Credit, subject to consent | Stage 1 sets credits; stage 5 verifies acceptance and regenerates §13 |
+Sections are named by title: only `master`'s SECURITY.md is numbered, and `dev`'s
+November 2024 policy is a different document with different numbers.
 
-Both clocks start at `created_at`. For a backlog item that means the deadline has often
-already passed — record the real dates in the Timeline section anyway.
+| Promise (*section*) | Where | Kept, or only surfaced |
+|---|---|---|
+| Acknowledgment in **5 business days** (*Target Timelines*) | Stage 1 | **Surfaced.** The skill drafts; a human must post it, nothing records that it was sent, and business-day arithmetic is absent |
+| Triage in **14 business days** (*Target Timelines*) | Stage 1 | **Surfaced.** The artefacts are real; no deadline is computed |
+| Remediation in **90 days** (*Target Timelines*) | Stage 3 | **Surfaced only.** Stage 3 carries no clock |
+| Disclosure in **120 days of report** (*Target Timelines*) | Stage 5 + the sweep's deadline query | **Surfaced.** Depends entirely on the sweep running daily |
+| Keep reporters informed (*Communication*) | Stages 1, 2, 5 | **Surfaced.** All three are human-in-the-UI actions |
+| Fix before publish (*Coordinated Disclosure*) | Stage 5 checklist | **Kept.** `gh release view` is a real gate |
+| Credit, subject to consent (*Recognition*) | Stages 1 and 5 | **Kept.** The `credits_detailed` query is a real gate |
+
+Both clocks start at `created_at`. For a backlog item the deadline has often already
+passed — record the real dates in the Timeline section anyway. Nothing here becomes
+*kept* rather than *surfaced* without the per-advisory ledger described below.
 
 ---
 
@@ -391,11 +486,20 @@ already passed — record the real dates in the Timeline section anyway.
 A scheduled run enumerates the queue and works items in rank order:
 
 ```bash
+# never answered — the acknowledgment backlog
+gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
+  | jq -r '.[] | select(.updated_at == .created_at) | [.ghsa_id, .severity, .summary] | @tsv'
+
+# approaching a deadline — every queued report, touched or not
 gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
   | jq -r --argjson now "$(date +%s)" '
-      .[] | select(.updated_at == .created_at)
-      | [.ghsa_id, .severity, (($now - (.created_at|fromdate))/86400|floor), .summary] | @tsv'
+      .[] | (($now - (.created_at|fromdate))/86400|floor) as $age | select($age >= 105)
+      | [.ghsa_id, .severity, $age, .summary] | @tsv' | sort -k3 -rn
 ```
+
+The second query is what carries the day-105 escalation and the 120-day backstop. It must
+not filter on `updated_at`: an advisory leaves the untouched set the moment stage 1 writes
+its metadata, and 30 of the 59 queued reports are already outside it.
 
 **What the sweep needs that this skill cannot give it:**
 
@@ -408,8 +512,8 @@ gh api "/repos/$REPO/security-advisories?state=triage&per_page=100" --paginate \
 - **A maintainer on duty.** Severity confirmation, disclosure, CVE, merge and publication
   are human. An unattended 03:00 run finishes at the end of stage 4 and no further.
 - **The other intake channels.** The sweep sees GitHub advisories only.
-  `security@agpt.co` is advertised in §2.1 but SECRT-2020 says the mailing list was never
-  set up; Huntr reports arrive with no advisory record at all.
+  `security@agpt.co` is advertised under *Reporting Channels* but SECRT-2020 says the
+  mailing list was never set up; Huntr reports arrive with no advisory record at all.
 - **Business-day arithmetic.** The 5- and 14-day promises are business days, holidays
   included.
 

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -80,6 +80,44 @@ file out of the repo tree, in one directory named once and used throughout:
 WORK=~/code/agpt/.claude/vuln/$GHSA && mkdir -p "$WORK"
 ```
 
+### Read the code as it was when the report arrived
+
+A verdict read off today's `dev` is a verdict about today's code, not about the report
+(Reinier, 2026-09-07: "verify each claim against `master` at the time of submission").
+Resolve the submission-time head first, and read there — `git show`/`git grep` take a
+commit, so nothing is checked out and no worktree state moves:
+
+```bash
+CREATED=$(gh api "/repos/$REPO/security-advisories/$GHSA" --jq .created_at)
+HEAD_AT=$(git rev-list -1 --before="$CREATED" origin/master)
+git show "$HEAD_AT:<path>"
+```
+
+`GHSA-7w5j-7f2q-4h2g` is why. Its excerpt of `.github/workflows/claude.yml` was accurate
+the day it was filed — at `7cc1edc61f` the gate did admit
+`author_association == 'COLLABORATOR'` — and `ed461156bd` narrowed it to `OWNER`/`MEMBER`
+27 hours later, so a September read showed a file the reporter had never seen. The report
+still fails, on a premise that does not move (`COLLABORATOR` means *invited to collaborate
+on the repository*, not *has had a PR merged*, which is `CONTRIBUTOR`) — but "the code
+does not say what you quoted" would have been the wrong reason.
+
+Two cheap queries settle most rows, and it is the second that does the work:
+
+| Query | What it settles |
+|---|---|
+| `git rev-parse "$HEAD_AT:<path>"` against the blob at the head you read | Identical blobs mean the verdict was read off the same bytes. Ran on seven reports on 2026-09-07 it settled two — active files move — so run it first and plan for a fresh read anyway. |
+| `git log --all -S'<the claimed sink>' -- <dir>` | Zero commits means the sink has never existed on any ref at any date, so no line-by-line reading is needed. Five of those same seven quoted a sink that returns zero. |
+
+**A zero from the sink search proves nothing until a control returns non-zero**, because a
+mistyped pathspec returns zero identically: `-- autogpt_platform/backend/backend/scripts`
+(one `backend` too many) gives 0 commits for `subprocess.run` where the real
+`autogpt_platform/backend/scripts` gives 19. Pair every search with a term you know that
+directory contains, and confirm the path has history at all:
+`git log --all --format= --name-only -- <path> | sort -u`.
+
+The triage row records all of it: the submission-time head, the named file's blob there
+and at the head you read, and the sink search with its control.
+
 ### Close it out instead, if any of these hold
 
 - The code is in `classic/` — out of scope per SECURITY.md.
@@ -89,41 +127,49 @@ WORK=~/code/agpt/.claude/vuln/$GHSA && mkdir -p "$WORK"
 - It is a later resubmission of an earlier report by the same reporter — and the duplicate
   test below passed.
 
-There is no advisory-comments API, so `description` is the **only** API-writable place
-for a closure reason. It goes in the *same* `PATCH` that sets the state, so a failed call
-leaves the advisory untouched rather than closed without explanation.
+**The closure reason is a comment on the advisory, never an append to its description**
+(Reinier, 2026-09-08, after seven closures appended one). The description is the
+reporter's submission; a maintainer's verdict written into it rewrites what they filed,
+and it is public the moment the advisory is published.
+
+No script can post that comment. GitHub exposes no advisory-comments endpoint —
+`GET /repos/$REPO/security-advisories/$GHSA/comments` returns 404 and
+`RepositoryAdvisory` is absent from GraphQL — so the note goes to a file and Reinier
+pastes it in the web UI.
 
 > **STOP — prepare this, do not run it.** `state` accepts only `published`, `closed` and
 > `draft`; `triage` returns 422, so a closure can never be undone through the API. Build
 > the payload, back the record up, and hand both to a human with your reason. The `PATCH`
 > is theirs to run.
 
+`advisory.sh close` does both halves — it backs the record up, PATCHes the state alone,
+and appends the note to `.claude/log/advisory-closure-notes-<date>.md`:
+
+```bash
+advisory.sh close "$GHSA" --duplicate-of GHSA-SURVIVOR --reason '<one-line reason>'
+advisory.sh close "$GHSA" --not-a-vulnerability --reason '<one-line reason>'
+```
+
+By hand, the state write carries nothing else:
+
 ```bash
 gh api "/repos/$REPO/security-advisories/$GHSA" > "$WORK/before.json"    # agent
-jq -n --rawfile d "$WORK/body.md" '{description: $d, state: "closed"}' > "$WORK/close.json"
 
 # human runs these two:
-gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" --input "$WORK/close.json"
+gh api -X PATCH "/repos/$REPO/security-advisories/$GHSA" -f state=closed
 gh api "/repos/$REPO/security-advisories/$GHSA" \
-  --jq '[.state, .closed_at, (.description|length)] | @tsv'    # read back and confirm
+  --jq '[.state, .closed_at, (.description|length)] | @tsv'    # description unchanged
 ```
 
-`body.md` is the original description, unchanged, followed by the block below — swap the heading for the reason that applies (`Closed as out of scope`, `Closed as spam`):
+The note itself is one paragraph — verdict, the evidence a reader can re-run, what the
+reporter should expect:
 
 ```markdown
----
-
-## 🤖 Closed as duplicate
-
-Duplicate of [GHSA-SURVIVOR](https://github.com/Significant-Gravitas/AutoGPT/security/advisories/GHSA-SURVIVOR)
-— <one-line reason>. Triage, credit and any resulting fix stay on GHSA-SURVIVOR, which
-remains open. No action is needed from the reporter.
-
-_Closed by a maintainer after an automated duplicate-triage pass, using @Pwuts's account._
+🤖 Closed as a duplicate of GHSA-SURVIVOR — <one-line reason>. Triage, credit and any
+resulting fix stay on GHSA-SURVIVOR, which remains open. No action is needed from you.
 ```
 
-The 🤖 marker goes **inside** the heading; `🤖 ## Title` renders as literal hashes.
-Descriptions are public once published and these closures post under Reinier's account.
+The 🤖 marker is the first visible thing, because these post under Reinier's account.
 
 ### Dedup — two steps, in this order
 
@@ -376,7 +422,8 @@ The note must separate the two things that get conflated:
 
 ```markdown
 ## Static code analysis
-<what the source shows — file:line, the missing check>
+<what the source shows — file:line at the submission-time head AND at current dev,
+ named as commits; say so when they are the same commit>
 
 ## Live server verification
 <what was actually executed against the running stack, and its response>

--- a/.claude/skills/process-vulnerability-report/SKILL.md
+++ b/.claude/skills/process-vulnerability-report/SKILL.md
@@ -93,13 +93,13 @@ HEAD_AT=$(git rev-list -1 --before="$CREATED" origin/master)
 git show "$HEAD_AT:<path>"
 ```
 
-`GHSA-7w5j-7f2q-4h2g` is why. Its excerpt of `.github/workflows/claude.yml` was accurate
-the day it was filed — at `7cc1edc61f` the gate did admit
-`author_association == 'COLLABORATOR'` — and `ed461156bd` narrowed it to `OWNER`/`MEMBER`
-27 hours later, so a September read showed a file the reporter had never seen. The report
-still fails, on a premise that does not move (`COLLABORATOR` means *invited to collaborate
-on the repository*, not *has had a PR merged*, which is `CONTRIBUTOR`) — but "the code
-does not say what you quoted" would have been the wrong reason.
+A report's excerpt goes stale on its own, sometimes within a day of filing: the files
+worth reporting on are the ones under active development, so an excerpt that was accurate
+at `created_at` routinely disagrees with today's `dev`. That disagreement is evidence
+about the elapsed time, never about the report. Such a report can still fail — but on a
+premise that does not move, such as what an identifier actually means or what a check
+actually admits. "The code does not say what you quoted" is the wrong reason, and the one
+that reads as sloppy to a researcher who quoted it correctly.
 
 Two cheap queries settle most rows, and it is the second that does the work:
 
@@ -189,23 +189,24 @@ done
 
 A same-reporter listing is **not** a duplicate set. Researchers file batches — most
 multi-report reporters in the queue are filing several different bugs at once, not
-resubmitting one. This is one reporter's, minutes apart, and every row is a different bug:
+resubmitting one. The shape to expect — one reporter, filed minutes apart, every row a
+different bug:
 
 ```
-GHSA-8vm4-8gj4-crrv  10:59:27  high      PATH_TRAVERSAL in data.py
-GHSA-r7xf-m4q6-qpc9  10:59:37  high      SSRF in client.py
-GHSA-f4vx-7gff-9c6c  11:00:38  critical  RCE in _utils.py
-GHSA-rm96-587h-qhg6  11:02:28  critical  RCE in linter.py
-GHSA-7353-x5vf-fr3c  11:05:14  medium    XSS in text.py
-GHSA-96rm-9gw4-8qvx  11:06:03  high      SSRF in manager.py
+GHSA-xxxx-xxxx-xxx1  09:14:02  high      PATH_TRAVERSAL in <module A>
+GHSA-xxxx-xxxx-xxx2  09:14:11  high      SSRF in <module B>
+GHSA-xxxx-xxxx-xxx3  09:15:20  critical  RCE in <module C>
+GHSA-xxxx-xxxx-xxx4  09:17:46  critical  RCE in <module D>
+GHSA-xxxx-xxxx-xxx5  09:20:33  medium    XSS in <module E>
+GHSA-xxxx-xxxx-xxx6  09:21:19  high      SSRF in <module F>
 ```
 
 **The test is: would one fix fix both?** Same file is not enough, and neither is the
 reporter calling it "the same pattern" — a systematic auditor's batch is the same class of
-bug in the same file at different call sites. Two live examples that pass a same-file test
-and fail this one: two token-reuse races in one OAuth module, at the authorization-code
-path and the refresh path; and two hardcoded defaults in one `.env` file, a JWT signing
-key and a Fernet key. Each pair needs two fixes, so each is two bugs.
+bug in the same file at different call sites. Two shapes that pass a same-file test and
+fail this one: one race reported against two call sites in a single module, each needing
+its own guard; and two weak defaults in a single config file, one per constant. Each pair
+needs two fixes, so each is two bugs.
 
 Summaries are not enough evidence for that call — they name behaviours, not lines. Fetch
 the batch and read the descriptions:
@@ -219,10 +220,10 @@ jq -r '[.ghsa_id, .created_at, .severity, .summary] | @tsv' "$WORK"/GHSA-*.json 
 ```
 
 **If the batch is a mix, it is not a duplicate set: close nothing and work each report on
-its own.** Two criticals in the listing above are RCEs in different files; a rule that
-keeps the earliest would close them both. That stop is about the batch as a whole — a
-genuine duplicate *pair* inside a mixed batch is still a duplicate, and the one-fix test
-governs it.
+its own.** The two criticals above are RCEs in different modules; a rule that keeps the
+earliest would close them both. That stop is about the batch as a whole — a genuine
+duplicate *pair* inside a mixed batch is still a duplicate, and the one-fix test governs
+it.
 
 #### Step 2 — within a confirmed duplicate set, the earliest survives
 


### PR DESCRIPTION
Adds a `/process-vulnerability-report` skill that takes one reported vulnerability from the GitHub security-advisory triage queue through to a published advisory.

A GitHub security advisory is a private record on the repo: outside researchers file one through a web form, it sits in state `triage` until a maintainer works it, and publishing makes it public and pushes it into GitHub's vulnerability database. This skill is the procedure for working one of those, start to finish.

### Stages

| # | Stage | Artefact | Decides |
|---|---|---|---|
| 1 | Triage | acknowledgment, dedup verdict, CVSS vector, metadata block | agent proposes; human confirms severity and sends the acknowledgment |
| 2 | Verify | reproduction note separating "proved live" from "read in source" | agent, run on Fable |
| 3 | Fix | fix PR with tests, GHSA id in the commit body | agent |
| 4 | Author the advisory body | the published description, in a fixed template | agent drafts |
| 5 | Raise to a maintainer | published advisory + regenerated SECURITY.md §13 | human reviews, merges, publishes |

Stage 1 works the same on a report filed five minutes ago and on one that has sat untouched since April, so the untouched backlog is cleared by running the skill per item rather than by a separate tool. A scheduled daily run can enumerate `?state=triage` and rank it; the skill names what such a sweep still needs and does not have — a durable per-advisory ledger, a way to actually send the acknowledgment, and a maintainer on duty for the human steps.

### What it changes about current practice

- **Authoring the advisory body becomes a stage.** 36 of 40 published advisories are the reporter's submission published verbatim, and only 16 of 40 mention a version or a fix anywhere in the prose. The skill carries a concrete template — Impact / Affected versions / Patches / Workarounds / Details / PoC / References / Credit / Timeline.
- **A CVSS vector is required, and re-derived independently.** Reporters overstate; the skill gives per-metric anchors for this codebase and a rule for handling disagreement (ours ships, both recorded, the maintainer settles a dispute once).
- **Affected versions are derived from git history, never the reporter's.** A numbered procedure in stage 1 walks the introducing commit (`git log -S` cross-checked against `git blame`) to the first platform release containing it (`git tag --contains <sha> --list 'autogpt-platform-beta-v*' | sort -V | head -1`), and the three notations the published corpus uses — two-sided bare semver, one-sided tag-named, and classic's `pip` form — are tabled so a run does not invent a fourth.
- **The disclosure clock starts at receipt**, and publication becomes per-advisory on the fix landing in a release rather than the periodic batch sweep.
- **Deduplication is two steps, in order.** Step 1 establishes that two reports are the same bug — the test is whether one fix fixes both, applied to the batch's full descriptions rather than its titles — and a mixed batch is not a duplicate set and closes nothing. Step 2 then picks the survivor by `created_at` alone. A same-reporter listing is not a duplicate set: most multi-report reporters in the queue are filing several different bugs at once, one of them six within seven minutes. Duplicates are only ever closed within one reporter, because a cross-reporter pair costs a researcher their credit and is a maintainer's decision.
- **The metadata write preserves existing credits.** GitHub replaces the `credits` array rather than appending to it, so a payload naming one reporter erases every co-reporter. The array is built from the advisory's current credits, the record is backed up first, and the credits are read back after.
- **The three irreversible writes are STOP points, not steps.** `state=closed`, `state=published` and the CVE request are prepared by the skill and executed by a human; `state` cannot be set back to `triage` (422), and publication pushes to GitHub's vulnerability database. The public-PR fix route requires named approval, per the standing rule against disclosing an unfixed vulnerability publicly.
- **Verification never closes anything.** Only `confirmed` and `already fixed` continue the flow, and `already fixed` goes to the publish path so the advisory, CVE and reporter credit survive. A stack that will not start is recorded as `could not run`, which is an infrastructure failure rather than a verdict about the report.
- **Closure reasons go in the `description`, in the same `PATCH` that sets the state.** There is no advisory-comments API, so that is the only API-writable place for one; a single call means a failure leaves the advisory untouched rather than closed without explanation. `state` cannot be set back to `triage` (422), so the skill takes a backup and reads the record back.
- **SECURITY.md §13 is regenerated from the API on every publication** via `.claude/bin/regen-security-credits.sh` (written separately).

The failure modes found in the existing corpus are explicit pre-publication checks: a duplicate closed while its identical twin was left open (4 live cases), credits left pending so a named researcher never reaches the acknowledgments list (17 on already-published advisories), unbounded affected-version ranges (6, plus 5 records naming no package at all), references never populated, and publish-before-fix.

### Verified

Documentation only — no code paths change and no advisory was touched. I executed every `gh api` and `jq` snippet in the skill that is read-only (queue enumeration and ranking, the four-state dedup listing, the same-reporter cluster listing ordered by `created_at`/`submission.accepted`, the untouched-age sweep, the credits-state query) against the live repository and corrected the ranking query, which had a `jq` scoping bug. I also verified the `jq --rawfile` payload that builds the close-with-reason request, and the day-105 deadline query, which returns 15 reports already past that mark including four criticals. The mutating calls themselves — `PATCH` for state/metadata/description, `POST .../forks`, `POST .../cve` — are stated from the GitHub API schema and were deliberately not run. I executed the version-derivation commands too: `git log -S` and `git blame` agree on `f9f358c526` for a real platform helper, `git tag --contains` puts it in `autogpt-platform-beta-v0.6.49`, and a 2024-10-01 commit — older than `v0.2.1`, the first platform tag — still reports `v0.2.1`, which is why the procedure compares dates rather than trusting that answer.

A blast-radius review of the first draft held it on four blockers, all of which I reproduced against the live queue before fixing: the survivor rule closed non-duplicates (42 of 59 queued reports were in range), `submission.accepted` is `false` on all 59 so the rule's second signal was inert, the verify stage closed reports unattended on any non-confirmed verdict, and every irreversible write was a runnable command while every human gate was prose. Also fixed from that review: the deadline sweep filtered on `updated_at` and so lost an advisory permanently once stage 1 touched it (30 of 59 already invisible); stage 4 overwrote the reporter's submission with no backup; scratch files landed in the repo tree; policy sections were cited by numbers that exist only in `master`'s SECURITY.md. Round 2 confirmed those four fixed and found a fifth blocker that predated them and was left as the only unguarded destructive write: the routine metadata `PATCH` replaced the advisory's credit list with a single name. I confirmed the replace semantics against GitHub's reference (*"To add a credit to an advisory, send the whole array of values."*) and the exposure against the queue — 12 reports credit two to five researchers, including two criticals near the top of the skill's own ranking — then dry-ran the corrected merge against a four-credit advisory and checked all four survive. Also taken from round 2: the duplicate test is now "one fix fixes both" rather than same-file (two token-reuse races in one OAuth module and two hardcoded defaults in one `.env` file each pass a same-file test and need two fixes); the batch's full records are fetched so the test runs on descriptions, not titles; `could not run` is excluded from the recommend-to-close branch; and the already-fixed route reaches stage 5 without being asked for a PR it never produced.

Those four off-path cases now have endings, each verified against the queue: a duplicate whose twin is a `draft` (all five drafts are maintainer-created, so the draft survives and the queued copy closes — after the reporter is added to the draft's credits); a withdrawn report (`withdrawn_at` is read-only and has never been set here, so a withdrawal arrives as a UI comment); a published advisory with no CVE (eight exist, seven from the two July batches, and the severity threshold on that checklist row is gone since every confirmed in-scope vulnerability gets one); and a fix that does not fix it, which is a stop point — `withdrawn` is not a writable `state`, so publication cannot be undone through the API and only GitHub Support can retract an advisory. Whether an incomplete fix earns a second CVE is named in the file as a question rather than answered.

The section numbers referenced (§2.1, §4.1, §4.2, §5, §9, §13) are from the SECURITY.md merged in #14335, which landed on `master`; `dev` still carries the November 2024 policy until the next sync.






