### PR TITLE
docs: fix links to removed or renamed files (FORGE-QUICKSTART, sso-guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Connect the apps that are yours. AutoGPT provides access to hundreds of AI model
 
 Looking for the original standalone AutoGPT agent? It remains available in [`classic/`](classic/) under the MIT License.
 
-- [Build an agent with Forge](classic/FORGE-QUICKSTART.md)
+- [Build an agent with Forge](classic/forge/README.md)
 - [Benchmark an agent with `agbenchmark`](https://pypi.org/project/agbenchmark/)
 - [Explore the Classic project](classic/README.md)
 

--- a/docs/platform/integrating/api-guide.md
+++ b/docs/platform/integrating/api-guide.md
@@ -37,7 +37,7 @@ OAuth is ideal for:
 - "Sign in with AutoGPT" (SSO, Single Sign-On) functionality
 - Applications that need user-specific permissions
 
-See the [SSO Integration Guide](sso-guide.md) for complete OAuth implementation details.
+See the [SSO Integration Guide](oauth-guide.md) for complete OAuth implementation details.
 
 ## Available Scopes
 
@@ -69,7 +69,7 @@ curl -H "X-API-Key: YOUR_API_KEY" \
 ### Using OAuth
 
 1. Register an OAuth application (contact platform administrator)
-2. Implement the OAuth flow as described in the [SSO Guide](sso-guide.md)
+2. Implement the OAuth flow as described in the [SSO Guide](oauth-guide.md)
 3. Use the obtained access token:
 
 ```bash


### PR DESCRIPTION
### Why

Two groups of broken docs links, each verified against the tree with `git ls-files`:

1. `README.md` still linked `classic/FORGE-QUICKSTART.md`, which was removed in the classic reorg (#11797). The Forge "Quick start" content now lives at `classic/forge/README.md`.
2. `docs/platform/integrating/api-guide.md` linked `sso-guide.md` twice, but that file doesn't exist — the guide is `oauth-guide.md` (listed as "OAuth & SSO" in SUMMARY.md).

### What

- `README.md`: `classic/FORGE-QUICKSTART.md` → `classic/forge/README.md`
- `docs/platform/integrating/api-guide.md`: `sso-guide.md` → `oauth-guide.md` (2 links)

### How

Docs-only change; link targets verified to exist on disk.

### Test Plan

- [ ] N/A — documentation only
