### PR TITLE
fix(backend/api): make v2 uploads findable, its rate limit legible, and its review endpoint match the internal one

### DIFF
--- a/autogpt_platform/backend/.env.default
+++ b/autogpt_platform/backend/.env.default
@@ -79,6 +79,10 @@ FRONTEND_BASE_URL=http://localhost:3000
 # links may target — JSON list of full origins or "regex:"-prefixed patterns,
 # same format as BACKEND_CORS_ALLOW_ORIGINS. Self-hosting needs nothing here.
 # TRUSTED_FRONTEND_ORIGINS=["regex:https://autogpt-pr-\\d+\\.vercel\\.app"]
+# Proxies between the client and this app that append to X-Forwarded-For. The
+# anonymous rate-limit bucket keys on the Nth entry from the right; set 0 when
+# nothing fronts the app, or the header is a caller-chosen bucket key.
+# TRUSTED_PROXY_COUNT=1
 
 # Media Storage (required for marketplace and library functionality)
 MEDIA_GCS_BUCKET_NAME=

--- a/autogpt_platform/backend/backend/api/external/v1/routes.py
+++ b/autogpt_platform/backend/backend/api/external/v1/routes.py
@@ -351,7 +351,7 @@ async def get_store_agents(
     if page_size < 1:
         raise HTTPException(status_code=422, detail="Page size must be greater than 0")
 
-    agents = await store_cache._get_cached_store_agents(
+    agents = await store_cache.get_cached_store_agents(
         featured=featured,
         creator=creator,
         sorted_by=sorted_by,
@@ -385,7 +385,7 @@ async def get_store_agent(
     """
     username = urllib.parse.unquote(username).lower()
     agent_name = urllib.parse.unquote(agent_name).lower()
-    agent = await store_cache._get_cached_agent_details(
+    agent = await store_cache.get_cached_agent_details(
         username=username, agent_name=agent_name
     )
     return agent
@@ -423,7 +423,7 @@ async def get_store_creators(
     if page_size < 1:
         raise HTTPException(status_code=422, detail="Page size must be greater than 0")
 
-    creators = await store_cache._get_cached_store_creators(
+    creators = await store_cache.get_cached_store_creators(
         featured=featured,
         search_query=search_query,
         sorted_by=sorted_by,
@@ -452,5 +452,5 @@ async def get_store_creator(
         CreatorDetails: Detailed information about the creator
     """
     username = urllib.parse.unquote(username).lower()
-    creator = await store_cache._get_cached_creator_details(username=username)
+    creator = await store_cache.get_cached_creator_details(username=username)
     return creator

--- a/autogpt_platform/backend/backend/api/external/v2/contract_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/contract_test.py
@@ -190,6 +190,27 @@ async def test_a_review_id_from_another_run_is_rejected(
     assert "node-from-another-run" in str(exc_info.value.detail)
 
 
+async def test_the_marketplace_listing_lookup_goes_through_the_store_db(
+    mocker: pytest_mock.MockFixture,
+):
+    """The route held a raw Prisma query, so the store's own view was bypassed."""
+    from backend.util.exceptions import NotFoundError
+
+    from . import graphs
+
+    mocker.patch.object(
+        graphs.store_db,
+        "get_store_agent_by_graph_id",
+        new=mock.AsyncMock(side_effect=NotFoundError("nope")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await graphs.get_marketplace_listing_for_graph(graph_id="graph-1", auth=_tenant)
+
+    assert exc_info.value.status_code == 404
+    assert "#graph-1" in str(exc_info.value.detail)
+
+
 async def test_a_review_belonging_to_another_run_is_not_reachable_through_this_one(
     mocker: pytest_mock.MockFixture,
 ):

--- a/autogpt_platform/backend/backend/api/external/v2/contract_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/contract_test.py
@@ -269,9 +269,11 @@ async def test_bearer_api_key_gets_the_authenticated_rate_limit(
         return_value=_api_key_auth,
     )
     authenticated = mocker.patch.object(
-        global_rate_limit._authenticated_limiter, "check"
+        global_rate_limit._authenticated_limiter, "check", return_value=None
     )
-    anonymous = mocker.patch.object(global_rate_limit._anonymous_limiter, "check")
+    anonymous = mocker.patch.object(
+        global_rate_limit._anonymous_limiter, "check", return_value=None
+    )
 
     await _call_rate_limit_middleware(headers=[(b"authorization", b"Bearer agpt_test")])
 

--- a/autogpt_platform/backend/backend/api/external/v2/contract_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/contract_test.py
@@ -29,6 +29,7 @@ from starlette.routing import Match
 
 from backend.api.external.middleware import resolve_auth_info
 from backend.api.external.v2.errors import add_v2_exception_handlers
+from backend.api.external.v2.models import AgentTriggerSetupRequest
 from backend.api.external.v2.pagination import (
     MAX_PAGE,
     Page,
@@ -189,6 +190,47 @@ async def test_a_review_id_from_another_run_is_rejected(
 
     assert exc_info.value.status_code == 404
     assert "node-from-another-run" in str(exc_info.value.detail)
+
+
+async def test_trigger_setup_calls_the_service_not_the_internal_route_handler(
+    mocker: pytest_mock.MockFixture,
+):
+    """A `Security()` default reaches a direct call as a sentinel, not a value.
+
+    The internal handler takes `user_id: str = Security(...)`; calling it from
+    here worked only while nothing else in its signature was a dependency.
+    """
+    from backend.api.features.library.routes import presets as internal_presets
+
+    from .library import presets as v2_presets
+
+    service = mocker.patch.object(
+        v2_presets, "setup_triggered_preset", new=mock.AsyncMock()
+    )
+    mocker.patch.object(
+        v2_presets.experts_db, "resolve_expert_for_graph", new=mock.AsyncMock()
+    )
+    mocker.patch.object(
+        v2_presets.AgentPreset, "from_internal", return_value=mock.Mock()
+    )
+    internal = mocker.patch.object(
+        internal_presets, "setup_trigger", new=mock.AsyncMock()
+    )
+
+    await v2_presets.setup_trigger(
+        request=AgentTriggerSetupRequest(
+            name="n",
+            description="d",
+            graph_id="graph-1",
+            graph_version=1,
+            trigger_config={},
+            credentials_inputs={},
+        ),
+        auth=_tenant,
+    )
+
+    internal.assert_not_awaited()
+    assert service.await_args.kwargs["user_id"] == _tenant.user_id
 
 
 async def test_deleting_an_unknown_schedule_is_a_404_by_type_not_by_message(

--- a/autogpt_platform/backend/backend/api/external/v2/contract_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/contract_test.py
@@ -186,8 +186,92 @@ async def test_a_review_id_from_another_run_is_rejected(
     with pytest.raises(HTTPException) as exc_info:
         await _submit({"node_exec_id": "node-from-another-run", "approved": True})
 
-    assert exc_info.value.status_code == 400
+    assert exc_info.value.status_code == 404
     assert "node-from-another-run" in str(exc_info.value.detail)
+
+
+async def test_a_review_belonging_to_another_run_is_not_reachable_through_this_one(
+    mocker: pytest_mock.MockFixture,
+):
+    """The URL's run is tenancy-checked; the reviews must be that run's own.
+
+    `get_reviews_by_node_exec_ids` scopes to the user, not to the org, so a
+    review of a run in another tenant would otherwise be decidable here.
+    """
+    elsewhere = _review("node-a", ReviewStatus.WAITING)
+    elsewhere.graph_exec_id = "run-2"
+    _mock_review_db(mocker, pending=[elsewhere], processed={}, still_pending=True)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _submit({"node_exec_id": "node-a", "approved": True})
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_reviews_are_refused_on_a_run_that_is_not_awaiting_them(
+    mocker: pytest_mock.MockFixture,
+):
+    """v2 had no status check where the internal route answers 409."""
+    from backend.api.features.executions.review import service as review_service
+    from backend.data.execution import ExecutionStatus
+
+    _mock_review_db(
+        mocker,
+        pending=[_review("node-a", ReviewStatus.WAITING)],
+        processed={},
+        still_pending=True,
+    )
+    mocker.patch.object(
+        review_service,
+        "get_graph_execution_meta",
+        new=mock.AsyncMock(return_value=mock.Mock(status=ExecutionStatus.COMPLETED)),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _submit({"node_exec_id": "node-a", "approved": True})
+
+    assert exc_info.value.status_code == 409
+
+
+async def test_an_auto_approved_review_records_the_node_and_ignores_edits(
+    mocker: pytest_mock.MockFixture,
+):
+    """The internal route has always supported this; v2 dropped it silently."""
+    from backend.api.features.executions.review import service as review_service
+
+    approved = _review("node-a", ReviewStatus.APPROVED)
+    _mock_review_db(
+        mocker,
+        pending=[approved],
+        processed={"node-a": approved},
+        still_pending=True,
+    )
+    mocker.patch.object(
+        review_service,
+        "get_node_executions",
+        new=mock.AsyncMock(
+            return_value=[mock.Mock(node_exec_id="node-a", node_id="node-def-1")]
+        ),
+    )
+    record = mocker.patch.object(
+        review_service, "create_auto_approval_record", new=mock.AsyncMock()
+    )
+
+    await _submit(
+        {
+            "node_exec_id": "node-a",
+            "approved": True,
+            "edited_payload": {"ignored": True},
+            "auto_approve_future": True,
+        }
+    )
+
+    record.assert_awaited_once()
+    assert record.await_args.kwargs["node_id"] == "node-def-1"
+    decisions = review_service.process_all_reviews_for_execution.await_args.kwargs[
+        "review_decisions"
+    ]
+    assert decisions["node-a"][1] is None
 
 
 async def test_a_failed_resume_does_not_fail_the_submission(
@@ -636,8 +720,9 @@ def _mock_review_db(
     processed: dict[str, PendingHumanReviewModel],
     still_pending: bool,
 ) -> None:
+    from backend.api.features.executions.review import service as review_service
     from backend.data import execution as execution_db
-    from backend.data import human_review
+    from backend.data.execution import ExecutionStatus
 
     # The run carries the tenancy the reviews are checked against.
     mocker.patch.object(
@@ -648,17 +733,22 @@ def _mock_review_db(
         ),
     )
     mocker.patch.object(
-        human_review,
-        "get_pending_reviews_for_execution",
-        new=mock.AsyncMock(return_value=pending),
+        review_service,
+        "get_reviews_by_node_exec_ids",
+        new=mock.AsyncMock(return_value={r.node_exec_id: r for r in pending}),
     )
     mocker.patch.object(
-        human_review,
+        review_service,
+        "get_graph_execution_meta",
+        new=mock.AsyncMock(return_value=mock.Mock(status=ExecutionStatus.REVIEW)),
+    )
+    mocker.patch.object(
+        review_service,
         "process_all_reviews_for_execution",
         new=mock.AsyncMock(return_value=processed),
     )
     mocker.patch.object(
-        human_review,
+        review_service,
         "has_pending_reviews_for_graph_exec",
         new=mock.AsyncMock(return_value=still_pending),
     )
@@ -666,26 +756,26 @@ def _mock_review_db(
 
 def _mock_resume_path(mocker: pytest_mock.MockFixture) -> mock.AsyncMock:
     """Stub everything the resume needs; returns the enqueue mock to assert on."""
+    from backend.api.features.executions.review import service as review_service
     from backend.data.graph import GraphSettings
-    from backend.executor import utils as execution_utils
-
-    from . import runs
 
     mocker.patch.object(
-        runs,
+        review_service,
         "get_user_by_id",
         new=mock.AsyncMock(return_value=mock.Mock(timezone="Europe/Amsterdam")),
     )
     mocker.patch.object(
-        runs, "get_graph_settings", new=mock.AsyncMock(return_value=GraphSettings())
+        review_service,
+        "get_graph_settings",
+        new=mock.AsyncMock(return_value=GraphSettings()),
     )
     mocker.patch.object(
-        runs,
+        review_service,
         "get_or_create_workspace",
         new=mock.AsyncMock(return_value=mock.Mock(id="workspace-1")),
     )
     enqueue = mock.AsyncMock()
-    mocker.patch.object(execution_utils, "add_graph_execution", new=enqueue)
+    mocker.patch.object(review_service, "add_graph_execution", new=enqueue)
     return enqueue
 
 

--- a/autogpt_platform/backend/backend/api/external/v2/contract_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/contract_test.py
@@ -8,6 +8,7 @@ transport exercises.
 """
 
 import base64
+import inspect
 import json
 import logging
 from datetime import datetime, timezone
@@ -188,6 +189,78 @@ async def test_a_review_id_from_another_run_is_rejected(
 
     assert exc_info.value.status_code == 404
     assert "node-from-another-run" in str(exc_info.value.detail)
+
+
+async def test_deleting_an_unknown_schedule_is_a_404_by_type_not_by_message(
+    mocker: pytest_mock.MockFixture,
+):
+    """The route matched "not found" in the message; a reworded error broke it."""
+    from backend.util.exceptions import NotFoundError
+
+    from . import schedules
+
+    mocker.patch.object(
+        schedules,
+        "_assert_schedule_in_tenant",
+        new=mock.AsyncMock(),
+    )
+    mocker.patch.object(
+        schedules,
+        "get_scheduler_client",
+        return_value=mock.Mock(
+            delete_schedule=mock.AsyncMock(side_effect=NotFoundError("Job #s-1 gone."))
+        ),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await schedules.delete_schedule(schedule_id="s-1", auth=_tenant)
+
+    assert exc_info.value.status_code == 404
+
+
+async def test_listing_runs_passes_the_status_and_time_filters_through(
+    mocker: pytest_mock.MockFixture,
+):
+    from backend.data.execution import ExecutionStatus
+
+    from . import runs
+
+    paginated = mocker.patch.object(
+        runs.execution_db,
+        "get_graph_executions_paginated",
+        new=mock.AsyncMock(
+            return_value=mock.Mock(executions=[], pagination=mock.Mock(total_items=0))
+        ),
+    )
+    since = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+    await runs.list_runs(
+        graph_id=None,
+        statuses=["RUNNING", "FAILED"],
+        started_after=since,
+        started_before=None,
+        page=PageRequest(limit=25),
+        auth=_tenant,
+    )
+
+    kwargs = paginated.await_args.kwargs
+    assert kwargs["statuses"] == [ExecutionStatus.RUNNING, ExecutionStatus.FAILED]
+    assert kwargs["created_time_gte"] == since
+
+
+async def test_the_review_status_filter_keeps_its_wire_name(
+    mocker: pytest_mock.MockFixture,
+):
+    """The parameter is `status` on the wire; naming it that in Python shadowed
+    the `starlette.status` the rest of the module raises through."""
+    from . import runs
+
+    parameter = next(
+        p
+        for p in inspect.signature(runs.list_reviews).parameters.values()
+        if p.name == "review_status"
+    )
+    assert parameter.default.alias == "status"
 
 
 async def test_the_marketplace_listing_lookup_goes_through_the_store_db(

--- a/autogpt_platform/backend/backend/api/external/v2/credits.py
+++ b/autogpt_platform/backend/backend/api/external/v2/credits.py
@@ -38,6 +38,7 @@ from .models import (
     TransactionType,
 )
 from .pagination import Page, PageRequest, page_request, single_page_request
+from .rate_limit import subscription_limiter
 from .tenancy import TenantContext, require_permission
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,12 @@ async def get_transactions(
 async def get_subscription_status(
     auth: TenantContext = Security(require_permission(APIKeyPermission.READ_CREDITS)),
 ) -> SubscriptionStatus:
-    """Get the current subscription tier, pricing, and pending changes."""
+    """Get the current subscription tier, pricing, and pending changes.
+
+    **Rate limit:** 60 requests per minute per user.
+    """
+    await subscription_limiter.check(auth.user_id)
+
     user = await get_user_by_id(auth.user_id)
     tier = user.subscription_tier or SubscriptionTier.NO_TIER
 

--- a/autogpt_platform/backend/backend/api/external/v2/errors.py
+++ b/autogpt_platform/backend/backend/api/external/v2/errors.py
@@ -34,6 +34,8 @@ from backend.util.exceptions import (
     NotAuthorizedError,
     NotFoundError,
     PreconditionFailed,
+    WebhookRegistrationError,
+    WebhookSetupUnavailableError,
 )
 
 logger = logging.getLogger(__name__)
@@ -68,8 +70,10 @@ def add_v2_exception_handlers(app: fastapi.FastAPI) -> None:
         ConflictError: status.HTTP_409_CONFLICT,
         FolderValidationError: status.HTTP_400_BAD_REQUEST,
         GraphActivationError: status.HTTP_400_BAD_REQUEST,
+        WebhookRegistrationError: status.HTTP_400_BAD_REQUEST,
         ValueError: status.HTTP_400_BAD_REQUEST,
         MissingConfigError: status.HTTP_503_SERVICE_UNAVAILABLE,
+        WebhookSetupUnavailableError: status.HTTP_503_SERVICE_UNAVAILABLE,
         PrismaError: status.HTTP_500_INTERNAL_SERVER_ERROR,
         Exception: status.HTTP_500_INTERNAL_SERVER_ERROR,
     }.items():

--- a/autogpt_platform/backend/backend/api/external/v2/files.py
+++ b/autogpt_platform/backend/backend/api/external/v2/files.py
@@ -4,7 +4,6 @@ V2 External API - Files Endpoints
 Provides file upload, download, listing, metadata, and deletion functionality.
 """
 
-import base64
 import logging
 import re
 from urllib.parse import quote
@@ -14,6 +13,7 @@ from fastapi.responses import RedirectResponse, Response
 from prisma.enums import APIKeyPermission
 from starlette import status
 
+from backend.api.features.workspace.service import store_workspace_upload
 from backend.data.workspace import (
     count_workspace_files,
     get_workspace,
@@ -21,9 +21,6 @@ from backend.data.workspace import (
     list_workspace_files,
     soft_delete_workspace_file,
 )
-from backend.util.cloud_storage import get_cloud_storage_handler
-from backend.util.settings import Settings
-from backend.util.virus_scanner import scan_content_safe
 from backend.util.workspace_storage import get_workspace_storage
 
 from .models import UploadWorkspaceFileResponse, WorkspaceFileInfo
@@ -32,7 +29,6 @@ from .rate_limit import file_upload_limiter
 from .tenancy import TenantContext, require_permission
 
 logger = logging.getLogger(__name__)
-settings = Settings()
 
 file_workspace_router = APIRouter(tags=["files"])
 
@@ -141,17 +137,6 @@ async def delete_file(
         )
 
 
-def _create_file_size_error(size_bytes: int, max_size_mb: int) -> HTTPException:
-    """Create standardized file size error response."""
-    return HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail=(
-            f"File size ({size_bytes} bytes) exceeds "
-            f"the maximum allowed size of {max_size_mb}MB"
-        ),
-    )
-
-
 @file_workspace_router.post(
     path="/upload",
     summary="Upload file to workspace",
@@ -160,73 +145,35 @@ def _create_file_size_error(size_bytes: int, max_size_mb: int) -> HTTPException:
 )
 async def upload_file(
     file: UploadFile = File(...),
-    expiration_hours: int = Query(
-        default=24, ge=1, le=48, description="Hours until file expires (1-48)"
+    overwrite: bool = Query(
+        default=False, description="Replace an existing file with the same path"
     ),
     auth: TenantContext = Security(require_permission(APIKeyPermission.WRITE_FILES)),
 ) -> UploadWorkspaceFileResponse:
     """
-    Upload a file to cloud storage for use with agents.
+    Upload a file to the user's workspace.
 
-    Returns a `file_uri` that can be passed to agent graph/node file inputs.
-    Uploaded files are virus-scanned before storage.
+    The file is listed by `GET /files` and can be passed to agent file inputs
+    as the returned `file_uri`. Uploads are virus-scanned before storage and
+    count against the account's storage quota.
 
     **Rate limit:** 20 requests per 5 minutes per user.
     """
     await file_upload_limiter.check(auth.user_id)
 
-    # Check file size limit
-    max_size_mb = settings.config.upload_file_size_limit_mb
-    max_size_bytes = max_size_mb * 1024 * 1024
-
-    # Try to get file size from headers first
-    if file.size is not None and file.size > max_size_bytes:
-        raise _create_file_size_error(file.size, max_size_mb)
-
-    # Read file content
-    content = await file.read()
-    content_size = len(content)
-
-    # Double-check file size after reading
-    if content_size > max_size_bytes:
-        raise _create_file_size_error(content_size, max_size_mb)
-
-    # Extract file info
-    file_name = file.filename or "uploaded_file"
-    content_type = file.content_type or "application/octet-stream"
-
-    # Virus scan the content
-    await scan_content_safe(content, filename=file_name)
-
-    # Check if cloud storage is configured
-    cloud_storage = await get_cloud_storage_handler()
-    if not cloud_storage.config.gcs_bucket_name:
-        # Fallback to base64 data URI when GCS is not configured
-        base64_content = base64.b64encode(content).decode("utf-8")
-        data_uri = f"data:{content_type};base64,{base64_content}"
-
-        return UploadWorkspaceFileResponse(
-            file_uri=data_uri,
-            file_name=file_name,
-            size=content_size,
-            content_type=content_type,
-            expires_in_hours=expiration_hours,
-        )
-
-    # Store in cloud storage
-    storage_path = await cloud_storage.store_file(
-        content=content,
-        filename=file_name,
-        expiration_hours=expiration_hours,
-        user_id=auth.user_id,
+    workspace_file = await store_workspace_upload(
+        auth.user_id, file, overwrite=overwrite
     )
 
     return UploadWorkspaceFileResponse(
-        file_uri=storage_path,
-        file_name=file_name,
-        size=content_size,
-        content_type=content_type,
-        expires_in_hours=expiration_hours,
+        id=workspace_file.id,
+        name=workspace_file.name,
+        path=workspace_file.path,
+        mime_type=workspace_file.mime_type,
+        size_bytes=workspace_file.size_bytes,
+        created_at=workspace_file.created_at,
+        updated_at=workspace_file.updated_at,
+        file_uri=f"workspace://{workspace_file.id}#{workspace_file.mime_type}",
     )
 
 

--- a/autogpt_platform/backend/backend/api/external/v2/files_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/files_test.py
@@ -6,6 +6,7 @@ never appeared in the list and had no id to download or delete.
 """
 
 import io
+import mimetypes
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
@@ -189,16 +190,10 @@ def _workspace_file(name: str, size_bytes: int) -> WorkspaceFile:
         name=name,
         path=name,
         storage_path=f"local://{name}",
-        mime_type=_mime_by_name.get(name, "application/octet-stream"),
+        # Same derivation the real WorkspaceManager applies.
+        mime_type=mimetypes.guess_type(name)[0] or "application/octet-stream",
         size_bytes=size_bytes,
     )
-
-
-_mime_by_name = {
-    "report.csv": "text/csv",
-    "clip.mp4": "video/mp4",
-    "notes.txt": "text/plain",
-}
 
 
 def _upload(

--- a/autogpt_platform/backend/backend/api/external/v2/files_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/files_test.py
@@ -1,0 +1,220 @@
+"""Uploads and the file listing must address the same storage.
+
+Before this, `POST /files/upload` wrote to the temporary cloud bucket while
+every other file endpoint read the persistent workspace, so an uploaded file
+never appeared in the list and had no id to download or delete.
+"""
+
+import io
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+from unittest import mock
+
+import pytest
+import pytest_mock
+from fastapi import HTTPException, UploadFile
+from prisma.enums import APIKeyPermission
+from starlette.datastructures import Headers
+
+from backend.api.external.v2.files import get_file, list_files, upload_file
+from backend.api.external.v2.pagination import PageRequest
+from backend.api.external.v2.tenancy import TenantContext
+from backend.data.workspace import Workspace, WorkspaceFile
+
+USER_ID = "user-1"
+ORG_ID = "org-1"
+WORKSPACE_ID = "ws-1"
+
+
+async def test_an_uploaded_file_is_listed_and_addressable(
+    workspace: dict[str, WorkspaceFile],
+) -> None:
+    """The whole of item 1.9: upload, then find the same file by the id it returned."""
+    uploaded = await upload_file(
+        file=_upload("report.csv", b"a,b\n1,2\n", "text/csv"),
+        overwrite=False,
+        auth=_auth(),
+    )
+
+    listing = await list_files(page=PageRequest(limit=25), auth=_auth())
+    assert [f.id for f in listing.items] == [uploaded.id]
+
+    found = await get_file(file_id=uploaded.id, auth=_auth())
+    assert (found.name, found.path) == ("report.csv", "report.csv")
+
+
+async def test_the_upload_returns_a_uri_agent_file_inputs_accept(
+    workspace: dict[str, WorkspaceFile],
+) -> None:
+    """`workspace://<id>#<mime>` is what `store_media_file` resolves for a run."""
+    uploaded = await upload_file(
+        file=_upload("clip.mp4", b"\x00\x01", "video/mp4"),
+        overwrite=False,
+        auth=_auth(),
+    )
+
+    assert uploaded.file_uri == f"workspace://{uploaded.id}#video/mp4"
+
+
+async def test_a_second_upload_of_the_same_name_conflicts_unless_overwritten(
+    workspace: dict[str, WorkspaceFile],
+) -> None:
+    await upload_file(file=_upload("notes.txt", b"one"), overwrite=False, auth=_auth())
+
+    with pytest.raises(HTTPException) as raised:
+        await upload_file(
+            file=_upload("notes.txt", b"two"), overwrite=False, auth=_auth()
+        )
+    assert raised.value.status_code == 409
+
+    replaced = await upload_file(
+        file=_upload("notes.txt", b"two"), overwrite=True, auth=_auth()
+    )
+    assert list(workspace) == [replaced.id]
+
+
+async def test_an_upload_over_the_storage_quota_is_undone(
+    workspace: dict[str, WorkspaceFile],
+    quota_bytes: mock.AsyncMock,
+) -> None:
+    """A write that breaches the quota must not survive as an unlisted file."""
+    quota_bytes.return_value = 1
+
+    with pytest.raises(HTTPException) as raised:
+        await upload_file(
+            file=_upload("big.bin", b"0" * 64), overwrite=False, auth=_auth()
+        )
+
+    assert raised.value.status_code == 413
+    assert workspace == {}
+
+
+@pytest.fixture
+def quota_bytes(mocker: pytest_mock.MockFixture) -> mock.AsyncMock:
+    return mocker.patch(
+        "backend.api.features.workspace.service.get_workspace_storage_limit_bytes",
+        new=mock.AsyncMock(return_value=0),
+    )
+
+
+@pytest.fixture
+def workspace(
+    mocker: pytest_mock.MockFixture, quota_bytes: mock.AsyncMock
+) -> dict[str, WorkspaceFile]:
+    """One in-memory workspace behind both the write path and the read path.
+
+    The point of the fixture: the upload endpoint and the listing endpoints
+    reach the *same* store, so a test can only pass if they do in production.
+    """
+    files: dict[str, WorkspaceFile] = {}
+
+    async def write_file(
+        content: bytes, filename: str, *, overwrite: bool = False, metadata=None
+    ) -> WorkspaceFile:
+        existing = next((f for f in files.values() if f.path == filename), None)
+        if existing and not overwrite:
+            raise ValueError(f"File already exists at path: {filename}")
+        if existing:
+            del files[existing.id]
+        file = _workspace_file(filename, len(content))
+        files[file.id] = file
+        return file
+
+    async def delete_file(file_id: str) -> None:
+        files.pop(file_id, None)
+
+    manager = mocker.patch(
+        "backend.api.features.workspace.service.WorkspaceManager"
+    ).return_value
+    manager.write_file = mock.AsyncMock(side_effect=write_file)
+    manager.delete_file = mock.AsyncMock(side_effect=delete_file)
+
+    mocker.patch(
+        "backend.api.features.workspace.service.get_or_create_workspace",
+        new=mock.AsyncMock(
+            return_value=Workspace(
+                id=WORKSPACE_ID,
+                user_id=USER_ID,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+        ),
+    )
+    mocker.patch(
+        "backend.api.features.workspace.service.get_workspace_total_size",
+        new=mock.AsyncMock(
+            side_effect=lambda _: sum(f.size_bytes for f in files.values())
+        ),
+    )
+    mocker.patch(
+        "backend.api.external.v2.files.file_upload_limiter.check",
+        new=mock.AsyncMock(),
+    )
+
+    async def get_workspace(user_id: str) -> Workspace:
+        return Workspace(
+            id=WORKSPACE_ID,
+            user_id=user_id,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+
+    mocker.patch(
+        "backend.api.external.v2.files.get_workspace",
+        new=mock.AsyncMock(side_effect=get_workspace),
+    )
+    mocker.patch(
+        "backend.api.external.v2.files.count_workspace_files",
+        new=mock.AsyncMock(side_effect=lambda _: len(files)),
+    )
+    mocker.patch(
+        "backend.api.external.v2.files.list_workspace_files",
+        new=mock.AsyncMock(side_effect=lambda **_: list(files.values())),
+    )
+    mocker.patch(
+        "backend.api.external.v2.files.get_workspace_file",
+        new=mock.AsyncMock(side_effect=lambda file_id, _: files.get(file_id)),
+    )
+    return files
+
+
+def _workspace_file(name: str, size_bytes: int) -> WorkspaceFile:
+    now = datetime.now(timezone.utc)
+    return WorkspaceFile(
+        id=str(uuid.uuid4()),
+        workspace_id=WORKSPACE_ID,
+        created_at=now,
+        updated_at=now,
+        name=name,
+        path=name,
+        storage_path=f"local://{name}",
+        mime_type=_mime_by_name.get(name, "application/octet-stream"),
+        size_bytes=size_bytes,
+    )
+
+
+_mime_by_name = {
+    "report.csv": "text/csv",
+    "clip.mp4": "video/mp4",
+    "notes.txt": "text/plain",
+}
+
+
+def _upload(
+    filename: str, content: bytes, content_type: Optional[str] = None
+) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers=Headers({"content-type": content_type} if content_type else {}),
+    )
+
+
+def _auth() -> TenantContext:
+    return TenantContext(
+        user_id=USER_ID,
+        scopes=[APIKeyPermission.READ_FILES, APIKeyPermission.WRITE_FILES],
+        type="api_key",
+        organization_id=ORG_ID,
+    )

--- a/autogpt_platform/backend/backend/api/external/v2/global_rate_limit.py
+++ b/autogpt_platform/backend/backend/api/external/v2/global_rate_limit.py
@@ -9,22 +9,28 @@ Reuses `resolve_auth_info` from the auth middleware to identify the user, and
 hands the result to the route's dependency through the request scope so the
 credential is verified once per request.
 
+Every response carries the caller's `X-RateLimit-*` position, and a 429 adds
+`Retry-After`, so a client can back off on the numbers instead of guessing.
+
 On auth-resolution failure or Redis errors the request passes through — the
 endpoint's own auth dependency handles 401, and the rate limiter fails open.
 """
 
 import logging
+from typing import Optional
 
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from backend.api.external.middleware import resolve_auth_info
-from backend.api.utils.rate_limit import RateLimiter
+from backend.api.utils.rate_limit import RateLimiter, RateLimitState
+from backend.util.settings import Settings
 
 from .errors import error_response
 
 logger = logging.getLogger(__name__)
+settings = Settings()
 
 _authenticated_limiter = RateLimiter("v2:global", max_requests=200, window_seconds=60)
 _anonymous_limiter = RateLimiter("v2:global:anon", max_requests=5, window_seconds=60)
@@ -66,18 +72,55 @@ class GlobalRateLimitMiddleware:
 
         try:
             if auth:
-                await _authenticated_limiter.check(auth.user_id)
+                state = await _authenticated_limiter.check(auth.user_id)
             else:
-                ip = (
-                    headers.get(b"x-forwarded-for", b"").decode().split(",")[0].strip()
-                    or (scope.get("client") or ("unknown",))[0]
-                )
-                await _anonymous_limiter.check(ip)
+                state = await _anonymous_limiter.check(client_ip(scope, headers))
         except HTTPException as exc:
             # The middleware sits outside the app, so the v2 exception handlers
             # never see this — build the same envelope by hand.
-            response = error_response(exc.status_code, str(exc.detail))
+            response = error_response(
+                exc.status_code, str(exc.detail), headers=exc.headers
+            )
             await response(scope, receive, send)
             return
 
-        await self.app(scope, receive, send)
+        await self.app(scope, receive, _with_rate_limit_headers(send, state))
+
+
+def client_ip(scope: Scope, headers: dict[bytes, bytes]) -> str:
+    """The caller's address, trusting only the proxies in front of us.
+
+    Each proxy appends the address it received the connection from, so with
+    `trusted_proxy_count` proxies the client is that many entries from the
+    right; anything further left the caller wrote itself and could use to
+    spread its requests over an unlimited number of buckets.
+    """
+    peer = (scope.get("client") or ("unknown",))[0]
+    hops = settings.config.trusted_proxy_count
+    if hops < 1:
+        return peer
+
+    forwarded = [
+        value.strip()
+        for value in headers.get(b"x-forwarded-for", b"").decode().split(",")
+        if value.strip()
+    ]
+    return forwarded[-hops] if len(forwarded) >= hops else peer
+
+
+def _with_rate_limit_headers(send: Send, state: Optional[RateLimitState]) -> Send:
+    """Attach the caller's window position to the response headers."""
+    if state is None:
+        return send
+
+    encoded = [
+        (name.lower().encode(), value.encode())
+        for name, value in state.headers().items()
+    ]
+
+    async def send_with_headers(message: Message) -> None:
+        if message["type"] == "http.response.start":
+            message.setdefault("headers", []).extend(encoded)
+        await send(message)
+
+    return send_with_headers

--- a/autogpt_platform/backend/backend/api/external/v2/graphs.py
+++ b/autogpt_platform/backend/backend/api/external/v2/graphs.py
@@ -8,18 +8,18 @@ import logging
 from typing import Optional
 from uuid import uuid4
 
-import prisma.models
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from prisma.enums import APIKeyPermission
 from starlette import status
 
 from backend.api.features.library import db as library_db
-from backend.api.features.store.model import StoreAgentDetails
+from backend.api.features.store import db as store_db
 from backend.data import graph as graph_db
 from backend.integrations.webhooks.graph_lifecycle_hooks import (
     before_graph_activate,
     on_graph_deactivate,
 )
+from backend.util.exceptions import NotFoundError
 
 from .integrations.helpers import get_credential_requirements
 from .models import (
@@ -448,12 +448,11 @@ async def get_marketplace_listing_for_graph(
     auth: TenantContext = Security(require_permission(APIKeyPermission.READ_STORE)),
 ) -> MarketplaceAgentDetails:
     """Get the marketplace listing for a given graph, if one exists."""
-    agent = await prisma.models.StoreAgent.prisma().find_first(
-        where={"graph_id": graph_id}
-    )
-    if not agent:
+    try:
+        agent = await store_db.get_store_agent_by_graph_id(graph_id)
+    except NotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"No marketplace listing found for graph {graph_id}",
+            detail=f"No marketplace listing found for graph #{graph_id}",
         )
-    return MarketplaceAgentDetails.from_internal(StoreAgentDetails.from_db(agent))
+    return MarketplaceAgentDetails.from_internal(agent)

--- a/autogpt_platform/backend/backend/api/external/v2/library/presets.py
+++ b/autogpt_platform/backend/backend/api/external/v2/library/presets.py
@@ -11,11 +11,10 @@ from fastapi import APIRouter, Depends, Query, Security
 from prisma.enums import APIKeyPermission
 from starlette import status
 
+from backend.api.features.experts import experts_db
 from backend.api.features.library import db as library_db
 from backend.api.features.library.model import LibraryAgentPresetCreatable
-from backend.api.features.library.model import (
-    TriggeredPresetSetupRequest as _TriggeredPresetSetupRequest,
-)
+from backend.api.features.library.triggers import setup_triggered_preset
 from backend.executor import utils as execution_utils
 
 from ..idempotency import idempotency_key, idempotent_run, replayed_run
@@ -128,23 +127,20 @@ async def setup_trigger(
     schema and credentials. Use it to populate `trigger_config` and
     `credentials_inputs`.
     """
-    # Use internal trigger setup endpoint to avoid logic duplication:
-    from backend.api.features.library.routes.presets import (
-        setup_trigger as _internal_setup_trigger,
-    )
-
-    internal_request = _TriggeredPresetSetupRequest(
-        name=request.name,
-        description=request.description,
+    # The shared service, not the internal route handler: that handler's
+    # `user_id` is a `Security()` parameter, so the first `Depends` added to
+    # its signature would reach this call as a sentinel object.
+    preset = await setup_triggered_preset(
+        user_id=auth.user_id,
         graph_id=request.graph_id,
         graph_version=request.graph_version,
+        name=request.name,
+        description=request.description,
         trigger_config=request.trigger_config,
         agent_credentials=request.credentials_inputs,
-    )
-
-    preset = await _internal_setup_trigger(
-        params=internal_request,
-        user_id=auth.user_id,
+        expert_id=await experts_db.resolve_expert_for_graph(
+            auth.user_id, request.graph_id
+        ),
     )
     return AgentPreset.from_internal(preset)
 

--- a/autogpt_platform/backend/backend/api/external/v2/marketplace.py
+++ b/autogpt_platform/backend/backend/api/external/v2/marketplace.py
@@ -83,7 +83,7 @@ async def list_agents(
     auth: TenantContext = Security(require_auth),
 ) -> Page[MarketplaceAgent]:
     """List agents available in the marketplace, with optional filtering and sorting."""
-    result = await store_cache._get_cached_store_agents(
+    result = await store_cache.get_cached_store_agents(
         featured=featured,
         creator=creator,
         sorted_by=StoreAgentsSortOptions(sorted_by) if sorted_by else None,
@@ -129,7 +129,7 @@ async def get_agent_details(
     username = urllib.parse.unquote(username).lower()
     agent_name = urllib.parse.unquote(agent_name).lower()
 
-    agent = await store_cache._get_cached_agent_details(
+    agent = await store_cache.get_cached_agent_details(
         username=username, agent_name=agent_name
     )
 
@@ -151,7 +151,7 @@ async def add_agent_to_library(
     username = urllib.parse.unquote(username).lower()
     agent_name = urllib.parse.unquote(agent_name).lower()
 
-    agent_details = await store_cache._get_cached_agent_details(
+    agent_details = await store_cache.get_cached_agent_details(
         username=username, agent_name=agent_name
     )
 
@@ -188,7 +188,7 @@ async def list_creators(
     auth: TenantContext = Security(require_auth),
 ) -> Page[MarketplaceCreatorDetails]:
     """List or search marketplace creators."""
-    result = await store_cache._get_cached_store_creators(
+    result = await store_cache.get_cached_store_creators(
         featured=featured,
         search_query=search_query,
         sorted_by=StoreCreatorsSortOptions(sorted_by) if sorted_by else None,
@@ -214,7 +214,7 @@ async def get_creator_details(
 ) -> MarketplaceCreatorDetails:
     """Get a marketplace creator's profile w/ stats."""
     username = urllib.parse.unquote(username).lower()
-    creator = await store_cache._get_cached_creator_details(username=username)
+    creator = await store_cache.get_cached_creator_details(username=username)
     return MarketplaceCreatorDetails.from_internal(creator)
 
 
@@ -239,7 +239,7 @@ async def get_profile(
             detail="Profile not found",
         )
 
-    creator = await store_cache._get_cached_creator_details(username=profile.username)
+    creator = await store_cache.get_cached_creator_details(username=profile.username)
     return MarketplaceCreatorDetails.from_internal(creator)
 
 

--- a/autogpt_platform/backend/backend/api/external/v2/mcp_server.py
+++ b/autogpt_platform/backend/backend/api/external/v2/mcp_server.py
@@ -119,7 +119,19 @@ def create_mcp_server() -> FastMCP:
     settings = Settings()
     base_url = settings.config.platform_base_url or "https://platform.agpt.co"
 
-    server = _ScopeAwareMCP(
+    tools = []
+    for tool in TOOL_REGISTRY.values():
+        allowed, required_perms = tool.allow_external_use
+        if not allowed or required_perms is None:
+            reason = EXTERNAL_USE_EXCLUSIONS.get(tool.name, "unclassified")
+            logger.debug(f"Skipping MCP tool {tool.name}: {reason}")
+            continue
+        tools.append(_mcp_tool(tool, required_perms))
+
+    logger.info(
+        f"MCP server created with {len(tools)} tools: {[t.name for t in tools]}"
+    )
+    return _ScopeAwareMCP(
         name="autogpt-platform",
         instructions=(
             "AutoGPT Platform MCP Server. "
@@ -130,22 +142,10 @@ def create_mcp_server() -> FastMCP:
             issuer_url=AnyHttpUrl(base_url),
             resource_server_url=AnyHttpUrl(f"{base_url}/external-api/v2/mcp"),
         ),
+        tools=tools,
         stateless_http=True,
         streamable_http_path="/",
     )
-
-    registered: list[str] = []
-    for tool in TOOL_REGISTRY.values():
-        allowed, required_perms = tool.allow_external_use
-        if not allowed or required_perms is None:
-            reason = EXTERNAL_USE_EXCLUSIONS.get(tool.name, "unclassified")
-            logger.debug(f"Skipping MCP tool {tool.name}: {reason}")
-            continue
-        _register_tool(server, tool, required_perms)
-        registered.append(tool.name)
-
-    logger.info(f"MCP server created with {len(registered)} tools: {registered}")
-    return server
 
 
 def create_mcp_app() -> Starlette:
@@ -275,15 +275,16 @@ def _create_tool_handler(
     return handler
 
 
-def _register_tool(
-    server: FastMCP, tool: BaseTool, required_perms: Sequence[APIKeyPermission]
-) -> None:
-    """Register a Copilot tool on the MCP server."""
-    required_scopes = [p.value for p in required_perms]
-    handler = _create_tool_handler(tool, required_scopes)
+def _mcp_tool(tool: BaseTool, required_perms: Sequence[APIKeyPermission]) -> MCPTool:
+    """Build an MCP tool from a Copilot tool.
 
-    mcp_tool = MCPTool(
-        fn=handler,
+    Constructed directly rather than through `FastMCP.add_tool`, which derives
+    the schema from the handler's signature; ours is `**kwargs` and the real
+    schema comes from the Copilot tool.
+    """
+    required_scopes = [p.value for p in required_perms]
+    return MCPTool(
+        fn=_create_tool_handler(tool, required_scopes),
         name=tool.name,
         title=None,
         description=tool.description,
@@ -294,7 +295,6 @@ def _register_tool(
         annotations=None,
         meta={META_KEY_REQUIRED_SCOPES: required_scopes},
     )
-    server._tool_manager._tools[tool.name] = mcp_tool
 
 
 # ---------------------------------------------------------------------------

--- a/autogpt_platform/backend/backend/api/external/v2/mcp_server.py
+++ b/autogpt_platform/backend/backend/api/external/v2/mcp_server.py
@@ -20,9 +20,11 @@ from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.fastmcp.server import Context
 from mcp.server.fastmcp.tools.base import Tool as MCPTool
 from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
+from mcp.shared.auth import ProtectedResourceMetadata
 from prisma.enums import APIKeyPermission
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
@@ -114,10 +116,20 @@ UNSCOPED_EXTERNAL_TOOLS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
+# The path `/mcp` ends up on, counting from the origin: the external API is
+# mounted at /external-api, v2 inside it, the MCP app inside that.
+MCP_RESOURCE_PATH = "/external-api/v2/mcp"
+
+# RFC 9728 §3.1: the well-known segment is inserted between host and resource
+# path, so this is the URL a client derives — and it is on the origin root.
+WELL_KNOWN_PROTECTED_RESOURCE_PATH = (
+    f"/.well-known/oauth-protected-resource{MCP_RESOURCE_PATH}"
+)
+
+
 def create_mcp_server() -> FastMCP:
     """Create the MCP server with all eligible Copilot tools registered."""
-    settings = Settings()
-    base_url = settings.config.platform_base_url or "https://platform.agpt.co"
+    base_url = _platform_base_url()
 
     tools = []
     for tool in TOOL_REGISTRY.values():
@@ -140,7 +152,7 @@ def create_mcp_server() -> FastMCP:
         token_verifier=ExternalAPITokenVerifier(),
         auth=AuthSettings(
             issuer_url=AnyHttpUrl(base_url),
-            resource_server_url=AnyHttpUrl(f"{base_url}/external-api/v2/mcp"),
+            resource_server_url=AnyHttpUrl(f"{base_url}{MCP_RESOURCE_PATH}"),
         ),
         tools=tools,
         stateless_http=True,
@@ -152,6 +164,27 @@ def create_mcp_app() -> Starlette:
     """Create the Starlette ASGI app for the MCP server."""
     server = create_mcp_server()
     return server.streamable_http_app()
+
+
+def protected_resource_metadata() -> ProtectedResourceMetadata:
+    """RFC 9728 metadata for the MCP server, to be served at the ORIGIN root.
+
+    FastMCP registers this document inside the `/mcp` sub-app, so it lands at
+    `/external-api/v2/mcp/.well-known/oauth-protected-resource/external-api/v2/mcp`
+    while a client — following the `resource_metadata` FastMCP itself puts in
+    `WWW-Authenticate` — asks the origin root for it and gets a 404. The root
+    app serves this instead; see `WELL_KNOWN_PROTECTED_RESOURCE_PATH`.
+    """
+    base_url = _platform_base_url()
+    return ProtectedResourceMetadata(
+        resource=AnyHttpUrl(f"{base_url}{MCP_RESOURCE_PATH}"),
+        authorization_servers=[AnyHttpUrl(base_url)],
+        resource_name="AutoGPT Platform MCP Server",
+    )
+
+
+def _platform_base_url() -> str:
+    return Settings().config.platform_base_url or "https://platform.agpt.co"
 
 
 # ---------------------------------------------------------------------------
@@ -242,14 +275,16 @@ def _create_tool_handler(
     """
 
     async def handler(ctx: Context, **kwargs: Any) -> str:
+        # Raised, not returned: a rejection returned as content is reported to
+        # the client as a successful call whose text happens to say "denied".
         access_token = get_access_token()
         if not access_token:
-            return "Authentication required"
+            raise ToolError("Authentication required")
 
         if required_scopes:
             missing = [s for s in required_scopes if s not in access_token.scopes]
             if missing:
-                return f"Missing required permission(s): {', '.join(missing)}"
+                raise ToolError(f"Missing required permission(s): {', '.join(missing)}")
 
         user_id = access_token.client_id
         organization_id, team_id = (

--- a/autogpt_platform/backend/backend/api/external/v2/mcp_server_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/mcp_server_test.py
@@ -1,12 +1,22 @@
 """Keep the MCP tool surface deliberate: every Copilot tool is classified."""
 
+from unittest import mock
+from urllib.parse import urlparse
+
+import pytest
+import pytest_mock
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from starlette.routing import Match
 
 from backend.api.external.v2.mcp_server import (
     EXTERNAL_USE_EXCLUSIONS,
     META_KEY_REQUIRED_SCOPES,
     UNSCOPED_EXTERNAL_TOOLS,
+    WELL_KNOWN_PROTECTED_RESOURCE_PATH,
+    _create_tool_handler,
     create_mcp_server,
+    protected_resource_metadata,
 )
 from backend.copilot.tools import TOOL_REGISTRY
 
@@ -27,6 +37,47 @@ async def test_the_server_carries_every_opted_in_tool_with_its_scopes():
     for name, tool in registered.items():
         expected = [p.value for p in (TOOL_REGISTRY[name].allow_external_use[1] or [])]
         assert (tool.meta or {}).get(META_KEY_REQUIRED_SCOPES) == expected
+
+
+def test_the_protected_resource_document_answers_where_clients_look():
+    """RFC 9728 discovery, at the URL the `WWW-Authenticate` header names.
+
+    FastMCP registers its own copy inside the `/mcp` mount, so the derived URL
+    — well-known segment first, resource path after — 404s unless the root app
+    serves it. This asserts against the real app, not a stand-in.
+    """
+    from mcp.server.auth.routes import build_resource_metadata_url
+
+    from backend.api.rest_api import app
+
+    metadata = protected_resource_metadata()
+    derived = urlparse(str(build_resource_metadata_url(metadata.resource)))
+    assert derived.path == WELL_KNOWN_PROTECTED_RESOURCE_PATH
+
+    scope = {"type": "http", "method": "GET", "path": derived.path, "headers": []}
+    assert any(
+        route.matches(scope)[0] == Match.FULL for route in app.routes
+    ), f"nothing on the root app answers {derived.path}"
+
+
+async def test_a_rejected_tool_call_is_an_error_not_a_successful_denial(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Returned text is reported to the client as a call that succeeded."""
+    handler = _create_tool_handler(next(iter(TOOL_REGISTRY.values())), ["READ_GRAPH"])
+
+    mocker.patch(
+        "backend.api.external.v2.mcp_server.get_access_token", return_value=None
+    )
+    with pytest.raises(ToolError, match="Authentication required"):
+        await handler(ctx=mock.Mock())
+
+    mocker.patch(
+        "backend.api.external.v2.mcp_server.get_access_token",
+        return_value=mock.Mock(scopes=["READ_RUN"]),
+    )
+    with pytest.raises(ToolError, match="READ_GRAPH"):
+        await handler(ctx=mock.Mock())
 
 
 def test_every_tool_is_either_exposed_or_explicitly_excluded():

--- a/autogpt_platform/backend/backend/api/external/v2/mcp_server_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/mcp_server_test.py
@@ -1,10 +1,32 @@
 """Keep the MCP tool surface deliberate: every Copilot tool is classified."""
 
+from mcp.server.fastmcp import FastMCP
+
 from backend.api.external.v2.mcp_server import (
     EXTERNAL_USE_EXCLUSIONS,
+    META_KEY_REQUIRED_SCOPES,
     UNSCOPED_EXTERNAL_TOOLS,
+    create_mcp_server,
 )
 from backend.copilot.tools import TOOL_REGISTRY
+
+
+async def test_the_server_carries_every_opted_in_tool_with_its_scopes():
+    """Registration goes through FastMCP's own constructor, not its internals.
+
+    Writing into `_tool_manager._tools` worked by accident of mcp 1.26.0's
+    layout; this fails the moment the supported path stops carrying the tools.
+    """
+    server = create_mcp_server()
+
+    exposed = {name for name, t in TOOL_REGISTRY.items() if t.allow_external_use[0]}
+    # The base listing: the subclass's own filters by the caller's scopes.
+    registered = {t.name: t for t in await FastMCP.list_tools(server)}
+    assert set(registered) == exposed
+
+    for name, tool in registered.items():
+        expected = [p.value for p in (TOOL_REGISTRY[name].allow_external_use[1] or [])]
+        assert (tool.meta or {}).get(META_KEY_REQUIRED_SCOPES) == expected
 
 
 def test_every_tool_is_either_exposed_or_explicitly_excluded():

--- a/autogpt_platform/backend/backend/api/external/v2/models.py
+++ b/autogpt_platform/backend/backend/api/external/v2/models.py
@@ -1353,16 +1353,6 @@ class CredentialRequirement(BaseModel):
 # ============================================================================
 
 
-class UploadWorkspaceFileResponse(BaseModel):
-    """Response after uploading a file to the user's workspace."""
-
-    file_uri: str = Field(description="URI to reference the uploaded file in agents")
-    file_name: str
-    size: int = Field(description="File size in bytes")
-    content_type: str
-    expires_in_hours: int
-
-
 class WorkspaceFileInfo(BaseModel):
     """Metadata for a file in the user's workspace."""
 
@@ -1373,6 +1363,14 @@ class WorkspaceFileInfo(BaseModel):
     size_bytes: int = Field(description="File size in bytes")
     created_at: datetime
     updated_at: datetime
+
+
+class UploadWorkspaceFileResponse(WorkspaceFileInfo):
+    """Response after uploading a file to the user's workspace."""
+
+    file_uri: str = Field(
+        description="URI to reference the uploaded file in agent file inputs"
+    )
 
 
 # ============================================================================

--- a/autogpt_platform/backend/backend/api/external/v2/models.py
+++ b/autogpt_platform/backend/backend/api/external/v2/models.py
@@ -927,6 +927,13 @@ class AgentRunReviewDecision(BaseModel):
     message: Optional[str] = Field(
         default=None, description="Optional message from reviewer", max_length=2000
     )
+    auto_approve_future: bool = Field(
+        default=False,
+        description=(
+            "Approve future reviews from this block automatically. Applies only "
+            "when this review is approved, and ignores `edited_payload`."
+        ),
+    )
 
 
 class AgentRunReviewsSubmitRequest(BaseModel):

--- a/autogpt_platform/backend/backend/api/external/v2/permissions_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/permissions_test.py
@@ -338,7 +338,9 @@ def _client() -> fastapi.testclient.TestClient:
 def _offline(mocker: pytest_mock.MockFixture) -> None:
     """No test here is about Redis or the org tables."""
     mocker.patch(
-        "backend.api.utils.rate_limit.RateLimiter.check", new_callable=mock.AsyncMock
+        "backend.api.utils.rate_limit.RateLimiter.check",
+        new_callable=mock.AsyncMock,
+        return_value=None,
     )
     mocker.patch(
         "backend.api.external.v2.tenancy.resolve_credential_tenancy",

--- a/autogpt_platform/backend/backend/api/external/v2/rate_limit.py
+++ b/autogpt_platform/backend/backend/api/external/v2/rate_limit.py
@@ -8,3 +8,8 @@ media_upload_limiter = RateLimiter(
 search_limiter = RateLimiter("v2:search", max_requests=30, window_seconds=60)
 graph_exec_limiter = RateLimiter("v2:graph_exec", max_requests=60, window_seconds=60)
 file_upload_limiter = RateLimiter("v2:file_upload", max_requests=20, window_seconds=300)
+# Every call fans out to uncached Stripe reads (proration, period end, pending
+# change), so the cap is the internal endpoint's: 60/min/user.
+subscription_limiter = RateLimiter(
+    "v2:subscription", max_requests=60, window_seconds=60
+)

--- a/autogpt_platform/backend/backend/api/external/v2/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/rate_limit_test.py
@@ -1,0 +1,145 @@
+"""Rate limiting as a contract: what a client is told, and what it is keyed on.
+
+A cap the caller cannot see forces it to retry blind, and an anonymous bucket
+keyed on a header the caller writes is not a cap at all.
+"""
+
+from unittest import mock
+
+import pytest
+import pytest_mock
+from fastapi import HTTPException
+
+from backend.api.external.v2 import credits
+from backend.api.external.v2.global_rate_limit import (
+    GlobalRateLimitMiddleware,
+    client_ip,
+)
+from backend.api.utils.rate_limit import RateLimiter
+
+PEER = "10.0.0.9"
+
+
+async def test_a_request_under_the_cap_is_told_where_it_stands(
+    redis: mock.AsyncMock,
+) -> None:
+    redis.incr.return_value = 3
+
+    state = await RateLimiter("t", max_requests=10, window_seconds=60).check("u1")
+
+    assert state is not None
+    assert state.headers()["X-RateLimit-Limit"] == "10"
+    assert state.headers()["X-RateLimit-Remaining"] == "7"
+    assert 1 <= int(state.headers()["X-RateLimit-Reset"]) <= 60
+
+
+async def test_a_blocked_request_carries_retry_after(redis: mock.AsyncMock) -> None:
+    """Without it a client retries blind, adding load to what the cap protects."""
+    redis.incr.return_value = 11
+
+    with pytest.raises(HTTPException) as raised:
+        await RateLimiter("t", max_requests=10, window_seconds=60).check("u1")
+
+    headers = raised.value.headers or {}
+    assert raised.value.status_code == 429
+    assert 1 <= int(headers["Retry-After"]) <= 60
+    assert headers["X-RateLimit-Remaining"] == "0"
+
+
+async def test_an_unmeasurable_window_publishes_no_numbers(
+    redis: mock.AsyncMock,
+) -> None:
+    """Redis is down: fail open, but do not report a count nobody measured."""
+    redis.incr.side_effect = ConnectionError("redis is gone")
+
+    assert (
+        await RateLimiter("t", max_requests=10, window_seconds=60).check("u1") is None
+    )
+
+
+async def test_the_response_carries_the_callers_window_position(
+    redis: mock.AsyncMock,
+) -> None:
+    redis.incr.return_value = 1
+    sent: list[dict] = []
+
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+
+    async def send(message):
+        sent.append(message)
+
+    await GlobalRateLimitMiddleware(app)(_scope(), _receive, send)
+
+    headers = dict(sent[0]["headers"])
+    assert headers[b"x-ratelimit-limit"] == b"5"
+    assert headers[b"x-ratelimit-remaining"] == b"4"
+
+
+@pytest.mark.parametrize(
+    "hops, forwarded, expected",
+    [
+        (1, "203.0.113.7", "203.0.113.7"),
+        # The spoofed entry sits left of the one our proxy appended.
+        (1, "1.2.3.4, 203.0.113.7", "203.0.113.7"),
+        (2, "203.0.113.7, 198.51.100.1", "203.0.113.7"),
+        (2, "9.9.9.9, 203.0.113.7, 198.51.100.1", "203.0.113.7"),
+        # Fewer hops than configured means the header did not come through
+        # our own proxies; the socket peer is the only trustworthy value.
+        (2, "203.0.113.7", PEER),
+        (1, "", PEER),
+        (0, "203.0.113.7", PEER),
+    ],
+)
+def test_the_anonymous_bucket_ignores_caller_written_hops(
+    mocker: pytest_mock.MockFixture, hops: int, forwarded: str, expected: str
+) -> None:
+    """A caller that can set the key picks its own bucket, so there is no cap."""
+    mocker.patch(
+        "backend.api.external.v2.global_rate_limit.settings.config.trusted_proxy_count",
+        hops,
+    )
+
+    headers = {b"x-forwarded-for": forwarded.encode()} if forwarded else {}
+    assert client_ip(_scope(), headers) == expected
+
+
+async def test_the_subscription_read_is_capped_before_it_reaches_stripe(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Uncached Stripe reads on every call, so the cap has to gate the fan-out."""
+    user = mocker.patch.object(credits, "get_user_by_id", new=mock.AsyncMock())
+    mocker.patch.object(
+        credits.subscription_limiter,
+        "check",
+        new=mock.AsyncMock(side_effect=HTTPException(status_code=429, detail="nope")),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await credits.get_subscription_status(auth=mock.Mock(user_id="u1"))
+
+    assert raised.value.status_code == 429
+    user.assert_not_awaited()
+
+
+@pytest.fixture
+def redis(mocker: pytest_mock.MockFixture) -> mock.AsyncMock:
+    client = mock.AsyncMock()
+    client.set.return_value = True
+    mocker.patch(
+        "backend.api.utils.rate_limit.get_redis_async",
+        new=mock.AsyncMock(return_value=client),
+    )
+    mocker.patch(
+        "backend.api.external.v2.global_rate_limit.resolve_auth_info",
+        new=mock.AsyncMock(return_value=None),
+    )
+    return client
+
+
+def _scope() -> dict:
+    return {"type": "http", "client": (PEER, 4242), "headers": []}
+
+
+async def _receive() -> dict:
+    return {"type": "http.request"}

--- a/autogpt_platform/backend/backend/api/external/v2/runs.py
+++ b/autogpt_platform/backend/backend/api/external/v2/runs.py
@@ -11,16 +11,12 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security
 from prisma.enums import APIKeyPermission, ReviewStatus
-from pydantic import JsonValue
 from starlette import status
 
+from backend.api.features.executions.review.model import ReviewItem
+from backend.api.features.executions.review.service import process_reviews
 from backend.data import execution as execution_db
 from backend.data import human_review as review_db
-from backend.data.execution import ExecutionContext
-from backend.data.graph import get_graph_settings
-from backend.data.model import USER_TIMEZONE_NOT_SET
-from backend.data.user import get_user_by_id
-from backend.data.workspace import get_or_create_workspace
 from backend.executor import utils as execution_utils
 from backend.util.settings import Settings
 
@@ -110,83 +106,27 @@ async def submit_reviews(
     # Reviews carry no organization of their own; the run they belong to does.
     await _assert_run_in_tenant(run_id, auth)
 
-    # Validate run_id: ensure the submitted node_exec_ids belong to this run
-    pending_reviews = await review_db.get_pending_reviews_for_execution(
+    outcome = await process_reviews(
+        auth.user_id,
+        [
+            ReviewItem(
+                node_exec_id=decision.node_exec_id,
+                approved=decision.approved,
+                reviewed_data=decision.edited_payload,
+                message=decision.message,
+                auto_approve_future=decision.auto_approve_future,
+            )
+            for decision in request.reviews
+        ],
         graph_exec_id=run_id,
-        user_id=auth.user_id,
+        organization_id=auth.organization_id,
+        team_id=auth.team_id,
     )
-    valid_node_exec_ids = {r.node_exec_id for r in pending_reviews}
-    submitted_ids = {d.node_exec_id for d in request.reviews}
-    invalid_ids = submitted_ids - valid_node_exec_ids
-    if invalid_ids:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Review IDs not found for run {run_id}: " f"{', '.join(invalid_ids)}"
-            ),
-        )
-
-    # Build review decisions dict for process_all_reviews_for_execution
-    review_decisions: dict[str, tuple[ReviewStatus, JsonValue | None, str | None]] = {}
-
-    for decision in request.reviews:
-        decision_status = (
-            ReviewStatus.APPROVED if decision.approved else ReviewStatus.REJECTED
-        )
-        review_decisions[decision.node_exec_id] = (
-            decision_status,
-            decision.edited_payload,
-            decision.message,
-        )
-
-    results = await review_db.process_all_reviews_for_execution(
-        user_id=auth.user_id,
-        review_decisions=review_decisions,
-    )
-
-    approved_count = sum(
-        1 for r in results.values() if r.status == ReviewStatus.APPROVED
-    )
-    rejected_count = sum(
-        1 for r in results.values() if r.status == ReviewStatus.REJECTED
-    )
-
-    # Resume graph execution if no more pending reviews remain
-    if results:
-        still_has_pending = await review_db.has_pending_reviews_for_graph_exec(run_id)
-        if not still_has_pending:
-            first_review = next(iter(results.values()))
-            try:
-                user = await get_user_by_id(auth.user_id)
-                settings = await get_graph_settings(
-                    user_id=auth.user_id, graph_id=first_review.graph_id
-                )
-                user_timezone = (
-                    user.timezone if user.timezone != USER_TIMEZONE_NOT_SET else "UTC"
-                )
-                workspace = await get_or_create_workspace(auth.user_id)
-                execution_context = ExecutionContext(
-                    human_in_the_loop_safe_mode=(settings.human_in_the_loop_safe_mode),
-                    sensitive_action_safe_mode=(settings.sensitive_action_safe_mode),
-                    user_timezone=user_timezone,
-                    workspace_id=workspace.id,
-                )
-                await execution_utils.add_graph_execution(
-                    graph_id=first_review.graph_id,
-                    user_id=auth.user_id,
-                    graph_exec_id=run_id,
-                    execution_context=execution_context,
-                    organization_id=auth.organization_id,
-                    team_id=auth.team_id,
-                )
-                logger.info(f"Resumed execution {run_id}")
-            except Exception as e:
-                logger.error(f"Failed to resume execution {run_id}: {e}")
 
     return AgentRunReviewsSubmitResponse(
         run_id=run_id,
-        approved_count=approved_count,
-        rejected_count=rejected_count,
+        approved_count=outcome.approved_count,
+        rejected_count=outcome.rejected_count,
     )
 
 

--- a/autogpt_platform/backend/backend/api/external/v2/runs.py
+++ b/autogpt_platform/backend/backend/api/external/v2/runs.py
@@ -7,7 +7,7 @@ Provides access to agent runs and human-in-the-loop reviews.
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Security
 from prisma.enums import APIKeyPermission, ReviewStatus
@@ -17,6 +17,7 @@ from backend.api.features.executions.review.model import ReviewItem
 from backend.api.features.executions.review.service import process_reviews
 from backend.data import execution as execution_db
 from backend.data import human_review as review_db
+from backend.data.execution import ExecutionStatus
 from backend.executor import utils as execution_utils
 from backend.util.settings import Settings
 
@@ -28,6 +29,7 @@ from .models import (
     AgentRunReviewsSubmitResponse,
     AgentRunReviewStatus,
     AgentRunShareResponse,
+    RunStatus,
 )
 from .pagination import Page, PageRequest, page_request
 from .tenancy import TenantContext, in_tenant, require_permission
@@ -55,8 +57,9 @@ async def list_reviews(
     run_id: Optional[str] = Query(
         default=None, description="Filter by graph execution ID"
     ),
-    status: Optional[AgentRunReviewStatus] = Query(
+    review_status: Optional[AgentRunReviewStatus] = Query(
         default=None,
+        alias="status",
         description="Filter by review status",
     ),
     page: PageRequest = Depends(page_request),
@@ -72,7 +75,7 @@ async def list_reviews(
     reviews, pagination = await review_db.get_reviews(
         user_id=auth.user_id,
         graph_exec_id=run_id,
-        status=ReviewStatus(status) if status else None,
+        status=ReviewStatus(review_status) if review_status else None,
         page=page.page,
         page_size=page.limit,
         organization_id=auth.organization_id,
@@ -142,13 +145,29 @@ async def submit_reviews(
 )
 async def list_runs(
     graph_id: Optional[str] = Query(default=None, description="Filter by graph ID"),
+    # `Annotated`, not `= Query(...)`: the latter leaves the sentinel as the
+    # Python default, and this handler is also called directly in tests.
+    statuses: Annotated[
+        Optional[list[RunStatus]],
+        Query(description="Filter by run status; repeat to match several"),
+    ] = None,
+    started_after: Annotated[
+        Optional[datetime], Query(description="Only runs created at or after this time")
+    ] = None,
+    started_before: Annotated[
+        Optional[datetime],
+        Query(description="Only runs created at or before this time"),
+    ] = None,
     page: PageRequest = Depends(page_request),
     auth: TenantContext = Security(require_permission(APIKeyPermission.READ_RUN)),
 ) -> Page[AgentGraphRun]:
-    """List agent runs, optionally filtered by graph ID."""
+    """List agent runs, optionally filtered by graph, status and creation time."""
     result = await execution_db.get_graph_executions_paginated(
         user_id=auth.user_id,
         graph_id=graph_id,
+        statuses=[ExecutionStatus(s) for s in statuses] if statuses else None,
+        created_time_gte=started_after,
+        created_time_lte=started_before,
         page=page.page,
         page_size=page.limit,
         organization_id=auth.organization_id,

--- a/autogpt_platform/backend/backend/api/external/v2/schedules.py
+++ b/autogpt_platform/backend/backend/api/external/v2/schedules.py
@@ -77,13 +77,11 @@ async def delete_schedule(
             schedule_id=schedule_id,
             user_id=auth.user_id,
         )
-    except Exception as e:
-        if "not found" in str(e).lower():
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Schedule #{schedule_id} not found",
-            )
-        raise
+    except NotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Schedule #{schedule_id} not found",
+        )
 
 
 @schedules_router.post(

--- a/autogpt_platform/backend/backend/api/external/v2/tenancy_test.py
+++ b/autogpt_platform/backend/backend/api/external/v2/tenancy_test.py
@@ -559,7 +559,9 @@ async def test_preset_and_review_listing_are_scoped_to_the_key_org(
     )
 
     await list_presets(graph_id=None, page=_page(), auth=_key_for(ORG_A))
-    await list_reviews(run_id=None, status=None, page=_page(), auth=_key_for(ORG_A))
+    await list_reviews(
+        run_id=None, review_status=None, page=_page(), auth=_key_for(ORG_A)
+    )
 
     assert presets.await_args.kwargs["organization_id"] == ORG_A
     assert reviews.await_args.kwargs["organization_id"] == ORG_A

--- a/autogpt_platform/backend/backend/api/features/executions/review/review_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/review_routes_test.py
@@ -166,7 +166,7 @@ async def test_process_review_action_approve_success(
 
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     mock_get_reviews_for_user.return_value = {"test_node_123": sample_pending_review}
 
@@ -176,7 +176,7 @@ async def test_process_review_action_approve_success(
     mock_get_reviews_for_execution.return_value = [sample_pending_review]
 
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     # Create approved review for return
     approved_review = PendingHumanReviewModel(
@@ -200,18 +200,18 @@ async def test_process_review_action_approve_success(
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
     mock_get_graph_exec.return_value = mock_graph_exec_meta
 
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
-    mocker.patch("backend.api.features.executions.review.routes.add_graph_execution")
+    mocker.patch("backend.api.features.executions.review.service.add_graph_execution")
 
     request_data = {
         "reviews": [
@@ -246,13 +246,13 @@ async def test_process_review_action_reject_success(
 
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     mock_get_reviews_for_user.return_value = {"test_node_123": sample_pending_review}
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -264,7 +264,7 @@ async def test_process_review_action_reject_success(
     mock_get_reviews_for_execution.return_value = [sample_pending_review]
 
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     rejected_review = PendingHumanReviewModel(
         node_exec_id="test_node_123",
@@ -286,7 +286,7 @@ async def test_process_review_action_reject_success(
     mock_process_all_reviews.return_value = {"test_node_123": rejected_review}
 
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
@@ -341,7 +341,7 @@ async def test_process_review_action_mixed_success(
 
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     mock_get_reviews_for_user.return_value = {
         "test_node_123": sample_pending_review,
@@ -354,7 +354,7 @@ async def test_process_review_action_mixed_success(
     mock_get_reviews_for_execution.return_value = [sample_pending_review, second_review]
 
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     # Create approved version of first review
     approved_review = PendingHumanReviewModel(
@@ -399,14 +399,14 @@ async def test_process_review_action_mixed_success(
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
     mock_get_graph_exec.return_value = mock_graph_exec_meta
 
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
@@ -465,14 +465,14 @@ async def test_process_review_action_review_not_found(
     """Test error when review is not found"""
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     # Return empty dict to simulate review not found
     mock_get_reviews_for_user.return_value = {}
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -486,7 +486,7 @@ async def test_process_review_action_review_not_found(
 
     # Mock process_all_reviews to simulate not finding reviews
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     # This should raise a ValueError with "Reviews not found" message based on the data/human_review.py logic
     mock_process_all_reviews.side_effect = ValueError(
@@ -519,13 +519,13 @@ async def test_process_review_action_partial_failure(
     """Test handling of partial failures in review processing"""
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     mock_get_reviews_for_user.return_value = {"test_node_123": sample_pending_review}
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -539,7 +539,7 @@ async def test_process_review_action_partial_failure(
 
     # Mock partial failure in processing
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     mock_process_all_reviews.side_effect = ValueError("Some reviews failed validation")
 
@@ -569,14 +569,14 @@ async def test_process_review_action_invalid_node_exec_id(
     """Test failure when trying to process review with invalid node execution ID"""
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     # Return empty dict to simulate review not found
     mock_get_reviews_for_user.return_value = {}
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -609,13 +609,13 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
     """Test that auto_approve_future_actions flag creates auto-approval records"""
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     mock_get_reviews_for_user.return_value = {"test_node_123": sample_pending_review}
 
     # Mock process_all_reviews
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     approved_review = PendingHumanReviewModel(
         node_exec_id="test_node_123",
@@ -638,7 +638,7 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
 
     # Mock get_node_executions to return node_id mapping
     mock_get_node_executions = mocker.patch(
-        "backend.api.features.executions.review.routes.get_node_executions"
+        "backend.api.features.executions.review.service.get_node_executions"
     )
     mock_node_exec = mocker.Mock(spec=NodeExecutionResult)
     mock_node_exec.node_exec_id = "test_node_123"
@@ -647,12 +647,12 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
 
     # Mock create_auto_approval_record
     mock_create_auto_approval = mocker.patch(
-        "backend.api.features.executions.review.routes.create_auto_approval_record"
+        "backend.api.features.executions.review.service.create_auto_approval_record"
     )
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -660,13 +660,13 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
 
     # Mock has_pending_reviews_for_graph_exec
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
     # Mock get_graph_settings to return custom settings
     mock_get_settings = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_settings"
+        "backend.api.features.executions.review.service.get_graph_settings"
     )
     mock_get_settings.return_value = GraphSettings(
         human_in_the_loop_safe_mode=True,
@@ -675,7 +675,7 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
 
     # Mock get_user_by_id to prevent database access
     mock_get_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_user_by_id"
+        "backend.api.features.executions.review.service.get_user_by_id"
     )
     mock_user = mocker.Mock()
     mock_user.timezone = "UTC"
@@ -683,7 +683,7 @@ async def test_process_review_action_auto_approve_creates_auto_approval_records(
 
     # Mock add_graph_execution
     mock_add_execution = mocker.patch(
-        "backend.api.features.executions.review.routes.add_graph_execution"
+        "backend.api.features.executions.review.service.add_graph_execution"
     )
 
     request_data = {
@@ -739,13 +739,13 @@ async def test_process_review_action_without_auto_approve_still_loads_settings(
     """Test that execution context is created with settings even without auto-approve"""
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     mock_get_reviews_for_user.return_value = {"test_node_123": sample_pending_review}
 
     # Mock process_all_reviews
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     approved_review = PendingHumanReviewModel(
         node_exec_id="test_node_123",
@@ -768,12 +768,12 @@ async def test_process_review_action_without_auto_approve_still_loads_settings(
 
     # Mock create_auto_approval_record - should NOT be called when auto_approve is False
     mock_create_auto_approval = mocker.patch(
-        "backend.api.features.executions.review.routes.create_auto_approval_record"
+        "backend.api.features.executions.review.service.create_auto_approval_record"
     )
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -781,13 +781,13 @@ async def test_process_review_action_without_auto_approve_still_loads_settings(
 
     # Mock has_pending_reviews_for_graph_exec
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
     # Mock get_graph_settings with sensitive_action_safe_mode enabled
     mock_get_settings = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_settings"
+        "backend.api.features.executions.review.service.get_graph_settings"
     )
     mock_get_settings.return_value = GraphSettings(
         human_in_the_loop_safe_mode=False,
@@ -796,7 +796,7 @@ async def test_process_review_action_without_auto_approve_still_loads_settings(
 
     # Mock get_user_by_id to prevent database access
     mock_get_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_user_by_id"
+        "backend.api.features.executions.review.service.get_user_by_id"
     )
     mock_user = mocker.Mock()
     mock_user.timezone = "UTC"
@@ -804,7 +804,7 @@ async def test_process_review_action_without_auto_approve_still_loads_settings(
 
     # Mock add_graph_execution
     mock_add_execution = mocker.patch(
-        "backend.api.features.executions.review.routes.add_graph_execution"
+        "backend.api.features.executions.review.service.add_graph_execution"
     )
 
     # Request WITHOUT auto_approve_future (defaults to False)
@@ -887,7 +887,7 @@ async def test_process_review_action_auto_approve_only_applies_to_approved_revie
 
     # Mock get_reviews_by_node_exec_ids (called to find the graph_exec_id)
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
     # Need to return both reviews in WAITING state (before processing)
     approved_review_waiting = PendingHumanReviewModel(
@@ -927,7 +927,7 @@ async def test_process_review_action_auto_approve_only_applies_to_approved_revie
 
     # Mock process_all_reviews
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     mock_process_all_reviews.return_value = {
         "node_exec_approved": approved_review,
@@ -936,7 +936,7 @@ async def test_process_review_action_auto_approve_only_applies_to_approved_revie
 
     # Mock get_node_executions to return node_id mapping
     mock_get_node_executions = mocker.patch(
-        "backend.api.features.executions.review.routes.get_node_executions"
+        "backend.api.features.executions.review.service.get_node_executions"
     )
     mock_node_exec = mocker.Mock(spec=NodeExecutionResult)
     mock_node_exec.node_exec_id = "node_exec_approved"
@@ -945,12 +945,12 @@ async def test_process_review_action_auto_approve_only_applies_to_approved_revie
 
     # Mock create_auto_approval_record
     mock_create_auto_approval = mocker.patch(
-        "backend.api.features.executions.review.routes.create_auto_approval_record"
+        "backend.api.features.executions.review.service.create_auto_approval_record"
     )
 
     # Mock get_graph_execution_meta to return execution in REVIEW status
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -958,19 +958,19 @@ async def test_process_review_action_auto_approve_only_applies_to_approved_revie
 
     # Mock has_pending_reviews_for_graph_exec
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
     # Mock get_graph_settings
     mock_get_settings = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_settings"
+        "backend.api.features.executions.review.service.get_graph_settings"
     )
     mock_get_settings.return_value = GraphSettings()
 
     # Mock get_user_by_id to prevent database access
     mock_get_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_user_by_id"
+        "backend.api.features.executions.review.service.get_user_by_id"
     )
     mock_user = mocker.Mock()
     mock_user.timezone = "UTC"
@@ -978,7 +978,7 @@ async def test_process_review_action_auto_approve_only_applies_to_approved_revie
 
     # Mock add_graph_execution
     mock_add_execution = mocker.patch(
-        "backend.api.features.executions.review.routes.add_graph_execution"
+        "backend.api.features.executions.review.service.add_graph_execution"
     )
 
     request_data = {
@@ -1033,7 +1033,7 @@ async def test_process_review_action_per_review_auto_approve_granularity(
     """Test that auto-approval can be set per-review (granular control)"""
     # Mock get_reviews_by_node_exec_ids - return different reviews based on node_exec_id
     mock_get_reviews_for_user = mocker.patch(
-        "backend.api.features.executions.review.routes.get_reviews_by_node_exec_ids"
+        "backend.api.features.executions.review.service.get_reviews_by_node_exec_ids"
     )
 
     # Create a mapping of node_exec_id to review
@@ -1090,7 +1090,7 @@ async def test_process_review_action_per_review_auto_approve_granularity(
 
     # Mock process_all_reviews - return 3 approved reviews
     mock_process_all_reviews = mocker.patch(
-        "backend.api.features.executions.review.routes.process_all_reviews_for_execution"
+        "backend.api.features.executions.review.service.process_all_reviews_for_execution"
     )
     mock_process_all_reviews.return_value = {
         "node_1_auto": PendingHumanReviewModel(
@@ -1148,7 +1148,7 @@ async def test_process_review_action_per_review_auto_approve_granularity(
 
     # Mock get_node_executions to return batch node data
     mock_get_node_executions = mocker.patch(
-        "backend.api.features.executions.review.routes.get_node_executions"
+        "backend.api.features.executions.review.service.get_node_executions"
     )
     # Create mock node executions for each review
     mock_node_execs = []
@@ -1161,12 +1161,12 @@ async def test_process_review_action_per_review_auto_approve_granularity(
 
     # Mock create_auto_approval_record
     mock_create_auto_approval = mocker.patch(
-        "backend.api.features.executions.review.routes.create_auto_approval_record"
+        "backend.api.features.executions.review.service.create_auto_approval_record"
     )
 
     # Mock get_graph_execution_meta
     mock_get_graph_exec = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_execution_meta"
+        "backend.api.features.executions.review.service.get_graph_execution_meta"
     )
     mock_graph_exec_meta = mocker.Mock()
     mock_graph_exec_meta.status = ExecutionStatus.REVIEW
@@ -1174,20 +1174,20 @@ async def test_process_review_action_per_review_auto_approve_granularity(
 
     # Mock has_pending_reviews_for_graph_exec
     mock_has_pending = mocker.patch(
-        "backend.api.features.executions.review.routes.has_pending_reviews_for_graph_exec"
+        "backend.api.features.executions.review.service.has_pending_reviews_for_graph_exec"
     )
     mock_has_pending.return_value = False
 
     # Mock settings and execution
     mock_get_settings = mocker.patch(
-        "backend.api.features.executions.review.routes.get_graph_settings"
+        "backend.api.features.executions.review.service.get_graph_settings"
     )
     mock_get_settings.return_value = GraphSettings(
         human_in_the_loop_safe_mode=False, sensitive_action_safe_mode=False
     )
 
-    mocker.patch("backend.api.features.executions.review.routes.add_graph_execution")
-    mocker.patch("backend.api.features.executions.review.routes.get_user_by_id")
+    mocker.patch("backend.api.features.executions.review.service.add_graph_execution")
+    mocker.patch("backend.api.features.executions.review.service.get_user_by_id")
 
     # Request with granular auto-approval:
     # - node_1_auto: auto_approve_future=True

--- a/autogpt_platform/backend/backend/api/features/executions/review/routes.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/routes.py
@@ -1,36 +1,18 @@
-import asyncio
 import logging
-from typing import Any, List
+from typing import List
 
 import autogpt_libs.auth as autogpt_auth_lib
 from fastapi import APIRouter, HTTPException, Query, Security, status
-from prisma.enums import ReviewStatus
 
-from backend.copilot.constants import (
-    is_copilot_synthetic_id,
-    parse_node_id_from_exec_id,
-)
-from backend.data.execution import (
-    ExecutionContext,
-    ExecutionStatus,
-    get_graph_execution_meta,
-    get_node_executions,
-)
-from backend.data.graph import get_graph_settings
+from backend.copilot.constants import is_copilot_synthetic_id
+from backend.data.execution import get_graph_execution_meta
 from backend.data.human_review import (
-    create_auto_approval_record,
     get_pending_reviews_for_execution,
     get_pending_reviews_for_user,
-    get_reviews_by_node_exec_ids,
-    has_pending_reviews_for_graph_exec,
-    process_all_reviews_for_execution,
 )
-from backend.data.model import USER_TIMEZONE_NOT_SET
-from backend.data.user import get_user_by_id
-from backend.data.workspace import get_or_create_workspace
-from backend.executor.utils import add_graph_execution
 
 from .model import PendingHumanReviewModel, ReviewRequest, ReviewResponse
+from .service import process_reviews
 
 logger = logging.getLogger(__name__)
 
@@ -39,38 +21,6 @@ router = APIRouter(
     tags=["v2", "executions", "review"],
     dependencies=[Security(autogpt_auth_lib.requires_user)],
 )
-
-
-async def _resolve_node_ids(
-    node_exec_ids: list[str],
-    graph_exec_id: str,
-    is_copilot: bool,
-) -> dict[str, str]:
-    """Resolve node_exec_id -> node_id for auto-approval records.
-
-    CoPilot synthetic IDs encode node_id in the format "{node_id}:{random}".
-    Graph executions look up node_id from NodeExecution records.
-    """
-    if not node_exec_ids:
-        return {}
-
-    if is_copilot:
-        return {neid: parse_node_id_from_exec_id(neid) for neid in node_exec_ids}
-
-    node_execs = await get_node_executions(
-        graph_exec_id=graph_exec_id, include_exec_data=False
-    )
-    node_exec_map = {ne.node_exec_id: ne.node_id for ne in node_execs}
-
-    result = {}
-    for neid in node_exec_ids:
-        if neid in node_exec_map:
-            result[neid] = node_exec_map[neid]
-        else:
-            logger.error(
-                f"Failed to resolve node_id for {neid}: Node execution not found."
-            )
-    return result
 
 
 @router.get(
@@ -167,209 +117,19 @@ async def process_review_action(
     user_id: str = Security(autogpt_auth_lib.get_user_id),
 ) -> ReviewResponse:
     """Process reviews with approve or reject actions."""
+    outcome = await process_reviews(user_id, request.reviews)
 
-    # Collect all node exec IDs from the request
-    all_request_node_ids = {review.node_exec_id for review in request.reviews}
-
-    if not all_request_node_ids:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="At least one review must be provided",
-        )
-
-    # Batch fetch all requested reviews (regardless of status for idempotent handling)
-    reviews_map = await get_reviews_by_node_exec_ids(
-        list(all_request_node_ids), user_id
-    )
-
-    # Validate all reviews were found (must exist, any status is OK for now)
-    missing_ids = all_request_node_ids - set(reviews_map.keys())
-    if missing_ids:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Review(s) not found: {', '.join(missing_ids)}",
-        )
-
-    # Validate all reviews belong to the same execution
-    graph_exec_ids = {review.graph_exec_id for review in reviews_map.values()}
-    if len(graph_exec_ids) > 1:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="All reviews in a single request must belong to the same execution.",
-        )
-
-    graph_exec_id = next(iter(graph_exec_ids))
-    is_copilot = is_copilot_synthetic_id(graph_exec_id)
-
-    # Validate execution status for graph executions (skip for CoPilot synthetic IDs)
-    if not is_copilot:
-        graph_exec_meta = await get_graph_execution_meta(
-            user_id=user_id, execution_id=graph_exec_id
-        )
-        if not graph_exec_meta:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Graph execution #{graph_exec_id} not found",
-            )
-        if graph_exec_meta.status not in (
-            ExecutionStatus.REVIEW,
-            ExecutionStatus.INCOMPLETE,
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Cannot process reviews while execution status is {graph_exec_meta.status}",
-            )
-
-    # Build review decisions map and track which reviews requested auto-approval
-    # Auto-approved reviews use original data (no modifications allowed)
-    review_decisions = {}
-    auto_approve_requests = {}  # Map node_exec_id -> auto_approve_future flag
-
-    for review in request.reviews:
-        review_status = (
-            ReviewStatus.APPROVED if review.approved else ReviewStatus.REJECTED
-        )
-        # If this review requested auto-approval, don't allow data modifications
-        reviewed_data = None if review.auto_approve_future else review.reviewed_data
-        review_decisions[review.node_exec_id] = (
-            review_status,
-            reviewed_data,
-            review.message,
-        )
-        auto_approve_requests[review.node_exec_id] = review.auto_approve_future
-
-    # Process all reviews
-    updated_reviews = await process_all_reviews_for_execution(
-        user_id=user_id,
-        review_decisions=review_decisions,
-    )
-
-    # Create auto-approval records for approved reviews that requested it
-    # Deduplicate by node_id to avoid race conditions when multiple reviews
-    # for the same node are processed in parallel
-    async def create_auto_approval_for_node(
-        node_id: str, review_result
-    ) -> tuple[str, bool]:
-        """
-        Create auto-approval record for a node.
-        Returns (node_id, success) tuple for tracking failures.
-        """
-        try:
-            await create_auto_approval_record(
-                user_id=user_id,
-                graph_exec_id=review_result.graph_exec_id,
-                graph_id=review_result.graph_id,
-                graph_version=review_result.graph_version,
-                node_id=node_id,
-                payload=review_result.payload,
-            )
-            return (node_id, True)
-        except Exception as e:
-            logger.error(
-                f"Failed to create auto-approval record for node {node_id}",
-                exc_info=e,
-            )
-            return (node_id, False)
-
-    # Collect node_exec_ids that need auto-approval and resolve their node_ids
-    node_exec_ids_needing_auto_approval = [
-        node_exec_id
-        for node_exec_id, review_result in updated_reviews.items()
-        if review_result.status == ReviewStatus.APPROVED
-        and auto_approve_requests.get(node_exec_id, False)
-    ]
-
-    node_id_map = await _resolve_node_ids(
-        node_exec_ids_needing_auto_approval, graph_exec_id, is_copilot
-    )
-
-    # Deduplicate by node_id — one auto-approval per node
-    nodes_needing_auto_approval: dict[str, Any] = {}
-    for node_exec_id in node_exec_ids_needing_auto_approval:
-        node_id = node_id_map.get(node_exec_id)
-        if node_id and node_id not in nodes_needing_auto_approval:
-            nodes_needing_auto_approval[node_id] = updated_reviews[node_exec_id]
-
-    # Execute all auto-approval creations in parallel (deduplicated by node_id)
-    auto_approval_results = await asyncio.gather(
-        *[
-            create_auto_approval_for_node(node_id, review_result)
-            for node_id, review_result in nodes_needing_auto_approval.items()
-        ],
-        return_exceptions=True,
-    )
-
-    # Count auto-approval failures
-    auto_approval_failed_count = 0
-    for result in auto_approval_results:
-        if isinstance(result, Exception):
-            auto_approval_failed_count += 1
-            logger.error(
-                f"Unexpected exception during auto-approval creation: {result}"
-            )
-        elif isinstance(result, tuple) and len(result) == 2 and not result[1]:
-            auto_approval_failed_count += 1
-
-    # Count results
-    approved_count = sum(
-        1
-        for review in updated_reviews.values()
-        if review.status == ReviewStatus.APPROVED
-    )
-    rejected_count = sum(
-        1
-        for review in updated_reviews.values()
-        if review.status == ReviewStatus.REJECTED
-    )
-
-    # Resume graph execution only for real graph executions (not CoPilot)
-    # CoPilot sessions are resumed by the LLM retrying run_block with review_id
-    if not is_copilot and updated_reviews:
-        still_has_pending = await has_pending_reviews_for_graph_exec(graph_exec_id)
-
-        if not still_has_pending:
-            first_review = next(iter(updated_reviews.values()))
-
-            try:
-                user = await get_user_by_id(user_id)
-                settings = await get_graph_settings(
-                    user_id=user_id, graph_id=first_review.graph_id
-                )
-
-                user_timezone = (
-                    user.timezone if user.timezone != USER_TIMEZONE_NOT_SET else "UTC"
-                )
-
-                workspace = await get_or_create_workspace(user_id)
-
-                execution_context = ExecutionContext(
-                    human_in_the_loop_safe_mode=settings.human_in_the_loop_safe_mode,
-                    sensitive_action_safe_mode=settings.sensitive_action_safe_mode,
-                    user_timezone=user_timezone,
-                    workspace_id=workspace.id,
-                )
-
-                await add_graph_execution(
-                    graph_id=first_review.graph_id,
-                    user_id=user_id,
-                    graph_exec_id=graph_exec_id,
-                    execution_context=execution_context,
-                )
-                logger.info(f"Resumed execution {graph_exec_id}")
-            except Exception as e:
-                logger.error(f"Failed to resume execution {graph_exec_id}: {str(e)}")
-
-    # Build error message if auto-approvals failed
     error_message = None
-    if auto_approval_failed_count > 0:
+    if outcome.auto_approval_failed_count:
         error_message = (
-            f"{auto_approval_failed_count} auto-approval setting(s) could not be saved. "
-            f"You may need to manually approve these reviews in future executions."
+            f"{outcome.auto_approval_failed_count} auto-approval setting(s) could "
+            f"not be saved. You may need to manually approve these reviews in "
+            f"future executions."
         )
 
     return ReviewResponse(
-        approved_count=approved_count,
-        rejected_count=rejected_count,
-        failed_count=auto_approval_failed_count,
+        approved_count=outcome.approved_count,
+        rejected_count=outcome.rejected_count,
+        failed_count=outcome.auto_approval_failed_count,
         error=error_message,
     )

--- a/autogpt_platform/backend/backend/api/features/executions/review/service.py
+++ b/autogpt_platform/backend/backend/api/features/executions/review/service.py
@@ -1,0 +1,280 @@
+"""Human-in-the-loop review processing, shared by the internal and v2 APIs.
+
+One implementation so the two surfaces cannot disagree about which reviews a
+request may touch, what a run's status has to be, or when execution resumes.
+"""
+
+import asyncio
+import logging
+from typing import Any, Optional, Sequence
+
+from fastapi import HTTPException, status
+from prisma.enums import ReviewStatus
+from pydantic import BaseModel, Field
+
+from backend.copilot.constants import (
+    is_copilot_synthetic_id,
+    parse_node_id_from_exec_id,
+)
+from backend.data.execution import (
+    ExecutionContext,
+    ExecutionStatus,
+    get_graph_execution_meta,
+    get_node_executions,
+)
+from backend.data.graph import get_graph_settings
+from backend.data.human_review import (
+    create_auto_approval_record,
+    get_reviews_by_node_exec_ids,
+    has_pending_reviews_for_graph_exec,
+    process_all_reviews_for_execution,
+)
+from backend.data.model import USER_TIMEZONE_NOT_SET
+from backend.data.user import get_user_by_id
+from backend.data.workspace import get_or_create_workspace
+from backend.executor.utils import add_graph_execution
+
+from .model import ReviewItem
+
+logger = logging.getLogger(__name__)
+
+
+class ReviewOutcome(BaseModel):
+    """What processing a batch of review decisions did."""
+
+    graph_exec_id: str
+    approved_count: int
+    rejected_count: int
+    auto_approval_failed_count: int = Field(
+        description="Approved reviews whose auto-approve-future record failed to save"
+    )
+
+
+async def process_reviews(
+    user_id: str,
+    reviews: Sequence[ReviewItem],
+    *,
+    graph_exec_id: Optional[str] = None,
+    organization_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+) -> ReviewOutcome:
+    """Approve or reject reviews, then resume the run once none are pending.
+
+    `graph_exec_id` pins the run the decisions must belong to, for a caller
+    that already knows it from the URL; without it the run is taken from the
+    reviews themselves, which must then all belong to one.
+    """
+    if not reviews:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one review must be provided",
+        )
+
+    reviews_map = await get_reviews_by_node_exec_ids(
+        [review.node_exec_id for review in reviews], user_id
+    )
+    missing_ids = {r.node_exec_id for r in reviews} - set(reviews_map)
+    if missing_ids:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Review(s) not found: {', '.join(sorted(missing_ids))}",
+        )
+
+    graph_exec_id = _one_execution(reviews_map.values(), graph_exec_id)
+    is_copilot = is_copilot_synthetic_id(graph_exec_id)
+    if not is_copilot:
+        await _assert_awaiting_review(user_id, graph_exec_id)
+
+    # An auto-approved review takes the original data: approving future runs of
+    # a block is not the place to also edit this one's payload.
+    updated_reviews = await process_all_reviews_for_execution(
+        user_id=user_id,
+        review_decisions={
+            review.node_exec_id: (
+                ReviewStatus.APPROVED if review.approved else ReviewStatus.REJECTED,
+                None if review.auto_approve_future else review.reviewed_data,
+                review.message,
+            )
+            for review in reviews
+        },
+    )
+
+    failed = await _record_auto_approvals(
+        user_id,
+        {r.node_exec_id: r.auto_approve_future for r in reviews},
+        updated_reviews,
+        graph_exec_id,
+        is_copilot,
+    )
+
+    # CoPilot sessions resume when the LLM retries run_block, not from here.
+    if not is_copilot and updated_reviews:
+        await _resume_if_nothing_pending(
+            user_id,
+            graph_exec_id,
+            updated_reviews,
+            organization_id=organization_id,
+            team_id=team_id,
+        )
+
+    return ReviewOutcome(
+        graph_exec_id=graph_exec_id,
+        approved_count=sum(
+            1 for r in updated_reviews.values() if r.status == ReviewStatus.APPROVED
+        ),
+        rejected_count=sum(
+            1 for r in updated_reviews.values() if r.status == ReviewStatus.REJECTED
+        ),
+        auto_approval_failed_count=failed,
+    )
+
+
+def _one_execution(reviews, graph_exec_id: Optional[str]) -> str:
+    """The single run every decision in the request belongs to."""
+    graph_exec_ids = {review.graph_exec_id for review in reviews}
+    if graph_exec_id is not None:
+        outside = graph_exec_ids - {graph_exec_id}
+        if outside:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Review(s) not found for run {graph_exec_id}",
+            )
+        return graph_exec_id
+
+    if len(graph_exec_ids) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="All reviews in a single request must belong to the same execution.",
+        )
+    return next(iter(graph_exec_ids))
+
+
+async def _assert_awaiting_review(user_id: str, graph_exec_id: str) -> None:
+    graph_exec_meta = await get_graph_execution_meta(
+        user_id=user_id, execution_id=graph_exec_id
+    )
+    if not graph_exec_meta:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Graph execution #{graph_exec_id} not found",
+        )
+    if graph_exec_meta.status not in (
+        ExecutionStatus.REVIEW,
+        ExecutionStatus.INCOMPLETE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Cannot process reviews while execution status is "
+                f"{graph_exec_meta.status}"
+            ),
+        )
+
+
+async def _record_auto_approvals(
+    user_id: str,
+    requested: dict[str, bool],
+    updated_reviews: dict[str, Any],
+    graph_exec_id: str,
+    is_copilot: bool,
+) -> int:
+    """Save one auto-approval per node, returning how many could not be saved."""
+    node_exec_ids = [
+        node_exec_id
+        for node_exec_id, review in updated_reviews.items()
+        if review.status == ReviewStatus.APPROVED and requested.get(node_exec_id, False)
+    ]
+    node_id_map = await _resolve_node_ids(node_exec_ids, graph_exec_id, is_copilot)
+
+    # Deduplicate by node_id — concurrent reviews of one node would otherwise race.
+    by_node: dict[str, Any] = {}
+    for node_exec_id in node_exec_ids:
+        node_id = node_id_map.get(node_exec_id)
+        if node_id and node_id not in by_node:
+            by_node[node_id] = updated_reviews[node_exec_id]
+
+    results = await asyncio.gather(
+        *[
+            _create_auto_approval(user_id, node_id, review)
+            for node_id, review in by_node.items()
+        ],
+        return_exceptions=True,
+    )
+    return sum(1 for saved in results if isinstance(saved, BaseException) or not saved)
+
+
+async def _create_auto_approval(user_id: str, node_id: str, review) -> bool:
+    try:
+        await create_auto_approval_record(
+            user_id=user_id,
+            graph_exec_id=review.graph_exec_id,
+            graph_id=review.graph_id,
+            graph_version=review.graph_version,
+            node_id=node_id,
+            payload=review.payload,
+        )
+        return True
+    except Exception as e:
+        logger.error(
+            f"Failed to create auto-approval record for node {node_id}", exc_info=e
+        )
+        return False
+
+
+async def _resolve_node_ids(
+    node_exec_ids: list[str], graph_exec_id: str, is_copilot: bool
+) -> dict[str, str]:
+    """Resolve node_exec_id -> node_id for auto-approval records.
+
+    CoPilot synthetic IDs encode node_id in the format "{node_id}:{random}".
+    """
+    if not node_exec_ids:
+        return {}
+    if is_copilot:
+        return {neid: parse_node_id_from_exec_id(neid) for neid in node_exec_ids}
+
+    node_execs = await get_node_executions(
+        graph_exec_id=graph_exec_id, include_exec_data=False
+    )
+    by_exec_id = {ne.node_exec_id: ne.node_id for ne in node_execs}
+    for missing in [neid for neid in node_exec_ids if neid not in by_exec_id]:
+        logger.error(f"Failed to resolve node_id for {missing}: execution not found.")
+    return {neid: by_exec_id[neid] for neid in node_exec_ids if neid in by_exec_id}
+
+
+async def _resume_if_nothing_pending(
+    user_id: str,
+    graph_exec_id: str,
+    updated_reviews: dict[str, Any],
+    *,
+    organization_id: Optional[str],
+    team_id: Optional[str],
+) -> None:
+    if await has_pending_reviews_for_graph_exec(graph_exec_id):
+        return
+
+    first_review = next(iter(updated_reviews.values()))
+    try:
+        user = await get_user_by_id(user_id)
+        settings = await get_graph_settings(
+            user_id=user_id, graph_id=first_review.graph_id
+        )
+        workspace = await get_or_create_workspace(user_id)
+        await add_graph_execution(
+            graph_id=first_review.graph_id,
+            user_id=user_id,
+            graph_exec_id=graph_exec_id,
+            execution_context=ExecutionContext(
+                human_in_the_loop_safe_mode=settings.human_in_the_loop_safe_mode,
+                sensitive_action_safe_mode=settings.sensitive_action_safe_mode,
+                user_timezone=(
+                    user.timezone if user.timezone != USER_TIMEZONE_NOT_SET else "UTC"
+                ),
+                workspace_id=workspace.id,
+            ),
+            organization_id=organization_id,
+            team_id=team_id,
+        )
+        logger.info(f"Resumed execution {graph_exec_id}")
+    except Exception as e:
+        logger.error(f"Failed to resume execution {graph_exec_id}: {e}")

--- a/autogpt_platform/backend/backend/api/features/store/cache.py
+++ b/autogpt_platform/backend/backend/api/features/store/cache.py
@@ -9,16 +9,16 @@ from . import db as store_db
 
 def clear_all_caches():
     """Clear all caches."""
-    _get_cached_store_agents.cache_clear()
-    _get_cached_agent_details.cache_clear()
-    _get_cached_store_creators.cache_clear()
-    _get_cached_creator_details.cache_clear()
+    get_cached_store_agents.cache_clear()
+    get_cached_agent_details.cache_clear()
+    get_cached_store_creators.cache_clear()
+    get_cached_creator_details.cache_clear()
 
 
 # Cache store agents list for 5 minutes
 # Different cache entries for different query combinations
 @cached(maxsize=5000, ttl_seconds=300, shared_cache=True)
-async def _get_cached_store_agents(
+async def get_cached_store_agents(
     featured: bool,
     creator: str | None,
     sorted_by: store_db.StoreAgentsSortOptions | None,
@@ -41,7 +41,7 @@ async def _get_cached_store_agents(
 
 # Cache individual agent details for 15 minutes
 @cached(maxsize=200, ttl_seconds=300, shared_cache=True)
-async def _get_cached_agent_details(
+async def get_cached_agent_details(
     username: str, agent_name: str, include_changelog: bool = False
 ):
     """Cached helper to get agent details."""
@@ -52,7 +52,7 @@ async def _get_cached_agent_details(
 
 # Cache creators list for 5 minutes
 @cached(maxsize=200, ttl_seconds=300, shared_cache=True)
-async def _get_cached_store_creators(
+async def get_cached_store_creators(
     featured: bool,
     search_query: str | None,
     sorted_by: store_db.StoreCreatorsSortOptions | None,
@@ -71,6 +71,6 @@ async def _get_cached_store_creators(
 
 # Cache individual creator details for 5 minutes
 @cached(maxsize=100, ttl_seconds=300, shared_cache=True)
-async def _get_cached_creator_details(username: str):
+async def get_cached_creator_details(username: str):
     """Cached helper to get creator details."""
     return await store_db.get_store_creator(username=username.lower())

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -429,6 +429,22 @@ async def get_store_agent_by_version_id(
         raise DatabaseError("Failed to fetch agent details") from e
 
 
+async def get_store_agent_by_graph_id(graph_id: str) -> store_model.StoreAgentDetails:
+    """Get the marketplace listing for a graph (APPROVED agents only)."""
+    try:
+        agent = await prisma.models.StoreAgent.prisma().find_first(
+            where={"graph_id": graph_id}
+        )
+        if not agent:
+            raise NotFoundError(f"No marketplace listing for graph {graph_id}")
+        return store_model.StoreAgentDetails.from_db(agent)
+    except NotFoundError:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting store agent details: {e}")
+        raise DatabaseError("Failed to fetch agent details") from e
+
+
 async def get_store_agent_details_as_admin(
     store_listing_version_id: str,
 ) -> store_model.StoreAgentDetails:

--- a/autogpt_platform/backend/backend/api/features/store/routes.py
+++ b/autogpt_platform/backend/backend/api/features/store/routes.py
@@ -171,7 +171,7 @@ async def get_agents(
     - Agent Details - Similar Agents
     - Creator Details - Agents By Creator
     """
-    agents = await store_cache._get_cached_store_agents(
+    agents = await store_cache.get_cached_store_agents(
         featured=featured,
         creator=creator,
         sorted_by=sorted_by,
@@ -197,7 +197,7 @@ async def get_agent_by_name(
     username = urllib.parse.unquote(username).lower()
     # URL decode the agent name since it comes from the URL path
     agent_name = urllib.parse.unquote(agent_name).lower()
-    agent = await store_cache._get_cached_agent_details(
+    agent = await store_cache.get_cached_agent_details(
         username=username, agent_name=agent_name, include_changelog=include_changelog
     )
     return agent
@@ -298,7 +298,7 @@ async def get_creators(
     page_size: int = Query(ge=1, default=20),
 ) -> store_model.CreatorsResponse:
     """List or search marketplace creators"""
-    creators = await store_cache._get_cached_store_creators(
+    creators = await store_cache.get_cached_store_creators(
         featured=featured,
         search_query=search_query,
         sorted_by=sorted_by,
@@ -316,7 +316,7 @@ async def get_creators(
 async def get_creator(username: str) -> store_model.CreatorDetails:
     """Get details on a marketplace creator"""
     username = urllib.parse.unquote(username).lower()
-    creator = await store_cache._get_cached_creator_details(username=username)
+    creator = await store_cache.get_cached_creator_details(username=username)
     return creator
 
 
@@ -601,10 +601,10 @@ async def get_cache_metrics():
         )
 
     # Add metrics for each cache
-    add_cache_metrics("store_agents", store_cache._get_cached_store_agents)
-    add_cache_metrics("agent_details", store_cache._get_cached_agent_details)
-    add_cache_metrics("store_creators", store_cache._get_cached_store_creators)
-    add_cache_metrics("creator_details", store_cache._get_cached_creator_details)
+    add_cache_metrics("store_agents", store_cache.get_cached_store_agents)
+    add_cache_metrics("agent_details", store_cache.get_cached_agent_details)
+    add_cache_metrics("store_creators", store_cache.get_cached_store_creators)
+    add_cache_metrics("creator_details", store_cache.get_cached_creator_details)
 
     # Add metadata/help text at the beginning
     prometheus_output = [

--- a/autogpt_platform/backend/backend/api/features/store/test_cache_delete.py
+++ b/autogpt_platform/backend/backend/api/features/store/test_cache_delete.py
@@ -51,10 +51,10 @@ class TestCacheDeletion:
             return_value=mock_response,
         ) as mock_db:
             # Clear cache first
-            store_cache._get_cached_store_agents.cache_clear()
+            store_cache.get_cached_store_agents.cache_clear()
 
             # First call - should hit database
-            result1 = await store_cache._get_cached_store_agents(
+            result1 = await store_cache.get_cached_store_agents(
                 featured=False,
                 creator=None,
                 sorted_by=None,
@@ -67,7 +67,7 @@ class TestCacheDeletion:
             assert result1.agents[0].agent_name == "Test Agent"
 
             # Second call with same params - should use cache
-            await store_cache._get_cached_store_agents(
+            await store_cache.get_cached_store_agents(
                 featured=False,
                 creator=None,
                 sorted_by=None,
@@ -79,7 +79,7 @@ class TestCacheDeletion:
             assert mock_db.call_count == 1  # No additional DB call
 
             # Third call with different params - should hit database
-            await store_cache._get_cached_store_agents(
+            await store_cache.get_cached_store_agents(
                 featured=True,  # Different param
                 creator=None,
                 sorted_by=None,
@@ -91,7 +91,7 @@ class TestCacheDeletion:
             assert mock_db.call_count == 2  # New DB call
 
             # Delete specific cache entry
-            deleted = store_cache._get_cached_store_agents.cache_delete(
+            deleted = store_cache.get_cached_store_agents.cache_delete(
                 featured=False,
                 creator=None,
                 sorted_by=None,
@@ -103,7 +103,7 @@ class TestCacheDeletion:
             assert deleted is True  # Entry was deleted
 
             # Try to delete non-existent entry
-            deleted = store_cache._get_cached_store_agents.cache_delete(
+            deleted = store_cache.get_cached_store_agents.cache_delete(
                 featured=False,
                 creator="nonexistent",
                 sorted_by=None,
@@ -115,7 +115,7 @@ class TestCacheDeletion:
             assert deleted is False  # Entry didn't exist
 
             # Call with deleted params - should hit database again
-            await store_cache._get_cached_store_agents(
+            await store_cache.get_cached_store_agents(
                 featured=False,
                 creator=None,
                 sorted_by=None,
@@ -127,7 +127,7 @@ class TestCacheDeletion:
             assert mock_db.call_count == 3  # New DB call after deletion
 
             # Call with featured=True - should still be cached
-            await store_cache._get_cached_store_agents(
+            await store_cache.get_cached_store_agents(
                 featured=True,
                 creator=None,
                 sorted_by=None,
@@ -142,7 +142,7 @@ class TestCacheDeletion:
     async def test_cache_info_after_deletions(self):
         """Test that cache_info correctly reflects deletions."""
         # Clear all caches first
-        store_cache._get_cached_store_agents.cache_clear()
+        store_cache.get_cached_store_agents.cache_clear()
 
         mock_response = StoreAgentsResponse(
             agents=[],
@@ -161,7 +161,7 @@ class TestCacheDeletion:
         ):
             # Add multiple entries
             for i in range(5):
-                await store_cache._get_cached_store_agents(
+                await store_cache.get_cached_store_agents(
                     featured=False,
                     creator=f"creator{i}",
                     sorted_by=None,
@@ -172,12 +172,12 @@ class TestCacheDeletion:
                 )
 
             # Check cache size
-            info = store_cache._get_cached_store_agents.cache_info()
+            info = store_cache.get_cached_store_agents.cache_info()
             assert info["size"] == 5
 
             # Delete some entries
             for i in range(2):
-                deleted = store_cache._get_cached_store_agents.cache_delete(
+                deleted = store_cache.get_cached_store_agents.cache_delete(
                     featured=False,
                     creator=f"creator{i}",
                     sorted_by=None,
@@ -189,7 +189,7 @@ class TestCacheDeletion:
                 assert deleted is True
 
             # Check cache size after deletion
-            info = store_cache._get_cached_store_agents.cache_info()
+            info = store_cache.get_cached_store_agents.cache_info()
             assert info["size"] == 3
 
     @pytest.mark.asyncio
@@ -210,10 +210,10 @@ class TestCacheDeletion:
             new_callable=AsyncMock,
             return_value=mock_response,
         ) as mock_db:
-            store_cache._get_cached_store_agents.cache_clear()
+            store_cache.get_cached_store_agents.cache_clear()
 
             # Test with all parameters
-            await store_cache._get_cached_store_agents(
+            await store_cache.get_cached_store_agents(
                 featured=True,
                 creator="testuser",
                 sorted_by=StoreAgentsSortOptions.RATING,
@@ -225,7 +225,7 @@ class TestCacheDeletion:
             assert mock_db.call_count == 1
 
             # Delete with exact same parameters
-            deleted = store_cache._get_cached_store_agents.cache_delete(
+            deleted = store_cache.get_cached_store_agents.cache_delete(
                 featured=True,
                 creator="testuser",
                 sorted_by=StoreAgentsSortOptions.RATING,
@@ -237,7 +237,7 @@ class TestCacheDeletion:
             assert deleted is True
 
             # Try to delete with slightly different parameters
-            deleted = store_cache._get_cached_store_agents.cache_delete(
+            deleted = store_cache.get_cached_store_agents.cache_delete(
                 featured=True,
                 creator="testuser",
                 sorted_by=StoreAgentsSortOptions.RATING,

--- a/autogpt_platform/backend/backend/api/features/workspace/routes.py
+++ b/autogpt_platform/backend/backend/api/features/workspace/routes.py
@@ -4,7 +4,6 @@ Workspace API routes for managing user file storage.
 
 import asyncio
 import logging
-import os
 import re
 from typing import Annotated, Literal
 from urllib.parse import quote
@@ -15,8 +14,8 @@ from fastapi import Query, UploadFile
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
-from backend.api.features.store.exceptions import VirusDetectedError, VirusScanError
 from backend.api.features.workspace.preview import build_preview_response
+from backend.api.features.workspace.service import store_workspace_upload
 from backend.copilot.rate_limit import get_workspace_storage_limit_bytes
 from backend.data.workspace import (
     WorkspaceFile,
@@ -26,8 +25,7 @@ from backend.data.workspace import (
     get_workspace_file,
     get_workspace_total_size,
 )
-from backend.util.settings import Config
-from backend.util.workspace import WorkspaceManager, format_bytes
+from backend.util.workspace import WorkspaceManager
 from backend.util.workspace_storage import get_workspace_storage
 
 
@@ -270,72 +268,9 @@ async def upload_file(
     so the agent's session-scoped tools can discover them automatically.
     """
     # Empty-string session_id drops session scoping; normalize to None.
-    session_id = session_id or None
-
-    config = Config()
-
-    # Sanitize filename — strip any directory components
-    filename = os.path.basename(file.filename or "upload") or "upload"
-
-    # Read file content with early abort on size limit
-    max_file_bytes = config.max_file_size_mb * 1024 * 1024
-    chunks: list[bytes] = []
-    total_size = 0
-    while chunk := await file.read(64 * 1024):  # 64KB chunks
-        total_size += len(chunk)
-        if total_size > max_file_bytes:
-            raise fastapi.HTTPException(
-                status_code=413,
-                detail=f"File exceeds maximum size of {config.max_file_size_mb} MB",
-            )
-        chunks.append(chunk)
-    content = b"".join(chunks)
-
-    # Get or create workspace
-    workspace = await get_or_create_workspace(user_id)
-
-    # Write file via WorkspaceManager (handles virus scan, per-file size,
-    # and per-user tier-based storage quota internally).
-    manager = WorkspaceManager(user_id, workspace.id, session_id)
-    try:
-        workspace_file = await manager.write_file(
-            content, filename, overwrite=overwrite, metadata={"origin": "user-upload"}
-        )
-    except VirusDetectedError as e:
-        raise fastapi.HTTPException(status_code=400, detail=str(e)) from e
-    except VirusScanError as e:
-        raise fastapi.HTTPException(status_code=500, detail=str(e)) from e
-    except ValueError as e:
-        # write_file raises ValueError for path-conflict, size-limit, and
-        # storage-quota cases; map each to its correct HTTP status.
-        message = str(e)
-        if message.startswith(("File too large", "Storage limit exceeded")):
-            raise fastapi.HTTPException(status_code=413, detail=message) from e
-        raise fastapi.HTTPException(status_code=409, detail=message) from e
-
-    # Post-write storage check — eliminates TOCTOU race on the quota.
-    # If a concurrent upload pushed us over the limit, undo this write.
-    storage_limit_bytes = await get_workspace_storage_limit_bytes(user_id)
-    new_total = await get_workspace_total_size(workspace.id)
-    if storage_limit_bytes and new_total > storage_limit_bytes:
-        try:
-            # Route through WorkspaceManager so the storage backend blob is
-            # removed too — soft_delete_workspace_file alone leaks the blob.
-            await manager.delete_file(workspace_file.id)
-        except Exception as e:
-            logger.warning(
-                f"Failed to delete over-quota file {workspace_file.id} "
-                f"in workspace {workspace.id}: {e}"
-            )
-        raise fastapi.HTTPException(
-            status_code=413,
-            detail=(
-                f"Storage limit exceeded. "
-                f"You've used {format_bytes(new_total)} of your "
-                f"{format_bytes(storage_limit_bytes)} quota. "
-                f"Delete some files or upgrade your plan for more storage."
-            ),
-        )
+    workspace_file = await store_workspace_upload(
+        user_id, file, session_id=session_id or None, overwrite=overwrite
+    )
 
     return UploadFileResponse(
         file_id=workspace_file.id,

--- a/autogpt_platform/backend/backend/api/features/workspace/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/workspace/routes_test.py
@@ -216,10 +216,10 @@ def test_list_files_null_metadata_coerced_to_empty_dict(
 # -- upload_file metadata tests --
 
 
-@patch("backend.api.features.workspace.routes.get_workspace_storage_limit_bytes")
-@patch("backend.api.features.workspace.routes.get_or_create_workspace")
-@patch("backend.api.features.workspace.routes.get_workspace_total_size")
-@patch("backend.api.features.workspace.routes.WorkspaceManager")
+@patch("backend.api.features.workspace.service.get_workspace_storage_limit_bytes")
+@patch("backend.api.features.workspace.service.get_or_create_workspace")
+@patch("backend.api.features.workspace.service.get_workspace_total_size")
+@patch("backend.api.features.workspace.service.WorkspaceManager")
 def test_upload_passes_user_upload_origin_metadata(
     mock_manager_cls, mock_total_size, mock_get_workspace, mock_storage_limit
 ):
@@ -242,9 +242,9 @@ def test_upload_passes_user_upload_origin_metadata(
     assert call_kwargs.kwargs.get("metadata") == {"origin": "user-upload"}
 
 
-@patch("backend.api.features.workspace.routes.get_or_create_workspace")
-@patch("backend.api.features.workspace.routes.get_workspace_total_size")
-@patch("backend.api.features.workspace.routes.WorkspaceManager")
+@patch("backend.api.features.workspace.service.get_or_create_workspace")
+@patch("backend.api.features.workspace.service.get_workspace_total_size")
+@patch("backend.api.features.workspace.service.WorkspaceManager")
 def test_upload_returns_409_on_file_conflict(
     mock_manager_cls, mock_total_size, mock_get_workspace
 ):
@@ -291,21 +291,21 @@ _MOCK_FILE = WorkspaceFile(
 
 def test_upload_happy_path(mocker):
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_total_size",
+        "backend.api.features.workspace.service.get_workspace_total_size",
         return_value=0,
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_storage_limit_bytes",
+        "backend.api.features.workspace.service.get_workspace_storage_limit_bytes",
         return_value=250 * 1024 * 1024,
     )
     mock_manager = mocker.MagicMock()
     mock_manager.write_file = mocker.AsyncMock(return_value=_MOCK_FILE)
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -319,7 +319,7 @@ def test_upload_happy_path(mocker):
 
 def test_upload_exceeds_max_file_size(mocker):
     """Files larger than max_file_size_mb should be rejected with 413."""
-    cfg = mocker.patch("backend.api.features.workspace.routes.Config")
+    cfg = mocker.patch("backend.api.features.workspace.service.Config")
     cfg.return_value.max_file_size_mb = 0  # 0 MB → any content is too big
 
     response = _upload(content=b"x" * 1024)
@@ -329,7 +329,7 @@ def test_upload_exceeds_max_file_size(mocker):
 def test_upload_storage_quota_exceeded(mocker):
     """WorkspaceManager.write_file raises ValueError when quota exceeded → 413."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mock_manager = mocker.MagicMock()
@@ -337,7 +337,7 @@ def test_upload_storage_quota_exceeded(mocker):
         side_effect=ValueError("Storage limit exceeded: 500 MB used of 250 MB (200.0%)")
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -349,23 +349,23 @@ def test_upload_storage_quota_exceeded(mocker):
 def test_upload_post_write_quota_race(mocker):
     """Concurrent upload tipping over limit after write should delete + 413."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     # Post-write total exceeds the tier-based limit (250 MB for FREE).
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_total_size",
+        "backend.api.features.workspace.service.get_workspace_total_size",
         return_value=600 * 1024 * 1024,
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_storage_limit_bytes",
+        "backend.api.features.workspace.service.get_workspace_storage_limit_bytes",
         return_value=250 * 1024 * 1024,
     )
     mock_manager = mocker.MagicMock()
     mock_manager.write_file = mocker.AsyncMock(return_value=_MOCK_FILE)
     mock_manager.delete_file = mocker.AsyncMock(return_value=True)
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -379,21 +379,21 @@ def test_upload_post_write_quota_race(mocker):
 def test_upload_any_extension(mocker):
     """Any file extension should be accepted — ClamAV is the security layer."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_total_size",
+        "backend.api.features.workspace.service.get_workspace_total_size",
         return_value=0,
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_storage_limit_bytes",
+        "backend.api.features.workspace.service.get_workspace_storage_limit_bytes",
         return_value=250 * 1024 * 1024,
     )
     mock_manager = mocker.MagicMock()
     mock_manager.write_file = mocker.AsyncMock(return_value=_MOCK_FILE)
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -406,7 +406,7 @@ def test_upload_blocked_by_virus_scan(mocker):
     from backend.api.features.store.exceptions import VirusDetectedError
 
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mock_manager = mocker.MagicMock()
@@ -414,7 +414,7 @@ def test_upload_blocked_by_virus_scan(mocker):
         side_effect=VirusDetectedError("Eicar-Test-Signature"),
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -425,21 +425,21 @@ def test_upload_blocked_by_virus_scan(mocker):
 def test_upload_file_without_extension(mocker):
     """Files without an extension should be accepted and stored as-is."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_total_size",
+        "backend.api.features.workspace.service.get_workspace_total_size",
         return_value=0,
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_storage_limit_bytes",
+        "backend.api.features.workspace.service.get_workspace_storage_limit_bytes",
         return_value=250 * 1024 * 1024,
     )
     mock_manager = mocker.MagicMock()
     mock_manager.write_file = mocker.AsyncMock(return_value=_MOCK_FILE)
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -456,21 +456,21 @@ def test_upload_file_without_extension(mocker):
 def test_upload_strips_path_components(mocker):
     """Path-traversal filenames should be reduced to their basename."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_total_size",
+        "backend.api.features.workspace.service.get_workspace_total_size",
         return_value=0,
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.get_workspace_storage_limit_bytes",
+        "backend.api.features.workspace.service.get_workspace_storage_limit_bytes",
         return_value=250 * 1024 * 1024,
     )
     mock_manager = mocker.MagicMock()
     mock_manager.write_file = mocker.AsyncMock(return_value=_MOCK_FILE)
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -547,7 +547,7 @@ def test_delete_file_no_workspace(mocker):
 def test_upload_write_file_too_large_returns_413(mocker):
     """write_file raises ValueError("File too large: …") → must map to 413."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mock_manager = mocker.MagicMock()
@@ -555,7 +555,7 @@ def test_upload_write_file_too_large_returns_413(mocker):
         side_effect=ValueError("File too large: 900 bytes exceeds 1MB limit")
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -567,7 +567,7 @@ def test_upload_write_file_too_large_returns_413(mocker):
 def test_upload_write_file_conflict_returns_409(mocker):
     """Non-'File too large' ValueErrors from write_file stay as 409."""
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mock_manager = mocker.MagicMock()
@@ -575,7 +575,7 @@ def test_upload_write_file_conflict_returns_409(mocker):
         side_effect=ValueError("File already exists at path: /sessions/x/a.txt")
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 
@@ -901,7 +901,7 @@ def test_upload_virus_scan_infrastructure_error_returns_500(mocker):
     from backend.api.features.store.exceptions import VirusScanError
 
     mocker.patch(
-        "backend.api.features.workspace.routes.get_or_create_workspace",
+        "backend.api.features.workspace.service.get_or_create_workspace",
         return_value=_make_workspace(),
     )
     mock_manager = mocker.MagicMock()
@@ -909,7 +909,7 @@ def test_upload_virus_scan_infrastructure_error_returns_500(mocker):
         side_effect=VirusScanError("ClamAV connection refused"),
     )
     mocker.patch(
-        "backend.api.features.workspace.routes.WorkspaceManager",
+        "backend.api.features.workspace.service.WorkspaceManager",
         return_value=mock_manager,
     )
 

--- a/autogpt_platform/backend/backend/api/features/workspace/service.py
+++ b/autogpt_platform/backend/backend/api/features/workspace/service.py
@@ -1,0 +1,115 @@
+"""Workspace writes shared by the internal API and the v2 external API.
+
+Both surfaces must apply the same virus scan, per-file size cap and storage
+quota; keeping one implementation is what stops them diverging.
+"""
+
+import logging
+import os
+
+import fastapi
+from fastapi import UploadFile
+
+from backend.api.features.store.exceptions import VirusDetectedError, VirusScanError
+from backend.copilot.rate_limit import get_workspace_storage_limit_bytes
+from backend.data.workspace import (
+    WorkspaceFile,
+    get_or_create_workspace,
+    get_workspace_total_size,
+)
+from backend.util.settings import Config
+from backend.util.workspace import WorkspaceManager, format_bytes
+
+logger = logging.getLogger(__name__)
+
+
+async def store_workspace_upload(
+    user_id: str,
+    file: UploadFile,
+    *,
+    session_id: str | None = None,
+    overwrite: bool = False,
+) -> WorkspaceFile:
+    """Write an uploaded file into the user's persistent workspace.
+
+    Raises `fastapi.HTTPException` with the status each failure earns: 400 for
+    a virus, 409 for a name conflict, 413 for size or quota, 500 for a scanner
+    outage.
+    """
+    filename = _sanitized_filename(file)
+    content = await _read_within_size_limit(file)
+
+    workspace = await get_or_create_workspace(user_id)
+    manager = WorkspaceManager(user_id, workspace.id, session_id)
+    try:
+        workspace_file = await manager.write_file(
+            content, filename, overwrite=overwrite, metadata={"origin": "user-upload"}
+        )
+    except VirusDetectedError as e:
+        raise fastapi.HTTPException(status_code=400, detail=str(e)) from e
+    except VirusScanError as e:
+        raise fastapi.HTTPException(status_code=500, detail=str(e)) from e
+    except ValueError as e:
+        # write_file raises ValueError for path-conflict, size-limit, and
+        # storage-quota cases; map each to its correct HTTP status.
+        message = str(e)
+        if message.startswith(("File too large", "Storage limit exceeded")):
+            raise fastapi.HTTPException(status_code=413, detail=message) from e
+        raise fastapi.HTTPException(status_code=409, detail=message) from e
+
+    await _undo_if_over_quota(manager, workspace_file, user_id, workspace.id)
+    return workspace_file
+
+
+def _sanitized_filename(file: UploadFile) -> str:
+    """Basename only — a path in the filename must not steer the write."""
+    return os.path.basename(file.filename or "upload") or "upload"
+
+
+async def _read_within_size_limit(file: UploadFile) -> bytes:
+    """Read the upload, aborting as soon as it passes the per-file cap."""
+    max_file_size_mb = Config().max_file_size_mb
+    max_file_bytes = max_file_size_mb * 1024 * 1024
+    chunks: list[bytes] = []
+    total_size = 0
+    while chunk := await file.read(64 * 1024):
+        total_size += len(chunk)
+        if total_size > max_file_bytes:
+            raise fastapi.HTTPException(
+                status_code=413,
+                detail=f"File exceeds maximum size of {max_file_size_mb} MB",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _undo_if_over_quota(
+    manager: WorkspaceManager,
+    workspace_file: WorkspaceFile,
+    user_id: str,
+    workspace_id: str,
+) -> None:
+    """Post-write quota check — eliminates the TOCTOU race a pre-check leaves."""
+    storage_limit_bytes = await get_workspace_storage_limit_bytes(user_id)
+    new_total = await get_workspace_total_size(workspace_id)
+    if not storage_limit_bytes or new_total <= storage_limit_bytes:
+        return
+
+    try:
+        # Route through WorkspaceManager so the storage backend blob is
+        # removed too — soft_delete_workspace_file alone leaks the blob.
+        await manager.delete_file(workspace_file.id)
+    except Exception as e:
+        logger.warning(
+            f"Failed to delete over-quota file {workspace_file.id} "
+            f"in workspace {workspace_id}: {e}"
+        )
+    raise fastapi.HTTPException(
+        status_code=413,
+        detail=(
+            f"Storage limit exceeded. "
+            f"You've used {format_bytes(new_total)} of your "
+            f"{format_bytes(storage_limit_bytes)} quota. "
+            f"Delete some files or upgrade your plan for more storage."
+        ),
+    )

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -12,6 +12,7 @@ from autogpt_libs.auth import add_auth_responses_to_openapi
 from autogpt_libs.auth import verify_settings as verify_auth_settings
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.routing import APIRoute
+from mcp.shared.auth import ProtectedResourceMetadata
 
 import backend.api.features.admin.block_cost_admin_routes
 import backend.api.features.admin.bot_analytics_routes
@@ -76,6 +77,10 @@ from backend.util.service import UnhealthyServiceError
 from backend.util.workspace_storage import shutdown_workspace_storage
 
 from .external.fastapi_app import external_api
+from .external.v2.mcp_server import (
+    WELL_KNOWN_PROTECTED_RESOURCE_PATH,
+    protected_resource_metadata,
+)
 from .features.analytics import router as analytics_router
 from .features.integrations.router import router as integrations_router
 from .middleware.security import SecurityHeadersMiddleware
@@ -452,6 +457,19 @@ app.include_router(
 register_webhook_adapters(app, _webhook_bot_backend)
 
 app.mount("/external-api", external_api)
+
+
+@app.get(
+    path=WELL_KNOWN_PROTECTED_RESOURCE_PATH,
+    tags=["mcp"],
+    dependencies=[],
+    include_in_schema=False,
+)
+async def mcp_protected_resource_metadata() -> ProtectedResourceMetadata:
+    """RFC 9728 discovery for the MCP server, which must answer at the origin
+    root — FastMCP serves its copy inside the `/mcp` mount, where no client
+    looks."""
+    return protected_resource_metadata()
 
 
 @app.get(path="/health", tags=["health"], dependencies=[])

--- a/autogpt_platform/backend/backend/api/utils/rate_limit.py
+++ b/autogpt_platform/backend/backend/api/utils/rate_limit.py
@@ -11,12 +11,29 @@ lets the request through rather than blocking all API traffic.
 
 import logging
 from datetime import UTC, datetime
+from typing import Optional
 
 from fastapi import HTTPException
+from pydantic import BaseModel
 
 from backend.data.redis_client import get_redis_async
 
 logger = logging.getLogger(__name__)
+
+
+class RateLimitState(BaseModel):
+    """Where a request left the caller's window, for the response headers."""
+
+    limit: int
+    remaining: int
+    reset_seconds: int
+
+    def headers(self) -> dict[str, str]:
+        return {
+            "X-RateLimit-Limit": str(self.limit),
+            "X-RateLimit-Remaining": str(self.remaining),
+            "X-RateLimit-Reset": str(self.reset_seconds),
+        }
 
 
 class RateLimiter:
@@ -27,12 +44,13 @@ class RateLimiter:
         self.max_requests = max_requests
         self.window_seconds = window_seconds
 
-    def _key(self, user_id: str, now: datetime) -> str:
-        bucket = int(now.timestamp()) // self.window_seconds
-        return f"rl:{self.name}:{user_id}:{bucket}"
+    async def check(self, user_id: str) -> Optional[RateLimitState]:
+        """Raise HTTP 429 if the user exceeds the per-window cap.
 
-    async def check(self, user_id: str) -> None:
-        """Raise HTTP 429 if the user exceeds the per-window cap."""
+        Returns where the request left the window, or `None` when the count is
+        unknown because Redis was unreachable — the caller then publishes no
+        `X-RateLimit-*` headers rather than a number it did not measure.
+        """
         now = datetime.now(UTC)
         key = self._key(user_id, now)
         try:
@@ -46,13 +64,33 @@ class RateLimiter:
                 user_id,
                 e,
             )
-            return
+            return None
 
+        state = RateLimitState(
+            limit=self.max_requests,
+            remaining=max(0, self.max_requests - count),
+            reset_seconds=self._reset_seconds(now),
+        )
         if count > self.max_requests:
+            # Without Retry-After a blocked client retries blind, turning one
+            # block into several more requests against what the cap protects.
             raise HTTPException(
                 status_code=429,
                 detail=(
                     f"Rate limit exceeded ({self.max_requests} requests "
                     f"per {self.window_seconds}s). Try again shortly."
                 ),
+                headers={
+                    "Retry-After": str(state.reset_seconds),
+                    **state.headers(),
+                },
             )
+        return state
+
+    def _key(self, user_id: str, now: datetime) -> str:
+        bucket = int(now.timestamp()) // self.window_seconds
+        return f"rl:{self.name}:{user_id}:{bucket}"
+
+    def _reset_seconds(self, now: datetime) -> int:
+        """Seconds until this fixed window rolls over."""
+        return self.window_seconds - (int(now.timestamp()) % self.window_seconds)

--- a/autogpt_platform/backend/backend/util/settings.py
+++ b/autogpt_platform/backend/backend/util/settings.py
@@ -394,6 +394,15 @@ class Config(UpdateTrackingModel["Config"], BaseSettings):
         "This is necessary to make sure webhooks find their way.",
     )
 
+    trusted_proxy_count: int = Field(
+        default=1,
+        ge=0,
+        description="How many proxies between the client and this app append to "
+        "X-Forwarded-For. The client IP is that many entries from the right; "
+        "everything further left is caller-controlled and must not be trusted. "
+        "0 ignores the header and uses the socket peer.",
+    )
+
     frontend_base_url: str = Field(
         default="",
         description="Can be used to explicitly set the base URL for the frontend. "


### PR DESCRIPTION
### Why / What / How

A v2 API client can now upload a file and find it again, back off on the rate limit it was actually given, and get the same answers from the human-in-the-loop review endpoint that the web app's own review endpoint gives. This is the third and last PR of the v2 roast's batch 2, covering roast items 1.9, the remainder of 1.13, and all of Tier 3.

`POST /files/upload` stored into the temporary cloud bucket while `GET /files` read the persistent workspace, so an uploaded file never appeared in the listing and had no id to download or delete. It writes to the workspace now and returns the file's id, path and a `workspace://<id>#<mime>` URI that agent file inputs already resolve — the internal upload route's body moved into `workspace/service.py` so both surfaces share one virus scan, size cap and quota check.

Every v2 response carries `X-RateLimit-Limit`, `-Remaining` and `-Reset`, and a 429 adds `Retry-After`. The anonymous bucket keyed on the first `X-Forwarded-For` value, which the caller writes, so one client could spread its requests over unlimited buckets and never reach the 5/min cap; it now reads the value `TRUSTED_PROXY_COUNT` hops from the right. `GET /credits/subscription` fans out to uncached Stripe reads on every call and gets the 60/min/user cap the internal endpoint got in #14231.

`POST /runs/{id}/reviews` reimplemented the internal review handler and had drifted three ways — 400 instead of 404 for an unknown review id, no check that the run was awaiting review at all, and no `auto_approve_future`. Both routes call one `process_reviews` now. v2 keeps what is v2's: the run comes from the URL and pins which reviews the request may decide, which is what stops a review of a run in another organization being decided through a run in this one (`get_reviews_by_node_exec_ids` scopes to the user, not the org).

### Changes 🏗️

**Item 1.9 — uploads and listings address one store.** `POST /files/upload` writes to the workspace; response carries `id`, `path`, `size_bytes`, timestamps and `file_uri`. `expiration_hours` is gone (workspace files do not expire), `overwrite` is new so a repeated filename is not a dead end.

**Item 1.13 — the rate limit becomes a contract.** `X-RateLimit-*` on every response, `Retry-After` on 429, no headers at all when Redis was unreachable and the count is unknown. Client IP from `TRUSTED_PROXY_COUNT` hops right. Per-user cap on `GET /credits/subscription`.

**Item 3.1 — one review implementation, and one trigger-setup call.** `executions/review/service.py`; `auto_approve_future` added to the v2 decision model. Behaviour changes for v2 callers: an unknown review id is 404 (was 400), and a run not in `REVIEW`/`INCOMPLETE` is 409 (was accepted). Separately, `POST /library/presets/trigger` called the internal route *handler* with `user_id=`, which works only while nothing else in that handler's signature is a dependency — the same `Security()`/`Depends()` sentinel shape that broke #14378's run handlers on two of three interpreters. It calls `setup_triggered_preset` now, and the two webhook failures the internal handler mapped by hand join v2's own exception table.

**Item 3.2 — three module boundaries.** The store's cached readers lose their `_` prefix (they were called from four modules already); `GET /graphs/{id}/marketplace-listing` calls `store_db.get_store_agent_by_graph_id` instead of running its own Prisma query; MCP tools go through `FastMCP(tools=[...])` instead of assigning into `server._tool_manager._tools`.

**Item 3.3 — MCP discovery and errors.** FastMCP builds the RFC 9728 metadata URL against the origin root but registers the document inside the `/mcp` sub-app, so the URL its own `WWW-Authenticate` header advertises returned 404. The root app serves it. Auth and permission refusals raise `ToolError` instead of being returned as content, which reached the client as a successful call whose text said "denied".

**Item 3.4 — the smaller ones.** `DELETE /schedules/{id}` catches `NotFoundError` instead of matching `"not found"` in the message; `list_reviews`'s `status` parameter is `review_status` with `alias="status"` so it no longer shadows `starlette.status`; `GET /runs` gains `statuses`, `started_after` and `started_before`.

**Configuration:** `TRUSTED_PROXY_COUNT` (default 1) is added to `.env.default`. It is one entry per proxy that appends to `X-Forwarded-For` between the client and the app, and **the right value is deployment-specific — production should confirm it before this ships.** Set too low, every unauthenticated request buckets on the proxy's own address instead of the caller's, and the shared 5/min anonymous cap starts returning 429 where a 401 belongs (the v2 docs page is the visible case; every v2 route requires auth, so authenticated traffic is keyed on the user either way).

### What this PR does not do

**MCP OAuth authorization-server discovery (part of 3.3) is not published, deliberately.** The platform has a real authorization server — consent screen at `{frontend}/auth/authorize`, `/api/oauth/token`, `/revoke`, `/introspect`, PKCE required — but no dynamic client registration, and the token endpoint takes credentials as JSON rather than form encoding. An RFC 8414 document would advertise a flow a conformant client still cannot complete, so it needs a product decision rather than a metadata file. The RFC 9728 half, which is unambiguous, is done.

The fourteen Tier 2 integration gaps are untouched; they need product decisions, and the batch report lists them.

### Stack

Based on #14378 → #14376 → #14314 → #12206's chain. The stack root (`pwuts/open-2923-v2-external-api`) is CONFLICTING with `dev` in `api/features/library/{db,db_test,model}.py` and `api/features/search/rate_limit.py`; PR C inherits that conflict and touches none of those four files.

### Verified

A stacked PR never triggers the backend suite on its own, so it was dispatched by hand: [run 34074113196](https://github.com/Significant-Gravitas/AutoGPT/actions/runs/34074113196) on `b6e99821f0`. [Run 34073114642](https://github.com/Significant-Gravitas/AutoGPT/actions/runs/34073114642) on `b72181b973` — the same tree minus a test-fake tidy — was green on all eight jobs. (A first dispatch on `cf71e0521b` lost `test (3.12)` to a runner-side `docker: unauthorized` pulling `pgvector/pgvector:pg15`; no tests ran in that job.)

Locally I executed the whole `backend/api/external/` package (149 tests, 138 of them v2's), `backend/api/features/library/`, `backend/api/features/{store,workspace,executions,search}/`, `backend/api/features/v1_test.py`, `backend/api/features/oauth_test.py`, `backend/util/architecture_test.py` and `backend/blocks/test/test_block.py` (1074 passed, 84 skipped). Every guard added here was broken once and watched failing — 18 mutations, table in the evidence comment below. One of them survived on the first attempt and the test was rewritten until it did not.

I did not exercise any of this against a running stack; the workspace write path, the rate-limit headers on a real response, and the MCP discovery document are covered by tests only.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Upload a file through v2 and find it in `GET /files`, `GET /files/{id}` (tests)
  - [x] Rate-limit headers on a successful response and on a 429 (tests)
  - [x] `X-Forwarded-For` spoofing does not move the anonymous bucket (parametrized test)
  - [x] Review submission: unknown id, another run's review, a run not in REVIEW, auto-approve (tests)
  - [x] MCP tools registered through the public constructor; RFC 9728 route on the real root app (tests)
  - [x] Trigger setup reaches the service and not the internal route handler (test)

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
