### PR TITLE
fix(frontend/copilot): read aloud falls back to our own TTS when the browser has no voices

### DIFF
--- a/autogpt_platform/backend/backend/api/features/chat/speech_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/speech_test.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import fastapi
 import fastapi.testclient
+import httpx
 import pytest
 import pytest_mock
 
@@ -202,6 +203,19 @@ def test_speech_503s_without_a_configured_key(
 
     assert response.status_code == 503
     record_usage.assert_not_awaited()
+
+
+def test_speech_bounds_a_hung_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The client's own 600 s default, across its two retries, is half an hour of
+    # silence on the path voice mode chunks to speak within a second.
+    monkeypatch.setattr(speech_module.settings.secrets, "openai_internal_api_key", "")
+    monkeypatch.setattr(speech_module.settings.secrets, "openai_api_key", "sk-test-key")
+
+    timeout = speech_module._speech_client().timeout
+
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read is not None and timeout.read <= 60
+    assert timeout.connect is not None and timeout.connect <= 10
 
 
 @pytest.fixture(autouse=True)

--- a/autogpt_platform/backend/backend/api/features/chat/speech_test.py
+++ b/autogpt_platform/backend/backend/api/features/chat/speech_test.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import fastapi
 import fastapi.testclient
-import httpx
 import pytest
 import pytest_mock
 
@@ -213,9 +212,8 @@ def test_speech_bounds_a_hung_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
 
     timeout = speech_module._speech_client().timeout
 
-    assert isinstance(timeout, httpx.Timeout)
-    assert timeout.read is not None and timeout.read <= 60
-    assert timeout.connect is not None and timeout.connect <= 10
+    assert timeout == speech_module.SPEECH_TIMEOUT
+    assert (timeout.read, timeout.connect) == (30.0, 5.0)
 
 
 @pytest.fixture(autouse=True)

--- a/autogpt_platform/backend/backend/copilot/speech.py
+++ b/autogpt_platform/backend/backend/copilot/speech.py
@@ -7,6 +7,7 @@ in-plan usage rather than a free side channel.
 
 import logging
 
+import httpx
 from openai import AsyncOpenAI
 
 from backend.copilot.config import ChatConfig
@@ -21,6 +22,10 @@ settings = Settings()
 # OpenAI rejects longer inputs outright; the client chunks at sentence
 # boundaries well below this, so hitting it means a malformed request.
 MAX_SPEECH_CHARS = 4096
+
+# One chunk is a sentence, not a generation, so the client's 600 s default bounds
+# nothing a listener is still waiting through. Connect fast-fails as elsewhere.
+SPEECH_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
 
 ALLOWED_VOICES = frozenset(
     {
@@ -137,4 +142,4 @@ def _speech_client() -> AsyncOpenAI:
     )
     if not api_key:
         raise SpeechUnavailable("no OpenAI API key configured")
-    return AsyncOpenAI(api_key=api_key)
+    return AsyncOpenAI(api_key=api_key, timeout=SPEECH_TIMEOUT)

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/AssistantMessageActions.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/AssistantMessageActions.tsx
@@ -89,7 +89,7 @@ export function AssistantMessageActions({
           <Icon icon={ThumbsDownIcon} size={16} />
         </MessageAction>
 
-        <TTSButton text={text} />
+        <TTSButton text={text} sessionID={sessionID} />
       </MessageActions>
 
       {showFeedbackModal && (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/TTSButton.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/TTSButton.tsx
@@ -1,23 +1,19 @@
 "use client";
 
 import { MessageAction } from "@/components/ai-elements/message";
-import { useTextToSpeech } from "@/components/contextual/Chat/components/ChatMessage/useTextToSpeech";
-import { stripMarkdownForSpeech } from "../../../voice/stripMarkdownForSpeech";
-import { useMemo } from "react";
 import { StopIcon, VolumeHighIcon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import { useTTSButton } from "./useTTSButton";
 
 interface Props {
   text: string;
+  sessionID: string | null;
 }
 
-export function TTSButton({ text }: Props) {
-  const cleanText = useMemo(() => stripMarkdownForSpeech(text), [text]);
-  const { status, isSupported, toggle } = useTextToSpeech(cleanText);
+export function TTSButton({ text, sessionID }: Props) {
+  const { canSpeak, isPlaying, toggle } = useTTSButton({ text, sessionID });
 
-  if (!isSupported || !cleanText) return null;
-
-  const isPlaying = status === "playing";
+  if (!canSpeak) return null;
 
   return (
     <MessageAction

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/TTSButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/TTSButton.test.tsx
@@ -37,12 +37,14 @@ function render(ui: React.ReactElement) {
   return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
-/** speechPlayer keeps one module-level <audio>, so this outlives a single test. */
+/** speechPlayer keeps one module-level <audio>, so these outlive a single test. */
 let autoEndPlayback = true;
+const audioPause = vi.fn();
 
 describe("TTSButton", () => {
   beforeEach(() => {
     autoEndPlayback = true;
+    audioPause.mockClear();
     stubSpeechSynthesis([]);
     stubAudio();
     global.URL.createObjectURL = vi.fn(() => "blob:chunk");
@@ -134,6 +136,9 @@ describe("TTSButton", () => {
 
     await userEvent.click(screen.getByRole("button"));
 
+    // Stop has to actually stop our audio — `speak` alone stays uncalled when
+    // the click does nothing at all, which is the same dead control.
+    expect(audioPause).toHaveBeenCalled();
     expect(speak).not.toHaveBeenCalled();
   });
 });
@@ -175,7 +180,7 @@ function stubAudio() {
       src = "";
       preload = "";
       play = vi.fn(async () => undefined);
-      pause = vi.fn();
+      pause = audioPause;
       addEventListener = vi.fn(
         (event: string, handler: () => void) =>
           autoEndPlayback && event === "ended" && setTimeout(handler, 0),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/TTSButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/TTSButton.test.tsx
@@ -1,0 +1,149 @@
+import {
+  cleanup,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted: `vi.mock` factories are lifted above every top-level binding.
+const { synthesizeSpeech, useGetFlag } = vi.hoisted(() => ({
+  synthesizeSpeech: vi.fn(
+    async (text: string, sessionID: string | null) =>
+      new Blob([`${sessionID}:${text}`]),
+  ),
+  useGetFlag: vi.fn(() => true),
+}));
+
+vi.mock("../../../../voice/speechApi", () => ({
+  synthesizeSpeech,
+}));
+
+vi.mock("@/services/feature-flags/use-get-flag", () => ({
+  Flag: { COPILOT_VOICE_MODE: "copilot-voice-mode" },
+  useGetFlag: () => useGetFlag(),
+}));
+
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import { TooltipProvider } from "@/components/atoms/Tooltip/BaseTooltip";
+import { TTSButton } from "../TTSButton";
+
+function render(ui: React.ReactElement) {
+  return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe("TTSButton", () => {
+  beforeEach(() => {
+    stubSpeechSynthesis([]);
+    stubAudio();
+    global.URL.createObjectURL = vi.fn(() => "blob:chunk");
+    global.URL.revokeObjectURL = vi.fn();
+    useGetFlag.mockReturnValue(true);
+    synthesizeSpeech.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("speaks through the browser when it has voices, without spending on synthesis", async () => {
+    const speak = stubSpeechSynthesis([{ name: "Samantha", lang: "en-US" }]);
+    render(<TTSButton text="A local voice reads this." sessionID="s-1" />);
+
+    await userEvent.click(await screen.findByRole("button"));
+
+    expect(speak).toHaveBeenCalledTimes(1);
+    expect(synthesizeSpeech).not.toHaveBeenCalled();
+  });
+
+  it("falls back to our own synthesis when the browser has no voices", async () => {
+    render(<TTSButton text="No local voice reads this." sessionID="s-1" />);
+
+    await userEvent.click(await screen.findByRole("button"));
+
+    await waitFor(() => expect(synthesizeSpeech).toHaveBeenCalled());
+    expect(synthesizeSpeech.mock.calls[0]).toEqual([
+      "No local voice reads this.",
+      "s-1",
+    ]);
+  });
+
+  it("splits a reply too long for one request into several", async () => {
+    const long = "This sentence is here to be spoken aloud. ".repeat(30);
+    render(<TTSButton text={long} sessionID={null} />);
+
+    await userEvent.click(await screen.findByRole("button"));
+
+    await waitFor(() => expect(synthesizeSpeech).toHaveBeenCalled());
+    const chunks = synthesizeSpeech.mock.calls.map((call) => call[0]);
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach((chunk) => expect(chunk.length).toBeLessThanOrEqual(4096));
+  });
+
+  it("attributes the cost to the session the message belongs to", async () => {
+    render(<TTSButton text="Bill this to the session." sessionID="s-42" />);
+
+    await userEvent.click(await screen.findByRole("button"));
+
+    await waitFor(() => expect(synthesizeSpeech).toHaveBeenCalled());
+    expect(synthesizeSpeech.mock.calls[0][1]).toBe("s-42");
+  });
+
+  it("hides itself when it has neither voices nor the flag that lets it synthesise", () => {
+    useGetFlag.mockReturnValue(false);
+    render(<TTSButton text="Nothing can speak this." sessionID="s-1" />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("still offers browser speech when the flag is off but voices exist", async () => {
+    useGetFlag.mockReturnValue(false);
+    stubSpeechSynthesis([{ name: "Samantha", lang: "en-US" }]);
+    render(<TTSButton text="A local voice reads this." sessionID="s-1" />);
+
+    // findByRole rejects when nothing matches, so this is a real presence check.
+    expect(await screen.findByRole("button")).not.toBeNull();
+  });
+});
+
+function stubSpeechSynthesis(voices: Partial<SpeechSynthesisVoice>[]) {
+  const speak = vi.fn();
+  vi.stubGlobal(
+    "SpeechSynthesisUtterance",
+    class {
+      constructor(public text: string) {}
+    },
+  );
+  vi.stubGlobal("speechSynthesis", {
+    getVoices: () => voices as SpeechSynthesisVoice[],
+    speak,
+    cancel: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  return speak;
+}
+
+function stubAudio() {
+  vi.stubGlobal(
+    "Audio",
+    class {
+      src = "";
+      preload = "";
+      play = vi.fn(async () => undefined);
+      pause = vi.fn();
+      addEventListener = vi.fn(
+        (event: string, handler: () => void) =>
+          event === "ended" && setTimeout(handler, 0),
+      );
+      removeEventListener = vi.fn();
+    },
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/TTSButton.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/__tests__/TTSButton.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   render as rtlRender,
   screen,
@@ -36,8 +37,12 @@ function render(ui: React.ReactElement) {
   return rtlRender(<TooltipProvider>{ui}</TooltipProvider>);
 }
 
+/** speechPlayer keeps one module-level <audio>, so this outlives a single test. */
+let autoEndPlayback = true;
+
 describe("TTSButton", () => {
   beforeEach(() => {
+    autoEndPlayback = true;
     stubSpeechSynthesis([]);
     stubAudio();
     global.URL.createObjectURL = vi.fn(() => "blob:chunk");
@@ -52,7 +57,9 @@ describe("TTSButton", () => {
   });
 
   it("speaks through the browser when it has voices, without spending on synthesis", async () => {
-    const speak = stubSpeechSynthesis([{ name: "Samantha", lang: "en-US" }]);
+    const { speak } = stubSpeechSynthesis([
+      { name: "Samantha", lang: "en-US" },
+    ]);
     render(<TTSButton text="A local voice reads this." sessionID="s-1" />);
 
     await userEvent.click(await screen.findByRole("button"));
@@ -103,16 +110,38 @@ describe("TTSButton", () => {
 
   it("still offers browser speech when the flag is off but voices exist", async () => {
     useGetFlag.mockReturnValue(false);
-    stubSpeechSynthesis([{ name: "Samantha", lang: "en-US" }]);
+    const { speak } = stubSpeechSynthesis([
+      { name: "Samantha", lang: "en-US" },
+    ]);
     render(<TTSButton text="A local voice reads this." sessionID="s-1" />);
 
-    // findByRole rejects when nothing matches, so this is a real presence check.
-    expect(await screen.findByRole("button")).not.toBeNull();
+    await userEvent.click(await screen.findByRole("button"));
+
+    expect(speak).toHaveBeenCalledTimes(1);
+    expect(synthesizeSpeech).not.toHaveBeenCalled();
+  });
+
+  it("keeps Stop on our own audio when voices arrive mid-playback", async () => {
+    // speech-dispatcher starting mid-reply flips `hasVoices`, which would
+    // otherwise hand Stop to the browser path and strand our audio playing.
+    autoEndPlayback = false;
+    const { speak, arriveVoices } = stubSpeechSynthesis([]);
+    render(<TTSButton text="No local voice reads this." sessionID="s-1" />);
+
+    await userEvent.click(await screen.findByRole("button"));
+    await waitFor(() => expect(synthesizeSpeech).toHaveBeenCalled());
+    act(() => arriveVoices([{ name: "Samantha", lang: "en-US" }]));
+
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(speak).not.toHaveBeenCalled();
   });
 });
 
 function stubSpeechSynthesis(voices: Partial<SpeechSynthesisVoice>[]) {
   const speak = vi.fn();
+  let current = voices;
+  let onVoicesChanged = () => {};
   vi.stubGlobal(
     "SpeechSynthesisUtterance",
     class {
@@ -120,15 +149,23 @@ function stubSpeechSynthesis(voices: Partial<SpeechSynthesisVoice>[]) {
     },
   );
   vi.stubGlobal("speechSynthesis", {
-    getVoices: () => voices as SpeechSynthesisVoice[],
+    getVoices: () => current as SpeechSynthesisVoice[],
     speak,
     cancel: vi.fn(),
     pause: vi.fn(),
     resume: vi.fn(),
-    addEventListener: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      if (event === "voiceschanged") onVoicesChanged = handler;
+    }),
     removeEventListener: vi.fn(),
   });
-  return speak;
+  return {
+    speak,
+    arriveVoices(later: Partial<SpeechSynthesisVoice>[]) {
+      current = later;
+      onVoicesChanged();
+    },
+  };
 }
 
 function stubAudio() {
@@ -141,7 +178,7 @@ function stubAudio() {
       pause = vi.fn();
       addEventListener = vi.fn(
         (event: string, handler: () => void) =>
-          event === "ended" && setTimeout(handler, 0),
+          autoEndPlayback && event === "ended" && setTimeout(handler, 0),
       );
       removeEventListener = vi.fn();
     },

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/useTTSButton.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/useTTSButton.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useTextToSpeech } from "@/components/contextual/Chat/components/ChatMessage/useTextToSpeech";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
+
+import { synthesizeSpeech } from "../../../voice/speechApi";
+import { takeSpeakableChunks } from "../../../voice/speechChunker";
+import {
+  createSpeechPlayer,
+  type SpeechPlayer,
+} from "../../../voice/speechPlayer";
+import { stripMarkdownForSpeech } from "../../../voice/stripMarkdownForSpeech";
+
+interface Args {
+  text: string;
+  sessionID: string | null;
+}
+
+export function useTTSButton({ text, sessionID }: Args) {
+  const cleanText = useMemo(() => stripMarkdownForSpeech(text), [text]);
+  const browser = useTextToSpeech(cleanText);
+  const server = useServerSpeech(cleanText, sessionID);
+
+  // The speech route 404s when voice mode is off for the user, so without the
+  // flag there is nothing to fall back to and the button must not offer one.
+  const canFallBack = useGetFlag(Flag.COPILOT_VOICE_MODE);
+  const viaServer = !browser.hasVoices;
+
+  return {
+    canSpeak: Boolean(cleanText) && (browser.hasVoices || canFallBack),
+    isPlaying: viaServer ? server.isPlaying : browser.status === "playing",
+    toggle: viaServer ? server.toggle : browser.toggle,
+  };
+}
+
+function useServerSpeech(text: string, sessionID: string | null) {
+  const { toast } = useToast();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const playerRef = useRef<SpeechPlayer | null>(null);
+  const reportedRef = useRef(false);
+  const sessionRef = useRef(sessionID);
+  sessionRef.current = sessionID;
+
+  useEffect(() => {
+    playerRef.current?.stop();
+    setIsPlaying(false);
+  }, [text]);
+
+  useEffect(() => () => playerRef.current?.destroy(), []);
+
+  return { isPlaying, toggle };
+
+  function toggle() {
+    if (isPlaying) {
+      playerRef.current?.stop();
+      setIsPlaying(false);
+      return;
+    }
+
+    const player = ensurePlayer();
+    // Must happen inside the click: that is the only gesture granting the
+    // shared <audio> element autoplay for the chunks that arrive later.
+    player.unlock();
+    reportedRef.current = false;
+    setIsPlaying(true);
+    // One request is capped at 4096 characters, which a long reply exceeds.
+    takeSpeakableChunks(text, true).chunks.forEach((chunk) =>
+      player.enqueue(chunk),
+    );
+  }
+
+  function ensurePlayer(): SpeechPlayer {
+    if (!playerRef.current) {
+      playerRef.current = createSpeechPlayer({
+        synthesize: (chunk) => synthesizeSpeech(chunk, sessionRef.current),
+        onIdle: () => setIsPlaying(false),
+        onError: report,
+      });
+    }
+    return playerRef.current;
+  }
+
+  // Every remaining chunk of a failed reply fails the same way; say it once.
+  function report(error: unknown) {
+    if (reportedRef.current) return;
+    reportedRef.current = true;
+    playerRef.current?.stop();
+    setIsPlaying(false);
+    console.error("[Read aloud]", error);
+    toast({
+      title: "Read aloud",
+      description:
+        error instanceof Error ? error.message : "Something went wrong.",
+      variant: "destructive",
+    });
+  }
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/useTTSButton.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatMessagesContainer/components/useTTSButton.ts
@@ -27,7 +27,10 @@ export function useTTSButton({ text, sessionID }: Args) {
   // The speech route 404s when voice mode is off for the user, so without the
   // flag there is nothing to fall back to and the button must not offer one.
   const canFallBack = useGetFlag(Flag.COPILOT_VOICE_MODE);
-  const viaServer = !browser.hasVoices;
+  // `hasVoices` flips reactively on `voiceschanged`; a flip mid-playback would
+  // move Stop to the other path and strand the audio that is already speaking.
+  const speaking = server.isPlaying || browser.status === "playing";
+  const viaServer = speaking ? server.isPlaying : !browser.hasVoices;
 
   return {
     canSpeak: Boolean(cleanText) && (browser.hasVoices || canFallBack),

--- a/autogpt_platform/frontend/src/components/contextual/Chat/components/ChatMessage/useTextToSpeech.ts
+++ b/autogpt_platform/frontend/src/components/contextual/Chat/components/ChatMessage/useTextToSpeech.ts
@@ -89,35 +89,28 @@ function pickBestVoice(
 
 export function useTextToSpeech(text: string) {
   const [status, setStatus] = useState<TTSStatus>("idle");
-  const [isSupported, setIsSupported] = useState(false);
+  // The API exists with zero voices (Linux without a running speech-dispatcher),
+  // where `speak` is a silent no-op — so the voice list, not the API, is the
+  // test for whether this can speak. State, not a ref: voices load async.
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
-  const cachedVoicesRef = useRef<SpeechSynthesisVoice[]>([]);
 
   useEffect(() => {
-    const supported = "speechSynthesis" in window;
-    setIsSupported(supported);
+    if (!("speechSynthesis" in window)) return;
 
-    if (supported) {
-      // Populate cache immediately (may already be available)
-      cachedVoicesRef.current = window.speechSynthesis.getVoices();
+    setVoices(window.speechSynthesis.getVoices());
 
-      // Listen for voiceschanged to populate cache when voices load async
-      function onVoicesChanged() {
-        cachedVoicesRef.current = window.speechSynthesis.getVoices();
-      }
-      window.speechSynthesis.addEventListener("voiceschanged", onVoicesChanged);
-
-      return () => {
-        window.speechSynthesis.removeEventListener(
-          "voiceschanged",
-          onVoicesChanged,
-        );
-        window.speechSynthesis.cancel();
-      };
+    function onVoicesChanged() {
+      setVoices(window.speechSynthesis.getVoices());
     }
+    window.speechSynthesis.addEventListener("voiceschanged", onVoicesChanged);
 
     return () => {
-      window.speechSynthesis?.cancel();
+      window.speechSynthesis.removeEventListener(
+        "voiceschanged",
+        onVoicesChanged,
+      );
+      window.speechSynthesis.cancel();
     };
   }, []);
 
@@ -142,7 +135,7 @@ export function useTextToSpeech(text: string) {
 
     const utterance = new SpeechSynthesisUtterance(text);
 
-    const voice = pickBestVoice(cachedVoicesRef.current);
+    const voice = pickBestVoice(voices);
     if (voice) utterance.voice = voice;
 
     utteranceRef.current = utterance;
@@ -184,7 +177,7 @@ export function useTextToSpeech(text: string) {
 
   return {
     status,
-    isSupported,
+    hasVoices: voices.length > 0,
     play,
     pause,
     stop,


### PR DESCRIPTION
### Why / What / How

**This makes a previously free button cost money.** "Read aloud" under each AutoPilot reply speaks through the browser's own `speechSynthesis`, which costs nothing. When the browser has no voices, it now synthesises through `POST /api/chat/speech` instead, which is metered against the caller's AutoPilot plan (`copilot:tts`, roughly $0.02 per 1k characters). A user who reads a long reply aloud spends real money where they previously spent none. That is the change worth deciding on; everything below is how it works.

**Why:** On Linux the browser gets its voices from `speech-dispatcher`. With that service stopped there are zero voices, `speak()` is a silent no-op, and the button still renders and looks clickable — nothing happens when you press it. This is not a regression; it has probably never worked on a stock Linux desktop.

**What:** With no browser voices, the button falls back to the platform's own text-to-speech — the same endpoint, player and chunker voice mode already uses. With voices, nothing changes: it still speaks locally and still costs nothing. With neither voices nor the flag that permits the fallback, the button hides instead of pretending it can speak.

**How:** `useTextToSpeech` derived `isSupported` from `"speechSynthesis" in window`, which is `true` with zero voices. It now tracks the voice list itself, in state rather than a ref so a late `voiceschanged` is reactive. `TTSButton` picks a path from that, and its new `useTTSButton` hook drives `createSpeechPlayer` for the fallback: the player is unlocked inside the click (autoplay is only granted to an element first played in a gesture), and the reply is split with `takeSpeakableChunks` because the route caps one request at 4096 characters.

### Three decisions

**1. Cost.** Stated above. Not resolved by this PR — it needs a product call before `copilot-voice-mode` goes on for everyone, since the flag is what admits the metered path.

**2. Flag gating: the fallback is gated on `copilot-voice-mode`, matching the route.** `POST /api/chat/speech` 404s when the flag is off, so an ungated fallback would be the same broken button with a new mechanism. The alternative — ungating the route — would expose a metered OpenAI proxy to every user, which is what the flag is there to prevent during rollout. So with no voices and no flag the button hides. That is honest and it is exactly reversible: turning the flag on turns the button on.

**3. Session attribution: threaded, not null.** `AssistantMessageActions` already receives `sessionID`, so passing it costs one prop and keeps per-session cost attribution for the same spend the chat turn is billed against. Passing `null` would have lost that for no benefit.

### Also here: a bound on a hung synthesis

`_speech_client()` took the OpenAI default of 600 s on read, and the client retries twice, so an upstream that accepts the connection and then stalls held a voice request for up to half an hour — on a path the chunker exists to make speak within about a second. It is now `httpx.Timeout(30.0, connect=5.0)`. The 30 is the floor `Config.llm_request_timeout_seconds` permits (`ge=30`, default 600) for a whole LLM generation, against a chunk capped at `MAX_CHUNK_CHARS` = 400 characters here; connect fast-fails at 5 s, matching `FAST_FAIL_TIMEOUT_SECONDS` in `util/llm/providers.request_timeout`. It is a bound taken from the platform's own numbers, not a measured p99 — no benchmark was run against OpenAI. `max_retries` stays at the default, so the effective worst case is ~90 s plus backoff rather than 1800 s.

**Not done here: caching the speech client.** #14322's review asked for `@cached(ttl_seconds=3600)` on `_speech_client()`, since a reply is synthesised one chunk at a time and each chunk currently opens a fresh pool. `backend/util/architecture_test.py::test_no_process_cached_loop_bound_clients` forbids it — a process-wide cache binds an `AsyncOpenAI`'s connection pool to the first event loop that uses it. `get_openai_client` is exempt only via that test's `_KNOWN_OFFENDERS` allowlist, as a "pre-existing offender tracked for future cleanup", and the sanctioned alternative it names, `per_loop_cached`, does not exist yet. The finding is real; its fix is a `util/cache.py` change and belongs in its own PR alongside migrating the two existing offenders.

### Changes 🏗️

- `useTextToSpeech`: `isSupported` → `hasVoices`, tracked in state from `getVoices()` at mount and on `voiceschanged`.
- `useTTSButton` (new): picks browser vs. platform synthesis, gates the fallback on `copilot-voice-mode`, drives the shared speech player, chunks the reply, and reports a failure once per playback rather than once per chunk.
- `TTSButton`: takes `sessionID`, renders nothing when it cannot speak.
- `AssistantMessageActions`: passes `sessionID` through.
- Tests: 7 new integration tests for the button.
- `copilot/speech.py`: `SPEECH_TIMEOUT` on the OpenAI client, plus a test that fails if the kwarg is dropped.

### Verified

I executed all of it except the audio itself, on this head, rebuilt onto current `dev`. Frontend: `pnpm test:unit` over `src/app/(platform)/copilot` is 2505 tests green across 196 files, including the 7 new ones covering the browser path, the fallback path, chunking, session attribution, and the button hiding when it has neither voices nor the flag; the pre-commit `types`, `lint` and `format` hooks passed on both commits. Backend: `speech_test.py` 16 passed, `util/architecture_test.py` 3 passed, `blocks/test/test_block.py` 1647 passed and 84 skipped.

The new `test_speech_bounds_a_hung_upstream` was mutated to prove it can fail — removing `timeout=SPEECH_TIMEOUT` makes it die on `assert (600 is not None and 600 <= 60)`, which is the client default it exists to catch. I also verified the caching claim before dropping it: `@cached` on `_speech_client()` fails `architecture_test.py` 1-of-3, and passes 3-of-3 once removed.

I confirmed the premise on a zero-voice Linux box rather than assuming it: `systemctl --user is-active speech-dispatcher` reports `inactive`, and headed Chromium there reports `"speechSynthesis" in window === true` with `getVoices().length === 0`. One correction to the original diagnosis: `voiceschanged` **does** fire on this machine, it just delivers an empty list — so waiting for the event is not a valid test for whether speech works, and only the voice count is. That is what this implements.

**What I did not verify: that a human hears audio.** That needs the running stack, which is reserved for voice-mode testing on this machine, and a 200 from the speech route would not have been evidence of it anyway. The synthesis, playback and chunking code on the fallback path is the code voice mode already ships and exercises.

No screenshots: the only visual difference is the button being absent where it would previously have rendered and done nothing. No new element, icon or layout is introduced, and I did not start a second stack to photograph an absence.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Zero browser voices + flag on → the button speaks through the platform route, chunked, attributed to the session
  - [x] Zero browser voices + flag off → the button does not render
  - [x] Browser voices present → speaks locally, no request to the speech route, flag irrelevant
  - [x] A reply longer than one request's cap is split into several
  - [ ] Audio is audible end to end on a zero-voice desktop (needs the stack; not run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
