### PR TITLE
feat(frontend): expert new-chat button in the sidebar and expert-aware empty session

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/EmptySession.tsx
@@ -9,8 +9,10 @@ import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { useLayoutEffect, useState } from "react";
 import {
+  getExpertInputPlaceholder,
   getGreetingName,
   getInputPlaceholder,
+  getIntroLine,
   getSuggestionThemes,
 } from "./helpers";
 import { SuggestionThemes } from "./components/SuggestionThemes/SuggestionThemes";
@@ -58,9 +60,15 @@ export function EmptySession({
   const intro = useOnboardingIntroCard();
   const isBrainDumpEnabled = useGetFlag(Flag.ONBOARDING_BRAIN_DUMP);
   const isExpertsEnabled = useGetFlag(Flag.HIRE_EXPERTS);
-  const { options, recipient, isLoadingRecipient, selectRecipient } =
-    useRecipientPicker();
+  const {
+    options,
+    recipient,
+    selectedExpert,
+    isLoadingRecipient,
+    selectRecipient,
+  } = useRecipientPicker();
   const isComposerDisabled = isCreatingSession || !!isInteractionLocked;
+  const introLine = isLoadingRecipient ? null : getIntroLine(selectedExpert);
 
   const { data: suggestedPromptsResponse, isLoading: isLoadingPrompts } =
     useGetV2GetSuggestedPrompts({
@@ -153,7 +161,7 @@ export function EmptySession({
             // moves it there rather than replacing it.
             <GreetingLoader />
           ) : (
-            <EmptyHero name={greetingName} />
+            <EmptyHero name={greetingName} intro={introLine} />
           )}
 
           {/* Held back while the greeting is on its way — it enters with
@@ -190,7 +198,11 @@ export function EmptySession({
                   onSend={onSend}
                   disabled={isComposerDisabled}
                   isUploadingFiles={isUploadingFiles}
-                  placeholder={inputPlaceholder}
+                  placeholder={
+                    selectedExpert
+                      ? getExpertInputPlaceholder(selectedExpert.name)
+                      : inputPlaceholder
+                  }
                   className={
                     isBrainDumpEnabled
                       ? "w-full [&_textarea]:min-h-[4.5rem]"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/__tests__/EmptySession.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/__tests__/EmptySession.test.tsx
@@ -1,0 +1,107 @@
+import { getListExpertIdentitiesMockHandler } from "@/app/api/__generated__/endpoints/experts/experts.msw";
+import type { Expert } from "@/app/api/__generated__/models/expert";
+import { server } from "@/mocks/mock-server";
+import {
+  normalizeWhitespace,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+import { withNuqsTestingAdapter } from "nuqs/adapters/testing";
+import { describe, expect, it, vi } from "vitest";
+
+import { EmptySession } from "../EmptySession";
+
+vi.mock("@/lib/auth/hooks/useAuth", () => ({
+  useAuth: () => ({ user: null, isUserLoading: false, isLoggedIn: true }),
+}));
+
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    useGetFlag: (flag: string) => flag === "hire-experts",
+    useFlagStatus: () => ({ enabled: false, ready: true }),
+  };
+});
+
+function makeExpert(args: { id: string; name: string; role: string }): Expert {
+  return {
+    ...args,
+    avatar_url: `https://example.com/${args.id}.png`,
+    bio: null,
+    skills: [],
+    tagline: "",
+    identity: `You are ${args.name}.`,
+    voice_preferences: "",
+    boundaries: "",
+    protected_soul_rules: [],
+    is_template: false,
+    source_template_id: `template-${args.id}`,
+    is_archived: false,
+    workflows: [],
+  };
+}
+
+const mariaExpert = makeExpert({
+  id: "expert-maria",
+  name: "Maria",
+  role: "Marketing Strategist",
+});
+const maxExpert = makeExpert({ id: "expert-max", name: "Max", role: "" });
+
+function renderEmptySession(searchParams: string) {
+  server.use(getListExpertIdentitiesMockHandler([mariaExpert, maxExpert]));
+  const Wrapper = withNuqsTestingAdapter({ searchParams });
+  return render(
+    <Wrapper>
+      <EmptySession
+        isCreatingSession={false}
+        onCreateSession={() => {}}
+        onSend={() => {}}
+      />
+    </Wrapper>,
+  );
+}
+
+describe("EmptySession — recipient-aware intro", () => {
+  it("introduces the selected expert by name and role", async () => {
+    const { container } = renderEmptySession("?expertId=expert-maria");
+
+    await waitFor(() =>
+      expect(normalizeWhitespace(container)).toContain(
+        "I'm Maria, your Marketing Strategist. What should I take on?",
+      ),
+    );
+    expect(
+      screen.getByPlaceholderText("What should Maria work on?"),
+    ).toBeDefined();
+  });
+
+  it("drops the role clause when the expert has none", async () => {
+    const { container } = renderEmptySession("?expertId=expert-max");
+
+    await waitFor(() =>
+      expect(normalizeWhitespace(container)).toContain(
+        "I'm Max. What should I take on?",
+      ),
+    );
+    expect(
+      screen.getByPlaceholderText("What should Max work on?"),
+    ).toBeDefined();
+  });
+
+  it("keeps the Autopilot intro without a selected expert", async () => {
+    const { container } = renderEmptySession("");
+
+    await waitFor(() =>
+      expect(normalizeWhitespace(container)).toContain(
+        "Tell me about your work — I'll find what to automate.",
+      ),
+    );
+    expect(screen.getByPlaceholderText(/What's your role/)).toBeDefined();
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/__tests__/EmptySession.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/__tests__/EmptySession.test.tsx
@@ -52,9 +52,12 @@ const mariaExpert = makeExpert({
   role: "Marketing Strategist",
 });
 const maxExpert = makeExpert({ id: "expert-max", name: "Max", role: "" });
+const samExpert = makeExpert({ id: "expert-sam", name: "Sam", role: "Sales" });
 
 function renderEmptySession(searchParams: string) {
-  server.use(getListExpertIdentitiesMockHandler([mariaExpert, maxExpert]));
+  server.use(
+    getListExpertIdentitiesMockHandler([mariaExpert, maxExpert, samExpert]),
+  );
   const Wrapper = withNuqsTestingAdapter({ searchParams });
   return render(
     <Wrapper>
@@ -79,6 +82,16 @@ describe("EmptySession — recipient-aware intro", () => {
     expect(
       screen.getByPlaceholderText("What should Maria work on?"),
     ).toBeDefined();
+  });
+
+  it("calls a bare-domain role an expert so the line still reads", async () => {
+    const { container } = renderEmptySession("?expertId=expert-sam");
+
+    await waitFor(() =>
+      expect(normalizeWhitespace(container)).toContain(
+        "I'm Sam, your Sales expert. What should I take on?",
+      ),
+    );
   });
 
   it("drops the role clause when the expert has none", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EmptyHero.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/components/EmptyHero.tsx
@@ -6,12 +6,15 @@ import { EditNameDialog } from "./EditNameDialog/EditNameDialog";
 
 interface Props {
   name: string;
+  /** Null holds the line back (recipient still resolving) without moving
+   * the composer below it. */
+  intro: string | null;
 }
 
 // The regular empty-session hero. While a greeting is being written
 // GreetingLoader renders in its place instead, and its orb travels into
 // the intro card's heading under a shared layout id.
-export function EmptyHero({ name }: Props) {
+export function EmptyHero({ name, intro }: Props) {
   return (
     <>
       <div className="mb-1 flex items-center justify-center gap-3">
@@ -20,11 +23,19 @@ export function EmptyHero({ name }: Props) {
           <EditNameDialog currentName={name} />
         </Text>
       </div>
-      <TextGenerateEffect
-        className="mb-8 !font-normal [&>div]:!mt-0 [&_div]:!text-[1.375rem] [&_div]:!leading-normal [&_div]:!tracking-normal"
-        duration={0.6}
-        words="Tell me about your work — I'll find what to automate."
-      />
+      {intro === null ? (
+        <div aria-hidden className="mb-8 text-[1.375rem] leading-normal">
+          &nbsp;
+        </div>
+      ) : (
+        // Keyed on the text so switching recipient re-types the line.
+        <TextGenerateEffect
+          key={intro}
+          className="mb-8 !font-normal [&>div]:!mt-0 [&_div]:!text-[1.375rem] [&_div]:!leading-normal [&_div]:!tracking-normal"
+          duration={0.6}
+          words={intro}
+        />
+      )}
     </>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { getExpertRoleLabel, getIntroLine } from "./helpers";
+
+describe("getExpertRoleLabel", () => {
+  // The nine roles the hire flow offers as presets (RoleStep/helpers.ts), which
+  // is the shape most hired experts will carry.
+  test.each([
+    ["Marketer", "Marketer"],
+    ["Developer", "Developer"],
+    ["Researcher", "Researcher"],
+    ["Writer", "Writer"],
+    ["Analyst", "Analyst"],
+    ["Recruiter", "Recruiter"],
+    ["Sales", "Sales expert"],
+    ["Support", "Support expert"],
+    ["Operations", "Operations expert"],
+  ])("labels the %s preset as %s", (role, expected) => {
+    expect(getExpertRoleLabel(role)).toBe(expected);
+  });
+
+  test.each([
+    ["Marketing Strategist", "Marketing Strategist"],
+    ["Product Manager", "Product Manager"],
+    ["Finance Director", "Finance Director"],
+    ["Executive Assistant", "Executive Assistant"],
+    ["Data Scientist", "Data Scientist"],
+    ["Technician", "Technician"],
+  ])("leaves the person-shaped custom role %s alone", (role, expected) => {
+    expect(getExpertRoleLabel(role)).toBe(expected);
+  });
+
+  test.each([
+    ["Marketing", "Marketing expert"],
+    ["Customer Success", "Customer Success expert"],
+    ["Social Media", "Social Media expert"],
+    ["SEO", "SEO expert"],
+    ["Legal", "Legal expert"],
+  ])("calls the bare-domain custom role %s an expert", (role, expected) => {
+    expect(getExpertRoleLabel(role)).toBe(expected);
+  });
+
+  // Only the head noun decides: "Customer" would pass the suffix test alone.
+  test("judges a multi-word role by its last word", () => {
+    expect(getExpertRoleLabel("Customer")).toBe("Customer");
+    expect(getExpertRoleLabel("Customer Care")).toBe("Customer Care expert");
+  });
+});
+
+describe("getIntroLine", () => {
+  test("introduces an expert whose role names a person", () => {
+    expect(getIntroLine({ name: "Maria", role: "Marketing Strategist" })).toBe(
+      "I'm Maria, your Marketing Strategist. What should I take on?",
+    );
+  });
+
+  test("introduces an expert whose role is a bare domain", () => {
+    expect(getIntroLine({ name: "Sam", role: "Sales" })).toBe(
+      "I'm Sam, your Sales expert. What should I take on?",
+    );
+  });
+
+  test("drops the role clause when there is no role", () => {
+    expect(getIntroLine({ name: "Max", role: null })).toBe(
+      "I'm Max. What should I take on?",
+    );
+    expect(getIntroLine({ name: "Max", role: "   " })).toBe(
+      "I'm Max. What should I take on?",
+    );
+  });
+
+  test("falls back to the Autopilot line without an expert", () => {
+    expect(getIntroLine(null)).toBe(
+      "Tell me about your work — I'll find what to automate.",
+    );
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.ts
@@ -3,13 +3,45 @@ import type { User } from "@/lib/auth/types";
 export const AUTOPILOT_INTRO =
   "Tell me about your work — I'll find what to automate.";
 
+// A role is free text, and the hire flow's own presets come in both shapes:
+// some name a person ("Marketer", "Analyst"), others just a domain ("Sales",
+// "Support", "Operations"). "I'm Max, your Sales." reads as an unfinished
+// sentence, so a domain gets "expert" appended while a role that already
+// names a person is used as it was written.
+const PERSON_NOUN_SUFFIXES = ["er", "or", "ist", "yst", "ant", "ian"];
+// Person-nouns that none of the suffixes catch.
+const PERSON_NOUNS = new Set([
+  "agent",
+  "assistant",
+  "chef",
+  "chief",
+  "expert",
+  "head",
+  "lead",
+  "pro",
+  "rep",
+  "specialist",
+]);
+
+function namesAPerson(role: string) {
+  // Only the last word decides: "Customer Success" is a domain even though
+  // "Customer" would pass the suffix test on its own.
+  const head = role.split(/\s+/).pop()?.toLowerCase() ?? "";
+  if (PERSON_NOUNS.has(head)) return true;
+  return PERSON_NOUN_SUFFIXES.some((suffix) => head.endsWith(suffix));
+}
+
+export function getExpertRoleLabel(role: string) {
+  return namesAPerson(role) ? role : `${role} expert`;
+}
+
 export function getIntroLine(
   expert: { name: string; role: string | null } | null,
 ) {
   if (!expert) return AUTOPILOT_INTRO;
   const role = expert.role?.trim();
   return role
-    ? `I'm ${expert.name}, your ${role}. What should I take on?`
+    ? `I'm ${expert.name}, your ${getExpertRoleLabel(role)}. What should I take on?`
     : `I'm ${expert.name}. What should I take on?`;
 }
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/helpers.ts
@@ -1,5 +1,22 @@
 import type { User } from "@/lib/auth/types";
 
+export const AUTOPILOT_INTRO =
+  "Tell me about your work — I'll find what to automate.";
+
+export function getIntroLine(
+  expert: { name: string; role: string | null } | null,
+) {
+  if (!expert) return AUTOPILOT_INTRO;
+  const role = expert.role?.trim();
+  return role
+    ? `I'm ${expert.name}, your ${role}. What should I take on?`
+    : `I'm ${expert.name}. What should I take on?`;
+}
+
+export function getExpertInputPlaceholder(expertName: string) {
+  return `What should ${expertName} work on?`;
+}
+
 export function getInputPlaceholder(width?: number) {
   if (!width) return "What's your role and what eats up most of your day?";
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/useRecipientPicker.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/useRecipientPicker.ts
@@ -34,6 +34,9 @@ export function useRecipientPicker() {
     [activeExpertIds, hasExpertsSettled, expertIdParam, setExpertIdParam],
   );
 
+  const selectedExpert =
+    activeExperts.find((expert) => expert.id === expertIdParam) ?? null;
+
   const options: RecipientOption[] = [
     AUTOPILOT_RECIPIENT,
     ...activeExperts.map((expert) => ({
@@ -48,6 +51,7 @@ export function useRecipientPicker() {
     recipient:
       options.find((option) => option.id === expertIdParam) ??
       AUTOPILOT_RECIPIENT,
+    selectedExpert,
     // Only a pending param can be mis-rendered as "Autopilot"; without one the
     // fallback is already the right answer.
     isLoadingRecipient: isLoadingExperts && !!expertIdParam,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/useRecipientPicker.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/EmptySession/useRecipientPicker.ts
@@ -13,7 +13,7 @@ export function useRecipientPicker() {
   const {
     activeExperts,
     activeExpertIds,
-    isLoadingExperts,
+    isExpertsEnabled,
     hasExpertsSettled,
   } = useExpertMap();
   const [expertIdParam, setExpertIdParam] = useQueryState(
@@ -53,8 +53,13 @@ export function useRecipientPicker() {
       AUTOPILOT_RECIPIENT,
     selectedExpert,
     // Only a pending param can be mis-rendered as "Autopilot"; without one the
-    // fallback is already the right answer.
-    isLoadingRecipient: isLoadingExperts && !!expertIdParam,
+    // fallback is already the right answer. Keyed on "not settled yet" rather
+    // than "fetching": an initial query that is pending but paused (offline)
+    // reports `isFetching: false` while it still has no roster to resolve
+    // against. Gated on the flag because with experts off the roster never
+    // settles and the Autopilot fallback is the only correct answer.
+    isLoadingRecipient:
+      isExpertsEnabled && !hasExpertsSettled && !!expertIdParam,
     selectRecipient(id: string | null) {
       void setExpertIdParam(id);
     },

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/useExpertMap.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/useExpertMap.ts
@@ -109,6 +109,7 @@ export function useExpertMap() {
   const canAddressExperts = isExpertsEnabled && !expertsQuery.isError;
 
   return {
+    isExpertsEnabled,
     expertsById: isExpertsEnabled ? expertCollections.expertsById : EMPTY_MAP,
     activeExperts: canAddressExperts
       ? expertCollections.activeExperts

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/RecentChats.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/RecentChats.tsx
@@ -11,19 +11,8 @@ import { Icon } from "@/components/atoms/Icon/Icon";
 import { PinIcon } from "@hugeicons/core-free-icons";
 import { ExpertChatGroup } from "./components/ExpertChatGroup/ExpertChatGroup";
 import { RecentChatItem } from "./components/RecentChatItem/RecentChatItem";
-import { groupSessionsByDate } from "./helpers";
+import { getNewChatHref, groupSessionsByDate } from "./helpers";
 import { useRecentChats } from "./useRecentChats";
-
-// Fired experts can't be addressed, so their group gets no new-chat entry:
-// the deep link would only fall back to Autopilot.
-function getNewChatHref(
-  expertId: string | null,
-  activeExpertIds: ReadonlySet<string>,
-) {
-  if (!expertId) return "/copilot";
-  if (!activeExpertIds.has(expertId)) return null;
-  return `/copilot?expertId=${encodeURIComponent(expertId)}`;
-}
 
 export function RecentChats() {
   const chatSharingEnabled = useGetFlag(Flag.CHAT_SHARING);

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/RecentChats.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/RecentChats.tsx
@@ -14,11 +14,22 @@ import { RecentChatItem } from "./components/RecentChatItem/RecentChatItem";
 import { groupSessionsByDate } from "./helpers";
 import { useRecentChats } from "./useRecentChats";
 
+// Fired experts can't be addressed, so their group gets no new-chat entry:
+// the deep link would only fall back to Autopilot.
+function getNewChatHref(
+  expertId: string | null,
+  activeExpertIds: ReadonlySet<string>,
+) {
+  if (!expertId) return "/copilot";
+  if (!activeExpertIds.has(expertId)) return null;
+  return `/copilot?expertId=${encodeURIComponent(expertId)}`;
+}
+
 export function RecentChats() {
   const chatSharingEnabled = useGetFlag(Flag.CHAT_SHARING);
   const chatPinningEnabled = useGetFlag(Flag.CHAT_PINNING);
   const isExpertsEnabled = useGetFlag(Flag.HIRE_EXPERTS);
-  const { expertsById } = useExpertMap();
+  const { expertsById, activeExpertIds } = useExpertMap();
   const {
     sessions,
     isLoading,
@@ -116,6 +127,7 @@ export function RecentChats() {
                     group.expertId ? (expert?.name ?? "Expert") : "Autopilot"
                   }
                   avatarUrl={expert?.avatarUrl ?? null}
+                  newChatHref={getNewChatHref(group.expertId, activeExpertIds)}
                   sessions={group.sessions}
                   renderItem={renderItem}
                 />

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/__tests__/expert-groups.test.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/__tests__/expert-groups.test.tsx
@@ -239,4 +239,39 @@ describe("RecentChats — expert groups", () => {
     expect(screen.getByText("autopilot chat 11")).toBeDefined();
     expect(screen.queryByText("expert-maria chat 1")).toBeNull();
   });
+
+  it("links each group header to a new chat, except for fired experts", async () => {
+    const maxExpert: Expert = {
+      ...mariaExpert,
+      id: "expert-max",
+      name: "Max",
+      is_archived: true,
+    };
+    const sessions = [
+      ...makeSessions(1),
+      ...makeSessions(1, mariaExpert.id),
+      ...makeSessions(1, maxExpert.id),
+    ];
+    server.use(
+      getGetV2ListSessionsMockHandler200({ sessions, total: sessions.length }),
+      getListExpertIdentitiesMockHandler([mariaExpert, maxExpert]),
+    );
+    renderRecentChats();
+
+    const mariaLink = await screen.findByRole("link", {
+      name: "New chat with Maria",
+    });
+    expect(mariaLink.getAttribute("href")).toBe(
+      "/copilot?expertId=expert-maria",
+    );
+    expect(
+      screen
+        .getByRole("link", { name: "New chat with Autopilot" })
+        .getAttribute("href"),
+    ).toBe("/copilot");
+    expect(groupHeader("Max")).toBeDefined();
+    expect(
+      screen.queryByRole("link", { name: "New chat with Max" }),
+    ).toBeNull();
+  });
 });

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/components/ExpertChatGroup/ExpertChatGroup.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/components/ExpertChatGroup/ExpertChatGroup.tsx
@@ -28,6 +28,14 @@ import { ReactNode, useState } from "react";
 
 export const EXPERT_GROUP_PREVIEW_COUNT = 10;
 
+// The chevron, the slot the header reserves next to it, and the new-chat link
+// that floats over that slot are all one size.
+const CHEVRON_SIZE_CLASS = "size-5";
+// Where that slot starts, measured in from the header's right edge: the
+// trigger's `px-2` (0.5rem) + the chevron's `size-5` (1.25rem) + the `gap-2`
+// between them (0.5rem) = 2.25rem. Change any of the three and this moves.
+const NEW_CHAT_LINK_OFFSET_CLASS = "right-9";
+
 interface Props {
   label: string;
   avatarUrl: string | null;
@@ -56,7 +64,8 @@ export function ExpertChatGroup({
       className="group/expert-group"
     >
       {/* The trigger is itself a button, so the new-chat link sits beside it
-          and floats over a slot the trigger reserves. */}
+          and floats over a slot the trigger reserves before the chevron —
+          long labels then truncate against the link rather than under it. */}
       <div className="group/expert-header relative mb-1 flex items-center rounded-md hover:bg-zinc-100">
         <CollapsibleTrigger
           aria-label={`${label} chats`}
@@ -72,12 +81,16 @@ export function ExpertChatGroup({
           </Avatar>
           <span className="truncate">{label}</span>
           {newChatHref && (
-            <span aria-hidden className="ml-auto size-5 shrink-0" />
+            <span
+              aria-hidden
+              className={cn("ml-auto shrink-0", CHEVRON_SIZE_CLASS)}
+            />
           )}
           <Icon
             icon={ArrowDown01Icon}
             className={cn(
-              "ease-[cubic-bezier(0.33,1,0.68,1)] size-5 shrink-0 text-zinc-400 transition-transform duration-200 group-data-[state=open]/expert-group:rotate-180 motion-reduce:transition-none",
+              "ease-[cubic-bezier(0.33,1,0.68,1)] shrink-0 text-zinc-400 transition-transform duration-200 group-data-[state=open]/expert-group:rotate-180 motion-reduce:transition-none",
+              CHEVRON_SIZE_CLASS,
               !newChatHref && "ml-auto",
             )}
           />
@@ -121,7 +134,11 @@ function NewChatLink({ href, label }: { href: string; label: string }) {
         <Link
           href={href}
           aria-label={name}
-          className="absolute right-9 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-zinc-500 transition-opacity group-focus-within/expert-header:opacity-100 group-hover/expert-header:opacity-100 hover:bg-zinc-200 hover:text-zinc-900 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 md:opacity-0"
+          className={cn(
+            "absolute top-1/2 flex -translate-y-1/2 items-center justify-center rounded-md text-zinc-500 transition-opacity group-focus-within/expert-header:opacity-100 group-hover/expert-header:opacity-100 hover:bg-zinc-200 hover:text-zinc-900 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 md:opacity-0",
+            CHEVRON_SIZE_CLASS,
+            NEW_CHAT_LINK_OFFSET_CLASS,
+          )}
         >
           <NewChatIcon />
         </Link>

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/components/ExpertChatGroup/ExpertChatGroup.tsx
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/components/ExpertChatGroup/ExpertChatGroup.tsx
@@ -8,13 +8,22 @@ import {
 } from "@/components/atoms/Avatar/Avatar";
 import { AutoGPTLogo } from "@/components/atoms/AutoGPTLogo/AutoGPTLogo";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import { LoadingSpinner } from "@/components/atoms/LoadingSpinner/LoadingSpinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from "@/components/atoms/Tooltip/BaseTooltip";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { SidebarMenu } from "@/components/ui/sidebar";
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { cn } from "@/lib/utils";
+import { ArrowDown01Icon, PlusSignIcon } from "@hugeicons/core-free-icons";
+import Link, { useLinkStatus } from "next/link";
 import { ReactNode, useState } from "react";
 
 export const EXPERT_GROUP_PREVIEW_COUNT = 10;
@@ -22,6 +31,7 @@ export const EXPERT_GROUP_PREVIEW_COUNT = 10;
 interface Props {
   label: string;
   avatarUrl: string | null;
+  newChatHref: string | null;
   sessions: SessionSummaryResponse[];
   renderItem: (session: SessionSummaryResponse) => ReactNode;
 }
@@ -29,6 +39,7 @@ interface Props {
 export function ExpertChatGroup({
   label,
   avatarUrl,
+  newChatHref,
   sessions,
   renderItem,
 }: Props) {
@@ -44,24 +55,35 @@ export function ExpertChatGroup({
       onOpenChange={setIsOpen}
       className="group/expert-group"
     >
-      <CollapsibleTrigger
-        aria-label={`${label} chats`}
-        className="mb-1 flex w-full items-center gap-2 rounded-md px-2 py-0.5 text-left text-sm font-medium text-zinc-900 hover:bg-zinc-100"
-      >
-        <Avatar className="h-6 w-6">
-          {avatarUrl ? (
-            <AvatarImage src={avatarUrl} alt={label} width={48} height={48} />
-          ) : null}
-          <AvatarFallback>
-            <AutoGPTLogo hideText viewBox="47 -1 42 42" className="size-4" />
-          </AvatarFallback>
-        </Avatar>
-        <span className="truncate">{label}</span>
-        <Icon
-          icon={ArrowDown01Icon}
-          className="ease-[cubic-bezier(0.33,1,0.68,1)] ml-auto size-5 shrink-0 text-zinc-400 transition-transform duration-200 group-data-[state=open]/expert-group:rotate-180 motion-reduce:transition-none"
-        />
-      </CollapsibleTrigger>
+      {/* The trigger is itself a button, so the new-chat link sits beside it
+          and floats over a slot the trigger reserves. */}
+      <div className="group/expert-header relative mb-1 flex items-center rounded-md hover:bg-zinc-100">
+        <CollapsibleTrigger
+          aria-label={`${label} chats`}
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-0.5 text-left text-sm font-medium text-zinc-900"
+        >
+          <Avatar className="h-6 w-6">
+            {avatarUrl ? (
+              <AvatarImage src={avatarUrl} alt={label} width={48} height={48} />
+            ) : null}
+            <AvatarFallback>
+              <AutoGPTLogo hideText viewBox="47 -1 42 42" className="size-4" />
+            </AvatarFallback>
+          </Avatar>
+          <span className="truncate">{label}</span>
+          {newChatHref && (
+            <span aria-hidden className="ml-auto size-5 shrink-0" />
+          )}
+          <Icon
+            icon={ArrowDown01Icon}
+            className={cn(
+              "ease-[cubic-bezier(0.33,1,0.68,1)] size-5 shrink-0 text-zinc-400 transition-transform duration-200 group-data-[state=open]/expert-group:rotate-180 motion-reduce:transition-none",
+              !newChatHref && "ml-auto",
+            )}
+          />
+        </CollapsibleTrigger>
+        {newChatHref && <NewChatLink href={newChatHref} label={label} />}
+      </div>
 
       {!isOpen && runningSessions.length > 0 && (
         <GroupBody>
@@ -88,6 +110,37 @@ export function ExpertChatGroup({
       </CollapsibleContent>
     </Collapsible>
   );
+}
+
+function NewChatLink({ href, label }: { href: string; label: string }) {
+  const name = `New chat with ${label}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Link
+          href={href}
+          aria-label={name}
+          className="absolute right-9 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-zinc-500 transition-opacity group-focus-within/expert-header:opacity-100 group-hover/expert-header:opacity-100 hover:bg-zinc-200 hover:text-zinc-900 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 md:opacity-0"
+        >
+          <NewChatIcon />
+        </Link>
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent side="top">{name}</TooltipContent>
+      </TooltipPortal>
+    </Tooltip>
+  );
+}
+
+function NewChatIcon() {
+  const { pending } = useLinkStatus();
+
+  if (pending) {
+    return <LoadingSpinner size="small" className="!size-4 text-zinc-500" />;
+  }
+
+  return <Icon icon={PlusSignIcon} className="size-4" />;
 }
 
 function GroupBody({ children }: { children: ReactNode }) {

--- a/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/helpers.ts
+++ b/autogpt_platform/frontend/src/components/layout/AppSidebar/components/RecentChats/helpers.ts
@@ -67,3 +67,14 @@ export function groupSessionsByDate<T extends { updated_at: string }>(
     .sort((a, b) => b[0] - a[0])
     .map(([, group]) => group);
 }
+
+// Fired experts can't be addressed, so their group gets no new-chat entry:
+// the deep link would only fall back to Autopilot.
+export function getNewChatHref(
+  expertId: string | null,
+  activeExpertIds: ReadonlySet<string>,
+) {
+  if (!expertId) return "/copilot";
+  if (!activeExpertIds.has(expertId)) return null;
+  return `/copilot?expertId=${encodeURIComponent(expertId)}`;
+}


### PR DESCRIPTION
### Why / What / How

**Why:** With experts enabled, the sidebar's "Recent chats" groups threads by expert, but starting a new chat with a given expert meant leaving the sidebar (Home → Chat, or the expert's marketplace page). And once you land on the empty session with an expert selected, the hero still spoke as Autopilot ("Tell me about your work — I'll find what to automate.") with an Autopilot-flavoured placeholder, so nothing told you who you were about to talk to.

**What:**
1. Each expert group header in the sidebar shows a small `+` link next to the collapse chevron that opens a fresh chat with that expert. The Autopilot group gets one too.
2. The empty session's intro line and composer placeholder follow the selected recipient (`?expertId=`), for every hired expert.

**How:**
- Sidebar: the header row wraps the existing `CollapsibleTrigger` and a sibling `Link` (a button can't nest inside a button). The trigger reserves a slot before the chevron so long names truncate before the `+` rather than underneath it. The link is hover/focus-revealed on desktop and always visible on touch, matching the `⋯` action on chat rows. It points at `/copilot?expertId=<id>` (or `/copilot` for Autopilot), the same deep link the Home page and hire flow already use. Fired experts are skipped: their deep link would only fall back to Autopilot.
- Empty session: `useRecipientPicker` already reads `?expertId=`; it now also exposes the selected expert identity (name + role from the identities endpoint the page already fetches). Copy:

  | Recipient | Intro line | Placeholder |
  |---|---|---|
  | Autopilot | Tell me about your work — I'll find what to automate. | unchanged (width-dependent) |
  | Expert whose role names a person | I'm Maria, your Marketing Strategist. What should I take on? | What should Maria work on? |
  | Expert whose role is a bare domain | I'm Sam, your Sales expert. What should I take on? | What should Sam work on? |
  | Expert without role | I'm Max. What should I take on? | What should Max work on? |

  The line is keyed on its text so switching recipient re-types it, and held back (same height) while a deep-linked expert is still resolving so the Autopilot line never flashes first.

### Changes 🏗️

- `ExpertChatGroup`: new `newChatHref` prop; header becomes a `group/expert-header` row with the trigger plus a hover-revealed `NewChatLink` (tooltip, `aria-label`, pending-navigation spinner via `useLinkStatus`).
- `RecentChats`: computes the href per group from `useExpertMap().activeExpertIds` (`null` for archived/unknown experts).
- `useRecipientPicker`: returns `selectedExpert` next to the chip `recipient`/`options`.
- `EmptySession/helpers.ts`: `getIntroLine(expert)`, `getExpertRoleLabel(role)` and `getExpertInputPlaceholder(name)`. `role` is free text and the hire flow's own presets come in both shapes — some name a person (`Marketer`, `Analyst`, `Writer`), others are a bare domain (`Sales`, `Support`, `Operations`). `"I'm Max, your Sales."` reads as an unfinished sentence, so a domain gets "expert" appended while a role that already names a person is used as written.
- `EmptyHero`: takes `intro: string | null`; null renders a same-height spacer.
- `EmptySession`: derives intro and placeholder from the selected expert, no new state.
- Tests: `expert-groups.test.tsx` covers the sidebar hrefs and the archived-expert omission; new `EmptySession.test.tsx` covers a person-shaped role, a bare-domain role, no role, and the Autopilot fallback.

### Agents and large language models used

- Claude Code with Claude Fable 5.1

### Checklist 📋

#### For code changes:
- [ ] I have clearly listed my changes in the PR description
- [ ] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] `prettier`, `eslint`, and `tsc --noEmit` pass on the changed files (done locally)
  - [ ] `expert-groups.test.tsx` and `EmptySession.test.tsx` pass in CI (not run locally)
  - [ ] Hover an expert group header: `+` appears left of the chevron, row stays highlighted while hovering the `+`
  - [ ] Click `+` on Maria: lands on `/copilot?expertId=…`, chip reads Maria, hero reads "I'm Maria, your <role>. What should I take on?", placeholder "What should Maria work on?"
  - [ ] Switch the chip to Max, then to Autopilot: the line re-types each time and the placeholder follows
  - [ ] Reload on `/copilot?expertId=…`: no Autopilot line flashes before the expert line
  - [ ] Click `+` on Autopilot: lands on `/copilot` with the original copy
  - [ ] Fired expert group has no `+`
  - [ ] Tab to the `+` with the keyboard: it becomes visible and the tooltip reads "New chat with <name>"
  - [ ] Long expert name truncates before the `+`, not under it

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

