### PR TITLE
fix(backend): Stop logging Ayrshare requests

### DIFF
--- a/autogpt_platform/backend/backend/integrations/ayrshare.py
+++ b/autogpt_platform/backend/backend/integrations/ayrshare.py
@@ -519,7 +519,6 @@ class AyrshareClient:
         response = await self._requests.post(
             self.POST_ENDPOINT, json=payload, headers=headers
         )
-        logger.warning(f"Ayrshare request: {payload} and headers: {headers}")
         if not response.ok:
             logger.error(
                 f"Ayrshare API request failed ({response.status}): {response.text()}"


### PR DESCRIPTION
### Why / What / How

The Ayrshare integration no longer logs every outbound request. The line was debug output left at warning level that dumped the whole request into the logs on each post, which made them noisy.

The error log right below it is unchanged: it reports the response status and body when a request fails, which is what is actually useful when diagnosing one.

### Changes 🏗️

- Removed the `logger.warning` call in `AyrshareClient.create_post` that logged the request payload and headers.

### Verified

I ran the three suites that cover this file and the two that every backend change runs, all against this commit: `backend/integrations/managed_providers/ayrshare_test.py` and `backend/data/block_cost_config_test.py` (36 passed), `backend/util/architecture_test.py` (3 passed), and `backend/blocks/test/test_block.py` (1650 passed, 84 skipped). The remaining log calls in the file were read rather than executed — none of them logs a request, and the deleted line was the only reference to the `headers` local other than the request call it was built for.

### Agents and large language models used

Claude Code with Claude Opus 5

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `backend/integrations/managed_providers/ayrshare_test.py` + `backend/data/block_cost_config_test.py` — 36 passed
  - [x] `backend/util/architecture_test.py` — 3 passed
  - [x] `backend/blocks/test/test_block.py` — 1650 passed, 84 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
