### PR TITLE
fix(backend): restore black formatting on dev

### DIFF
--- a/autogpt_platform/backend/backend/data/org_credit_test.py
+++ b/autogpt_platform/backend/backend/data/org_credit_test.py
@@ -243,4 +243,3 @@ class TestOrgCreditModelTopUp:
 
         assert result == 500
         mock_prisma.query_raw.assert_called_once()
-


### PR DESCRIPTION
Dev's tracked copy of `autogpt_platform/backend/backend/data/org_credit_test.py` fails `poetry run black --check` under the repo's pinned black 24.10.0 (a trailing blank line), so every branch that merges dev inherits a red lint check regardless of what it touches. This PR removes that trailing blank line to restore clean formatting; no other backend files were unformatted.

Verified: ran `poetry run black --check backend/data/org_credit_test.py` before (failed) and after (passed) the fix, and `poetry run black --check backend/` across the whole backend tree afterward (1515 files, all clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
