### PR TITLE
fix(backend): seed E2E embeddings before CI dumps the database for its cache

### DIFF
--- a/autogpt_platform/backend/test/e2e_test_data.py
+++ b/autogpt_platform/backend/test/e2e_test_data.py
@@ -14,7 +14,9 @@ Image/Video URL Domains Used:
 
 import asyncio
 import json
+import os
 import random
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List
@@ -28,6 +30,10 @@ from pydantic import SecretStr
 # Import API functions from the backend
 from backend.api.features.library.db import create_library_agent, create_preset
 from backend.api.features.library.model import LibraryAgentPresetCreatable
+from backend.api.features.search.embeddings import (
+    backfill_all_content_types,
+    get_embedding_stats,
+)
 from backend.api.features.store.db import (
     create_store_submission,
     review_store_submission,
@@ -40,6 +46,7 @@ from backend.data.db import prisma
 from backend.data.graph import Graph, Link, Node, create_graph, make_graph_model
 from backend.data.model import APIKeyCredentials
 from backend.data.user import get_or_create_user
+from backend.util.clients import get_openai_client
 from backend.util.encryption import JSONCryptor
 from backend.util.json import SafeJson
 
@@ -81,6 +88,13 @@ _DOCKER_TEMPLATE_PATH = Path(
 E2E_MARKETPLACE_AGENT_TEMPLATE_PATH = (
     _LOCAL_TEMPLATE_PATH if _LOCAL_TEMPLATE_PATH.exists() else _DOCKER_TEMPLATE_PATH
 )
+# CI dumps this database for its cache after seeding, so anything left unembedded
+# here is re-embedded on every cache hit. Batch size is concurrency, not a page size.
+EMBEDDING_BACKFILL_BATCH_SIZE = int(os.getenv("E2E_EMBEDDING_BATCH_SIZE", "100"))
+EMBEDDING_BACKFILL_TIMEOUT_SECONDS = float(
+    os.getenv("E2E_EMBEDDING_TIMEOUT_SECONDS", "900")
+)
+
 SEEDED_TEST_EMAILS = [
     "test123@example.com",
     "e2e.qa.auth@example.com",
@@ -1266,6 +1280,8 @@ class TestDataCreator:
         except Exception as e:
             print(f"Error refreshing materialized views: {e}")
 
+        await self.backfill_content_embeddings()
+
         print("E2E test data creation completed successfully!")
 
         # Print summary
@@ -1284,6 +1300,43 @@ class TestDataCreator:
         print(f"   • Top agents (approved): >= {GUARANTEED_TOP_AGENTS}")
         print(f"   • Library agents per user: >= {MIN_AGENTS_PER_USER}")
         print("\n🚀 Your E2E test database is ready to use!")
+
+    async def backfill_content_embeddings(self):
+        """Drive embedding coverage to 100% so the CI cache dump carries it."""
+        if not get_openai_client():
+            print("⏭️  No embedding backend configured — skipping embedding backfill")
+            return
+
+        print("Backfilling content embeddings...")
+        deadline = time.monotonic() + EMBEDDING_BACKFILL_TIMEOUT_SECONDS
+        while True:
+            totals = (await get_embedding_stats())["totals"]
+            missing = totals["without_embeddings"]
+            if missing == 0:
+                print(
+                    f"✅ Embeddings complete: {totals['total']} items, "
+                    f"{totals['coverage_percent']}% coverage"
+                )
+                return
+
+            if time.monotonic() >= deadline:
+                print(
+                    "::warning title=e2e-embeddings-incomplete::Embedding backfill "
+                    f"timed out with {missing} items missing "
+                    f"({totals['coverage_percent']}% coverage). The cached dump will "
+                    "be incomplete and every cache hit will re-run the backfill."
+                )
+                return
+
+            print(f"   {missing} items without embeddings — backfilling...")
+            result = await backfill_all_content_types(EMBEDDING_BACKFILL_BATCH_SIZE)
+            if result["totals"]["success"] == 0:
+                print(
+                    "::warning title=e2e-embeddings-stalled::Embedding backfill made "
+                    f"no progress ({result['totals']['message']}); giving up with "
+                    f"{missing} items missing."
+                )
+                return
 
 
 async def main():

--- a/autogpt_platform/backend/test/e2e_test_data.py
+++ b/autogpt_platform/backend/test/e2e_test_data.py
@@ -1310,37 +1310,46 @@ class TestDataCreator:
         print("Backfilling content embeddings...")
         deadline = time.monotonic() + EMBEDDING_BACKFILL_TIMEOUT_SECONDS
         while True:
-            stats = await get_embedding_stats()
-            # On failure get_embedding_stats reports zero missing, which would read
-            # as complete coverage and cache a dump with no embeddings in it.
-            if "error" in stats:
-                print(
-                    "::warning title=e2e-embeddings-unknown::Could not read embedding "
-                    f"stats ({stats['error']}); skipping backfill. The cached dump "
-                    "will be incomplete."
+            try:
+                # Both awaits reach the network, and one stuck embedding call is
+                # 600s x 3 attempts under the OpenAI client's defaults — longer than
+                # the whole deadline. Checking the clock between them bounds nothing.
+                stats = await asyncio.wait_for(
+                    get_embedding_stats(), _seconds_left(deadline)
                 )
-                return
+                # On failure get_embedding_stats reports zero missing, which would
+                # read as complete coverage and cache a dump with no embeddings.
+                if "error" in stats:
+                    print(
+                        "::warning title=e2e-embeddings-unknown::Could not read "
+                        f"embedding stats ({stats['error']}); skipping backfill. "
+                        "The cached dump will be incomplete."
+                    )
+                    return
 
-            totals = stats["totals"]
-            missing = totals["without_embeddings"]
-            if missing == 0:
-                print(
-                    f"✅ Embeddings complete: {totals['total']} items, "
-                    f"{totals['coverage_percent']}% coverage"
+                totals = stats["totals"]
+                missing = totals["without_embeddings"]
+                if missing == 0:
+                    print(
+                        f"✅ Embeddings complete: {totals['total']} items, "
+                        f"{totals['coverage_percent']}% coverage"
+                    )
+                    return
+
+                print(f"   {missing} items without embeddings — backfilling...")
+                result = await asyncio.wait_for(
+                    backfill_all_content_types(EMBEDDING_BACKFILL_BATCH_SIZE),
+                    _seconds_left(deadline),
                 )
-                return
-
-            if time.monotonic() >= deadline:
+            except asyncio.TimeoutError:
                 print(
                     "::warning title=e2e-embeddings-incomplete::Embedding backfill "
-                    f"timed out with {missing} items missing "
-                    f"({totals['coverage_percent']}% coverage). The cached dump will "
-                    "be incomplete and every cache hit will re-run the backfill."
+                    f"did not reach full coverage within "
+                    f"{EMBEDDING_BACKFILL_TIMEOUT_SECONDS:.0f}s. The cached dump "
+                    "will be incomplete and every cache hit will re-run the backfill."
                 )
                 return
 
-            print(f"   {missing} items without embeddings — backfilling...")
-            result = await backfill_all_content_types(EMBEDDING_BACKFILL_BATCH_SIZE)
             if result["totals"]["success"] == 0:
                 print(
                     "::warning title=e2e-embeddings-stalled::Embedding backfill made "
@@ -1348,6 +1357,11 @@ class TestDataCreator:
                     f"{missing} items missing."
                 )
                 return
+
+
+def _seconds_left(deadline: float) -> float:
+    """Remaining budget, floored at 0 so an expired deadline times out at once."""
+    return max(0.0, deadline - time.monotonic())
 
 
 async def main():

--- a/autogpt_platform/backend/test/e2e_test_data.py
+++ b/autogpt_platform/backend/test/e2e_test_data.py
@@ -1310,7 +1310,18 @@ class TestDataCreator:
         print("Backfilling content embeddings...")
         deadline = time.monotonic() + EMBEDDING_BACKFILL_TIMEOUT_SECONDS
         while True:
-            totals = (await get_embedding_stats())["totals"]
+            stats = await get_embedding_stats()
+            # On failure get_embedding_stats reports zero missing, which would read
+            # as complete coverage and cache a dump with no embeddings in it.
+            if "error" in stats:
+                print(
+                    "::warning title=e2e-embeddings-unknown::Could not read embedding "
+                    f"stats ({stats['error']}); skipping backfill. The cached dump "
+                    "will be incomplete."
+                )
+                return
+
+            totals = stats["totals"]
             missing = totals["without_embeddings"]
             if missing == 0:
                 print(

--- a/autogpt_platform/backend/test/test_e2e_test_data_embeddings.py
+++ b/autogpt_platform/backend/test/test_e2e_test_data_embeddings.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for the E2E seeder's embedding backfill phase.
+Stubs the search-embedding functions to avoid needing a database or an LLM.
+"""
+
+from test import e2e_test_data
+from unittest.mock import patch
+
+import pytest
+
+
+def _stats(missing: int, total: int = 5584):
+    return {
+        "totals": {
+            "without_embeddings": missing,
+            "total": total,
+            "coverage_percent": round((total - missing) / total * 100, 1),
+        }
+    }
+
+
+class _Recorder:
+    """Serves a stats sequence and records the backfill calls it triggers."""
+
+    def __init__(self, stats_sequence, success=1):
+        self._stats = list(stats_sequence)
+        self._success = success
+        self.batch_sizes: list[int] = []
+
+    async def get_stats(self):
+        return self._stats.pop(0) if len(self._stats) > 1 else self._stats[0]
+
+    async def backfill(self, batch_size):
+        self.batch_sizes.append(batch_size)
+        return {
+            "totals": {
+                "success": self._success,
+                "message": f"Overall: {self._success} succeeded",
+            }
+        }
+
+
+@pytest.fixture
+def seeder():
+    return e2e_test_data.TestDataCreator.__new__(e2e_test_data.TestDataCreator)
+
+
+async def _run(seeder, recorder, *, client=object()):
+    with (
+        patch.object(e2e_test_data, "get_openai_client", return_value=client),
+        patch.object(e2e_test_data, "get_embedding_stats", recorder.get_stats),
+        patch.object(e2e_test_data, "backfill_all_content_types", recorder.backfill),
+    ):
+        await seeder.backfill_content_embeddings()
+
+
+async def test_skips_when_no_embedding_backend(seeder):
+    """A stack without an embedding backend must not attempt any API call."""
+    recorder = _Recorder([_stats(5584)])
+    await _run(seeder, recorder, client=None)
+    assert recorder.batch_sizes == []
+
+
+async def test_skips_when_already_covered(seeder):
+    recorder = _Recorder([_stats(0)])
+    await _run(seeder, recorder)
+    assert recorder.batch_sizes == []
+
+
+async def test_backfills_until_coverage_is_complete(seeder):
+    recorder = _Recorder([_stats(5584), _stats(2000), _stats(0)])
+    await _run(seeder, recorder)
+    assert recorder.batch_sizes == [
+        e2e_test_data.EMBEDDING_BACKFILL_BATCH_SIZE,
+        e2e_test_data.EMBEDDING_BACKFILL_BATCH_SIZE,
+    ]
+
+
+async def test_gives_up_when_the_backfill_stops_making_progress(seeder):
+    """A backfill that only fails must not spin until the deadline."""
+    recorder = _Recorder([_stats(500)], success=0)
+    await _run(seeder, recorder)
+    assert len(recorder.batch_sizes) == 1
+
+
+async def test_returns_on_deadline_instead_of_blocking_the_dump(seeder, monkeypatch):
+    monkeypatch.setattr(e2e_test_data, "EMBEDDING_BACKFILL_TIMEOUT_SECONDS", 0.0)
+    recorder = _Recorder([_stats(500)])
+    await _run(seeder, recorder)
+    assert recorder.batch_sizes == []

--- a/autogpt_platform/backend/test/test_e2e_test_data_embeddings.py
+++ b/autogpt_platform/backend/test/test_e2e_test_data_embeddings.py
@@ -3,6 +3,8 @@ Unit tests for the E2E seeder's embedding backfill phase.
 Stubs the search-embedding functions to avoid needing a database or an LLM.
 """
 
+import asyncio
+import time
 from test import e2e_test_data
 from unittest.mock import patch
 
@@ -96,3 +98,47 @@ async def test_returns_on_deadline_instead_of_blocking_the_dump(seeder, monkeypa
     recorder = _Recorder([_stats(500)])
     await _run(seeder, recorder)
     assert recorder.batch_sizes == []
+
+
+async def _hang(*_args, **_kwargs):
+    """Block until cancelled — a helper that never returns on its own."""
+    await asyncio.Event().wait()
+
+
+@pytest.mark.parametrize(
+    "stalled_helper", ["get_embedding_stats", "backfill_all_content_types"]
+)
+async def test_deadline_fires_while_a_helper_hangs(seeder, monkeypatch, stalled_helper):
+    """A stuck call must not outlive the deadline: both awaits are bounded.
+
+    One embedding call is 600s x 3 attempts under the OpenAI client's defaults,
+    so a clock check between the awaits would never be reached.
+    """
+    monkeypatch.setattr(e2e_test_data, "EMBEDDING_BACKFILL_TIMEOUT_SECONDS", 0.25)
+    recorder = _Recorder([_stats(5584)])
+    patches = {
+        "get_openai_client": object(),
+        "get_embedding_stats": recorder.get_stats,
+        "backfill_all_content_types": recorder.backfill,
+        stalled_helper: _hang,
+    }
+    with (
+        patch.object(
+            e2e_test_data,
+            "get_openai_client",
+            return_value=patches.pop("get_openai_client"),
+        ),
+        patch.object(
+            e2e_test_data, "get_embedding_stats", patches["get_embedding_stats"]
+        ),
+        patch.object(
+            e2e_test_data,
+            "backfill_all_content_types",
+            patches["backfill_all_content_types"],
+        ),
+    ):
+        started = time.monotonic()
+        # The outer bound is the assertion: without wait_for inside the loop this
+        # never returns, and the test fails here instead of hanging the suite.
+        await asyncio.wait_for(seeder.backfill_content_embeddings(), timeout=10)
+        assert time.monotonic() - started < 5

--- a/autogpt_platform/backend/test/test_e2e_test_data_embeddings.py
+++ b/autogpt_platform/backend/test/test_e2e_test_data_embeddings.py
@@ -67,6 +67,14 @@ async def test_skips_when_already_covered(seeder):
     assert recorder.batch_sizes == []
 
 
+async def test_does_not_claim_coverage_when_stats_are_unreadable(seeder):
+    """get_embedding_stats reports zero missing on failure; that is not 100%."""
+    broken = dict(_stats(0, 5584), error="connection refused")
+    recorder = _Recorder([broken])
+    await _run(seeder, recorder)
+    assert recorder.batch_sizes == []
+
+
 async def test_backfills_until_coverage_is_complete(seeder):
     recorder = _Recorder([_stats(5584), _stats(2000), _stats(0)])
     await _run(seeder, recorder)


### PR DESCRIPTION
### Why / What / How

Makes the E2E test-data cache carry the search embeddings, so a cache hit no longer re-runs the embedding backfill it was supposed to skip.

The fullstack CI job seeds a database for the Playwright suite and `pg_dump`s it into the Actions cache. The dump fires the instant seeding finishes, while the scheduler's startup backfill is still generating embeddings — so it captures whatever happened to be written by that moment. On run 34269702623 (`dev`, 2026-09-08) that was **804 of ~6,000 embeddings**; 2,408 more were generated after the dump and thrown away. A later run that restores that cache still finds **4,823 items missing (19.7% coverage, documentation at 7.5%)** and backfills them again.

This drives coverage to 100% from the seeder itself, before the step that dumps, using the same `backfill_all_content_types` the scheduler calls. Polling the scheduler's own pass instead would not work: it starts before the store agents exist, so it completes without them.

Measured on this PR's own runs: a cache hit now generates **23 embeddings instead of 2,087** and the scheduler logs `All content has embeddings, skipping backfill`; a cold run costs 2 m 39 s more and produces a dump worth restoring. Numbers and method in the two comments below.

**Read the cost section before the wall-clock claim.** The measured cache hit rate is 10% — 2 of the last 20 runs — and the cause is cache eviction, not this bug. Until that is fixed, most runs pay the cold cost and few collect the warm benefit.

### Changes 🏗️

- `test/e2e_test_data.py` gains a final `backfill_content_embeddings()` phase that loops `backfill_all_content_types` until `get_embedding_stats()` reports zero missing.
- It is bounded three ways: a deadline (`E2E_EMBEDDING_TIMEOUT_SECONDS`, default 900), a no-progress check that gives up when a whole batch fails, and a skip when no embedding backend is configured. Both network awaits are wrapped in `asyncio.wait_for` with the deadline's remaining budget, because a stuck embedding call is 600 s × 3 attempts under the OpenAI client's defaults and a clock check between the awaits would bound nothing. On timeout it emits a `::warning::` and returns, so the dump still happens rather than CI hanging.
- Batch size is `E2E_EMBEDDING_BATCH_SIZE`, default 100 — the value the scheduler already runs at against OpenAI's rate limits.
- A stats-read failure is not treated as complete coverage: `get_embedding_stats` returns `without_embeddings=0` alongside an `error` key when it fails, which would otherwise cache a dump with no embeddings and report success.
- Seven new unit tests, one per path.

No configuration changes: no new secret, no `.env.default` or `docker-compose.yml` change. The two env vars are optional overrides with defaults in code. The seeder is also run by `platform-preview-seed-fixture.yml`, which configures no OpenAI key — the skip-when-unconfigured guard means that job is unaffected.

### Two findings worth separating from this change

**The cache key is not the problem, and `migrations/**` is not why runs miss.** The key was byte-identical (`e2e-test-data-ffdd677f…`) across every run sampled between 11:31Z and 21:46Z on 2026-09-08, and no migration landed on `dev` that day — yet 18 of the last 20 runs missed. The cause is eviction: the repo holds 20 caches totalling 12 GiB against GitHub's 10 GiB limit, so entries turn over continuously, and every cache in the repo was created inside one 16-minute window. Nine ~1 GiB poetry caches dominate it (the same lockfile under `poetry-Linux-…`, `py3.11-…`, `py3.12-…`, `py3.13-…`). The only surviving `e2e-test-data` entry is scoped to a `gh-readonly-queue/…` ref that no longer exists.

So I have **not** touched the key. Removing `migrations/**` would trade schema safety for no measured gain, and `restore-keys` would be worse — a partial match restores a dump built against a different schema. Making the poetry caches stop evicting everything else is what would raise the hit rate, and it belongs to whoever owns those keys.

**`SCHEDULER_STARTUP_EMBEDDING_BACKFILL=false` in this workflow does nothing.** Nothing in the codebase reads that name (`grep -rn SCHEDULER_STARTUP_EMBEDDING_BACKFILL` returns only the workflow line); the startup backfill is gated on `Scheduler.register_system_tasks`, which defaults to `True`. Anyone reading the workflow would reasonably conclude the backfill is off in CI. It is not — it runs on every run and, in both runs I measured, was still generating embeddings when the job ended. I have left the line alone rather than make it work, since the goal here is that the backfill has nothing to do, not that it is switched off.

### Honest cost

This moves embedding work onto the critical path: the seed step now waits for full coverage before dumping, where today that work happens later and overlaps the Playwright suite. Cold runs get longer; warm runs get shorter and stop racing the tests. The cached dump also grows, since each row carries a 1536-dim vector: 9.8 MiB to 29 MiB, measured.

**At the measured 10% hit rate this is not yet a wall-clock win, and that claim stays contingent until the eviction above is fixed** — a cache that does not survive cannot repay a cold-path cost. What it does buy on every run, hit or miss, is determinism: today the E2E suite runs against a database whose embeddings are ~40% complete and still changing underneath it.

### Agents and large language models used

Claude Code with Claude Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `test/test_e2e_test_data_embeddings.py` — 7 tests, all paths (no backend, already covered, unreadable stats, converges, stalls, deadline, deadline while a call hangs)
  - [x] Each of the four guards mutated and watched to fail
  - [x] `backend/util/architecture_test.py` + `test/` targeted — 24 passed
  - [x] `backend/blocks/test/test_block.py` — 1647 passed, 84 skipped
  - [x] End-to-end behaviour in CI — cold and warm runs measured on this PR, posted in comments

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

