### PR TITLE
ci(backend): widen the AutoPilot tool-schema budget to 65,000 chars

### DIFF
--- a/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
+++ b/autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py
@@ -112,7 +112,14 @@ from backend.copilot.tools import TOOL_REGISTRY
 # Bumped 59_000 -> 61_000 for update_expert (the Autopilot-side soul edit,
 # same confirm gate) and raise_expert's color palette enum + persona-name
 # guidance. Merged registry measures 59625 chars; ~1.4k headroom.
-_CHAR_BUDGET = 61_000
+# Bumped 61_000 -> 65_000. That 1.4k of headroom was gone 17 days later:
+# nine tools grew 50-400 chars each with no single PR at fault, dev reached
+# 60,984, and the next PR to add anything was ejected from the merge queue.
+# Sized against what concurrent in-flight PRs add in AGGREGATE (the ten v0.7.5
+# PRs add 1,763) rather than against whatever sits on dev today, because each
+# branch's CI only ever sees its own delta. Registry measures 62,747 with all
+# ten merged; 2,253 headroom.
+_CHAR_BUDGET = 65_000
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Why / What / How

Raises `_CHAR_BUDGET` in `tool_schema_test.py` from 61,000 to 65,000 characters, and replaces the stale comment above it.

**This widens a gate; it does not fix a problem.** The tool-schema budget is a drift alarm — it serialises every schema in `TOOL_REGISTRY` and fails if the total passes a threshold — and nothing about 61,000 is physically meaningful. What it caught is real drift, and the honest response is a deliberately sized new threshold rather than a claim that anything is now smaller.

`dev` alone measures **60,984 of 61,000 — sixteen characters of headroom**, against a comment claiming ~1,400. That is why #14434 was ejected from the merge queue at 22:34Z: it is green on its own head, green on `dev`, and the merged combination measures 61,037. It adds 53 characters and had the bad luck to be first.

This is accumulation, not one bad PR. The last bump (#14099, 2026-08-23) granted 1,376 characters of headroom, and the comment recording that was accurate when written — I measured `dev` at that commit at 59,624. Seventeen days later it is gone, spread across nine tools with no single contribution over 411 characters:

| tool | at #14099 | today | Δ |
|---|---:|---:|---:|
| `list_team` | — | 411 | +411 (new tool) |
| `raise_expert` | 1,793 | 2,118 | +325 |
| `ask_question` | 806 | 986 | +180 |
| `hire_expert` | 610 | 722 | +112 |
| `list_workspace_files` | 604 | 691 | +87 |
| `read_workspace_file` | 1,060 | 1,132 | +72 |
| `delegate_to_expert` | 1,206 | 1,268 | +62 |
| `write_workspace_file` | 1,217 | 1,271 | +54 |
| `run_sub_session` | 881 | 935 | +54 |
| `store_skill` | 711 | 712 | +1 |
| | | | **net +1,358** |

Every one of those authors was reading a comment that promised 1,400 characters of room and adding something that plainly fitted. A wrong comment next to the constant is most of how this reached a release cut unnoticed, so it is corrected in the same diff.

### Why 65,000 and not 63,000

The instinct is to pick the smaller number, and one of the ten release PRs (#14424) already proposes 63,000. **63,000 leaves 253 characters over the final state** — less than one new parameter description, and about three days at the drift rate measured above (~80 chars/day). The next tool anyone adds ejects a PR from the merge queue again.

**65,000 leaves 2,253 characters, sized against what concurrent in-flight PRs add in aggregate rather than against whatever sits on `dev` today.** That is the number that matters, because each branch's CI only ever sees its own delta — a global counter can only fail once the branches are combined, which is the merge queue, which is the most expensive place to discover it. The ten v0.7.5 PRs add 1,763 characters between them and every one of them is individually green. Headroom smaller than that aggregate guarantees another ejection. 2,253 also buys roughly 28 days at the observed drift rate, against the 17 days the last bump bought.

It remains a real ceiling: 3.5% above today's merged total, and any single PR adding a substantial tool without thinking still trips it.

### #11220 is a twelfth PR, and it sharpens the ordering question

[#11220](https://github.com/Significant-Gravitas/AutoGPT/pull/11220) is not in the release set I measured, but it touches two registry tools (`manage_presets`, `setup_agent_webhook_trigger`) and sets the budget to 62,000. Measured: its head merged into `dev` is 61,162, a net **+178** — it adds `trigger_config` and `constant_inputs` on top of a trim to the same two tools. All ten release PRs plus #11220 measures **62,925**, which leaves 2,075 against this PR's 65,000. So it does not change the recommendation.

It does change what the smaller ceilings are worth. That same end state leaves **75 characters** under 63,000, and **exceeds 62,000 by 925**. Neither of the other two proposed values survives the set of PRs currently in flight, whichever order they land in — and each is carried by a PR whose own CI is green, because no branch can see the sum. Landing this one first is what makes the order stop mattering.

### Why not trim instead

Trimming is a legitimate answer and it is not available tonight at this size. The merged set is 1,747 characters over the current budget, against copy that twenty-one separate bump comments each argue is load-bearing, with no test that would notice if the model behaved worse after a cut.

Two measurements bound how much a trim could yield. **Only 53% of the serialized total is description text at all** — 33,164 of 62,747 characters; the rest is JSON structure: keys, braces, type names, parameter names, enum values. And the clearest genuine redundancy in the whole registry is `connect_integration`, which states its supported-providers rule three times ("ONLY call this tool for one of the supported providers listed above — do NOT call it for Google, Gmail, Slack…", "Double-check that the provider is in the supported list above before calling.", "The `provider` parameter must match what the failing CLI/API actually needs."). Collapsing those to one recovers about **230 characters**. Closing 1,747 would need eight such wins, and after `connect_integration` there are not eight — `schedule_followup`'s 850-character description, the next largest, spends every sentence on a distinct rule.

A trim pass is worth doing on its own merits, with someone watching model behaviour. It is not a release-night lever.

### Changes 🏗️

- `_CHAR_BUDGET`: 61,000 → 65,000 in `autogpt_platform/backend/backend/copilot/tools/tool_schema_test.py`.
- Replaces the trailing comment, which claimed "~1.4k headroom" when the true figure was 16, with the measured drift and the sizing rule for the new number.

No product code changes; the diff is one file and eight lines.

### Verified

I measured every one of the ten v0.7.5 PRs merged into `dev` individually, and all ten merged together, then ran the gate against the combined tree.

The measurement is validated two ways before any number below was trusted. My script's total is byte-identical to the test function's own assertion message on `dev` (60,984), and merging #14434 into `dev` locally reproduces the CI failure exactly — 61,037, matching run 34284792185. Local and CI agree, so the note in the file about env-flagged registrations pushing CI higher no longer applies.

Executed on this branch: `backend/copilot/tools/tool_schema_test.py` (217 passed), `backend/util/architecture_test.py` (3 passed), `backend/blocks/test/test_block.py` (1,647 passed, 84 skipped).

Executed on this branch with all ten release PRs merged in locally: `tool_schema_test.py`, 223 passed, registry measuring 62,747 across 73 tools — the new budget holds against the actual end state, which is the claim this PR rests on. #14424 conflicts on the `_CHAR_BUDGET` line in that merge, as it must, since it changes the same line to 63,000; that conflict is the intended outcome and makes the newer number visible to whoever resolves it, rather than silently regressing.

Reasoned about but not executed: nothing bearing on the number. The gate is a pure function of the registry.

Full measurement tables, per-PR and per-tool, are in a comment below.

### Agents and large language models used

Claude Code with Claude Opus 5

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `tool_schema_test.py` passes on this branch (217 passed)
  - [x] `tool_schema_test.py` passes on this branch with all ten v0.7.5 PRs merged in (223 passed, 62,747 chars vs the 65,000 budget)
  - [x] `architecture_test.py` and `blocks/test/test_block.py` pass, as they scan the whole tree and no diff points at them
  - [x] The gate still fails when it should: setting the budget to 1 produces `Tool schemas use 60984 chars … exceeding budget of 1 chars`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
