### PR TITLE
fix(platform): calm the Recent work card on Home

### DIFF
--- a/autogpt_platform/backend/backend/api/features/home/helpers.py
+++ b/autogpt_platform/backend/backend/api/features/home/helpers.py
@@ -74,7 +74,8 @@ def agent_refs_by_graph(
 ) -> dict[str, AgentRef]:
     agents = {
         ref.graph_id: AgentRef(
-            name=ref.name or UNKNOWN_AGENT.name, library_agent_id=ref.id
+            name=ref.name or UNKNOWN_AGENT.name,
+            library_agent_id=None if ref.is_deleted else ref.id,
         )
         for ref in refs
     }

--- a/autogpt_platform/backend/backend/api/features/home/helpers_test.py
+++ b/autogpt_platform/backend/backend/api/features/home/helpers_test.py
@@ -1,10 +1,16 @@
 from datetime import datetime, timezone
 
 from backend.api.features.experts.models import Expert, ExpertWorkflowRef
+from backend.api.features.library.model import LibraryAgentRef
 from backend.executor.scheduler import GraphExecutionJobInfo
 
 from .activity import compose_upcoming_tasks
-from .helpers import experts_by_schedule, next_runs_by_expert, parse_datetime
+from .helpers import (
+    agent_refs_by_graph,
+    experts_by_schedule,
+    next_runs_by_expert,
+    parse_datetime,
+)
 
 SHARED_GRAPH = "graph-shared"
 
@@ -124,3 +130,18 @@ def test_parse_datetime_pins_naive_values_to_utc() -> None:
 
 def test_parse_datetime_returns_none_for_garbage() -> None:
     assert parse_datetime("not-a-timestamp") is None
+
+
+def test_a_removed_library_agent_still_names_its_runs_without_a_link() -> None:
+    refs = [
+        LibraryAgentRef(id="lib-live", graph_id="graph-live", name="Inbox triage"),
+        LibraryAgentRef(
+            id="lib-gone", graph_id="graph-gone", name="Sum Agent", is_deleted=True
+        ),
+    ]
+
+    agents = agent_refs_by_graph([], refs)
+
+    assert agents["graph-live"].library_agent_id == "lib-live"
+    assert agents["graph-gone"].name == "Sum Agent"
+    assert agents["graph-gone"].library_agent_id is None

--- a/autogpt_platform/backend/backend/api/features/home/models.py
+++ b/autogpt_platform/backend/backend/api/features/home/models.py
@@ -153,9 +153,12 @@ class HomeRecentWorkGroup(BaseModel):
     latest_at: datetime
     runs: list[HomeBriefingOutcome] = Field(default_factory=list)
     items: list[HomeRecentWorkItem] = Field(default_factory=list)
-    # Runs and items past the per-group caps, so the group can say how much
-    # more there was without listing it.
-    more_count: int = 0
+    # Week totals per kind, uncapped, so the header can state how much the
+    # actor did even when the rows below are a slice of it.
+    run_count: int = 0
+    file_count: int = 0
+    integration_count: int = 0
+    schedule_count: int = 0
 
 
 class HomeRecentWork(BaseModel):

--- a/autogpt_platform/backend/backend/api/features/home/recent_work.py
+++ b/autogpt_platform/backend/backend/api/features/home/recent_work.py
@@ -110,13 +110,16 @@ def compose_recent_work(
 def _compose_group(found: _Bucket) -> HomeRecentWorkGroup:
     # Runs arrive failures-first then newest-first; events arrive newest-first.
     # Both orders are worth keeping, so the caps slice rather than re-sort.
+    categories = [item.category for item in found.items]
     return HomeRecentWorkGroup(
         actor=found.actor,
         latest_at=found.latest_at or datetime.min.replace(tzinfo=timezone.utc),
         runs=found.runs[:_MAX_RUNS_PER_GROUP],
         items=found.items[:_MAX_ITEMS_PER_GROUP],
-        more_count=max(0, len(found.runs) - _MAX_RUNS_PER_GROUP)
-        + max(0, len(found.items) - _MAX_ITEMS_PER_GROUP),
+        run_count=len(found.runs),
+        file_count=categories.count("file"),
+        integration_count=categories.count("integration"),
+        schedule_count=categories.count("schedule"),
     )
 
 

--- a/autogpt_platform/backend/backend/api/features/home/recent_work_test.py
+++ b/autogpt_platform/backend/backend/api/features/home/recent_work_test.py
@@ -145,6 +145,8 @@ def test_groups_runs_and_deliverables_under_the_actor_that_did_them() -> None:
     assert [run.id for run in notes_group.runs] == ["run-notes"]
     assert [item.id for item in notes_group.items] == ["e2"]
     assert notes_group.items[0].link is None
+    assert (notes_group.run_count, notes_group.integration_count) == (1, 1)
+    assert (maria_group.run_count, maria_group.file_count) == (1, 1)
 
 
 def test_an_executor_event_follows_its_run_to_the_expert() -> None:
@@ -240,7 +242,10 @@ def test_groups_are_capped_and_report_the_overflow() -> None:
     group = work.groups[0]
     assert len(group.runs) == _MAX_RUNS_PER_GROUP
     assert len(group.items) == _MAX_ITEMS_PER_GROUP
-    assert group.more_count == 5
+    # The header counts the whole week even though the rows are a slice.
+    assert group.run_count == _MAX_RUNS_PER_GROUP + 2
+    assert group.file_count == _MAX_ITEMS_PER_GROUP + 3
+    assert group.integration_count == 0
     assert work.total_count == _MAX_ITEMS_PER_GROUP + 3
 
 

--- a/autogpt_platform/backend/backend/api/features/home/service.py
+++ b/autogpt_platform/backend/backend/api/features/home/service.py
@@ -81,7 +81,10 @@ async def build_home_dashboard(
     # All depend on the gathered data (graph ids / session ids / timezone) but
     # not on each other, so these reads cost no extra round-trip.
     library_refs, persisted_briefing, session_titles = await asyncio.gather(
-        library_db.get_library_agent_refs_by_graph_ids(user_id, graph_ids),
+        # Removed agents keep naming their past runs on the Recent work card.
+        library_db.get_library_agent_refs_by_graph_ids(
+            user_id, graph_ids, include_deleted=True
+        ),
         _persisted_briefing(user_id=user_id, timezone_name=data.timezone_name, now=now),
         _get_session_titles(user_id=user_id, session_ids=work_session_ids),
     )

--- a/autogpt_platform/backend/backend/api/features/library/db.py
+++ b/autogpt_platform/backend/backend/api/features/library/db.py
@@ -451,7 +451,7 @@ async def get_library_agent_id_by_graph_id(user_id: str, graph_id: str) -> str |
 
 
 async def get_library_agent_refs_by_graph_ids(
-    user_id: str, graph_ids: list[str]
+    user_id: str, graph_ids: list[str], *, include_deleted: bool = False
 ) -> list[library_model.LibraryAgentRef]:
     """Resolve display name + id for the given graphs in one query.
 
@@ -462,20 +462,29 @@ async def get_library_agent_refs_by_graph_ids(
     ``@@unique([userId, agentGraphId, agentGraphVersion])`` allows several
     rows per graph, so exactly one ref per graph is returned — the newest
     version — instead of whichever row the DB happened to return last.
+
+    With ``include_deleted`` a graph whose every library row was removed
+    still resolves to its last name, marked ``is_deleted``; a live row
+    always wins over a removed one.
     """
     if not graph_ids:
         return []
+    where: prisma.types.LibraryAgentWhereInput = {
+        "userId": user_id,
+        "agentGraphId": {"in": graph_ids},
+    }
+    if not include_deleted:
+        where["isDeleted"] = False
     agents = await prisma.models.LibraryAgent.prisma().find_many(
-        where={
-            "userId": user_id,
-            "agentGraphId": {"in": graph_ids},
-            "isDeleted": False,
-        },
-        order=[{"agentGraphVersion": "asc"}],
+        where=where,
+        order=[{"isDeleted": "desc"}, {"agentGraphVersion": "asc"}],
     )
     newest_by_graph = {
         agent.agentGraphId: library_model.LibraryAgentRef(
-            id=agent.id, graph_id=agent.agentGraphId, name=agent.name or ""
+            id=agent.id,
+            graph_id=agent.agentGraphId,
+            name=agent.name or "",
+            is_deleted=agent.isDeleted,
         )
         for agent in agents
     }

--- a/autogpt_platform/backend/backend/api/features/library/model.py
+++ b/autogpt_platform/backend/backend/api/features/library/model.py
@@ -143,6 +143,8 @@ class LibraryAgentRef(pydantic.BaseModel):
     id: str
     graph_id: str
     name: str
+    # A removed agent still names its past runs; it just cannot be linked.
+    is_deleted: bool = False
 
 
 class RecentExecution(pydantic.BaseModel):

--- a/autogpt_platform/frontend/src/app/(platform)/home/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/__tests__/main.test.tsx
@@ -187,7 +187,7 @@ const dashboard: HomeDashboardResponse = {
         latest_at: NOW,
         runs: [cameraResearch, schedulingFailure],
         items: [],
-        more_count: 13,
+        run_count: 14,
       },
     ],
   },
@@ -216,7 +216,7 @@ test("renders every Home tile from the aggregate API", async () => {
   expect(screen.getByText("Connect your calendar for Maria")).toBeDefined();
   expect(screen.getByRole("heading", { name: "Recent work" })).toBeDefined();
   expect(screen.getByText("Your camera research is ready")).toBeDefined();
-  expect(screen.getByText("Plus 13 more")).toBeDefined();
+  expect(screen.getByText("14 runs")).toBeDefined();
   expect(screen.getByRole("heading", { name: "Your team" })).toBeDefined();
   expect(
     screen.getByRole("link", { name: /View all 10 experts/ }),

--- a/autogpt_platform/frontend/src/app/(platform)/home/__tests__/recent-work.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/__tests__/recent-work.test.tsx
@@ -72,6 +72,18 @@ const recentWork: HomeRecentWork = {
           cost_cents: 42,
           link: "/library/agents/lib-2?activeTab=runs&activeItem=run-1",
         },
+        {
+          id: "run-3",
+          status: "completed",
+          title: "Newsletter draft is ready",
+          summary: "Drafted the September newsletter from last week's notes.",
+          expert: maria,
+          agent_name: "Newsletter Writer",
+          occurred_at: NOW,
+          duration_seconds: 300,
+          cost_cents: 12,
+          link: "/library/agents/lib-3?activeTab=runs&activeItem=run-3",
+        },
       ],
       items: [
         {
@@ -93,7 +105,9 @@ const recentWork: HomeRecentWork = {
           occurred_at: NOW,
         },
       ],
-      more_count: 6,
+      run_count: 3,
+      file_count: 2,
+      schedule_count: 1,
     },
     {
       actor: {
@@ -125,7 +139,8 @@ const recentWork: HomeRecentWork = {
           provider: "google",
         },
       ],
-      more_count: 0,
+      run_count: 1,
+      integration_count: 1,
     },
     {
       actor: { kind: "autopilot", name: "Autopilot", link: "/copilot" },
@@ -141,7 +156,7 @@ const recentWork: HomeRecentWork = {
           link: "/copilot?sessionId=session-2",
         },
       ],
-      more_count: 0,
+      file_count: 1,
     },
   ],
 };
@@ -206,12 +221,22 @@ test("groups the week's runs and deliverables by who did them", async () => {
     within(mariaGroup).getByText("2026-08-28-code-review-metrics.md"),
   ).toBeDefined();
   expect(within(mariaGroup).getByText("persian.sh blog draft")).toBeDefined();
-  expect(within(mariaGroup).getByText("Plus 6 more")).toBeDefined();
+  expect(
+    within(mariaGroup).getByText("3 runs · 2 files · 1 schedule"),
+  ).toBeDefined();
+  // Only the first run tells its story; later completed runs are one line.
+  expect(
+    within(mariaGroup).getByText("Newsletter draft is ready"),
+  ).toBeDefined();
+  expect(
+    within(mariaGroup).queryByText(/Drafted the September newsletter/),
+  ).toBeNull();
 
   const workflowGroup = screen.getByRole("article", {
     name: "Release Note Generator",
   });
   expect(within(workflowGroup).getByText("Workflow")).toBeDefined();
+  expect(within(workflowGroup).getByText("1 run · 1 action")).toBeDefined();
   expect(within(workflowGroup).getByText("Failed")).toBeDefined();
   expect(
     within(workflowGroup).getByText("Release notes could not be generated"),

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/RecentWork.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/RecentWork.tsx
@@ -46,7 +46,7 @@ export function RecentWork({ dashboard, className }: Props) {
           description="Runs, files, integrations and schedules from your experts and workflows will appear here."
         />
       ) : (
-        <div className="divide-y divide-zinc-100">
+        <div className="divide-y divide-zinc-200">
           {briefing.narrative ? (
             <Text
               variant="body"

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/components/OutcomeRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/components/OutcomeRow.tsx
@@ -1,8 +1,4 @@
-import {
-  AlertDiamondIcon,
-  ArrowUpRight01Icon,
-  CheckListIcon,
-} from "@hugeicons/core-free-icons";
+import { AlertDiamondIcon, CheckListIcon } from "@hugeicons/core-free-icons";
 import Link from "next/link";
 import type { HomeBriefingOutcome } from "@/app/api/__generated__/models/homeBriefingOutcome";
 import { Icon } from "@/components/atoms/Icon/Icon";
@@ -17,13 +13,92 @@ interface Props {
   /** An expert runs workflows, so the run names which one; a workflow
    *  group already carries the name in its header. */
   showAgentName: boolean;
+  /** Title and time only: for the runs after the first in a group. */
+  compact?: boolean;
 }
 
 const ROW_CLASS = "flex gap-2 py-2";
+const LINK_CLASS =
+  "-mx-1 rounded px-1 outline-none transition-colors hover:bg-zinc-50 focus-visible:bg-zinc-50";
 
-export function OutcomeRow({ outcome, timezone, showAgentName }: Props) {
+export function OutcomeRow({
+  outcome,
+  timezone,
+  showAgentName,
+  compact = false,
+}: Props) {
   const failed = outcome.status === "failed";
-  const meta = [
+  const mark = (
+    <span
+      className={cn(
+        "mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-md",
+        failed ? "bg-rose-50 text-rose-600" : "bg-zinc-100 text-zinc-500",
+      )}
+    >
+      <Icon
+        icon={failed ? AlertDiamondIcon : CheckListIcon}
+        size={11}
+        aria-hidden="true"
+      />
+    </span>
+  );
+
+  const content = compact ? (
+    <>
+      {mark}
+      <Text
+        variant="body"
+        className="min-w-0 flex-1 truncate text-[13px] leading-5 text-zinc-700"
+      >
+        {outcome.title}
+      </Text>
+      <span className="shrink-0 text-[11px] tabular-nums text-zinc-400">
+        {formatWorkTime(outcome.occurred_at, timezone)}
+      </span>
+    </>
+  ) : (
+    <>
+      {mark}
+      <div className="min-w-0 flex-1">
+        <Text
+          variant="body-medium"
+          className="text-pretty text-[13px] leading-5 text-zinc-900"
+        >
+          {outcome.title}
+        </Text>
+        <Text
+          variant="small"
+          className="mt-0.5 line-clamp-2 text-pretty text-[13px] leading-5 text-zinc-500"
+        >
+          {outcome.summary}
+        </Text>
+        <RunMeta
+          outcome={outcome}
+          timezone={timezone}
+          showAgentName={showAgentName}
+        />
+      </div>
+    </>
+  );
+
+  if (!outcome.link) {
+    return (
+      <div className={cn(ROW_CLASS, compact && "items-center")}>{content}</div>
+    );
+  }
+  return (
+    <Link
+      href={outcome.link}
+      className={cn(ROW_CLASS, LINK_CLASS, compact && "items-center")}
+    >
+      {content}
+    </Link>
+  );
+}
+
+function RunMeta({ outcome, timezone, showAgentName }: Omit<Props, "compact">) {
+  const failed = outcome.status === "failed";
+  const parts = [
     failed ? (
       <span key="status" className="font-medium text-rose-600">
         Failed
@@ -49,65 +124,14 @@ export function OutcomeRow({ outcome, timezone, showAgentName }: Props) {
     ) : null,
   ].filter(Boolean);
 
-  const content = (
-    <>
-      <span
-        className={cn(
-          "mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-md",
-          failed ? "bg-rose-50 text-rose-600" : "bg-zinc-100 text-zinc-500",
-        )}
-      >
-        <Icon
-          icon={failed ? AlertDiamondIcon : CheckListIcon}
-          size={11}
-          aria-hidden="true"
-        />
-      </span>
-      <div className="min-w-0 flex-1">
-        <Text
-          variant="body-medium"
-          className="text-pretty text-[13px] leading-5 text-zinc-900"
-        >
-          {outcome.title}
-        </Text>
-        <Text
-          variant="small"
-          className="mt-0.5 line-clamp-2 text-pretty text-[13px] leading-5 text-zinc-500"
-        >
-          {outcome.summary}
-        </Text>
-        <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-zinc-400">
-          {meta.map((part, index) => (
-            <span key={index} className="flex items-center gap-x-1.5">
-              {index > 0 ? <span aria-hidden="true">·</span> : null}
-              {part}
-            </span>
-          ))}
-        </div>
-      </div>
-      {outcome.link ? (
-        <Icon
-          icon={ArrowUpRight01Icon}
-          size={14}
-          className="mt-1 shrink-0 text-zinc-300 transition-colors group-hover:text-zinc-600"
-          aria-hidden="true"
-        />
-      ) : null}
-    </>
-  );
-
-  if (!outcome.link) {
-    return <div className={ROW_CLASS}>{content}</div>;
-  }
   return (
-    <Link
-      href={outcome.link}
-      className={cn(
-        ROW_CLASS,
-        "group -mx-1 rounded px-1 outline-none transition-colors hover:bg-zinc-50 focus-visible:bg-zinc-50",
-      )}
-    >
-      {content}
-    </Link>
+    <div className="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-zinc-400">
+      {parts.map((part, index) => (
+        <span key={index} className="flex items-center gap-x-1.5">
+          {index > 0 ? <span aria-hidden="true">·</span> : null}
+          {part}
+        </span>
+      ))}
+    </div>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/components/WorkGroup.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/components/WorkGroup.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import type { HomeRecentWorkGroup } from "@/app/api/__generated__/models/homeRecentWorkGroup";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
-import { getActorKindLabel } from "../helpers";
+import { formatGroupCounts, getActorKindLabel } from "../helpers";
 import { ActorMark } from "./ActorMark";
 import { OutcomeRow } from "./OutcomeRow";
 import { WorkItemRow } from "./WorkItemRow";
@@ -22,18 +22,21 @@ export function WorkGroup({ group, timezone }: Props) {
       <ActorMark actor={actor} />
       <Text
         variant="body-medium"
-        className="truncate text-[13px] leading-5 text-zinc-900"
+        className="truncate text-sm font-semibold leading-5 text-zinc-900"
       >
         {actor.name}
       </Text>
-      <span className="shrink-0 rounded-full border border-zinc-200 px-1.5 text-[10px] font-medium uppercase leading-4 tracking-[0.04em] text-zinc-500">
+      <span className="shrink-0 rounded-full border border-zinc-200 bg-white px-1.5 text-[10px] font-medium uppercase leading-4 tracking-[0.04em] text-zinc-500">
         {getActorKindLabel(actor.kind)}
+      </span>
+      <span className="ml-auto shrink-0 text-[11px] tabular-nums text-zinc-400">
+        {formatGroupCounts(group)}
       </span>
       {actor.link ? (
         <Icon
           icon={ArrowUpRight01Icon}
           size={14}
-          className="ml-auto shrink-0 text-zinc-300 transition-colors group-hover:text-zinc-600"
+          className="shrink-0 text-zinc-300 transition-colors group-hover:text-zinc-600"
           aria-hidden="true"
         />
       ) : null}
@@ -41,43 +44,40 @@ export function WorkGroup({ group, timezone }: Props) {
   );
 
   return (
-    <article className="px-4 py-3" aria-label={actor.name}>
-      {actor.link ? (
-        <Link
-          href={actor.link}
-          className="group -mx-1 block rounded px-1 outline-none focus-visible:bg-zinc-50"
-        >
-          {header}
-        </Link>
-      ) : (
-        header
-      )}
+    <article aria-label={actor.name}>
+      <div className="bg-zinc-50/80 px-4 py-2">
+        {actor.link ? (
+          <Link
+            href={actor.link}
+            className="group block rounded outline-none focus-visible:ring-2 focus-visible:ring-zinc-300"
+          >
+            {header}
+          </Link>
+        ) : (
+          header
+        )}
+      </div>
       {runs.length > 0 ? (
-        <div className="mt-1 divide-y divide-zinc-100">
-          {runs.map((run) => (
+        <div className="divide-y divide-zinc-100 px-4">
+          {/* One run tells the story; the rest are a line each, unless they
+              failed and need a look. */}
+          {runs.map((run, index) => (
             <OutcomeRow
               key={run.id}
               outcome={run}
               timezone={timezone}
               showAgentName={actor.kind === "expert"}
+              compact={index > 0 && run.status !== "failed"}
             />
           ))}
         </div>
       ) : null}
       {items.length > 0 ? (
-        <div className="mt-1.5 flex flex-col gap-1">
+        <div className="flex flex-col gap-1 px-4 py-2">
           {items.map((item) => (
             <WorkItemRow key={item.id} item={item} timezone={timezone} />
           ))}
         </div>
-      ) : null}
-      {group.more_count ? (
-        <Text
-          variant="small"
-          className="mt-1.5 pl-[26px] text-[11px] text-zinc-400"
-        >
-          Plus {group.more_count} more
-        </Text>
       ) : null}
     </article>
   );

--- a/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/home/components/RecentWork/helpers.ts
@@ -7,6 +7,7 @@ import {
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
+import type { HomeRecentWorkGroup } from "@/app/api/__generated__/models/homeRecentWorkGroup";
 import type { HomeRecentWorkItemCategory } from "@/app/api/__generated__/models/homeRecentWorkItemCategory";
 import type { HomeWorkActorKind } from "@/app/api/__generated__/models/homeWorkActorKind";
 
@@ -44,4 +45,20 @@ export function formatWorkTime(
     hour: "numeric",
     minute: "2-digit",
   }).format(new Date(value));
+}
+
+export function formatGroupCounts(group: HomeRecentWorkGroup): string {
+  return [
+    countLabel(group.run_count ?? 0, "run"),
+    countLabel(group.file_count ?? 0, "file"),
+    countLabel(group.integration_count ?? 0, "action"),
+    countLabel(group.schedule_count ?? 0, "schedule"),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function countLabel(count: number, noun: string): string | null {
+  if (count === 0) return null;
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -21638,9 +21638,24 @@
             "type": "array",
             "title": "Items"
           },
-          "more_count": {
+          "run_count": {
             "type": "integer",
-            "title": "More Count",
+            "title": "Run Count",
+            "default": 0
+          },
+          "file_count": {
+            "type": "integer",
+            "title": "File Count",
+            "default": 0
+          },
+          "integration_count": {
+            "type": "integer",
+            "title": "Integration Count",
+            "default": 0
+          },
+          "schedule_count": {
+            "type": "integer",
+            "title": "Schedule Count",
             "default": 0
           }
         },


### PR DESCRIPTION
### Why / What / How

**Why:** After #14342 the Recent work card groups work by actor, but a week of activity rendered as a wall of text: every run showed its full AI summary, group headers had the same weight as run titles, dividers between groups and between rows looked identical, and every row carried an arrow. Runs of a graph that was removed from the library showed under the placeholder name "Agent task".

**What:** Fewer words and a clear hierarchy. Group headers sit on a tinted band with a semibold name, the kind badge, and the week's counts ("3 runs · 2 files"). Inside a group only the first run keeps its summary; later completed runs are a single line each, and failed runs always expand. Groups are separated more strongly than rows, the arrow only appears on the group header, and the "Plus N more" line is replaced by the header counts. Removed library agents keep naming their runs.

**How:**
- `HomeRecentWorkGroup` carries `run_count`, `file_count`, `integration_count`, `schedule_count` (week totals, uncapped) instead of `more_count`.
- `get_library_agent_refs_by_graph_ids` gains `include_deleted`; a live row always wins over a removed one, and refs are marked `is_deleted`. Home passes `include_deleted=True` and drops the library link for removed agents. Other callers (the briefing job, the executor RPC) keep the default and are unchanged.
- `OutcomeRow` gets a `compact` mode; `WorkGroup` decides which runs expand.
- `openapi.json` is the exporter's own output.

### Changes 🏗️

- `backend/api/features/library/{model,db}.py`: `LibraryAgentRef.is_deleted`, `include_deleted` lookup.
- `backend/api/features/home/{models,recent_work,helpers,service}.py`: per-kind counts, removed-agent naming.
- `frontend/.../RecentWork/components/{WorkGroup,OutcomeRow}.tsx`, `helpers.ts`, `RecentWork.tsx`: header band, counts, compact runs, stronger group dividers.
- Tests: `recent_work_test.py`, `helpers_test.py`, `recent-work.test.tsx`, `main.test.tsx`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `ruff`, `pyright` clean on the changed backend modules
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` clean; home integration tests pass (29)
  - [ ] Backend pytest for the home feature: not run locally because the session fixture needs the docker stack; CI covers it
  - [ ] Load `/home` with several runs of one workflow and confirm only the first shows a summary, and that a removed agent's runs show its real name

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

For `data/*.py`-style changes: the library lookup is scoped by `userId` exactly as before; `include_deleted` only relaxes the `isDeleted` filter within the caller's own rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
