### PR TITLE
fix(backend): drop first-person voice from run activity summaries

### DIFF
--- a/autogpt_platform/backend/backend/executor/activity_status_generator.py
+++ b/autogpt_platform/backend/backend/executor/activity_status_generator.py
@@ -64,10 +64,13 @@ DEFAULT_SYSTEM_PROMPT = """You are an AI assistant analyzing what an agent execu
 You need to provide both a user-friendly summary AND a correctness assessment.
 
 FOR THE ACTIVITY STATUS:
-- Write from the user's perspective about what they accomplished, NOT about technical execution details
+- Describe what was accomplished as a neutral outcome, NOT about technical execution details
+- NEVER write in the first person: no 'I', 'I used', 'I calculated', 'It seems like I', 'It looks like I'
+- Do not address the user as 'you' and do not hedge with 'It seems like' or 'It looks like'
+- Lead with the result itself, e.g. 'Added 2 and 3 and produced 5.' or 'Release notes were generated covering the latest updates.'
 - Focus on the ACTUAL TASK the user wanted done, not the internal workflow steps
 - Avoid technical terms like 'workflow', 'execution', 'components', 'nodes', 'processing', etc.
-- Keep it to 3 sentences maximum. Be conversational and human-friendly
+- Keep it to 3 sentences maximum. Be plain and human-friendly
 
 FOR THE CORRECTNESS SCORE:
 - Provide a score from 0.0 to 1.0 indicating how well the execution achieved its intended purpose
@@ -137,11 +140,11 @@ INTENTION-BASED EVALUATION:
 - Match the outputs to the stated intention, not just technical completion
 
 PROVIDE:
-activity_status: 1-3 sentences about what the user accomplished, such as:
-- 'I analyzed your resume and provided detailed feedback for the IT industry.'
-- 'I couldn't complete the task because critical steps failed to produce any results.'
-- 'I failed to generate the content you requested due to missing API access.'
-- 'I extracted key information from your documents and organized it into a summary.'
+activity_status: 1-3 sentences describing the outcome, never in the first person, such as:
+- 'Analyzed the resume and provided detailed feedback for the IT industry.'
+- 'The task could not be completed because critical steps failed to produce any results.'
+- 'Content generation failed due to missing API access.'
+- 'Key information was extracted from the documents and organized into a summary.'
 - 'The task failed because the blog post creation step didn't produce any output.'
 
 correctness_score: A float score from 0.0 to 1.0 based on how well the intended purpose was achieved:


### PR DESCRIPTION
### Why / What / How

**Why:** The Home page's Recent work list shows run summaries written as the agent speaking in the first person: "I used the Sum Agent to add two numbers together…", "It seems like I used the calculator…". That reads oddly next to the workflow name and makes the summaries sound like chat replies rather than outcomes.

**What:** Rewrites the activity status prompt so summaries describe the outcome neutrally, e.g. "Added 2 and 3 and produced 5." or "The calculator was used to perform some addition operations…".

**How:** Replaces the "write from the user's perspective" rule in `DEFAULT_SYSTEM_PROMPT` with explicit rules: never first person, never address the user as "you", no "It seems like" hedging, lead with the result. Updates the example summaries in `DEFAULT_USER_PROMPT` to match. Prompt-only change; no schema or code path changes.

### Changes 🏗️

- `backend/executor/activity_status_generator.py`: reword the activity status rules and examples so the model stops writing "I …" summaries.

### Agents and large language models used

- Claude Code with Claude Fable 5.1

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Run a workflow with the `ai-agent-execution-summary` flag enabled and confirm the new run summary on Home is not written in the first person

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)