### PR TITLE
ci(platform): upgrade conflict label action to Node.js 24

### DIFF
--- a/.github/workflows/repo-pr-label.yml
+++ b/.github/workflows/repo-pr-label.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update PRs with conflict labels
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3.1.0
         with:
           dirtyLabel: "conflicts"
           #removeOnDirtyLabel: "PR: ready to ship"


### PR DESCRIPTION
### Why / What / How

The merge-conflict labeling workflow still uses `eps1lon/actions-label-merge-conflict@releases/2.x`, which targets the deprecated Node.js 20 Actions runtime. GitHub currently forces it to run on Node.js 24 and emits a deprecation warning on every PR label run.

Upgrade the action to `v3.1.0`, whose metadata explicitly declares `node24`. The v3 action retains the inputs used by this workflow, so label and conflict-comment behavior stays unchanged.

### Changes 🏗️

- Upgrade `eps1lon/actions-label-merge-conflict` from `releases/2.x` to `v3.1.0`.
- Keep the existing token, label, and conflict-comment configuration unchanged.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `git diff --check`
  - [x] Confirmed `v3.1.0` declares `runs.using: node24`
  - [x] Confirmed `repoToken`, `dirtyLabel`, `commentOnDirty`, and `commentOnClean` remain supported inputs

#### For configuration changes:
- [x] `.env.default` is already compatible with this change
- [x] `docker-compose.yml` is already compatible with this change
- [x] The complete workflow configuration change is listed above