### PR TITLE
feat(backend/copilot): recalibrate AutoPilot's per-plan daily and weekly spend limits

### DIFF
--- a/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/subscription_routes_test.py
@@ -261,8 +261,8 @@ def test_get_subscription_status_pro(
     # so the frontend never renders a multiplier badge for a hidden row.
     assert set(data["tier_multipliers"].keys()) == set(data["tier_costs"].keys())
     assert data["tier_multipliers"]["BASIC"] == 1.0
-    assert data["tier_multipliers"]["PRO"] == 5.0
-    assert data["tier_multipliers"]["MAX"] == 20.0
+    assert data["tier_multipliers"]["PRO"] == 1.25
+    assert data["tier_multipliers"]["MAX"] == 10.6667
     assert data["tier_multipliers"]["BUSINESS"] == 60.0
 
 

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -359,9 +359,10 @@ class ChatConfig(BaseSettings):
     # These defaults act as the ceiling when LaunchDarkly is unreachable;
     # the live per-tier values come from the COPILOT_*_COST_LIMIT flags.
     daily_cost_limit_microdollars: int = Field(
-        default=1_000_000,
+        default=2_000_000,
         description="Max cost per day in microdollars, resets at midnight UTC. "
-        "0 means no spend allowed (will block); there is no unlimited tier.",
+        "Held at two fifths of the weekly limit. 0 means no spend allowed "
+        "(will block); there is no unlimited tier.",
     )
     weekly_cost_limit_microdollars: int = Field(
         default=5_000_000,

--- a/autogpt_platform/backend/backend/copilot/config.py
+++ b/autogpt_platform/backend/backend/copilot/config.py
@@ -359,10 +359,9 @@ class ChatConfig(BaseSettings):
     # These defaults act as the ceiling when LaunchDarkly is unreachable;
     # the live per-tier values come from the COPILOT_*_COST_LIMIT flags.
     daily_cost_limit_microdollars: int = Field(
-        default=2_000_000,
+        default=2_500_000,
         description="Max cost per day in microdollars, resets at midnight UTC. "
-        "Held at two fifths of the weekly limit. 0 means no spend allowed "
-        "(will block); there is no unlimited tier.",
+        "0 means no spend allowed (will block); there is no unlimited tier.",
     )
     weekly_cost_limit_microdollars: int = Field(
         default=5_000_000,

--- a/autogpt_platform/backend/backend/copilot/rate_limit.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit.py
@@ -100,8 +100,8 @@ class SubscriptionTier(str, Enum):
 
 # Default multiplier applied to the base cost limits (from LD / config) for each
 # tier. Used as the fallback when the LD flag ``copilot-tier-multipliers`` is
-# unset or unparseable — see ``get_tier_multipliers``.  BUSINESS matches
-# ENTERPRISE (60x); MAX sits at 20x as the self-service $320 tier. Float-typed
+# unset or unparseable — see ``get_tier_multipliers``.  PRO and MAX are the two
+# self-serve plans; their multipliers set what those plans allow. Float-typed
 # so LD-provided fractional multipliers (e.g. 8.5×) compose naturally; the
 # eventual ``int(base * multiplier)`` in ``get_global_rate_limits`` keeps the
 # downstream microdollar math integer.
@@ -111,12 +111,12 @@ _DEFAULT_TIER_MULTIPLIERS: dict[SubscriptionTier, float] = {
     # all rate-limited routes (CoPilot chat, AutoPilot) refuse with 429
     # before any business logic runs. This is the backend half of the
     # paywall (the frontend modal nudges UI users; this gate enforces
-    # server-side regardless of client). BASIC stays as a future paid-tier
-    # option; for now it falls back to the same baseline as paid tiers.
+    # server-side regardless of client). BASIC is not sold today and stays on
+    # the base limits.
     SubscriptionTier.NO_TIER: 0.0,
     SubscriptionTier.BASIC: 1.0,
-    SubscriptionTier.PRO: 5.0,
-    SubscriptionTier.MAX: 20.0,
+    SubscriptionTier.PRO: 1.25,
+    SubscriptionTier.MAX: 10.6667,
     SubscriptionTier.BUSINESS: 60.0,
     SubscriptionTier.ENTERPRISE: 60.0,
 }

--- a/autogpt_platform/backend/backend/copilot/rate_limit_test.py
+++ b/autogpt_platform/backend/backend/copilot/rate_limit_test.py
@@ -882,8 +882,8 @@ class TestSubscriptionTier:
         # rate-limited routes refuse with 429 (backend half of the paywall).
         assert TIER_MULTIPLIERS[SubscriptionTier.NO_TIER] == 0.0
         assert TIER_MULTIPLIERS[SubscriptionTier.BASIC] == 1.0
-        assert TIER_MULTIPLIERS[SubscriptionTier.PRO] == 5.0
-        assert TIER_MULTIPLIERS[SubscriptionTier.MAX] == 20.0
+        assert TIER_MULTIPLIERS[SubscriptionTier.PRO] == 1.25
+        assert TIER_MULTIPLIERS[SubscriptionTier.MAX] == 10.6667
         assert TIER_MULTIPLIERS[SubscriptionTier.BUSINESS] == 60.0
         assert TIER_MULTIPLIERS[SubscriptionTier.ENTERPRISE] == 60.0
         assert TIER_MULTIPLIERS is _DEFAULT_TIER_MULTIPLIERS
@@ -1721,8 +1721,8 @@ class TestGetGlobalRateLimitsWithTiers:
         assert tier == SubscriptionTier.BASIC
 
     @pytest.mark.asyncio
-    async def test_pro_tier_5x_multiplier(self):
-        """Pro tier should multiply limits by 5."""
+    async def test_pro_tier_multiplier(self):
+        """Pro tier should multiply limits by 1.25."""
         with (
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
@@ -1738,13 +1738,13 @@ class TestGetGlobalRateLimitsWithTiers:
                 _USER, 2_500_000, 12_500_000
             )
 
-        assert daily == 12_500_000
-        assert weekly == 62_500_000
+        assert daily == 3_125_000
+        assert weekly == 15_625_000
         assert tier == SubscriptionTier.PRO
 
     @pytest.mark.asyncio
-    async def test_max_tier_20x_multiplier(self):
-        """Max tier should multiply limits by 20 (self-service $320 tier)."""
+    async def test_max_tier_multiplier(self):
+        """Max tier should multiply limits by 10.6667."""
         with (
             patch(
                 "backend.copilot.rate_limit.get_user_tier",
@@ -1760,8 +1760,8 @@ class TestGetGlobalRateLimitsWithTiers:
                 _USER, 2_500_000, 12_500_000
             )
 
-        assert daily == 50_000_000
-        assert weekly == 250_000_000
+        assert daily == 26_666_750
+        assert weekly == 133_333_750
         assert tier == SubscriptionTier.MAX
 
     @pytest.mark.asyncio
@@ -1878,7 +1878,7 @@ class TestTierLimitsRespected:
     @pytest.mark.asyncio
     async def test_pro_user_allowed_above_basic_limit(self):
         """A PRO user with usage above the BASIC limit should be allowed."""
-        # Usage: 3M tokens (above BASIC limit of 2.5M, below PRO limit of 12.5M)
+        # Usage: 3M tokens (above BASIC limit of 2.5M, below PRO limit of 3.125M)
         mock_redis = AsyncMock()
         mock_redis.get = AsyncMock(side_effect=["3000000", "3000000"])
 
@@ -1900,10 +1900,10 @@ class TestTierLimitsRespected:
             daily, weekly, tier = await get_global_rate_limits(
                 _USER, self._BASE_DAILY, self._BASE_WEEKLY
             )
-            # PRO: 5x multiplier
-            assert daily == 12_500_000
+            # PRO: 1.25x multiplier
+            assert daily == 3_125_000
             assert tier == SubscriptionTier.PRO
-            # Should NOT raise — 3M < 12.5M
+            # Should NOT raise — 3M < 3.125M
             await check_rate_limit(
                 _USER, daily_cost_limit=daily, weekly_cost_limit=weekly
             )
@@ -2253,7 +2253,7 @@ class TestTierLimitsEnforced:
         basic_daily = int(self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.BASIC])
         pro_daily = int(self._BASE_DAILY * TIER_MULTIPLIERS[SubscriptionTier.PRO])
         # Usage above BASIC limit but below PRO limit
-        usage = basic_daily + 500_000
+        usage = basic_daily + (pro_daily - basic_daily) // 2
         assert usage < pro_daily, "test sanity: usage must be under PRO limit"
 
         mock_redis = AsyncMock()


### PR DESCRIPTION
AutoPilot's spend limits are set per plan: a Pro user gets $3.13 a day and $6.25 a week, a Max user $26.67 a day and $53.33 a week. Pro and Max are the only two plans a user can be on, so these are the only two figures that change what anyone experiences today.

### Why / What / How

**Why.** The limits in force were not the ones the two plans are meant to carry, on either the daily or the weekly window, and the gap between Pro and Max did not match what the plans are sold as. This sets both plans to their intended allowances.

**What.** Two knobs move. `ChatConfig.daily_cost_limit_microdollars` goes from `1_000_000` to `2_500_000`, and the `PRO` and `MAX` tier multipliers go from `5.0` and `20.0` to `1.25` and `10.6667`. The weekly base is untouched at `5_000_000`.

**How.** A limit is `int(base × tier multiplier)`, one base pair for every tier (`copilot/rate_limit.py:1141-1188`). Two plans with different daily-to-weekly shapes cannot both be expressed by moving the base alone, so the base carries the daily change and the two multipliers carry the per-plan levels. Leaving the weekly base at `5_000_000` is what keeps every other tier's weekly allowance exactly where it was.

### What each plan gets

| Plan | Tier | Daily before | Daily after | Weekly before | Weekly after |
|---|---|---:|---:|---:|---:|
| Pro | `PRO` | $5.00 | **$3.13** | $25.00 | **$6.25** |
| Max | `MAX` | $20.00 | **$26.67** | $100.00 | **$53.33** |
| no subscription | `NO_TIER` | $0.00 | $0.00 | $0.00 | $0.00 |

The three tiers nobody can subscribe to keep the weekly allowance they had: `BASIC` $5.00, `BUSINESS` and `ENTERPRISE` $300.00. Their daily allowance rises with the base — `BASIC` $1.00 → $2.50, `BUSINESS` and `ENTERPRISE` $60.00 → $150.00 — which changes nothing they can reach, because seven days at the daily limit still exceeds the weekly limit and the weekly cap binds first. `BASIC` is the drained legacy tier, `BUSINESS` is contact-sales with no Stripe price, and `ENTERPRISE` is admin-granted.

One user-visible side effect: the paywall renders each plan's badge from these multipliers relative to the lowest visible plan, so Max's badge becomes `8.5x rate limits` — the ratio its plan card already advertises, where it previously read `4.0x`.

### This changes production spend

These defaults are what production enforces. Both LaunchDarkly flags that could override them — `copilot-cost-limits` and `copilot-tier-multipliers` — are off and serve `{}`, and both parsers return `None` for that (`copilot/rate_limit.py:188-231` and `146-186`), which makes `get_global_rate_limits` fall through to the `ChatConfig` values and the defaults in this file. No environment override exists in the backend deployment's Helm values either.

Both flags hold stored values from an earlier shape that no longer produce these numbers. Neither is on; if either is switched on, its value needs updating first.

### Changes 🏗️

- `copilot/config.py`: `daily_cost_limit_microdollars` default `1_000_000` → `2_500_000`.
- `copilot/rate_limit.py`: `PRO` multiplier `5.0` → `1.25`, `MAX` `20.0` → `10.6667`; comments updated to match.
- `copilot/rate_limit_test.py`, `api/features/subscription_routes_test.py`: assertions that pinned the old multipliers now pin the new ones, and the test that places usage between the `BASIC` and `PRO` limits derives that point from the multipliers instead of a hardcoded offset that no longer sits between them.

Configuration: no `.env.default` or `docker-compose.yml` change — neither declares the cost-limit keys, so both already fall through to the code default.

### Verified

I read the resulting limits out of `get_global_rate_limits` itself for all six tiers, with the LaunchDarkly lookups stubbed to their production state, rather than computing them on paper: Pro lands on $3.125 daily and $6.25 weekly exactly, Max on $26.6668 and $53.3335, and `BASIC`, `BUSINESS` and `ENTERPRISE` keep the weekly allowances above. I executed `copilot/config_test.py`, `copilot/rate_limit_test.py`, `copilot/reset_usage_test.py` and `util/architecture_test.py` (271 passed), `api/features/admin/rate_limit_admin_routes_test.py`, `api/features/chat/routes_test.py` and `api/features/subscription_routes_test.py` (251 passed, snapshots included), and `blocks/test/test_block.py` (1647 passed, 84 skipped). I did not exercise a real chat turn against a running stack, and the paywall badge change is read off the frontend's existing relative-multiplier helper rather than rendered.

### Agents and large language models used

Claude Code with Claude Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Per-tier limits read back out of `get_global_rate_limits` for all six tiers
  - [x] `copilot/config_test.py`, `copilot/rate_limit_test.py`, `copilot/reset_usage_test.py`, `util/architecture_test.py` — 271 passed
  - [x] `api/features/admin/rate_limit_admin_routes_test.py`, `api/features/chat/routes_test.py`, `api/features/subscription_routes_test.py` — 251 passed
  - [x] `blocks/test/test_block.py` — 1647 passed, 84 skipped

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
