### PR TITLE
fix(backend): shrink LLM retry timeout to remaining shared deadline

### DIFF
--- a/autogpt_platform/backend/backend/blocks/llm.py
+++ b/autogpt_platform/backend/backend/blocks/llm.py
@@ -240,6 +240,12 @@ def get_parallel_tool_calls_param(
     return parallel_tool_calls
 
 
+def remaining_attempt_timeout(
+    deadline: float, per_attempt_timeout: float, now: float
+) -> float:
+    return min(deadline - now, per_attempt_timeout)
+
+
 async def llm_call(
     credentials: APIKeyCredentials,
     llm_model: LLMModel,
@@ -251,6 +257,7 @@ async def llm_call(
     parallel_tool_calls=None,
     compress_prompt_to_fit: bool = True,
     execution_context: "ExecutionContext | None" = None,
+    timeout_seconds: float | None = None,
 ) -> LLMResponse:
     """Block-side LLM entry point. Wraps the provider dispatch in a hard timeout
     so that no single request can park an executor thread indefinitely.
@@ -260,6 +267,9 @@ async def llm_call(
     the block retry loop. Copilot and dream call the provider layer directly and
     raise no spend alert; they carry no execution context to attribute one to.
     """
+    timeout = (
+        LLM_REQUEST_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+    )
     started = time.monotonic()
     with track_llm_call(
         graph_exec_id=execution_context.graph_exec_id if execution_context else None,
@@ -282,7 +292,8 @@ async def llm_call(
                 # Same budget as the provider layer, but this one starts before
                 # prompt compression, so it always fires first for block callers;
                 # the provider deadline is there for callers that skip this seam.
-                timeout=LLM_REQUEST_TIMEOUT_SECONDS,
+                # Retry loops may pass a leftover shared-deadline slice.
+                timeout=timeout,
             )
         # SDK-native timeouts never reach the wait_for, so both are caught here
         # to keep this the single place that reports burned spend.
@@ -298,7 +309,7 @@ async def llm_call(
                 error=e,
             )
             if isinstance(e, asyncio.TimeoutError):
-                raise _block_timeout_error(llm_model, max_tokens) from e
+                raise _block_timeout_error(llm_model, max_tokens, timeout) from e
             raise
 
 
@@ -558,6 +569,7 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
         tools: list[dict] | None = None,
         ollama_host: str = "localhost:11434",
         execution_context: "ExecutionContext | None" = None,
+        timeout_seconds: float | None = None,
     ) -> LLMResponse:
         """
         Test mocks work only on class functions, this wraps the llm_call function
@@ -574,6 +586,7 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
             ollama_host=ollama_host,
             compress_prompt_to_fit=compress_prompt_to_fit,
             execution_context=execution_context,
+            timeout_seconds=timeout_seconds,
         )
 
     async def run(
@@ -621,8 +634,16 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
         error_feedback_message = ""
         llm_model = input_data.model
         total_provider_cost: float | None = None
+        loop = asyncio.get_running_loop()
+        per_attempt_timeout = LLM_REQUEST_TIMEOUT_SECONDS
+        deadline = loop.time() + per_attempt_timeout
 
         for retry_count in range(input_data.retry):
+            attempt_timeout = remaining_attempt_timeout(
+                deadline, per_attempt_timeout, loop.time()
+            )
+            if attempt_timeout <= 0:
+                break
             logger.debug(f"LLM request: {prompt}")
             try:
                 llm_response = await self.llm_call(
@@ -637,6 +658,7 @@ class AIStructuredResponseGeneratorBlock(AIBlockBase):
                     ollama_host=input_data.ollama_host,
                     max_tokens=input_data.max_tokens,
                     execution_context=kwargs.get("execution_context"),
+                    timeout_seconds=attempt_timeout,
                 )
                 response_text = llm_response.response
                 # Accumulate token counts and provider_cost for every attempt
@@ -973,12 +995,19 @@ def _log_timeout_outcome(
     )
 
 
-def _block_timeout_error(llm_model: LLMModel, max_tokens: int | None) -> TimeoutError:
+def _block_timeout_error(
+    llm_model: LLMModel,
+    max_tokens: int | None,
+    timeout_seconds: float | None = None,
+) -> TimeoutError:
     """Provider-agnostic timeout text plus the one remedy only blocks expose."""
     budget = max_tokens or llm_model.max_output_tokens
     hint = f" (currently {budget})" if budget else ""
+    timeout = (
+        LLM_REQUEST_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+    )
     return TimeoutError(
-        f"{timeout_error(f'{llm_model.metadata.provider}/{llm_model.value}', LLM_REQUEST_TIMEOUT_SECONDS)}"
+        f"{timeout_error(f'{llm_model.metadata.provider}/{llm_model.value}', timeout)}"
         f" You can also lower the advanced Max Tokens setting{hint}."
     )
 

--- a/autogpt_platform/backend/backend/blocks/test/test_llm.py
+++ b/autogpt_platform/backend/backend/blocks/test/test_llm.py
@@ -1859,6 +1859,79 @@ class TestLLMRequestTimeout:
             call_count["n"] == 1
         ), f"Expected exactly 1 call (no retry on timeout), got {call_count['n']}"
 
+    def test_remaining_attempt_timeout_uses_leftover_budget(self):
+        per_attempt = 10.0
+        deadline = 100.0
+        assert llm.remaining_attempt_timeout(deadline, per_attempt, now=90.0) == 10.0
+        assert llm.remaining_attempt_timeout(deadline, per_attempt, now=94.0) == 6.0
+        assert llm.remaining_attempt_timeout(deadline, per_attempt, now=100.0) == 0.0
+
+    @pytest.mark.asyncio
+    async def test_structured_block_retries_use_remaining_deadline(self, monkeypatch):
+        """A slow-then-malformed first attempt must not get a fresh full timeout.
+
+        The retry loop shares one deadline: each attempt is
+        ``min(remaining, per_attempt_timeout)``.
+        """
+        per_attempt = 0.5
+        first_delay = 0.12
+        monkeypatch.setattr(llm, "LLM_REQUEST_TIMEOUT_SECONDS", per_attempt)
+
+        captured_timeouts: list[float] = []
+        real_wait_for = asyncio.wait_for
+
+        async def tracking_wait_for(aw, timeout: float, **kwargs):
+            captured_timeouts.append(timeout)
+            return await real_wait_for(aw, timeout=timeout)
+
+        monkeypatch.setattr(llm.asyncio, "wait_for", tracking_wait_for)
+
+        call_n = {"n": 0}
+
+        def _llm_response(text: str) -> llm.LLMResponse:
+            return llm.LLMResponse(
+                raw_response="",
+                prompt=[],
+                response=text,
+                tool_calls=None,
+                prompt_tokens=1,
+                completion_tokens=1,
+                reasoning=None,
+            )
+
+        async def fake_provider_call(*args, **kwargs):
+            call_n["n"] += 1
+            if call_n["n"] == 1:
+                await asyncio.sleep(first_delay)
+                return _llm_response(
+                    '<json_output id="test123456">{"wrong": "key"}</json_output>'
+                )
+            return _llm_response(
+                '<json_output id="test123456">{"key": "value"}</json_output>'
+            )
+
+        monkeypatch.setattr(llm, "_llm_call", fake_provider_call)
+
+        block = llm.AIStructuredResponseGeneratorBlock()
+        input_data = llm.AIStructuredResponseGeneratorBlock.Input(
+            prompt="Hello",
+            expected_format={"key": "value"},
+            model=llm.DEFAULT_LLM_MODEL,
+            credentials=llm.TEST_CREDENTIALS_INPUT,  # type: ignore
+            retry=3,
+        )
+
+        with patch("secrets.token_hex", return_value="test123456"):
+            async for _ in block.run(input_data, credentials=llm.TEST_CREDENTIALS):
+                pass
+
+        assert call_n["n"] == 2
+        assert len(captured_timeouts) == 2
+        assert captured_timeouts[0] <= per_attempt
+        assert captured_timeouts[1] < captured_timeouts[0]
+        assert captured_timeouts[1] <= captured_timeouts[0] - first_delay + 0.05
+        assert captured_timeouts[1] > 0
+
 
 class TestLLMModelMissingHandler:
     """``LLMModel._missing_`` resolves provider-prefixed slugs back to enum


### PR DESCRIPTION
Fixes #14293

## Why

Deferred from #14206: the LLM block retry loop gave each attempt a fresh full request timeout, so retries times timeout could approach the per-node execution cap. This PR changes that contract so one shared deadline covers the whole logical call.

## What

`AIStructuredResponseGeneratorBlock` now computes a wall-clock deadline at call start. Each retry is bounded by `min(remaining, per_attempt_timeout)` through the existing `asyncio.wait_for` in `llm_call`.

## How

- Helper `remaining_attempt_timeout` clips each attempt to leftover budget
- `llm_call` accepts optional `timeout_seconds` and passes it to `asyncio.wait_for`
- Fast validation failures still retry; a slow-then-malformed first attempt no longer gets a new full window

## Tests

- `test_remaining_attempt_timeout_uses_leftover_budget` pins the leftover math
- `test_structured_block_retries_use_remaining_deadline` asserts the second wait_for timeout shrinks after a slow invalid first attempt

Local: focused timeout tests pass; full `test_llm.py` and architecture checks for the touched area pass.

Draft because this is a non-trivial retry-contract change.
