### PR TITLE
feat(backend): add Google Gemini 3.8 Flash support

### DIFF
--- a/autogpt_platform/backend/backend/data/llm_registry/catalog.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/catalog.py
@@ -586,6 +586,20 @@ def _build_catalog() -> CatalogPayload:
                 ),
             ),
             CatalogModel(
+                slug="google/gemini-3.8-flash",
+                display_name="Gemini 3.8 Flash",
+                provider="open_router",
+                creator="google",
+                context_window=1048576,
+                max_output_tokens=65536,
+                price_tier=1,
+                cost=CatalogModelCost(
+                    run_credits=3,
+                    input_credits_per_1m=112.5,
+                    output_credits_per_1m=562.5,
+                ),
+            ),
+            CatalogModel(
                 slug="gryphe/mythomax-l2-13b",
                 display_name="MythoMax L2 13B",
                 provider="open_router",

--- a/autogpt_platform/backend/backend/data/llm_registry/catalog_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/catalog_test.py
@@ -211,9 +211,7 @@ def test_gemini_3_8_flash_bills_at_authored_rates():
         "cache_creation": 0.0,
     }
     assert MODEL_METADATA[flash].max_output_tokens == 65536
-    flash_entry = next(
-        m for m in CATALOG.models if m.slug == "google/gemini-3.8-flash"
-    )
+    flash_entry = next(m for m in CATALOG.models if m.slug == "google/gemini-3.8-flash")
     assert flash_entry.price_tier == 1
     assert flash_entry.context_window == 1048576
 

--- a/autogpt_platform/backend/backend/data/llm_registry/catalog_test.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/catalog_test.py
@@ -198,6 +198,26 @@ def test_claude_fable_5_1_bills_at_authored_rates():
     assert fable_entry.context_window == 200000
 
 
+def test_gemini_3_8_flash_bills_at_authored_rates():
+    """Gemini 3.8 Flash (OpenRouter, Google intro list price $0.75/$3.75
+    per 1M through 2026-12-31) — flat tier and per-1M projections must
+    match the authored catalog entry."""
+    flash = LLMModel("google/gemini-3.8-flash")
+    assert MODEL_COST[flash] == 3
+    assert TOKEN_COST[flash].model_dump() == {
+        "input": 112.5,
+        "output": 562.5,
+        "cache_read": 0.0,
+        "cache_creation": 0.0,
+    }
+    assert MODEL_METADATA[flash].max_output_tokens == 65536
+    flash_entry = next(
+        m for m in CATALOG.models if m.slug == "google/gemini-3.8-flash"
+    )
+    assert flash_entry.price_tier == 1
+    assert flash_entry.context_window == 1048576
+
+
 def test_provider_usd_prices_are_all_or_nothing():
     """A half-authored provider USD price must refuse to construct — it
     would silently underprice against the transport family default."""

--- a/autogpt_platform/backend/backend/data/llm_registry/llm_models.py
+++ b/autogpt_platform/backend/backend/data/llm_registry/llm_models.py
@@ -199,6 +199,7 @@ class LLMModel(str, Enum, metaclass=LLMModelMeta):
     GEMINI_2_5_FLASH = "google/gemini-2.5-flash"
     GEMINI_2_0_FLASH = "google/gemini-2.0-flash-001"
     GEMINI_3_1_FLASH_LITE_PREVIEW = "google/gemini-3.1-flash-lite-preview"
+    GEMINI_3_8_FLASH = "google/gemini-3.8-flash"
     GEMINI_2_5_FLASH_LITE = "google/gemini-2.5-flash-lite"
     GEMINI_2_0_FLASH_LITE = "google/gemini-2.0-flash-lite-001"
     MISTRAL_LARGE_3 = "mistralai/mistral-large-2512"


### PR DESCRIPTION
## Summary
Google released **Gemini 3.8 Flash** (GA 2026-09-02) and it was missing from AutoGPT's LLM catalog. This adds it following the existing catalog-as-code pattern.

## Changes
- **catalog.py**: new `CatalogModel` entry for `google/gemini-3.8-flash` (provider=`open_router`, creator=`google`), placed alongside the other `google/gemini-3.x` entries. `context_window=1048576`, `max_output_tokens=65536`, matching sibling Gemini 3.x entries. No cache-pricing fields, consistent with the other OpenRouter-routed Google models in this catalog.
- **Pricing**: Google's intro list price ($0.75 / $3.75 per 1M input/output tokens, active through 2026-12-31) converted via the catalog's established USD-to-credits factor (×150): `input_credits_per_1m=112.5`, `output_credits_per_1m=562.5`. `run_credits=3`, `price_tier=1` — positioned between `gemini-3-flash-preview` (run_credits=2, tier=1) and `gemini-3.1-pro-preview` (run_credits=5, tier=2), reflecting GA flash-tier pricing above a preview flash model but well below the pro tier.
- **llm_models.py**: added `GEMINI_3_8_FLASH = "google/gemini-3.8-flash"` enum member.
- **catalog_test.py**: added `test_gemini_3_8_flash_bills_at_authored_rates`, pinning `MODEL_COST`, `TOKEN_COST`, `max_output_tokens`, `price_tier`, and `context_window` for the new model.

## Scope note
Checked open PR #14386 ("add direct Google Gemini LLM provider support") — it registers six *existing* Gemini model IDs as part of a separate "direct provider" architecture feature and does not touch `gemini-3.8-flash`, so this is a distinct, non-overlapping addition.

## Verification
Since the full `backend.blocks` import chain requires a generated Prisma client unavailable in this environment, I verified correctness with a standalone script that imports only `backend.data.llm_registry.llm_models` and `backend.data.llm_registry.catalog`, reimplements the same `_model_cost_from_catalog`/`_token_cost_from_catalog` projection logic from `block_cost_config.py`, and asserts against it — confirming `MODEL_COST`, `TOKEN_COST`, and metadata all resolve correctly, and that no `LLMModel` member is missing a cost mapping. All assertions passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive catalog and enum entry with an existing billing guard test; no auth, routing, or execution-path changes beyond making a new model available.
> 
> **Overview**
> Registers **Gemini 3.8 Flash** (`google/gemini-3.8-flash`) in the canonical LLM catalog so it can be selected and billed like other OpenRouter Google Gemini models.
> 
> The new `CatalogModel` sits with the other Gemini 3.x entries: **OpenRouter** routing, 1M context / 65K max output, **tier 1**, and per-token credits derived from Google’s intro list pricing (**3** run credits; **112.5** / **562.5** input/output credits per 1M). `llm_models.py` adds `GEMINI_3_8_FLASH` on the `LLMModel` enum, and `catalog_test.py` adds `test_gemini_3_8_flash_bills_at_authored_rates` so `MODEL_COST`, `TOKEN_COST`, and metadata projections stay aligned with the authored catalog row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5a5b3ed5a7640b4713901684a8d31d7453860d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->