### PR TITLE
fix(backend): match sensitive header names case-insensitively when following redirects

### DIFF
--- a/autogpt_platform/backend/backend/util/request.py
+++ b/autogpt_platform/backend/backend/util/request.py
@@ -88,6 +88,9 @@ def _is_ip_blocked(ip: str) -> bool:
     return any(ip_addr in network for network in BLOCKED_IP_NETWORKS)
 
 
+SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "cookie"})
+
+
 def _remove_insecure_headers(headers: dict, old_url: URL, new_url: URL) -> dict:
     """
     Removes sensitive headers (Authorization, Proxy-Authorization, Cookie)
@@ -98,9 +101,10 @@ def _remove_insecure_headers(headers: dict, old_url: URL, new_url: URL) -> dict:
         or (old_url.hostname != new_url.hostname)
         or (old_url.port != new_url.port)
     ):
-        headers.pop("Authorization", None)
-        headers.pop("Proxy-Authorization", None)
-        headers.pop("Cookie", None)
+        # Header names are case-insensitive, and callers do send e.g.
+        # ``authorization``; matching on the exact key would miss those.
+        for name in [n for n in headers if n.lower() in SENSITIVE_HEADERS]:
+            headers.pop(name)
     return headers
 
 

--- a/autogpt_platform/backend/backend/util/request_test.py
+++ b/autogpt_platform/backend/backend/util/request_test.py
@@ -1,7 +1,14 @@
+from urllib.parse import urlparse
+
 import pytest
 from aiohttp import web
 
-from backend.util.request import _is_ip_blocked, pin_url, validate_url_host
+from backend.util.request import (
+    _is_ip_blocked,
+    _remove_insecure_headers,
+    pin_url,
+    validate_url_host,
+)
 
 
 @pytest.mark.parametrize(
@@ -244,3 +251,39 @@ async def test_ipv4_mapped_ipv6_bypass(
     else:
         url, _, ip_addresses = await validate_url_host(raw_url)
         assert ip_addresses  # Should have resolved IPs
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "Authorization",
+        "authorization",
+        "AUTHORIZATION",
+        "Proxy-Authorization",
+        "proxy-authorization",
+        "PROXY-AUTHORIZATION",
+        "Cookie",
+        "cookie",
+        "CoOkIe",
+    ],
+)
+@pytest.mark.parametrize(
+    "new_url, expect_stripped",
+    [
+        ("https://example.com/b", False),
+        ("https://other.example.com/b", True),
+        ("http://example.com/b", True),
+        ("https://example.com:8443/b", True),
+    ],
+)
+def test_sensitive_headers_are_stripped_regardless_of_case(
+    header_name: str, new_url: str, expect_stripped: bool
+):
+    headers = {header_name: "secret", "X-Keep": "kept"}
+
+    result = _remove_insecure_headers(
+        headers, urlparse("https://example.com/a"), urlparse(new_url)
+    )
+
+    assert (header_name not in result) is expect_stripped
+    assert result["X-Keep"] == "kept"


### PR DESCRIPTION
### Why / What / How

`Requests._request` drops `Authorization`, `Proxy-Authorization` and `Cookie` before following a redirect whose scheme, host or port differs from the original — but it matched those names by exact key, and HTTP header names are case-insensitive. A caller that spells one in lower case therefore kept it across the redirect. `blocks/talking_head.py` sends `authorization`, so this was reachable in practice.

`_remove_insecure_headers` now pops every key whose lowercased name is one of the three. Nothing else changes; the blocks that send lowercase header names are untouched.

#14303 (approved, unmerged) rewrites the same three lines of this function, so whichever lands second will need a rebase.

### Changes 🏗️

- `backend/util/request.py`: `_remove_insecure_headers` matches the three sensitive header names case-insensitively, via a new module-level `SENSITIVE_HEADERS`.
- `backend/util/request_test.py`: parametrized test over `Authorization`, `Proxy-Authorization` and `Cookie` in lower, upper and mixed case × four redirect targets — same-origin (kept) and differing host, scheme and port (stripped).

### Verified

I executed `backend/util/request_test.py` (87 passed), `backend/util/architecture_test.py` (3 passed) and `backend/blocks/test/test_block.py` (1647 passed, 84 skipped) locally on 3.13, and confirmed the new test fails without the fix by reverting it (18 of 36 cases fail, then pass again once restored). Commands and output are in a comment below. I reasoned about, but did not execute, the redirect path end-to-end against a live server; the test exercises `_remove_insecure_headers` directly.

### Agents and large language models used

Claude Code with Claude Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] A cross-origin redirect strips `Authorization`, `Proxy-Authorization` and `Cookie` whatever their casing
  - [x] A same-origin redirect keeps them
  - [x] Non-sensitive headers survive both
  - [x] Reverting the fix makes the new test fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
