### PR TITLE
fix(backend): isolate copilot dispatch sleep mocks

### DIFF
--- a/autogpt_platform/backend/backend/copilot/executor/manager_test.py
+++ b/autogpt_platform/backend/backend/copilot/executor/manager_test.py
@@ -7,8 +7,11 @@ pin its retry/give-up contract.
 """
 
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from time import sleep as original_sleep
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -76,29 +79,51 @@ def test_dispatch_preserves_codex_transport_for_engine_switch(
     assert kwargs["llm_credential_id"] == "cred-codex"
 
 
-def test_dispatch_retries_until_success():
+@pytest.fixture
+def mock_dispatch_sleep():
+    mock_sleep = MagicMock()
+    with patch(
+        "backend.copilot.executor.manager.time", SimpleNamespace(sleep=mock_sleep)
+    ):
+        yield mock_sleep
+
+
+def test_dispatch_sleep_mock_does_not_affect_other_threads(mock_dispatch_sleep):
+    def sleep_in_other_thread():
+        sleeper = time.sleep
+        sleeper(0)
+        return sleeper
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        sleeper = executor.submit(sleep_in_other_thread).result(timeout=5)
+
+    assert sleeper is original_sleep
+    mock_dispatch_sleep.assert_not_called()
+
+
+def test_dispatch_retries_until_success(mock_dispatch_sleep):
     with (
         patch(
             "backend.copilot.executor.manager.schedule_turn",
             new_callable=AsyncMock,
             side_effect=[RuntimeError("rmq down"), RuntimeError("rmq down"), None],
         ) as mock_schedule,
-        patch("backend.copilot.executor.manager.time.sleep") as mock_sleep,
     ):
         _dispatch_engine_switch_continuation("sess-1", _SWITCH)
 
     assert mock_schedule.await_count == 3
-    assert mock_sleep.call_count == 2
+    assert mock_dispatch_sleep.call_args_list == [call(1), call(2)]
 
 
-def test_dispatch_gives_up_after_bounded_attempts_with_user_visible_marker():
+def test_dispatch_gives_up_after_bounded_attempts_with_user_visible_marker(
+    mock_dispatch_sleep,
+):
     with (
         patch(
             "backend.copilot.executor.manager.schedule_turn",
             new_callable=AsyncMock,
             side_effect=RuntimeError("rmq down"),
         ) as mock_schedule,
-        patch("backend.copilot.executor.manager.time.sleep"),
         patch(
             "backend.copilot.executor.manager._persist_switch_failure_marker"
         ) as mock_marker,
@@ -106,6 +131,7 @@ def test_dispatch_gives_up_after_bounded_attempts_with_user_visible_marker():
         _dispatch_engine_switch_continuation("sess-1", _SWITCH)
 
     assert mock_schedule.await_count == _SWITCH_DISPATCH_ATTEMPTS
+    assert mock_dispatch_sleep.call_args_list == [call(1), call(2)]
     mock_marker.assert_called_once_with("sess-1")
 
 


### PR DESCRIPTION
### Why / What / How

The dispatch retry tests patched the shared standard-library `time.sleep` attribute. Unrelated threads could enter that mock and lose their real delay, causing otherwise successful retries to fail the sleep-count assertion.

Replace the manager's `time` binding with a test-local namespace through a shared fixture. Both retry tests retain three scheduling attempts and now assert the exact delay sequence, `[1, 2]`. A deterministic regression verifies that another thread still calls the original sleep function without touching the manager's mock.

Closes #14371.

### Changes 🏗️

- Isolate the sleep dependency in both affected tests.
- Add a thread-isolation regression using `sleep(0)`, with no elapsed-time assertion.
- Preserve bounded retry and failure-marker coverage; production code is unchanged.

### Agents and large language models used

Codex with GPT-6 for implementation and independent review.

### Checklist 📋

- [x] Changes and test plan are described above.
- [x] Regression confirmed to fail with the original shared patch.
- [x] Six source-extracted test cases and their fixtures pass with the fix (Windows, Python 3.12.14, pytest 8.4.2; application dependencies stubbed).
- [x] Ruff, isort, Black formatting, and `git diff --check` pass.
- [x] Independent review: PASS, no actionable findings.
- [ ] Run the actual manager test module and backend CI matrix (Python 3.11, 3.12, 3.13).

Local full-module collection is blocked by the available environment's generated Prisma client missing `BriefingFrequency`; Docker services are unavailable. The isolated harness does not validate the application import graph, backend session fixtures, or the exact historical 4,427-call CI event. GitHub Actions should provide the full-suite validation.

No configuration changes.
