### PR TITLE
fix(backend/executor): stop unpickling paused/fired schedules on every get_execution_schedules read

### DIFF
--- a/autogpt_platform/backend/backend/api/features/orgs/regression_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/regression_test.py
@@ -1372,6 +1372,13 @@ class TestRegressionSchedules:
         other_job.name = "other-job"
 
         scheduler.scheduler.get_jobs = MagicMock(return_value=[owned_job, other_job])
+        # get_graph_execution_schedules (include_paused=False) reads the
+        # active-jobs path, which queries the jobstore directly rather than
+        # going through scheduler.get_jobs — see Scheduler._get_active_jobs_cached.
+        scheduler._execution_jobstore = MagicMock()
+        scheduler._execution_jobstore._get_jobs = MagicMock(
+            return_value=[owned_job, other_job]
+        )
 
         results = scheduler.get_graph_execution_schedules(user_id=USER_ID)
 

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1726,6 +1726,21 @@ class Scheduler(AppService):
         # Configure executors to limit concurrency without skipping jobs
         from apscheduler.executors.pool import ThreadPoolExecutor
 
+        # Kept as a named reference (rather than only living inside the
+        # ``jobstores=`` dict below) so ``_get_active_jobs_cached`` can query
+        # its table directly with a server-side filter — see that method for
+        # why the stock ``get_all_jobs()`` isn't enough.
+        self._execution_jobstore = SQLAlchemyJobStore(
+            engine=create_engine(
+                url=db_url,
+                pool_size=self.db_pool_size(),
+                max_overflow=0,
+            ),
+            metadata=MetaData(schema=db_schema),
+            # this one is pre-existing so it keeps the default table name.
+            tablename="apscheduler_jobs",
+        )
+
         self.scheduler = BackgroundScheduler(
             executors={
                 "default": ThreadPoolExecutor(
@@ -1738,17 +1753,7 @@ class Scheduler(AppService):
                 "misfire_grace_time": None,  # No time limit for missed jobs
             },
             jobstores={
-                Jobstores.EXECUTION.value: SQLAlchemyJobStore(
-                    engine=create_engine(
-                        url=db_url,
-                        pool_size=self.db_pool_size(),
-                        max_overflow=0,
-                    ),
-                    metadata=MetaData(schema=db_schema),
-                    # this one is pre-existing so it keeps the
-                    # default table name.
-                    tablename="apscheduler_jobs",
-                ),
+                Jobstores.EXECUTION.value: self._execution_jobstore,
                 Jobstores.BATCHED_NOTIFICATIONS.value: SQLAlchemyJobStore(
                     engine=create_engine(
                         url=db_url,
@@ -2255,6 +2260,40 @@ class Scheduler(AppService):
             if self._jobs_cache_version == version_at_start:
                 self._jobs_cache = jobs
                 self._jobs_cache_expires_at = time.monotonic() + self._JOBS_CACHE_TTL_S
+        return jobs
+
+    # Second cache, keyed off the same lock/version, for the ``next_run_time
+    # IS NOT NULL`` (non-paused) rows only. This is what every caller except
+    # the pause/resume lifecycle lookups (``include_paused=True``) actually
+    # wants, and unlike ``_get_jobs_cached`` it pushes that filter down to
+    # SQL instead of unpickling every paused/already-fired row in Python
+    # only to throw it away — ``apscheduler_jobs`` accumulates those forever
+    # (nothing deletes a paused or fired-once job), so on a table with a
+    # meaningful history the unfiltered scan is what Sentry was flagging as
+    # a slow, unbounded query. ``next_run_time`` already carries a btree
+    # index from APScheduler's own table definition, so this needs no
+    # schema change.
+    _active_jobs_cache: list[JobObj] | None = None
+    _active_jobs_cache_expires_at: float = 0.0
+
+    def _get_active_jobs_cached(self) -> list[JobObj]:
+        with self._jobs_cache_lock:
+            now = time.monotonic()
+            if (
+                self._active_jobs_cache is not None
+                and now < self._active_jobs_cache_expires_at
+            ):
+                return self._active_jobs_cache
+            version_at_start = self._jobs_cache_version
+        jobs = self._execution_jobstore._get_jobs(
+            self._execution_jobstore.jobs_t.c.next_run_time.isnot(None)
+        )
+        with self._jobs_cache_lock:
+            if self._jobs_cache_version == version_at_start:
+                self._active_jobs_cache = jobs
+                self._active_jobs_cache_expires_at = (
+                    time.monotonic() + self._JOBS_CACHE_TTL_S
+                )
                 # The one scheduler metric with an alert on it was never set.
                 # Only an accepted read may publish it: a read that was
                 # invalidated mid-query is stale by definition and must not
@@ -2268,6 +2307,8 @@ class Scheduler(AppService):
         with self._jobs_cache_lock:
             self._jobs_cache = None
             self._jobs_cache_expires_at = 0.0
+            self._active_jobs_cache = None
+            self._active_jobs_cache_expires_at = 0.0
             self._jobs_cache_version += 1
 
     @expose
@@ -2294,18 +2335,22 @@ class Scheduler(AppService):
         schedules remain owner-only for scoped calls. Trusted global callers
         that provide neither *user_id* nor *organization_id* receive all jobs.
 
-        Paused jobs (``next_run_time is None``) are hidden by default, which
-        is what keeps a fired expert's suspended schedules out of every user
-        -facing listing. *include_paused* is for the lifecycle callers that
-        have to find them again to resume them. Fired one-shot jobs share
-        the same null marker, so they resurface too — filter by kind/id if
-        that matters to the caller.
+        Paused jobs (``next_run_time is None``) are hidden by default —
+        excluded at the SQL level via ``_get_active_jobs_cached`` rather than
+        filtered out afterwards — which is what keeps a fired expert's
+        suspended schedules out of every user-facing listing. *include_paused*
+        is for the lifecycle callers that have to find them again to resume
+        them; that path reads the unfiltered ``_get_jobs_cached`` instead.
+        Fired one-shot jobs share the same null marker, so they resurface too
+        — filter by kind/id if that matters to the caller.
         """
-        jobs: list[JobObj] = self._get_jobs_cached()
+        jobs: list[JobObj] = (
+            self._get_jobs_cached()
+            if include_paused
+            else self._get_active_jobs_cached()
+        )
         results: list[Union[GraphExecutionJobInfo, CopilotTurnJobInfo]] = []
         for job in jobs:
-            if job.next_run_time is None and not include_paused:
-                continue
             info = _job_to_info(job)
             if info is None:
                 continue

--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -2217,14 +2217,15 @@ class Scheduler(AppService):
             if isinstance(info, GraphExecutionJobInfo)
         ]
 
-    # Process-wide cache for ``scheduler.get_jobs(EXECUTION)``. APScheduler
-    # has no SQL-level user_id / kind filter — it loads every row and
-    # unpickles each ``job.kwargs`` in Python.  The /library page now
-    # fires THREE separate calls into this method on cold load (existing
-    # graph schedules + new copilot followups + briefing-pill counts),
-    # so we memoise the unfiltered list for a few seconds.  Mutations
-    # (`add_*_schedule`, `delete_schedule`) clear the cache so user-visible
-    # latency on writes is unchanged.
+    # Process-wide cache for ``scheduler.get_jobs(EXECUTION)`` — the fully
+    # unfiltered row set, including paused schedules and already-fired
+    # one-shot jobs. APScheduler has no SQL-level user_id / kind filter
+    # either way — it loads every row and unpickles each ``job.kwargs`` in
+    # Python — so this is now only worth paying for on the rare
+    # ``include_paused=True`` lifecycle lookups; see the sibling
+    # ``_get_active_jobs_cached`` below for the path everything else takes.
+    # Mutations (`add_*_schedule`, `delete_schedule`) clear both caches so
+    # user-visible latency on writes is unchanged.
     _JOBS_CACHE_TTL_S = 5.0
     _jobs_cache: list[JobObj] | None = None
     _jobs_cache_expires_at: float = 0.0

--- a/autogpt_platform/backend/backend/executor/scheduler_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_test.py
@@ -53,6 +53,50 @@ async def test_agent_schedule(server: SpinTestServer):
     assert len(schedules) == 0
 
 
+@pytest.mark.asyncio(loop_scope="session")
+async def test_paused_schedule_excluded_unless_include_paused(server: SpinTestServer):
+    """AUTOGPT-SERVER-9NB regression: get_execution_schedules must exclude a
+    paused schedule via the SQL-level ``next_run_time IS NOT NULL`` filter
+    (Scheduler._get_active_jobs_cached), not just via the old in-Python
+    check — and ``include_paused=True`` must still find it through the
+    unfiltered ``_get_jobs_cached`` path used by pause/resume lifecycle
+    callers. Exercised against the real apscheduler_jobs table."""
+    await db.connect()
+    test_user = await create_test_user()
+    test_graph = await server.agent_server.test_create_graph(
+        create_graph=CreateGraph(graph=create_test_graph()),
+        user_id=test_user.id,
+    )
+
+    scheduler = get_scheduler_client()
+    schedule = await scheduler.add_execution_schedule(
+        graph_id=test_graph.id,
+        user_id=test_user.id,
+        graph_version=1,
+        cron="0 0 * * *",
+        input_data={"input": "data"},
+        input_credentials={},
+    )
+
+    assert await scheduler.pause_schedule(schedule.id, user_id=test_user.id) is True
+
+    active_only = await scheduler.get_execution_schedules(
+        graph_id=test_graph.id, user_id=test_user.id
+    )
+    assert len(active_only) == 0
+
+    with_paused = await scheduler.get_execution_schedules(
+        graph_id=test_graph.id, user_id=test_user.id, include_paused=True
+    )
+    assert [s.id for s in with_paused] == [schedule.id]
+
+    assert await scheduler.resume_schedule(schedule.id, user_id=test_user.id) is True
+    active_after_resume = await scheduler.get_execution_schedules(
+        graph_id=test_graph.id, user_id=test_user.id
+    )
+    assert [s.id for s in active_after_resume] == [schedule.id]
+
+
 # ---------------------------------------------------------------------------
 # Community rebuild @expose methods — lightweight unit tests
 #
@@ -855,20 +899,20 @@ def _counter(name: str, **labels) -> float:
     return REGISTRY.get_sample_value(name, labels) or 0.0
 
 
-def test_get_jobs_cached_sets_the_scheduler_jobs_gauge():
+def test_get_active_jobs_cached_sets_the_scheduler_jobs_gauge():
     """autogpt_scheduler_jobs has an alert on it and was never set."""
     from unittest.mock import MagicMock
 
     from backend.executor.scheduler import Scheduler
 
     s = Scheduler.__new__(Scheduler)
-    s._jobs_cache = None
-    s._jobs_cache_expires_at = 0.0
+    s._active_jobs_cache = None
+    s._active_jobs_cache_expires_at = 0.0
     s._jobs_cache_version = 0
-    s.scheduler = MagicMock()
-    s.scheduler.get_jobs.return_value = [object(), object(), object()]
+    s._execution_jobstore = MagicMock()
+    s._execution_jobstore._get_jobs.return_value = [object(), object(), object()]
 
-    assert len(s._get_jobs_cached()) == 3
+    assert len(s._get_active_jobs_cached()) == 3
     assert (
         _counter("autogpt_scheduler_jobs", job_type="execution", status="scheduled")
         == 3
@@ -876,7 +920,7 @@ def test_get_jobs_cached_sets_the_scheduler_jobs_gauge():
 
 
 def test_stale_read_invalidated_mid_query_does_not_overwrite_the_gauge():
-    """An invalidation that lands while get_jobs() is in flight rejects the
+    """An invalidation that lands while the DB query is in flight rejects the
     cache write; the gauge must be rejected with it, or a slow stale read can
     overwrite a newer count that another reader already published."""
     from unittest.mock import MagicMock
@@ -884,14 +928,14 @@ def test_stale_read_invalidated_mid_query_does_not_overwrite_the_gauge():
     from backend.executor.scheduler import Scheduler
 
     s = Scheduler.__new__(Scheduler)
-    s._jobs_cache = None
-    s._jobs_cache_expires_at = 0.0
+    s._active_jobs_cache = None
+    s._active_jobs_cache_expires_at = 0.0
     s._jobs_cache_version = 0
-    s.scheduler = MagicMock()
+    s._execution_jobstore = MagicMock()
 
     # A fresh, accepted read publishes 5.
-    s.scheduler.get_jobs.return_value = [object()] * 5
-    s._get_jobs_cached()
+    s._execution_jobstore._get_jobs.return_value = [object()] * 5
+    s._get_active_jobs_cached()
 
     def gauge() -> float:
         return _counter(
@@ -902,14 +946,14 @@ def test_stale_read_invalidated_mid_query_does_not_overwrite_the_gauge():
 
     # Now a read whose query is interrupted by an invalidation: it returns a
     # different count, but the version moved, so the cache write is skipped.
-    s._jobs_cache = None
-    s._jobs_cache_expires_at = 0.0
+    s._active_jobs_cache = None
+    s._active_jobs_cache_expires_at = 0.0
 
-    def _slow_query_then_invalidated(**_):
+    def _slow_query_then_invalidated(*_args, **_kwargs):
         s._invalidate_jobs_cache()
         return [object()] * 2
 
-    s.scheduler.get_jobs.side_effect = _slow_query_then_invalidated
-    assert len(s._get_jobs_cached()) == 2  # caller still gets the list
-    assert s._jobs_cache is None  # write-back was rejected
+    s._execution_jobstore._get_jobs.side_effect = _slow_query_then_invalidated
+    assert len(s._get_active_jobs_cached()) == 2  # caller still gets the list
+    assert s._active_jobs_cache is None  # write-back was rejected
     assert gauge() == 5  # and so was the gauge update

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -1592,6 +1592,10 @@ class TestScheduleOrgVisibility:
         sched, jobs, fake_job_to_info = self._scheduler_with_jobs(infos)
         with (
             patch.object(Scheduler, "_get_jobs_cached", lambda self: jobs),
+            # None of these fixture jobs are paused, so the active-only path
+            # (what get_execution_schedules actually calls unless
+            # include_paused=True) can return the same list.
+            patch.object(Scheduler, "_get_active_jobs_cached", lambda self: jobs),
             patch(
                 "backend.executor.scheduler._job_to_info",
                 side_effect=fake_job_to_info,


### PR DESCRIPTION
### Why / What / How

**Why:** Sentry flagged `/get_graph_execution_schedules` for a slow, unbounded DB query (AUTOGPT-SERVER-9NB). `Scheduler.get_execution_schedules()` — which backs both that RPC and the `/schedules` REST routes — reads through a 5s process-wide cache. On a cache miss it called APScheduler's stock `SQLAlchemyJobStore.get_all_jobs()`, which runs `SELECT id, job_state FROM apscheduler_jobs ORDER BY next_run_time` with **no WHERE clause** — scanning and unpickling every row in the table. That includes paused schedules and already-fired one-shot jobs (APScheduler marks both with `next_run_time = NULL`), neither of which anything ever deletes, and both of which the caller immediately discards in Python for every caller except the two pause/resume lifecycle lookups. As that dead-row backlog grows, the query only gets slower.

**What:** Added a second cache, `_get_active_jobs_cached`, that pushes a `next_run_time IS NOT NULL` filter down to SQL via the jobstore's existing `next_run_time` btree index (already present on APScheduler's stock table definition — no schema change or migration needed). `get_execution_schedules` now reads through it by default; the two `include_paused=True` lifecycle callers (pause/resume) keep reading the original unfiltered cache, since they need to find paused rows too.

**How:** Kept the `SQLAlchemyJobStore` instance backing the `EXECUTION` jobstore as a named `self._execution_jobstore` reference (instead of only living inline in the `jobstores=` dict) so the new cache method can query its table directly with a server-side filter, reusing the same engine/connection pool the scheduler already uses (no extra DB connections). The `SCHEDULER_JOBS` gauge (labeled `status="scheduled"`) now updates from the active-only count, which is the more accurate reading for that label.

### Changes 🏗️

- `backend/executor/scheduler.py`: new `_get_active_jobs_cached()` method with SQL-level `next_run_time IS NOT NULL` filtering; `get_execution_schedules()` now dispatches to it unless `include_paused=True`.
- `backend/executor/scheduler_test.py`: new integration test `test_paused_schedule_excluded_unless_include_paused` (add → list → pause → list excludes it → list with `include_paused=True` finds it → resume → list finds it again), run against a real Postgres-backed `apscheduler_jobs` table.
- `backend/executor/scheduler_unit_test.py`, `backend/api/features/orgs/regression_test.py`: updated two existing mocks that only stubbed the old unfiltered `_get_jobs_cached` path to also stub the new active-jobs path.

### Agents and large language models used

Claude Code worker on tester VM, Sonnet/Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `poetry run test backend/executor/scheduler_test.py` — 56 passed (real Postgres + real APScheduler jobstore, including the new pause/resume regression test)
  - [x] `poetry run test` on the 8 other files calling `get_execution_schedules`/`get_graph_execution_schedules` (`scheduler_unit_test.py`, `v1_test.py`, `experts/scheduling_test.py`, `home/service_test.py`, `experts/experts_db_test.py`, `copilot/tools/session_context_test.py`, `copilot/tools/manage_schedules_test.py`, `orgs/regression_test.py`) — 498 passed, 12 xfailed
  - [x] `poetry run ruff check` / `isort --check` / `black --check` / `pyright` on all touched files — clean

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)