### PR TITLE
fix(backend/api): make v2 permissions match what each endpoint reaches

### DIFF
--- a/autogpt_platform/backend/backend/api/external/fastapi_app.py
+++ b/autogpt_platform/backend/backend/api/external/fastapi_app.py
@@ -9,9 +9,12 @@ from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 
 from backend.monitoring.instrumentation import instrument_fastapi
+from backend.util.settings import AppEnvironment, Settings
 
 from .v1.app import v1_app
 from .v2.app import v2_app
+
+settings = Settings()
 
 DESCRIPTION = """
 The external API provides programmatic access to the AutoGPT Platform for building
@@ -51,11 +54,12 @@ async def root_redirect() -> RedirectResponse:
 external_api.mount("/v1", v1_app)
 external_api.mount("/v2", v2_app)
 
-# Add Prometheus instrumentation to the main app
+# The scrape endpoint stays mounted for Prometheus everywhere; only the local
+# docs advertise it, which is how the internal app has treated it since it landed.
 instrument_fastapi(
     external_api,
     service_name="external-api",
     expose_endpoint=True,
     endpoint="/metrics",
-    include_in_schema=True,
+    include_in_schema=settings.config.app_env == AppEnvironment.LOCAL,
 )

--- a/autogpt_platform/backend/backend/api/external/v2/global_rate_limit.py
+++ b/autogpt_platform/backend/backend/api/external/v2/global_rate_limit.py
@@ -5,7 +5,10 @@ ASGI middleware that enforces per-user and per-IP request caps across all v2
 endpoints. Authenticated users get 200 req/min keyed by user ID; unauthenticated
 sessions get 5 req/min keyed by client IP.
 
-Reuses `resolve_auth_info` from the auth middleware to identify the user.
+Reuses `resolve_auth_info` from the auth middleware to identify the user, and
+hands the result to the route's dependency through the request scope so the
+credential is verified once per request.
+
 On auth-resolution failure or Redis errors the request passes through — the
 endpoint's own auth dependency handles 401, and the rate limiter fails open.
 """
@@ -50,6 +53,16 @@ class GlobalRateLimitMiddleware:
             auth = await resolve_auth_info(api_key=api_key, bearer=bearer)
         except HTTPException:
             auth = None
+        except Exception as exc:
+            # Fail open on anything the auth backend throws that is not a
+            # rejection; the route's own dependency will answer 401 or 500.
+            logger.warning(f"Rate-limit auth resolution failed: {exc}")
+            auth = None
+
+        # The route's auth dependency reads this instead of verifying the same
+        # credential a second time; an API key costs a Scrypt hash per check.
+        if auth:
+            scope.setdefault("state", {})["v2_auth"] = auth
 
         try:
             if auth:

--- a/autogpt_platform/backend/backend/api/external/v2/integrations/credentials.py
+++ b/autogpt_platform/backend/backend/api/external/v2/integrations/credentials.py
@@ -17,7 +17,9 @@ from backend.data.model import (
     APIKeyCredentials,
     HostScopedCredentials,
     UserPasswordCredentials,
+    is_sdk_default,
 )
+from backend.integrations.credentials_store import is_system_credential
 
 from ..models import CredentialCreateRequest, CredentialInfo
 from ..pagination import Page, PageRequest, page_request
@@ -116,8 +118,17 @@ async def delete_credential(
     """
     Delete an integration credential.
 
-    Any agents using this credential will fail on their next run.
+    Platform-provided credentials cannot be deleted. Any agents using this
+    credential will fail on their next run.
     """
+    # An SDK default is not the caller's credential at all, so it is not there
+    # to find; a system or AutoGPT-managed one is, and refusing says so.
+    if is_sdk_default(credential_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Credential #{credential_id} not found",
+        )
+
     existing = await creds_manager.store.get_creds_by_id(
         user_id=auth.user_id, credentials_id=credential_id
     )
@@ -125,6 +136,11 @@ async def delete_credential(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Credential #{credential_id} not found",
+        )
+    if is_system_credential(credential_id) or existing.is_managed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Platform-managed credentials cannot be deleted",
         )
 
     await creds_manager.delete(auth.user_id, credential_id)

--- a/autogpt_platform/backend/backend/api/external/v2/mcp_server.py
+++ b/autogpt_platform/backend/backend/api/external/v2/mcp_server.py
@@ -94,6 +94,20 @@ EXTERNAL_USE_EXCLUSIONS: dict[str, str] = {
     "bash_exec": "sandboxed shell on platform infrastructure",
 }
 
+# Tools exposed without any permission, with the reason. A tool that spends
+# platform money or acts through a platform-owned account must name a permission
+# in its `allow_external_use` instead; mcp_server_test.py fails on any other tool
+# that opts in with an empty permission list.
+UNSCOPED_EXTERNAL_TOOLS: dict[str, str] = {
+    "get_doc_page": "serves a published documentation page",
+    "search_docs": "searches published documentation",
+    "get_mcp_guide": "returns static guidance text",
+    "get_agent_building_guide": "returns static guidance text",
+    "validate_agent_graph": "pure check over JSON the caller supplied",
+    "fix_agent_graph": "pure rewrite of JSON the caller supplied",
+    "find_agent": "public marketplace listings, as v2's own /marketplace serves",
+}
+
 
 # ---------------------------------------------------------------------------
 # Server factory

--- a/autogpt_platform/backend/backend/api/external/v2/mcp_server_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/mcp_server_test.py
@@ -1,6 +1,9 @@
 """Keep the MCP tool surface deliberate: every Copilot tool is classified."""
 
-from backend.api.external.v2.mcp_server import EXTERNAL_USE_EXCLUSIONS
+from backend.api.external.v2.mcp_server import (
+    EXTERNAL_USE_EXCLUSIONS,
+    UNSCOPED_EXTERNAL_TOOLS,
+)
 from backend.copilot.tools import TOOL_REGISTRY
 
 
@@ -32,3 +35,23 @@ def test_exposed_tools_declare_permissions_as_a_sequence():
         allowed, perms = tool.allow_external_use
         if allowed:
             assert perms is not None, f"{name} opted in without a permission list"
+
+
+def test_no_tool_is_exposed_unscoped_without_a_stated_reason():
+    """An empty permission list means any key can drive the tool.
+
+    That is right for published docs and public listings and wrong for anything
+    that spends platform money or acts through a platform-owned account, so the
+    open set is enumerated rather than inferred.
+    """
+    unscoped = {
+        name
+        for name, tool in TOOL_REGISTRY.items()
+        if tool.allow_external_use[0] and not tool.allow_external_use[1]
+    }
+    assert unscoped == set(UNSCOPED_EXTERNAL_TOOLS), (
+        "unlisted tools exposed with no permission: "
+        f"{sorted(unscoped - set(UNSCOPED_EXTERNAL_TOOLS))}; "
+        "listed but no longer unscoped: "
+        f"{sorted(set(UNSCOPED_EXTERNAL_TOOLS) - unscoped)}"
+    )

--- a/autogpt_platform/backend/backend/api/external/v2/models.py
+++ b/autogpt_platform/backend/backend/api/external/v2/models.py
@@ -10,14 +10,12 @@ Route files should import models from here rather than defining them locally.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Optional, Self, TypeAlias
 
 from pydantic import BaseModel, Field, JsonValue, field_validator
 
 import backend.blocks._base as block_types
-from backend.api.features.search.hybrid_search import (
-    ContentTypeValue as SearchContentType,
-)
 
 if TYPE_CHECKING:
     from backend.api.features.executions.review.model import PendingHumanReviewModel
@@ -1159,6 +1157,9 @@ class CredentialInfo(BaseModel):
         description="Permission scopes granted to this credential"
     )
     expires_at: Optional[datetime]
+    is_managed: bool = Field(
+        description="Provided by the platform; cannot be updated or deleted"
+    )
 
     @classmethod
     def from_internal(cls, cred: Credentials) -> Self:
@@ -1179,6 +1180,7 @@ class CredentialInfo(BaseModel):
             title=cred.title,
             username=username,
             scopes=scopes,
+            is_managed=cred.is_managed,
             expires_at=(
                 datetime.fromtimestamp(expires_at, tz=timezone.utc)
                 if expires_at
@@ -1583,6 +1585,21 @@ class MarketplaceMediaUploadResponse(BaseModel):
     """Response after uploading media."""
 
     url: str = Field(description="Public URL of the uploaded media")
+
+
+class SearchContentType(str, Enum):
+    """What a v2 caller may search over.
+
+    Chat sessions are searchable internally but have no v2 surface and no scope
+    that could grant them, so they are not a value this API accepts.
+    """
+
+    STORE_AGENT = "STORE_AGENT"
+    BLOCK = "BLOCK"
+    INTEGRATION = "INTEGRATION"
+    DOCUMENTATION = "DOCUMENTATION"
+    LIBRARY_AGENT = "LIBRARY_AGENT"
+    WORKSPACE_FILE = "WORKSPACE_FILE"
 
 
 class MarketplaceSearchResult(BaseModel):

--- a/autogpt_platform/backend/backend/api/external/v2/permissions_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/permissions_test.py
@@ -1,0 +1,347 @@
+"""
+Tests for what a v2 credential is allowed to reach.
+
+Least privilege is the point: a key granted one scope must not be a way to read
+data, spend platform money, or destroy platform state that its scopes never
+mentioned. Each test here pins one such hole shut.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from unittest import mock
+
+import fastapi
+import fastapi.testclient
+import pytest
+import pytest_mock
+from prisma.enums import APIKeyPermission, ContentType
+from pydantic import SecretStr
+
+from backend.api.external.v2.errors import add_v2_exception_handlers
+from backend.api.external.v2.models import SearchContentType
+from backend.api.external.v2.pagination import PageRequest
+from backend.api.external.v2.tenancy import TenantContext, require_auth
+from backend.data.auth.base import APIAuthorizationInfo
+from backend.data.model import APIKeyCredentials, is_sdk_default
+from backend.integrations.credentials_store import SYSTEM_CREDENTIAL_IDS
+
+USER_ID = "user-1"
+ORG_ID = "org-1"
+
+
+# ============================================================================
+# Search: a private content type costs the scope that guards it elsewhere
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "content_type,scope",
+    [
+        (SearchContentType.LIBRARY_AGENT, APIKeyPermission.READ_LIBRARY),
+        (SearchContentType.WORKSPACE_FILE, APIKeyPermission.READ_FILES),
+    ],
+)
+async def test_searching_private_content_without_its_scope_is_refused(
+    mocker: pytest_mock.MockFixture,
+    content_type: SearchContentType,
+    scope: APIKeyPermission,
+) -> None:
+    """A zero-scope key asked for these and got the caller's own rows back."""
+    hybrid = _mock_hybrid_search(mocker)
+
+    with pytest.raises(fastapi.HTTPException) as raised:
+        await search_with(mocker, [content_type], scopes=[])
+
+    assert raised.value.status_code == 403
+    assert scope.value in str(raised.value.detail)
+    hybrid.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "content_type,scope",
+    [
+        (SearchContentType.LIBRARY_AGENT, APIKeyPermission.READ_LIBRARY),
+        (SearchContentType.WORKSPACE_FILE, APIKeyPermission.READ_FILES),
+    ],
+)
+async def test_searching_private_content_with_its_scope_is_allowed(
+    mocker: pytest_mock.MockFixture,
+    content_type: SearchContentType,
+    scope: APIKeyPermission,
+) -> None:
+    hybrid = _mock_hybrid_search(mocker)
+
+    await search_with(mocker, [content_type], scopes=[scope])
+
+    assert hybrid.await_args.kwargs["content_types"] == [
+        ContentType(content_type.value)
+    ]
+
+
+async def test_search_without_content_types_asks_only_for_public_ones(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """v2 names the default rather than inheriting whatever the engine picks."""
+    hybrid = _mock_hybrid_search(mocker)
+
+    await search_with(mocker, None, scopes=[])
+
+    assert hybrid.await_args.kwargs["content_types"] == [
+        ContentType.STORE_AGENT,
+        ContentType.BLOCK,
+        ContentType.INTEGRATION,
+        ContentType.DOCUMENTATION,
+    ]
+
+
+def test_chat_sessions_are_not_a_searchable_content_type() -> None:
+    """No v2 scope covers chat, so the parameter cannot name it at all."""
+    assert "CHAT_SESSION" in {t.value for t in ContentType}
+    assert "CHAT_SESSION" not in {t.value for t in SearchContentType}
+
+
+# ============================================================================
+# Sharing: both directions cost the same scopes
+# ============================================================================
+
+
+def test_share_and_unshare_require_the_same_permissions() -> None:
+    """Unsharing needed only SHARE_RUN while sharing needed READ_RUN as well."""
+    assert _published_scopes("/runs/{run_id}/share", "post") == _published_scopes(
+        "/runs/{run_id}/share", "delete"
+    )
+    assert _published_scopes("/runs/{run_id}/share", "delete") == {
+        "READ_RUN",
+        "SHARE_RUN",
+    }
+
+
+# ============================================================================
+# Credentials: the platform's own credentials are not the caller's to delete
+# ============================================================================
+
+
+async def test_deleting_a_system_credential_is_refused(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """`delete_creds_by_id` raises ValueError on these, which v2 reported as a
+    400 blaming the caller. The internal route answers 403."""
+    from .integrations.credentials import delete_credential
+
+    system_id = sorted(SYSTEM_CREDENTIAL_IDS)[0]
+    deleter = _mock_creds_store(mocker, _credential(system_id))
+
+    with pytest.raises(fastapi.HTTPException) as raised:
+        await delete_credential(credential_id=system_id, auth=_tenant())
+
+    assert raised.value.status_code == 403
+    deleter.assert_not_awaited()
+
+
+async def test_deleting_a_managed_credential_is_refused(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    from .integrations.credentials import delete_credential
+
+    deleter = _mock_creds_store(mocker, _credential("managed-1", is_managed=True))
+
+    with pytest.raises(fastapi.HTTPException) as raised:
+        await delete_credential(credential_id="managed-1", auth=_tenant())
+
+    assert raised.value.status_code == 403
+    deleter.assert_not_awaited()
+
+
+async def test_deleting_an_sdk_default_credential_is_not_found(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    from .integrations.credentials import delete_credential
+
+    cred_id = "openai-default"
+    assert is_sdk_default(cred_id)
+    deleter = _mock_creds_store(mocker, _credential(cred_id))
+
+    with pytest.raises(fastapi.HTTPException) as raised:
+        await delete_credential(credential_id=cred_id, auth=_tenant())
+
+    assert raised.value.status_code == 404
+    deleter.assert_not_awaited()
+
+
+async def test_deleting_an_ordinary_credential_still_works(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """The guards above must not have closed the endpoint's actual job."""
+    from .integrations.credentials import delete_credential
+
+    deleter = _mock_creds_store(mocker, _credential("mine-1"))
+
+    await delete_credential(credential_id="mine-1", auth=_tenant())
+
+    deleter.assert_awaited_once_with(USER_ID, "mine-1")
+
+
+def test_credential_listing_says_which_credentials_are_the_platform_s() -> None:
+    """Without this, managed and user credentials are indistinguishable."""
+    from .models import CredentialInfo
+
+    assert CredentialInfo.from_internal(_credential("a", is_managed=True)).is_managed
+    assert not CredentialInfo.from_internal(_credential("b")).is_managed
+
+
+# ============================================================================
+# Auth: verified once per request, and the limiter never blocks on its own bugs
+# ============================================================================
+
+
+async def test_the_route_reuses_the_credential_the_middleware_verified() -> None:
+    """An API key costs a Scrypt hash to verify; it was paid twice per request."""
+    calls = _resolve_calls()
+
+    with mock.patch("backend.api.external.middleware.validate_api_key", new=calls):
+        response = _client().get("/probe", headers={"X-API-Key": "k"})
+
+    assert response.status_code == 200, response.text
+    assert calls.count == 1
+
+
+async def test_a_transient_auth_failure_in_the_limiter_does_not_fail_the_request() -> (
+    None
+):
+    """The limiter caught only HTTPException around auth resolution, so any
+    other error propagated out of it and the route never ran — a blip in the
+    credential store 500'd a request the route itself could have served."""
+    calls = _resolve_calls(fail_first=True)
+
+    with mock.patch("backend.api.external.middleware.validate_api_key", new=calls):
+        response = _client().get("/probe", headers={"X-API-Key": "k"})
+
+    assert response.status_code == 200, response.text
+    assert calls.count == 2
+
+
+# ---------------------------------------------------------------------------
+
+
+def _tenant(scopes: Optional[list[APIKeyPermission]] = None) -> TenantContext:
+    return TenantContext(
+        user_id=USER_ID,
+        scopes=list(APIKeyPermission) if scopes is None else scopes,
+        type="api_key",
+        organization_id=ORG_ID,
+    )
+
+
+def _page() -> PageRequest:
+    return PageRequest(limit=20, page=1, cursor=None)
+
+
+def _mock_hybrid_search(mocker: pytest_mock.MockFixture):
+    return mocker.patch(
+        "backend.api.external.v2.search.unified_hybrid_search",
+        new_callable=mock.AsyncMock,
+        return_value=([], 0),
+    )
+
+
+async def search_with(
+    mocker: pytest_mock.MockFixture,
+    content_types: Optional[list[SearchContentType]],
+    scopes: list[APIKeyPermission],
+):
+    from .search import search
+
+    mocker.patch(
+        "backend.api.external.v2.search.search_limiter.check",
+        new_callable=mock.AsyncMock,
+    )
+    return await search(
+        query="q",
+        content_types=content_types,
+        category=None,
+        page=_page(),
+        auth=_tenant(scopes=scopes),
+    )
+
+
+def _published_scopes(path: str, method: str) -> set[str]:
+    """The scopes the OpenAPI document tells a caller the endpoint needs."""
+    from .app import v2_app
+
+    operation = v2_app.openapi()["paths"][path][method]
+    return {
+        scope
+        for requirement in operation["security"]
+        for scopes in requirement.values()
+        for scope in scopes
+    }
+
+
+def _credential(cred_id: str, is_managed: bool = False) -> APIKeyCredentials:
+    return APIKeyCredentials(
+        id=cred_id,
+        provider="openai",
+        title="t",
+        api_key=SecretStr("secret"),
+        is_managed=is_managed,
+    )
+
+
+def _mock_creds_store(mocker: pytest_mock.MockFixture, credential: APIKeyCredentials):
+    mocker.patch(
+        "backend.api.external.v2.integrations.credentials.creds_manager.store"
+        ".get_creds_by_id",
+        new_callable=mock.AsyncMock,
+        return_value=credential,
+    )
+    return mocker.patch(
+        "backend.api.external.v2.integrations.credentials.creds_manager.delete",
+        new_callable=mock.AsyncMock,
+    )
+
+
+def _resolve_calls(fail_first: bool = False):
+    """An API-key validator that counts how often the request verified the key."""
+
+    async def validate(key: str) -> APIAuthorizationInfo:
+        validate.count += 1
+        if fail_first and validate.count == 1:
+            raise RuntimeError("credential store is briefly unreachable")
+        return APIAuthorizationInfo(
+            user_id=USER_ID,
+            scopes=list(APIKeyPermission),
+            type="api_key",
+            created_at=datetime.now(tz=timezone.utc),
+            organization_id=ORG_ID,
+        )
+
+    validate.count = 0
+    return validate
+
+
+def _client() -> fastapi.testclient.TestClient:
+    """A one-route v2-shaped app: the real middleware over the real dependency."""
+    from .global_rate_limit import GlobalRateLimitMiddleware
+
+    app = fastapi.FastAPI()
+
+    @app.get("/probe")
+    async def probe(auth: TenantContext = fastapi.Security(require_auth)) -> str:
+        return auth.user_id
+
+    app.add_middleware(GlobalRateLimitMiddleware)
+    add_v2_exception_handlers(app)
+    return fastapi.testclient.TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _offline(mocker: pytest_mock.MockFixture) -> None:
+    """No test here is about Redis or the org tables."""
+    mocker.patch(
+        "backend.api.utils.rate_limit.RateLimiter.check", new_callable=mock.AsyncMock
+    )
+    mocker.patch(
+        "backend.api.external.v2.tenancy.resolve_credential_tenancy",
+        new_callable=mock.AsyncMock,
+        return_value=(ORG_ID, None),
+    )

--- a/autogpt_platform/backend/backend/api/external/v2/runs.py
+++ b/autogpt_platform/backend/backend/api/external/v2/runs.py
@@ -366,7 +366,9 @@ async def enable_sharing(
 )
 async def disable_sharing(
     run_id: str = Path(description="Graph Execution ID"),
-    auth: TenantContext = Security(require_permission(APIKeyPermission.SHARE_RUN)),
+    auth: TenantContext = Security(
+        require_permission(APIKeyPermission.READ_RUN, APIKeyPermission.SHARE_RUN)
+    ),
 ) -> None:
     """Disable public sharing for a run."""
     execution = await execution_db.get_graph_execution(

--- a/autogpt_platform/backend/backend/api/external/v2/search.py
+++ b/autogpt_platform/backend/backend/api/external/v2/search.py
@@ -7,12 +7,13 @@ Cross-domain hybrid search across agents, blocks, and documentation.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query, Security
-from prisma.enums import ContentType as SearchContentType
+from fastapi import APIRouter, Depends, HTTPException, Query, Security
+from prisma.enums import APIKeyPermission, ContentType
+from starlette import status
 
 from backend.api.features.search.hybrid_search import unified_hybrid_search
 
-from .models import MarketplaceSearchResult
+from .models import MarketplaceSearchResult, SearchContentType
 from .pagination import Page, PageRequest, page_request
 from .rate_limit import search_limiter
 from .tenancy import TenantContext, require_auth
@@ -39,16 +40,28 @@ async def search(
     """
     Search the platform's content and capabilities (hybrid search: literal + semantic).
 
-    Searches across agents, blocks, and documentation. Results are ranked
-    by a combination of keyword matching and semantic similarity.
+    Searches public agents, blocks and documentation by default. The caller's own
+    library agents and workspace files are searchable too, each requiring the same
+    permission that its own endpoints require.
 
     **Rate limit:** 30 requests per minute per user.
     """
     await search_limiter.check(auth.user_id)
 
+    requested = content_types or PUBLIC_CONTENT_TYPES
+    for content_type in requested:
+        if (scope := PRIVATE_CONTENT_TYPE_SCOPES.get(content_type)) and (
+            scope not in auth.scopes
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Searching {content_type.value} requires the "
+                f"{scope.value} permission",
+            )
+
     results, total_count = await unified_hybrid_search(
         query=query,
-        content_types=content_types,
+        content_types=[ContentType(t.value) for t in requested],
         category=category,
         page=page.page,
         page_size=page.limit,
@@ -58,7 +71,7 @@ async def search(
     return page.paged(
         [
             MarketplaceSearchResult(
-                content_type=r["content_type"],
+                content_type=SearchContentType(r["content_type"]),
                 content_id=r["content_id"],
                 searchable_text=r["searchable_text"],
                 metadata=r.get("metadata"),
@@ -69,3 +82,17 @@ async def search(
         ],
         total_count=total_count,
     )
+
+
+# Searching these reaches the caller's own rows, so each costs the permission
+# that guards the same data elsewhere in v2. Everything else is public content.
+PRIVATE_CONTENT_TYPE_SCOPES: dict[SearchContentType, APIKeyPermission] = {
+    SearchContentType.LIBRARY_AGENT: APIKeyPermission.READ_LIBRARY,
+    SearchContentType.WORKSPACE_FILE: APIKeyPermission.READ_FILES,
+}
+
+# Named here rather than left to the internal default, so v2's contract does not
+# change when that default does.
+PUBLIC_CONTENT_TYPES = [
+    t for t in SearchContentType if t not in PRIVATE_CONTENT_TYPE_SCOPES
+]

--- a/autogpt_platform/backend/backend/api/external/v2/tenancy.py
+++ b/autogpt_platform/backend/backend/api/external/v2/tenancy.py
@@ -21,7 +21,8 @@ import logging
 from typing import Literal, Optional, Protocol, TypeVar
 
 from autogpt_libs.auth.dependencies import TEAM_HEADER_NAME
-from fastapi import Header, HTTPException, Security
+from fastapi import Header, HTTPException, Request, Security
+from fastapi.security import HTTPAuthorizationCredentials
 from prisma.enums import APIKeyPermission
 from pydantic import BaseModel
 from starlette import status
@@ -52,7 +53,9 @@ class TenantContext(BaseModel):
 
 
 async def require_auth(
-    auth: APIAuthorizationInfo = Security(middleware.require_auth),
+    request: Request,
+    api_key: Optional[str] = Security(middleware.api_key_header),
+    bearer: Optional[HTTPAuthorizationCredentials] = Security(middleware.bearer_auth),
     requested_team: Optional[str] = Header(
         default=None,
         alias=TEAM_HEADER_NAME,
@@ -66,7 +69,18 @@ async def require_auth(
 
     Every v2 route reaches this one dependency, so tests override it once and
     `tenancy_test` can assert no handler bypasses it.
+
+    Takes the credential the rate-limit middleware already verified for this
+    request; verifying it again costs a second Scrypt hash on every API-key call.
     """
+    auth = getattr(
+        request.state, "v2_auth", None
+    ) or await middleware.resolve_auth_info(api_key=api_key, bearer=bearer)
+    if auth is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication. Provide API key or access token.",
+        )
     return await resolve_tenant(auth, requested_team)
 
 

--- a/autogpt_platform/backend/backend/copilot/tools/feature_requests.py
+++ b/autogpt_platform/backend/backend/copilot/tools/feature_requests.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any
 
+from prisma.enums import APIKeyPermission
 from pydantic import SecretStr
 
 from backend.blocks.linear._api import LinearClient
@@ -134,7 +135,8 @@ class SearchFeatureRequestsTool(BaseTool):
 
     @property
     def allow_external_use(self):
-        return True, []
+        # Reaches the platform's own Linear workspace, on the platform's key.
+        return True, [APIKeyPermission.USE_TOOLS]
 
     @property
     def description(self) -> str:
@@ -234,7 +236,8 @@ class CreateFeatureRequestTool(BaseTool):
 
     @property
     def allow_external_use(self):
-        return True, []
+        # Reaches the platform's own Linear workspace, on the platform's key.
+        return True, [APIKeyPermission.USE_TOOLS]
 
     @property
     def description(self) -> str:

--- a/autogpt_platform/backend/backend/copilot/tools/web_fetch.py
+++ b/autogpt_platform/backend/backend/copilot/tools/web_fetch.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import aiohttp
 import html2text
+from prisma.enums import APIKeyPermission
 
 from backend.copilot.model import ChatSession
 from backend.util.request import Requests
@@ -72,7 +73,8 @@ class WebFetchTool(BaseTool):
 
     @property
     def allow_external_use(self):
-        return True, []
+        # Fetches a caller-chosen URL from platform infrastructure.
+        return True, [APIKeyPermission.USE_TOOLS]
 
     @property
     def description(self) -> str:

--- a/autogpt_platform/backend/backend/copilot/tools/web_search.py
+++ b/autogpt_platform/backend/backend/copilot/tools/web_search.py
@@ -31,6 +31,7 @@ from typing import Any
 from openai import AsyncOpenAI
 from openai.types import CompletionUsage
 from openai.types.chat import ChatCompletion
+from prisma.enums import APIKeyPermission
 
 from backend.copilot.config import ChatConfig
 from backend.copilot.model import ChatSession
@@ -72,7 +73,8 @@ class WebSearchTool(BaseTool):
 
     @property
     def allow_external_use(self):
-        return True, []
+        # Each call bills the platform's OpenRouter account.
+        return True, [APIKeyPermission.USE_TOOLS]
 
     @property
     def description(self) -> str:

--- a/autogpt_platform/backend/schema.prisma
+++ b/autogpt_platform/backend/schema.prisma
@@ -2046,7 +2046,7 @@ enum APIKeyPermission {
   EXECUTE_BLOCK // Can execute individual blocks (v1 only)
   READ_BLOCK // Can get block information
   WRITE_LIBRARY // Can add agents to library
-  USE_TOOLS // Can use chat tools via external API (v1 only)
+  USE_TOOLS // Can use v1 chat tools, and v2 MCP tools that spend platform resources
   MANAGE_INTEGRATIONS // Can initiate OAuth flows and create credentials
   READ_INTEGRATIONS // Can list credentials and providers
   DELETE_INTEGRATIONS // Can delete credentials

--- a/docs/platform/integrating/api-guide.md
+++ b/docs/platform/integrating/api-guide.md
@@ -205,6 +205,7 @@ When creating API keys or using OAuth, request only the scopes your application 
 | `IDENTITY` | Read who the credentials act as, and in which organization (`GET /me`) |
 | `READ_FILES` | List and download workspace files |
 | `WRITE_FILES` | Upload and delete workspace files |
+| `USE_TOOLS` | Use MCP tools that spend platform resources: web search, web fetch, feature requests |
 
 A few endpoints require two scopes at once:
 
@@ -213,9 +214,12 @@ A few endpoints require two scopes at once:
 | `POST /graphs/{graph_id}/schedules` | `WRITE_SCHEDULE` + `RUN_AGENT` |
 | `POST /library/presets/setup-trigger` | `WRITE_LIBRARY` + `RUN_AGENT` |
 | `POST /runs/{run_id}/share` | `READ_RUN` + `SHARE_RUN` |
+| `DELETE /runs/{run_id}/share` | `READ_RUN` + `SHARE_RUN` |
 
 Public marketplace reads (`GET /marketplace/agents`, `/creators`, and their detail
-routes) and `GET /search` require valid credentials but no particular scope.
+routes) require valid credentials but no particular scope, and so does `GET /search`
+over public content. Searching your own content costs the scope that endpoint costs:
+`content_types=LIBRARY_AGENT` needs `READ_LIBRARY`, `WORKSPACE_FILE` needs `READ_FILES`.
 
 ### Legacy Scopes (v1 only)
 
@@ -223,7 +227,6 @@ routes) and `GET /search` require valid credentials but no particular scope.
 |-------|-------------|
 | `EXECUTE_GRAPH` | Execute graphs directly (use `RUN_AGENT` in v2) |
 | `EXECUTE_BLOCK` | Execute individual blocks |
-| `USE_TOOLS` | Use chat tools via external API |
 
 ## Support
 


### PR DESCRIPTION
Closes six places where a v2 external API credential could reach past the scopes it was granted, and one where the public schema advertised an endpoint that is not part of the contract.

`GET /search` was the sharpest. It is guarded by `require_auth` alone and passed `content_types` straight through to the internal engine, which honours an explicit `LIBRARY_AGENT`, `WORKSPACE_FILE` or `CHAT_SESSION` and scopes the query to the caller's own rows. A key with **zero** permissions could therefore read workspace file names and chat-session text that `GET /files` protects with `READ_FILES`. Each private content type now costs the scope its own endpoints cost, and chat sessions leave the accepted set entirely — v2 has no chat surface and no scope that could grant one. v2 also names the public default rather than inheriting whatever the engine picks.

Four MCP tools were exposed with an empty permission list while consuming platform-owned resources: `web_search` bills the platform's OpenRouter account per call, `web_fetch` retrieves a caller-chosen URL from platform infrastructure, and `search_feature_requests` / `create_feature_request` read and write the platform's own Linear workspace on the platform's API key. All four now require `USE_TOOLS`. The seven that stay open — published documentation, static guides, pure JSON validators, and public marketplace listings — are enumerated in `UNSCOPED_EXTERNAL_TOOLS` with a reason each, and a test fails on any future tool that opts in with an empty list without being listed there. Those seven all serve content v2's own REST surface already serves under auth alone.

`DELETE /runs/{run_id}/share` required only `SHARE_RUN` where `POST` on the same path required `READ_RUN` as well. Both now require both.

`DELETE /integrations/credentials/{id}` had no equivalent of the internal route's refusal to delete platform-provided credentials. The roast marked the consequence as unverified; it is not corruption — `IntegrationCredentialsStore.delete_creds_by_id` raises `ValueError` for a system id or an `is_managed` credential — but v2's handler mapped that to **400**, blaming the caller for a refusal the platform made. It now answers 403 for system-managed and AutoGPT-managed credentials and 404 for an SDK default, matching `api/features/integrations/router.py`. `is_managed` also reaches `CredentialInfo`, so a client can tell a platform credential from its own before trying.

The global rate-limit middleware caught only `HTTPException` around auth resolution, so a transient failure in the credential store propagated out of the middleware and the route never ran — a 500 on a request the route itself could have served. It now fails open as its module docstring already claimed. In the same place, the credential the middleware verified is handed to the route through the request scope, so an API key is no longer Scrypt-verified twice per request.

Finally, `/external-api/metrics` was in the public OpenAPI schema unconditionally. The Prometheus scrape endpoint stays mounted; only the schema entry goes, which is how the internal app has treated it since it was added.

**Verified.** I executed the new `permissions_test.py` (14 tests) and the extended `mcp_server_test.py`, the full `backend/api/external/v2/` suite (88 passed, against 73 at the branch point), and `backend/util/architecture_test.py`. Nine of the guards were broken one at a time and watched failing; the table is in the evidence comment. The metrics line is the one change with no test that can fail — an absence assertion there passes vacuously because the scrape endpoint is not even mounted unless `ENABLE_METRICS` is set — so it is verified by running the app under both `APP_ENV` values instead, output in the same comment. `backend/blocks/test/test_block.py` is the remaining suite; it and the backend CI run are reported in the comment.

Stacked on #14314 (v2 tenancy). Batch 2 of the v2 API roast; the contract-shape half follows in a separate PR.
