### PR TITLE
feat(platform): require a short CTA-style sub_heading on marketplace listings, with a backfill script

### DIFF
--- a/autogpt_platform/backend/backend/api/features/orgs/regression_test.py
+++ b/autogpt_platform/backend/backend/api/features/orgs/regression_test.py
@@ -1273,6 +1273,7 @@ class TestRegressionStore:
                     graph_version=GRAPH_VERSION,
                     slug=SLUG,
                     name="Test Agent",
+                    sub_heading="Find test agents fast",
                 )
 
         # The initial graph lookup must include userId
@@ -1302,6 +1303,7 @@ class TestRegressionStore:
                 user_id=USER_ID,
                 store_listing_version_id=STORE_LISTING_VERSION_ID,
                 name="Updated",
+                sub_heading="Find test agents fast",
             )
 
     @pytest.mark.asyncio
@@ -2182,6 +2184,7 @@ class TestPR15MarketplaceOrg:
                     graph_version=GRAPH_VERSION,
                     slug=SLUG,
                     name="Test Agent",
+                    sub_heading="Find test agents fast",
                     organization_id="org-1",
                 )
 

--- a/autogpt_platform/backend/backend/api/features/store/db.py
+++ b/autogpt_platform/backend/backend/api/features/store/db.py
@@ -837,12 +837,12 @@ async def create_store_submission(
     graph_version: int,
     slug: str,
     name: str,
+    sub_heading: str,
     video_url: str | None = None,
     agent_output_demo_url: str | None = None,
     image_urls: list[str] = [],
     description: str = "",
     instructions: str | None = None,
-    sub_heading: str = "",
     categories: list[str] = [],
     changes_summary: str | None = "Initial Submission",
     recommended_schedule_cron: str | None = None,
@@ -860,7 +860,7 @@ async def create_store_submission(
         video_url: Optional URL to video demo
         image_urls: List of image URLs for the listing
         description: Description of the agent
-        sub_heading: Optional sub-heading for the agent
+        sub_heading: Short CTA line shown under the agent name
         categories: List of categories for the agent
         changes_summary: Summary of changes made in this submission
 
@@ -1040,11 +1040,11 @@ async def edit_store_submission(
     user_id: str,
     store_listing_version_id: str,
     name: str,
+    sub_heading: str,
     video_url: str | None = None,
     agent_output_demo_url: str | None = None,
     image_urls: list[str] = [],
     description: str = "",
-    sub_heading: str = "",
     categories: list[str] = [],
     changes_summary: str | None = "Update submission",
     recommended_schedule_cron: str | None = None,
@@ -1061,7 +1061,7 @@ async def edit_store_submission(
         video_url: Optional URL to video demo
         image_urls: List of image URLs for the listing
         description: Description of the agent
-        sub_heading: Optional sub-heading for the agent
+        sub_heading: Short CTA line shown under the agent name
         categories: List of categories for the agent
         changes_summary: Summary of changes made in this submission
 

--- a/autogpt_platform/backend/backend/api/features/store/db_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/db_test.py
@@ -259,6 +259,7 @@ async def test_create_store_submission(mocker):
         graph_version=1,
         slug="test-agent",
         name="Test Agent",
+        sub_heading="Find test agents fast",
         description="Test description",
     )
 
@@ -1070,6 +1071,7 @@ async def test_edit_store_submission_blocks_cross_org(mocker):
             user_id="user-1",
             store_listing_version_id="slv-1",
             name="New Name",
+            sub_heading="Find test agents fast",
             organization_id="org-A",
         )
     mock_client.update.assert_not_called()

--- a/autogpt_platform/backend/backend/api/features/store/model.py
+++ b/autogpt_platform/backend/backend/api/features/store/model.py
@@ -1,6 +1,6 @@
 import datetime
 import enum
-from typing import TYPE_CHECKING, List, Self
+from typing import TYPE_CHECKING, Annotated, List, Self
 
 import prisma.enums
 import pydantic
@@ -11,6 +11,25 @@ from .categories import validate_canonical_categories
 
 if TYPE_CHECKING:
     import prisma.models
+
+
+SUB_HEADING_MAX_LENGTH = 100
+
+# Surfaced as a one-line card subtitle, so it must be a short CTA rather than a
+# description; whitespace-only is stripped to "" and rejected as empty.
+SubHeading = Annotated[
+    str,
+    pydantic.StringConstraints(
+        strip_whitespace=True, min_length=1, max_length=SUB_HEADING_MAX_LENGTH
+    ),
+    pydantic.Field(
+        description=(
+            "Short call-to-action line describing what the agent does for the "
+            "user, e.g. 'Find decision-makers at any company in seconds'. "
+            f"Required; max {SUB_HEADING_MAX_LENGTH} characters."
+        ),
+    ),
+]
 
 
 class ChangelogEntry(pydantic.BaseModel):
@@ -318,7 +337,7 @@ class StoreSubmissionRequest(pydantic.BaseModel):
     )
     slug: str
     name: str
-    sub_heading: str
+    sub_heading: SubHeading
     video_url: str | None = None
     agent_output_demo_url: str | None = None
     image_urls: list[str] = []
@@ -335,7 +354,7 @@ class StoreSubmissionRequest(pydantic.BaseModel):
 
 class StoreSubmissionEditRequest(pydantic.BaseModel):
     name: str
-    sub_heading: str
+    sub_heading: SubHeading
     video_url: str | None = None
     agent_output_demo_url: str | None = None
     image_urls: list[str] = []

--- a/autogpt_platform/backend/backend/api/features/store/model_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/model_test.py
@@ -1,0 +1,66 @@
+import pydantic
+import pytest
+
+from .model import (
+    SUB_HEADING_MAX_LENGTH,
+    StoreSubmissionEditRequest,
+    StoreSubmissionRequest,
+)
+
+SUBMISSION_MODELS = [StoreSubmissionRequest, StoreSubmissionEditRequest]
+
+
+def build(model: type[pydantic.BaseModel], sub_heading: str):
+    common = {
+        "name": "Lead Finder",
+        "sub_heading": sub_heading,
+        "categories": ["sales"],
+    }
+    if model is StoreSubmissionRequest:
+        common |= {"graph_id": "graph-1", "graph_version": 1, "slug": "lead-finder"}
+    return model(**common)
+
+
+@pytest.mark.parametrize("model", SUBMISSION_MODELS)
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n "])
+def test_a_blank_sub_heading_is_rejected(model, blank):
+    with pytest.raises(pydantic.ValidationError) as exc:
+        build(model, blank)
+    assert exc.value.errors()[0]["type"] == "string_too_short"
+
+
+@pytest.mark.parametrize("model", SUBMISSION_MODELS)
+def test_a_cta_sub_heading_is_accepted(model):
+    cta = "Find decision-makers at any company in seconds"
+    assert build(model, cta).sub_heading == cta
+
+
+@pytest.mark.parametrize("model", SUBMISSION_MODELS)
+def test_surrounding_whitespace_is_stripped(model):
+    assert build(model, "  Find leads fast  ").sub_heading == "Find leads fast"
+
+
+@pytest.mark.parametrize("model", SUBMISSION_MODELS)
+def test_the_length_ceiling_is_enforced_on_the_stripped_value(model):
+    at_limit = "x" * SUB_HEADING_MAX_LENGTH
+    assert build(model, f"  {at_limit}  ").sub_heading == at_limit
+
+    with pytest.raises(pydantic.ValidationError) as exc:
+        build(model, "x" * (SUB_HEADING_MAX_LENGTH + 1))
+    assert exc.value.errors()[0]["type"] == "string_too_long"
+
+
+@pytest.mark.parametrize("model", SUBMISSION_MODELS)
+def test_sub_heading_has_no_default(model):
+    """A missing key must 422 rather than silently persisting an empty line."""
+    with pytest.raises(pydantic.ValidationError) as exc:
+        model.model_validate(
+            {
+                "graph_id": "graph-1",
+                "graph_version": 1,
+                "slug": "lead-finder",
+                "name": "Lead Finder",
+                "categories": ["sales"],
+            }
+        )
+    assert any(e["loc"] == ("sub_heading",) for e in exc.value.errors())

--- a/autogpt_platform/backend/backend/api/features/store/model_test.py
+++ b/autogpt_platform/backend/backend/api/features/store/model_test.py
@@ -10,17 +10,6 @@ from .model import (
 SUBMISSION_MODELS = [StoreSubmissionRequest, StoreSubmissionEditRequest]
 
 
-def build(model: type[pydantic.BaseModel], sub_heading: str):
-    common = {
-        "name": "Lead Finder",
-        "sub_heading": sub_heading,
-        "categories": ["sales"],
-    }
-    if model is StoreSubmissionRequest:
-        common |= {"graph_id": "graph-1", "graph_version": 1, "slug": "lead-finder"}
-    return model(**common)
-
-
 @pytest.mark.parametrize("model", SUBMISSION_MODELS)
 @pytest.mark.parametrize("blank", ["", "   ", "\t\n "])
 def test_a_blank_sub_heading_is_rejected(model, blank):
@@ -64,3 +53,14 @@ def test_sub_heading_has_no_default(model):
             }
         )
     assert any(e["loc"] == ("sub_heading",) for e in exc.value.errors())
+
+
+def build(model: type[pydantic.BaseModel], sub_heading: str):
+    common = {
+        "name": "Lead Finder",
+        "sub_heading": sub_heading,
+        "categories": ["sales"],
+    }
+    if model is StoreSubmissionRequest:
+        common |= {"graph_id": "graph-1", "graph_version": 1, "slug": "lead-finder"}
+    return model(**common)

--- a/autogpt_platform/backend/scripts/backfill_store_sub_headings.py
+++ b/autogpt_platform/backend/scripts/backfill_store_sub_headings.py
@@ -1,0 +1,215 @@
+"""Backfill an empty ``StoreListingVersion.subHeading`` with a generated CTA.
+
+Marketplace listings now require a short call-to-action sub-heading, but rows
+predating that rule can hold an empty string, which leaves preview cards to
+fall back on the full description. This generates a one-line CTA from the
+listing's name and description via ``gpt-4o-mini`` and, with ``--apply``,
+writes it back.
+
+Every run writes a CSV of ``id,name,description,proposed_sub_heading`` so the
+generated lines can be reviewed before anything is written.
+
+Usage::
+
+    poetry run python scripts/backfill_store_sub_headings.py            # dry run
+    poetry run python scripts/backfill_store_sub_headings.py --apply
+
+Dry run is the default; ``--apply`` is the only thing that writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_CSV_PATH = Path("store_sub_heading_backfill.csv")
+
+MODEL = "gpt-4o-mini"
+MAX_OUTPUT_TOKENS = 40
+# One stuck call otherwise inherits the OpenAI client's 600s default (x2 retries).
+CALL_TIMEOUT_SECONDS = 30.0
+RATE_LIMIT_DELAY_SECONDS = 0.2
+
+SYSTEM_PROMPT = (
+    "You write one-line marketplace taglines for automation agents. "
+    "Given an agent's name and description, reply with a single "
+    "call-to-action line of at most {max_length} characters saying what the "
+    "agent does for the user. Start with a verb, name the outcome rather "
+    "than the mechanism, and use sentence case with no trailing period. "
+    "Example: 'Find decision-makers at any company in seconds'. "
+    "Output only the line."
+)
+
+
+async def main(
+    limit: int | None,
+    include_unapproved: bool,
+    csv_path: Path,
+    apply: bool,
+) -> int:
+    if not os.environ.get("DATABASE_URL"):
+        raise SystemExit("DATABASE_URL must be set")
+
+    # Imported lazily so --help works without the backend env being loaded.
+    from backend.api.features.store.model import SUB_HEADING_MAX_LENGTH
+    from backend.data.db import connect, disconnect
+
+    await connect()
+    try:
+        rows = await find_listings_without_sub_heading(limit, include_unapproved)
+        print(
+            f"{len(rows)} listing version(s) with an empty subHeading"
+            f"{'' if include_unapproved else ' (APPROVED only)'}."
+        )
+        if not rows:
+            return 0
+
+        proposals = await generate_sub_headings(rows, SUB_HEADING_MAX_LENGTH)
+        write_csv(csv_path, proposals)
+        print(f"Wrote {len(proposals)} proposal(s) to {csv_path}")
+
+        for row_id, name, _description, proposed in proposals[:5]:
+            print(f"  {row_id}  {name!r}\n    -> {proposed!r}")
+
+        if not apply:
+            print("\nDry run: nothing written. Re-run with --apply to persist.")
+            return 0
+
+        written = await persist_sub_headings(proposals)
+        print(f"Updated {written} listing version(s).")
+        return 0
+    finally:
+        await disconnect()
+
+
+async def find_listings_without_sub_heading(
+    limit: int | None, include_unapproved: bool
+) -> list[tuple[str, str, str]]:
+    from prisma import get_client
+
+    # Prisma has no "empty once trimmed" string filter, and a whitespace-only
+    # sub-heading is as empty as "" to the API validator that strips it.
+    status_clause = (
+        "" if include_unapproved else "AND \"submissionStatus\" = 'APPROVED'"
+    )
+    limit_clause = f"LIMIT {int(limit)}" if limit else ""
+    rows = await get_client().query_raw(
+        f"""
+        SELECT id, name, description
+        FROM platform."StoreListingVersion"
+        WHERE btrim("subHeading") = '' AND "isDeleted" = false
+        {status_clause}
+        ORDER BY "createdAt" DESC
+        {limit_clause}
+        """
+    )
+    return [(r["id"], r["name"], r["description"]) for r in rows]
+
+
+async def generate_sub_headings(
+    rows: list[tuple[str, str, str]], max_length: int
+) -> list[tuple[str, str, str, str]]:
+    from backend.util.clients import get_openai_client
+
+    client = get_openai_client()
+    if client is None:
+        raise SystemExit("No OpenAI client configured (OPENAI_API_KEY unset)")
+
+    system_prompt = SYSTEM_PROMPT.format(max_length=max_length)
+    proposals: list[tuple[str, str, str, str]] = []
+    for index, (row_id, name, description) in enumerate(rows, start=1):
+        try:
+            response = await asyncio.wait_for(
+                client.chat.completions.create(
+                    model=MODEL,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {
+                            "role": "user",
+                            "content": f"Name: {name}\nDescription: {description}",
+                        },
+                    ],
+                    max_tokens=MAX_OUTPUT_TOKENS,
+                ),
+                timeout=CALL_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            print(f"  [{index}/{len(rows)}] timed out on {row_id}", file=sys.stderr)
+            continue
+        except Exception as exc:  # noqa: BLE001 - one bad row must not end the run
+            print(f"  [{index}/{len(rows)}] failed on {row_id}: {exc}", file=sys.stderr)
+            continue
+
+        proposed = clean_sub_heading(
+            response.choices[0].message.content or "", max_length
+        )
+        if proposed:
+            proposals.append((row_id, name, description, proposed))
+        else:
+            print(
+                f"  [{index}/{len(rows)}] empty generation for {row_id}",
+                file=sys.stderr,
+            )
+
+        await asyncio.sleep(RATE_LIMIT_DELAY_SECONDS)
+
+    return proposals
+
+
+def clean_sub_heading(raw: str, max_length: int) -> str:
+    """Strip the quoting and trailing period models add, then enforce the cap."""
+    line = raw.strip().split("\n")[0].strip().strip('"').strip("'").rstrip(".").strip()
+    if len(line) <= max_length:
+        return line
+    # Truncating mid-word would ship a broken line; drop the row for review instead.
+    return ""
+
+
+def write_csv(path: Path, proposals: list[tuple[str, str, str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id", "name", "description", "proposed_sub_heading"])
+        writer.writerows(proposals)
+
+
+async def persist_sub_headings(proposals: list[tuple[str, str, str, str]]) -> int:
+    from prisma import get_client
+
+    client = get_client()
+    written = 0
+    for row_id, _name, _description, proposed in proposals:
+        # The emptiness re-check keeps a concurrent edit from being overwritten.
+        written += await client.execute_raw(
+            """
+            UPDATE platform."StoreListingVersion"
+            SET "subHeading" = $2
+            WHERE id = $1 AND btrim("subHeading") = ''
+            """,
+            row_id,
+            proposed,
+        )
+    return written
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--include-unapproved",
+        action="store_true",
+        help="Also cover DRAFT/PENDING/REJECTED versions, which fail validation on edit.",
+    )
+    parser.add_argument("--csv", type=Path, default=DEFAULT_CSV_PATH)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the generated sub-headings. Without it the run is read-only.",
+    )
+    args = parser.parse_args()
+    raise SystemExit(
+        asyncio.run(main(args.limit, args.include_unapproved, args.csv, args.apply))
+    )

--- a/autogpt_platform/frontend/src/app/api/openapi.json
+++ b/autogpt_platform/frontend/src/app/api/openapi.json
@@ -28358,7 +28358,13 @@
       "StoreSubmissionEditRequest": {
         "properties": {
           "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "sub_heading": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Sub Heading",
+            "description": "Short call-to-action line describing what the agent does for the user, e.g. 'Find decision-makers at any company in seconds'. Required; max 100 characters."
+          },
           "video_url": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"
@@ -28416,7 +28422,13 @@
           },
           "slug": { "type": "string", "title": "Slug" },
           "name": { "type": "string", "title": "Name" },
-          "sub_heading": { "type": "string", "title": "Sub Heading" },
+          "sub_heading": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Sub Heading",
+            "description": "Short call-to-action line describing what the agent does for the user, e.g. 'Find decision-makers at any company in seconds'. Required; max 100 characters."
+          },
           "video_url": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Video Url"

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
@@ -191,10 +191,9 @@ export function EditAgentForm({
                         id={field.name}
                         labelVariant="body"
                         label="Tagline"
-                        labelTooltip="Shown under the agent name and as the one-line subtitle on preview cards, so keep it to a single short line."
+                        labelTooltip="The one-line subtitle shown under the agent name and on preview cards. Start with a verb and name the outcome for the user."
                         type="text"
                         placeholder="Find decision-makers at any company in seconds"
-                        hint="Say what the agent does for the user, starting with a verb."
                         error={form.formState.errors.subheader?.message}
                         required
                         {...field}

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/EditAgentForm.tsx
@@ -190,11 +190,13 @@ export function EditAgentForm({
                       <Input
                         id={field.name}
                         labelVariant="body"
-                        label="Subheader"
-                        labelTooltip="One-sentence tagline displayed under the title."
+                        label="Tagline"
+                        labelTooltip="Shown under the agent name and as the one-line subtitle on preview cards, so keep it to a single short line."
                         type="text"
-                        placeholder="A concise tagline for your agent"
+                        placeholder="Find decision-makers at any company in seconds"
+                        hint="Say what the agent does for the user, starting with a verb."
                         error={form.formState.errors.subheader?.message}
+                        required
                         {...field}
                       />
                     )}

--- a/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/useEditAgentForm.ts
+++ b/autogpt_platform/frontend/src/components/contextual/EditAgentModal/components/useEditAgentForm.ts
@@ -8,6 +8,7 @@ import { StoreSubmissionEditRequest } from "@/app/api/__generated__/models/store
 import { useToast } from "@/components/molecules/Toast/use-toast";
 import { useStoreCategories } from "@/hooks/useStoreCategories";
 import { validateYouTubeUrl } from "@/lib/utils";
+import { SUB_HEADING_MAX } from "../../PublishAgentModal/components/AgentInfoStep/helpers";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import React from "react";
@@ -35,8 +36,12 @@ export const useEditAgentForm = ({
       .max(100, "Title must be less than 100 characters"),
     subheader: z
       .string()
-      .min(1, "Subheader is required")
-      .max(200, "Subheader must be less than 200 characters"),
+      .trim()
+      .min(1, "Tagline is required")
+      .max(
+        SUB_HEADING_MAX,
+        `Tagline must be ${SUB_HEADING_MAX} characters or less`,
+      ),
     youtubeLink: z
       .string()
       .refine(validateYouTubeUrl, "Please enter a valid YouTube URL"),

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -232,10 +232,9 @@ export function AgentInfoStep({
                           id={field.name}
                           labelVariant="body"
                           label="Tagline"
-                          labelTooltip="Shown under the agent name and as the one-line subtitle on preview cards, so keep it to a single short line."
+                          labelTooltip="The one-line subtitle shown under the agent name and on preview cards. Start with a verb and name the outcome for the user."
                           type="text"
                           placeholder="Find decision-makers at any company in seconds"
-                          hint="Say what the agent does for the user, starting with a verb."
                           error={form.formState.errors.subheader?.message}
                           required
                           {...field}

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/AgentInfoStep.tsx
@@ -22,6 +22,7 @@ import { StepFooter } from "../StepFooter";
 import { ThumbnailImages } from "./components/ThumbnailImages";
 import { CharCountedTextarea } from "./components/CharCountedTextarea";
 import { Props, useAgentInfoStep } from "./useAgentInfoStep";
+import { SUB_HEADING_MAX } from "./helpers";
 import {
   Album01Icon,
   AlertCircleIcon,
@@ -223,16 +224,23 @@ export function AgentInfoStep({
                     control={form.control}
                     name="subheader"
                     render={({ field }) => (
-                      <Input
-                        id={field.name}
-                        labelVariant="body"
-                        label="Subheader"
-                        labelTooltip="One-sentence tagline displayed under the title."
-                        type="text"
-                        placeholder="A concise tagline for your agent"
-                        error={form.formState.errors.subheader?.message}
-                        {...field}
-                      />
+                      <CharCountedTextarea
+                        max={SUB_HEADING_MAX}
+                        value={field.value ?? ""}
+                      >
+                        <Input
+                          id={field.name}
+                          labelVariant="body"
+                          label="Tagline"
+                          labelTooltip="Shown under the agent name and as the one-line subtitle on preview cards, so keep it to a single short line."
+                          type="text"
+                          placeholder="Find decision-makers at any company in seconds"
+                          hint="Say what the agent does for the user, starting with a verb."
+                          error={form.formState.errors.subheader?.message}
+                          required
+                          {...field}
+                        />
+                      </CharCountedTextarea>
                     )}
                   />
                 </div>

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/helpers.test.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/__tests__/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { publishAgentSchemaFactory } from "../helpers";
+import { SUB_HEADING_MAX, publishAgentSchemaFactory } from "../helpers";
 
 const validBase = {
   title: "My Agent",
@@ -76,14 +76,54 @@ describe("publishAgentSchemaFactory", () => {
     expect(result.success).toBe(true);
   });
 
-  it("treats title and subheader as optional on updates", () => {
+  it("treats the title as optional on updates", () => {
     const result = publishAgentSchemaFactory(true).safeParse({
       ...validBase,
       title: "",
-      subheader: "",
       changesSummary: "Refreshed copy",
     });
     expect(result.success).toBe(true);
+  });
+
+  it.each([false, true])(
+    "requires a non-blank tagline (isMarketplaceUpdate=%s)",
+    (isUpdate) => {
+      for (const subheader of ["", "   ", "\t\n "]) {
+        const result = publishAgentSchemaFactory(isUpdate).safeParse({
+          ...validBase,
+          subheader,
+          changesSummary: "Refreshed copy",
+        });
+        expect(result.success).toBe(false);
+      }
+    },
+  );
+
+  it("accepts a CTA-shaped tagline and trims it", () => {
+    const result = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      subheader: "  Find decision-makers at any company in seconds  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.subheader).toBe(
+        "Find decision-makers at any company in seconds",
+      );
+    }
+  });
+
+  it("caps the tagline at the shared length ceiling", () => {
+    const atLimit = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      subheader: "x".repeat(SUB_HEADING_MAX),
+    });
+    expect(atLimit.success).toBe(true);
+
+    const overLimit = publishAgentSchemaFactory(false).safeParse({
+      ...validBase,
+      subheader: "x".repeat(SUB_HEADING_MAX + 1),
+    });
+    expect(overLimit.success).toBe(false);
   });
 
   it("still requires a category on updates, which overwrite the stored ones", () => {

--- a/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/helpers.ts
+++ b/autogpt_platform/frontend/src/components/contextual/PublishAgentModal/components/AgentInfoStep/helpers.ts
@@ -1,6 +1,9 @@
 import z from "zod";
 import { validateYouTubeUrl } from "@/lib/utils";
 
+// Mirrors SUB_HEADING_MAX_LENGTH in backend/api/features/store/model.py.
+export const SUB_HEADING_MAX = 100;
+
 // Create conditional schema that changes based on whether it's a marketplace update
 export const publishAgentSchemaFactory = (
   isMarketplaceUpdate: boolean = false,
@@ -24,18 +27,14 @@ export const publishAgentSchemaFactory = (
           .string()
           .min(1, "Title is required")
           .max(100, "Title must be less than 100 characters"),
-    subheader: isMarketplaceUpdate
-      ? z
-          .string()
-          .optional()
-          .refine(
-            (val) => !val || val.length <= 200,
-            "Subheader must be less than 200 characters",
-          )
-      : z
-          .string()
-          .min(1, "Subheader is required")
-          .max(200, "Subheader must be less than 200 characters"),
+    subheader: z
+      .string()
+      .trim()
+      .min(1, "Tagline is required")
+      .max(
+        SUB_HEADING_MAX,
+        `Tagline must be ${SUB_HEADING_MAX} characters or less`,
+      ),
     slug: isMarketplaceUpdate
       ? z
           .string()

--- a/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
+++ b/autogpt_platform/frontend/src/playwright/pages/marketplace.page.ts
@@ -255,8 +255,8 @@ export class MarketplacePage extends BasePage {
 
     await publishAgentModal.getByLabel("Title").fill(agentTitle);
     await publishAgentModal
-      .getByLabel("Subheader")
-      .fill("A deterministic marketplace submission");
+      .getByLabel("Tagline")
+      .fill("Publish a deterministic marketplace submission");
     await publishAgentModal.getByLabel("Slug").fill(agentSlug);
 
     await publishAgentModal.getByRole("combobox", { name: "Category" }).click();


### PR DESCRIPTION
### Why / What / How

A marketplace listing's `sub_heading` is the one-line subtitle preview cards show under the agent name, and today it can be empty or 200 characters long — so a card either falls back to the truncated full description or clips the sub-heading mid-sentence. This makes `sub_heading` a required, CTA-shaped line, capped at 100 characters, and adds a script to fill in rows that predate the rule.

**Backend.** `StoreSubmissionRequest` and `StoreSubmissionEditRequest` share a `SubHeading` annotated type that strips surrounding whitespace, then rejects the empty result and caps the stripped value at `SUB_HEADING_MAX_LENGTH = 100`. Whitespace-only input is therefore rejected, not stored. The `create_store_submission` / `edit_store_submission` DB helpers lose their `sub_heading: str = ""` defaults, which were the one path that could write an empty line past the API. Response models are untouched: existing rows still read back fine, validation only applies on write.

**Why 100.** The agent detail page clamps the sub-heading to two lines and the copilot preview card to one, so this has to be a line, not a paragraph. Against the 1,605 listing versions on the shared dev database the 100-character cap rejects exactly one row — the 112-character outlier that is precisely the case that truncates badly. p50 is 16 characters, p90 34, p99 55, and the longest genuine CTA in the corpus is 70 ("Automate research, writing, and publishing for high-ranking blog posts"), so a real tagline has comfortable headroom.

**Frontend.** The publish and edit forms name the field "Tagline", with a worked placeholder ("Find decision-makers at any company in seconds"), a hint asking for a verb-first line about the outcome, a live character counter and inline validation. The publish form now requires it on the marketplace-update path too: it was optional there and sent `sub_heading: ""` to an API that accepted it, which is how an empty sub-heading gets written today.

**Backfill.** `scripts/backfill_store_sub_headings.py` finds listing versions whose sub-heading is empty once trimmed, generates a CTA from the listing's name and description with `gpt-4o-mini`, and writes a CSV of `id,name,description,proposed_sub_heading` for review. Dry run is the default; `--apply` is the only thing that writes, and each write re-checks emptiness so a concurrent edit is never clobbered.

**The dev database has zero rows to backfill** — 0 empty sub-headings across all 1,605 listing versions, in both `--include-unapproved` and APPROVED-only modes. The script is a no-op there; the production count is unknown to me. Cost if it does have rows: measured at 302 input and 12 output tokens per row on real long-description listings, so **$0.000052/row — about $0.52 for 10,000 rows** at gpt-4o-mini list price. I have not run it with `--apply` anywhere.

### Changes 🏗️

- `sub_heading` is required, whitespace-stripped and capped at 100 characters on marketplace submission create and edit; the OpenAPI schema now carries `minLength`/`maxLength` and a description.
- `create_store_submission` / `edit_store_submission` take `sub_heading` as a required argument instead of defaulting it to `""`.
- Publish and edit forms relabel the field to "Tagline" with CTA placeholder, hint, character counter and inline validation; the publish form requires it on marketplace updates as well.
- `src/playwright/pages/marketplace.page.ts` follows the label rename.
- New `scripts/backfill_store_sub_headings.py`, dry-run by default, with a reviewable CSV and a per-call timeout.
- New `backend/api/features/store/model_test.py` covering the validation in both directions.

### Screenshots

Attached in a comment: the "Listing basics" step before and after. Capturing them needed a temporary `pg` alias in `.storybook/main.ts` plus a throwaway story — Storybook's webpack build otherwise dies resolving `src/lib/auth/auth.ts`, which constructs a `pg` Pool at import time. Neither is in the commit.

| | Before | After |
|---|---|---|
| Label | Subheader | Tagline |
| Placeholder | A concise tagline for your agent | Find decision-makers at any company in seconds |
| Tooltip | One-sentence tagline displayed under the title. | The one-line subtitle shown under the agent name and on preview cards. Start with a verb and name the outcome for the user. |
| Character counter | none | live `n / 100` |
| Cap | 200 | 100 |
| `required` on the input | no | yes — the HTML attribute for assistive tech; the `Input` atom renders no asterisk |

The first capture caught a real defect and it is fixed in this branch: `CharCountedTextarea` positions its counter `absolute right-0 top-0`, and the `Input` atom renders `hint` right-aligned on the same label row, so "0 / 100" printed straight through "starting with a verb". The guidance moved into the tooltip, which is what every other field in this form uses — `hint` on `Input` has no other caller in the codebase.

### Verified

I executed the new `model_test.py` (14 passed) and proved it load-bearing by reverting the constraint — 10 of 14 fail, including every blank-rejection case. I ran the two mandatory backend suites, `backend/util/architecture_test.py` and `backend/blocks/test/test_block.py` (1,653 passed, 84 skipped), plus `backend/api/features/orgs/regression_test.py` and `backend/api/features/store/db_test.py` (130 passed, 12 xfailed) — the two files that call the db helpers whose `sub_heading` default this PR removes, and the full frontend unit suite (`vitest run`, 669 files / 6,946 tests passed, under `LC_ALL=en_US.UTF-8`), plus `tsc --noEmit` clean. The full-suite run predates the counter/hint fix; I re-ran `src/components/contextual` after it (48 files / 423 tests passed). I confirmed pydantic 2.12.5 and zod 3.25.76 both strip before length-checking, so whitespace-only is rejected and a padded 100-character value is accepted. I ran the backfill's dry run against the shared dev database (0 rows, no writes) and exercised its generation path on six real listings, which produced verb-first CTAs of 64–86 characters, all inside the cap. Because dev has nothing to backfill, I tested the whole script end to end against a throwaway `pgvector/pgvector:pg16` container seeded with four rows — empty, whitespace-only, already-set, and unapproved. Selection took the first two and left the other two alone, the dry run changed nothing, `--apply` wrote both, and a second `--apply` found zero, so it is idempotent. `--include-unapproved` picked up the pending row. The container is gone.

I did not run the Playwright E2E suite, so the `marketplace.page.ts` label change is verified by grep and type-check rather than execution. I did not run the backfill with `--apply` against any database.

### Agents and large language models used

Claude Code with Claude Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] New backend validation tests, both directions, plus a mutation proving they fail without the constraint
  - [x] `backend/util/architecture_test.py` and `backend/blocks/test/test_block.py`
  - [x] Full frontend unit suite and `tsc --noEmit`
  - [x] Backfill dry run against the shared dev database, and its generation path on real listings
  - [ ] GitHub CI passes for this PR

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
