### PR TITLE
docs: point the Forge quickstart link at a file that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Connect the apps that are yours. AutoGPT provides access to hundreds of AI model
 
 Looking for the original standalone AutoGPT agent? It remains available in [`classic/`](classic/) under the MIT License.
 
-- [Build an agent with Forge](classic/FORGE-QUICKSTART.md)
+- [Build an agent with Forge](classic/forge/README.md)
 - [Benchmark an agent with `agbenchmark`](https://pypi.org/project/agbenchmark/)
 - [Explore the Classic project](classic/README.md)
 


### PR DESCRIPTION
The README's "AutoGPT Classic" section links to `classic/FORGE-QUICKSTART.md`, which
is not in the repository - the link 404s. The two sibling links in the same list
(`agbenchmark` on PyPI and `classic/README.md`) both resolve.

`classic/forge/README.md` is the closest match: it is the Forge package's own readme,
it opens with a Quick Start section, and it sits under `classic/` like the other link
in that list.

Verified by resolving every repo-relative link in `README.md`: one was missing before
this change and none are missing after. Putting the old path back makes the count go
to 1 again and names the path, so the check is not passing by default.

One line, README only.
