### PR TITLE
fix(backend/copilot): cap the compaction window pin at the routed model's real window

### DIFF
--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -442,9 +442,8 @@ class ChatConfig(BaseSettings):
         validation_alias=AliasChoices("CHAT_CLAUDE_AGENT_CONTEXT_WINDOW"),
         description="Context window the SDK subprocess is held to, in tokens "
         "(sets ``CLAUDE_CODE_AUTO_COMPACT_WINDOW``; see ``sdk/env.py``). Only "
-        "raise it on a route that really serves 1M — past the provider's real "
-        "window the compaction trigger never fires (at 1M on Moonshot it lands "
-        "at 967K against Kimi's 262,144).",
+        "raise it on a route that really serves 1M; Moonshot routes cap it at "
+        "the SKU's catalog window, Anthropic routes take it as given.",
     )
     claude_agent_autocompact_pct_override: int = Field(
         default=50,

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -441,9 +441,9 @@ class ChatConfig(BaseSettings):
         le=1_000_000,
         validation_alias=AliasChoices("CHAT_CLAUDE_AGENT_CONTEXT_WINDOW"),
         description="Context window the SDK subprocess is held to, in tokens "
-        "(sets ``CLAUDE_CODE_AUTO_COMPACT_WINDOW``; see ``sdk/env.py``). Only "
-        "raise it on a route that really serves 1M; Moonshot routes cap it at "
-        "the SKU's catalog window, Anthropic routes take it as given.",
+        "(sets ``CLAUDE_CODE_AUTO_COMPACT_WINDOW``; see ``sdk/env.py``). "
+        "Moonshot routes use the lower of this and the SKU's catalog window; "
+        "Anthropic routes take it as given.",
     )
     claude_agent_autocompact_pct_override: int = Field(
         default=50,

--- a/autogpt_platform/backend/backend/copilot/moonshot.py
+++ b/autogpt_platform/backend/backend/copilot/moonshot.py
@@ -76,6 +76,11 @@ def _overrides_from_catalog() -> dict[str, tuple[float, float]]:
 # Import-time snapshot is safe: the catalog is immutable within a process
 # (the file only changes at deploy), same lifecycle as every projection.
 _RATE_OVERRIDES_USD_PER_MTOK: dict[str, tuple[float, float]] = _overrides_from_catalog()
+_CONTEXT_WINDOWS: dict[str, int] = {
+    m.slug: m.context_window
+    for m in get_catalog().models
+    if m.slug.startswith(_MOONSHOT_PREFIX)
+}
 
 
 def is_moonshot_model(model: str | None) -> bool:
@@ -164,3 +169,13 @@ def moonshot_supports_cache_control(model: str | None) -> bool:
     ballpark as Anthropic's ~60-95% on continuations.
     """
     return is_moonshot_model(model)
+
+
+def moonshot_context_window(model: str | None) -> int | None:
+    """Catalog context window for a Moonshot *model*, or None if unknown.
+
+    The CLI's model table has no Moonshot entry, so callers that must not
+    exceed the provider's real window have nowhere else to read it from.
+    Also None for non-Moonshot slugs, which the CLI knows itself.
+    """
+    return _CONTEXT_WINDOWS.get(model) if model else None

--- a/autogpt_platform/backend/backend/copilot/moonshot_test.py
+++ b/autogpt_platform/backend/backend/copilot/moonshot_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from backend.copilot.moonshot import (
     is_moonshot_model,
+    moonshot_context_window,
     moonshot_supports_cache_control,
     override_cost_usd,
     rate_card_usd,
@@ -177,3 +178,31 @@ class TestSupportsCacheControl:
     )
     def test_non_moonshot_does_not_support_cache_control(self, model) -> None:
         assert moonshot_supports_cache_control(model) is False
+
+
+class TestMoonshotContextWindow:
+    """The catalog is the only place the real Kimi window is written down."""
+
+    @pytest.mark.parametrize(
+        "model, expected",
+        [
+            ("moonshotai/kimi-k2.5", 262_144),
+            ("moonshotai/kimi-k2.6", 262_144),
+            ("moonshotai/kimi-k2-thinking", 262_144),
+            ("moonshotai/kimi-k3", 1_048_576),
+        ],
+    )
+    def test_reads_the_catalog_window(self, model, expected) -> None:
+        assert moonshot_context_window(model) == expected
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "moonshotai/kimi-k9-unreleased",
+            "anthropic/claude-sonnet-5",
+            "",
+            None,
+        ],
+    )
+    def test_none_for_unlisted_and_non_moonshot(self, model) -> None:
+        assert moonshot_context_window(model) is None

--- a/autogpt_platform/backend/backend/copilot/sdk/env.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/env.py
@@ -13,7 +13,7 @@ import re
 from urllib.parse import urlparse
 
 from backend.copilot.config import ChatConfig
-from backend.copilot.moonshot import is_moonshot_model
+from backend.copilot.moonshot import is_moonshot_model, moonshot_context_window
 from backend.copilot.sdk.subscription import validate_subscription
 
 # ChatConfig is stateless (reads env vars) — a separate instance is fine.
@@ -178,13 +178,14 @@ def build_sdk_env(
     # the model table, the 1M capability flags and the server-side experiment
     # branches that newer CLIs consult — without it the compaction trigger is
     # an emergent property of whichever bundled CLI we happen to ship.
-    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(config.claude_agent_context_window)
+    window = _pinned_context_window(model)
+    env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(window)
 
     # The window above is clamped by the model's own window, which this
     # kill-switch holds at 200K; keeping it set past that point would swallow
     # the raise silently.  1M is GA (no beta header) on Sonnet 4.6+/5, so the
     # experimental-betas flag above does not cover it.
-    if config.claude_agent_context_window <= _CLI_DEFAULT_CONTEXT_WINDOW:
+    if window <= _CLI_DEFAULT_CONTEXT_WINDOW:
         env["CLAUDE_CODE_DISABLE_1M_CONTEXT"] = "1"
 
     # Trigger threshold, as a percentage of the window pinned above (CLI
@@ -214,6 +215,21 @@ def build_sdk_env(
 
 # What the CLI assumes any Claude model's window to be once 1M is gated off.
 _CLI_DEFAULT_CONTEXT_WINDOW = 200_000
+
+
+def _pinned_context_window(model: str | None) -> int:
+    """Configured window pin, capped at a Moonshot route's real window.
+
+    A pin above what the provider serves puts the compaction trigger past the
+    point the provider rejects the turn, so compaction never fires.  Anthropic
+    is deliberately not capped: the catalog holds every Anthropic entry at 200K
+    pending the Claude-5 tokenizer soak, which would cancel a legitimate raise.
+    An unlisted Kimi SKU falls back to the window the CLI assumes anyway.
+    """
+    window = config.claude_agent_context_window
+    if not is_moonshot_model(model):
+        return window
+    return min(window, moonshot_context_window(model) or _CLI_DEFAULT_CONTEXT_WINDOW)
 
 
 # Sonnet 5's tokenizer counts ~30% more tokens than 4.x for the same text,

--- a/autogpt_platform/backend/backend/copilot/sdk/env_test.py
+++ b/autogpt_platform/backend/backend/copilot/sdk/env_test.py
@@ -633,7 +633,8 @@ class TestContextWindowPin:
     """The window the CLI compacts against is ours, not the CLI's guess.
 
     At or below the default, ``CLAUDE_CODE_DISABLE_1M_CONTEXT`` holds the model
-    window itself at 200K too, making the default a real cap.
+    window itself at 200K too, making the default a real cap.  On Moonshot
+    routes the pin is capped at the catalog's real window for the SKU.
     """
 
     @pytest.mark.parametrize(
@@ -654,6 +655,43 @@ class TestContextWindowPin:
             from backend.copilot.sdk.env import build_sdk_env
 
             result = build_sdk_env(model="anthropic/claude-sonnet-5")
+
+        assert result.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == expected
+        assert ("CLAUDE_CODE_DISABLE_1M_CONTEXT" in result) is kill_switch
+
+    @pytest.mark.parametrize(
+        "model, window, expected, kill_switch",
+        [
+            # Kimi K2.x really serves 262,144: a 1M pin would put the trigger
+            # at ~967K, past the point the provider rejects the request.
+            ("moonshotai/kimi-k2.5", 1_000_000, "262144", False),
+            ("moonshotai/kimi-k2-thinking", 500_000, "262144", False),
+            # K3 really does serve 1M, so the raise survives there.
+            ("moonshotai/kimi-k3", 1_000_000, "1000000", False),
+            # A SKU the catalog does not carry falls back to the window the
+            # CLI assumes anyway, rather than to an unbounded raise.
+            ("moonshotai/kimi-k3.0", 1_000_000, "200000", True),
+            # At or below the real window the configured pin is untouched.
+            ("moonshotai/kimi-k2.5", 262_144, "262144", False),
+            ("moonshotai/kimi-k2.5", 200_000, "200000", True),
+        ],
+    )
+    def test_pin_capped_at_moonshot_real_window(
+        self, model, window, expected, kill_switch
+    ):
+        """The CLI's model table has no Moonshot entry, so the pin is the only
+        thing holding the trigger inside Kimi's real window."""
+        cfg = _make_config(
+            use_openrouter=True,
+            api_key="sk-or-test",
+            base_url="https://openrouter.ai/api/v1",
+            thinking_standard_model=model,
+            claude_agent_context_window=window,
+        )
+        with patch("backend.copilot.sdk.env.config", cfg):
+            from backend.copilot.sdk.env import build_sdk_env
+
+            result = build_sdk_env(model=model)
 
         assert result.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == expected
         assert ("CLAUDE_CODE_DISABLE_1M_CONTEXT" in result) is kill_switch


### PR DESCRIPTION
Caps the copilot's compaction window pin at the routed model's real context window, so raising `CHAT_CLAUDE_AGENT_CONTEXT_WINDOW` on a Moonshot route can no longer push the CLI's compaction trigger past the point Kimi rejects the turn.

### Why / What / How

**Why.** #14208 made the CLI's compaction trigger a number the repo owns, by writing `ChatConfig.claude_agent_context_window` into `CLAUDE_CODE_AUTO_COMPACT_WINDOW`. That write was unconditional while the sibling `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` 16 lines below is gated on `is_moonshot_model`. On a Moonshot route, whose real window is 262,144, a 1M pin put the trigger at ~967K: compaction never fires and the session grows until the provider rejects it. The autoreviewer flagged it as *Model-gate the window pin* and #14208 shipped it as documentation, deferring the design call.

**What.** `sdk/env.py:181` now pins `_pinned_context_window(model)` instead of the raw config value, and the 1M kill-switch six lines below keys off that same capped number so it cannot swallow a raise that survived the cap.

**How.** Capped rather than gated: dropping the pin on Moonshot would hand the trigger back to the CLI's own model table — the emergent behaviour #14208 removed — so the pin stays unconditional and is clamped by `min(pin, catalog window)` on Moonshot routes only, because the catalog deliberately holds every Anthropic entry at 200K pending the Claude-5 tokenizer soak (`llm_registry/catalog.py:193`) and clamping there would cancel the raise on the routes that really do serve 1M. A Kimi SKU the catalog does not carry falls back to the 200K the CLI assumes anyway rather than to an unbounded raise.

Behaviour on every non-Moonshot route is byte-identical: across a 140-route matrix (10 models × 7 window settings × direct/OpenRouter) 28 environments change and all 28 are Moonshot. Evidence in the comment below.

### Changes 🏗️

- `copilot/sdk/env.py` — `_pinned_context_window()` caps the configured pin at a Moonshot route's catalog window; `CLAUDE_CODE_AUTO_COMPACT_WINDOW` and the `CLAUDE_CODE_DISABLE_1M_CONTEXT` kill-switch both read the capped value.
- `copilot/moonshot.py` — `moonshot_context_window()` exposes the catalog's real window per Kimi SKU, as an import-time snapshot alongside the existing rate-card one.
- `copilot/config.py` — `claude_agent_context_window`'s description now states the cap instead of warning about the footgun it removes.
- Tests in `copilot/sdk/env_test.py` and `copilot/moonshot_test.py`.

No configuration changes: the field, its bounds and its default (200,000) are unchanged.

### Agents and large language models used

Claude Code with Claude Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] The Moonshot cap fires and is load-bearing — new parametrized cases fail first, pass after, and fail again under two mutations
  - [x] Non-Moonshot routes are unchanged — full `build_sdk_env` output diffed across a 140-route matrix, before vs after
  - [x] `moonshot_context_window` reads the catalog for every listed Kimi SKU and returns None for unlisted and non-Moonshot slugs
  - [x] Repo-wide suites that no diff points at

Verified: I executed `copilot/sdk/env_test.py` (61 passed), `copilot/moonshot_test.py` (41), `copilot/config_test.py` + `sdk/env_test.py` + `sdk/service_helpers_test.py` (286), `data/llm_registry` (67), `util/architecture_test.py` (3) and `blocks/test/test_block.py` (1647 passed, 84 skipped), plus the before/after env matrix and the mutation table in the comment below. I did not exercise a live CLI subprocess against Moonshot — the trigger arithmetic inside the CLI is reasoned about, not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
