### PR TITLE
fix(backend): hold every expert credential path to the grant list

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/credentials.py
+++ b/autogpt_platform/backend/backend/api/features/experts/credentials.py
@@ -236,6 +236,19 @@ async def revoke_expert_credential(
     return _to_refs(await _grants(expert_id), await _user_credentials(user_id))
 
 
+async def settle_credential_seed(user_id: str, expert_id: str) -> None:
+    """Freeze the allow-list before the expert changes its own workflows.
+
+    Seeding derives grants from installed workflows, so an install made from
+    the expert's own session must not be able to feed it. Stamped even when a
+    workflow failed to derive: a missing grant is visible and fixable, while a
+    self-granted one is not.
+    """
+    expert = await _owned_expert(user_id, expert_id)
+    await _seed_if_needed(user_id, expert)
+    await _stamp_seeded(expert.id)
+
+
 async def expert_allowed_credential_ids(user_id: str, expert_id: str) -> list[str]:
     """The credential ids *expert_id* may use. Enforcement's source of truth.
 

--- a/autogpt_platform/backend/backend/api/features/experts/credentials_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/credentials_test.py
@@ -11,6 +11,7 @@ from backend.api.features.experts.credentials import (
     _derive_from_workflows,
     _to_refs,
     filter_credentials_for_expert,
+    settle_credential_seed,
 )
 from backend.data.model import APIKeyCredentials, CredentialsMetaInput
 from backend.executor.utils import _enforce_expert_credential_scope
@@ -201,3 +202,25 @@ async def test_a_run_with_no_credentials_skips_the_lookup_entirely(
     await _enforce_expert_credential_scope("user-1", "expert-1", None)
 
     accessor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_settling_the_seed_stamps_even_when_derivation_was_incomplete(
+    mocker: pytest_mock.MockFixture,
+):
+    expert = SimpleNamespace(id="expert-1", Workflows=[], credentialsSeededAt=None)
+    mocker.patch(
+        "backend.api.features.experts.credentials._owned_expert",
+        AsyncMock(return_value=expert),
+    )
+    seed = mocker.patch(
+        "backend.api.features.experts.credentials._seed_if_needed", AsyncMock()
+    )
+    stamp = mocker.patch(
+        "backend.api.features.experts.credentials._stamp_seeded", AsyncMock()
+    )
+
+    await settle_credential_seed("user-1", "expert-1")
+
+    seed.assert_awaited_once_with("user-1", expert)
+    stamp.assert_awaited_once_with("expert-1")

--- a/autogpt_platform/backend/backend/api/features/experts/experts_db.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db.py
@@ -29,6 +29,9 @@ from backend.api.features.experts.credentials import (
 from backend.api.features.experts.credentials import (
     revoke_expert_credential as revoke_expert_credential,
 )
+from backend.api.features.experts.credentials import (
+    settle_credential_seed as settle_credential_seed,
+)
 from backend.api.features.experts.errors import (
     ACTIVE_EXPERT_LIMIT,
     LIFETIME_RAISED_EXPERT_LIMIT,

--- a/autogpt_platform/backend/backend/copilot/tools/continue_run_block.py
+++ b/autogpt_platform/backend/backend/copilot/tools/continue_run_block.py
@@ -129,7 +129,7 @@ class ContinueRunBlockTool(BaseTool):
         )
 
         matched_creds, missing_creds = await resolve_block_credentials(
-            user_id, block, input_data
+            user_id, block, input_data, session.expert_id
         )
         if missing_creds:
             return ErrorResponse(

--- a/autogpt_platform/backend/backend/copilot/tools/continue_run_block_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/continue_run_block_test.py
@@ -184,3 +184,36 @@ class TestContinueRunBlock:
         mock_db.delete_review_by_node_exec_id.assert_called_once_with(
             review_id, _TEST_USER_ID
         )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_continuation_resolves_credentials_under_the_experts_grants():
+    """The approved continuation re-resolves credentials, so it must be held
+    to the expert's grants like the original run_block call."""
+    tool = ContinueRunBlockTool()
+    session = make_session(user_id=_TEST_USER_ID, expert_id="expert-a")
+    review_id = "copilot-node-some-block:abc12345"
+    review = _make_review_model(
+        review_id, graph_exec_id=f"copilot-session-{session.session_id}"
+    )
+    mock_db = MagicMock()
+    mock_db.get_reviews_by_node_exec_ids = AsyncMock(return_value={review_id: review})
+    block = MagicMock()
+    block.name = "Some Block"
+
+    with (
+        patch(
+            "backend.copilot.tools.continue_run_block.review_db",
+            return_value=mock_db,
+        ),
+        patch("backend.copilot.tools.continue_run_block.get_block", return_value=block),
+        patch(
+            "backend.copilot.tools.continue_run_block.resolve_block_credentials",
+            new_callable=AsyncMock,
+            return_value=({}, {"credentials": {}}),
+        ) as resolve,
+    ):
+        await tool._execute(user_id=_TEST_USER_ID, session=session, review_id=review_id)
+
+    resolve.assert_awaited_once()
+    assert resolve.await_args_list[0].args[3] == "expert-a"

--- a/autogpt_platform/backend/backend/copilot/tools/expert_resources.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_resources.py
@@ -16,7 +16,7 @@ from backend.data.db_accessors import chat_db, experts_db
 from backend.util.exceptions import ExpertNotFoundError, NotFoundError
 
 from .base import BaseTool
-from .expert_scope import resolve_target_expert
+from .expert_scope import resolve_target_expert, settle_expert_grants
 from .models import ErrorResponse, ResponseType, ToolResponseBase
 from .utils import fetch_graph_from_store_slug
 
@@ -119,6 +119,7 @@ class InstallExpertWorkflowTool(BaseTool):
                         message=f"Marketplace agent '{username_agent_slug}' not found",
                         session_id=session_id,
                     )
+            await settle_expert_grants(user_id, session)
             ref: ExpertWorkflowRef = await experts_db().install_workflow(
                 user_id,
                 target,
@@ -331,6 +332,15 @@ async def _change_grant(
     session_id = session.session_id
     if not user_id:
         return ErrorResponse(message="Authentication required", session_id=session_id)
+    if session.expert_id is not None:
+        return ErrorResponse(
+            message=(
+                "An expert cannot change credential grants. Use "
+                "request_credential_grant to ask the user for access."
+            ),
+            error="access_denied",
+            session_id=session_id,
+        )
     target = await resolve_target_expert(user_id, session, expert_id.strip() or None)
     if isinstance(target, ErrorResponse):
         return target

--- a/autogpt_platform/backend/backend/copilot/tools/expert_resources_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_resources_test.py
@@ -46,6 +46,7 @@ def experts():
         )
     )
     db.install_workflow = AsyncMock(return_value=_ref())
+    db.settle_credential_seed = AsyncMock()
     db.remove_workflow = AsyncMock()
     db.grant_expert_credentials = AsyncMock(return_value=[_cred()])
     db.revoke_expert_credential = AsyncMock(return_value=[])
@@ -242,3 +243,33 @@ async def test_grant_request_fails_when_it_cannot_be_recorded(experts):
     assert isinstance(result, ErrorResponse)
     assert result.error == "request_not_recorded"
     assert session.metadata.pending_question is None
+
+
+async def test_expert_cannot_grant_itself(experts):
+    result = await GrantExpertCredentialTool()._execute(
+        "user-1", _session("expert-a"), expert_id="expert-a", credential_id="cred-1"
+    )
+    assert isinstance(result, ErrorResponse) and result.error == "access_denied"
+    experts.grant_expert_credentials.assert_not_awaited()
+
+
+async def test_expert_install_settles_its_grants_before_the_workflow_lands(experts):
+    order: list[str] = []
+    experts.settle_credential_seed.side_effect = lambda *_: order.append("settle")
+    experts.install_workflow.side_effect = lambda *_, **__: (
+        order.append("install") or _ref()
+    )
+    result = await InstallExpertWorkflowTool()._execute(
+        "user-1", _session("expert-a"), library_agent_id="lib-1"
+    )
+    assert isinstance(result, ExpertWorkflowResponse)
+    assert order == ["settle", "install"]
+    experts.settle_credential_seed.assert_awaited_once_with("user-1", "expert-a")
+
+
+async def test_autopilot_install_does_not_touch_the_experts_grants(experts):
+    result = await InstallExpertWorkflowTool()._execute(
+        "user-1", _session(None), expert_id="expert-a", library_agent_id="lib-1"
+    )
+    assert isinstance(result, ExpertWorkflowResponse)
+    experts.settle_credential_seed.assert_not_awaited()

--- a/autogpt_platform/backend/backend/copilot/tools/expert_scope.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_scope.py
@@ -135,6 +135,18 @@ async def resolve_target_expert(
     return expert.id
 
 
+async def settle_expert_grants(user_id: str, session: ChatSession) -> None:
+    """An expert installing a workflow on itself must not widen its own grants.
+
+    The allow-list is seeded from the expert's workflows on first read, so
+    settle it before the install lands; otherwise the new workflow's
+    credentials would be granted by the expert's own action.
+    """
+    if session.expert_id is None:
+        return
+    await experts_db().settle_credential_seed(user_id, session.expert_id)
+
+
 async def install_saved_agent(
     user_id: str, session: ChatSession, result: ToolResponseBase
 ) -> ToolResponseBase:
@@ -147,6 +159,7 @@ async def install_saved_agent(
     if session.expert_id is None or not isinstance(result, AgentSavedResponse):
         return result
     try:
+        await settle_expert_grants(user_id, session)
         await experts_db().install_workflow(
             user_id, session.expert_id, library_agent_id=result.library_agent_id
         )

--- a/autogpt_platform/backend/backend/copilot/tools/expert_scope_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/expert_scope_test.py
@@ -34,6 +34,7 @@ def experts():
     )
     db.install_workflow = AsyncMock()
     db.expert_allowed_credential_ids = AsyncMock(return_value=["granted-cred"])
+    db.settle_credential_seed = AsyncMock()
     with patch(f"{_PATH}.experts_db", return_value=db):
         yield db
 
@@ -179,3 +180,11 @@ async def test_hint_lists_owned_but_ungranted_credentials(experts):
     assert "granted-cred" not in hint and "other-cred" not in hint
     assert "grant_expert_credential" in hint
     assert none == "" and personal == ""
+
+
+async def test_agent_built_by_expert_settles_grants_before_install(experts):
+    order: list[str] = []
+    experts.settle_credential_seed.side_effect = lambda *_: order.append("settle")
+    experts.install_workflow.side_effect = lambda *_, **__: order.append("install")
+    await install_saved_agent("user-1", _expert_session(), _saved())
+    assert order == ["settle", "install"]

--- a/autogpt_platform/backend/backend/copilot/tools/handoff_to_expert_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/handoff_to_expert_test.py
@@ -676,14 +676,15 @@ class TestExpertToolGate:
     experts_enabled=False for user_id=None)."""
 
     def test_flag_off_disables_every_team_group(self) -> None:
-        assert expert_tool_disabled_groups(experts_enabled=False, expert_id=None) == [
-            "experts",
-            "expert_admin",
-            "delegation",
-        ]
-        assert expert_tool_disabled_groups(
-            experts_enabled=False, expert_id="expert-a"
-        ) == ["experts", "expert_admin", "delegation"]
+        expected = ["experts", "expert_admin", "delegation", "expert_resources"]
+        assert (
+            expert_tool_disabled_groups(experts_enabled=False, expert_id=None)
+            == expected
+        )
+        assert (
+            expert_tool_disabled_groups(experts_enabled=False, expert_id="expert-a")
+            == expected
+        )
 
     def test_plain_session_loses_expert_session_tools(self) -> None:
         assert expert_tool_disabled_groups(experts_enabled=True, expert_id=None) == [

--- a/autogpt_platform/backend/backend/copilot/tools/test_run_mcp_tool.py
+++ b/autogpt_platform/backend/backend/copilot/tools/test_run_mcp_tool.py
@@ -1355,3 +1355,57 @@ async def test_lookup_tool_schema_returns_none_on_any_failure():
     schema = await tool._lookup_tool_schema(mock_client, "notion-update-page")
 
     assert schema is None
+
+
+# ---------------------------------------------------------------------------
+# Expert credential grants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_an_ungranted_mcp_credential_is_refused_for_an_expert():
+    response = await _run_with_grants([])
+    assert isinstance(response, ErrorResponse)
+    assert response.error == "credential_not_granted"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_a_granted_mcp_credential_is_used():
+    response = await _run_with_grants(["mcp-cred"])
+    assert isinstance(response, MCPToolsDiscoveredResponse)
+
+
+async def _run_with_grants(allowed: list[str]):
+    """Discover tools in an expert session whose grant list is *allowed*, with
+    one stored MCP credential for the server."""
+    creds = OAuth2Credentials(
+        id="mcp-cred",
+        provider="mcp",
+        title="MCP: remote.mcpservers.org",
+        access_token=SecretStr("test-token-abc"),
+        scopes=[],
+        metadata={"mcp_server_url": _SERVER_URL},
+    )
+    experts = MagicMock()
+    experts.expert_allowed_credential_ids = AsyncMock(return_value=allowed)
+    client = AsyncMock()
+    client.list_tools = AsyncMock(return_value=_make_tool_list("fetch"))
+
+    with (
+        patch(
+            "backend.copilot.tools.run_mcp_tool.validate_url_host",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "backend.copilot.tools.run_mcp_tool.auto_lookup_mcp_credential",
+            new_callable=AsyncMock,
+            return_value=creds,
+        ),
+        patch("backend.data.db_accessors.experts_db", return_value=experts),
+        patch("backend.copilot.tools.run_mcp_tool.MCPClient", return_value=client),
+    ):
+        return await RunMCPToolTool()._execute(
+            user_id=_USER_ID,
+            session=make_session(_USER_ID, expert_id="expert-a"),
+            server_url=_SERVER_URL,
+        )

--- a/autogpt_platform/backend/backend/copilot/tools/utils_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/utils_test.py
@@ -3,8 +3,10 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import SecretStr
 
-from backend.data.model import CredentialsFieldInfo
+from backend.blocks.http import SendAuthenticatedWebRequestBlock
+from backend.data.model import CredentialsFieldInfo, HostScopedCredentials
 
 
 def _make_regular_field() -> CredentialsFieldInfo:
@@ -74,3 +76,56 @@ async def test_match_user_credentials_excludes_auto_creds():
     assert len(matched) == 0
     assert len(missing) == 1
     assert "github_api_key" in missing[0]
+
+
+async def test_a_block_run_in_an_expert_session_uses_only_a_granted_credential():
+    matched, missing = await _resolve_for("expert-a", ["granted-cred"])
+    assert matched["credentials"].id == "granted-cred"
+    assert missing == []
+
+
+async def test_an_ungranted_credential_surfaces_as_missing_not_as_a_match():
+    matched, missing = await _resolve_for("expert-a", [])
+    assert matched == {}
+    assert len(missing) == 1
+
+
+async def test_a_plain_session_keeps_every_account_credential():
+    matched, _ = await _resolve_for(None, [])
+    assert matched["credentials"].id == "ungranted-cred"
+
+
+def _host_cred(cred_id: str) -> HostScopedCredentials:
+    return HostScopedCredentials(
+        id=cred_id,
+        provider="http",
+        host="api.example.com",
+        headers={"Authorization": SecretStr("Bearer token")},
+        title=cred_id,
+    )
+
+
+async def _resolve_for(expert_id: str | None, allowed: list[str]):
+    """Resolve an authenticated-request block against two account credentials
+    for the same host, only one of which the expert has been granted."""
+    from backend.copilot.tools.helpers import resolve_block_credentials
+
+    experts = MagicMock()
+    experts.expert_allowed_credential_ids = AsyncMock(return_value=allowed)
+    with (
+        patch(
+            "backend.copilot.tools.utils.IntegrationCredentialsManager"
+        ) as MockCredsMgr,
+        patch("backend.data.db_accessors.experts_db", return_value=experts),
+    ):
+        MockCredsMgr.return_value.store = AsyncMock()
+        MockCredsMgr.return_value.store.get_all_creds.return_value = [
+            _host_cred("ungranted-cred"),
+            _host_cred("granted-cred"),
+        ]
+        return await resolve_block_credentials(
+            "test-user",
+            SendAuthenticatedWebRequestBlock(),
+            {"url": "https://api.example.com/v1/data"},
+            expert_id,
+        )

--- a/autogpt_platform/backend/backend/data/db_manager.py
+++ b/autogpt_platform/backend/backend/data/db_manager.py
@@ -524,6 +524,7 @@ class DatabaseManager(AppService):
     resolve_private_expert_tenancy = _(experts_db.resolve_private_expert_tenancy)
     enforce_expert_run_budget = _(experts_scheduling.enforce_expert_run_budget)
     expert_allowed_credential_ids = _(expert_credentials.expert_allowed_credential_ids)
+    settle_credential_seed = _(expert_credentials.settle_credential_seed)
     update_soul = _(experts_db.update_soul)
     update_soul_if_current = _(experts_db.update_soul_if_current)
     update_soul_fields = _(experts_db.update_soul_fields)
@@ -913,6 +914,7 @@ class DatabaseManagerAsyncClient(AppServiceClient):
     resolve_private_expert_tenancy = d.resolve_private_expert_tenancy
     enforce_expert_run_budget = d.enforce_expert_run_budget
     expert_allowed_credential_ids = d.expert_allowed_credential_ids
+    settle_credential_seed = d.settle_credential_seed
     update_soul = d.update_soul
     update_soul_if_current = d.update_soul_if_current
     update_soul_fields = d.update_soul_fields


### PR DESCRIPTION
### Changes 🏗️

Holds every expert credential path to the grant list: the approved continuation of a reviewed block, the seed that an install could widen, and the grant/revoke tools — and gives three guards the tests they never had.

This also makes #14415 green on its own head. The stack merges bottom-up, so `dev` will hold this PR's state as a real commit; three of the fixes it needs currently live only on `abhi/expert-grant-card` at the top of the stack, and one test it needs to pass is fixed there too.

The approved continuation of a reviewed block resolved credentials against the whole account. `continue_run_block` called `resolve_block_credentials` without the expert, so a block held to one granted account at `run_block` time could execute with a different one after approval, and a grant revoked between the review and the approval had no effect. It now passes `session.expert_id`, like every other block path.

An unseeded expert could widen its own grants by installing a workflow. The allow-list is seeded from the expert's installed workflows the first time it is read; an expert whose list was not yet stamped could install a library workflow and have that workflow's credentials derived into its own grants on the next read. `install_expert_workflow` and the auto-install of an agent the expert just built now settle the seed first, and `grant_expert_credential` / `revoke_expert_credential` refuse an expert session outright rather than relying on the tool-group gate alone.

Three guards had no test that fails when they are removed — the point of the whole ownership boundary is that a prohibition is only real if something breaks when it goes:

- `scope_credentials_to_expert`, the single filter behind block runs, MCP tools and webhook setup. Removing it entirely left every suite green; the test that appeared to cover it patched the matcher out and asserted only that the expert id was forwarded. The new tests run two account credentials for the same host through `resolve_block_credentials` and assert the ungranted one is neither matched nor silently preferred.
- The MCP grant check. No test anywhere failed when an expert was allowed to use an ungranted MCP credential.
- `handoff_to_expert_test::TestExpertToolGate::test_flag_off_disables_every_team_group` asserts the old disabled-group list, which is what makes #14415 red on `test (3.11)`, `(3.12)` and `(3.13)` on its own head. The one-line assertion fix is moved down from `c0fc8ff82e`, so this PR is green.

**Moved rather than rewritten.** The `continue_run_block` fix, the settle-before-install fix and the test-assertion fix already exist on `abhi/expert-grant-card` (`03168cca3e`, `f235c7757c`, `c0fc8ff82e`); the code here is those hunks verbatim, so the version that lands is the one already written and reviewed rather than a third variant. The rest of `03168cca3e` — picker credentials (`_credentials_id`) on `acquire_auto_credentials`, the MCP and validation-error card annotations — is left where it is: it is 460 lines across 17 files and moving it down would be a larger change than the gap it closes on this head.

### Verified

I ran `copilot/tools/` — `expert_scope_test`, `expert_resources_test`, `utils_test`, `test_run_mcp_tool`, `run_mcp_tool_test`, `continue_run_block_test`, `handoff_to_expert_test`, `http_credentials_test`, `block_display_test`, `helpers_test`, `list_team_test` — plus `api/features/experts/credentials_test.py`, `util/architecture_test.py` and `blocks/test/test_block.py`.

Every guard was mutated back out and the right test failed each time; the mutation table is in a comment below. `credentials_test.py`'s DB-backed neighbours and the frontend suites were not run here.

Backed by a hand-fired backend CI run, because a PR stacked on a feature branch never triggers `platform-backend-ci.yml` on `pull_request` and a skipped workflow leaves no check row: https://github.com/Significant-Gravitas/AutoGPT/actions/runs/34219135467 — success on head `3086eed502`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

### Agents and large language models used

- Claude Code — Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
