### PR TITLE
dx(platform): record agent and model attribution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,11 @@
 
 <!-- List the key changes. Keep it higher level than the diff but specific enough to highlight what's new/modified. -->
 
+### Agents and large language models used
+
+<!-- List each agent platform with its model name/version (e.g. Claude Code with Claude Opus 4.1).
+Write None if no agents were used, or unknown for unavailable model details. -->
+
 ### Checklist 📋
 
 #### For code changes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ For every commit you create in this repository, ensure the commit message includ
 Co-authored-by: MODEL NAME/VERSION (AGENT PLATFORM) <COAUTHOR EMAIL>
 ```
 
-- Your harness (e.g. Claude Code) may add this trailer automatically. Do not add a duplicate; ensure the resulting trailer identifies both the model and platform.
+- Your harness may add this trailer automatically. Do not add a duplicate; ensure the resulting trailer identifies both the model and platform.
 - Replace the placeholders with the model name/version reported by your runtime and the agent platform (e.g. Codex, Claude Code, or AutoGPT). Write `unknown` for unavailable model details; do not guess.
 - Use the platform's configured co-author email, or `agent@example.invalid` if none is available.
 - Include exactly one trailer per distinct platform/model pair that contributed to the commit, after a blank line at the end of the commit message. Preserve existing human co-author trailers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,11 +56,23 @@ Use conventional commit messages for all commits (e.g. `feat(backend): add API`)
 Types: - feat - fix - refactor - ci - dx (developer experience)
 Scopes: - platform - platform/library - platform/marketplace - backend - backend/executor - frontend - frontend/library - frontend/marketplace - blocks
 
+## Commit attribution
+
+For every commit you create in this repository, append a `Co-authored-by:` trailer identifying the large language model and agent platform:
+
+```text
+Co-authored-by: MODEL NAME/VERSION (AGENT PLATFORM) <COAUTHOR EMAIL>
+```
+
+- Replace the placeholders with the model name/version reported by your runtime and the agent platform (e.g. Codex, Claude Code, or AutoGPT). Write `unknown` for unavailable model details; do not guess.
+- Use the platform's configured co-author email, or `agent@example.invalid` if none is available.
+- Add one trailer per distinct platform/model pair that contributed to the commit, after a blank line at the end of the commit message. Preserve existing human co-author trailers.
+
 ## Pull requests
 
 - Use the template in `.github/PULL_REQUEST_TEMPLATE.md`.
 - Rely on the pre-commit checks for linting and formatting
-- Fill out the **Changes** section and the checklist.
+- Fill out the **Changes**, **Agents and large language models used**, and checklist sections. List each platform with its model name/version, or `None` if no agents were used.
 - Use conventional commit titles with a scope (e.g. `feat(frontend): add feature`).
 - Keep out-of-scope changes under 20% of the PR.
 - Ensure PR descriptions are complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,15 +58,16 @@ Scopes: - platform - platform/library - platform/marketplace - backend - backend
 
 ## Commit attribution
 
-For every commit you create in this repository, append a `Co-authored-by:` trailer identifying the large language model and agent platform:
+For every commit you create in this repository, ensure the commit message includes a `Co-authored-by:` trailer identifying the large language model and agent platform:
 
 ```text
 Co-authored-by: MODEL NAME/VERSION (AGENT PLATFORM) <COAUTHOR EMAIL>
 ```
 
+- Your harness (e.g. Claude Code) may add this trailer automatically. Do not add a duplicate; ensure the resulting trailer identifies both the model and platform.
 - Replace the placeholders with the model name/version reported by your runtime and the agent platform (e.g. Codex, Claude Code, or AutoGPT). Write `unknown` for unavailable model details; do not guess.
 - Use the platform's configured co-author email, or `agent@example.invalid` if none is available.
-- Add one trailer per distinct platform/model pair that contributed to the commit, after a blank line at the end of the commit message. Preserve existing human co-author trailers.
+- Include exactly one trailer per distinct platform/model pair that contributed to the commit, after a blank line at the end of the commit message. Preserve existing human co-author trailers.
 
 ## Pull requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
 @AGENTS.md
-
-Follow the commit attribution requirements in `AGENTS.md`: every commit you create must include a `Co-authored-by:` trailer naming the actual model name/version and agent platform.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,3 @@
 @AGENTS.md
+
+Follow the commit attribution requirements in `AGENTS.md`: every commit you create must include a `Co-authored-by:` trailer naming the actual model name/version and agent platform.


### PR DESCRIPTION
### Why / What / How

Make agent-assisted contributions explicit in commit history and pull requests. Require `Co-authored-by:` trailers naming the actual model/version and agent platform, and add one combined PR disclosure section. Claude Code receives the shared rule through its existing `@AGENTS.md` import.

### Changes 🏗️

- Add repository-wide commit attribution instructions to `AGENTS.md`, including automatic harness attribution without duplicate trailers, multiple contributors, unknown model details, and a fallback email.
- Add **Agents and large language models used** to the PR template: list platform/model pairs, or `None` when no agents were used.

### Agents and large language models used

Codex with GPT-6 (implementation and independent review).

### Checklist 📋

- [x] Changes are listed above.
- [x] Reviewed the final two-file diff against the requested behavior; verified `CLAUDE.md` remains identical to `dev` and imports `AGENTS.md`.
- [x] Checked added-line whitespace, UTF-8 BOMs, conflict markers, and file sizes.
- [x] Verified the co-author trailer format with `git interpret-trailers --parse`.

Documentation only; application tests do not apply. The full pre-commit suite was not run because its tooling is unavailable in this workspace. No configuration changes.
