### PR TITLE
docs(backend): align docstrings with actual signatures

### DIFF
--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -562,7 +562,7 @@ async def create_library_agent(
     Adds an agent to the user's library (LibraryAgent table).
 
     Args:
-        agent: The agent/Graph to add to the library.
+        graph: The agent/Graph to add to the library.
         user_id: The user to whom the agent will be added.
         hitl_safe_mode: Whether HITL blocks require manual review (default True).
         sensitive_action_safe_mode: Whether sensitive action blocks require review.

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -651,11 +651,10 @@ async def upload_file(
     Args:
         file: The file to upload
         user_id: The user ID
-        provider: Cloud storage provider ("gcs", "s3", "azure")
         expiration_hours: Hours until file expires (1-48)
 
     Returns:
-        Dict containing the cloud storage path and signed URL
+        UploadFileResponse with the storage path and signed URL
     """
     if expiration_hours < 1 or expiration_hours > 48:
         raise HTTPException(

--- a/autogpt_platform/backend/backend/blocks/wordpress/_api.py
+++ b/autogpt_platform/backend/backend/blocks/wordpress/_api.py
@@ -108,7 +108,6 @@ def make_oauth_authorize_url(
         client_id: Your application's client ID from WordPress.com
         redirect_uri: The URI for the authorize response redirect
         scopes: Optional list of scopes. Defaults to single blog access if not provided.
-        blog: Optional blog URL or ID for a WordPress.com blog or Jetpack site.
 
     Returns:
         The authorization URL that the user should visit
@@ -457,8 +456,8 @@ async def create_post(
     Create a new post on a WordPress site.
 
     Args:
+        credentials: The WordPress credentials used to authorize the request
         site: Site ID or domain (e.g., "myblog.wordpress.com" or "123456789")
-        access_token: OAuth access token
         post_data: Post data using CreatePostRequest model
 
     Returns:

--- a/autogpt_platform/backend/backend/executor/manager.py
+++ b/autogpt_platform/backend/backend/executor/manager.py
@@ -226,10 +226,12 @@ async def execute_node(
     persist the execution result, and return the subsequent node to be executed.
 
     Args:
-        db_client: The client to send execution updates to the server.
-        creds_manager: The manager to acquire and release credentials.
+        node: The node to execute.
         data: The execution data for executing the current node.
+        execution_processor: The processor managing the node execution lifecycle.
         execution_stats: The execution statistics to be updated.
+        nodes_input_masks: Optional input masks applied to node inputs.
+        nodes_to_skip: Optional set of node IDs to skip execution for.
 
     Returns:
         The subsequent node to be enqueued, or None if there is no subsequent node.

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -6736,7 +6736,7 @@
       "post": {
         "tags": ["v1", "files"],
         "summary": "Upload file to cloud storage",
-        "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    provider: Cloud storage provider (\"gcs\", \"s3\", \"azure\")\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    Dict containing the cloud storage path and signed URL",
+        "description": "Upload a file to cloud storage and return a storage key that can be used\nwith FileStoreBlock and AgentFileInputBlock.\n\nArgs:\n    file: The file to upload\n    user_id: The user ID\n    expiration_hours: Hours until file expires (1-48)\n\nReturns:\n    UploadFileResponse with the storage path and signed URL",
         "operationId": "postV1Upload file to cloud storage",
         "security": [{ "HTTPBearerJWT": [] }],
         "parameters": [


### PR DESCRIPTION
### Why

Four backend docstrings documented parameters that no longer exist (or missed parameters that do), which misleads IDE tooltips and, for `upload_file`, the OpenAPI/Swagger docs. Each item verified against the signature directly above it.

### What

- `executor/manager.py` `execute_node`: documented `db_client` / `creds_manager` (both refactored away into `ExecutionProcessor`) while the actual `node`, `execution_processor`, `nodes_input_masks`, `nodes_to_skip` parameters were undocumented — now documented.
- `api/features/library/db.py` `create_library_agent`: documented `agent`, the parameter is `graph`.
- `api/features/v1.py` `upload_file`: documented a nonexistent `provider` parameter and a `Dict` return type; the return annotation is `UploadFileResponse` — docstring now matches (this one renders in OpenAPI docs).
- `blocks/wordpress/_api.py`: `make_oauth_authorize_url` documented a `blog` parameter it does not take (removed); `create_post` documented `access_token` while auth flows through the `credentials` parameter (entry renamed).

### How

Docstring-only change; no behavior or annotations touched.

### Test Plan

- [x] `python -m compileall` on the four touched files passes; docs-only diff
