### PR TITLE
fix(frontend): stop the hire kickoff from telling the expert to run a workflow

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/expertKickoff.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/__tests__/expertKickoff.test.ts
@@ -67,7 +67,7 @@ describe("buildKickoffMessage", () => {
     );
     expect(message.text).toContain("You were just hired.");
     expect(message.text).toContain("Introduce yourself in 2-3 sentences");
-    expect(message.text).toContain("run_agent");
+    expect(message.text).toContain("ask which one to start");
     expect(message.text).toContain("If no workflow is installed");
     expect(message.text).toContain("Never pretend a run succeeded.");
     expect(message.text).not.toContain("EXPERT_KICKOFF");

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/expertKickoff.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/expertKickoff.ts
@@ -7,13 +7,15 @@ const LEGACY_MARKER_PATTERN =
   /^\[\[EXPERT_KICKOFF:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\](?:\n\n)?/i;
 const PENDING_TTL_MS = 2 * 60 * 1000;
 
+// Never instruct the expert to start a workflow here: one click on Hire ran a
+// Gmail send (SECRT-2622). Any redesign of this message stays ask-first.
 const KICKOFF_PROMPT =
   "You were just hired. Introduce yourself in 2-3 sentences in your voice. " +
   "If you have installed workflows, state the day-one job they support and " +
-  "start the first bundled workflow with run_agent. If no workflow is " +
-  "installed, explain the outcomes you can help with and ask which one to " +
-  "start. If required access or credentials are missing, ask for exactly the " +
-  "one connection the next job needs and why. Never pretend a run succeeded.";
+  "ask which one to start. If no workflow is installed, explain the outcomes " +
+  "you can help with and ask which one to start. If required access or " +
+  "credentials are missing, ask for exactly the one connection the next job " +
+  "needs and why. Never pretend a run succeeded.";
 
 export interface ExpertKickoffMetadata {
   kind: typeof EXPERT_KICKOFF_KIND;


### PR DESCRIPTION
The kickoff prompt an expert receives when you click Hire no longer tells it to start a workflow — it asks which job to start instead, in both the with-workflows and no-workflows branches.

The prompt said "state the day-one job they support and start the first bundled workflow with run_agent", so one Hire click was enough to fire a real run against the user's connected accounts — it sent a Gmail message from a colleague's connected account. Cutting only the run clause would have left an expert *with* workflows no instruction at all while one without still got the ask-which-one branch, so the ask branch is now unconditional.

Before:

> You were just hired. Introduce yourself in 2-3 sentences in your voice. **If you have installed workflows, state the day-one job they support and start the first bundled workflow with run_agent. If no workflow is installed, explain the outcomes you can help with and ask which one to start.** If required access or credentials are missing, ask for exactly the one connection the next job needs and why. Never pretend a run succeeded.

After:

> You were just hired. Introduce yourself in 2-3 sentences in your voice. **If you have installed workflows, state the day-one job they support and ask which one to start. If no workflow is installed, explain the outcomes you can help with and ask which one to start.** If required access or credentials are missing, ask for exactly the one connection the next job needs and why. Never pretend a run succeeded.

The constant carries a two-line comment saying the prompt must never instruct the model to start a workflow unprompted, so the rule travels into any conflict hunk — this message is being redesigned as an onboarding flow, and the instruction must not come back with it.

This reverses the auto-run half of SECRT-2531, whose "run (or offer to run) her first bundled workflow" is what the old prompt implemented and what fired the Gmail send. No "offer to run" phrasing replaces it — asking which one to start is the whole behaviour, so the expert starts nothing the user did not ask for.

Addresses SECRT-2622. The product decision on what the kickoff should say, and the onboarding redesign, stay open on the ticket.

### Changes

- `expertKickoff.ts`: `KICKOFF_PROMPT` asks which job to start in both branches; `run_agent` is gone from the prompt.
- `__tests__/expertKickoff.test.ts`: the one assertion that pinned `run_agent` now pins the replacement clause. No new test — a guard test against the instruction returning was explicitly not wanted.

### Verified

On `ffd89f6bcb` I ran `npx vitest run src/app/(platform)/copilot/__tests__/` — 28 files, 326 tests, all pass — and the ChatMessagesContainer suite that renders a kickoff message, 3 files, 86 tests, all pass, both under `LC_ALL=en_US.UTF-8`; the frontend Prettier and `tsc` pre-commit hooks passed on commit. I grepped the whole repo for the removed wording and for `run_agent` — `src/playwright/` pins neither and no checked-in snapshot carries the prompt text, and the backend's `routes_test.py` uses only the unchanged `"You were just hired."` literal. No screenshot: the prompt is sent to the model, not rendered to the user, so there is no visual change.

### Checklist

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan

### Agents and large language models used

- Claude Code — Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

