### PR TITLE
fix(frontend): use solid expert colors for covers

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/raise/components/ColorStep/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/raise/components/ColorStep/helpers.ts
@@ -3,6 +3,7 @@ export interface ColorOption {
   label: string;
   // Written out in full so Tailwind's scanner keeps the class.
   swatchClassName: string;
+  coverClassName: string;
   // Gradient stop for a surface washed in the expert's color.
   washFromClassName: string;
   // Border + tint for answers rendered in the expert's color.
@@ -25,6 +26,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "rose-300",
     label: "Rose",
     swatchClassName: "bg-rose-300",
+    coverClassName: "bg-rose-200",
     washFromClassName: "from-rose-100",
     bubbleClassName: "border-rose-300 bg-rose-50",
     textClassName: "text-rose-700",
@@ -38,6 +40,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "red-300",
     label: "Red",
     swatchClassName: "bg-red-300",
+    coverClassName: "bg-red-200",
     washFromClassName: "from-red-100",
     bubbleClassName: "border-red-300 bg-red-50",
     textClassName: "text-red-700",
@@ -50,6 +53,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "orange-300",
     label: "Orange",
     swatchClassName: "bg-orange-300",
+    coverClassName: "bg-orange-200",
     washFromClassName: "from-orange-100",
     bubbleClassName: "border-orange-300 bg-orange-50",
     textClassName: "text-orange-700",
@@ -64,6 +68,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "amber-300",
     label: "Amber",
     swatchClassName: "bg-amber-300",
+    coverClassName: "bg-amber-200",
     washFromClassName: "from-amber-100",
     bubbleClassName: "border-amber-300 bg-amber-50",
     textClassName: "text-amber-700",
@@ -77,6 +82,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "yellow-300",
     label: "Yellow",
     swatchClassName: "bg-yellow-300",
+    coverClassName: "bg-yellow-200",
     washFromClassName: "from-yellow-100",
     bubbleClassName: "border-yellow-300 bg-yellow-50",
     textClassName: "text-yellow-700",
@@ -91,6 +97,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "lime-300",
     label: "Lime",
     swatchClassName: "bg-lime-300",
+    coverClassName: "bg-lime-200",
     washFromClassName: "from-lime-100",
     bubbleClassName: "border-lime-300 bg-lime-50",
     textClassName: "text-lime-700",
@@ -104,6 +111,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "green-300",
     label: "Green",
     swatchClassName: "bg-green-300",
+    coverClassName: "bg-green-200",
     washFromClassName: "from-green-100",
     bubbleClassName: "border-green-300 bg-green-50",
     textClassName: "text-green-700",
@@ -117,6 +125,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "emerald-300",
     label: "Emerald",
     swatchClassName: "bg-emerald-300",
+    coverClassName: "bg-emerald-200",
     washFromClassName: "from-emerald-100",
     bubbleClassName: "border-emerald-300 bg-emerald-50",
     textClassName: "text-emerald-700",
@@ -131,6 +140,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "teal-300",
     label: "Teal",
     swatchClassName: "bg-teal-300",
+    coverClassName: "bg-teal-200",
     washFromClassName: "from-teal-100",
     bubbleClassName: "border-teal-300 bg-teal-50",
     textClassName: "text-teal-700",
@@ -144,6 +154,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "cyan-300",
     label: "Cyan",
     swatchClassName: "bg-cyan-300",
+    coverClassName: "bg-cyan-200",
     washFromClassName: "from-cyan-100",
     bubbleClassName: "border-cyan-300 bg-cyan-50",
     textClassName: "text-cyan-700",
@@ -157,6 +168,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "sky-300",
     label: "Sky",
     swatchClassName: "bg-sky-300",
+    coverClassName: "bg-sky-200",
     washFromClassName: "from-sky-100",
     bubbleClassName: "border-sky-300 bg-sky-50",
     textClassName: "text-sky-700",
@@ -169,6 +181,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "blue-300",
     label: "Blue",
     swatchClassName: "bg-blue-300",
+    coverClassName: "bg-blue-200",
     washFromClassName: "from-blue-100",
     bubbleClassName: "border-blue-300 bg-blue-50",
     textClassName: "text-blue-700",
@@ -182,6 +195,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "indigo-300",
     label: "Indigo",
     swatchClassName: "bg-indigo-300",
+    coverClassName: "bg-indigo-200",
     washFromClassName: "from-indigo-100",
     bubbleClassName: "border-indigo-300 bg-indigo-50",
     textClassName: "text-indigo-700",
@@ -196,6 +210,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "violet-300",
     label: "Violet",
     swatchClassName: "bg-violet-300",
+    coverClassName: "bg-violet-200",
     washFromClassName: "from-violet-100",
     bubbleClassName: "border-violet-300 bg-violet-50",
     textClassName: "text-violet-700",
@@ -210,6 +225,7 @@ export const COLOR_OPTIONS: ColorOption[] = [
     id: "fuchsia-300",
     label: "Fuchsia",
     swatchClassName: "bg-fuchsia-300",
+    coverClassName: "bg-fuchsia-200",
     washFromClassName: "from-fuchsia-100",
     bubbleClassName: "border-fuchsia-300 bg-fuchsia-50",
     textClassName: "text-fuchsia-700",
@@ -236,6 +252,10 @@ export function bubbleClassFor(id: string | null) {
 
 export function swatchClassFor(id: string | null) {
   return findColorOption(id)?.swatchClassName;
+}
+
+export function coverClassFor(id: string | null) {
+  return findColorOption(id)?.coverClassName;
 }
 
 export function washFromClassFor(id: string | null) {

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertTeamCard/components/ExpertCover.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertTeamCard/components/ExpertCover.tsx
@@ -1,3 +1,4 @@
+import { coverClassFor } from "@/app/(platform)/raise/components/ColorStep/helpers";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Text } from "@/components/atoms/Text/Text";
 import { cn } from "@/lib/utils";
@@ -9,7 +10,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 import Image from "next/image";
-import { type ExpertRosterStatus, getExpertCoverSrc } from "../../../helpers";
+import type { ExpertRosterStatus } from "../../../helpers";
 
 type CoverStatus = ExpertRosterStatus | "built-in";
 
@@ -52,16 +53,19 @@ export function ExpertCover({ className, color, status }: Props) {
     <div
       className={cn(
         "relative h-28 w-full overflow-hidden rounded-lg bg-zinc-100",
+        coverClassFor(color ?? null),
         className,
       )}
     >
-      <Image
-        src={getExpertCoverSrc(color)}
-        alt=""
-        fill
-        sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-        className="object-cover"
-      />
+      {status === "built-in" ? (
+        <Image
+          src="/experts/covers/autopilot.jpg"
+          alt=""
+          fill
+          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+          className="object-cover"
+        />
+      ) : null}
       {statusStyle ? (
         <Text
           variant="small-medium"

--- a/autogpt_platform/frontend/src/app/(platform)/team/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/helpers.ts
@@ -4,7 +4,6 @@ import { ExpertWorkflowRef } from "@/app/api/__generated__/models/expertWorkflow
 import { GraphExecutionJobInfo } from "@/app/api/__generated__/models/graphExecutionJobInfo";
 import { CopilotSkillInfo } from "@/app/api/__generated__/models/copilotSkillInfo";
 import { LibraryAgent } from "@/app/api/__generated__/models/libraryAgent";
-import { findColorOption } from "@/app/(platform)/raise/components/ColorStep/helpers";
 import { formatDistanceToNow } from "date-fns";
 
 /** Section headings sit outside the cards, so they need the cards' own content
@@ -324,14 +323,6 @@ export function getAutopilotSummary({
       0,
     ),
   };
-}
-
-/** Covers live at `public/experts/covers/<color token>.jpg`, one per raise-flow
- *  accent. Experts without a colour (marketplace templates) and Autopilot
- *  share `autopilot.jpg`. */
-export function getExpertCoverSrc(color: string | null | undefined) {
-  const token = findColorOption(color ?? null)?.id ?? "autopilot";
-  return `/experts/covers/${token}.jpg`;
 }
 
 export const WORKFLOW_FILTERS = [


### PR DESCRIPTION
### Why / What / How

Expert covers currently show decorative cloud images. Use a solid, lighter shade of each expert’s selected color instead.
Expert cards, detail headers, and workflow cards now use the matching Tailwind 200 shade.
Add explicit cover classes to the existing color palette and apply them through the shared ExpertCover component. Keep the neutral fallback, status badges, and explicitly supplied Autopilot image.

### Changes 🏗️

- Replace default cloud images with solid expert-color covers.
- Add 200-shade cover classes for all 15 supported colors.
- Remove the unused cloud image lookup.

### Agents and large language models used

Codex with GPT-6.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format`
  - [x] `pnpm lint`
  - [x] `pnpm types`
  - [x] `pnpm test:unit 'src/app/(platform)/team'` — 149 tests passed across 12 files

The full unit suite and browser testing were not run. Static self-review found no actionable issues.

<details>
  <summary>Example test plan</summary>
  
  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
