### PR TITLE
fix(backend): enforce string truncation size limits

### DIFF
--- a/autogpt_platform/backend/backend/util/truncate.py
+++ b/autogpt_platform/backend/backend/util/truncate.py
@@ -12,10 +12,29 @@ def _truncate_string_middle(value: str, limit: int) -> str:
     if len(value) <= limit:
         return value
 
-    head_len = max(1, limit // 2)
-    tail_len = limit - head_len  # ensures total == limit
-    omitted = len(value) - (head_len + tail_len)
-    return f"{value[:head_len]}… (omitted {omitted} chars)…{value[-tail_len:]}"
+    if limit == 0:
+        return ""
+
+    omitted = len(value)
+    marker = f"… (omitted {omitted} chars)…"
+    while len(marker) <= limit:
+        retained = limit - len(marker)
+        if retained < 2:
+            break
+        actual_omitted = len(value) - retained
+        if actual_omitted == omitted:
+            head_len = (retained + 1) // 2
+            tail_len = retained - head_len
+            tail = value[-tail_len:] if tail_len else ""
+            return f"{value[:head_len]}{marker}{tail}"
+        omitted = actual_omitted
+        marker = f"… (omitted {omitted} chars)…"
+
+    retained = limit - 1
+    head_len = (retained + 1) // 2
+    tail_len = retained - head_len
+    tail = value[-tail_len:] if tail_len else ""
+    return f"{value[:head_len]}…{tail}"
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +97,9 @@ def truncate(value: Any, size_limit: int) -> Any:
     does not exceed size_limit characters. Uses binary search to find the
     largest str_limit and list_limit that fit.
     """
+
+    if size_limit < 0:
+        raise ValueError("size_limit must be non-negative")
 
     # Fast path: plain strings don't need the binary search machinery.
     if isinstance(value, str):

--- a/autogpt_platform/backend/backend/util/truncate_test.py
+++ b/autogpt_platform/backend/backend/util/truncate_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from backend.util.truncate import truncate
+
+
+def test_truncate_string_respects_size_limit():
+    value = "0123456789" * 10
+
+    result = truncate(value, 30)
+
+    assert len(result) <= 30
+    assert result.startswith(value[0])
+    assert result.endswith(value[-1])
+    assert "omitted 91 chars" in result
+
+
+@pytest.mark.parametrize("size_limit", [0, 1, 5, 20])
+def test_truncate_string_respects_short_size_limits(size_limit: int):
+    result = truncate("0123456789" * 10, size_limit)
+
+    assert len(result) <= size_limit
+
+
+def test_truncate_string_returns_value_within_limit_unchanged():
+    value = "short value"
+
+    assert truncate(value, len(value)) == value
+
+
+def test_truncate_string_preserves_ends_when_full_marker_has_no_context():
+    value = "0123456789" * 10
+
+    result = truncate(value, 22)
+
+    assert len(result) == 22
+    assert result.startswith(value[0])
+    assert result.endswith(value[-1])
+
+
+@pytest.mark.parametrize("value", ["value", {"key": "value"}, 42])
+def test_truncate_rejects_negative_size_limit(value: object):
+    with pytest.raises(ValueError, match="size_limit must be non-negative"):
+        truncate(value, -1)


### PR DESCRIPTION
### Why / What / How

`backend.util.truncate.truncate()` promises that its result will fit within `size_limit`, but the plain-string fast path appended the omission marker outside that budget. Very small limits also triggered Python's `value[-0:]` behavior, which could expand a 100-character value to 122 characters instead of truncating it.

This change makes the string helper budget the complete omission marker, falls back to a compact ellipsis when the detailed marker cannot fit alongside useful context, and rejects negative limits consistently at the public API boundary.

Closes #14328. GitHub auto-closes only on a merge into the default branch (`master`), so merging this into `dev` leaves #14328 open — it needs closing by hand.

### Changes 🏗️

- Keep truncated plain-string results within `size_limit`.
- Preserve the beginning and end of the value whenever the available budget allows it.
- Handle zero and negative limits explicitly.
- Add regression coverage for normal, tiny, boundary, unchanged, and invalid limits.
- Resize the `read_expert_chat` paging fixture, whose expected page contents assumed the old overshoot. A transcript row is capped at `_MAX_MESSAGE_CHARS` (2,000) and a page at `_MAX_PAGE_CHARS` (8,000); a 2,500-char row used to truncate to 2,022, so three rows fit a page, and now truncates to exactly 2,000, so four do. The fixture grows from five rows to six to keep two rows on the far side of the cursor.

### Verified

Reproduced the failure the paging test showed on a tree with `dev` merged in, and confirmed its cause: reverting only `truncate.py` to `dev`'s copy in the working tree turns those tests green again, with nothing else changed. Three mutations of the paging code — reversing the drop direction, disabling the page cap, and removing the per-row `truncate` call — each turn the resized test red, so its assertions still bite.

The new truncation was stress-tested over 60,000 random `(limit, length)` pairs across ASCII, CJK, emoji and accented text: no result exceeded its limit, none hung, and all encode as valid UTF-8. The previous implementation exceeded its limit at every edge sampled — limit 0 returned 122 characters, limit 5 returned 26, limit 2,000 returned 2,022 — and returned nearly the whole string for a negative limit where this raises `ValueError`.

Executed: `backend/copilot/tools/expert_chats_test.py` (20 passed), `backend/util/truncate_test.py` with `backend/util/architecture_test.py` (13), `backend/copilot/sdk/tool_adapter_test.py` with `backend/copilot/tools/base_test.py` and `backend/copilot/response_model_test.py` (100 passed, 3 xfailed), `backend/executor/activity_status_generator_test.py` (31), `backend/blocks/test/test_block.py` (1,734 passed, 84 skipped), and `ruff check`, `ruff format --check`, `isort` and `black` on the touched files. Reasoned about but not executed locally: the rest of the backend matrix, which CI covers.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run python -m pytest --confcutdir=backend/util backend/util/truncate_test.py -q` (10 passed)
  - [x] `poetry run python -m ruff check backend/util/truncate.py backend/util/truncate_test.py`
  - [x] `poetry run python -m black --check backend/util/truncate.py backend/util/truncate_test.py`
  - [x] `poetry run python -m isort --check-only --profile black backend/util/truncate.py backend/util/truncate_test.py`
