### PR TITLE
docs(backend): codify accepted review findings as AGENTS.md rules

### DIFF
--- a/autogpt_platform/backend/AGENTS.md
+++ b/autogpt_platform/backend/AGENTS.md
@@ -64,10 +64,13 @@ poetry run pytest path/to/test.py --snapshot-update
 - **Absolute imports** — use `from backend.module import ...` for cross-package imports. Single-dot relative (`from .sibling import ...`) is acceptable for sibling modules within the same package (e.g., blocks). Avoid double-dot relative imports (`from ..parent import ...`) — use the absolute path instead
 - **No duck typing** — no `hasattr`/`getattr`/`isinstance` for type dispatch; use typed interfaces/unions/protocols
 - **Pydantic models** over dataclass/namedtuple/dict for structured data
+- **Field descriptions** — one or two lines; anything longer belongs in a doc, not a schema
 - **No linter suppressors** — no `# type: ignore`, `# noqa`, `# pyright: ignore`; fix the type/code
 - **List comprehensions** over manual loop-and-append
 - **Early return** — guard clauses first, avoid deep nesting
+- **No functions that exist only to hold a block** — a helper whose only job is wrapping one statement (e.g. a `try` inside a `with`) adds a signature and a call site without removing complexity; inline it. A refactor that makes the file longer while adding indirection has failed its own justification — revert it
 - **f-strings vs printf syntax in log statements** — Use `%s` for deferred interpolation in `debug` statements, f-strings elsewhere for readability: `logger.debug("Processing %s items", count)`, `logger.info(f"Processing {count} items")`
+- **Verify the alert path for new logs/metrics** — a log line or metric only alerts someone if something is listening; check the receiving integration's configured level rather than assuming, and for a metric, know which alert rule watches it or accept that nothing does
 - **Sanitize error paths** — `os.path.basename()` in error messages to avoid leaking directory structure
 - **TOCTOU awareness** — avoid check-then-act patterns for file access and credit charging
 - **`Security()` vs `Depends()`** — use `Security()` for auth deps to get proper OpenAPI security spec
@@ -85,6 +88,9 @@ poetry run pytest path/to/test.py --snapshot-update
 - Mock at boundaries — mock where the symbol is **used**, not where it's **defined**
 - After refactoring, update mock targets to match new module paths
 - Use `AsyncMock` for async functions (`from unittest.mock import AsyncMock`)
+- Parametrize near-identical tests — five tests asserting the same fact with different inputs are one `@pytest.mark.parametrize` test; a copy-pasted stack of near-identical tests is a fixture
+- An absence test must be able to fail — before keeping a test that asserts something does *not* happen, make the mutation it's meant to catch and confirm the test goes red first; a test that can't fail has no power to catch a regression
+- Run `backend/util/architecture_test.py` (~9s) and `backend/blocks/test/test_block.py` (~50s) for every backend change, whatever you touched — both scan the whole tree and no diff points at them. The first rejects a new file that imports `dataclass` (this repo requires pydantic for structured data); the second is the only suite that executes the `test_mock` lambdas declared inside block definitions, not in test files
 
 ### Test-Driven Development (TDD)
 


### PR DESCRIPTION
## Summary

`autogpt_platform/backend/AGENTS.md` is the contribution guide coding agents and contributors read before touching the backend; its **Code Style** and **Testing Approach** sections list house rules for this repo. This PR adds six new rules to those two sections, generalized from review feedback that was verified and accepted during another PR's review.

### Why / What / How

Why: Accepted review feedback teaches a repo-wide lesson exactly once, in one PR; without codifying it, the same class of mistake (an alert nobody receives, a helper that exists only to wrap a block, an untested absence assertion, a whole-tree suite missed by a scoped run) recurs on the next PR that didn't see that review.

What: Adds three rules to **Code Style** — short field descriptions, no functions that exist only to hold a block, verify the alert path before trusting a new log/metric to notify anyone — and three to **Testing Approach** — parametrize near-identical tests, an absence test must be shown to fail before it's trusted, and two whole-tree suites belong to every backend change.

How: Each new bullet matches the file's existing voice (bold lead term + em dash + one-line reason for Code Style, plain sentence for Testing Approach) and states no more than the rule and its reason — no anecdotes, no PR references.

### Changes 🏗️

- `autogpt_platform/backend/AGENTS.md` — **Code Style**: added "Field descriptions", "No functions that exist only to hold a block", "Verify the alert path for new logs/metrics". **Testing Approach**: added "Parametrize near-identical tests", "An absence test must be able to fail", "Run `architecture_test.py` + `test_block.py` for every backend change".

### Verified

- Sentry: `sentry_sdk.integrations.logging.LoggingIntegration.__init__` signature on the installed version defaults `event_level: Optional[int] = 40` (`logging.ERROR`); `backend/util/metrics.py:283` calls `LoggingIntegration()` with no arguments — confirmed a `WARNING` log produces no Sentry event as installed.
- `backend/util/architecture_test.py`: added a throwaway file importing `dataclass` under `backend/`, ran the suite (failed with `AssertionError: Backend code must use a pydantic BaseModel instead of stdlib dataclasses`), removed the file, ran again (3 passed). Runtime: ~9s.
- `backend/blocks/test/test_block.py`: confirmed `test_mock={...}` is declared inside a block source file (e.g. `backend/blocks/ai_image_customizer.py:125`, not a `_test.py` file), and traced `test_available_blocks` → `execute_block_test()` in `backend/util/test.py:125`, which reads `block.test_mock`. Runtime: 1074 passed, 84 skipped in ~50s.

Not run: full `poetry run test` (docs-only change, no code touched); frontend suite (not applicable).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Verified each factual claim locally (Sentry default, architecture_test.py fail/pass cycle, test_mock call chain, real runtimes) — see Verified above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
