### PR TITLE
feat(team): open expert chat in inline right-side drawer

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/team/components/AutopilotCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/AutopilotCard.tsx
@@ -16,12 +16,14 @@ interface Props {
   skillCount: number;
   scheduleCount: number;
   workflowCount: number;
+  onChat: () => void;
 }
 
 export function AutopilotCard({
   skillCount,
   scheduleCount,
   workflowCount,
+  onChat,
 }: Props) {
   return (
     <section
@@ -68,12 +70,11 @@ export function AutopilotCard({
 
       <div className="flex items-center gap-2 px-4 pb-4">
         <Button
-          as="NextLink"
-          href="/copilot"
           variant="secondary"
           size="small"
           className={`${ACTION_BUTTON_CLASS} flex-1`}
           leftIcon={<Icon icon={PencilEdit02Icon} size={14} />}
+          onClick={onChat}
         >
           Chat
         </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/ExpertChatDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/ExpertChatDrawer.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Expert } from "@/app/api/__generated__/models/expert";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/atoms/Avatar/Avatar";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Robot01Icon } from "@hugeicons/core-free-icons";
+import { CopilotChatHost } from "../../../copilot/CopilotChatHost";
+
+interface Props {
+  open: boolean;
+  /** The expert to chat with, or `null` for Autopilot (the generalist). */
+  expert: Expert | null;
+  onClose: () => void;
+}
+
+/**
+ * Right-side drawer that hosts the full copilot chat inline on the Team page.
+ * The chat is URL-driven (`expertId`/`sessionId`/`kickoff` query params handled
+ * in useTeamPage), so mounting the real `CopilotChatHost` here gives faithful
+ * streaming/tools/sessions with no forked logic. Radix unmounts the drawer
+ * content on close, so each open starts from the freshly-set params.
+ */
+export function ExpertChatDrawer({ open, expert, onClose }: Props) {
+  const title = expert ? `Chat with ${expert.name}` : "Chat with Autopilot";
+  const subtitle = expert
+    ? expert.role
+    : "Your built-in generalist — runs the shop";
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col overflow-hidden p-0 sm:w-1/2 sm:max-w-none"
+      >
+        <div className="border-b border-zinc-200 bg-white px-6 py-5 pr-12 sm:px-8">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-11 w-11">
+              {expert?.avatar_url ? (
+                <AvatarImage src={expert.avatar_url} alt={expert.name} />
+              ) : null}
+              <AvatarFallback>
+                {expert ? (
+                  expert.name
+                ) : (
+                  <Icon icon={Robot01Icon} size={22} />
+                )}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <SheetTitle>{title}</SheetTitle>
+              <SheetDescription>{subtitle}</SheetDescription>
+            </div>
+          </div>
+        </div>
+
+        {/* Definite-height flex-col parent so CopilotChatHost's `min-h-0
+            flex-1` chain lets the messages area absorb growth (SheetContent is
+            `inset-y-0 h-full`, giving the viewport-bound height it needs). */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <CopilotChatHost
+            droppedFiles={[]}
+            onDroppedFilesConsumed={() => {}}
+            hasFloatingControls={false}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertTeamCard/ExpertTeamCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertTeamCard/ExpertTeamCard.tsx
@@ -57,6 +57,7 @@ interface Props {
   onInstallWorkflow: (expertId: string) => void;
   onEditSoul: (expertId: string) => void;
   onAssignPod: (expertId: string, podId: string | null) => void;
+  onChat: (expertId: string) => void;
 }
 
 export function ExpertTeamCard({
@@ -67,6 +68,7 @@ export function ExpertTeamCard({
   onInstallWorkflow,
   onEditSoul,
   onAssignPod,
+  onChat,
 }: Props) {
   const blurb = getExpertBlurb(expert);
   const needsSetupCount = getNeedsSetupCount(expert, schedules);
@@ -249,12 +251,11 @@ export function ExpertTeamCard({
 
       <div className="flex items-center gap-2 px-4 pb-4">
         <Button
-          as="NextLink"
-          href={`/copilot?expertId=${expert.id}`}
           variant="secondary"
           size="small"
           className={FOOTER_BUTTON_CLASS}
           leftIcon={<ChatCircle size={14} />}
+          onClick={() => onChat(expert.id)}
         >
           Chat
         </Button>

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/TeamRoster/TeamRoster.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/TeamRoster/TeamRoster.tsx
@@ -20,6 +20,7 @@ interface Props {
   experts: Expert[];
   schedulesForExpert: (expert: Expert) => GraphExecutionJobInfo[];
   renderCard: (expert: Expert) => ReactNode;
+  onAutopilotChat: () => void;
 }
 
 export function TeamRoster({
@@ -27,6 +28,7 @@ export function TeamRoster({
   experts,
   schedulesForExpert,
   renderCard,
+  onAutopilotChat,
 }: Props) {
   const { query, setQuery, filter, setFilter, isNarrowed, visibleExperts } =
     useTeamRosterView({ experts, schedulesForExpert });
@@ -38,6 +40,7 @@ export function TeamRoster({
       skillCount={summary.skillCount}
       scheduleCount={summary.scheduleCount}
       workflowCount={summary.workflowCount}
+      onChat={onAutopilotChat}
     />
   );
 

--- a/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/page.tsx
@@ -16,6 +16,7 @@ import { KanbanIcon, UserGroupIcon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { notFound } from "next/navigation";
 import { EmptyTeamState } from "./components/EmptyTeamState";
+import { ExpertChatDrawer } from "./components/ExpertChatDrawer/ExpertChatDrawer";
 import { ExpertTeamCard } from "./components/ExpertTeamCard/ExpertTeamCard";
 import { ExpertTeamCardSkeleton } from "./components/ExpertTeamCardSkeleton";
 import { NewPodDialog } from "./components/NewPodDialog/NewPodDialog";
@@ -59,6 +60,11 @@ export default function TeamPage() {
     createPod,
     isCreatingPod,
     assignPod,
+    isChatOpen,
+    chatExpert,
+    openExpertChat,
+    openAutopilotChat,
+    closeChat,
   } = useTeamPage({ enabled: Boolean(enabled) && ready });
 
   if (!ready) {
@@ -88,6 +94,7 @@ export default function TeamPage() {
         onInstallWorkflow={installWorkflow}
         onEditSoul={openSoul}
         onAssignPod={assignPod}
+        onChat={openExpertChat}
       />
     );
   }
@@ -140,6 +147,7 @@ export default function TeamPage() {
               experts={hiredExperts}
               schedulesForExpert={schedulesForExpert}
               renderCard={renderCard}
+              onAutopilotChat={openAutopilotChat}
             />
 
             {!isLoading && !isError && hiredExperts.length === 0 ? (
@@ -172,6 +180,11 @@ export default function TeamPage() {
       </main>
 
       <SoulDrawer key={soulDrawerKey} expert={soulExpert} onClose={closeSoul} />
+      <ExpertChatDrawer
+        open={isChatOpen}
+        expert={chatExpert}
+        onClose={closeChat}
+      />
     </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/team/useTeamPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/useTeamPage.ts
@@ -13,6 +13,7 @@ import { ExpertPod } from "@/app/api/__generated__/models/expertPod";
 import { okData } from "@/app/api/helpers";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
+import { parseAsString, useQueryState } from "nuqs";
 import { useState } from "react";
 import {
   getAssignToastTitle,
@@ -31,6 +32,16 @@ export function useTeamPage({ enabled }: Args) {
   const [soulExpertId, setSoulExpertId] = useState<string | null>(null);
   const [soulDrawerKey, setSoulDrawerKey] = useState(0);
   const [isNewPodOpen, setIsNewPodOpen] = useState(false);
+  // The inline chat drawer reuses the real copilot chat, which is driven by
+  // these URL params. `isChatOpen` is the drawer's own marker so Autopilot
+  // (no expertId) is distinguishable from "closed".
+  const [chatExpertId, setChatExpertId] = useQueryState(
+    "expertId",
+    parseAsString,
+  );
+  const [, setChatSessionId] = useQueryState("sessionId", parseAsString);
+  const [, setChatKickoff] = useQueryState("kickoff", parseAsString);
+  const [isChatOpen, setIsChatOpen] = useState(false);
 
   const expertsQuery = useListExperts({
     query: { select: (res) => (okData(res) ?? []) as Expert[], enabled },
@@ -177,6 +188,30 @@ export function useTeamPage({ enabled }: Args) {
     setIsNewPodOpen(false);
   }
 
+  // Opening a chat always starts a fresh session: clear sessionId/kickoff so
+  // the copilot mounts a new conversation, then point it at the right expert
+  // (or Autopilot when expertId is null).
+  function openExpertChat(expertId: string) {
+    void setChatSessionId(null);
+    void setChatKickoff(null);
+    void setChatExpertId(expertId);
+    setIsChatOpen(true);
+  }
+
+  function openAutopilotChat() {
+    void setChatSessionId(null);
+    void setChatKickoff(null);
+    void setChatExpertId(null);
+    setIsChatOpen(true);
+  }
+
+  function closeChat() {
+    setIsChatOpen(false);
+    void setChatExpertId(null);
+    void setChatSessionId(null);
+    void setChatKickoff(null);
+  }
+
   return {
     hiredExperts,
     pods,
@@ -207,5 +242,11 @@ export function useTeamPage({ enabled }: Args) {
     createPod,
     isCreatingPod,
     assignPod,
+    isChatOpen,
+    chatExpert:
+      hiredExperts.find((expert) => expert.id === chatExpertId) ?? null,
+    openExpertChat,
+    openAutopilotChat,
+    closeChat,
   };
 }


### PR DESCRIPTION
## What

Clicking **Chat** on the Team page (expert cards **and** the Autopilot card) now opens the full copilot chat **inline in a right-side drawer** instead of navigating to \`/copilot\`. No new page — just an inline chat panel.

## How

- **New \`ExpertChatDrawer\`** embeds the real \`CopilotChatHost\` (real streaming, tools, sessions — no forked chat logic) inside a right-side \`Sheet\`. \`expert = null\` targets Autopilot.
- **\`useTeamPage\`** drives the chat through the existing \`expertId\` / \`sessionId\` / \`kickoff\` query params. Opening a chat always clears \`sessionId\`/\`kickoff\` so a fresh conversation mounts; Radix unmounts drawer content on close, so each open starts clean.
- Wired \`onChat\` / \`onAutopilotChat\` through \`ExpertTeamCard\`, \`AutopilotCard\`, \`TeamRoster\`, and \`page.tsx\`.

## Files
- \`team/components/ExpertChatDrawer/ExpertChatDrawer.tsx\` (new)
- \`team/useTeamPage.ts\`
- \`team/components/ExpertTeamCard/ExpertTeamCard.tsx\`
- \`team/components/AutopilotCard.tsx\`
- \`team/components/TeamRoster/TeamRoster.tsx\`
- \`team/page.tsx\`

## Testing
Typecheck/lint were not run locally (sandbox RAM couldn't install deps); relying on CI. Manual static review confirmed import paths and prop wiring. Please verify CI \`types\`/\`lint\` are green.