### PR TITLE
feat(backend/copilot): experts do the public-data part of the job when a connection is skipped

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
@@ -3503,6 +3503,24 @@ def test_to_expert_run_reports_how_the_run_started():
     assert triggered.source == "trigger"
 
 
+@pytest.mark.parametrize(
+    "execution_status",
+    [
+        prisma.enums.AgentExecutionStatus.FAILED,
+        prisma.enums.AgentExecutionStatus.TERMINATED,
+    ],
+)
+def test_to_expert_run_never_reports_a_failed_run_as_completed(execution_status):
+    run = experts_db._to_expert_run(
+        _run_execution(executionStatus=execution_status),
+        _run_workflow(),
+        "unknown",
+        None,
+        needs_review=False,
+    )
+    assert run.status == execution_status.value.lower()
+
+
 def test_to_expert_run_names_a_library_only_workflow():
     run = experts_db._to_expert_run(
         _run_execution(),

--- a/autogpt_platform/backend/backend/copilot/expert_context.py
+++ b/autogpt_platform/backend/backend/copilot/expert_context.py
@@ -227,6 +227,14 @@ async def _expert_session_context(
         f"workflow's purpose, prefer running it with `run_agent` using the "
         f"IDs below over building something new:\n"
         f"{workflow_lines}\n"
+        # The skip comes after the kickoff message's ask, so the rule lives in
+        # session context, which every later turn sees, not in that message.
+        f"If the user skips or declines a connection a workflow needs, do the "
+        f"part of the job public data allows (research, drafts) and save it as "
+        f"a workspace file with its sources; say what stays blocked and which "
+        f"one connection would unlock it. If public data does not support "
+        f"useful work, say so. Never report a workflow as run, or a step as "
+        f"completed, when it was blocked or failed.\n"
         f"</expert_workflows>\n\n"
     )
     return workflows_block + teammates

--- a/autogpt_platform/backend/backend/copilot/expert_context_test.py
+++ b/autogpt_platform/backend/backend/copilot/expert_context_test.py
@@ -390,6 +390,25 @@ class TestBuildExpertContextExpertSession:
         assert "run_agent" in result
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("workflows", [[_workflow()], []])
+    async def test_workflows_block_covers_a_skipped_connection(self, workflows):
+        from backend.copilot.expert_context import build_expert_context
+
+        mock_db = MagicMock()
+        mock_db.get_expert = AsyncMock(return_value=_expert(workflows=workflows))
+        mock_db.list_experts = AsyncMock(return_value=[])
+        with patch(f"{_EC}.experts_db", MagicMock(return_value=mock_db)):
+            result = await build_expert_context("user-1", "exp-1")
+
+        block = result.split("</expert_workflows>")[0]
+        assert "skips or declines a connection" in block
+        assert "public data allows (research, drafts)" in block
+        assert "workspace file with its sources" in block
+        assert "which one connection would unlock it" in block
+        assert "If public data does not support useful work, say so" in block
+        assert "Never report a workflow as run, or a step as completed" in block
+
+    @pytest.mark.asyncio
     async def test_lists_teammates_excluding_self_with_delegation_rule(self):
         from backend.copilot.expert_context import build_expert_context
 


### PR DESCRIPTION
When a user skips a connection that an expert's workflow needs, the expert now does the part of its day-one job that public data allows instead of stopping at the access request. It delivers that work as a workspace file with its sources, says what stays blocked and which one connection would unlock it, says so when public data cannot support useful work, and never reports a blocked or failed step as completed. SECRT-2603.

### Why / What / How

**Why:** SECRT-2531 gave hired experts a day-one kickoff that runs the first bundled workflow or asks, in voice, for the one connection it needs. Nothing told the expert what to do when the user declines that ask, so the thread stopped at the request. The Experts PRD requires public-data work when a connection is skipped, with real deliverables and honest status.

**What:** One rule added to the `<expert_workflows>` block that `backend/copilot/expert_context.py` injects into every expert session. Two tests: one proving the rule is delivered (with and without installed workflows), one pinning that a FAILED or TERMINATED run never surfaces as `completed` on the /team Work list.

**How:** The rule lives in session context rather than in the kickoff message because the skip happens on the turn after the expert's ask. The block is persisted into the session's first user message, so every later turn sees it, and it is stripped from the displayed thread like the other server-injected blocks. The kickoff prompt itself (`frontend/.../copilot/expertKickoff.ts`) is unchanged: it renders as the user's own visible first message, and its "ask for exactly one connection" line stays the first move.

No status code changed. There is no server path that marks a blocked or failed kickoff Completed today: a run blocked on credentials never starts, so no `ExpertRun` row exists; a failed run maps to `failed` (`experts_db.py::_to_expert_run`); the briefing filters to COMPLETED/FAILED before labelling. The new status test pins that mapping at the one surface where the word Completed is shown to the user. The only "completed" the expert controls is its own checklist and prose, which the rule addresses.

**Reach:** the block is written into a session's first user message once, and both engines skip re-injection on later turns. Experts hired before this ships therefore get the rule only in a new thread, not in the thread they already have. A one-line version of the rule in the per-turn `<expert_identity>` system-prompt suffix would close that gap for existing threads on their next turn, at the cost of roughly sixty tokens on every expert turn; not built here, flagged as an option.

### Changes 🏗️

- `backend/copilot/expert_context.py`: the skipped-connection rule appended inside the `<expert_workflows>` block.
- `backend/copilot/expert_context_test.py`: `test_workflows_block_covers_a_skipped_connection`, parametrized over an expert with and without installed workflows.
- `backend/api/features/experts/experts_db_test.py`: `test_to_expert_run_never_reports_a_failed_run_as_completed`, parametrized over FAILED and TERMINATED.

### Agents and large language models used

Claude Code with Claude Fable 5.1.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `backend/copilot/expert_context_test.py`: 38 passed (36 existing + 2 new cases)
  - [x] `backend/api/features/experts/experts_db_test.py -k to_expert_run`: 6 passed (4 existing + 2 new cases)
  - [x] Mutation: removing the rule fails the new prompt test; hardcoding `status="completed"` fails the new status test (output in a comment)
  - [x] `backend/util/architecture_test.py`: 3 passed
  - [x] `backend/blocks/test/test_block.py`: 1647 passed, 84 skipped

**Verified:** I executed the four suites above and both mutations. The expert's behaviour itself, a hire followed by a skipped connection, is not exercised here: no app stack was running, and the rule's effect on the model is verified in the manual hire-loop QA (SECRT-2525). The prompt-assembly tests prove only that the rule is delivered to the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
