### PR TITLE
feat(backend): add expert budget endpoint and run source

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/experts_db.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db.py
@@ -39,6 +39,7 @@ from backend.api.features.experts.models import (
     ExpertIdentity,
     ExpertPod,
     ExpertRun,
+    ExpertRunSource,
     ExpertRunStatus,
     ExpertSoulFieldsPatch,
     ExpertSoulUpdate,
@@ -404,6 +405,7 @@ async def list_expert_runs(
         where={"userId": user_id, "expertId": expert_id, "isDeleted": False},
         order={"createdAt": "desc"},
         take=limit,
+        include={"AgentPreset": True},
     )
     if not executions:
         return []
@@ -590,6 +592,13 @@ def _node_exec_inputs(
     }
 
 
+def _run_source(execution: prisma.models.AgentGraphExecution) -> ExpertRunSource:
+    preset = getattr(execution, "AgentPreset", None)
+    if preset is None:
+        return "manual"
+    return "trigger" if preset.webhookId else "scheduled"
+
+
 def _to_expert_run(
     execution: prisma.models.AgentGraphExecution,
     workflow: prisma.models.ExpertWorkflow | None,
@@ -618,6 +627,7 @@ def _to_expert_run(
         output_type=output_type,
         output_key=output_key,
         needs_review=needs_review,
+        source=_run_source(execution),
         started_at=execution.startedAt,
         ended_at=execution.endedAt,
         link=run_link(library_agent_id, execution.id),
@@ -1064,6 +1074,28 @@ async def update_avatar(user_id: str, expert_id: str, avatar_url: str | None) ->
             "visibility": ResourceVisibility.PRIVATE,
         },
         data={"avatarUrl": avatar_url},
+    )
+    if updated == 0:
+        raise ExpertNotFoundError(expert_id)
+
+    expert = await get_expert(user_id, expert_id)
+    if expert is None:
+        raise ExpertNotFoundError(expert_id)
+    return expert
+
+
+async def update_budget(
+    user_id: str, expert_id: str, weekly_budget: int | None
+) -> Expert:
+    updated = await prisma.models.Expert.prisma().update_many(
+        where={
+            "id": expert_id,
+            "ownerUserId": user_id,
+            "isTemplate": False,
+            "isArchived": False,
+            "visibility": ResourceVisibility.PRIVATE,
+        },
+        data={"weeklyBudget": weekly_budget},
     )
     if updated == 0:
         raise ExpertNotFoundError(expert_id)

--- a/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
@@ -3480,6 +3480,29 @@ def test_to_expert_run_uses_workflow_name_and_deep_link():
     )
 
 
+def test_to_expert_run_reports_how_the_run_started():
+    manual = experts_db._to_expert_run(
+        _run_execution(), _run_workflow(), "table", "result", needs_review=False
+    )
+    scheduled = experts_db._to_expert_run(
+        _run_execution(AgentPreset=SimpleNamespace(webhookId=None)),
+        _run_workflow(),
+        "table",
+        "result",
+        needs_review=False,
+    )
+    triggered = experts_db._to_expert_run(
+        _run_execution(AgentPreset=SimpleNamespace(webhookId="wh-1")),
+        _run_workflow(),
+        "table",
+        "result",
+        needs_review=False,
+    )
+    assert manual.source == "manual"
+    assert scheduled.source == "scheduled"
+    assert triggered.source == "trigger"
+
+
 def test_to_expert_run_names_a_library_only_workflow():
     run = experts_db._to_expert_run(
         _run_execution(),

--- a/autogpt_platform/backend/backend/api/features/experts/models.py
+++ b/autogpt_platform/backend/backend/api/features/experts/models.py
@@ -345,9 +345,7 @@ class ExpertBudgetUpdate(BaseModel):
     ``None`` falls back to the platform default; ``0`` disables the cap.
     """
 
-    weekly_budget: int | None = Field(
-        default=None, ge=0, le=WEEKLY_BUDGET_MAX_CREDITS
-    )
+    weekly_budget: int | None = Field(default=None, ge=0, le=WEEKLY_BUDGET_MAX_CREDITS)
 
 
 class ExpertAvatarUpdate(BaseModel):

--- a/autogpt_platform/backend/backend/api/features/experts/models.py
+++ b/autogpt_platform/backend/backend/api/features/experts/models.py
@@ -186,6 +186,11 @@ class ExpertPod(BaseModel):
     created_at: datetime
 
 
+# How an expert run was started: from a cron preset, a webhook preset, or
+# by hand (including from chat).
+ExpertRunSource = Literal["scheduled", "trigger", "manual"]
+
+
 class ExpertRun(BaseModel):
     """One expert-attributed execution, for the /team Work surface."""
 
@@ -198,6 +203,7 @@ class ExpertRun(BaseModel):
     # Which output pin was classified, so the viewer opens exactly that value.
     output_key: str | None
     needs_review: bool
+    source: ExpertRunSource = "manual"
     started_at: datetime | None
     ended_at: datetime | None
     link: str | None
@@ -331,6 +337,17 @@ class ExpertSoulUpdate(BaseModel):
     @classmethod
     def strip_optional_fields(cls, value: object) -> object:
         return _strip_optional_soul_field(value)
+
+
+class ExpertBudgetUpdate(BaseModel):
+    """Set an expert's weekly spend cap in credits (100 = $1).
+
+    ``None`` falls back to the platform default; ``0`` disables the cap.
+    """
+
+    weekly_budget: int | None = Field(
+        default=None, ge=0, le=WEEKLY_BUDGET_MAX_CREDITS
+    )
 
 
 class ExpertAvatarUpdate(BaseModel):

--- a/autogpt_platform/backend/backend/api/features/experts/routes.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes.py
@@ -450,9 +450,7 @@ async def update_expert_budget(
     user_id: str = Security(autogpt_auth_lib.get_user_id),
 ) -> Expert:
     try:
-        return await experts_db.update_budget(
-            user_id, expert_id, request.weekly_budget
-        )
+        return await experts_db.update_budget(user_id, expert_id, request.weekly_budget)
     except experts_db.ExpertNotFoundError as e:
         raise fastapi.HTTPException(status_code=404, detail=str(e))
 

--- a/autogpt_platform/backend/backend/api/features/experts/routes.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes.py
@@ -15,6 +15,7 @@ from backend.api.features.experts.models import (
     Expert,
     ExpertActivity,
     ExpertAvatarUpdate,
+    ExpertBudgetUpdate,
     ExpertCredentialRef,
     ExpertDetachPreview,
     ExpertIdentity,
@@ -434,6 +435,24 @@ async def update_expert_avatar(
 ) -> Expert:
     try:
         return await experts_db.update_avatar(user_id, expert_id, request.avatar_url)
+    except experts_db.ExpertNotFoundError as e:
+        raise fastapi.HTTPException(status_code=404, detail=str(e))
+
+
+@router.patch(
+    "/{expert_id}/budget",
+    operation_id="update_expert_budget",
+    responses={404: {"description": "Expert not found"}},
+)
+async def update_expert_budget(
+    expert_id: str,
+    request: ExpertBudgetUpdate,
+    user_id: str = Security(autogpt_auth_lib.get_user_id),
+) -> Expert:
+    try:
+        return await experts_db.update_budget(
+            user_id, expert_id, request.weekly_budget
+        )
     except experts_db.ExpertNotFoundError as e:
         raise fastapi.HTTPException(status_code=404, detail=str(e))
 

--- a/autogpt_platform/backend/backend/api/features/experts/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes_test.py
@@ -21,6 +21,7 @@ from backend.api.features.experts import experts_db
 from backend.api.features.experts.errors import ExpertScheduleCleanupError
 from backend.api.features.experts.models import (
     PROTECTED_SOUL_RULES,
+    WEEKLY_BUDGET_MAX_CREDITS,
     Expert,
     ExpertActivity,
     ExpertActivityDay,
@@ -997,6 +998,43 @@ def test_update_expert_budget_rejects_negative(
     )
 
     response = client.patch("/experts/expert-1/budget", json={"weekly_budget": -1})
+
+    assert response.status_code == 422
+    mock_update.assert_not_awaited()
+
+
+def test_update_expert_budget_accepts_the_upper_bound(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_update = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.update_budget",
+        new_callable=AsyncMock,
+        return_value=_make_expert(weekly_budget=WEEKLY_BUDGET_MAX_CREDITS),
+    )
+
+    response = client.patch(
+        "/experts/expert-1/budget", json={"weekly_budget": WEEKLY_BUDGET_MAX_CREDITS}
+    )
+
+    assert response.status_code == 200
+    mock_update.assert_awaited_once_with(
+        test_user_id, "expert-1", WEEKLY_BUDGET_MAX_CREDITS
+    )
+
+
+def test_update_expert_budget_rejects_above_the_upper_bound(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mock_update = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.update_budget",
+        new_callable=AsyncMock,
+    )
+
+    response = client.patch(
+        "/experts/expert-1/budget",
+        json={"weekly_budget": WEEKLY_BUDGET_MAX_CREDITS + 1},
+    )
 
     assert response.status_code == 422
     mock_update.assert_not_awaited()

--- a/autogpt_platform/backend/backend/api/features/experts/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes_test.py
@@ -984,6 +984,7 @@ def test_update_expert_budget_null_restores_default(
     response = client.patch("/experts/expert-1/budget", json={"weekly_budget": None})
 
     assert response.status_code == 200
+    assert response.json()["weekly_budget"] is None
     mock_update.assert_awaited_once_with(test_user_id, "expert-1", None)
 
 

--- a/autogpt_platform/backend/backend/api/features/experts/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/routes_test.py
@@ -954,6 +954,67 @@ def test_update_expert_soul_not_found_returns_404(
 # ─── Avatar ────────────────────────────────────────────────────────────
 
 
+def test_update_expert_budget_returns_updated_expert(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_update = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.update_budget",
+        new_callable=AsyncMock,
+        return_value=_make_expert(weekly_budget=5_000),
+    )
+
+    response = client.patch("/experts/expert-1/budget", json={"weekly_budget": 5000})
+
+    assert response.status_code == 200
+    assert response.json()["weekly_budget"] == 5_000
+    mock_update.assert_awaited_once_with(test_user_id, "expert-1", 5_000)
+
+
+def test_update_expert_budget_null_restores_default(
+    mocker: pytest_mock.MockerFixture,
+    test_user_id: str,
+) -> None:
+    mock_update = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.update_budget",
+        new_callable=AsyncMock,
+        return_value=_make_expert(weekly_budget=None),
+    )
+
+    response = client.patch("/experts/expert-1/budget", json={"weekly_budget": None})
+
+    assert response.status_code == 200
+    mock_update.assert_awaited_once_with(test_user_id, "expert-1", None)
+
+
+def test_update_expert_budget_rejects_negative(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mock_update = mocker.patch(
+        "backend.api.features.experts.routes.experts_db.update_budget",
+        new_callable=AsyncMock,
+    )
+
+    response = client.patch("/experts/expert-1/budget", json={"weekly_budget": -1})
+
+    assert response.status_code == 422
+    mock_update.assert_not_awaited()
+
+
+def test_update_expert_budget_not_found_returns_404(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    mocker.patch(
+        "backend.api.features.experts.routes.experts_db.update_budget",
+        new_callable=AsyncMock,
+        side_effect=experts_db.ExpertNotFoundError("expert-1"),
+    )
+
+    response = client.patch("/experts/expert-1/budget", json={"weekly_budget": 100})
+
+    assert response.status_code == 404
+
+
 def test_update_expert_avatar_returns_updated_expert(
     mocker: pytest_mock.MockerFixture,
     test_user_id: str,

--- a/autogpt_platform/backend/snapshots/expert_runs_list
+++ b/autogpt_platform/backend/snapshots/expert_runs_list
@@ -9,6 +9,7 @@
     "needs_review": false,
     "output_key": "result",
     "output_type": "table",
+    "source": "manual",
     "started_at": null,
     "status": "completed"
   },
@@ -22,6 +23,7 @@
     "needs_review": false,
     "output_key": "result",
     "output_type": "doc",
+    "source": "manual",
     "started_at": null,
     "status": "completed"
   }

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -6492,6 +6492,52 @@
         }
       }
     },
+    "/api/experts/{expert_id}/budget": {
+      "patch": {
+        "tags": ["v2", "experts", "experts", "private"],
+        "summary": "Update Expert Budget",
+        "operationId": "update_expert_budget",
+        "security": [{ "HTTPBearerJWT": [] }],
+        "parameters": [
+          {
+            "name": "expert_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Expert Id" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ExpertBudgetUpdate" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Expert" }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/HTTP401NotAuthenticatedError"
+          },
+          "404": { "description": "Expert not found" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/experts/{expert_id}/credentials": {
       "get": {
         "tags": ["v2", "experts", "experts", "private"],
@@ -19803,6 +19849,20 @@
         "title": "ExpertAvatarUpdate",
         "description": "Swap an expert's picture. ``None`` clears it back to the generated marble."
       },
+      "ExpertBudgetUpdate": {
+        "properties": {
+          "weekly_budget": {
+            "anyOf": [
+              { "type": "integer", "maximum": 1000000.0, "minimum": 0.0 },
+              { "type": "null" }
+            ],
+            "title": "Weekly Budget"
+          }
+        },
+        "type": "object",
+        "title": "ExpertBudgetUpdate",
+        "description": "Set an expert's weekly spend cap in credits (100 = $1).\n\n``None`` falls back to the platform default; ``0`` disables the cap."
+      },
       "ExpertCredentialRef": {
         "properties": {
           "credential_id": { "type": "string", "title": "Credential Id" },
@@ -19895,6 +19955,12 @@
             "title": "Output Key"
           },
           "needs_review": { "type": "boolean", "title": "Needs Review" },
+          "source": {
+            "type": "string",
+            "enum": ["scheduled", "trigger", "manual"],
+            "title": "Source",
+            "default": "manual"
+          },
           "started_at": {
             "anyOf": [
               { "type": "string", "format": "date-time" },


### PR DESCRIPTION
### Why / What / How

**Why:** The expert page needs to let owners change an expert's weekly budget, and the Work tab needs to say how a run started. Neither was exposed by the API.

**What:** A budget update endpoint and a `source` field on expert runs.

**How:** `PATCH /api/experts/{expert_id}/budget` mirrors the avatar update (owner-scoped `update_many`, 404 when the expert is not a live private hire). `ExpertRun.source` is derived from the execution's `AgentPreset`: webhook preset → `trigger`, other preset → `scheduled`, none → `manual`. The field defaults to `manual` so existing constructors and clients keep working.

### Changes 🏗️

- `ExpertBudgetUpdate` model: `weekly_budget` in credits, 0…1,000,000, `null` restores the platform default
- `experts_db.update_budget` and the `update_expert_budget` route
- `ExpertRunSource` literal and `ExpertRun.source`; runs query now includes `AgentPreset`
- Route tests for 200 / null / 422 / 404 on the budget endpoint, db test for the three run sources
- `expert_runs_list` snapshot refreshed
- `frontend/src/app/api/openapi.json` spliced by hand with the new path and schema fields (`source` is optional on the client so it works against older backends)

Data access: `update_budget` filters by `ownerUserId` like the other expert writes.

### Agents and large language models used

Claude Code with Claude Fable 5.1

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run pytest backend/api/features/experts/routes_test.py backend/api/features/experts/experts_db_test.py -k "expert_run or budget"`
  - [ ] Manual: PATCH the budget for a hired expert and confirm the /team card meter updates
