### PR TITLE
style(backend): drop the trailing blank line black rejects in org_credit_test

### DIFF
--- a/autogpt_platform/backend/backend/data/org_credit_test.py
+++ b/autogpt_platform/backend/backend/data/org_credit_test.py
@@ -243,4 +243,3 @@ class TestOrgCreditModelTopUp:
 
         assert result == 500
         mock_prisma.query_raw.assert_called_once()
-


### PR DESCRIPTION
dev currently fails `poetry run lint`: black wants the trailing blank line at the end of `backend/data/org_credit_test.py` removed. The file arrived via a security-advisory fork merge, which does not run this repo's lint. Every merge-queue build inherits the failure, so #14324 and #14334 were removed from the queue. One-line whitespace fix, no code change.