### PR TITLE
docs(platform): add guide for using llmman via the Ollama provider

### DIFF
--- a/docs/platform/SUMMARY.md
+++ b/docs/platform/SUMMARY.md
@@ -41,6 +41,7 @@
 
 * [Using Google Gemini](gemini.md)
 * [Using Ollama](ollama.md)
+* [Using llmman](llmman.md)
 * [AutoPilot on a self-hosted LLM (no API keys)](copilot-local-llm.md)
 * [Using AI/ML API](aimlapi.md)
 * [Using D-ID](d_id.md)

--- a/docs/platform/copilot-local-llm.md
+++ b/docs/platform/copilot-local-llm.md
@@ -23,6 +23,7 @@ equally well:
 | Ollama on the same Docker host, via Docker Desktop | `http://host.docker.internal:11434/v1` |
 | Ollama on a separate LAN box | `http://ollama.lab.local:11434/v1` |
 | Ollama behind an HTTPS reverse proxy on the public internet | `https://ollama.example.com/v1` |
+| [llmman](llmman.md) on the same Docker host | `http://192.168.1.42:17434/v1` (LAN IP) |
 | [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html), [LocalAI](https://localai.io/), [LM Studio](https://lmstudio.ai/), [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy) | their respective `/v1` URLs |
 | A managed OpenAI-compatible API you don't pay AutoGPT for | its `/v1` URL |
 

--- a/docs/platform/llmman.md
+++ b/docs/platform/llmman.md
@@ -1,0 +1,88 @@
+# Running llmman with AutoGPT
+
+> **Important**: Like Ollama, llmman is only usable when self-hosting the AutoGPT platform. It cannot be used with the cloud-hosted version.
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port **17434**. Because it speaks the same `/api/chat` protocol as Ollama, AutoGPT's existing **Ollama** provider works with it unchanged — the only difference from the [Ollama guide](ollama.md) is the port.
+
+## Prerequisites
+
+1. Complete the [AutoGPT Setup](/platform/getting-started) steps first.
+2. Install llmman:
+
+   **Linux/macOS:**
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+   ```
+
+   **Windows (PowerShell):**
+   ```powershell
+   irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex
+   ```
+
+## Setup Steps
+
+### 1. Launch llmman
+
+AutoGPT runs in Docker, so llmman must listen on an address the containers can reach — not its `127.0.0.1` default. Set `LLMMAN_HOST` (format `[host][:port]`) and start the server:
+
+**Linux/macOS (Terminal):**
+```bash
+export LLMMAN_HOST=0.0.0.0:17434
+llmman serve
+```
+
+**Windows (Command Prompt):**
+```cmd
+set LLMMAN_HOST=0.0.0.0:17434
+llmman serve
+```
+
+In a second terminal, pull a model. llmman pulls models as OCI artifacts (Docker Hub, GHCR, quay, any registry) or straight from Hugging Face:
+
+```bash
+llmman pull gemma4
+# or
+llmman pull hf.co/unsloth/Qwen3.5-0.8B-GGUF
+```
+
+Check what is available with:
+```bash
+curl http://localhost:17434/api/tags
+```
+
+### 2. Allow the backend to reach llmman
+
+The Ollama host you enter in a block is checked against an SSRF allowlist. Private/LAN addresses are rejected unless they match `OLLAMA_HOST` in the backend environment, so add your host machine's IP and llmman's port to `autogpt_platform/backend/.env`:
+
+```bash
+OLLAMA_HOST=192.168.0.39:17434
+```
+
+Find your IPv4 address with `ipconfig` (Windows) or `ip addr show` / `ifconfig` (Linux/macOS). Then start (or restart) the platform:
+
+```bash
+cd autogpt_platform
+docker compose up -d --build
+```
+
+### 3. Using llmman with AutoGPT
+
+1. Open [http://localhost:3000/build](http://localhost:3000/build) and add an AI Text Generator block (any AI LLM block works).
+2. **API Key**: enter any value (e.g. `not-needed`) — llmman does not require authentication.
+3. **LLM Model**: pick an **Ollama** model. The name AutoGPT sends must match a model llmman has pulled, so either pull a model under one of the built-in Ollama slugs (`llama3.2`, `llama3`, `llama3.1:405b`, `dolphin-mistral:latest`) or add your own — see below.
+4. **Ollama Host**: enter the same value you put in `OLLAMA_HOST`, e.g. `192.168.0.39:17434`.
+5. Add a prompt, save the graph, and run it.
+
+## Using other models
+
+To expose a model such as `gemma4` or `hf.co/unsloth/Qwen3.5-0.8B-GGUF` in the dropdown, add a catalog entry with `provider="ollama"` and a matching `LLMModel` name, exactly as described in [Add Custom Models](ollama.md#add-custom-models-advanced). The slug must be the name llmman serves it under (as listed by `/api/tags`).
+
+## AutoPilot (OpenAI-compatible path)
+
+The [AutoPilot self-hosted LLM guide](copilot-local-llm.md) uses the OpenAI-compatible `/v1` endpoint rather than the Ollama API. llmman serves `/v1/chat/completions` (with tools) and `/v1/embeddings`, so the same guide applies with `CHAT_BASE_URL=http://<host-ip>:17434/v1`.
+
+## Troubleshooting
+
+- **Connection refused**: use your host machine's IP rather than `localhost`/`127.0.0.1`, and make sure llmman was started with `LLMMAN_HOST=0.0.0.0:17434`. Verify with `curl http://localhost:17434/api/tags` on the host.
+- **Host rejected / SSRF error**: the value in the "Ollama Host" field must match `OLLAMA_HOST` in `backend/.env` (hostname and port).
+- **Model not found**: the selected model must be pulled in llmman under exactly that name.


### PR DESCRIPTION
### Why / What / How

[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (plus OpenAI-/Anthropic-compatible ones) on port 17434, so AutoGPT's existing Ollama provider already works with it.

- New `docs/platform/llmman.md`, modelled on `ollama.md`: install, `LLMMAN_HOST=0.0.0.0:17434`, pulling models, block setup, custom-model pointer, AutoPilot `/v1` note, troubleshooting.
- Documents the `OLLAMA_HOST` SSRF allowlist step explicitly: `192.168.0.0/16` is in `BLOCKED_IP_NETWORKS`, so a LAN host on a non-default port is otherwise rejected by `validate_url_host`.
- Docs-only rather than a new `ProviderName`: that would touch credentials, block costs, catalog, `llm_models.py`, `providers.py` and three frontend icon maps to reach the same `ollama.AsyncClient` path.
- `docs/platform/SUMMARY.md`: list the page under "Using AI Services".
- `docs/platform/copilot-local-llm.md`: add an llmman row to the `CHAT_BASE_URL` table.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] All relative `.md` links and the `#add-custom-models-advanced` anchor resolve
  - [x] Confirmed `192.168.0.0/16` is in `BLOCKED_IP_NETWORKS` and `_trusted_ollama_hostnames()` reads `Config.ollama_host`

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**) — none; docs only

**Testing:** link/anchor check across the three files; no docs CI covers `docs/platform/**`. Not run end-to-end against a live llmman server inside the Docker stack.

> AI-assisted, reviewed before submitting.
