### PR TITLE
fix(backend/executor): bind the scheduler's RPC port before the embedding backfill

### DIFF
--- a/autogpt_platform/backend/backend/executor/scheduler.py
+++ b/autogpt_platform/backend/backend/executor/scheduler.py
@@ -1889,8 +1889,13 @@ class Scheduler(AppService):
                 id="ensure_embeddings_coverage",
                 trigger="interval",
                 hours=6,
+                # Due now rather than called inline below: run_service() is what
+                # starts the event loop uvicorn binds the RPC port on.
+                next_run_time=datetime.now(timezone.utc),
                 replace_existing=True,
                 max_instances=1,  # Prevent overlapping runs
+                misfire_grace_time=None,
+                coalesce=True,
                 jobstore=Jobstores.EXECUTION.value,
             )
 
@@ -1911,18 +1916,6 @@ class Scheduler(AppService):
         self.scheduler.add_listener(job_missed_listener, EVENT_JOB_MISSED)
         self.scheduler.add_listener(job_max_instances_listener, EVENT_JOB_MAX_INSTANCES)
         self.scheduler.start()
-
-        # Run embedding backfill immediately on startup
-        # This ensures blocks/docs are searchable right away, not after 6 hours
-        # Safe to run on multiple pods - uses upserts and checks for existing embeddings
-        if self.register_system_tasks:
-            logger.info("Running embedding backfill on startup...")
-            try:
-                result = ensure_embeddings_coverage()
-                logger.info(f"Startup embedding backfill complete: {result}")
-            except Exception as e:
-                logger.error(f"Startup embedding backfill failed: {e}")
-                # Don't fail startup - the scheduled job will retry later
 
         # Keep the service running since BackgroundScheduler doesn't block
         super().run_service()

--- a/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
+++ b/autogpt_platform/backend/backend/executor/scheduler_unit_test.py
@@ -8,6 +8,7 @@ backend test job (and counted by codecov), not just the integration suite.
 import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import NamedTuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1486,14 +1487,23 @@ def test_add_graph_schedule_keeps_autopilot_tenancy():
 # ---------------------------------------------------------------------------
 
 
-def _registered_jobs(monkeypatch, interval_hours: int) -> list:
+class _StartupRun(NamedTuple):
+    add_job_calls: list
+    embedding_backfill: MagicMock
+    backfill_calls_at_readiness: int
+
+
+def _registered_jobs(monkeypatch, interval_hours: int) -> _StartupRun:
     """Drive ``Scheduler.run_service`` with every heavy dependency stubbed and
-    a mock APScheduler, returning the list of ``add_job`` mock calls."""
+    a mock APScheduler, recording what it registered and what it ran before
+    handing over to ``AppService.run_service``."""
     monkeypatch.setattr(
         f"{_SCHEDULER_PATH}.config.stripe_tier_reconcile_interval_hours",
         interval_hours,
     )
     mock_scheduler = MagicMock()
+    embedding_backfill = MagicMock(return_value=None)
+    at_readiness = []
     with (
         patch(f"{_SCHEDULER_PATH}.BackgroundScheduler", return_value=mock_scheduler),
         patch(f"{_SCHEDULER_PATH}.load_dotenv"),
@@ -1506,12 +1516,17 @@ def _registered_jobs(monkeypatch, interval_hours: int) -> list:
             f"{_SCHEDULER_PATH}._extract_schema_from_url",
             return_value=("public", "sqlite://"),
         ),
-        patch(f"{_SCHEDULER_PATH}.ensure_embeddings_coverage", return_value=None),
+        patch(f"{_SCHEDULER_PATH}.ensure_embeddings_coverage", embedding_backfill),
         # super().run_service() blocks forever keeping the service alive; no-op it.
-        patch("backend.util.service.AppService.run_service", return_value=None),
+        patch(
+            "backend.util.service.AppService.run_service",
+            side_effect=lambda: at_readiness.append(embedding_backfill.call_count),
+        ),
     ):
         Scheduler(register_system_tasks=True).run_service()
-    return mock_scheduler.add_job.call_args_list
+    return _StartupRun(
+        mock_scheduler.add_job.call_args_list, embedding_backfill, at_readiness[0]
+    )
 
 
 def test_reconcile_stripe_tiers_job_registered_with_interval_and_single_instance(
@@ -1519,7 +1534,7 @@ def test_reconcile_stripe_tiers_job_registered_with_interval_and_single_instance
 ):
     """The sweep must be registered as an interval job keyed off the configured
     interval setting and capped to a single concurrent instance."""
-    calls = _registered_jobs(monkeypatch, interval_hours=6)
+    calls = _registered_jobs(monkeypatch, interval_hours=6).add_job_calls
 
     matches = [c for c in calls if c.args and c.args[0] is reconcile_stripe_tiers]
     assert len(matches) == 1
@@ -1533,9 +1548,38 @@ def test_reconcile_stripe_tiers_job_registered_with_interval_and_single_instance
 
 def test_reconcile_stripe_tiers_interval_follows_config_setting(monkeypatch):
     """Changing the configured interval changes the registered ``seconds``."""
-    calls = _registered_jobs(monkeypatch, interval_hours=12)
+    calls = _registered_jobs(monkeypatch, interval_hours=12).add_job_calls
     match = next(c for c in calls if c.args and c.args[0] is reconcile_stripe_tiers)
     assert match.kwargs["seconds"] == 12 * 3600
+
+
+def test_embedding_backfill_does_not_delay_rpc_readiness(monkeypatch):
+    """``AppService.run_service`` starts the event loop uvicorn is scheduled
+    onto, so anything run before it keeps the RPC port closed. The backfill
+    takes minutes on a fresh stack; it must not sit on that path."""
+    run = _registered_jobs(monkeypatch, interval_hours=6)
+
+    assert run.backfill_calls_at_readiness == 0
+
+
+def test_embedding_backfill_is_registered_to_run_immediately(monkeypatch):
+    """Dropping the startup call must not delay coverage: the six-hourly job
+    is due now, and cannot be skipped as a misfire however late it starts."""
+    before = datetime.now(timezone.utc)
+    run = _registered_jobs(monkeypatch, interval_hours=6)
+
+    jobs = [
+        c for c in run.add_job_calls if c.kwargs["id"] == "ensure_embeddings_coverage"
+    ]
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job.args[0] is run.embedding_backfill
+    assert before <= job.kwargs["next_run_time"] <= datetime.now(timezone.utc)
+    assert job.kwargs["trigger"] == "interval"
+    assert job.kwargs["hours"] == 6
+    assert job.kwargs["max_instances"] == 1
+    assert job.kwargs["misfire_grace_time"] is None
+    assert job.kwargs["coalesce"] is True
 
 
 class TestScheduleOrgVisibility:


### PR DESCRIPTION
### Why / What / How

The scheduler now accepts RPC connections as soon as it starts, instead of ~4.5 minutes later.

The fix is [@ntindle](https://github.com/ntindle)'s, from #14350 ("fix(backend): preserve startup indexing without blocking readiness"). That PR is layer 11 of a twelve-deep `codex/ci-*` stack and cannot land until the whole stack does; this lifts the scheduler hunk out of it against `dev` so the E2E flakes it causes stop before tomorrow's `dev` → `master` release merge.

`Scheduler.run_service()` ran the search-embedding backfill synchronously before calling `AppService.run_service()`, and that call is what starts the event loop `uvicorn.serve()` was already scheduled onto (`backend/util/service.py:513-521` builds the server on its own thread and schedules the coroutine onto `shared_event_loop`; the loop only spins inside `AppService.run_service()`). Port 8003 therefore stayed closed for the whole backfill. On a fresh stack the scheduler reports `Total: 5584 items without embeddings (0.0% coverage) - processing all` and takes about four and a half minutes, which is longer than an entire Playwright E2E run — so `GET /api/graphs/{id}/schedules` and `GET /api/schedules/followups` 500 with `All connection attempts failed` for the whole suite, and the Library agent page renders an error card in place of its run sidebar. In CI run 34233328612 the scheduler logged `Startup embedding backfill complete` at 13:52:18,905 and `Uvicorn running on http://0.0.0.0:8003` 76 ms later, having started the backfill at 13:47:41,810.

The existing six-hourly `ensure_embeddings_coverage` job now carries `next_run_time=datetime.now(timezone.utc)`, so the backfill still runs at startup — just on APScheduler's thread rather than ahead of the port binding. `misfire_grace_time=None` keeps a late run from being skipped as a misfire, and `coalesce=True` collapses a backlog into one run.

### Changes 🏗️

- `ensure_embeddings_coverage` job registration gains `next_run_time` (now), `misfire_grace_time=None` and `coalesce=True`.
- The synchronous `if self.register_system_tasks:` backfill block before `super().run_service()` is deleted.
- Two tests on `run_service`'s startup path: one asserts the backfill has not run by the time `AppService.run_service()` is reached, one asserts the job is registered due-now and un-skippable.

**Taken from #14350, and left out:** the hunk there reads `hours=0 if config.scheduler_startup_embedding_backfill else 6`, gating the immediate run on a setting that only exists on the unmerged stack. This PR is the ordering fix alone, so the setting is left out and the job is unconditionally due now — matching `dev`'s current behaviour, where the startup backfill is likewise unconditional. #14350 also touches `single-container/Dockerfile` and its entrypoint test; none of that is here.

**Known follow-up, not fixed here:** `.github/workflows/platform-fullstack-ci.yml:168` writes `SCHEDULER_STARTUP_EMBEDDING_BACKFILL=false` into `backend/.env`, and nothing on `dev` reads that name — `git grep` finds it in the workflow file and nowhere else, because the setting that would honour it lives only on the stack. CI has believed the startup backfill was off since that line was added on 2026-04-14 in #12682.

### Agents and large language models used

Claude Code with Claude Opus 5.

### Verified

I ran both new tests against `dev`'s ordering and against this branch: red then green, `assert 1 == 0` on the readiness ordering and `KeyError: 'next_run_time'` on the registration. I also ran the whole `scheduler_unit_test.py` (95 passed), `backend/util/architecture_test.py`, `blocks/test/test_block.py` (1647 passed, 84 skipped) and the full `backend/executor` suite (512 passed, 6 failed) — the six are pre-existing `manager_test.py` failures on this machine (402 insufficient balance), which I confirmed by restoring both changed files to their `dev` contents and watching the same six fail. Separately I reproduced the port-binding delay against the real `AppService` class: 6.27 s to accept with the work on the pre-`run_service()` path, 0.25 s with it moved off, while the work still runs. Logs in a comment below.

I have not run the Playwright E2E suite locally; the CI E2E job on this PR is the check for that.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Both new tests fail on `dev`'s ordering and pass on this branch
  - [x] `scheduler_unit_test.py`, `architecture_test.py`, `blocks/test/test_block.py`, `backend/executor` — no new failures
  - [x] Port-binding delay reproduced and removed against the production `AppService`
  - [ ] Full-stack CI E2E on this PR
