### PR TITLE
fix(frontend): prefer sub_heading over the long description on link-preview cards

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/__tests__/generateMetadata.test.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/__tests__/generateMetadata.test.ts
@@ -88,11 +88,12 @@ describe("generateMetadata", () => {
     );
   });
 
-  test("previews the agent's own name, description and image", async () => {
+  test("previews the agent's own name, sub-heading and image", async () => {
     mockGetSpecificAgent.mockResolvedValue({
       data: {
         agent_name: "An Agent",
-        description: "What the agent does",
+        sub_heading: "Summarises yesterday's runs",
+        description: "- a bullet\n- another bullet\nand a long tail",
         agent_image: ["https://cdn.example.com/agent.png"],
       },
     });
@@ -103,12 +104,35 @@ describe("generateMetadata", () => {
 
     expect(metadata.title).toBe("An Agent - AutoGPT Marketplace");
     expect(metadata.openGraph?.title).toBe("An Agent - AutoGPT Marketplace");
-    expect(metadata.openGraph?.description).toBe("What the agent does");
+    expect(metadata.openGraph?.description).toBe("Summarises yesterday's runs");
     expect(metadata.openGraph?.images).toEqual([
       "https://cdn.example.com/agent.png",
     ]);
     expect(metadata.twitter).toMatchObject({ card: "summary_large_image" });
   });
+
+  test.each([
+    ["missing", undefined],
+    ["empty", ""],
+  ])(
+    "falls back to the agent name when sub_heading is %s",
+    async (_label, sub_heading) => {
+      mockGetSpecificAgent.mockResolvedValue({
+        data: {
+          agent_name: "An Agent",
+          sub_heading,
+          description: "The long listing description",
+          agent_image: [],
+        },
+      });
+
+      const metadata = await generateMetadata({
+        params: Promise.resolve(params),
+      });
+
+      expect(metadata.openGraph?.description).toBe("An Agent");
+    },
+  );
 
   test("uses only the first image when the listing carries several", async () => {
     mockGetSpecificAgent.mockResolvedValue({

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/agent/[creator]/[slug]/page.tsx
@@ -29,7 +29,7 @@ export async function generateMetadata({
 
   return buildPageMetadata({
     title: `${agent.agent_name} - AutoGPT Marketplace`,
-    description: agent.description,
+    description: agent.sub_heading || agent.agent_name,
     path: `/marketplace/agent/${params.creator}/${params.slug}`,
     images: agent.agent_image?.slice(0, 1),
     type: "article",

--- a/autogpt_platform/frontend/src/lib/__tests__/metadata.test.ts
+++ b/autogpt_platform/frontend/src/lib/__tests__/metadata.test.ts
@@ -43,6 +43,37 @@ describe("buildPageMetadata", () => {
     expect(metadata.twitter).toMatchObject({ card: "summary" });
   });
 
+  test("keeps a description that fits under the cap", () => {
+    const description = "Sends a summary of yesterday's runs every morning.";
+    const metadata = buildPageMetadata({ title: "An Agent", description });
+
+    expect(metadata.description).toBe(description);
+    expect(metadata.openGraph?.description).toBe(description);
+    expect(metadata.twitter?.description).toBe(description);
+  });
+
+  test("cuts an over-long description on a word boundary", () => {
+    const description = `${"word ".repeat(60)}tail`;
+    const metadata = buildPageMetadata({ title: "An Agent", description });
+
+    const summary = metadata.description as string;
+    expect(summary.length).toBeLessThanOrEqual(201);
+    expect(summary.endsWith("…")).toBe(true);
+    expect(summary).not.toMatch(/wor…$/);
+    expect(summary.slice(0, -1).endsWith("word")).toBe(true);
+  });
+
+  test.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["blank", "   "],
+  ])("omits the description when it is %s", (_label, description) => {
+    const metadata = buildPageMetadata({ title: "An Agent", description });
+
+    expect(metadata.description).toBeUndefined();
+    expect(metadata.openGraph?.description).toBeUndefined();
+  });
+
   test("resolves the canonical and og:url against the site URL", () => {
     vi.stubEnv("NEXT_PUBLIC_FRONTEND_BASE_URL", "https://platform.agpt.co");
 

--- a/autogpt_platform/frontend/src/lib/metadata.ts
+++ b/autogpt_platform/frontend/src/lib/metadata.ts
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 
 const SITE_NAME = "AutoGPT";
+// X truncates around 200 characters, the tightest of the platforms we target.
+const DESCRIPTION_MAX_LENGTH = 200;
 
 interface PageMetadataOptions {
   title: string;
@@ -23,7 +25,7 @@ export function buildPageMetadata({
   const cardImages = (images ?? []).filter(
     (image): image is string => typeof image === "string" && image.length > 0,
   );
-  const summary = description || undefined;
+  const summary = toCardDescription(description);
 
   return {
     title,
@@ -44,6 +46,19 @@ export function buildPageMetadata({
       ...(cardImages.length > 0 ? { images: cardImages } : {}),
     },
   };
+}
+
+// Unfurlers cut a long description at their own limit, mid-word; cutting on a
+// word boundary first keeps the last word of the card whole.
+function toCardDescription(description?: string | null): string | undefined {
+  const text = description?.trim();
+  if (!text) return undefined;
+  if (text.length <= DESCRIPTION_MAX_LENGTH) return text;
+
+  const clipped = text.slice(0, DESCRIPTION_MAX_LENGTH);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const body = lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped;
+  return `${body.trimEnd()}…`;
 }
 
 // Falls back rather than returning a value `new URL()` would reject: the root


### PR DESCRIPTION
### Why / What / How

**Why:** Sharing a marketplace agent link put the listing's full description in the preview card. That field is long-form prose with markdown bullets, so the card showed literal `-` characters and a sentence cut mid-word wherever the platform's limit fell. Listings already carry `sub_heading`, a one-line summary written for exactly this.

**What:** The agent card's description is now the listing's `sub_heading`, falling back to the agent's name when it is empty. `buildPageMetadata` also caps whatever it is given at 200 characters, cutting on a word boundary.

**How:** One line in the agent page's `generateMetadata` changes the source field. The cap lives in `buildPageMetadata` as a last resort rather than at the call site, so a long description on any page degrades readably instead of being cut mid-word by the unfurler. 200 is X's limit, the tightest of the platforms these cards target.

Two pages deliberately keep their current source. The creator page has no `sub_heading` on `CreatorDetails` — only `description`, which is already a short profile bio. The expert page already does the same thing this PR does, reading `expert.tagline || expert.bio`.

### Changes 🏗️

- `marketplace/agent/[creator]/[slug]/page.tsx`: `description: agent.sub_heading || agent.agent_name`.
- `lib/metadata.ts`: add `toCardDescription`, a 200-character word-boundary cap applied to every page's description; blank and whitespace-only input still omits the tag entirely.
- Tests for both `sub_heading` branches and for the cap.

### Rendered output

Taken from `buildPageMetadata` on this branch, for the listing `pwuts/github-review-notification-cleanup`:

```
sub_heading present  → og:description = "Clears stale GitHub review notifications each morning"
sub_heading empty    → og:description = "GitHub Review Notification Cleanup"
```

What the same card carried before, from the long description:

```
og:description = "- Watches your GitHub notifications\n- Clears review requests you already answered\n- Runs every morning before standup and posts a digest to Slack so nothing is missed by the team"
```

### Agents and large language models used

Claude Code with Claude Opus 5.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format`, `pnpm lint`, `pnpm types` — clean; the remaining lint warnings are pre-existing `no-img-element` ones in files this PR does not touch.
  - [x] 492 tests pass across `src/lib` and `src/app/(platform)/marketplace` (`LC_ALL=en_US.UTF-8`, since two unrelated tests in this repo fail under a Dutch locale).
  - [x] Mutation-checked: restoring `description: agent.description` turns all three new metadata tests red.
  - [ ] GitHub CI passes for this PR.

#### For configuration changes:

- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

### Verified

I executed the frontend format, lint and type checks and the 492 tests named above, including a test for each `sub_heading` branch and for the word-boundary cap. I proved those tests can fail by restoring the old source field and watching all three go red, and the rendered descriptions quoted above are real output from `buildPageMetadata` on this branch, not hand-written examples.

I did not fetch a real listing through a live unfurler; the card text is asserted at the metadata layer, which is the value Next renders into `og:description`.

Making `sub_heading` required and backfilling existing listings is separate work owned elsewhere; this PR reads the field as it stands today and falls back when it is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
