### PR TITLE
feat(frontend/marketplace): render live generated avatars on expert cards and pages

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/__tests__/experts-section.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/__tests__/experts-section.test.tsx
@@ -128,6 +128,37 @@ describe("Marketplace ExpertsSection", () => {
     expect(rosterRequested).toBe(false);
   });
 
+  test("renders a live generated face for experts without an uploaded picture", async () => {
+    server.use(
+      getListExpertTemplatesMockHandler([
+        { ...mariaTemplate, avatar_url: "/avatars/round.sky.glasses.svg" },
+      ]),
+      getListExpertsMockHandler([]),
+    );
+
+    render(<MainMarkeplacePage />);
+
+    const card = await screen.findByRole("link", { name: /Maria/ });
+    const face = card.querySelector('svg[data-testid="bot-avatar"]');
+    expect(face).not.toBeNull();
+    expect(face?.getAttribute("data-avatar")).toBe("round.sky.glasses");
+    expect(card.querySelector("img")).toBeNull();
+  });
+
+  test("keeps an uploaded picture as a static image", async () => {
+    server.use(
+      getListExpertTemplatesMockHandler([
+        { ...mariaTemplate, avatar_url: "https://example.com/maria.png" },
+      ]),
+      getListExpertsMockHandler([]),
+    );
+
+    render(<MainMarkeplacePage />);
+
+    const card = await screen.findByRole("link", { name: /Maria/ });
+    expect(card.querySelector('svg[data-testid="bot-avatar"]')).toBeNull();
+  });
+
   test("stays hidden and fetches nothing for signed-in users outside the beta", async () => {
     hireExpertsFlag.enabled = false;
     let templatesRequested = false;

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/components/ExpertCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/components/ExpertCard.tsx
@@ -1,9 +1,4 @@
 import { Expert } from "@/app/api/__generated__/models/expert";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/components/atoms/Avatar/Avatar";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { getExpertAccent } from "../helpers";
@@ -13,6 +8,7 @@ import {
   FlashIcon,
 } from "@hugeicons/core-free-icons";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import { ExpertFace } from "./ExpertFace";
 
 interface Props {
   expert: Expert;
@@ -37,12 +33,7 @@ export function ExpertCard({ expert, isHired }: Props) {
       />
       <div className="relative flex flex-1 flex-col gap-4 p-6">
         <div className="flex items-start justify-between gap-3">
-          <Avatar className="h-20 w-20 bg-white shadow-sm ring-1 ring-black/5">
-            {expert.avatar_url ? (
-              <AvatarImage src={expert.avatar_url} alt={expert.name} />
-            ) : null}
-            <AvatarFallback>{expert.name}</AvatarFallback>
-          </Avatar>
+          <ExpertFace expert={expert} size={80} className="h-20 w-20" />
           <span
             className={cn(
               "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium",

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/components/ExpertFace.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/components/ExpertsSection/components/ExpertFace.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Expert } from "@/app/api/__generated__/models/expert";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@/components/atoms/Avatar/Avatar";
+import { BotAvatar } from "@/components/molecules/BotAvatar/BotAvatar";
+import {
+  expertAvatarConfig,
+  isUploadedAvatar,
+} from "@/components/molecules/BotAvatar/helpers";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  expert: Pick<Expert, "name" | "avatar_url" | "color">;
+  size: number;
+  className?: string;
+}
+
+/** A generated or missing avatar renders as the live BotAvatar so the face
+ *  blinks and follows the pointer like everywhere else; only a real upload
+ *  falls back to a static image. */
+export function ExpertFace({ expert, size, className }: Props) {
+  if (isUploadedAvatar(expert.avatar_url)) {
+    return (
+      <Avatar
+        className={cn("bg-white shadow-sm ring-1 ring-black/5", className)}
+      >
+        <AvatarImage src={expert.avatar_url ?? undefined} alt={expert.name} />
+        <AvatarFallback>{expert.name}</AvatarFallback>
+      </Avatar>
+    );
+  }
+  return (
+    <BotAvatar
+      config={expertAvatarConfig({
+        name: expert.name,
+        avatarUrl: expert.avatar_url,
+        color: expert.color,
+      })}
+      size={size}
+      trackPointer
+      showBadge={false}
+      title={expert.name}
+      className={cn("shrink-0", className)}
+    />
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/experts/[expertId]/components/ExpertPageHeader.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/experts/[expertId]/components/ExpertPageHeader.tsx
@@ -1,9 +1,5 @@
 import { Expert } from "@/app/api/__generated__/models/expert";
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@/components/atoms/Avatar/Avatar";
+import { ExpertFace } from "@/app/(platform)/marketplace/components/ExpertsSection/components/ExpertFace";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { cn } from "@/lib/utils";
 import { ReactNode } from "react";
@@ -19,12 +15,7 @@ export function ExpertPageHeader({ expert, accent, actions }: Props) {
   return (
     <header>
       <div className="flex flex-wrap items-center gap-4 sm:gap-5">
-        <Avatar className="h-18 w-18 shrink-0 bg-white shadow-sm ring-1 ring-black/5">
-          {expert.avatar_url ? (
-            <AvatarImage src={expert.avatar_url} alt={expert.name} />
-          ) : null}
-          <AvatarFallback>{expert.name}</AvatarFallback>
-        </Avatar>
+        <ExpertFace expert={expert} size={72} className="h-18 w-18 shrink-0" />
         <div className="min-w-0 flex-1">
           <h1 className="text-[28px] font-semibold leading-8 tracking-[-0.02em] text-zinc-900">
             {expert.name}

--- a/autogpt_platform/frontend/src/app/(platform)/marketplace/experts/__tests__/expert-page.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/marketplace/experts/__tests__/expert-page.test.tsx
@@ -117,6 +117,21 @@ describe("Marketplace expert page", () => {
     mockUseAuth.mockReturnValue({ user: { id: "user-1" }, isLoggedIn: true });
   });
 
+  test("renders the live generated face in the header", async () => {
+    server.use(
+      getListExpertTemplatesMockHandler([mariaTemplate]),
+      getListExpertsMockHandler([]),
+    );
+
+    renderPage();
+
+    const heading = await screen.findByRole("heading", { name: "Maria" });
+    const header = heading.closest("header");
+    expect(
+      header?.querySelector('svg[data-testid="bot-avatar"]'),
+    ).not.toBeNull();
+  });
+
   test("shows the profile and hires from the page", async () => {
     server.use(
       getListExpertTemplatesMockHandler([mariaTemplate]),


### PR DESCRIPTION
### Why / What / How

**Why:** Marketplace expert cards and the expert page header rendered a generated avatar as a static `<img>` of its SVG, so the face was frozen while the same expert blinks and tracks the pointer everywhere else (chat header, team page, sidebar).

**What:** Generated or missing avatars now render through the live `BotAvatar`; uploaded pictures keep the static image path.

**How:** New `ExpertFace` component holds the one switch (`isUploadedAvatar`) and is used by `ExpertCard` and `ExpertPageHeader`. Pointer tracking is on so the card face is reactive.

### Changes 🏗️

- Add `ExpertFace` (marketplace `ExpertsSection/components`) rendering `BotAvatar` with `trackPointer` for generated avatars, `Avatar`/`AvatarImage` for uploads.
- `ExpertCard` and `ExpertPageHeader` use it instead of inlining `Avatar`.
- Tests: card renders `svg[data-testid="bot-avatar"]` with the right `data-avatar` for a generated URL, a static image path for an upload; header renders the live face.

### Agents and large language models used

Claude Code with Claude Fable 5.1.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm exec tsc --noEmit` clean
  - [x] `pnpm exec vitest run 'src/app/(platform)/marketplace'`: 18 files, 94 tests pass
  - [x] eslint on the changed files clean
  - [ ] Visual check on local marketplace with the seeded 23-expert roster

#### For configuration changes:
- [x] `.env.default` is updated or already compatible with my changes
- [x] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)