### PR TITLE
refactor(backend): move the API-key routes into their own feature module

### DIFF
--- a/autogpt_platform/backend/backend/api/features/api_keys/model.py
+++ b/autogpt_platform/backend/backend/api/features/api_keys/model.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+import pydantic
+
+from backend.data.auth.api_key import APIKeyInfo, APIKeyPermission
+
+
+class CreateAPIKeyRequest(pydantic.BaseModel):
+    name: str
+    permissions: list[APIKeyPermission]
+    description: Optional[str] = None
+
+
+class CreateAPIKeyResponse(pydantic.BaseModel):
+    api_key: APIKeyInfo
+    plain_text_key: str
+
+
+class UpdatePermissionsRequest(pydantic.BaseModel):
+    permissions: list[APIKeyPermission]

--- a/autogpt_platform/backend/backend/api/features/api_keys/routes.py
+++ b/autogpt_platform/backend/backend/api/features/api_keys/routes.py
@@ -1,0 +1,96 @@
+from typing import Annotated
+
+from autogpt_libs.auth import get_request_context, get_user_id, requires_user
+from autogpt_libs.auth.models import RequestContext
+from fastapi import APIRouter, HTTPException, Security
+
+from backend.api.features.api_keys.model import (
+    CreateAPIKeyRequest,
+    CreateAPIKeyResponse,
+    UpdatePermissionsRequest,
+)
+from backend.data.auth import api_key as api_key_db
+from backend.data.tenancy import get_user_team_ids
+
+router = APIRouter(dependencies=[Security(requires_user)])
+
+
+@router.post("", summary="Create new API key")
+async def create_api_key(
+    request: CreateAPIKeyRequest,
+    user_id: Annotated[str, Security(get_user_id)],
+    ctx: Annotated[RequestContext, Security(get_request_context)],
+) -> CreateAPIKeyResponse:
+    """Create a new API key"""
+    api_key_info, plain_text_key = await api_key_db.create_api_key(
+        name=request.name,
+        user_id=user_id,
+        permissions=request.permissions,
+        description=request.description,
+        organization_id=ctx.org_id,
+    )
+    return CreateAPIKeyResponse(api_key=api_key_info, plain_text_key=plain_text_key)
+
+
+@router.get("", summary="List user API keys")
+async def get_api_keys(
+    user_id: Annotated[str, Security(get_user_id)],
+    ctx: Annotated[RequestContext, Security(get_request_context)],
+) -> list[api_key_db.APIKeyInfo]:
+    """List all API keys for the user"""
+    team_ids = await get_user_team_ids(user_id, ctx.org_id) if ctx.org_id else []
+    return await api_key_db.list_user_api_keys(
+        user_id, organization_id=ctx.org_id or None, team_ids=team_ids
+    )
+
+
+@router.get("/{key_id}", summary="Get specific API key")
+async def get_api_key(
+    key_id: str,
+    user_id: Annotated[str, Security(get_user_id)],
+    ctx: Annotated[RequestContext, Security(get_request_context)],
+) -> api_key_db.APIKeyInfo:
+    """Get a specific API key"""
+    api_key = await api_key_db.get_api_key_by_id(
+        key_id, user_id, organization_id=ctx.org_id or None
+    )
+    if not api_key:
+        raise HTTPException(status_code=404, detail="API key not found")
+    return api_key
+
+
+@router.delete("/{key_id}", summary="Revoke API key")
+async def delete_api_key(
+    key_id: str,
+    user_id: Annotated[str, Security(get_user_id)],
+    ctx: Annotated[RequestContext, Security(get_request_context)],
+) -> api_key_db.APIKeyInfo:
+    """Revoke an API key"""
+    return await api_key_db.revoke_api_key(
+        key_id, user_id, organization_id=ctx.org_id or None
+    )
+
+
+@router.post("/{key_id}/suspend", summary="Suspend API key")
+async def suspend_key(
+    key_id: str,
+    user_id: Annotated[str, Security(get_user_id)],
+    ctx: Annotated[RequestContext, Security(get_request_context)],
+) -> api_key_db.APIKeyInfo:
+    """Suspend an API key"""
+    return await api_key_db.suspend_api_key(
+        key_id, user_id, organization_id=ctx.org_id or None
+    )
+
+
+@router.put("/{key_id}/permissions", summary="Update key permissions")
+async def update_permissions(
+    key_id: str,
+    request: UpdatePermissionsRequest,
+    user_id: Annotated[str, Security(get_user_id)],
+    ctx: Annotated[RequestContext, Security(get_request_context)],
+) -> api_key_db.APIKeyInfo:
+    """Update API key permissions"""
+    return await api_key_db.update_api_key_permissions(
+        key_id, user_id, request.permissions, organization_id=ctx.org_id or None
+    )

--- a/autogpt_platform/backend/backend/api/features/api_keys/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/api_keys/routes_test.py
@@ -1,0 +1,48 @@
+"""Pins the mounted API-key surface, which the v1.py split must not move.
+
+Operation IDs are derived from each route's summary and first tag, so renaming
+either silently renames the generated frontend client's method.
+"""
+
+import pytest
+
+from backend.api.rest_api import app
+
+EXPECTED_OPERATIONS = {
+    ("get", "/api/api-keys"): "getV1List user api keys",
+    ("post", "/api/api-keys"): "postV1Create new api key",
+    ("delete", "/api/api-keys/{key_id}"): "deleteV1Revoke api key",
+    ("get", "/api/api-keys/{key_id}"): "getV1Get specific api key",
+    ("put", "/api/api-keys/{key_id}/permissions"): "putV1Update key permissions",
+    ("post", "/api/api-keys/{key_id}/suspend"): "postV1Suspend api key",
+}
+
+
+@pytest.mark.parametrize(
+    "method,path,operation_id",
+    [(m, p, oid) for (m, p), oid in EXPECTED_OPERATIONS.items()],
+)
+def test_api_key_operation_is_published(method: str, path: str, operation_id: str):
+    operation = app.openapi()["paths"][path][method]
+    assert operation["operationId"] == operation_id
+    assert operation["tags"] == ["v1", "api-keys"]
+
+
+def test_api_key_surface_has_no_other_operations():
+    published = {
+        (method, path)
+        for path, operations in app.openapi()["paths"].items()
+        if path.startswith("/api/api-keys")
+        for method in operations
+    }
+    assert published == set(EXPECTED_OPERATIONS)
+
+
+@pytest.mark.parametrize("path", sorted({p for _, p in EXPECTED_OPERATIONS}))
+def test_api_key_path_is_served_by_this_module(path: str):
+    handlers = {
+        route.endpoint.__module__
+        for route in app.routes
+        if getattr(route, "path", None) == path
+    }
+    assert handlers == {"backend.api.features.api_keys.routes"}

--- a/autogpt_platform/backend/backend/api/features/api_keys/routes_test.py
+++ b/autogpt_platform/backend/backend/api/features/api_keys/routes_test.py
@@ -1,10 +1,11 @@
-"""Pins the mounted API-key surface, which the v1.py split must not move.
+"""Pins the published API-key surface: paths, operation IDs and tags are contract.
 
-Operation IDs are derived from each route's summary and first tag, so renaming
+Operation IDs are built from each route's summary and first tag, so renaming
 either silently renames the generated frontend client's method.
 """
 
 import pytest
+from fastapi.routing import APIRoute
 
 from backend.api.rest_api import app
 
@@ -43,6 +44,6 @@ def test_api_key_path_is_served_by_this_module(path: str):
     handlers = {
         route.endpoint.__module__
         for route in app.routes
-        if getattr(route, "path", None) == path
+        if isinstance(route, APIRoute) and route.path == path
     }
     assert handlers == {"backend.api.features.api_keys.routes"}

--- a/autogpt_platform/backend/backend/api/features/orgs/regression_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/regression_test.py
@@ -3047,9 +3047,9 @@ class TestPR18Cutover:
         # After cutover, the route should ALWAYS set org (not conditionally)
         import inspect
 
-        from backend.api.features import v1 as api_v1
+        from backend.api.features.api_keys import routes as api_key_routes
 
-        route_src = inspect.getsource(api_v1.create_api_key)
+        route_src = inspect.getsource(api_key_routes.create_api_key)
         assert (
             "if ctx.org_id" not in route_src
         ), "Route should always set organizationId, not conditionally"

--- a/autogpt_platform/backend/backend/api/features/v1.py
+++ b/autogpt_platform/backend/backend/api/features/v1.py
@@ -47,14 +47,11 @@ from backend.api.features.experts import experts_db
 from backend.api.features.store.exceptions import VirusDetectedError, VirusScanError
 from backend.api.features.workspace.routes import create_file_download_response
 from backend.api.model import (
-    CreateAPIKeyRequest,
-    CreateAPIKeyResponse,
     CreateGraph,
     GraphExecutionSource,
     RequestTopUp,
     SetGraphActiveVersion,
     TimezoneResponse,
-    UpdatePermissionsRequest,
     UpdateTimezoneRequest,
     UploadFileResponse,
 )
@@ -74,7 +71,6 @@ from backend.copilot.tools.skills import (
 )
 from backend.data import execution as execution_db
 from backend.data import graph as graph_db
-from backend.data.auth import api_key as api_key_db
 from backend.data.block import BlockInput, CompletedBlockOutput
 from backend.data.credit import (
     AutoTopUpConfig,
@@ -2904,119 +2900,3 @@ async def delete_copilot_skill(
     except SkillNotFoundError as exc:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail=str(exc))
     return {"name": slug}
-
-
-########################################################
-#####################  API KEY ##############################
-########################################################
-
-
-@v1_router.post(
-    "/api-keys",
-    summary="Create new API key",
-    tags=["api-keys"],
-    dependencies=[Security(requires_user)],
-)
-async def create_api_key(
-    request: CreateAPIKeyRequest,
-    user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> CreateAPIKeyResponse:
-    """Create a new API key"""
-    api_key_info, plain_text_key = await api_key_db.create_api_key(
-        name=request.name,
-        user_id=user_id,
-        permissions=request.permissions,
-        description=request.description,
-        organization_id=ctx.org_id,
-    )
-    return CreateAPIKeyResponse(api_key=api_key_info, plain_text_key=plain_text_key)
-
-
-@v1_router.get(
-    "/api-keys",
-    summary="List user API keys",
-    tags=["api-keys"],
-    dependencies=[Security(requires_user)],
-)
-async def get_api_keys(
-    user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> list[api_key_db.APIKeyInfo]:
-    """List all API keys for the user"""
-    team_ids = await get_user_team_ids(user_id, ctx.org_id) if ctx.org_id else []
-    return await api_key_db.list_user_api_keys(
-        user_id, organization_id=ctx.org_id or None, team_ids=team_ids
-    )
-
-
-@v1_router.get(
-    "/api-keys/{key_id}",
-    summary="Get specific API key",
-    tags=["api-keys"],
-    dependencies=[Security(requires_user)],
-)
-async def get_api_key(
-    key_id: str,
-    user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> api_key_db.APIKeyInfo:
-    """Get a specific API key"""
-    api_key = await api_key_db.get_api_key_by_id(
-        key_id, user_id, organization_id=ctx.org_id or None
-    )
-    if not api_key:
-        raise HTTPException(status_code=404, detail="API key not found")
-    return api_key
-
-
-@v1_router.delete(
-    "/api-keys/{key_id}",
-    summary="Revoke API key",
-    tags=["api-keys"],
-    dependencies=[Security(requires_user)],
-)
-async def delete_api_key(
-    key_id: str,
-    user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> api_key_db.APIKeyInfo:
-    """Revoke an API key"""
-    return await api_key_db.revoke_api_key(
-        key_id, user_id, organization_id=ctx.org_id or None
-    )
-
-
-@v1_router.post(
-    "/api-keys/{key_id}/suspend",
-    summary="Suspend API key",
-    tags=["api-keys"],
-    dependencies=[Security(requires_user)],
-)
-async def suspend_key(
-    key_id: str,
-    user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> api_key_db.APIKeyInfo:
-    """Suspend an API key"""
-    return await api_key_db.suspend_api_key(
-        key_id, user_id, organization_id=ctx.org_id or None
-    )
-
-
-@v1_router.put(
-    "/api-keys/{key_id}/permissions",
-    summary="Update key permissions",
-    tags=["api-keys"],
-    dependencies=[Security(requires_user)],
-)
-async def update_permissions(
-    key_id: str,
-    request: UpdatePermissionsRequest,
-    user_id: Annotated[str, Security(get_user_id)],
-    ctx: Annotated[RequestContext, Security(get_request_context)],
-) -> api_key_db.APIKeyInfo:
-    """Update API key permissions"""
-    return await api_key_db.update_api_key_permissions(
-        key_id, user_id, request.permissions, organization_id=ctx.org_id or None
-    )

--- a/autogpt_platform/backend/backend/api/model.py
+++ b/autogpt_platform/backend/backend/api/model.py
@@ -3,7 +3,6 @@ from typing import Any, Literal, Optional
 
 import pydantic
 
-from backend.data.auth.api_key import APIKeyInfo, APIKeyPermission
 from backend.data.graph import Graph
 from backend.data.onboarding_steps import OnboardingStep
 from backend.util.timezone_name import TimeZoneName
@@ -45,23 +44,8 @@ class CreateGraph(pydantic.BaseModel):
     source: GraphCreationSource | None = None
 
 
-class CreateAPIKeyRequest(pydantic.BaseModel):
-    name: str
-    permissions: list[APIKeyPermission]
-    description: Optional[str] = None
-
-
-class CreateAPIKeyResponse(pydantic.BaseModel):
-    api_key: APIKeyInfo
-    plain_text_key: str
-
-
 class SetGraphActiveVersion(pydantic.BaseModel):
     active_graph_version: int
-
-
-class UpdatePermissionsRequest(pydantic.BaseModel):
-    permissions: list[APIKeyPermission]
 
 
 class RequestTopUp(pydantic.BaseModel):

--- a/autogpt_platform/backend/backend/api/rest_api.py
+++ b/autogpt_platform/backend/backend/api/rest_api.py
@@ -28,6 +28,7 @@ import backend.api.features.admin.platform_cost_routes
 import backend.api.features.admin.rate_limit_admin_routes
 import backend.api.features.admin.store_admin_routes
 import backend.api.features.admin.test_data_routes
+import backend.api.features.api_keys.routes as api_keys_routes
 import backend.api.features.auth_email.routes as auth_email_routes
 import backend.api.features.briefings.routes
 import backend.api.features.builder
@@ -379,6 +380,11 @@ app.add_exception_handler(PreconditionFailed, handle_internal_http_error(428))
 app.add_exception_handler(Exception, handle_internal_http_error(500))
 
 app.include_router(backend.api.features.v1.v1_router, tags=["v1"], prefix="/api")
+app.include_router(
+    api_keys_routes.router,
+    tags=["v1", "api-keys"],
+    prefix="/api/api-keys",
+)
 app.include_router(
     auth_email_routes.auth_email_router,
     prefix="/api/auth/email",


### PR DESCRIPTION
Moves the six `/api/api-keys` routes out of `backend/api/features/v1.py` into their own feature module, `backend/api/features/api_keys/`, with no change to the published API.

### Why / What / How

**Why.** `v1.py` is a router module of just over 3,000 lines — the residue of the API layout that predates feature modules — and this PR takes 120 of them out of it. Every one of its neighbours in `backend/api/features/` (`library/`, `store/`, `orgs/`, `search/`, `chat/`, …) is already a package with its own routes module and router; `v1.py` is the part that was never split. It has eight distinct reasons to change, and the API-key routes are one of them.

**What.** The API KEY section — `create_api_key`, `get_api_keys`, `get_api_key`, `delete_api_key`, `suspend_key`, `update_permissions` — moves to `backend/api/features/api_keys/routes.py`. The three models it owns (`CreateAPIKeyRequest`, `CreateAPIKeyResponse`, `UpdatePermissionsRequest`) move from the shared `backend/api/model.py` to `backend/api/features/api_keys/model.py`; nothing else referenced them, and their `APIKeyInfo`/`APIKeyPermission` import goes with them.

**How.** The new router is mounted at `prefix="/api/api-keys"` with `tags=["v1", "api-keys"]`, which is exactly the tag list the routes had before (mount-level `["v1"]` plus route-level `["api-keys"]`). That matters: `custom_generate_unique_id` builds each `operationId` from the first tag and the route summary, so both are load-bearing on the generated frontend client. The per-route `dependencies=[Security(requires_user)]` — identical on all six — is hoisted to the router; the dependency tree that FastAPI builds is unchanged, which the route-table diff below confirms.

The route docstrings stay, because FastAPI publishes them as each operation's `description`.

### Changes 🏗️

- New `backend/api/features/api_keys/` package: `routes.py` (6 routes), `model.py` (3 models), `routes_test.py`.
- `backend/api/features/v1.py`: −120 lines (the section plus its now-unused imports).
- `backend/api/model.py`: −16 lines (the three models and their import).
- `backend/api/rest_api.py`: +6 (import and mount).
- `backend/api/features/orgs/regression_test.py`: `test_create_api_key_sets_org_context` reads the route's source with `inspect.getsource`, so its import moves to the new module. This was the only reference to a moved symbol anywhere in the repo.

### Verified

**The exported OpenAPI schema is byte-identical before and after** — `json.dumps(before, sort_keys=True) == json.dumps(after, sort_keys=True)` is `True`, and the committed `frontend/src/app/api/openapi.json` has an empty diff after running the `export-api-schema` hook. `pnpm generate:api` then produces no change to the generated client, and `tsc --noEmit` passes.

**All 357 operations still resolve to the same handler.** I dumped, for every path+method in the spec, which route Starlette's first-match-wins matcher actually picks, before and after. The only differences are the six API-key operations' module paths (`backend.api.features.v1.*` → `backend.api.features.api_keys.routes.*`). Nothing else moved, and nothing became unresolvable — so no route shadows or is shadowed by the moved set. Registration order is also unchanged, because the API-key routes were last in `v1_router` and the new mount immediately follows it; the spec's four `/api/api-keys*` paths are the only ones that could collide, and there is no `/api/{param}` route anywhere.

**Per-route, the app's route table is identical apart from those module names**: tags, `operationId`, `unique_id`, summary, description, status code, response class, route dependencies and the full flattened dependency tree all match.

The new `routes_test.py` pins that surface for the seven splits still to come. I checked it can fail, with three mutations: renaming one summary (1 failed), hiding one route from the schema (2 failed), and changing the mount prefix to `/api/apikeys` (11 failed). All reverted, baseline green again.

Executed: `backend/api` in full (2333 passed), `backend/util/architecture_test.py` (3 passed), `backend/blocks/test/test_block.py` (1647 passed, 84 skipped), `backend/api/features/orgs/regression_test.py` (95 passed, 12 xfailed), `backend/api/utils/api_key_auth_test.py` + the two onboarding tests that import `v1_router` (50 passed). Two failures in the `backend/api` run are pre-existing and not from this change: `ws_api_test.py::test_health_endpoint_returns_ok` passes when run alone (suite interference), and `search/content_handlers_integration_test.py::test_ensure_content_embedding_blocks` fails identically on clean `dev` at `4ac3646361` with this commit absent. Not executed: anything outside `backend/api`, `backend/util` and `backend/blocks`.

Full evidence in a comment below.

### Next in the sequence

Bottom-up through `v1.py`'s own banner comments, so each PR is small and the API-surface check above is the acceptance test each time. Next is **COPILOT SKILLS** (4 routes + 3 models), then Schedules (5 routes + 1 model), then Graphs, Credits, Blocks, Onboarding, Auth. Bottom-up because the sections at the bottom are the smallest and the least entangled — Graphs, in the middle, is the one `rest_api.py` still imports five symbols from directly, so it wants the pattern to be settled first.

### Agents and large language models used

Claude Code with Claude Opus 5

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Exported the OpenAPI schema before and after and diffed it — byte-identical
  - [x] Regenerated the frontend API client (`pnpm generate:api`) — no diff — and ran `tsc --noEmit`
  - [x] Dumped which handler answers every one of the 357 spec operations, before and after — only the six moved endpoints' module paths differ
  - [x] Diffed the app's full route table per route — tags, operation IDs, dependencies, response models all unchanged
  - [x] Ran `backend/api`, `architecture_test.py`, `test_block.py`, and the org regression suite
  - [x] Proved the new surface test can fail, with three mutations

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

