### PR TITLE
feat(backend): add Claude Fable 5.1 support

### DIFF
--- a/autogpt_platform/backend/backend/data/llm_registry/catalog.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/catalog.py
@@ -236,6 +236,36 @@ def _build_catalog() -> CatalogPayload:
                     provider_output_usd_per_1m=15.00,
                 ),
             ),
+            CatalogModel(
+                slug="claude-fable-5-1",
+                display_name="Claude Fable 5.1",
+                provider="anthropic",
+                creator="anthropic",
+                # Same compaction-cap convention as the rest of the Claude
+                # 5 family: native window is 1M, capped at 200K here.
+                context_window=200000,
+                max_output_tokens=128000,
+                price_tier=3,
+                supports_tools=True,
+                supports_json_output=True,
+                supports_reasoning=True,
+                # $10/1M in, $50/1M out (Anthropic list price, unchanged
+                # from Fable 5) at the catalog's standard usd_per_1m x 150
+                # factor -> 1500/7500 credits, matching gpt-6-astra which
+                # ships the same $10/$50 rate. Cache reads are Fable 5.1's
+                # headline price cut: $0.25/1M (75% below Fable 5) rather
+                # than the family's usual 0.1x-of-input ratio. Cache writes
+                # keep the standard 1.25x-of-input convention ($12.50/1M).
+                cost=CatalogModelCost(
+                    run_credits=20,
+                    input_credits_per_1m=1500.0,
+                    output_credits_per_1m=7500.0,
+                    cache_read_credits_per_1m=37.5,
+                    cache_creation_credits_per_1m=1875.0,
+                    provider_input_usd_per_1m=10.00,
+                    provider_output_usd_per_1m=50.00,
+                ),
+            ),
             # ----- Groq -----
             CatalogModel(
                 slug="llama-3.1-8b-instant",

--- a/autogpt_platform/backend/backend/data/llm_registry/catalog_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/catalog_test.py
@@ -180,6 +180,24 @@ def test_gpt6_astra_bills_at_authored_rates():
     assert astra_entry.context_window == 1050000
 
 
+def test_claude_fable_5_1_bills_at_authored_rates():
+    """Claude Fable 5.1 (Anthropic list price $10/$50 per 1M, cache reads cut
+    75% to $0.25/1M) — flat tier and per-1M projections must match the
+    authored catalog entry."""
+    fable = LLMModel("claude-fable-5-1")
+    assert MODEL_COST[fable] == 20
+    assert TOKEN_COST[fable].model_dump() == {
+        "input": 1500.0,
+        "output": 7500.0,
+        "cache_read": 37.5,
+        "cache_creation": 1875.0,
+    }
+    assert MODEL_METADATA[fable].max_output_tokens == 128000
+    fable_entry = next(m for m in CATALOG.models if m.slug == "claude-fable-5-1")
+    assert fable_entry.price_tier == 3
+    assert fable_entry.context_window == 200000
+
+
 def test_provider_usd_prices_are_all_or_nothing():
     """A half-authored provider USD price must refuse to construct — it
     would silently underprice against the transport family default."""

--- a/autogpt_platform/backend/backend/data/llm_registry/llm_models.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/llm_models.py
@@ -178,6 +178,7 @@ class LLMModel(str, Enum, metaclass=LLMModelMeta):
     CLAUDE_5_OPUS = "claude-opus-5"
     CLAUDE_4_6_SONNET = "claude-sonnet-4-6"
     CLAUDE_5_SONNET = "claude-sonnet-5"
+    CLAUDE_5_1_FABLE = "claude-fable-5-1"
     # AI/ML API models
     AIML_API_LLAMA3_3_70B = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
     # Groq models


### PR DESCRIPTION
## Summary
Adds **Claude Fable 5.1** (Anthropic, released 2026-09-01, model id `claude-fable-5-1`) to the LLM catalog — a currently-missing, generally-available major model.

## Changes
- `catalog.py`: new `CatalogModel` entry for `claude-fable-5-1`. Same $10/$50 per-1M input/output list price as Fable 5, but with cache reads cut 75% to $0.25/1M — Fable 5.1's headline pricing change per Anthropic's announcement. Cache writes keep the family's standard 1.25x-of-input convention ($12.50/1M). `run_credits=20` and `price_tier=3` match `gpt-6-astra`, which ships the identical $10/$50 rate.
- `llm_models.py`: new `CLAUDE_5_1_FABLE = "claude-fable-5-1"` enum member. No change needed to `CLAUDE_5_FAMILY_PREFIXES` — the existing `"claude-fable-5"` prefix already covers this slug via `str.startswith`.
- `catalog_test.py`: new `test_claude_fable_5_1_bills_at_authored_rates` billing-pin test, asserting `MODEL_COST`, `TOKEN_COST`, `price_tier`, and `context_window` against the authored catalog entry (mirrors the `test_gpt6_astra_bills_at_authored_rates` pattern).

## Scope note
Claude Mythos 5.1 (Fable 5.1's sibling release, same announcement) is intentionally **excluded**: Anthropic restricts it to trusted-access programs (cybersecurity/life-sciences vetted orgs) only, not broadly available via standard API credentials — consistent with the catalog's convention of listing only generally-accessible models.

## Verification
Full `pytest` isn't runnable in this environment (heavy `backend.blocks` import chain requires a generated `prisma` client). Verified instead by importing `catalog.py`/`llm_models.py` directly and replicating `block_cost_config.py`'s catalog-projection logic (`_model_cost_from_catalog`/`_token_cost_from_catalog`) inline — all assertions from the new test pass:
- `MODEL_COST[claude-fable-5-1] == 20`
- `TOKEN_COST[claude-fable-5-1] == {input: 1500.0, output: 7500.0, cache_read: 37.5, cache_creation: 1875.0}`
- `MODEL_METADATA[claude-fable-5-1].max_output_tokens == 128000`
- catalog entry `price_tier == 3`, `context_window == 200000`
- every `LLMModel` enum member (including the new one) resolves a `MODEL_COST` entry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive catalog and enum entry with a billing pin test; no routing or auth changes, though incorrect credit math would affect charges for users who select this model.
> 
> **Overview**
> Adds **Claude Fable 5.1** (`claude-fable-5-1`) as a selectable Anthropic model by extending the catalog-as-code database, the `LLMModel` enum, and catalog billing guards.
> 
> The new catalog entry follows other Claude 5 models (200K compaction cap, tools/JSON/reasoning flags, tier 3) with **$10/$50 per 1M** input/output credits aligned to `gpt-6-astra`, plus **cache read** pricing at **$0.25/1M** (37.5 credits) instead of the usual 0.1× input ratio. `CLAUDE_5_1_FABLE` is added in `llm_models.py`; existing `claude-fable-5` family prefixes already cover the slug.
> 
> `test_claude_fable_5_1_bills_at_authored_rates` pins projected `MODEL_COST`, `TOKEN_COST`, metadata, `price_tier`, and `context_window` to the authored catalog row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b404b27227ece87fa53d4a1f92ee3dd60b2d606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->