### PR TITLE
docs(platform): fix broken screenshot paths (../imgs -> ../content/imgs)

### DIFF
--- a/docs/platform/aimlapi.md
+++ b/docs/platform/aimlapi.md
@@ -24,7 +24,7 @@ Make sure AutoGPT is running and accessible at:
 
 > 💡 Keep AutoGPT running in a terminal or Docker throughout the session.
 
-![Step 1 AutoGPT Running](../imgs/aimlapi/Step%201%20AutoGPT%20Running.png)
+![Step 1 AutoGPT Running](../content/imgs/aimlapi/Step%201%20AutoGPT%20Running.png)
 
 ---
 
@@ -35,7 +35,7 @@ Open your browser and go to:
 
 Or click **“Build”** in the navigation bar.
 
-![Step 2 Build Screen](../imgs/aimlapi/Step%202%20Build%20Screen.png)
+![Step 2 Build Screen](../content/imgs/aimlapi/Step%202%20Build%20Screen.png)
 
 ---
 
@@ -43,12 +43,12 @@ Or click **“Build”** in the navigation bar.
 
 1. Click the **"Blocks"** button on the left sidebar.
 
-![Step 3 AI Block](../imgs/aimlapi/Step%203%20AI%20Block.png)
+![Step 3 AI Block](../content/imgs/aimlapi/Step%203%20AI%20Block.png)
 
 2. In the search bar, type `AI Text Generator`.
 3. Drag the block into the canvas.
 
-![Step 4 AI Generator Block](../imgs/aimlapi/Step%204%20AI%20Generator%20Block.png)
+![Step 4 AI Generator Block](../content/imgs/aimlapi/Step%204%20AI%20Generator%20Block.png)
 
 ---
 
@@ -58,7 +58,7 @@ Click the AI Text Generator block to configure it.
 
 In the **LLM Model** dropdown, select one of the supported models from AI/ML API:
 
-![Step 5 AIMLAPI Models](../imgs/aimlapi/Step%205%20AIMLAPI%20Models.png)
+![Step 5 AIMLAPI Models](../content/imgs/aimlapi/Step%205%20AIMLAPI%20Models.png)
 
 | Model ID                                       | Speed  | Reasoning Quality | Best For                 |
 | ---------------------------------------------- | ------ | ----------------- | ------------------------ |
@@ -82,13 +82,13 @@ Inside the **AI Text Generator** block:
 🔐 You can get your key from:
 [https://aimlapi.com/app/keys/](https://aimlapi.com/app/keys?utm_source=autogpt&utm_medium=github&utm_campaign=integration)
 
-![Key Placeholder](../imgs/aimlapi/Step%206.1%20Key%20Placeholder.png)
+![Key Placeholder](../content/imgs/aimlapi/Step%206.1%20Key%20Placeholder.png)
 
-![Key Empty](../imgs/aimlapi/Step%206.2%20No%20Fill%20Key%20Placeholder.png)
+![Key Empty](../content/imgs/aimlapi/Step%206.2%20No%20Fill%20Key%20Placeholder.png)
 
-![Key Filled](../imgs/aimlapi/Step%206.3%20Filled%20Key%20Placeholder.png)
+![Key Filled](../content/imgs/aimlapi/Step%206.3%20Filled%20Key%20Placeholder.png)
 
-![Overview](../imgs/aimlapi/Step%206.4%20Overview.png)
+![Overview](../content/imgs/aimlapi/Step%206.4%20Overview.png)
 
 ---
 
@@ -99,7 +99,7 @@ Click the **“Save”** button at the top-right of the builder interface:
 1. Give your agent a name (e.g., `aimlapi_test_agent`).
 2. Click **“Save Agent”** to confirm.
 
-![Save Agent](../imgs/aimlapi/Step%207.1%20Save.png)
+![Save Agent](../content/imgs/aimlapi/Step%207.1%20Save.png)
 
 > 💡 Saving allows reuse, scheduling, and chaining in larger workflows.
 
@@ -112,7 +112,7 @@ From the workspace:
 1. Press **“Run”** next to your saved agent.
 2. The request will be sent to the selected AI/ML API model.
 
-![Run Agent](../imgs/aimlapi/Step%208%20Run.png)
+![Run Agent](../content/imgs/aimlapi/Step%208%20Run.png)
 
 ---
 
@@ -122,7 +122,7 @@ From the workspace:
 2. Check the **Output** panel below it.
 3. You can copy, export, or pass the result to further blocks.
 
-![Agent Output](../imgs/aimlapi/Step%209%20Output.png)
+![Agent Output](../content/imgs/aimlapi/Step%209%20Output.png)
 
 ---
 

--- a/docs/platform/ollama.md
+++ b/docs/platform/ollama.md
@@ -19,10 +19,10 @@ To properly set up Ollama for network access, choose one of these methods:
 
 1. Open the Ollama desktop application
 2. Go to **Settings** and toggle **"Expose Ollama to the network"**
-   ![Expose Ollama to Network](../imgs/ollama/Ollama-Expose-Network.png)
+   ![Expose Ollama to Network](../content/imgs/ollama/Ollama-Expose-Network.png)
 3. Click on the model name field in the "New Chat" window
 4. Search for "llama3.2" (or your preferred model)
-   ![Select llama3.2 model](../imgs/ollama/Ollama-Select-llama3.2.png)
+   ![Select llama3.2 model](../content/imgs/ollama/Ollama-Select-llama3.2.png)
 5. Click on it to start the download and load the model to be used
 
 ??? note "Method B: Using Docker (Alternative)"
@@ -99,12 +99,12 @@ This command starts both the backend and frontend services. Once running, visit 
 Now that both Ollama and the AutoGPT platform are running, we can use Ollama with AutoGPT:
 
 1. Add an AI Text Generator block to your workspace (it can work with any AI LLM block but for this example will be using the AI Text Generator block):
-   ![Add AI Text Generator Block](../imgs/ollama/Select-AI-block.png)
+   ![Add AI Text Generator Block](../content/imgs/ollama/Select-AI-block.png)
 
 2. **Configure the API Key field**: Enter any value (e.g., "dummy" or "not-needed") since Ollama doesn't require authentication.
 
 3. In the "LLM Model" dropdown, select "llama3.2" (This is the model we downloaded earlier)
-   ![Select Ollama Model](../imgs/ollama/Ollama-Select-Llama32.png)
+   ![Select Ollama Model](../content/imgs/ollama/Ollama-Select-Llama32.png)
 
    > **Compatible Models**: The following Ollama models are available in AutoGPT by default:
    > - `llama3.2` (Recommended for most use cases)
@@ -137,15 +137,15 @@ Now that both Ollama and the AutoGPT platform are running, we can use Ollama wit
    192.168.0.39:11434
    ```
 
-   ![Ollama Remote Host](../imgs/ollama/Ollama-Remote-Host.png)
+   ![Ollama Remote Host](../content/imgs/ollama/Ollama-Remote-Host.png)
 
    > **Important**: Since AutoGPT runs in Docker containers, you must use your host machine's IP address instead of `localhost` or `127.0.0.1`. Docker containers cannot reach `localhost` on the host machine.
 
 5. Add prompts to your AI block, save the graph, and run it:
-   ![Add Prompt](../imgs/ollama/Ollama-Add-Prompts.png)
+   ![Add Prompt](../content/imgs/ollama/Ollama-Add-Prompts.png)
 
 That's it! You've successfully setup the AutoGPT platform and made a LLM call to Ollama.
-![Ollama Output](../imgs/ollama/Ollama-Output.png)
+![Ollama Output](../content/imgs/ollama/Ollama-Output.png)
 
 ### Using Ollama on a Remote Server with AutoGPT
 
@@ -174,7 +174,7 @@ Then you can use the same steps above but you need to add the Ollama server's IP
 192.168.0.39:11434
 ```
 
-![Ollama Remote Host](../imgs/ollama/Ollama-Remote-Host.png)
+![Ollama Remote Host](../content/imgs/ollama/Ollama-Remote-Host.png)
 
 ## Add Custom Models (Advanced)
 


### PR DESCRIPTION
### Why

`docs/platform/ollama.md` and `docs/platform/aimlapi.md` referenced their screenshots via `../imgs/...`, but `docs/imgs/` does not exist — the GitBook assets live under `docs/content/imgs/...`. Every screenshot on both pages rendered as a broken image (20 links total: 8 in ollama.md, 12 in aimlapi.md).

### What

Replaced the `../imgs/` prefix with `../content/imgs/` in both files. All 20 target files verified to exist on disk after the fix (the aimlapi filenames contain spaces; the existing `%20` URL encoding is kept).

### How

Docs-only change; programmatic path-resolution check: 20/20 resolve.

### Test Plan

- [ ] N/A — documentation only
