### PR TITLE
feat(backend): scope expert sessions to their own workspace files

### DIFF
--- a/autogpt_platform/backend/backend/copilot/context.py
+++ b/autogpt_platform/backend/backend/copilot/context.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from backend.copilot.model import ChatSession
 from backend.data.db_accessors import workspace_db
+from backend.data.workspace_scope import WorkspaceAccessDeniedError, WorkspaceScope
 from backend.util.workspace import WorkspaceManager
 
 if TYPE_CHECKING:
@@ -269,15 +270,40 @@ def resolve_sandbox_path(path: str) -> str:
     return normalized
 
 
+async def current_workspace_scope(user_id: str) -> WorkspaceScope | None:
+    """Resolve the file/skill grants for the turn currently executing.
+
+    The scope derives from the server-resolved session the executor placed
+    in the execution context — never from a session or expert ID a tool
+    argument names. Outside a copilot turn (REST endpoints, cleanup jobs,
+    tests) there is no expert acting, so the owner's full workspace applies.
+    """
+    _, session = get_execution_context()
+    if session is None:
+        return None
+    if session.user_id != user_id:
+        raise WorkspaceAccessDeniedError(
+            "Workspace access denied: the executing session belongs to another user."
+        )
+    if session.expert_id is None:
+        return None
+    scope = await workspace_db().resolve_expert_workspace_scope(
+        user_id, session.expert_id
+    )
+    return scope.with_session(session.session_id)
+
+
 async def get_workspace_manager(user_id: str, session_id: str) -> WorkspaceManager:
     """Create a session-scoped :class:`WorkspaceManager`.
 
     Placed here (rather than in ``tools/workspace_files``) so that modules
     like ``sdk/file_ref`` can import it without triggering the heavy
-    ``tools/__init__`` import chain.
+    ``tools/__init__`` import chain. Expert turns get a manager confined to
+    the expert's resolved scope (see :func:`current_workspace_scope`).
     """
     workspace = await workspace_db().get_or_create_workspace(user_id)
-    return WorkspaceManager(user_id, workspace.id, session_id)
+    scope = await current_workspace_scope(user_id)
+    return WorkspaceManager(user_id, workspace.id, session_id, scope=scope)
 
 
 def is_allowed_local_path(path: str, sdk_cwd: str | None = None) -> bool:

--- a/autogpt_platform/backend/backend/copilot/context_isolation_test.py
+++ b/autogpt_platform/backend/backend/copilot/context_isolation_test.py
@@ -1,0 +1,62 @@
+"""``get_workspace_manager`` derives the expert scope from the executing
+session placed in the context by the executor — never from arguments."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.copilot.context import get_workspace_manager, set_execution_context
+from backend.copilot.model import ChatSession
+from backend.data.workspace_scope import WorkspaceAccessDeniedError, WorkspaceScope
+
+
+@pytest.fixture
+def db():
+    db = MagicMock()
+    db.get_or_create_workspace = AsyncMock(return_value=MagicMock(id="ws-1"))
+    db.resolve_expert_workspace_scope = AsyncMock(
+        return_value=WorkspaceScope(
+            expert_id="expert-a", session_ids=["older"], skill_names=["assigned"]
+        )
+    )
+    with patch("backend.copilot.context.workspace_db", return_value=db):
+        yield db
+    set_execution_context(None, None)
+
+
+async def test_expert_turn_gets_scoped_manager_including_current_session(db):
+    session = ChatSession.new("user-1", dry_run=False, expert_id="expert-a")
+    set_execution_context("user-1", session)
+    manager = await get_workspace_manager("user-1", session.session_id)
+    assert manager.scope is not None
+    assert manager.scope.session_ids == ["older", session.session_id]
+    db.resolve_expert_workspace_scope.assert_awaited_once_with("user-1", "expert-a")
+
+
+async def test_scope_follows_the_executing_session_not_the_requested_one(db):
+    session = ChatSession.new("user-1", dry_run=False, expert_id="expert-a")
+    set_execution_context("user-1", session)
+    manager = await get_workspace_manager("user-1", "some-other-session")
+    assert manager.scope is not None
+    assert manager.scope.expert_id == "expert-a"
+
+
+async def test_personal_autopilot_turn_is_unrestricted(db):
+    session = ChatSession.new("user-1", dry_run=False)
+    set_execution_context("user-1", session)
+    manager = await get_workspace_manager("user-1", session.session_id)
+    assert manager.scope is None
+    db.resolve_expert_workspace_scope.assert_not_awaited()
+
+
+async def test_outside_a_turn_is_unrestricted(db):
+    set_execution_context(None, None)
+    manager = await get_workspace_manager("user-1", "session-1")
+    assert manager.scope is None
+
+
+async def test_session_of_another_user_is_refused(db):
+    session = ChatSession.new("someone-else", dry_run=False, expert_id="expert-a")
+    set_execution_context("someone-else", session)
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await get_workspace_manager("user-1", session.session_id)

--- a/autogpt_platform/backend/backend/copilot/tools/workspace_files.py
+++ b/autogpt_platform/backend/backend/copilot/tools/workspace_files.py
@@ -4,6 +4,7 @@ import base64
 import logging
 import mimetypes
 import os
+import re
 from typing import Any, Optional
 
 from backend.api.features.store.exceptions import VirusDetectedError, VirusScanError
@@ -20,6 +21,7 @@ from backend.copilot.context import (
 from backend.copilot.model import ChatSession
 from backend.copilot.tools.sandbox import make_session_path
 from backend.data.activity_event import ActivityEventDraft
+from backend.data.workspace_scope import WorkspaceAccessDeniedError
 from backend.util.settings import Config
 from backend.util.workspace import WorkspaceManager
 
@@ -427,7 +429,11 @@ class ListWorkspaceFilesTool(BaseTool):
                 },
                 "include_all_sessions": {
                     "type": "boolean",
-                    "description": "Include files from all sessions (default: false).",
+                    "description": (
+                        "Include files from all sessions (default: false). "
+                        "Expert chats only ever see their own sessions and "
+                        "assigned skills."
+                    ),
                 },
             },
             "required": [],
@@ -489,6 +495,10 @@ class ListWorkspaceFilesTool(BaseTool):
                 message="\n".join(lines),
                 session_id=session_id,
             )
+        except WorkspaceAccessDeniedError as e:
+            return ErrorResponse(
+                message=str(e), error="access_denied", session_id=session_id
+            )
         except Exception as e:
             logger.error(f"Error listing workspace files: {e}", exc_info=True)
             return ErrorResponse(
@@ -515,7 +525,9 @@ class ReadWorkspaceFileTool(BaseTool):
             "Small text/image files return inline; large/binary return metadata+URL. "
             "Use save_to_path to copy to working dir for processing. "
             "Use offset/length for paginated reads. "
-            "Paths scoped to current session; use /sessions/<id>/... for cross-session access."
+            "Paths scoped to current session; use /sessions/<id>/... for "
+            "cross-session access (expert chats are limited to their own "
+            "sessions and assigned skills)."
         )
 
     @property
@@ -725,6 +737,10 @@ class ReadWorkspaceFileTool(BaseTool):
             )
         except FileNotFoundError as e:
             return ErrorResponse(message=str(e), session_id=session_id)
+        except WorkspaceAccessDeniedError as e:
+            return ErrorResponse(
+                message=str(e), error="access_denied", session_id=session_id
+            )
         except Exception as e:
             logger.error(f"Error reading workspace file: {e}", exc_info=True)
             return ErrorResponse(
@@ -742,6 +758,7 @@ class ReadWorkspaceFileTool(BaseTool):
 # registry. Reads stay open so the model can still inspect sibling
 # references inside a skill bundle.
 _SKILLS_REGISTRY_PREFIX = "skills/"
+_EXPERT_SKILLS_REGISTRY_RE = re.compile(r"^experts/[^/]+/skills(/|$)")
 _SKILLS_REGISTRY_ERROR = (
     "Path is managed by the skills registry; use store_skill / "
     "delete_skill instead. (read_workspace_file can still read "
@@ -758,7 +775,11 @@ def _path_under_skills_registry(path: str | None) -> bool:
     # Strip leading slashes + whitespace, lower-case so case variants
     # (``Skills/foo``) cannot bypass the check.
     normalised = path.strip().lstrip("/").lower()
-    return normalised.startswith(_SKILLS_REGISTRY_PREFIX) or normalised == "skills"
+    return (
+        normalised.startswith(_SKILLS_REGISTRY_PREFIX)
+        or normalised == "skills"
+        or _EXPERT_SKILLS_REGISTRY_RE.match(normalised) is not None
+    )
 
 
 class WriteWorkspaceFileTool(BaseTool):
@@ -774,7 +795,9 @@ class WriteWorkspaceFileTool(BaseTool):
             "Write a file to persistent workspace (survives across sessions). "
             "Provide exactly one of: content (text), content_base64 (binary), "
             f"or source_path (copy from working dir). Max {_MAX_FILE_SIZE_MB}MB. "
-            "Paths scoped to current session; use /sessions/<id>/... for cross-session access."
+            "Paths scoped to current session; use /sessions/<id>/... for "
+            "cross-session access (expert chats are limited to their own "
+            "sessions and assigned skills)."
         )
 
     @property
@@ -977,6 +1000,10 @@ class WriteWorkspaceFileTool(BaseTool):
         except VirusScanError as e:
             logger.error(f"Virus scan infrastructure error: {e}", exc_info=True)
             return ErrorResponse(message=str(e), session_id=session_id)
+        except WorkspaceAccessDeniedError as e:
+            return ErrorResponse(
+                message=str(e), error="access_denied", session_id=session_id
+            )
         except ValueError as e:
             msg = str(e)
             if msg.startswith("Storage limit exceeded"):
@@ -1096,6 +1123,10 @@ class DeleteWorkspaceFileTool(BaseTool):
                     f"({file_info.size_bytes:,} bytes)"
                 ),
                 session_id=session_id,
+            )
+        except WorkspaceAccessDeniedError as e:
+            return ErrorResponse(
+                message=str(e), error="access_denied", session_id=session_id
             )
         except Exception as e:
             logger.error(f"Error deleting workspace file: {e}", exc_info=True)

--- a/autogpt_platform/backend/backend/copilot/tools/workspace_files_isolation_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/workspace_files_isolation_test.py
@@ -1,0 +1,97 @@
+"""Workspace tools cannot reach outside an expert session's scope through
+``include_all_sessions``, explicit ``/sessions/<id>/`` paths, or file IDs."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.copilot.model import ChatSession
+from backend.copilot.tools.models import ErrorResponse
+from backend.copilot.tools.workspace_files import (
+    DeleteWorkspaceFileTool,
+    ListWorkspaceFilesTool,
+    ReadWorkspaceFileTool,
+    WorkspaceFileListResponse,
+    WriteWorkspaceFileTool,
+)
+from backend.data.workspace_scope import WorkspaceScope
+from backend.util.workspace import WorkspaceManager
+from backend.util.workspace_test import _make_workspace_file
+
+SCOPE = WorkspaceScope(expert_id="expert-a", session_ids=["expert-a"])
+
+
+@pytest.fixture
+def db():
+    db = MagicMock()
+    db.get_workspace_file = AsyncMock(
+        return_value=_make_workspace_file(path="/sessions/expert-b/private.txt")
+    )
+    db.get_workspace_file_by_path = AsyncMock(return_value=_make_workspace_file())
+    db.list_workspace_files = AsyncMock(return_value=[])
+    db.count_workspace_files = AsyncMock(return_value=0)
+    db.soft_delete_workspace_file = AsyncMock()
+    manager = WorkspaceManager("user-1", "ws-1", "expert-a", scope=SCOPE)
+    with (
+        patch("backend.util.workspace.workspace_db", return_value=db),
+        patch(
+            "backend.copilot.tools.workspace_files.get_workspace_manager",
+            new=AsyncMock(return_value=manager),
+        ),
+    ):
+        yield db
+
+
+def _session() -> ChatSession:
+    session = ChatSession.new("user-1", dry_run=False, expert_id="expert-a")
+    session.session_id = "expert-a"
+    return session
+
+
+async def test_include_all_sessions_is_confined_to_the_scope(db):
+    result = await ListWorkspaceFilesTool()._execute(
+        "user-1", _session(), include_all_sessions=True
+    )
+    assert isinstance(result, WorkspaceFileListResponse)
+    assert (
+        db.list_workspace_files.call_args.kwargs["allowed_path_prefixes"]
+        == SCOPE.read_prefixes
+    )
+
+
+async def test_read_by_foreign_file_id_is_denied(db):
+    result = await ReadWorkspaceFileTool()._execute(
+        "user-1", _session(), file_id="foreign"
+    )
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "access_denied"
+
+
+async def test_read_by_explicit_foreign_path_is_denied(db):
+    result = await ReadWorkspaceFileTool()._execute(
+        "user-1", _session(), path="/sessions/expert-b/private.txt"
+    )
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "access_denied"
+    db.get_workspace_file_by_path.assert_not_awaited()
+
+
+async def test_write_into_foreign_session_is_denied(db):
+    result = await WriteWorkspaceFileTool()._execute(
+        "user-1",
+        _session(),
+        filename="x.txt",
+        content="x",
+        path="/sessions/expert-b/x.txt",
+    )
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "access_denied"
+
+
+async def test_delete_by_foreign_file_id_is_denied(db):
+    result = await DeleteWorkspaceFileTool()._execute(
+        "user-1", _session(), file_id="foreign"
+    )
+    assert isinstance(result, ErrorResponse)
+    assert result.error == "access_denied"
+    db.soft_delete_workspace_file.assert_not_awaited()

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -179,6 +179,7 @@ from backend.data.workspace import (
     get_workspace_file_by_path,
     get_workspace_total_size,
     list_workspace_files,
+    resolve_expert_workspace_scope,
     soft_delete_workspace_file,
 )
 from backend.platform_linking import db as platform_linking_db
@@ -441,6 +442,7 @@ class DatabaseManager(AppService):
     get_workspace_total_size = _(get_workspace_total_size)
     list_workspace_files = _(list_workspace_files)
     soft_delete_workspace_file = _(soft_delete_workspace_file)
+    resolve_expert_workspace_scope = _(resolve_expert_workspace_scope)
 
     # ============ Understanding ============ #
     get_business_understanding = _(get_business_understanding)
@@ -831,6 +833,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     get_workspace_total_size = d.get_workspace_total_size
     list_workspace_files = d.list_workspace_files
     soft_delete_workspace_file = d.soft_delete_workspace_file
+    resolve_expert_workspace_scope = d.resolve_expert_workspace_scope
 
     # ============ Credits ============ #
     spend_credits = d.spend_credits

--- a/autogpt_platform/backend/backend/data/workspace.py
+++ b/autogpt_platform/backend/backend/data/workspace.py
@@ -14,6 +14,9 @@ from prisma.errors import UniqueViolationError
 from prisma.models import UserWorkspace, UserWorkspaceFile
 from prisma.types import UserWorkspaceFileWhereInput
 
+from backend.data.workspace_scope import (
+    resolve_expert_workspace_scope as resolve_expert_workspace_scope,
+)
 from backend.util.json import SafeJson
 
 _UUID_RE = re.compile(
@@ -262,6 +265,7 @@ async def list_workspace_files(
     metadata_not_equals: Optional[dict] = None,
     folder_id: Optional[str] = None,
     root_only: bool = False,
+    allowed_path_prefixes: Optional[list[str]] = None,
 ) -> list[WorkspaceFile]:
     """
     List files in a workspace.
@@ -288,10 +292,16 @@ async def list_workspace_files(
         folder_id: If set, only return files in this folder.
         root_only: If True, only return root-level files (folderId IS NULL).
             Ignored when ``folder_id`` is set.
+        allowed_path_prefixes: When set, only files whose path starts with
+            one of these prefixes are returned (ANDed with ``path_prefix``).
+            An empty list matches nothing. Used to apply an expert session's
+            resolved scope inside the query so pagination stays correct.
 
     Returns:
         List of WorkspaceFile instances
     """
+    if allowed_path_prefixes is not None and not allowed_path_prefixes:
+        return []
     where_clause: UserWorkspaceFileWhereInput = {"workspaceId": workspace_id}
 
     if not include_deleted:
@@ -326,6 +336,9 @@ async def list_workspace_files(
     if name_contains:
         where_clause["name"] = {"contains": name_contains, "mode": "insensitive"}
 
+    if allowed_path_prefixes:
+        where_clause["OR"] = _path_prefix_filters(allowed_path_prefixes)
+
     files = await UserWorkspaceFile.prisma().find_many(
         where=where_clause,
         order={"createdAt": "desc"},
@@ -335,10 +348,17 @@ async def list_workspace_files(
     return [WorkspaceFile.from_db(f) for f in files]
 
 
+def _path_prefix_filters(prefixes: list[str]) -> list[UserWorkspaceFileWhereInput]:
+    return [
+        {"path": {"startswith": p if p.startswith("/") else f"/{p}"}} for p in prefixes
+    ]
+
+
 async def count_workspace_files(
     workspace_id: str,
     path_prefix: Optional[str] = None,
     include_deleted: bool = False,
+    allowed_path_prefixes: Optional[list[str]] = None,
 ) -> int:
     """
     Count files in a workspace.
@@ -347,10 +367,13 @@ async def count_workspace_files(
         workspace_id: The workspace ID
         path_prefix: Optional path prefix to filter (e.g., "/sessions/abc123/")
         include_deleted: Whether to include soft-deleted files
+        allowed_path_prefixes: See :func:`list_workspace_files`.
 
     Returns:
         Number of files
     """
+    if allowed_path_prefixes is not None and not allowed_path_prefixes:
+        return 0
     where_clause: UserWorkspaceFileWhereInput = {"workspaceId": workspace_id}
     if not include_deleted:
         where_clause["isDeleted"] = False
@@ -360,6 +383,9 @@ async def count_workspace_files(
         if not path_prefix.startswith("/"):
             path_prefix = f"/{path_prefix}"
         where_clause["path"] = {"startswith": path_prefix}
+
+    if allowed_path_prefixes:
+        where_clause["OR"] = _path_prefix_filters(allowed_path_prefixes)
 
     return await UserWorkspaceFile.prisma().count(where=where_clause)
 

--- a/autogpt_platform/backend/backend/data/workspace_scope.py
+++ b/autogpt_platform/backend/backend/data/workspace_scope.py
@@ -1,0 +1,124 @@
+"""Trusted resource scope for expert chat sessions.
+
+Resolved from persisted session attribution — never from tool arguments. An
+expert session may read and write under its own sessions and its own skills
+folder, and read under sessions it delegated. ``None`` scope means
+unrestricted: the account owner acting through personal AutoPilot, REST
+endpoints, or system paths.
+"""
+
+import posixpath
+from typing import cast
+
+import prisma
+from prisma.enums import ResourceVisibility
+from prisma.models import ChatSession as PrismaChatSession
+from prisma.models import Expert as PrismaExpert
+from pydantic import BaseModel, Field
+
+SESSIONS_ROOT = "/sessions/"
+EXPERTS_ROOT = "/experts/"
+
+EXPERT_FILE_ACCESS_DENIED = (
+    "This file is outside this expert's scope. Experts can only access files "
+    "from their own sessions and their own skills. Open personal AutoPilot to "
+    "work with other files."
+)
+EXPERT_SKILL_SCOPE_DENIED = (
+    "Experts can only use and manage their own skills. Open personal AutoPilot "
+    "to manage another expert's skills or the account's skills."
+)
+
+
+class WorkspaceAccessDeniedError(PermissionError):
+    """A workspace operation fell outside the caller's resolved scope."""
+
+
+def session_path_prefix(session_id: str) -> str:
+    return f"{SESSIONS_ROOT}{session_id}/"
+
+
+def expert_skills_folder(expert_id: str) -> str:
+    return f"{EXPERTS_ROOT}{expert_id}/skills"
+
+
+class WorkspaceScope(BaseModel):
+    """Grants for one expert. Safe for RPC transport."""
+
+    expert_id: str
+    session_ids: list[str] = Field(default_factory=list)
+    delegated_session_ids: list[str] = Field(default_factory=list)
+
+    def with_session(self, session_id: str) -> "WorkspaceScope":
+        if session_id in self.session_ids:
+            return self
+        return self.model_copy(update={"session_ids": [*self.session_ids, session_id]})
+
+    @property
+    def skills_prefix(self) -> str:
+        return f"{expert_skills_folder(self.expert_id)}/"
+
+    @property
+    def write_prefixes(self) -> list[str]:
+        return [session_path_prefix(s) for s in self.session_ids] + [self.skills_prefix]
+
+    @property
+    def read_prefixes(self) -> list[str]:
+        return self.write_prefixes + [
+            session_path_prefix(s) for s in self.delegated_session_ids
+        ]
+
+    def allows_path(self, path: str, *, write: bool = False) -> bool:
+        if not path.startswith("/") or "\\" in path or posixpath.normpath(path) != path:
+            return False
+        prefixes = self.write_prefixes if write else self.read_prefixes
+        return any(path.startswith(prefix) for prefix in prefixes)
+
+
+async def resolve_expert_workspace_scope(
+    user_id: str, expert_id: str
+) -> WorkspaceScope:
+    """Resolve the grants for *expert_id* owned by *user_id*.
+
+    Fails closed: a missing, archived, or foreign expert yields a scope with
+    no session grants at all (callers add the current session explicitly).
+    """
+    expert = await PrismaExpert.prisma().find_first(
+        where={
+            "id": expert_id,
+            "ownerUserId": user_id,
+            "isTemplate": False,
+            "isArchived": False,
+            "visibility": ResourceVisibility.PRIVATE,
+        }
+    )
+    if expert is None:
+        return _NoGrants(expert_id=expert_id)
+
+    own_sessions = await PrismaChatSession.prisma().find_many(
+        where={"userId": user_id, "expertId": expert_id}
+    )
+    delegated_sessions = await PrismaChatSession.prisma().find_many(
+        where={
+            "userId": user_id,
+            "metadata": cast(
+                prisma.types.JsonFilter,
+                {"path": ["delegated_by_expert_id"], "equals": prisma.Json(expert_id)},
+            ),
+        }
+    )
+    return WorkspaceScope(
+        expert_id=expert_id,
+        session_ids=[row.id for row in own_sessions],
+        delegated_session_ids=[
+            row.id for row in delegated_sessions if row.expertId != expert_id
+        ],
+    )
+
+
+class _NoGrants(WorkspaceScope):
+    """Scope for an expert that no longer exists for this owner."""
+
+    @property
+    def write_prefixes(self) -> list[str]:
+        return [session_path_prefix(s) for s in self.session_ids]

--- a/autogpt_platform/backend/backend/data/workspace_scope_db_test.py
+++ b/autogpt_platform/backend/backend/data/workspace_scope_db_test.py
@@ -1,0 +1,90 @@
+"""Real-database coverage for the expert scope resolver, including the JSON
+metadata filter that grants read access to delegated sub-sessions."""
+
+import uuid
+
+import prisma.models
+import pytest
+
+from backend.copilot.db import create_chat_session
+from backend.copilot.model import ChatSessionMetadata
+from backend.data.user import get_or_create_user
+from backend.data.workspace_scope import resolve_expert_workspace_scope
+from backend.util.test import SpinTestServer
+
+
+async def _user() -> str:
+    suffix = uuid.uuid4().hex[:8]
+    user = await get_or_create_user(
+        {
+            "sub": str(uuid.uuid4()),
+            "email": f"scope-{suffix}@example.com",
+            "name": "Scope Owner",
+        }
+    )
+    return user.id
+
+
+async def _expert(user_id: str, skills: list[str]) -> str:
+    row = await prisma.models.Expert.prisma().create(
+        data={
+            "ownerUserId": user_id,
+            "name": "Nova",
+            "role": "",
+            "identity": "nova",
+            "skills": skills,
+        }
+    )
+    return row.id
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_resolver_collects_own_delegated_and_skill_grants(
+    server: SpinTestServer,
+):
+    owner = await _user()
+    expert_a = await _expert(owner, ["Assigned"])
+    expert_b = await _expert(owner, ["other"])
+    own = await create_chat_session(str(uuid.uuid4()), owner, expert_id=expert_a)
+    foreign = await create_chat_session(str(uuid.uuid4()), owner, expert_id=expert_b)
+    personal = await create_chat_session(str(uuid.uuid4()), owner)
+    delegated = await create_chat_session(
+        str(uuid.uuid4()),
+        owner,
+        expert_id=expert_b,
+        metadata=ChatSessionMetadata(
+            delegated_by_expert_id=expert_a, delegated_by_session_id=own.session_id
+        ),
+    )
+
+    scope = await resolve_expert_workspace_scope(owner, expert_a)
+
+    assert scope.session_ids == [own.session_id]
+    assert scope.delegated_session_ids == [delegated.session_id]
+    assert scope.allows_path(f"/experts/{expert_a}/skills/mine/SKILL.md", write=True)
+    assert not scope.allows_path(f"/experts/{expert_b}/skills/theirs/SKILL.md")
+    assert not scope.allows_path("/skills/autopilot/SKILL.md")
+    assert not scope.allows_path(f"/sessions/{foreign.session_id}/x.txt")
+    assert not scope.allows_path(f"/sessions/{personal.session_id}/x.txt")
+    assert scope.allows_path(f"/sessions/{delegated.session_id}/x.txt")
+    assert not scope.allows_path(f"/sessions/{delegated.session_id}/x.txt", write=True)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_resolver_fails_closed_for_foreign_or_archived_expert(
+    server: SpinTestServer,
+):
+    owner = await _user()
+    stranger = await _user()
+    expert = await _expert(stranger, ["assigned"])
+    await create_chat_session(str(uuid.uuid4()), stranger, expert_id=expert)
+
+    foreign_scope = await resolve_expert_workspace_scope(owner, expert)
+    assert foreign_scope.read_prefixes == []
+    assert not foreign_scope.allows_path(f"/experts/{expert}/skills/x/SKILL.md")
+
+    await prisma.models.Expert.prisma().update(
+        where={"id": expert}, data={"isArchived": True}
+    )
+    archived_scope = await resolve_expert_workspace_scope(stranger, expert)
+    assert archived_scope.read_prefixes == []

--- a/autogpt_platform/backend/backend/data/workspace_scope_test.py
+++ b/autogpt_platform/backend/backend/data/workspace_scope_test.py
@@ -1,0 +1,67 @@
+import pytest
+
+from backend.data import workspace as workspace_module
+from backend.data.workspace_scope import WorkspaceScope, resolve_expert_workspace_scope
+
+SCOPE = WorkspaceScope(
+    expert_id="expert-a",
+    session_ids=["expert-a", "expert-a-old"],
+    delegated_session_ids=["sub-1"],
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/sessions/expert-a/file.txt",
+        "/sessions/expert-a-old/nested/file.txt",
+        "/experts/expert-a/skills/mine/SKILL.md",
+        "/experts/expert-a/skills/mine/references/a.md",
+    ],
+)
+def test_own_sessions_and_own_skills_are_readable_and_writable(path: str):
+    assert SCOPE.allows_path(path)
+    assert SCOPE.allows_path(path, write=True)
+
+
+@pytest.mark.parametrize("path", ["/sessions/sub-1/result.json"])
+def test_delegated_sessions_are_read_only(path: str):
+    assert SCOPE.allows_path(path)
+    assert not SCOPE.allows_path(path, write=True)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/sessions/expert-b/private.txt",
+        "/sessions/personal/private.txt",
+        "/sessions/expert-a-older/private.txt",
+        "/sessions/expert-a/../expert-b/private.txt",
+        "/sessions/expert-a//file.txt",
+        "sessions/expert-a/file.txt",
+        "/sessions/expert-a/..\\expert-b/x",
+        "/skills/autopilot-skill/SKILL.md",
+        "/skills/autopilot-skill/references/private.txt",
+        "/experts/expert-b/skills/theirs/SKILL.md",
+        "/experts/expert-a/skills",
+        "/experts/expert-a-x/skills/mine/SKILL.md",
+        "/root-file.txt",
+    ],
+)
+def test_everything_else_is_denied(path: str):
+    assert not SCOPE.allows_path(path)
+    assert not SCOPE.allows_path(path, write=True)
+
+
+def test_resolver_is_reachable_through_the_direct_db_accessor():
+    assert (
+        workspace_module.resolve_expert_workspace_scope
+        is resolve_expert_workspace_scope
+    )
+
+
+def test_with_session_returns_new_scope_without_mutating():
+    widened = SCOPE.with_session("expert-a-new")
+    assert "expert-a-new" in widened.session_ids
+    assert "expert-a-new" not in SCOPE.session_ids
+    assert widened.with_session("expert-a-new") is widened

--- a/autogpt_platform/backend/backend/util/workspace.py
+++ b/autogpt_platform/backend/backend/util/workspace.py
@@ -16,6 +16,11 @@ from prisma.errors import UniqueViolationError
 from backend.copilot.rate_limit import get_workspace_storage_limit_bytes
 from backend.data.db_accessors import workspace_db
 from backend.data.workspace import WorkspaceFile
+from backend.data.workspace_scope import (
+    EXPERT_FILE_ACCESS_DENIED,
+    WorkspaceAccessDeniedError,
+    WorkspaceScope,
+)
 from backend.util.settings import Config
 from backend.util.virus_scanner import scan_content_safe
 from backend.util.workspace_storage import compute_file_checksum, get_workspace_storage
@@ -48,7 +53,11 @@ class WorkspaceManager:
     """
 
     def __init__(
-        self, user_id: str, workspace_id: str, session_id: Optional[str] = None
+        self,
+        user_id: str,
+        workspace_id: str,
+        session_id: Optional[str] = None,
+        scope: Optional[WorkspaceScope] = None,
     ):
         """
         Initialize WorkspaceManager.
@@ -57,12 +66,33 @@ class WorkspaceManager:
             user_id: The user's ID
             workspace_id: The workspace ID
             session_id: Optional session ID for session-scoped file access
+            scope: Resolved grants for an expert session. ``None`` means the
+                account owner is acting and every file in the workspace is
+                reachable. When set, every operation — by path or by file ID,
+                including listings and counts — is confined to the scope.
         """
         self.user_id = user_id
         self.workspace_id = workspace_id
         self.session_id = session_id
+        self.scope = scope
         # Session path prefix for file isolation
         self.session_path = f"/sessions/{session_id}" if session_id else ""
+
+    def _authorize_path(self, path: str, *, write: bool = False) -> None:
+        if self.scope is not None and not self.scope.allows_path(path, write=write):
+            logger.warning(
+                "Workspace access denied for expert %s (write=%s): %s",
+                self.scope.expert_id,
+                write,
+                path,
+            )
+            raise WorkspaceAccessDeniedError(EXPERT_FILE_ACCESS_DENIED)
+
+    def _authorize_file(self, file: WorkspaceFile, *, write: bool = False) -> None:
+        self._authorize_path(file.path, write=write)
+
+    def _allowed_prefixes(self) -> Optional[list[str]]:
+        return None if self.scope is None else self.scope.read_prefixes
 
     def _resolve_path(self, path: str) -> str:
         """
@@ -137,6 +167,7 @@ class WorkspaceManager:
         """
         db = workspace_db()
         resolved_path = self._resolve_path(path)
+        self._authorize_path(resolved_path)
         file = await db.get_workspace_file_by_path(self.workspace_id, resolved_path)
         if file is None:
             raise FileNotFoundError(f"File not found at path: {resolved_path}")
@@ -161,6 +192,7 @@ class WorkspaceManager:
         file = await db.get_workspace_file(file_id, self.workspace_id)
         if file is None:
             raise FileNotFoundError(f"File not found: {file_id}")
+        self._authorize_file(file)
 
         storage = await get_workspace_storage()
         return await storage.retrieve(file.storage_path)
@@ -218,6 +250,7 @@ class WorkspaceManager:
 
         # Resolve path with session prefix
         path = self._resolve_path(path)
+        self._authorize_path(path, write=True)
 
         # Enforce per-user workspace storage quota (tier-based).
         # For overwrites, subtract the existing file's size so replacing a file
@@ -397,6 +430,7 @@ class WorkspaceManager:
             metadata_not_equals=metadata_not_equals,
             folder_id=folder_id,
             root_only=root_only,
+            allowed_path_prefixes=self._allowed_prefixes(),
         )
 
     async def delete_file(self, file_id: str) -> bool:
@@ -413,6 +447,7 @@ class WorkspaceManager:
         file = await db.get_workspace_file(file_id, self.workspace_id)
         if file is None:
             return False
+        self._authorize_file(file, write=True)
 
         # Delete from storage
         storage = await get_workspace_storage()
@@ -459,6 +494,7 @@ class WorkspaceManager:
         file = await db.get_workspace_file(file_id, self.workspace_id)
         if file is None:
             raise FileNotFoundError(f"File not found: {file_id}")
+        self._authorize_file(file)
 
         storage = await get_workspace_storage()
         return await storage.get_download_url(file.storage_path, expires_in)
@@ -474,7 +510,10 @@ class WorkspaceManager:
             WorkspaceFile instance or None
         """
         db = workspace_db()
-        return await db.get_workspace_file(file_id, self.workspace_id)
+        file = await db.get_workspace_file(file_id, self.workspace_id)
+        if file is not None:
+            self._authorize_file(file)
+        return file
 
     async def get_file_info_by_path(self, path: str) -> Optional[WorkspaceFile]:
         """
@@ -491,6 +530,7 @@ class WorkspaceManager:
         """
         db = workspace_db()
         resolved_path = self._resolve_path(path)
+        self._authorize_path(resolved_path)
         return await db.get_workspace_file_by_path(self.workspace_id, resolved_path)
 
     async def get_file_count(
@@ -516,5 +556,7 @@ class WorkspaceManager:
         db = workspace_db()
 
         return await db.count_workspace_files(
-            self.workspace_id, path_prefix=effective_path
+            self.workspace_id,
+            path_prefix=effective_path,
+            allowed_path_prefixes=self._allowed_prefixes(),
         )

--- a/autogpt_platform/backend/backend/util/workspace_isolation_test.py
+++ b/autogpt_platform/backend/backend/util/workspace_isolation_test.py
@@ -1,0 +1,146 @@
+"""Expert-scoped WorkspaceManager: every path- and ID-based operation must
+stay inside the expert's resolved grants."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.data.workspace_scope import WorkspaceAccessDeniedError, WorkspaceScope
+from backend.util.workspace import WorkspaceManager
+from backend.util.workspace_test import _make_workspace_file
+
+SCOPE = WorkspaceScope(
+    expert_id="expert-a",
+    session_ids=["expert-a", "expert-a-old"],
+    delegated_session_ids=["sub-1"],
+)
+
+
+@pytest.fixture
+def db():
+    db = MagicMock()
+    db.get_workspace_file = AsyncMock(
+        return_value=_make_workspace_file(path="/sessions/expert-b/private.txt")
+    )
+    db.get_workspace_file_by_path = AsyncMock(return_value=_make_workspace_file())
+    db.list_workspace_files = AsyncMock(return_value=[])
+    db.count_workspace_files = AsyncMock(return_value=0)
+    db.soft_delete_workspace_file = AsyncMock()
+    db.get_workspace_total_size = AsyncMock(return_value=0)
+    with patch("backend.util.workspace.workspace_db", return_value=db):
+        yield db
+
+
+@pytest.fixture
+def storage():
+    storage = AsyncMock()
+    storage.retrieve.return_value = b"allowed"
+    with patch("backend.util.workspace.get_workspace_storage", return_value=storage):
+        yield storage
+
+
+def _expert_manager() -> WorkspaceManager:
+    return WorkspaceManager("user-1", "ws-1", "expert-a", scope=SCOPE)
+
+
+def _skills_manager() -> WorkspaceManager:
+    """Session-less manager, as the skills registry builds it."""
+    return WorkspaceManager("user-1", "ws-1", None, scope=SCOPE)
+
+
+@pytest.mark.parametrize(
+    "operation", ["read_file_by_id", "get_file_info", "delete_file", "get_download_url"]
+)
+async def test_foreign_file_id_is_denied(db, storage, operation: str):
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await getattr(_expert_manager(), operation)("foreign-file")
+    storage.retrieve.assert_not_awaited()
+    storage.delete.assert_not_awaited()
+    storage.get_download_url.assert_not_awaited()
+    db.soft_delete_workspace_file.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/sessions/expert-b/private.txt",
+        "/sessions/personal/private.txt",
+        "/sessions/expert-a-older/private.txt",
+        "/sessions/expert-a/../expert-b/private.txt",
+    ],
+)
+async def test_explicit_paths_cannot_escape_scope(db, path: str):
+    manager = _expert_manager()
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await manager.read_file(path)
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await manager.get_file_info_by_path(path)
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await manager.write_file(b"x", "private.txt", path=path, overwrite=True)
+    db.get_workspace_file_by_path.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/skills/autopilot/SKILL.md",
+        "/skills/autopilot/references/private.txt",
+        "/experts/expert-b/skills/theirs/SKILL.md",
+    ],
+)
+async def test_other_owners_skill_files_are_denied(db, path: str):
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await _skills_manager().read_file(path)
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await _skills_manager().write_file(b"x", "f", path=path, overwrite=True)
+    db.get_workspace_file_by_path.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "relative.txt",
+        "/sessions/expert-a-old/file.txt",
+        "/sessions/sub-1/result.json",
+    ],
+)
+async def test_own_and_delegated_paths_are_readable(db, storage, path: str):
+    assert await _expert_manager().read_file(path) == b"allowed"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/experts/expert-a/skills/mine/SKILL.md",
+        "/experts/expert-a/skills/mine/references/file.txt",
+    ],
+)
+async def test_own_skill_files_are_readable(db, storage, path: str):
+    assert await _skills_manager().read_file(path) == b"allowed"
+
+
+async def test_delegated_session_is_not_writable(db):
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await _expert_manager().write_file(
+            b"x", "f", path="/sessions/sub-1/result.json", overwrite=True
+        )
+
+
+async def test_listing_and_counts_are_filtered_inside_the_query(db):
+    manager = _expert_manager()
+    await manager.list_files(include_all_sessions=True, limit=1, offset=4)
+    await manager.get_file_count(include_all_sessions=True)
+    list_kwargs = db.list_workspace_files.call_args.kwargs
+    assert list_kwargs["allowed_path_prefixes"] == SCOPE.read_prefixes
+    assert list_kwargs["path_prefix"] is None
+    assert list_kwargs["offset"] == 4
+    count_kwargs = db.count_workspace_files.call_args.kwargs
+    assert count_kwargs["allowed_path_prefixes"] == SCOPE.read_prefixes
+
+
+async def test_owner_without_scope_keeps_full_access(db, storage):
+    manager = WorkspaceManager("user-1", "ws-1", "personal")
+    assert await manager.read_file("/sessions/expert-b/private.txt") == b"allowed"
+    assert await manager.read_file_by_id("foreign-file") == b"allowed"
+    await manager.list_files(include_all_sessions=True)
+    assert db.list_workspace_files.call_args.kwargs["allowed_path_prefixes"] is None


### PR DESCRIPTION
Related to [SECRT-2598 — Keep each expert's files separate](https://linear.app/autogpt/issue/SECRT-2598).

### Why / What / How

**Why:** An expert chat session could list, read, write, delete, and download any file in the owner's workspace — other experts' sessions, personal AutoPilot sessions, and every `/skills/` file — via `include_all_sessions`, explicit `/sessions/<other>/` paths, or bare file IDs. `WorkspaceManager` scoped only by workspace; `session_id` was a default path prefix, not a boundary.

**What:** Expert sessions are confined to their own sessions (read/write), sessions they delegated (read-only), and their own skills folder. Personal AutoPilot, REST endpoints, and out-of-turn callers stay unrestricted so the account owner keeps full access.

**How:** A `WorkspaceScope` is resolved from the executor's server-loaded session (`session.expert_id`), never from tool arguments, and attached to the `WorkspaceManager`. Every path- and ID-based operation checks it; listings and counts push the allowed prefixes into the SQL query so pagination stays correct.

### Changes 🏗️

- `backend/data/workspace_scope.py`: scope model + DB resolver (own sessions, delegated sessions via `delegated_by_expert_id`, fails closed for missing/archived experts).
- `backend/util/workspace.py`: enforce scope on read/write/delete/download/info; `backend/data/workspace.py`: `allowed_path_prefixes` filter for list/count.
- `backend/copilot/context.py`: `get_workspace_manager` derives the scope from the execution context.
- `workspace_files.py` tools return a clear `access_denied` error.
- Tests: scope unit + DB-backed resolver, manager isolation, context isolation, tool-level isolation.

### Agents and large language models used

Claude Code with Claude Fable 5.1

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Expert B cannot list/read/delete Expert A's files by path or file ID (`workspace_isolation_test`, `workspace_files_isolation_test`)
  - [x] Expert A reads its own older sessions and delegated sub-session files
  - [x] Personal AutoPilot keeps full workspace access
  - [x] Resolver verified against a real database (`workspace_scope_db_test`)

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
