### PR TITLE
fix(backend): probe Redis with a socket instead of connect() in collection-time skipifs

### DIFF
--- a/autogpt_platform/backend/backend/api/conn_manager_integration_test.py
+++ b/autogpt_platform/backend/backend/api/conn_manager_integration_test.py
@@ -28,21 +28,8 @@ from backend.data.execution import (
     graph_all_channel,
 )
 
-
-def _has_live_cluster() -> bool:
-    try:
-        c = redis_client.connect()
-    except Exception:  # noqa: BLE001 — any connect failure → skip
-        return False
-    try:
-        c.close()
-    except Exception:
-        pass
-    return True
-
-
 pytestmark = pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip conn_manager integration",
 )
 

--- a/autogpt_platform/backend/backend/data/e2e_redis_rabbit_test.py
+++ b/autogpt_platform/backend/backend/data/e2e_redis_rabbit_test.py
@@ -33,18 +33,6 @@ from backend.executor.utils import (
 )
 
 
-def _has_live_cluster() -> bool:
-    try:
-        c = redis_client.connect()
-    except Exception:  # noqa: BLE001 — any connect failure → skip
-        return False
-    try:
-        c.close()
-    except Exception:
-        pass
-    return True
-
-
 def _has_live_rabbit() -> bool:
     """Probe the rabbitmq host:port from settings; skip if unreachable."""
     import socket
@@ -62,7 +50,7 @@ def _has_live_rabbit() -> bool:
 
 
 cluster_only = pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip e2e integration",
 )
 rabbit_only = pytest.mark.skipif(

--- a/autogpt_platform/backend/backend/data/event_bus_test.py
+++ b/autogpt_platform/backend/backend/data/event_bus_test.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
+from backend.data import redis_client
 from backend.data.event_bus import (
     AsyncRedisEventBus,
     RedisEventBus,
@@ -81,23 +82,9 @@ def test_assert_no_wildcard_guard():
 # Live SSUBSCRIBE round-trip; skipped when no cluster is reachable.
 
 
-def _has_live_cluster() -> bool:
-    from backend.data import redis_client
-
-    try:
-        c = redis_client.connect()
-    except Exception:  # noqa: BLE001 - any connect failure → skip the test
-        return False
-    try:
-        c.close()
-    except Exception:
-        pass
-    return True
-
-
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip SSUBSCRIBE integration",
 )
 async def test_ssubscribe_end_to_end_async():
@@ -137,7 +124,7 @@ async def test_ssubscribe_end_to_end_async():
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip execution-bus integration",
 )
 async def test_execution_bus_listen_and_listen_graph_both_deliver():

--- a/autogpt_platform/backend/backend/data/redis_client.py
+++ b/autogpt_platform/backend/backend/data/redis_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import os
+import socket
+import time
 from collections.abc import AsyncGenerator
 from weakref import ReferenceType, WeakKeyDictionary, ref
 
@@ -91,6 +93,39 @@ def _address_remap(addr: tuple[str, int]) -> tuple[str, int]:
         return addr
     _, port = addr
     return HOST, port
+
+
+def server_reachable(timeout: float = 1.0) -> bool:
+    """Probe the configured `HOST:PORT` with a single TCP connect.
+
+    Safe to call from collection-time ``skipif`` guards: unlike
+    :func:`connect`, a dead host fails after ``timeout`` seconds instead of
+    retrying for ~45 minutes (``conn_retry``'s defaults) before the guard
+    can resolve.
+
+    ``timeout`` bounds the whole probe: when `HOST` resolves to several
+    addresses, the remaining time is re-derived for each attempt instead of
+    being spent per address. DNS resolution itself happens outside any
+    socket timeout; it is assumed to be healthy in environments where this
+    guard is used.
+    """
+    deadline = time.monotonic() + timeout
+    try:
+        infos = socket.getaddrinfo(HOST, PORT, type=socket.SOCK_STREAM)
+    except OSError:
+        return False
+    for family, socktype, proto, _, address in infos:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        try:
+            with socket.socket(family, socktype, proto) as sock:
+                sock.settimeout(remaining)
+                if sock.connect_ex(address) == 0:
+                    return True
+        except OSError:
+            continue
+    return False
 
 
 @conn_retry("Redis", "Acquiring connection")

--- a/autogpt_platform/backend/backend/data/redis_client_test.py
+++ b/autogpt_platform/backend/backend/data/redis_client_test.py
@@ -4,6 +4,7 @@ Patches the redis-py constructors + ``ping()`` so no real Redis is needed.
 """
 
 import asyncio
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -690,3 +691,51 @@ def test_sharded_pubsub_reconnect_after_forced_disconnect() -> None:
         ps2.close()
         client2.close()
         redis_client.disconnect()
+
+
+class TestServerReachable:
+    """Unit tests for the collection-time reachability probe."""
+
+    def test_true_for_a_live_tcp_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        with listener:
+            monkeypatch.setattr(redis_client, "HOST", "127.0.0.1")
+            monkeypatch.setattr(redis_client, "PORT", port)
+            assert redis_client.server_reachable() is True
+
+    def test_false_when_connection_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+        listener.close()  # nothing is listening on the port anymore
+        monkeypatch.setattr(redis_client, "HOST", "127.0.0.1")
+        monkeypatch.setattr(redis_client, "PORT", port)
+        assert redis_client.server_reachable() is False
+
+    def test_false_when_host_does_not_resolve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fail_getaddrinfo(*args: object, **kwargs: object) -> list:
+            raise OSError("resolution failed")
+
+        monkeypatch.setattr(redis_client.socket, "getaddrinfo", _fail_getaddrinfo)
+        monkeypatch.setattr(redis_client, "HOST", "127.0.0.1")
+        monkeypatch.setattr(redis_client, "PORT", 6379)
+        assert redis_client.server_reachable() is False
+
+    def test_false_when_the_deadline_is_already_spent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        with listener:
+            monkeypatch.setattr(redis_client, "HOST", "127.0.0.1")
+            monkeypatch.setattr(redis_client, "PORT", port)
+            assert redis_client.server_reachable(timeout=0) is False

--- a/autogpt_platform/backend/backend/data/redis_client_test.py
+++ b/autogpt_platform/backend/backend/data/redis_client_test.py
@@ -242,20 +242,8 @@ async def test_disconnect_async_no_cached_client_is_noop() -> None:
 # Skipped when no cluster is reachable so CI without docker doesn't flap.
 
 
-def _has_live_cluster() -> bool:
-    try:
-        c = redis_client.connect()
-    except Exception:  # noqa: BLE001 — any connect failure → skip the test
-        return False
-    try:
-        c.close()
-    except Exception:
-        pass
-    return True
-
-
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip sharded pub/sub integration",
 )
 def test_sharded_pubsub_end_to_end_sync() -> None:
@@ -291,7 +279,7 @@ def test_sharded_pubsub_end_to_end_sync() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip sharded pub/sub integration",
 )
 async def test_sharded_spublish_end_to_end_async() -> None:
@@ -551,7 +539,7 @@ def _channels_on_distinct_shards(n: int = 3) -> list[str]:
 
 
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip multi-shard integration",
 )
 def test_resolve_shard_for_channel_lands_on_distinct_shards() -> None:
@@ -567,7 +555,7 @@ def test_resolve_shard_for_channel_lands_on_distinct_shards() -> None:
 
 
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip multi-shard integration",
 )
 def test_sharded_pubsub_concurrent_subscribers_on_three_shards() -> None:
@@ -618,7 +606,7 @@ def test_sharded_pubsub_concurrent_subscribers_on_three_shards() -> None:
 
 
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip multi-shard integration",
 )
 def test_sharded_pubsub_idle_subscriber_survives_health_check_window() -> None:
@@ -656,7 +644,7 @@ def test_sharded_pubsub_idle_subscriber_survives_health_check_window() -> None:
 
 
 @pytest.mark.skipif(
-    not _has_live_cluster(),
+    not redis_client.server_reachable(),
     reason="local redis cluster not reachable; skip multi-shard integration",
 )
 def test_sharded_pubsub_reconnect_after_forced_disconnect() -> None:


### PR DESCRIPTION
### Why / What / How

Fixes #14321.

**Why:** Several backend test modules decide whether to run live-Redis integration tests via `pytest.mark.skipif(...)` guards that call `redis_client.connect()`. pytest evaluates those guards at collection time, and `connect()` is wrapped in `conn_retry` (max_retry=100, up to 30 s between attempts), so collecting one of these files on a machine without the aux stack blocks for roughly 45 minutes per guard with no output — indistinguishable from a hang. CI is unaffected (it provisions the Redis cluster), so this silently costs developers and agents only.

**What:** Adds a `server_reachable()` helper to `backend/data/redis_client.py` that probes `HOST:PORT` with a single 1-second TCP connect, and replaces every collection-time `connect()` probe with it: the two guards in `event_bus_test.py`, the `cluster_only` marker in `e2e_redis_rabbit_test.py`, all six guards in `redis_client_test.py`, and the module-level `pytestmark` in `conn_manager_integration_test.py`. This removes the five-plus divergent local copies of `_has_live_cluster()` the issue points at (the file-local versions also under-counted: `redis_client_test.py` alone evaluated the expensive probe six times per collection).

**How:** The helper reuses the module's own `HOST`/`PORT` resolution (including `REDIS_CLUSTER_HOST` precedence), so a developer's customized env stays in sync. Semantics are preserved: a reachable Redis still passes the guard and runs the tests; an unreachable one now fails the guard in ~1 s instead of ~45 minutes. The RabbitMQ probe in `e2e_redis_rabbit_test.py` already uses a plain socket probe and is left as is.

### Changes 🏗️

- `backend/data/redis_client.py`: add `server_reachable(timeout=1.0)` — plain TCP probe of the configured host/port, documented as collection-time safe.
- `backend/data/event_bus_test.py`, `backend/data/e2e_redis_rabbit_test.py`, `backend/data/redis_client_test.py`, `backend/api/conn_manager_integration_test.py`: drop the local `_has_live_cluster()` helpers that called `connect()` and use `redis_client.server_reachable()` in every skipif guard.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Baseline (issue reproduction): with `REDIS_HOST=10.255.255.1` (black hole), `import backend.data.redis_client_test` on unmodified `master` was still logging `Acquiring connection failed ... Retrying now...` when killed at 75 s — the import never completed.
  - [x] After the change: the same import plus the other three affected modules complete in ~1-9 s each against the black-hole host.
  - [x] `server_reachable()` returns `False` against the black-hole address and `True` against a live local TCP listener (probed via a reloaded module with `REDIS_CLUSTER_HOST`/`REDIS_PORT` overrides, so the helper follows the documented env precedence).
  - [x] `pytest --collect-only` over `conn_manager_integration_test.py`, `redis_client_test.py` and `event_bus_test.py` with no reachable Redis collects 56 tests in 12.6 s — collection no longer stalls.
  - [x] `black`, `isort` and `ruff check` pass on all five changed files.