### PR TITLE
fix(frontend): improve mobile chat and expert layouts

### DIFF
--- a/autogpt_platform/frontend/src/app/(no-navbar)/share/chat/[token]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/share/chat/[token]/page.tsx
@@ -35,7 +35,7 @@ function SharedChatChrome({
   children: ReactNode;
 }) {
   return (
-    <div className="flex h-screen w-full flex-col bg-background">
+    <div className="flex h-dvh min-h-0 w-full flex-col bg-background">
       <ShareHeader
         title={title}
         subtitle={subtitle}
@@ -151,8 +151,10 @@ export default function SharedChatPage() {
           // revoked link.  Keep the chrome (so the viewer knows the
           // share is real) and show an inline retry instead of the
           // permanent not-found card.
-          <div className="flex shrink-0 items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900">
-            <span>Couldn&apos;t load messages. The share link is valid.</span>
+          <div className="flex shrink-0 flex-col items-start gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+            <span className="min-w-0">
+              Couldn&apos;t load messages. The share link is valid.
+            </span>
             <button
               onClick={retry}
               className="rounded border border-amber-300 bg-white px-2 py-0.5 font-medium hover:bg-amber-100"

--- a/autogpt_platform/frontend/src/app/(no-navbar)/share/components/ShareHeader/ShareActions.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/share/components/ShareHeader/ShareActions.tsx
@@ -44,6 +44,7 @@ export function ShareActions() {
       <Button
         size="small"
         variant="secondary"
+        className="min-w-0 sm:min-w-[5.5rem]"
         onClick={handleCopy}
         leftIcon={
           copied ? (
@@ -59,7 +60,13 @@ export function ShareActions() {
           CTA — flickering it in then out on hydration looks broken to
           signed-in users opening their own share. */}
       {!isUserLoading && !isLoggedIn && (
-        <Button size="small" variant="primary" as="NextLink" href="/signup">
+        <Button
+          size="small"
+          variant="primary"
+          as="NextLink"
+          href="/signup"
+          className="min-w-0 sm:min-w-[5.5rem]"
+        >
           Sign up
         </Button>
       )}

--- a/autogpt_platform/frontend/src/app/(no-navbar)/share/components/ShareHeader/ShareHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/share/components/ShareHeader/ShareHeader.tsx
@@ -26,7 +26,7 @@ export function ShareHeader({ title, subtitle, actions }: Props) {
     <header
       className={
         "grid shrink-0 grid-cols-[1fr_auto] grid-rows-[auto_auto] gap-x-4 " +
-        "gap-y-2 border-b border-border bg-background px-4 py-3 " +
+        "gap-y-2 border-b border-border bg-background px-4 pb-3 pt-[max(0.75rem,env(safe-area-inset-top))] " +
         "[grid-template-areas:'logo_logo'_'title_actions'] " +
         "sm:grid-cols-[1fr_auto_1fr] sm:grid-rows-1 " +
         "sm:items-center sm:[grid-template-areas:'title_logo_actions']"

--- a/autogpt_platform/frontend/src/app/(no-navbar)/share/components/ShareHeader/__tests__/ShareActions.test.tsx
+++ b/autogpt_platform/frontend/src/app/(no-navbar)/share/components/ShareHeader/__tests__/ShareActions.test.tsx
@@ -43,9 +43,13 @@ describe("ShareActions", () => {
     });
     render(<ShareActions />);
 
-    expect(screen.getByRole("button", { name: /copy link/i })).toBeDefined();
+    const copy = screen.getByRole("button", { name: /copy link/i });
+    expect(copy.className).toContain("min-w-0");
+    expect(copy.className).toContain("sm:min-w-[5.5rem]");
     const signUp = screen.getByRole("link", { name: /sign up/i });
     expect(signUp.getAttribute("href")).toBe("/signup");
+    expect(signUp.className).toContain("min-w-0");
+    expect(signUp.className).toContain("sm:min-w-[5.5rem]");
   });
 
   test("hides Sign up CTA when the viewer is signed in", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/BuilderChatPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/BuilderChatPanel.tsx
@@ -49,7 +49,10 @@ export function BuilderChatPanel({ className }: Props) {
   return (
     <div
       className={cn(
-        "pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col items-end gap-2",
+        "pointer-events-none fixed z-50 flex flex-col",
+        isOpen
+          ? "inset-0 items-stretch gap-0 sm:bottom-4 sm:left-auto sm:right-4 sm:top-auto sm:items-end sm:gap-2"
+          : "bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 items-end gap-2",
         className,
       )}
     >
@@ -59,7 +62,7 @@ export function BuilderChatPanel({ className }: Props) {
             ref={panelRef}
             role="complementary"
             aria-label="Builder chat panel"
-            className="pointer-events-auto flex h-[70vh] max-h-[calc(100vh-6rem)] w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-2xl sm:h-[75vh]"
+            className="pointer-events-auto flex h-dvh max-h-none w-full max-w-none flex-col overflow-hidden bg-white sm:h-[75vh] sm:max-h-[calc(100dvh-6rem)] sm:w-[26rem] sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:border sm:border-slate-200 sm:shadow-2xl"
           >
             <PanelHeader
               onClose={handleToggle}
@@ -101,7 +104,7 @@ export function BuilderChatPanel({ className }: Props) {
                       queuedMessages={queuedMessages}
                     />
                   </div>
-                  <div className="relative shrink-0 border-t border-slate-100 bg-white px-3 pb-2 pt-2">
+                  <div className="relative shrink-0 border-t border-slate-100 bg-white px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-2">
                     <ChatInput
                       inputId="builder-chat-input"
                       onSend={onSend}
@@ -130,7 +133,8 @@ export function BuilderChatPanel({ className }: Props) {
         aria-expanded={isOpen}
         aria-label={isOpen ? "Close chat" : "Chat with builder"}
         className={cn(
-          "pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-colors",
+          "pointer-events-auto h-12 w-12 items-center justify-center rounded-full shadow-lg transition-colors",
+          isOpen ? "hidden sm:flex" : "flex",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 focus-visible:ring-offset-2",
           isOpen
             ? "bg-slate-800 text-white hover:bg-slate-700"

--- a/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/__tests__/BuilderChatPanel.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/build/components/BuilderChatPanel/__tests__/BuilderChatPanel.test.tsx
@@ -76,6 +76,19 @@ describe("BuilderChatPanel", () => {
     expect(screen.getByRole("complementary")).toBeDefined();
   });
 
+  it("uses a full viewport panel on phones and preserves the floating desktop panel", () => {
+    mockUseBuilderChatPanel.mockReturnValue(makeMockHook({ isOpen: true }));
+    render(<BuilderChatPanel />);
+
+    const panel = screen.getByRole("complementary");
+    expect(panel.className).toContain("h-dvh");
+    expect(panel.className).toContain("max-w-none");
+    expect(panel.className).toContain("sm:w-[26rem]");
+    expect(screen.getByLabelText("Close chat").className).toContain(
+      "hidden sm:flex",
+    );
+  });
+
   it("shows bootstrapping state when isBootstrapping is true", () => {
     mockUseBuilderChatPanel.mockReturnValue(
       makeMockHook({ isOpen: true, isBootstrapping: true }),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/CopilotPage.tsx
@@ -77,13 +77,12 @@ export function CopilotPage() {
       // content height and the accordion pushes the input below the fold.
       // The new layout gets the full viewport — its inset header overlays the
       // chat (see PlatformChrome) instead of stacking above it. The classic
-      // layout subtracts the navbar + preview banner. `svh` keeps the input
-      // visible when mobile browser chrome is shown.
+      // layout subtracts the navbar + preview banner.
       style={
         showNewLayout
-          ? { height: "100svh" }
+          ? { height: "100dvh" }
           : {
-              height: `calc(100vh - ${NAVBAR_HEIGHT_PX}px - var(--preview-banner-height, 0px))`,
+              height: `calc(100dvh - ${NAVBAR_HEIGHT_PX}px - var(--preview-banner-height, 0px))`,
             }
       }
       className="min-h-0"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ArtifactPanel/ArtifactPanel.tsx
@@ -102,7 +102,7 @@ export function ArtifactPanel({ mobile, hasExternalClose }: Props) {
             aria-hidden="true"
           />
           <Drawer.Content
-            className="fixed right-0 top-0 z-[70] flex h-full w-full flex-col bg-white shadow-xl outline-none"
+            className="fixed right-0 top-0 z-[70] flex h-dvh w-full flex-col bg-white pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] shadow-xl outline-none sm:w-[min(36rem,100vw)]"
             style={{ userSelect: "text" }}
             aria-describedby={undefined}
           >

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatContainer/ChatContainer.tsx
@@ -294,7 +294,7 @@ export const ChatContainer = ({
                     animate={{ opacity: 1 }}
                     transition={{ duration: 0.3 }}
                     className={cn(
-                      "ease-[cubic-bezier(0.32,0.72,0,1)] relative mx-auto w-full max-w-3xl px-3 pb-6 pt-2 transition-transform duration-300 will-change-transform motion-reduce:transition-none",
+                      "ease-[cubic-bezier(0.32,0.72,0,1)] relative mx-auto w-full max-w-3xl px-3 pb-[max(1.5rem,env(safe-area-inset-bottom))] pt-2 transition-transform duration-300 will-change-transform motion-reduce:transition-none",
                       areFilesOpen && "xl:-translate-x-40",
                     )}
                   >

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/ChatInput.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/ChatInput.tsx
@@ -23,7 +23,6 @@ import {
 } from "react";
 import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
 import {
-  type Attachment,
   type WorkspaceAttachment,
   partitionAttachments,
   workspaceItemToAttachment,
@@ -47,6 +46,7 @@ import {
   getFilesFromClipboard,
 } from "./helpers";
 import { useChatInput } from "./useChatInput";
+import { useChatInputDraft } from "./useChatInputDraft";
 import { useChatMentions } from "./useChatMentions";
 import { useOnboardingMicGlow } from "./useOnboardingMicGlow";
 import { useVoiceRecording } from "./useVoiceRecording";
@@ -86,6 +86,7 @@ interface Props {
   /** Compact composer for side panels: tighter radius, flat shadow, smaller
    *  controls, and no per-message connection chip. */
   variant?: "default" | "compact";
+  draft?: ReturnType<typeof useChatInputDraft>;
 }
 
 export function ChatInput({
@@ -106,6 +107,7 @@ export function ChatInput({
   recipientPicker,
   stacked = false,
   variant = "default",
+  draft,
 }: Props) {
   const { isDryRun, setIsDryRun } = useCopilotUIStore();
   // Still the CHAT_MODE_OPTION flag, which no longer names what it gates: the
@@ -115,7 +117,9 @@ export function ChatInput({
   // hide both survivors until someone created them.
   const showAdvancedComposerControls = useGetFlag(Flag.CHAT_MODE_OPTION);
   const showWorkspaceFiles = useGetFlag(Flag.CHAT_WORKSPACE_FILES);
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const localDraft = useChatInputDraft();
+  const currentDraft = draft ?? localDraft;
+  const { attachments, setAttachments } = currentDraft;
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [isMultiline, setIsMultiline] = useState(false);
 
@@ -139,7 +143,7 @@ export function ChatInput({
       ]);
       onDroppedFilesConsumed?.();
     }
-  }, [droppedFiles, onDroppedFilesConsumed]);
+  }, [droppedFiles, onDroppedFilesConsumed, setAttachments]);
 
   const hasAttachments = attachments.length > 0;
   // isBusy disables non-essential interactions (attachment menu, voice recording)
@@ -176,6 +180,7 @@ export function ChatInput({
     disabled: isTextareaDisabled,
     canSendEmpty: hasAttachments,
     inputId,
+    draft: currentDraft,
   });
 
   const mentions = useChatMentions({
@@ -369,7 +374,7 @@ export function ChatInput({
               onMultilineChange={setIsMultiline}
               className={cn(
                 stacked && "px-0.5 py-1",
-                isCompact && "text-sm leading-5 md:text-sm",
+                isCompact && "text-base leading-5 md:text-sm",
               )}
             />
             {isRecording && !value && (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInput.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInput.ts
@@ -1,6 +1,7 @@
 import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
+import type { useChatInputDraft } from "./useChatInputDraft";
 
 interface Args {
   onSend: (message: string) => void;
@@ -8,6 +9,7 @@ interface Args {
   /** Allow sending when text is empty (e.g. when files are attached). */
   canSendEmpty?: boolean;
   inputId?: string;
+  draft?: Pick<ReturnType<typeof useChatInputDraft>, "value" | "setValue">;
 }
 
 export function useChatInput({
@@ -15,8 +17,11 @@ export function useChatInput({
   disabled = false,
   canSendEmpty = false,
   inputId = "chat-input",
+  draft,
 }: Args) {
-  const [value, setValue] = useState("");
+  const [localValue, setLocalValue] = useState("");
+  const value = draft?.value ?? localValue;
+  const setValue = draft?.setValue ?? setLocalValue;
   const [isSending, setIsSending] = useState(false);
   // Synchronous guard against double-submit — refs update immediately,
   // unlike state which batches and can leave a gap for a second call.
@@ -39,7 +44,7 @@ export function useChatInput({
       ) as HTMLTextAreaElement | null;
       textarea?.focus();
     },
-    [initialPrompt, setInitialPrompt, inputId],
+    [initialPrompt, setInitialPrompt, inputId, setValue],
   );
 
   useEffect(

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInputDraft.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInputDraft.ts
@@ -1,0 +1,9 @@
+import { useState } from "react";
+import type { Attachment } from "../../helpers/workspaceAttachments";
+
+export function useChatInputDraft() {
+  const [value, setValue] = useState("");
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+
+  return { value, setValue, attachments, setAttachments };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/ContextPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ContextPanel/ContextPanel.tsx
@@ -53,7 +53,7 @@ export function ContextPanel({ sessionId, mobile }: Props) {
       >
         <SheetContent
           side="right"
-          className="flex w-full flex-col p-0 sm:max-w-full"
+          className="flex w-full flex-col p-0 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] sm:max-w-xl"
         >
           <SheetHeader className="mt-12 p-2 text-left">
             <SheetTitle className="text-sm font-medium text-zinc-900">

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/MobileHeader/MobileHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/MobileHeader/MobileHeader.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@/components/atoms/Button/Button";
-import { NAVBAR_HEIGHT_PX } from "@/lib/constants";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { useCopilotUIStore } from "../../store";
 import { Folder01Icon, Menu01Icon } from "@hugeicons/core-free-icons";
@@ -10,10 +9,7 @@ export function MobileHeader() {
   const toggleContextPanel = useCopilotUIStore((s) => s.toggleContextPanel);
   const isContextPanelEnabled = useGetFlag(Flag.ARTIFACTS);
   return (
-    <div
-      className="fixed z-50 flex gap-2"
-      style={{ left: "1rem", top: `${NAVBAR_HEIGHT_PX + 20}px` }}
-    >
+    <div className="z-10 flex shrink-0 gap-2 px-4 pt-4">
       <Button
         variant="icon"
         size="icon"

--- a/autogpt_platform/frontend/src/app/(platform)/settings/memory/components/MemoryChatPanel/MemoryChatPanel.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/memory/components/MemoryChatPanel/MemoryChatPanel.tsx
@@ -45,12 +45,12 @@ export function MemoryChatPanel({
   const isStreaming = status === "streaming" || status === "submitted";
 
   return (
-    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col items-end">
+    <div className="pointer-events-none fixed inset-0 z-50 flex flex-col items-stretch sm:bottom-4 sm:left-auto sm:right-4 sm:top-auto sm:items-end">
       <CopilotChatActionsProvider onSend={onSend}>
         <div
           role="complementary"
           aria-label="Memory chat panel"
-          className="pointer-events-auto flex h-[70vh] max-h-[calc(100vh-6rem)] w-[26rem] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-2xl sm:h-[75vh]"
+          className="pointer-events-auto flex h-dvh max-h-none w-full max-w-none flex-col overflow-hidden bg-white sm:h-[75vh] sm:max-h-[calc(100dvh-6rem)] sm:w-[26rem] sm:max-w-[calc(100vw-2rem)] sm:rounded-xl sm:border sm:border-zinc-200 sm:shadow-2xl"
         >
           <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-3">
             <div className="flex items-center gap-2">
@@ -98,7 +98,7 @@ export function MemoryChatPanel({
                     queuedMessages={queuedMessages}
                   />
                 </div>
-                <div className="relative shrink-0 border-t border-zinc-100 bg-white px-3 pb-2 pt-2">
+                <div className="relative shrink-0 border-t border-zinc-100 bg-white px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-2">
                   <ChatInput
                     inputId="memory-chat-input"
                     onSend={onSend}

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertIntegrationsSection/ExpertConnectServiceDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertIntegrationsSection/ExpertConnectServiceDialog.tsx
@@ -142,7 +142,7 @@ export function ExpertConnectServiceDialog({
                       </Text>
                     </div>
                     {isLoading ? (
-                      <div className="grid grid-cols-2 gap-2">
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                         {[0, 1, 2, 3].map((row) => (
                           <Skeleton
                             key={row}
@@ -202,7 +202,7 @@ export function ExpertConnectServiceDialog({
                           <div className="relative">
                             <ul
                               ref={attachList}
-                              className="grid grid-cols-2 gap-2 overflow-y-auto pr-1"
+                              className="grid grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2"
                               aria-label="Services"
                             >
                               {providers.map((provider) => (

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertIntegrationsSection/UseExistingCredentialsDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertIntegrationsSection/UseExistingCredentialsDialog.tsx
@@ -189,7 +189,7 @@ export function UseExistingCredentialsDialog({
                 <div className="relative">
                   <ul
                     ref={attachList}
-                    className="grid grid-cols-2 gap-2 overflow-y-auto pr-1"
+                    className="grid grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2"
                     aria-label="Existing connections"
                   >
                     {groups.map((group) => (

--- a/autogpt_platform/frontend/src/app/(platform)/team/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/__tests__/main.test.tsx
@@ -301,6 +301,126 @@ describe("TeamPage", () => {
     ).toBeDefined();
   });
 
+  test("keeps an expert chat draft when resizing between phone and desktop", async () => {
+    server.use(
+      getListExpertsMockHandler([hiredMaria]),
+      getGetV2ListSessionsMockHandler200({ sessions: [], total: 0 }),
+    );
+    const originalWidth = window.innerWidth;
+    const user = userEvent.setup();
+    function resize(width: number) {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: width,
+      });
+      fireEvent(window, new Event("resize"));
+    }
+    try {
+      resize(360);
+      render(<TeamPage />);
+      await screen.findByText("Maria");
+      await user.click(screen.getAllByRole("button", { name: "Chat" })[1]);
+      await screen.findByRole("dialog", { name: "Chat with Maria" });
+      await user.type(
+        screen.getByPlaceholderText("Message Maria…"),
+        "Keep my draft",
+      );
+      const fileInput = screen
+        .getByRole("dialog", { name: "Chat with Maria" })
+        .querySelector<HTMLInputElement>('input[type="file"]');
+      if (!fileInput) throw new Error("Missing composer file input");
+      await user.upload(
+        fileInput,
+        new File(["draft attachment"], "mobile-note.txt", {
+          type: "text/plain",
+        }),
+      );
+      expect(screen.getByText("mobile-note.txt")).toBeDefined();
+      resize(728);
+      expect(
+        (screen.getByPlaceholderText("Message Maria…") as HTMLTextAreaElement)
+          .value,
+      ).toBe("Keep my draft");
+      resize(1024);
+      await screen.findByRole("complementary", { name: "Chat with Maria" });
+      expect(
+        (screen.getByPlaceholderText("Message Maria…") as HTMLTextAreaElement)
+          .value,
+      ).toBe("Keep my draft");
+      expect(screen.getByText("mobile-note.txt")).toBeDefined();
+      resize(360);
+      await screen.findByRole("dialog", { name: "Chat with Maria" });
+      expect(
+        (screen.getByPlaceholderText("Message Maria…") as HTMLTextAreaElement)
+          .value,
+      ).toBe("Keep my draft");
+      expect(screen.getByText("mobile-note.txt")).toBeDefined();
+      await user.click(
+        screen.getByRole("button", { name: "Close chat panel" }),
+      );
+      await user.click(screen.getAllByRole("button", { name: "Chat" })[0]);
+      await screen.findByRole("dialog", { name: "Chat with Autopilot" });
+      await waitFor(() => {
+        expect(
+          (
+            screen.getByPlaceholderText(
+              "Message Autopilot…",
+            ) as HTMLTextAreaElement
+          ).value,
+        ).toBe("");
+        expect(screen.queryByText("mobile-note.txt")).toBeNull();
+      });
+    } finally {
+      resize(originalWidth);
+    }
+  });
+
+  test("keeps unsaved Soul edits when resizing between phone and desktop", async () => {
+    server.use(getListExpertsMockHandler([hiredMaria]));
+    const originalWidth = window.innerWidth;
+    const user = userEvent.setup();
+    function resize(width: number) {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: width,
+      });
+      fireEvent(window, new Event("resize"));
+    }
+    try {
+      resize(360);
+      render(<TeamPage />);
+      await user.click(
+        await screen.findByRole("button", { name: "Edit Soul" }),
+      );
+      await screen.findByRole("dialog", { name: "Maria's Soul" });
+      await user.clear(screen.getByLabelText("Identity and personality"));
+      await user.type(
+        screen.getByLabelText("Identity and personality"),
+        "Keep my unsaved expert edit",
+      );
+      resize(1024);
+      await screen.findByRole("complementary", { name: "Maria's Soul" });
+      expect(
+        (
+          screen.getByLabelText(
+            "Identity and personality",
+          ) as HTMLTextAreaElement
+        ).value,
+      ).toBe("Keep my unsaved expert edit");
+      resize(360);
+      await screen.findByRole("dialog", { name: "Maria's Soul" });
+      expect(
+        (
+          screen.getByLabelText(
+            "Identity and personality",
+          ) as HTMLTextAreaElement
+        ).value,
+      ).toBe("Keep my unsaved expert edit");
+    } finally {
+      resize(originalWidth);
+    }
+  });
+
   test("counts the integrations an expert has been granted", async () => {
     const credentialRequests = vi.fn();
     server.use(

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/ExpertChatDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/ExpertChatDrawer.tsx
@@ -151,7 +151,7 @@ function ChatPanelBody({ target, identity, chat }: BodyProps) {
             </div>
           </div>
         )}
-        <div className="shrink-0 px-3 pb-5 pt-2">
+        <div className="shrink-0 px-3 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-2">
           <ChatInput
             inputId="expert-chat-input"
             variant="compact"

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/ExpertChatDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/ExpertChatDrawer.tsx
@@ -99,6 +99,7 @@ interface BodyProps {
 
 function ChatPanelBody({ target, identity, chat }: BodyProps) {
   const {
+    draft,
     sessionId,
     messages,
     status,
@@ -155,6 +156,7 @@ function ChatPanelBody({ target, identity, chat }: BodyProps) {
           <ChatInput
             inputId="expert-chat-input"
             variant="compact"
+            draft={draft}
             onSend={onSend}
             disabled={isResolvingSession || isCreating}
             isStreaming={isStreaming}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/useExpertChatDrawer.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/ExpertChatDrawer/useExpertChatDrawer.ts
@@ -1,4 +1,5 @@
 import { convertChatSessionMessagesToUiMessages } from "@/app/(platform)/copilot/helpers/convertChatSessionToUiMessages";
+import { useChatInputDraft } from "@/app/(platform)/copilot/components/ChatInput/useChatInputDraft";
 import { queueFollowUpMessage } from "@/app/(platform)/copilot/helpers/queueFollowUpMessage";
 import { latestExpertSessionParams } from "@/app/(platform)/copilot/expertSessionQuery";
 import { useCopilotPendingChips } from "@/app/(platform)/copilot/useCopilotPendingChips";
@@ -36,6 +37,9 @@ export function useExpertChatDrawer({
   seedPrompt,
 }: Args) {
   const expertId = target?.expertId ?? null;
+  const draft = useChatInputDraft();
+  const { setValue: setDraftValue, setAttachments: setDraftAttachments } =
+    draft;
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [skipLatest, setSkipLatest] = useState(false);
@@ -114,7 +118,9 @@ export function useExpertChatDrawer({
     setMessages([]);
     pendingPromptRef.current = null;
     setSeedToSend(seedPrompt);
-  }, [threadKey, seedPrompt, setMessages]);
+    setDraftValue("");
+    setDraftAttachments([]);
+  }, [threadKey, seedPrompt, setMessages, setDraftValue, setDraftAttachments]);
 
   const startSessionRef = useRef(startSession);
   startSessionRef.current = startSession;
@@ -139,6 +145,8 @@ export function useExpertChatDrawer({
     setSessionId(null);
     setMessages([]);
     pendingPromptRef.current = null;
+    setDraftValue("");
+    setDraftAttachments([]);
   }
 
   async function startSession(firstMessage: string) {
@@ -207,6 +215,7 @@ export function useExpertChatDrawer({
   const isResolvingSession = !sessionId && wantsLatest && latestQuery.isLoading;
 
   return {
+    draft,
     sessionId,
     startNewThread,
     messages,

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulDrawer.tsx
@@ -19,6 +19,7 @@ interface Props {
 }
 
 export function SoulDrawer({ expert, onClose }: Props) {
+  const editor = useSoulDrawer({ expert, onClose });
   return (
     <ExpertSidePanel
       identity={
@@ -29,7 +30,9 @@ export function SoulDrawer({ expert, onClose }: Props) {
       closeLabel="Close Soul panel"
       onClose={onClose}
     >
-      {expert ? <SoulPanelBody expert={expert} onClose={onClose} /> : null}
+      {expert ? (
+        <SoulPanelBody expert={expert} onClose={onClose} editor={editor} />
+      ) : null}
     </ExpertSidePanel>
   );
 }
@@ -37,13 +40,11 @@ export function SoulDrawer({ expert, onClose }: Props) {
 interface BodyProps {
   expert: Expert;
   onClose: () => void;
+  editor: ReturnType<typeof useSoulDrawer>;
 }
 
-function SoulPanelBody({ expert, onClose }: BodyProps) {
-  const { soul, updateField, save, isPending, canSave } = useSoulDrawer({
-    expert,
-    onClose,
-  });
+function SoulPanelBody({ expert, onClose, editor }: BodyProps) {
+  const { soul, updateField, save, isPending, canSave } = editor;
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null,
   );

--- a/autogpt_platform/frontend/src/app/(platform)/team/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/helpers.ts
@@ -81,7 +81,7 @@ export function getAutopilotSkills(
 /** Sized by the available width, not the viewport, so the roster reflows
  *  when a side panel takes space. */
 export const TEAM_GRID_CLASS =
-  "grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4";
+  "grid grid-cols-[repeat(auto-fill,minmax(min(100%,300px),1fr))] gap-4";
 
 /** Mirrors `CreatePodRequest.name`'s `max_length` on the backend. */
 export const POD_NAME_MAX_LENGTH = 100;

--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatContainer/TourChatContainer.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatContainer/TourChatContainer.tsx
@@ -23,7 +23,7 @@ export function TourChatContainer({ chat }: Props) {
           footer={isDemoComplete ? <TourEndCard /> : null}
         />
         {!isDemoComplete && (
-          <div className="relative px-3 pb-2 pt-2">
+          <div className="relative px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-2">
             <TourPromptBar
               key={`${chat.turnIndex}:${chat.currentUserPrompt ?? ""}`}
               prompt={chat.currentUserPrompt}

--- a/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatHeader/TourChatHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(public)/tour/chat/components/TourChatHeader/TourChatHeader.tsx
@@ -17,7 +17,7 @@ export function TourChatHeader({ scenarioLabel, scenarioIcon }: Props) {
   const { isCopied, handleShare } = useTourChatHeader();
 
   return (
-    <header className="flex shrink-0 items-center justify-between gap-2 border-b border-zinc-200/70 bg-white/70 px-3 py-2 backdrop-blur-sm md:px-4">
+    <header className="flex shrink-0 items-center justify-between gap-2 border-b border-zinc-200/70 bg-white/70 px-3 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))] backdrop-blur-sm md:px-4">
       <div className="flex min-w-0 items-center gap-1.5">
         {/* On mobile this is the only way to reach the sidebar. */}
         <div className="md:hidden">
@@ -42,9 +42,12 @@ export function TourChatHeader({ scenarioLabel, scenarioIcon }: Props) {
             <Icon icon={Link02Icon} className="size-4" />
           )
         }
-        className="shrink-0"
+        className="min-w-0 shrink-0 sm:min-w-[5.5rem]"
       >
-        <span>{isCopied ? "Link copied" : "Share this demo"}</span>
+        <span className="sm:hidden">{isCopied ? "Copied" : "Share"}</span>
+        <span className="hidden sm:inline">
+          {isCopied ? "Link copied" : "Share this demo"}
+        </span>
       </Button>
     </header>
   );

--- a/autogpt_platform/frontend/src/app/layout.tsx
+++ b/autogpt_platform/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { fonts } from "@/components/styles/fonts";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import React from "react";
 
 import "./globals.css";
@@ -24,6 +24,10 @@ const faviconPath = isDev
   : isLocal
     ? "/favicon-local.ico"
     : "/favicon.ico";
+
+export const viewport: Viewport = {
+  interactiveWidget: "resizes-content",
+};
 
 export const metadata: Metadata = {
   title: "AutoGPT Platform",

--- a/autogpt_platform/frontend/src/components/molecules/FullscreenDialog/FullscreenDialog.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/FullscreenDialog/FullscreenDialog.tsx
@@ -20,7 +20,7 @@ export function FullscreenDialog({ title, onClose, children }: Props) {
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-background" />
         <Dialog.Content
-          className="fixed inset-0 z-50 flex flex-col bg-background"
+          className="fixed inset-0 z-50 flex flex-col bg-background pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]"
           aria-describedby={undefined}
           onOpenAutoFocus={() => {
             previousFocus.current =

--- a/autogpt_platform/frontend/src/components/molecules/FullscreenDialog/__tests__/FullscreenDialog.test.tsx
+++ b/autogpt_platform/frontend/src/components/molecules/FullscreenDialog/__tests__/FullscreenDialog.test.tsx
@@ -29,6 +29,8 @@ test("focuses and traps the mobile panel, hides the background, and restores foc
   await waitFor(() =>
     expect(dialog.contains(document.activeElement)).toBe(true),
   );
+  expect(dialog.className).toContain("safe-area-inset-top");
+  expect(dialog.className).toContain("safe-area-inset-bottom");
   expect(
     screen.queryByRole("button", { name: "Background action" }),
   ).toBeNull();


### PR DESCRIPTION
### Why / What / How

Chat panels and expert dialogs need to fit narrow phones and adapt when a foldable changes width. This draft starts the responsive pass with full-screen builder and memory chat below 640px, compact share controls, safe-area spacing, and single-column expert connection dialogs on phones. Larger breakpoints retain the existing desktop layout.

Work is ongoing. Before/after screenshots, iPhone-size checks, fold/unfold transition checks, and desktop comparisons will be attached as each surface is verified. Chat and experts are first; admin pages follow.

### Changes 🏗️

- Make builder and memory chat use the available mobile viewport, keeping floating panels at larger widths.
- Add mobile safe-area spacing to chat composers, headers, and expert overlays.
- Compact shared-chat and tour actions on narrow screens, and stack shared-chat error controls.
- Fit context and artifact drawers to phone and small-tablet widths.
- Stack expert connection and existing-credential cards below the small breakpoint.
- Extend focused component coverage for the initial responsive changes.

### Agents and large language models used

OpenAI Codex with GPT-6; earlier session work used another Codex model whose exact version is unavailable.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Run whole-frontend formatting, lint, type checking, and integration tests; attach results.
  - [ ] Verify chat and expert surfaces at 402px, 360px, and 728px widths, including live fold/unfold transitions with draft text preserved.
  - [ ] Verify breakpoint edges at 640px, 768px, and 1024px and compare the 1440px desktop layout.
  - [ ] Upload before/after screenshots for every changed surface.
  - [ ] Exercise overflow, error, dialog-close, and keyboard-focus cases.

<details>
  <summary>Example test plan</summary>

  - [ ] Create from scratch and execute an agent with at least 3 blocks
  - [ ] Import an agent from file upload, and confirm it executes correctly
  - [ ] Upload agent to marketplace
  - [ ] Import an agent from marketplace and confirm it executes correctly
  - [ ] Edit an agent from monitor, and confirm it executes correctly
</details>

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

<details>
  <summary>Examples of configuration changes</summary>

  - Changing ports
  - Adding new services that need to communicate with each other
  - Secrets or environment variable changes
  - New or infrastructure changes such as databases
</details>
