### PR TITLE
feat(frontend): align folder rows and add multi-select to the files table

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/selection.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/__tests__/selection.test.tsx
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+import { server } from "@/mocks/mock-server";
+import { http, HttpResponse } from "msw";
+import { getListExpertIdentitiesMockHandler } from "@/app/api/__generated__/endpoints/experts/experts.msw";
+import {
+  getGetWorkspaceStorageUsageMockHandler,
+  getListWorkspaceFilesMockHandler,
+  getListWorkspaceFoldersMockHandler,
+} from "@/app/api/__generated__/endpoints/workspace/workspace.msw";
+import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+import type { WorkspaceFolder } from "@/app/api/__generated__/models/workspaceFolder";
+import { FILE_DRAG_MIME } from "../components/WorkspaceFolders/drag";
+
+vi.mock("@/services/feature-flags/use-get-flag", () => ({
+  Flag: { ARTIFACTS_PAGE: "artifacts-page" },
+  useGetFlag: () => true,
+  useFlagStatus: () => ({ enabled: true, ready: true }),
+}));
+
+beforeEach(() => {
+  server.use(getListExpertIdentitiesMockHandler([]));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/artifacts",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+}));
+
+vi.mock("framer-motion", async (importActual) => {
+  const actual = await importActual<typeof import("framer-motion")>();
+  return { ...actual, useReducedMotion: () => true };
+});
+
+import ArtifactsPage from "../page";
+
+const PROXY = "/api/proxy/api/workspace";
+
+function makeFile(
+  overrides: Partial<WorkspaceFileItem> = {},
+): WorkspaceFileItem {
+  return {
+    id: "file-base",
+    name: "base.txt",
+    path: "/base.txt",
+    mime_type: "text/plain",
+    size_bytes: 1024,
+    folder_id: null,
+    metadata: {},
+    origin: "generated",
+    created_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<WorkspaceFolder> = {}): WorkspaceFolder {
+  return {
+    id: "fld-1",
+    workspace_id: "ws-1",
+    name: "Reports",
+    file_count: 2,
+    created_at: "2026-05-01T00:00:00Z" as unknown as Date,
+    updated_at: "2026-05-01T00:00:00Z" as unknown as Date,
+    ...overrides,
+  };
+}
+
+function useBaseHandlers(files: WorkspaceFileItem[]) {
+  server.use(
+    getGetWorkspaceStorageUsageMockHandler({
+      used_bytes: 0,
+      limit_bytes: 1_000_000_000,
+      used_percent: 0,
+      file_count: 0,
+    }),
+    getListWorkspaceFilesMockHandler({ files, offset: 0, has_more: false }),
+    getListWorkspaceFoldersMockHandler({
+      folders: [makeFolder({ id: "fld-1", name: "Reports" })],
+    }),
+  );
+}
+
+function makeDataTransfer() {
+  const store: Record<string, string> = {};
+  return {
+    store,
+    dataTransfer: {
+      setData: (key: string, value: string) => {
+        store[key] = value;
+      },
+      getData: (key: string) => store[key] ?? "",
+      setDragImage: () => {},
+      get types() {
+        return Object.keys(store);
+      },
+    },
+  };
+}
+
+const TWO_FILES = [
+  makeFile({ id: "f1", name: "one.txt" }),
+  makeFile({ id: "f2", name: "two.txt" }),
+];
+
+describe("ArtifactsPage - row selection", () => {
+  test("clicking a thumbnail selects the row without opening it", async () => {
+    useBaseHandlers(TWO_FILES);
+
+    render(<ArtifactsPage />);
+
+    const toggle = await screen.findByLabelText("Select one.txt");
+    fireEvent.click(toggle);
+
+    expect(await screen.findByTestId("artifacts-selection-bar")).toBeDefined();
+    expect(screen.getByText("1 selected")).toBeDefined();
+    expect(screen.queryByTestId("file-viewer")).toBeNull();
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(screen.queryByTestId("artifacts-selection-bar")).toBeNull(),
+    );
+    expect(screen.getByText("Modified")).toBeDefined();
+  });
+
+  test("select all and clear work from the selection bar", async () => {
+    useBaseHandlers(TWO_FILES);
+
+    render(<ArtifactsPage />);
+
+    fireEvent.click(await screen.findByLabelText("Select one.txt"));
+    fireEvent.click(await screen.findByTestId("artifacts-select-all"));
+
+    expect(await screen.findByText("2 selected")).toBeDefined();
+    expect(screen.queryByTestId("artifacts-select-all")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Clear selection"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("artifacts-selection-bar")).toBeNull(),
+    );
+  });
+
+  test("deleting the selection deletes every selected file", async () => {
+    useBaseHandlers(TWO_FILES);
+    const deleted: string[] = [];
+    server.use(
+      http.delete(`${PROXY}/files/:fileId`, ({ params }) => {
+        deleted.push(String(params.fileId));
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<ArtifactsPage />);
+
+    fireEvent.click(await screen.findByLabelText("Select one.txt"));
+    fireEvent.click(await screen.findByLabelText("Select two.txt"));
+    fireEvent.click(await screen.findByTestId("artifacts-selection-delete"));
+
+    await waitFor(() => expect(deleted.sort()).toEqual(["f1", "f2"]));
+  });
+
+  test("a cancelled delete confirmation deletes nothing", async () => {
+    useBaseHandlers(TWO_FILES);
+    let deleteCalled = false;
+    server.use(
+      http.delete(`${PROXY}/files/:fileId`, () => {
+        deleteCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<ArtifactsPage />);
+
+    fireEvent.click(await screen.findByLabelText("Select one.txt"));
+    fireEvent.click(await screen.findByTestId("artifacts-selection-delete"));
+
+    expect(await screen.findByText("1 selected")).toBeDefined();
+    expect(deleteCalled).toBe(false);
+  });
+
+  test("moving the selection posts one bulk move with every id", async () => {
+    useBaseHandlers(TWO_FILES);
+    let body: { file_ids: string[]; folder_id: string | null } | null = null;
+    server.use(
+      http.post(`${PROXY}/folders/files/bulk-move`, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    render(<ArtifactsPage />);
+
+    fireEvent.click(await screen.findByLabelText("Select one.txt"));
+    fireEvent.click(await screen.findByLabelText("Select two.txt"));
+    fireEvent.click(await screen.findByTestId("artifacts-selection-move"));
+    expect(await screen.findByText("Move 2 files to:")).toBeDefined();
+    fireEvent.click(await screen.findByTestId("move-to-folder-option"));
+
+    await waitFor(() =>
+      expect(body).toEqual({ file_ids: ["f1", "f2"], folder_id: "fld-1" }),
+    );
+  });
+
+  test("dragging a selected row onto a folder moves the whole selection", async () => {
+    useBaseHandlers(TWO_FILES);
+    let body: { file_ids: string[]; folder_id: string | null } | null = null;
+    server.use(
+      http.post(`${PROXY}/folders/files/bulk-move`, async ({ request }) => {
+        body = (await request.json()) as typeof body;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    render(<ArtifactsPage />);
+
+    fireEvent.click(await screen.findByLabelText("Select one.txt"));
+    fireEvent.click(await screen.findByLabelText("Select two.txt"));
+
+    const { store, dataTransfer } = makeDataTransfer();
+    const [firstRow] = screen.getAllByTestId("artifacts-list-item");
+    const folder = await screen.findByTestId("workspace-folder");
+    fireEvent.dragStart(firstRow, { dataTransfer });
+    fireEvent.dragOver(folder, { dataTransfer });
+    fireEvent.drop(folder, { dataTransfer });
+    fireEvent.dragEnd(firstRow, { dataTransfer });
+
+    expect(store[FILE_DRAG_MIME]).toBe("f1,f2");
+    await waitFor(() =>
+      expect(body).toEqual({ file_ids: ["f1", "f2"], folder_id: "fld-1" }),
+    );
+  });
+
+  test("dragging an unselected row carries only that file", async () => {
+    useBaseHandlers(TWO_FILES);
+    server.use(
+      http.post(`${PROXY}/folders/files/bulk-move`, () =>
+        HttpResponse.json([]),
+      ),
+    );
+
+    render(<ArtifactsPage />);
+
+    fireEvent.click(await screen.findByLabelText("Select one.txt"));
+
+    const { store, dataTransfer } = makeDataTransfer();
+    const [, secondRow] = screen.getAllByTestId("artifacts-list-item");
+    fireEvent.dragStart(secondRow, { dataTransfer });
+    fireEvent.dragEnd(secondRow, { dataTransfer });
+
+    expect(store[FILE_DRAG_MIME]).toBe("f2");
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactCard/ArtifactCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactCard/ArtifactCard.tsx
@@ -49,7 +49,7 @@ const REDUCED_CARD_VARIANTS: Variants = {
 export function ArtifactCard({ file, onOpen, index = 0 }: Props) {
   const typeIcon = getFileTypeIcon(file.mime_type, file.name);
   const reduceMotion = useReducedMotion();
-  const { handleDragStart, handleDragEnd } = useFileDrag(file.id, file.name);
+  const { handleDragStart, handleDragEnd } = useFileDrag([file.id], file.name);
 
   return (
     <motion.li

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsList.tsx
@@ -72,7 +72,9 @@ export function ArtifactsList({
           />
         </div>
       ) : (
+        // Keyed so the row selection resets whenever the listing changes.
         <ArtifactsTable
+          key={listKey}
           files={files}
           isLoading={isLoading}
           emptyState={emptyState}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/ArtifactsTable.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/ArtifactsTable.tsx
@@ -8,10 +8,12 @@ import { motion, useReducedMotion } from "framer-motion";
 import type { Variants } from "framer-motion";
 import { EmptyState } from "../EmptyState";
 import type { EmptyStateContent } from "../helpers";
+import { SelectionBar } from "../SelectionBar/SelectionBar";
 import { FileRow } from "./FileRow";
 import { FolderRows } from "./FolderRows";
 import { SkeletonRow } from "./SkeletonRow";
 import { DATE_CELL_CLASS, ROW_GRID_CLASS, SIZE_CELL_CLASS } from "./row-layout";
+import { useFileSelection } from "./useFileSelection";
 
 interface Props {
   files: WorkspaceFileItem[];
@@ -42,29 +44,39 @@ export function ArtifactsTable({
   onOpen,
 }: Props) {
   const reduceMotion = useReducedMotion();
+  const selection = useFileSelection(files);
 
   return (
     <div data-testid="artifacts-table">
-      <div className={cn(ROW_GRID_CLASS, "px-2 pb-2")}>
-        <Text variant="body" as="span" className="text-zinc-500">
-          Name
-        </Text>
-        <Text
-          variant="body"
-          as="span"
-          className={cn(DATE_CELL_CLASS, "text-zinc-500")}
-        >
-          Modified
-        </Text>
-        <Text
-          variant="body"
-          as="span"
-          className={cn(SIZE_CELL_CLASS, "text-zinc-500")}
-        >
-          Size
-        </Text>
-        <span aria-hidden className="min-w-10" />
-      </div>
+      {selection.selectedFiles.length > 0 ? (
+        <SelectionBar
+          selectedFiles={selection.selectedFiles}
+          totalCount={files.length}
+          onSelectAll={selection.selectAll}
+          onClear={selection.clear}
+        />
+      ) : (
+        <div className={cn(ROW_GRID_CLASS, "px-2 pb-2")}>
+          <Text variant="body" as="span" className="text-zinc-500">
+            Name
+          </Text>
+          <Text
+            variant="body"
+            as="span"
+            className={cn(DATE_CELL_CLASS, "text-zinc-500")}
+          >
+            Modified
+          </Text>
+          <Text
+            variant="body"
+            as="span"
+            className={cn(SIZE_CELL_CLASS, "text-zinc-500")}
+          >
+            Size
+          </Text>
+          <span aria-hidden />
+        </div>
+      )}
       <TooltipProvider delayDuration={450} skipDelayDuration={300}>
         <motion.ul
           key={listKey}
@@ -91,6 +103,9 @@ export function ArtifactsTable({
                 file={file}
                 onOpen={onOpen}
                 index={index}
+                isSelected={selection.isSelected(file)}
+                selectedIds={selection.selectedIds}
+                onToggleSelect={selection.toggle}
               />
             ))
           )}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/FileRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/FileRow.tsx
@@ -9,7 +9,7 @@ import {
   TooltipTrigger,
 } from "@/components/atoms/Tooltip/BaseTooltip";
 import { cn } from "@/lib/utils";
-import { PencilEdit02Icon } from "@hugeicons/core-free-icons";
+import { PencilEdit02Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { motion, useReducedMotion } from "framer-motion";
 import { useState } from "react";
@@ -35,6 +35,10 @@ interface Props {
   onOpen: (file: WorkspaceFileItem) => void;
   /** Position in the list; drives the small entrance stagger. */
   index?: number;
+  isSelected: boolean;
+  /** Every selected file id; a drag from a selected row carries all of them. */
+  selectedIds: string[];
+  onToggleSelect: (file: WorkspaceFileItem) => void;
 }
 
 // Long enough that skimming down the list doesn't flash previews; short
@@ -42,9 +46,18 @@ interface Props {
 // provider's skip delay opens the next preview immediately.
 const PREVIEW_DELAY_MS = 450;
 
-export function FileRow({ file, onOpen, index = 0 }: Props) {
+export function FileRow({
+  file,
+  onOpen,
+  index = 0,
+  isSelected,
+  selectedIds,
+  onToggleSelect,
+}: Props) {
   const reduceMotion = useReducedMotion();
-  const { handleDragStart, handleDragEnd } = useFileDrag(file.id, file.name);
+  const dragIds = isSelected ? selectedIds : [file.id];
+  const dragLabel = dragIds.length > 1 ? `${dragIds.length} files` : file.name;
+  const { handleDragStart, handleDragEnd } = useFileDrag(dragIds, dragLabel);
   const [isRenameOpen, setIsRenameOpen] = useState(false);
 
   return (
@@ -56,18 +69,44 @@ export function FileRow({ file, onOpen, index = 0 }: Props) {
       className={cn(
         ROW_GRID_CLASS,
         "group cursor-pointer px-2 transition-colors has-[[data-state=open]]:bg-zinc-50 hover:bg-zinc-50",
+        isSelected && "bg-zinc-100 hover:bg-zinc-100",
       )}
       data-testid="artifacts-list-item"
+      data-selected={isSelected || undefined}
       draggable
       onClick={() => onOpen(file)}
       onDragStartCapture={handleDragStart}
       onDragEndCapture={handleDragEnd}
     >
-      {/* The name is the row's accessible control: it takes focus, Enter
-          bubbles a click up to the row, and hovering (or focusing) it opens
-          the large preview. The rename pencil sits beside it, outside the
-          preview trigger. */}
+      {/* The thumbnail toggles the row's selection; the name is the row's
+          accessible open control: it takes focus, Enter bubbles a click up to
+          the row, and hovering (or focusing) it opens the large preview. The
+          rename pencil sits beside it, outside the preview trigger. */}
       <div className="flex min-w-0 items-center gap-1 justify-self-start">
+        <button
+          type="button"
+          aria-label={`Select ${file.name}`}
+          aria-pressed={isSelected}
+          className="group/select relative my-2.5 mr-3 shrink-0 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleSelect(file);
+          }}
+          data-testid="artifacts-select"
+        >
+          <FileThumbnail file={file} />
+          <span
+            aria-hidden
+            className={cn(
+              "pointer-events-none absolute inset-0 flex items-center justify-center rounded-xl text-white transition-opacity",
+              isSelected
+                ? "bg-zinc-900/80 opacity-100"
+                : "bg-zinc-900/60 opacity-0 group-hover/select:opacity-100 group-focus-visible/select:opacity-100",
+            )}
+          >
+            <Icon icon={Tick02Icon} size={20} />
+          </span>
+        </button>
         <Tooltip delayDuration={PREVIEW_DELAY_MS}>
           <TooltipTrigger asChild>
             <button
@@ -75,7 +114,6 @@ export function FileRow({ file, onOpen, index = 0 }: Props) {
               className={NAME_BUTTON_CLASS}
               data-testid="artifacts-card-open"
             >
-              <FileThumbnail file={file} />
               <Text
                 variant="body-medium"
                 as="span"

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/FolderRow.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/FolderRow.tsx
@@ -11,7 +11,7 @@ import {
 import { motion, useReducedMotion } from "framer-motion";
 import { useState } from "react";
 import type { DragEvent } from "react";
-import { FILE_DRAG_MIME } from "../../WorkspaceFolders/drag";
+import { FILE_DRAG_MIME, readFileDragIds } from "../../WorkspaceFolders/drag";
 import { FOLDER_STYLE } from "../../WorkspaceFolders/folder-constants";
 import { formatDayLabel, formatFullDate } from "../helpers";
 import {
@@ -32,7 +32,7 @@ interface Props {
   onOpen: () => void;
   onEdit: () => void;
   onDelete: () => void;
-  onFileDrop: (fileId: string) => void;
+  onFileDrop: (fileIds: string[]) => void;
 }
 
 const ACTION_BUTTON_CLASS =
@@ -69,8 +69,8 @@ export function FolderRow({
   function handleDrop(e: DragEvent<HTMLLIElement>) {
     e.preventDefault();
     setIsDragOver(false);
-    const fileId = e.dataTransfer.getData(FILE_DRAG_MIME);
-    if (fileId) onFileDrop(fileId);
+    const fileIds = readFileDragIds(e.dataTransfer);
+    if (fileIds.length > 0) onFileDrop(fileIds);
   }
 
   return (

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/FolderRows.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/FolderRows.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function FolderRows({ onSelectFolder }: Props) {
-  const { folders, isLoading, isError, error, moveFileToFolder } =
+  const { folders, isLoading, isError, error, moveFilesToFolder } =
     useArtifactsFolders();
   const [editing, setEditing] = useState<WorkspaceFolder | null>(null);
   const [deleting, setDeleting] = useState<WorkspaceFolder | null>(null);
@@ -51,8 +51,8 @@ export function FolderRows({ onSelectFolder }: Props) {
           onOpen={() => onSelectFolder(folder.id)}
           onEdit={() => setEditing(folder)}
           onDelete={() => setDeleting(folder)}
-          onFileDrop={(fileId) => {
-            moveFileToFolder({ fileId, folderId: folder.id }).catch(() => {});
+          onFileDrop={(fileIds) => {
+            moveFilesToFolder({ fileIds, folderId: folder.id }).catch(() => {});
           }}
         />
       ))}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/row-layout.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/row-layout.ts
@@ -1,13 +1,14 @@
 import type { Variants } from "framer-motion";
 
 // Column template shared by the header and every row so cells line up.
-// Modified and Size collapse on narrow screens; the trailing column sizes to
-// the row actions.
+// Modified and Size collapse on narrow screens. The trailing column has a
+// fixed width (room for two icon buttons) so rows with a different number of
+// actions don't shift the other columns.
 export const ROW_GRID_CLASS =
-  "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 sm:grid-cols-[minmax(0,1fr)_7rem_auto] md:grid-cols-[minmax(0,1fr)_8rem_6rem_auto]";
+  "grid grid-cols-[minmax(0,1fr)_4.5rem] items-center gap-3 sm:grid-cols-[minmax(0,1fr)_7rem_4.5rem] md:grid-cols-[minmax(0,1fr)_8rem_6rem_4.5rem]";
 export const DATE_CELL_CLASS = "hidden truncate sm:block";
 export const SIZE_CELL_CLASS = "hidden tabular-nums md:block";
-export const ACTIONS_CELL_CLASS = "flex min-w-10 justify-end";
+export const ACTIONS_CELL_CLASS = "flex justify-end";
 
 // Sized to its content (its wrapper is not stretched across the column) so
 // the hover preview, which anchors to this button, opens beside the name.

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/useFileSelection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/ArtifactsTable/useFileSelection.ts
@@ -1,0 +1,42 @@
+import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+import { useState } from "react";
+
+/**
+ * Multi-select for table rows. The selection is derived from the current
+ * `files`, so an id that leaves the list (deleted, moved, paged out) drops out
+ * of the selection on its own.
+ */
+export function useFileSelection(files: WorkspaceFileItem[]) {
+  const [selectedIdSet, setSelectedIdSet] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const selectedFiles = files.filter((file) => selectedIdSet.has(file.id));
+  const selectedIds = selectedFiles.map((file) => file.id);
+
+  function toggle(file: WorkspaceFileItem) {
+    setSelectedIdSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(file.id)) next.delete(file.id);
+      else next.add(file.id);
+      return next;
+    });
+  }
+
+  function selectAll() {
+    setSelectedIdSet(new Set(files.map((file) => file.id)));
+  }
+
+  function clear() {
+    setSelectedIdSet(new Set());
+  }
+
+  return {
+    selectedFiles,
+    selectedIds,
+    isSelected: (file: WorkspaceFileItem) => selectedIdSet.has(file.id),
+    toggle,
+    selectAll,
+    clear,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/FileActionsMenu.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/FileActionsMenu.tsx
@@ -133,8 +133,8 @@ export function FileActionsMenu({ file, className }: Props) {
       )}
       {isMoveOpen && (
         <MoveToFolderDialog
-          fileId={file.id}
-          fileName={file.name}
+          fileIds={[file.id]}
+          subject={`“${file.name}”`}
           currentFolderId={file.folder_id}
           isOpen={isMoveOpen}
           setIsOpen={setIsMoveOpen}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/SelectionBar/SelectionBar.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/SelectionBar/SelectionBar.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+import { Button } from "@/components/atoms/Button/Button";
+import { Icon } from "@/components/atoms/Icon/Icon";
+import { Text } from "@/components/atoms/Text/Text";
+import {
+  Cancel01Icon,
+  Delete02Icon,
+  Folder01Icon,
+} from "@hugeicons/core-free-icons";
+import { MoveToFolderDialog } from "../../MoveToFolderDialog/MoveToFolderDialog";
+import { useSelectionBar } from "./useSelectionBar";
+
+interface Props {
+  selectedFiles: WorkspaceFileItem[];
+  totalCount: number;
+  onSelectAll: () => void;
+  onClear: () => void;
+}
+
+export function SelectionBar({
+  selectedFiles,
+  totalCount,
+  onSelectAll,
+  onClear,
+}: Props) {
+  const {
+    isMoveOpen,
+    setIsMoveOpen,
+    isDeleting,
+    handleDelete,
+    moveSubject,
+    sharedFolderId,
+  } = useSelectionBar(selectedFiles, onClear);
+  const count = selectedFiles.length;
+
+  return (
+    <div
+      className="flex h-[1.875rem] items-center justify-between gap-3 px-2 pb-2"
+      data-testid="artifacts-selection-bar"
+    >
+      <div className="flex items-center gap-3">
+        <Text variant="body-medium" as="span" className="text-zinc-900">
+          {count} selected
+        </Text>
+        {count < totalCount ? (
+          <button
+            type="button"
+            className="text-sm text-zinc-500 underline-offset-2 hover:text-zinc-900 hover:underline"
+            onClick={onSelectAll}
+            data-testid="artifacts-select-all"
+          >
+            Select all {totalCount}
+          </button>
+        ) : null}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={() => setIsMoveOpen(true)}
+          data-testid="artifacts-selection-move"
+        >
+          <Icon icon={Folder01Icon} size={14} />
+          Move to folder
+        </Button>
+        <Button
+          variant="outline"
+          size="xs"
+          disabled={isDeleting}
+          onClick={handleDelete}
+          className="text-red-600 hover:bg-red-50 hover:text-red-700"
+          data-testid="artifacts-selection-delete"
+        >
+          <Icon icon={Delete02Icon} size={14} />
+          {isDeleting ? "Deleting…" : "Delete"}
+        </Button>
+        <button
+          type="button"
+          aria-label="Clear selection"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900"
+          onClick={onClear}
+          data-testid="artifacts-selection-clear"
+        >
+          <Icon icon={Cancel01Icon} size={16} />
+        </button>
+      </div>
+      {isMoveOpen && (
+        <MoveToFolderDialog
+          fileIds={selectedFiles.map((file) => file.id)}
+          subject={moveSubject}
+          currentFolderId={sharedFolderId}
+          isOpen={isMoveOpen}
+          setIsOpen={setIsMoveOpen}
+          onMoved={onClear}
+        />
+      )}
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/SelectionBar/useSelectionBar.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/SelectionBar/useSelectionBar.ts
@@ -1,0 +1,81 @@
+import { deleteWorkspaceFile } from "@/app/api/__generated__/endpoints/workspace/workspace";
+import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
+import { useToast } from "@/components/molecules/Toast/use-toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { invalidateWorkspaceFileQueries } from "../helpers";
+
+export function useSelectionBar(
+  selectedFiles: WorkspaceFileItem[],
+  onDone: () => void,
+) {
+  const [isMoveOpen, setIsMoveOpen] = useState(false);
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const count = selectedFiles.length;
+
+  const { mutateAsync: deleteFiles, isPending: isDeleting } = useMutation({
+    // There is no bulk delete endpoint, so delete one by one and report how
+    // many failed; the ones that succeeded leave the list on refetch.
+    mutationFn: async (fileIds: string[]) => {
+      const results = await Promise.allSettled(
+        fileIds.map((fileId) => deleteWorkspaceFile(fileId)),
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0) {
+        throw new Error(
+          `${failed} of ${fileIds.length} files could not be deleted.`,
+        );
+      }
+    },
+    onSettled: () => invalidateWorkspaceFileQueries(queryClient),
+    onSuccess: (_, fileIds) => {
+      toast({
+        title:
+          fileIds.length === 1
+            ? "File deleted"
+            : `${fileIds.length} files deleted`,
+      });
+      onDone();
+    },
+    onError: (error) => {
+      toast({
+        title: "Failed to delete files",
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  async function handleDelete() {
+    if (isDeleting || count === 0) return;
+    const confirmed = window.confirm(
+      count === 1
+        ? `Delete "${selectedFiles[0].name}"?`
+        : `Delete ${count} files?`,
+    );
+    if (!confirmed) return;
+    try {
+      await deleteFiles(selectedFiles.map((file) => file.id));
+    } catch {
+      // Already surfaced by the mutation's onError toast.
+    }
+  }
+
+  const firstFolderId = selectedFiles[0]?.folder_id ?? null;
+  const sharedFolderId = selectedFiles.every(
+    (file) => (file.folder_id ?? null) === firstFolderId,
+  )
+    ? firstFolderId
+    : null;
+
+  return {
+    isMoveOpen,
+    setIsMoveOpen,
+    isDeleting,
+    handleDelete,
+    moveSubject: count === 1 ? `“${selectedFiles[0].name}”` : `${count} files`,
+    sharedFolderId,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/helpers.ts
@@ -9,6 +9,12 @@ import {
   Video01Icon,
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
+import {
+  getGetWorkspaceStorageUsageQueryKey,
+  getListWorkspaceFoldersQueryKey,
+} from "@/app/api/__generated__/endpoints/workspace/workspace";
+import type { QueryClient } from "@tanstack/react-query";
+import { ARTIFACTS_LIST_QUERY_KEY } from "../../useArtifactsPage";
 
 export type FileOrigin =
   | { kind: "session"; sessionId: string; href: string }
@@ -413,4 +419,18 @@ export function getEmptyState(opts: {
     showUpload: true,
     chatHref: "/copilot",
   };
+}
+
+/**
+ * Refetches everything a file deletion touches: the listing, the folder rows
+ * (which show file counts) and the storage footer.
+ */
+export function invalidateWorkspaceFileQueries(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: ARTIFACTS_LIST_QUERY_KEY });
+  queryClient.invalidateQueries({
+    queryKey: getListWorkspaceFoldersQueryKey(),
+  });
+  queryClient.invalidateQueries({
+    queryKey: getGetWorkspaceStorageUsageQueryKey(),
+  });
 }

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/useFileActionsMenu.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/ArtifactsList/useFileActionsMenu.ts
@@ -1,14 +1,13 @@
-import {
-  getGetWorkspaceStorageUsageQueryKey,
-  getListWorkspaceFoldersQueryKey,
-  useDeleteWorkspaceFile,
-} from "@/app/api/__generated__/endpoints/workspace/workspace";
+import { useDeleteWorkspaceFile } from "@/app/api/__generated__/endpoints/workspace/workspace";
 import type { WorkspaceFileItem } from "@/app/api/__generated__/models/workspaceFileItem";
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { ARTIFACTS_LIST_QUERY_KEY } from "../../useArtifactsPage";
-import { deriveFileOrigin, downloadFileBlob } from "./helpers";
+import {
+  deriveFileOrigin,
+  downloadFileBlob,
+  invalidateWorkspaceFileQueries,
+} from "./helpers";
 
 export function useFileActionsMenu(file: WorkspaceFileItem) {
   const origin = deriveFileOrigin(file.path);
@@ -21,17 +20,7 @@ export function useFileActionsMenu(file: WorkspaceFileItem) {
     useDeleteWorkspaceFile({
       mutation: {
         onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: ARTIFACTS_LIST_QUERY_KEY,
-          });
-          // Folder rows show file counts and the footer shows storage used,
-          // so both go stale after a deletion.
-          queryClient.invalidateQueries({
-            queryKey: getListWorkspaceFoldersQueryKey(),
-          });
-          queryClient.invalidateQueries({
-            queryKey: getGetWorkspaceStorageUsageQueryKey(),
-          });
+          invalidateWorkspaceFileQueries(queryClient);
           toast({ title: "File deleted" });
         },
         onError: (error) => {

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/MoveToFolderDialog/MoveToFolderDialog.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/MoveToFolderDialog/MoveToFolderDialog.tsx
@@ -8,28 +8,36 @@ import { Folder01Icon, Home01Icon } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
 
 interface Props {
-  fileId: string;
-  fileName: string;
+  fileIds: string[];
+  /** What is being moved, as shown in the prompt: `“report.pdf”` or `3 files`. */
+  subject: string;
+  /** Folder every file already sits in; offered as neither a destination nor
+      hidden root. `null` when the files are at the root or in mixed folders. */
   currentFolderId?: string | null;
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
+  onMoved?: () => void;
 }
 
 export function MoveToFolderDialog({
-  fileId,
-  fileName,
+  fileIds,
+  subject,
   currentFolderId,
   isOpen,
   setIsOpen,
+  onMoved,
 }: Props) {
-  const { folders, moveFileToFolder } = useArtifactsFolders();
+  const { folders, moveFilesToFolder } = useArtifactsFolders();
   const destinationFolders = folders.filter((f) => f.id !== currentFolderId);
 
   function handleMove(folderId: string | null) {
     // Close only on success; the hook toasts on error and we keep the dialog
     // open so the user can retry without re-opening it.
-    moveFileToFolder({ fileId, folderId })
-      .then(() => setIsOpen(false))
+    moveFilesToFolder({ fileIds, folderId })
+      .then(() => {
+        setIsOpen(false);
+        onMoved?.();
+      })
       .catch(() => {});
   }
 
@@ -42,7 +50,7 @@ export function MoveToFolderDialog({
       <Dialog.Content>
         <div className="flex flex-col gap-1">
           <Text variant="small" className="mb-1 text-zinc-500">
-            Move &ldquo;{fileName}&rdquo; to:
+            Move {subject} to:
           </Text>
           {currentFolderId != null && (
             <Button

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/WorkspaceFolder.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/WorkspaceFolder.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Text } from "@/components/atoms/Text/Text";
-import { FILE_DRAG_MIME } from "./drag";
+import { FILE_DRAG_MIME, readFileDragIds } from "./drag";
 import { FOLDER_STYLE } from "./folder-constants";
 import {
   Delete02Icon,
@@ -20,7 +20,7 @@ interface Props {
   onEdit: () => void;
   onDelete: () => void;
   onClick: () => void;
-  onFileDrop: (fileId: string, folderId: string) => void;
+  onFileDrop: (fileIds: string[], folderId: string) => void;
 }
 
 export function WorkspaceFolder({
@@ -53,8 +53,8 @@ export function WorkspaceFolder({
   function handleDrop(e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault();
     setIsDragOver(false);
-    const fileId = e.dataTransfer.getData(FILE_DRAG_MIME);
-    if (fileId) onFileDrop(fileId, id);
+    const fileIds = readFileDragIds(e.dataTransfer);
+    if (fileIds.length > 0) onFileDrop(fileIds, id);
   }
 
   return (

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/WorkspaceFolders.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/WorkspaceFolders.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 export function WorkspaceFolders({ onSelectFolder }: Props) {
-  const { folders, isLoading, isError, error, moveFileToFolder } =
+  const { folders, isLoading, isError, error, moveFilesToFolder } =
     useArtifactsFolders();
 
   const [editing, setEditing] = useState<WorkspaceFolderModel | null>(null);
@@ -58,8 +58,8 @@ export function WorkspaceFolders({ onSelectFolder }: Props) {
             onClick={() => onSelectFolder(folder.id)}
             onEdit={() => setEditing(folder)}
             onDelete={() => setDeleting(folder)}
-            onFileDrop={(fileId, folderId) => {
-              moveFileToFolder({ fileId, folderId }).catch(() => {});
+            onFileDrop={(fileIds, folderId) => {
+              moveFilesToFolder({ fileIds, folderId }).catch(() => {});
             }}
           />
         ))}

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/drag.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/drag.ts
@@ -1,5 +1,22 @@
-/** DataTransfer MIME type used when dragging a file card onto a folder. */
+/** DataTransfer MIME type used when dragging file cards/rows onto a folder. */
 export const FILE_DRAG_MIME = "application/workspace-file-id";
+
+// File ids are UUIDs, so a comma can't appear inside one.
+const ID_SEPARATOR = ",";
+
+export function writeFileDragData(
+  dataTransfer: DataTransfer,
+  fileIds: string[],
+) {
+  dataTransfer.setData(FILE_DRAG_MIME, fileIds.join(ID_SEPARATOR));
+}
+
+export function readFileDragIds(dataTransfer: DataTransfer): string[] {
+  return dataTransfer
+    .getData(FILE_DRAG_MIME)
+    .split(ID_SEPARATOR)
+    .filter(Boolean);
+}
 
 const FILE_GLYPH = `<svg width="20" height="20" viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34ZM160,51.31,188.69,80H160ZM200,216H56V40h88V88a8,8,0,0,0,8,8h48V216Z"></path></svg>`;
 
@@ -16,7 +33,7 @@ function escapeHtml(value: string): string {
  * dragging a file card, so the cursor carries a compact file chip instead of a
  * snapshot of the whole card. Caller is responsible for removing it on dragend.
  */
-export function createFileDragImage(fileName: string): HTMLElement {
+export function createFileDragImage(label: string): HTMLElement {
   const el = document.createElement("div");
   el.style.cssText = [
     "position:absolute",
@@ -34,7 +51,7 @@ export function createFileDragImage(fileName: string): HTMLElement {
     "box-shadow:0 4px 12px rgba(0,0,0,0.08)",
   ].join(";");
   el.innerHTML = `${FILE_GLYPH}<span style="color:#18181b;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:160px;">${escapeHtml(
-    fileName,
+    label,
   )}</span>`;
   return el;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/useFileDrag.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/components/WorkspaceFolders/useFileDrag.ts
@@ -1,12 +1,14 @@
 import { useEffect, useRef } from "react";
 import type { DragEvent } from "react";
-import { createFileDragImage, FILE_DRAG_MIME } from "./drag";
+import { createFileDragImage, writeFileDragData } from "./drag";
 
 /**
  * Drag handlers for a file card/row so it can be dropped onto a folder. Owns
  * the off-screen drag-image node and removes it on dragend or unmount.
+ * `fileIds` are the files carried by the drag; `label` is shown in the chip
+ * under the cursor.
  */
-export function useFileDrag(fileId: string, fileName: string) {
+export function useFileDrag(fileIds: string[], label: string) {
   const dragImageRef = useRef<HTMLElement | null>(null);
 
   // Clean up a leftover drag-image node if the element unmounts mid-drag
@@ -20,9 +22,9 @@ export function useFileDrag(fileId: string, fileName: string) {
 
   function handleDragStart(e: DragEvent<HTMLElement>) {
     dragImageRef.current?.remove();
-    e.dataTransfer.setData(FILE_DRAG_MIME, fileId);
+    writeFileDragData(e.dataTransfer, fileIds);
     e.dataTransfer.effectAllowed = "move";
-    const dragImage = createFileDragImage(fileName);
+    const dragImage = createFileDragImage(label);
     document.body.appendChild(dragImage);
     e.dataTransfer.setDragImage(dragImage, 16, 16);
     dragImageRef.current = dragImage;

--- a/autogpt_platform/frontend/src/app/(platform)/artifacts/useArtifactsFolders.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/artifacts/useArtifactsFolders.ts
@@ -74,12 +74,17 @@ export function useArtifactsFolders() {
 
   const moveMutation = useBulkMoveWorkspaceFiles({
     mutation: {
-      onSuccess: () => {
+      onSuccess: (_, variables) => {
         invalidate();
-        toast({ title: "File moved" });
+        const count = variables.data.file_ids.length;
+        toast({ title: count === 1 ? "File moved" : `${count} files moved` });
       },
-      onError: () => {
-        toast({ title: "Failed to move file", variant: "destructive" });
+      onError: (_, variables) => {
+        const count = variables.data.file_ids.length;
+        toast({
+          title: count === 1 ? "Failed to move file" : "Failed to move files",
+          variant: "destructive",
+        });
       },
     },
   });
@@ -101,9 +106,9 @@ export function useArtifactsFolders() {
     deleteFolder: (folderId: string) =>
       deleteMutation.mutateAsync({ folderId }),
     isDeleting: deleteMutation.isPending,
-    moveFileToFolder: (args: { fileId: string; folderId: string | null }) =>
+    moveFilesToFolder: (args: { fileIds: string[]; folderId: string | null }) =>
       moveMutation.mutateAsync({
-        data: { file_ids: [args.fileId], folder_id: args.folderId },
+        data: { file_ids: args.fileIds, folder_id: args.folderId },
       }),
   };
 }


### PR DESCRIPTION
### Why / What / How

**Why:** In the Files table, folder rows' Modified and Size cells sat to the left of the file rows' cells. Folder rows have two action buttons and file rows one, and the trailing grid column was auto-sized, so each row type got a different column width. Separately, there was no way to act on several files at once: each file had to be dragged or moved through its menu one by one.

**What:**
- Fixed-width actions column so folder and file cells line up with the header.
- Clicking a file's thumbnail selects the row (click again to deselect). The thumbnail shows a tick overlay on hover and when selected.
- With rows selected, the header row becomes a selection bar: `N selected`, Select all, Move to folder, Delete, and Clear.
- Dragging a selected row carries every selected file; dropping on a folder (row or grid card) moves them all.
- Move to folder from the bar posts one bulk move with every selected id; Delete confirms once and deletes each file.

**How:**
- `row-layout.ts`: trailing column is `4.5rem` (room for two icon buttons) at every breakpoint.
- The drag payload now carries a comma-separated id list (`drag.ts` gained `writeFileDragData`/`readFileDragIds`); `useFileDrag` takes `fileIds` and a label, and drop targets read the list.
- `useArtifactsFolders.moveFileToFolder` became `moveFilesToFolder({ fileIds, folderId })`; toasts pluralise by count.
- `MoveToFolderDialog` takes `fileIds` + `subject` and an `onMoved` callback.
- New `useFileSelection` (table-scoped, derived from the current `files` so removed files drop out; the table is keyed by `listKey` so filter changes reset it) and `SelectionBar` + `useSelectionBar` (bulk delete via `Promise.allSettled`, reporting how many failed; no bulk delete endpoint exists).
- Shared `invalidateWorkspaceFileQueries` helper used by the row menu delete and the bulk delete.

### Changes 🏗️

- `ArtifactsTable/row-layout.ts`, `ArtifactsTable.tsx`: fixed actions column; header swaps to `SelectionBar` when files are selected.
- `ArtifactsTable/FileRow.tsx`: thumbnail is a select toggle (`aria-pressed`, `Select <name>`); selected row styling; drag carries the selection.
- `ArtifactsTable/useFileSelection.ts`: new.
- `SelectionBar/SelectionBar.tsx`, `SelectionBar/useSelectionBar.ts`: new.
- `WorkspaceFolders/drag.ts`, `useFileDrag.ts`, `WorkspaceFolder.tsx`, `WorkspaceFolders.tsx`, `ArtifactsTable/FolderRow.tsx`, `FolderRows.tsx`: multi-id drag payload and drop.
- `useArtifactsFolders.ts`, `MoveToFolderDialog.tsx`, `FileActionsMenu.tsx`, `ArtifactCard.tsx`: bulk move plumbing.
- `ArtifactsList/helpers.ts`, `useFileActionsMenu.ts`: shared query invalidation.
- `__tests__/selection.test.tsx`: new integration tests (select/deselect, select all/clear, bulk delete, cancelled delete, bulk move, multi-file drag, single-file drag while another row is selected).

### Agents and large language models used

- Claude Code with Claude Fable 5.1

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [ ] I have tested my changes according to the test plan:
  - [ ] Folder rows' Modified and Size cells line up with file rows and the header at md, sm and mobile widths
  - [ ] Clicking a thumbnail selects the row without opening the viewer; clicking the name still opens it
  - [ ] Selection bar shows the count, Select all, Move to folder, Delete and Clear
  - [ ] Dragging a selected row onto a folder moves every selected file; dragging an unselected row moves only that file
  - [ ] Move to folder from the bar moves all selected files and clears the selection
  - [ ] Delete from the bar confirms once, deletes every selected file, and refreshes counts/storage
  - [ ] Changing the search, origin, expert or folder filter clears the selection
  - [ ] `pnpm test:unit` passes (`selection.test.tsx`, `folders.test.tsx`, `main.test.tsx`)

#### For configuration changes:
- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
