### PR TITLE
perf(platform): build the backend image once instead of eight times

### DIFF
--- a/autogpt_platform/README.md
+++ b/autogpt_platform/README.md
@@ -114,11 +114,14 @@ Here are some common scenarios where you might use multiple Docker Compose comma
    ```
    docker compose stop
    docker compose rm -f
-   docker compose pull
-   docker compose up -d
+   docker compose pull --ignore-buildable
+   docker compose up -d --build
    ```
 
-   This stops all services, removes containers, pulls the latest images, and restarts the system.
+   This stops all services, removes containers, pulls the latest images, and
+   restarts the system. `--ignore-buildable` skips the services this repo
+   builds from source; without it `pull` tries to fetch them from a registry
+   they were never published to and fails.
 
 5. Developing with live updates:
 

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -188,6 +188,7 @@ services:
       - "5672:5672"
 
   rest_server:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -225,6 +226,7 @@ services:
         max-file: "3"
 
   executor:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -262,6 +264,7 @@ services:
         max-file: "3"
 
   copilot_executor:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -302,6 +305,7 @@ services:
         max-file: "3"
 
   websocket_server:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -335,6 +339,7 @@ services:
         max-file: "3"
 
   database_manager:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -364,6 +369,7 @@ services:
         max-file: "3"
 
   scheduler_server:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -399,6 +405,7 @@ services:
         max-file: "3"
 
   notification_server:
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -432,6 +439,7 @@ services:
         max-file: "3"
   platform_linking_manager:
     profiles: ["bot"]
+    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile

--- a/autogpt_platform/docker-compose.platform.yml
+++ b/autogpt_platform/docker-compose.platform.yml
@@ -188,7 +188,7 @@ services:
       - "5672:5672"
 
   rest_server:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -226,7 +226,7 @@ services:
         max-file: "3"
 
   executor:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -264,7 +264,7 @@ services:
         max-file: "3"
 
   copilot_executor:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -305,7 +305,7 @@ services:
         max-file: "3"
 
   websocket_server:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -339,7 +339,7 @@ services:
         max-file: "3"
 
   database_manager:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -369,7 +369,7 @@ services:
         max-file: "3"
 
   scheduler_server:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -405,7 +405,7 @@ services:
         max-file: "3"
 
   notification_server:
-    image: autogpt_platform-backend:latest
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile
@@ -438,8 +438,8 @@ services:
         max-size: "10m"
         max-file: "3"
   platform_linking_manager:
+    image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest
     profiles: ["bot"]
-    image: autogpt_platform-backend:latest
     build:
       context: ../
       dockerfile: autogpt_platform/backend/Dockerfile


### PR DESCRIPTION
### Why / What / How

**Why:** `docker compose build` spends most of its time exporting the same image over and over. Eight services (`rest_server`, `executor`, `copilot_executor`, `websocket_server`, `database_manager`, `scheduler_server`, `notification_server`, `platform_linking_manager`) declare byte-identical builds — same context, same Dockerfile, `target: server`, no differing build args — and differ only in the `command` each container runs. Compose has no way to know they are the same image, so it builds it, then exports it once per service.

The export steps dominate a full build, at roughly half an hour each, writing the same ~3.7 GB of layers and contending for the same disk:

```
#80 DONE 2023.8s  [rest_server]          exporting to image
#74 DONE 2019.9s  [notification_server]  exporting to image
#78 DONE 2019.5s  [scheduler_server]     exporting to image
#75 DONE 2019.4s  [copilot_executor]     exporting to image
#77 DONE 1822.4s  [executor]             exporting to image
#79 DONE 1487.9s  [database_manager]     exporting to image
```

(They overlap rather than running back to back, so the saving is not the sum of those times — the point is that seven of the eight exports are redundant.)

**What:** the eight `target: server` services share one `image:` name, so compose builds and exports once and seven services reuse the result.

**How:** one line per service. Nothing else changes — each container still runs its own `command` from that image, which is exactly what it already did; they were identical images under eight different auto-generated names.

The image name is `${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest` rather than a literal. Compose's auto-naming was `<project>-<service>`, so a second stack under `-p something` used to get its own images; a hardcoded tag would make every project build and overwrite the same one, and two stacks on a host would silently clobber each other. The default project name is the directory name, so an unqualified `docker compose up` resolves to `autogpt_platform-backend:latest` exactly as before.

### Changes 🏗️

- `autogpt_platform/docker-compose.platform.yml`: the eight `target: server` services share `image: ${COMPOSE_PROJECT_NAME:-autogpt_platform}-backend:latest`.
- `autogpt_platform/README.md`: the maintenance sequence now uses `docker compose pull --ignore-buildable` and `up -d --build`. Giving a buildable service an explicit `image:` makes `pull` try to fetch it, and these images are never published, so a bare `pull` fails with `pull access denied`.

### Verification

Measured on a full source build of a real stack (12-core VM), not estimated:

| | |
|---|---|
| Backend images created by the build | **1** (`autogpt_platform-backend:latest`) |
| Running backend containers sharing that image ID | **7 of 7**, all `cd12b0169348` |
| Pre-existing per-service tags | untouched, still dated from the previous build — none recreated |

Isolation and pull behaviour, checked against the same stack:

```
$ docker compose config          | grep backend:latest
    image: autogpt_platform-backend:latest        # unchanged default

$ docker compose -p testbed2 config | grep backend:latest
    image: testbed2-backend:latest                # isolated per project

$ docker compose pull --ignore-buildable rest_server
 Image autogpt_platform-backend:latest  Skipped - Image can be built
```

Note for anyone upgrading: the old per-service tags become orphans once this lands. `docker image prune` reclaims them.

### Agents and large language models used

Claude Code with Claude Opus 5

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Full `docker compose up -d --build` from clean: one backend image built and exported, not eight
  - [x] All seven running backend services resolve to the same image ID
  - [x] Each service still runs its own `command` — stack comes up healthy and serves traffic
  - [x] Default project name produces the same image tag as before the change
  - [x] `-p <other>` produces a distinct tag, so two stacks on one host cannot clobber each other
  - [x] `docker compose pull --ignore-buildable` skips the buildable services instead of failing

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)
