### PR TITLE
fix(backend): never drop a user's tier on an unauthoritative payment-flag read

### DIFF
--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -160,6 +160,20 @@ def _stub_subscription_status_lookups(mocker: pytest_mock.MockFixture) -> None:
     )
 
 
+def _patch_payment_flag(
+    mocker: pytest_mock.MockFixture,
+    *,
+    enabled: bool = True,
+    authoritative: bool = True,
+) -> Mock:
+    """Stub the single ENABLE_PLATFORM_PAYMENT read in update_subscription_tier."""
+    return mocker.patch(
+        "backend.api.features.v1.evaluate_feature_flag",
+        new_callable=AsyncMock,
+        return_value=(enabled, authoritative),
+    )
+
+
 @pytest.mark.parametrize(
     "url,expected",
     [
@@ -398,19 +412,13 @@ def test_update_subscription_tier_no_tier_no_payment(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
-    async def mock_feature_disabled(*args, **kwargs):
-        return False
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_disabled,
-    )
-    mocker.patch(
+    _patch_payment_flag(mocker, enabled=False)
+    mock_set_tier = mocker.patch(
         "backend.api.features.v1.set_subscription_tier",
         new_callable=AsyncMock,
     )
@@ -419,6 +427,42 @@ def test_update_subscription_tier_no_tier_no_payment(
 
     assert response.status_code == 200
     assert response.json()["url"] == ""
+    mock_set_tier.assert_awaited_once_with(TEST_USER_ID, SubscriptionTier.NO_TIER)
+
+
+def test_update_subscription_tier_no_tier_unreadable_flag_keeps_tier(
+    client: fastapi.testclient.TestClient,
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """A payment flag that could not be evaluated must not drop the user's tier.
+
+    An unreadable flag yields False exactly like a genuine "payment off", so
+    the DB flip would strip entitlement from a user Stripe keeps billing.
+    """
+    mock_user = Mock()
+    mock_user.subscription_tier = SubscriptionTier.PRO
+
+    mocker.patch(
+        "backend.api.features.v1.get_user_by_id",
+        new_callable=AsyncMock,
+        return_value=mock_user,
+    )
+    _patch_payment_flag(mocker, enabled=False, authoritative=False)
+    mock_set_tier = mocker.patch(
+        "backend.api.features.v1.set_subscription_tier",
+        new_callable=AsyncMock,
+    )
+    mock_cancel = mocker.patch(
+        "backend.api.features.v1.cancel_stripe_subscription",
+        new_callable=AsyncMock,
+    )
+
+    response = client.post("/credits/subscription", json={"tier": "NO_TIER"})
+
+    assert response.status_code == 502
+    assert "contact support" in response.json()["detail"].lower()
+    mock_set_tier.assert_not_awaited()
+    mock_cancel.assert_not_awaited()
 
 
 def test_update_subscription_tier_paid_beta_user(
@@ -429,18 +473,12 @@ def test_update_subscription_tier_paid_beta_user(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_disabled(*args, **kwargs):
-        return False
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_disabled,
-    )
+    _patch_payment_flag(mocker, enabled=False)
 
     response = client.post("/credits/subscription", json={"tier": "PRO"})
 
@@ -456,18 +494,12 @@ def test_update_subscription_tier_paid_requires_urls(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -491,18 +523,12 @@ def test_update_subscription_tier_currency_mismatch_returns_422(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.MAX
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         side_effect=stripe.InvalidRequestError(
@@ -538,18 +564,12 @@ def test_update_subscription_tier_non_currency_invalid_request_returns_502(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.MAX
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         side_effect=stripe.InvalidRequestError(
@@ -579,18 +599,12 @@ def test_update_subscription_tier_creates_checkout(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -623,18 +637,12 @@ def test_update_subscription_tier_forwards_datafast_headers(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -674,18 +682,12 @@ def test_update_subscription_tier_forwards_yearly_billing_cycle(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -731,18 +733,12 @@ def test_update_subscription_tier_yearly_unconfigured_returns_422(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1._get_stripe_price_amount",
         new_callable=AsyncMock,
@@ -785,18 +781,12 @@ def test_update_subscription_tier_creates_checkout_with_yearly_billing(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1._get_stripe_price_amount",
         new_callable=AsyncMock,
@@ -846,18 +836,12 @@ def test_update_subscription_tier_rejects_open_redirect(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.BASIC
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.get_user_by_id",
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -941,11 +925,7 @@ def test_update_subscription_tier_same_tier_releases_pending_change(
         "backend.api.features.v1.create_subscription_checkout",
         new_callable=AsyncMock,
     )
-    feature_mock = mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    feature_mock = _patch_payment_flag(mocker)
 
     response = client.post(
         "/credits/subscription",
@@ -1055,9 +1035,6 @@ def test_update_subscription_tier_no_tier_with_payment_schedules_cancel_and_does
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mock_cancel = mocker.patch(
         "backend.api.features.v1.cancel_stripe_subscription",
         new_callable=AsyncMock,
@@ -1071,10 +1048,7 @@ def test_update_subscription_tier_no_tier_with_payment_schedules_cancel_and_does
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
 
     response = client.post("/credits/subscription", json={"tier": "NO_TIER"})
 
@@ -1091,9 +1065,6 @@ def test_update_subscription_tier_no_tier_cancel_failure_returns_502(
     mock_user = Mock()
     mock_user.subscription_tier = SubscriptionTier.PRO
 
-    async def mock_feature_enabled(*args, **kwargs):
-        return True
-
     mocker.patch(
         "backend.api.features.v1.cancel_stripe_subscription",
         side_effect=stripe.StripeError(
@@ -1105,10 +1076,7 @@ def test_update_subscription_tier_no_tier_cancel_failure_returns_502(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        side_effect=mock_feature_enabled,
-    )
+    _patch_payment_flag(mocker)
 
     response = client.post("/credits/subscription", json={"tier": "NO_TIER"})
 
@@ -1244,11 +1212,7 @@ def test_update_subscription_tier_paid_to_paid_modifies_subscription(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1289,11 +1253,7 @@ def test_update_subscription_tier_max_checkout(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1338,11 +1298,7 @@ def test_update_subscription_tier_no_active_sub_falls_through_to_checkout(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1403,11 +1359,7 @@ def test_update_subscription_tier_priced_basic_no_sub_falls_through_to_checkout(
         "backend.api.features.v1.get_subscription_price_id",
         side_effect=mock_price_id,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1472,11 +1424,7 @@ def test_update_subscription_tier_target_without_ld_price_returns_422(
         "backend.api.features.v1.get_subscription_price_id",
         side_effect=mock_price_id,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     checkout_mock = mocker.patch(
         "backend.api.features.v1.create_subscription_checkout",
         new_callable=AsyncMock,
@@ -1520,11 +1468,7 @@ def test_update_subscription_tier_pro_to_max_card_declined_returns_402(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1562,11 +1506,7 @@ def test_update_subscription_tier_pro_to_max_authentication_required_returns_402
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1611,11 +1551,7 @@ def test_update_subscription_tier_pro_to_max_subscription_payment_intent_require
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1657,11 +1593,7 @@ def test_update_subscription_tier_pro_to_max_no_payment_method_returns_402(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1713,11 +1645,7 @@ def test_update_subscription_tier_paid_to_paid_stripe_error_returns_502(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -1755,11 +1683,7 @@ def test_update_subscription_tier_no_tier_no_stripe_subscription(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     # Simulate no active Stripe subscriptions — returns False
     cancel_mock = mocker.patch(
         "backend.api.features.v1.cancel_stripe_subscription",
@@ -1888,11 +1812,7 @@ def test_update_subscription_tier_downgrade_paid_to_paid_schedules(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     modify_mock = mocker.patch(
         "backend.api.features.v1.modify_stripe_subscription_for_tier",
         new_callable=AsyncMock,
@@ -2138,11 +2058,7 @@ def test_update_subscription_tier_same_tier_cycle_change_routes_to_modify(
         new_callable=AsyncMock,
         return_value=mock_user,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     mocker.patch(
         "backend.api.features.v1.get_subscription_price_id",
         side_effect=price_lookup,
@@ -2245,11 +2161,7 @@ def test_update_subscription_tier_same_tier_no_stripe_sub_falls_through_to_check
         new_callable=AsyncMock,
         return_value=None,
     )
-    mocker.patch(
-        "backend.api.features.v1.is_feature_enabled",
-        new_callable=AsyncMock,
-        return_value=True,
-    )
+    _patch_payment_flag(mocker)
     release_mock = mocker.patch(
         "backend.api.features.v1.release_pending_subscription_schedule",
         new_callable=AsyncMock,

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -166,7 +166,7 @@ from backend.util.exceptions import (
     InsufficientBalanceError,
     NotFoundError,
 )
-from backend.util.feature_flag import Flag, is_feature_enabled
+from backend.util.feature_flag import Flag, evaluate_feature_flag
 from backend.util.json import dumps
 from backend.util.settings import Settings
 from backend.util.timezone_utils import (
@@ -1200,7 +1200,7 @@ async def update_subscription_tier(
             )
         return await get_subscription_status(user_id)
 
-    payment_enabled = await is_feature_enabled(
+    payment_enabled, payment_flag_authoritative = await evaluate_feature_flag(
         Flag.ENABLE_PLATFORM_PAYMENT, user_id, default=False
     )
 
@@ -1233,6 +1233,20 @@ async def update_subscription_tier(
                 # never-paid).
                 await set_subscription_tier(user_id, tier)
             return await get_subscription_status(user_id)
+        if not payment_flag_authoritative:
+            # An unreadable flag reads False exactly like payment being off, and
+            # the DB flip below would strand a still-billing Stripe subscription.
+            logger.error(
+                f"Refusing to cancel subscription for user {user_id}: "
+                f"{Flag.ENABLE_PLATFORM_PAYMENT} could not be evaluated"
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    "Unable to cancel your subscription right now. "
+                    "Please try again or contact support."
+                ),
+            )
         await set_subscription_tier(user_id, tier)
         return await get_subscription_status(user_id)
 


### PR DESCRIPTION
### Why / What / How

Cancelling a subscription no longer drops a user's tier when the payment feature flag could not be read.

`is_feature_enabled` returns `False` both when a flag is genuinely off and when LaunchDarkly could not be evaluated, and `update_subscription_tier` branched on that raw boolean. On a `NO_TIER` (cancel) request with `ENABLE_PLATFORM_PAYMENT` reading `False`, the handler skipped `cancel_stripe_subscription` and force-set the DB tier to `NO_TIER` in the cancel branch of `update_subscription_tier`. During an LD outage that stripped a paying user's entitlement while Stripe kept billing them, and nothing reconciled the two.

The flag now goes through `evaluate_feature_flag` — the `(enabled, authoritative)` reader added by #14308 for exactly this class of bug. An unauthoritative read takes neither branch: the tier and the Stripe subscription are left as they are, and the handler returns the 502 it already returns when a cancellation cannot be completed. A genuine `False` keeps today's behaviour unchanged. The error is logged at `ERROR`, which is the level Sentry's `LoggingIntegration` turns into an event (`event_level` defaults to 40; `metrics.py:283` constructs it with no arguments).

Out of scope: `copilot/rate_limit.py:1302` and `copilot/tools/platform_info.py:88` read the same flag and treat `False` as "billing is off, grant access". Failing closed there would paywall users during an outage, so the direction is a product decision rather than a bug fix.

### Changes 🏗️

- `api/features/v1.py` — `update_subscription_tier` reads `ENABLE_PLATFORM_PAYMENT` via `evaluate_feature_flag`; the cancel path refuses to flip the DB tier when the read is unauthoritative.
- `api/features/subscription_routes_test.py` — new test for the unauthoritative read; the genuine-off test now asserts the tier *is* set. The 28 copy-pasted flag patches collapse into one `_patch_payment_flag` helper (net −123 lines).

### Agents and large language models used

Claude Code with Claude Opus 5.

**Verified.** I executed `subscription_routes_test.py` (56 passed), `v1_test.py` + `v1_stripe_webhook_test.py` + `credits_rate_limit_test.py` + `v1_share_test.py` (103 passed), `util/architecture_test.py` (3 passed) and `blocks/test/test_block.py` (1647 passed, 84 skipped), and ran two mutations to prove the new tests can fail. I did not exercise a real LaunchDarkly outage or a live Stripe subscription; the flag boundary is mocked at `evaluate_feature_flag`, as it was before. Logs in a comment below.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Unauthoritative flag read on a cancel request: 502, `set_subscription_tier` not awaited, `cancel_stripe_subscription` not awaited
  - [x] Genuine flag-off cancel request: 200, tier set to `NO_TIER` — unchanged from before
  - [x] Flag on: Stripe cancellation still scheduled, DB tier untouched (existing test)
  - [x] Mutation: guard removed → the new test fails `assert 200 == 502`; guard widened to fire on any `False` → the genuine-off test fails `assert 502 == 200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
