### PR TITLE
fix(backend): use the timezone AutoPilot was given when scheduling an agent

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/run_agent.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent.py
@@ -1159,12 +1159,9 @@ class RunAgentTool(BaseTool):
                 session_id=session_id,
             )
 
-        # Get or create library agent
-        library_agent = await get_or_create_library_agent(graph, user_id)
-        emit_tool_display_name(library_agent.name)
-
         # Precedence mirrors POST /graphs/{graph_id}/schedules: an explicit
         # timezone wins over the user's stored preference, which wins over UTC.
+        # Resolved before the library agent, so a rejected timezone persists nothing.
         if timezone:
             # Never silently downgrade to UTC here — the model has already told
             # the user which timezone it is scheduling in.
@@ -1182,6 +1179,10 @@ class RunAgentTool(BaseTool):
         else:
             user = await user_db().get_user_by_id(user_id)
             user_timezone = get_user_timezone_or_utc(user.timezone)
+
+        # Get or create library agent
+        library_agent = await get_or_create_library_agent(graph, user_id)
+        emit_tool_display_name(library_agent.name)
 
         # Create schedule — the scheduler re-validates credentials via
         # ``validate_and_construct_node_execution_input`` and will raise

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent.py
@@ -28,6 +28,7 @@ from backend.util.exceptions import (
 from backend.util.timezone_utils import (
     convert_utc_time_to_user_timezone,
     get_user_timezone_or_utc,
+    validate_timezone,
 )
 
 from .base import BaseTool
@@ -117,7 +118,7 @@ class RunAgentInput(BaseModel):
     use_defaults: bool = False
     schedule_name: str = ""
     cron: str = ""
-    timezone: str = "UTC"
+    timezone: str = ""
     wait_for_result: int = Field(default=0, ge=0, le=MAX_TOOL_WAIT_SECONDS)
     dry_run: bool = Field(default=False)
     save_as_preset: bool = False
@@ -208,7 +209,7 @@ class RunAgentTool(BaseTool):
                 },
                 "timezone": {
                     "type": "string",
-                    "description": "IANA timezone (default: UTC).",
+                    "description": "IANA timezone for the cron expression. Omit to use the user's configured timezone.",
                 },
                 "wait_for_result": {
                     "type": "integer",
@@ -1162,9 +1163,25 @@ class RunAgentTool(BaseTool):
         library_agent = await get_or_create_library_agent(graph, user_id)
         emit_tool_display_name(library_agent.name)
 
-        # Get user timezone
-        user = await user_db().get_user_by_id(user_id)
-        user_timezone = get_user_timezone_or_utc(user.timezone if user else timezone)
+        # Precedence mirrors POST /graphs/{graph_id}/schedules: an explicit
+        # timezone wins over the user's stored preference, which wins over UTC.
+        if timezone:
+            # Never silently downgrade to UTC here — the model has already told
+            # the user which timezone it is scheduling in.
+            if not validate_timezone(timezone):
+                return ErrorResponse(
+                    message=(
+                        f"'{timezone}' is not a valid IANA timezone. Use a name "
+                        "like 'Europe/London', or omit it to use the user's "
+                        "configured timezone."
+                    ),
+                    error="invalid_timezone",
+                    session_id=session_id,
+                )
+            user_timezone = timezone
+        else:
+            user = await user_db().get_user_by_id(user_id)
+            user_timezone = get_user_timezone_or_utc(user.timezone)
 
         # Create schedule — the scheduler re-validates credentials via
         # ``validate_and_construct_node_execution_input`` and will raise

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 
 from backend.data.execution import ExecutionStatus
+from backend.data.model import USER_TIMEZONE_NOT_SET
 from backend.executor.scheduler import GraphExecutionJobInfo
 from backend.executor.utils import is_credential_validation_error_message
 from backend.util.exceptions import (
@@ -901,6 +902,118 @@ async def test_run_agent_schedule_structural_error_returns_error_response(
     # user should see the validation error, not the credential setup card.
     assert result_data.get("error") == "graph_validation_failed"
     assert result_data.get("type") != "setup_requirements"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_schedule_prefers_explicit_timezone_over_stored_preference(
+    setup_test_data,
+):
+    """The QA repro: AutoPilot asks for a timezone, confirms it back to the
+    user, and the schedule must be created in that one — not the profile's."""
+    _, fake_scheduler = await _schedule_with_timezone(
+        setup_test_data,
+        stored_timezone="Europe/Amsterdam",
+        timezone="Europe/London",
+    )
+
+    kwargs = fake_scheduler.add_execution_schedule.await_args.kwargs
+    assert kwargs["user_timezone"] == "Europe/London"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_schedule_without_explicit_timezone_uses_stored_preference(
+    setup_test_data,
+):
+    _, fake_scheduler = await _schedule_with_timezone(
+        setup_test_data, stored_timezone="Europe/Amsterdam"
+    )
+
+    kwargs = fake_scheduler.add_execution_schedule.await_args.kwargs
+    assert kwargs["user_timezone"] == "Europe/Amsterdam"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_schedule_falls_back_to_utc_when_user_has_no_timezone(
+    setup_test_data,
+):
+    _, fake_scheduler = await _schedule_with_timezone(
+        setup_test_data, stored_timezone=USER_TIMEZONE_NOT_SET
+    )
+
+    kwargs = fake_scheduler.add_execution_schedule.await_args.kwargs
+    assert kwargs["user_timezone"] == "UTC"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_schedule_rejects_invalid_explicit_timezone(setup_test_data):
+    """An unknown timezone is refused, never silently downgraded to UTC —
+    the model has already told the user which timezone it is scheduling in."""
+    response, fake_scheduler = await _schedule_with_timezone(
+        setup_test_data,
+        stored_timezone="Europe/Amsterdam",
+        timezone="Mars/Olympus_Mons",
+    )
+
+    assert response is not None
+    assert isinstance(response.output, str)
+    result_data = orjson.loads(response.output)
+    assert result_data.get("error") == "invalid_timezone"
+    assert "Mars/Olympus_Mons" in result_data["message"]
+    assert fake_scheduler.add_execution_schedule.await_count == 0
+
+
+async def _schedule_with_timezone(
+    setup_test_data, *, stored_timezone: str, **run_agent_kwargs
+):
+    """Schedule an agent and hand back (response, scheduler mock)."""
+    user = setup_test_data["user"]
+    store_submission = setup_test_data["store_submission"]
+    tool = RunAgentTool()
+
+    fake_scheduler = AsyncMock()
+    fake_scheduler.add_execution_schedule.return_value = GraphExecutionJobInfo(
+        id=str(uuid.uuid4()),
+        name="My Schedule",
+        next_run_time="",
+        timezone="UTC",
+        user_id=user.id,
+        graph_id=str(uuid.uuid4()),
+        graph_version=1,
+        cron="0 10 * * *",
+        input_data={},
+    )
+
+    with (
+        patch(
+            "backend.copilot.tools.run_agent.get_scheduler_client",
+            return_value=fake_scheduler,
+        ),
+        patch(
+            "backend.copilot.tools.run_agent.user_db",
+            _fake_user_db(stored_timezone),
+        ),
+    ):
+        response = await tool.execute(
+            user_id=user.id,
+            session_id=str(uuid.uuid4()),
+            tool_call_id=str(uuid.uuid4()),
+            username_agent_slug=(f"{user.email.split('@')[0]}/{store_submission.slug}"),
+            inputs={"test_input": "value"},
+            schedule_name="My Schedule",
+            cron="0 10 * * *",
+            dry_run=False,
+            session=make_session(user_id=user.id),
+            **run_agent_kwargs,
+        )
+    return response, fake_scheduler
+
+
+def _fake_user_db(stored_timezone: str):
+    """Stub ``user_db()`` so the stored timezone under test is exact,
+    independent of whatever the shared fixture user happens to carry."""
+    fake = MagicMock()
+    fake.get_user_by_id = AsyncMock(return_value=MagicMock(timezone=stored_timezone))
+    return MagicMock(return_value=fake)
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/run_agent_test.py
@@ -22,6 +22,7 @@ from ._test_data import (
 )
 from .models import ErrorResponse, ExecutionStartedResponse, SetupRequirementsResponse
 from .run_agent import RunAgentInput, RunAgentTool
+from .utils import get_or_create_library_agent
 
 # This is so the formatter doesn't remove the fixture imports
 setup_llm_test_data = setup_llm_test_data
@@ -910,7 +911,7 @@ async def test_schedule_prefers_explicit_timezone_over_stored_preference(
 ):
     """The QA repro: AutoPilot asks for a timezone, confirms it back to the
     user, and the schedule must be created in that one — not the profile's."""
-    _, fake_scheduler = await _schedule_with_timezone(
+    _, fake_scheduler, _ = await _schedule_with_timezone(
         setup_test_data,
         stored_timezone="Europe/Amsterdam",
         timezone="Europe/London",
@@ -924,7 +925,7 @@ async def test_schedule_prefers_explicit_timezone_over_stored_preference(
 async def test_schedule_without_explicit_timezone_uses_stored_preference(
     setup_test_data,
 ):
-    _, fake_scheduler = await _schedule_with_timezone(
+    _, fake_scheduler, _ = await _schedule_with_timezone(
         setup_test_data, stored_timezone="Europe/Amsterdam"
     )
 
@@ -936,7 +937,7 @@ async def test_schedule_without_explicit_timezone_uses_stored_preference(
 async def test_schedule_falls_back_to_utc_when_user_has_no_timezone(
     setup_test_data,
 ):
-    _, fake_scheduler = await _schedule_with_timezone(
+    _, fake_scheduler, _ = await _schedule_with_timezone(
         setup_test_data, stored_timezone=USER_TIMEZONE_NOT_SET
     )
 
@@ -948,7 +949,7 @@ async def test_schedule_falls_back_to_utc_when_user_has_no_timezone(
 async def test_schedule_rejects_invalid_explicit_timezone(setup_test_data):
     """An unknown timezone is refused, never silently downgraded to UTC —
     the model has already told the user which timezone it is scheduling in."""
-    response, fake_scheduler = await _schedule_with_timezone(
+    response, fake_scheduler, library_agent_spy = await _schedule_with_timezone(
         setup_test_data,
         stored_timezone="Europe/Amsterdam",
         timezone="Mars/Olympus_Mons",
@@ -960,12 +961,14 @@ async def test_schedule_rejects_invalid_explicit_timezone(setup_test_data):
     assert result_data.get("error") == "invalid_timezone"
     assert "Mars/Olympus_Mons" in result_data["message"]
     assert fake_scheduler.add_execution_schedule.await_count == 0
+    # A rejected schedule must not have added the agent to the user's library.
+    assert library_agent_spy.await_count == 0
 
 
 async def _schedule_with_timezone(
     setup_test_data, *, stored_timezone: str, **run_agent_kwargs
 ):
-    """Schedule an agent and hand back (response, scheduler mock)."""
+    """Schedule an agent and hand back (response, scheduler mock, library-agent spy)."""
     user = setup_test_data["user"]
     store_submission = setup_test_data["store_submission"]
     tool = RunAgentTool()
@@ -983,6 +986,8 @@ async def _schedule_with_timezone(
         input_data={},
     )
 
+    library_agent_spy = AsyncMock(wraps=get_or_create_library_agent)
+
     with (
         patch(
             "backend.copilot.tools.run_agent.get_scheduler_client",
@@ -991,6 +996,10 @@ async def _schedule_with_timezone(
         patch(
             "backend.copilot.tools.run_agent.user_db",
             _fake_user_db(stored_timezone),
+        ),
+        patch(
+            "backend.copilot.tools.run_agent.get_or_create_library_agent",
+            library_agent_spy,
         ),
     ):
         response = await tool.execute(
@@ -1005,7 +1014,7 @@ async def _schedule_with_timezone(
             session=make_session(user_id=user.id),
             **run_agent_kwargs,
         )
-    return response, fake_scheduler
+    return response, fake_scheduler, library_agent_spy
 
 
 def _fake_user_db(stored_timezone: str):


### PR DESCRIPTION
### Why / What / How

When AutoPilot schedules an agent, the schedule is now created in the timezone the user actually picked in the chat, instead of their profile default.

The v0.7.5 release QA reproduced the bug end to end against dev-builder: asked to schedule an agent daily at 10:00, AutoPilot asked which timezone through its question widget, was told `Europe/London`, and confirmed back "every day at 10:00 (Europe/London)" — but `GET /api/schedules` returned `timezone: "Europe/Amsterdam"`, an hour off in absolute terms. The user was told one thing and got another.

The cause is one line in `_schedule_agent`:

```python
user = await user_db().get_user_by_id(user_id)
user_timezone = get_user_timezone_or_utc(user.timezone if user else timezone)
```

`get_user_by_id` raises on a missing row rather than returning `None`, so the `else` branch is unreachable and the model's `timezone` argument was never consulted. The tool schema still advertised it, which is why the model asked the user for it at all.

The precedence is now the one `POST /graphs/{graph_id}/schedules` already documents and implements — explicit timezone, then the user's stored preference, then UTC — so the copilot tool and the REST API agree. The `timezone` field's default changed from `"UTC"` to `""`, because with a `"UTC"` default an omitted argument is indistinguishable from an explicit one and would have overridden every user's stored preference.

An unknown timezone is refused with an `invalid_timezone` error rather than silently falling back. `get_user_timezone_or_utc` swallows an invalid value to UTC with only a log line, which for a value the model has just read back to the user would recreate the same class of bug; and letting it through reaches the scheduler as an opaque `ZoneInfoNotFoundError` across the RPC boundary. This mirrors how `schedule_followup` pre-validates cron locally, for the same reason.

No caller depended on the old behaviour: the frontend scheduling UI never sends a per-schedule timezone (it only displays the profile one), so it was already on the fallback path.

### Changes 🏗️

- `run_agent.py`: explicit timezone → stored user preference → UTC in `_schedule_agent`, replacing the dead `if user else timezone` branch.
- `RunAgentInput.timezone` defaults to `""` so "omitted" is distinguishable from "explicitly UTC".
- Invalid IANA timezone returns `ErrorResponse(error="invalid_timezone")` and creates no schedule.
- Tool schema description states the fallback instead of claiming a UTC default.
- Four tests covering the precedence and the invalid-timezone refusal.

### Agents and large language models used

Claude Code with Claude Opus 5

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] An explicit timezone differing from the user's stored one is honoured
  - [x] No explicit timezone falls back to the stored preference
  - [x] A user with no stored timezone gets UTC
  - [x] An unknown timezone is refused and no schedule is created
  - [x] Each of the four tests was killed by mutating the fix back out

**Verified.** I executed the four new tests plus the six pre-existing `test_run_agent_schedule_*` tests (10 passed), the other 26 tests in `run_agent_test.py`, `backend/util/architecture_test.py` (3 passed) and `backend/blocks/test/test_block.py` (1647 passed, 84 skipped). Each new test was proved able to fail by mutating the fix back out — see the comment below for the mutation table. Three tests in `run_agent_test.py` hang on my machine (`test_run_agent`, `test_run_agent_with_llm_credentials`, `test_run_agent_with_use_defaults`), all on the real-execution path this PR does not touch; `test_run_agent` hangs identically with this branch's changes fully reverted to `dev`, so the hang is environmental and I am relying on CI for those three. I did not exercise the fix through a live AutoPilot chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
