### PR TITLE
fix(backend): hold workspace:// block inputs to the expert's file scope

### DIFF
--- a/autogpt_platform/backend/backend/data/workspace_scope_test.py
+++ b/autogpt_platform/backend/backend/data/workspace_scope_test.py
@@ -1,7 +1,11 @@
 import pytest
 
 from backend.data import workspace as workspace_module
-from backend.data.workspace_scope import WorkspaceScope, resolve_expert_workspace_scope
+from backend.data.workspace_scope import (
+    WorkspaceScope,
+    _NoGrants,
+    resolve_expert_workspace_scope,
+)
 
 SCOPE = WorkspaceScope(
     expert_id="expert-a",
@@ -51,6 +55,13 @@ def test_delegated_sessions_are_read_only(path: str):
 def test_everything_else_is_denied(path: str):
     assert not SCOPE.allows_path(path)
     assert not SCOPE.allows_path(path, write=True)
+
+
+def test_a_missing_expert_keeps_its_own_turn_but_loses_its_skills_folder():
+    scope = _NoGrants(expert_id="expert-a").with_session("live")
+    assert scope.allows_path("/sessions/live/tool-output.json", write=True)
+    assert not scope.allows_path("/experts/expert-a/skills/mine/SKILL.md")
+    assert not scope.allows_path("/experts/expert-a/skills/mine/SKILL.md", write=True)
 
 
 def test_resolver_is_reachable_through_the_direct_db_accessor():

--- a/autogpt_platform/backend/backend/util/file.py
+++ b/autogpt_platform/backend/backend/util/file.py
@@ -153,14 +153,19 @@ async def store_media_file(
     if not user_id:
         raise ValueError("execution_context.user_id is required")
 
-    # Create workspace_manager if we have workspace_id (with session scoping)
     # Import here to avoid circular import (file.py → workspace.py → data → blocks → file.py)
+    from backend.copilot.context import current_workspace_scope
     from backend.util.workspace import WorkspaceManager
 
     workspace_manager: WorkspaceManager | None = None
     if execution_context.workspace_id:
+        # A block input names a workspace file, so this manager needs the same
+        # expert grants as the session's own file tools.
         workspace_manager = WorkspaceManager(
-            user_id, execution_context.workspace_id, execution_context.session_id
+            user_id,
+            execution_context.workspace_id,
+            execution_context.session_id,
+            scope=await current_workspace_scope(user_id),
         )
     # Build base path
     base_path = Path(get_exec_file_path(graph_exec_id, ""))

--- a/autogpt_platform/backend/backend/util/file_isolation_test.py
+++ b/autogpt_platform/backend/backend/util/file_isolation_test.py
@@ -1,0 +1,106 @@
+"""A ``workspace://`` block input is a second door into the workspace: it must
+be held to the same expert grants as the session's own file tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.copilot.context import set_execution_context
+from backend.copilot.model import ChatSession
+from backend.data.execution import ExecutionContext
+from backend.data.workspace_scope import WorkspaceAccessDeniedError, WorkspaceScope
+from backend.util.file import store_media_file
+from backend.util.type import MediaFileType
+from backend.util.workspace_test import _make_workspace_file
+
+OWN_SESSION = "expert-a-session"
+FOREIGN_PATH = "/sessions/personal/private.txt"
+
+
+@pytest.fixture
+def scope_db():
+    db = MagicMock()
+    db.resolve_expert_workspace_scope = AsyncMock(
+        return_value=WorkspaceScope(expert_id="expert-a", session_ids=[OWN_SESSION])
+    )
+    with patch("backend.copilot.context.workspace_db", return_value=db):
+        yield db
+    set_execution_context(None, None)
+
+
+@pytest.fixture
+def workspace_db_mock():
+    db = MagicMock()
+    db.get_workspace_file = AsyncMock(
+        return_value=_make_workspace_file(path=FOREIGN_PATH)
+    )
+    db.get_workspace_file_by_path = AsyncMock(
+        return_value=_make_workspace_file(path=FOREIGN_PATH)
+    )
+    storage = AsyncMock()
+    storage.retrieve.return_value = b"secret"
+    with (
+        patch("backend.util.workspace.workspace_db", return_value=db),
+        patch("backend.util.workspace.get_workspace_storage", return_value=storage),
+        patch("backend.util.file.get_cloud_storage_handler", AsyncMock()),
+        patch("backend.util.file.scan_content_safe", AsyncMock()),
+    ):
+        yield db, storage
+
+
+def _context(session_id: str) -> ExecutionContext:
+    return ExecutionContext(
+        user_id="user-1",
+        graph_exec_id="copilot-session-block",
+        workspace_id="ws-1",
+        session_id=session_id,
+    )
+
+
+def _start_expert_turn() -> None:
+    session = ChatSession.new("user-1", dry_run=False, expert_id="expert-a")
+    session.session_id = OWN_SESSION
+    set_execution_context("user-1", session)
+
+
+@pytest.mark.parametrize("ref", [f"workspace://{FOREIGN_PATH}", "workspace://file-id"])
+async def test_expert_block_input_cannot_leave_the_experts_scope(
+    scope_db, workspace_db_mock, ref: str
+):
+    _, storage = workspace_db_mock
+    _start_expert_turn()
+    with pytest.raises(WorkspaceAccessDeniedError):
+        await store_media_file(
+            MediaFileType(ref),
+            _context(OWN_SESSION),
+            return_format="for_external_api",
+        )
+    storage.retrieve.assert_not_awaited()
+
+
+async def test_expert_block_input_reads_its_own_session_file(
+    scope_db, workspace_db_mock
+):
+    db, _ = workspace_db_mock
+    own = f"/sessions/{OWN_SESSION}/notes.txt"
+    db.get_workspace_file_by_path.return_value = _make_workspace_file(path=own)
+    _start_expert_turn()
+    result = await store_media_file(
+        MediaFileType(f"workspace://{own}"),
+        _context(OWN_SESSION),
+        return_format="for_external_api",
+    )
+    assert result.startswith("data:")
+
+
+async def test_personal_autopilot_block_input_stays_unrestricted(
+    scope_db, workspace_db_mock
+):
+    set_execution_context("user-1", ChatSession.new("user-1", dry_run=False))
+    result = await store_media_file(
+        MediaFileType(f"workspace://{FOREIGN_PATH}"),
+        _context("personal"),
+        return_format="for_external_api",
+    )
+    assert result.startswith("data:")
+    scope_db.resolve_expert_workspace_scope.assert_not_awaited()


### PR DESCRIPTION
### Changes 🏗️

Holds a `workspace://` block input to the same expert file scope as the session's own file tools. A block input that names a workspace file is resolved by `store_media_file`, which built its own `WorkspaceManager` with no scope; a block run from an expert chat therefore read any file in the account, by path or by file ID, while `read_workspace_file` in the same chat was confined to the expert's sessions and skills. `store_media_file` now passes `current_workspace_scope(user_id)` — the same server-resolved scope `get_workspace_manager` uses, derived from the executing session, never from a tool argument.

This closes the two rules #14413 states that the block path walked around: "an expert cannot touch another expert's or AutoPilot's sessions, or anyone else's skills, **by path or by file ID**", and "an expert cannot see, run or edit another expert's skills" — an expert's skills live at a deterministic workspace path.

Also adds the missing test for the fail-closed half of `_NoGrants`: a missing, archived or foreign expert keeps the session it is executing but loses its skills folder. Deleting that override left every suite green before this PR.

**Not covered, deliberately:** blocks running inside a *graph* execution. There the copilot session is not in scope (separate process), and a graph run writes its files at the workspace root with no session folder, so applying an expert scope there would deny an expert's own workflow outputs. Scoping that path needs a rule for where a workflow run's files live — `ExecutionContext.expert_id` is already carried there when that decision is made.

### Verified

I ran `util/file_test.py`, the new `util/file_isolation_test.py`, `util/sandbox_files_test.py`, `util/workspace_test.py`, `util/workspace_isolation_test.py`, `data/workspace_scope_test.py`, `copilot/context_isolation_test.py`, `copilot/tools/workspace_files_test.py` + `workspace_files_isolation_test.py`, `copilot/tools/helpers_test.py`, `blocks/replicate/replicate_block_file_input_test.py` (161 + 59 passed), plus `util/architecture_test.py` and `blocks/test/test_block.py` (1647 passed, 84 skipped).

Both new guards were mutated back out and the right test failed each time — logs in a comment below. `data/workspace_scope_db_test.py` needs the app stack and was not run here; CI covers it.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

### Agents and large language models used

- Claude Code — Claude Opus 5
