### PR TITLE
fix(frontend): refresh every expert list after connecting a service

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/integrations.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/__tests__/integrations.test.tsx
@@ -539,6 +539,89 @@ describe("managing an expert's integrations", () => {
     await waitFor(() => expect(granted).toEqual([["cred-notion"]]));
   });
 
+  it("shows the credential the dialog created without a reload", async () => {
+    const teamNotion = {
+      id: "cred-notion",
+      provider: "notion",
+      type: "api_key",
+      title: "Team Notion",
+    };
+    const notionRef: ExpertCredentialRef = {
+      credential_id: "cred-notion",
+      provider: "notion",
+      title: "Team Notion",
+      type: "api_key",
+    };
+    let granted: ExpertCredentialRef[] = [linkedin];
+    const seoAudit = {
+      id: "wf-1",
+      store_listing_version_id: "slv-1",
+      library_agent_id: "lib-1",
+      graph_id: "graph-1",
+      name: "SEO Audit",
+      description: null,
+      schedule_cron: "0 9 * * 1",
+      schedule_id: null,
+    };
+
+    server.use(
+      // The grant is what lets the backend create the schedule this
+      // workflow was waiting on, so the expert itself changes too.
+      getGetExpertMockHandler(() => ({
+        ...maria,
+        workflows: [
+          granted.length > 1
+            ? { ...seoAudit, schedule_id: "sched-1" }
+            : seoAudit,
+        ],
+      })),
+      http.get("*/api/experts/expert-maria/credentials", () =>
+        HttpResponse.json(granted),
+      ),
+      http.get("*/api/integrations/providers", () =>
+        HttpResponse.json([
+          {
+            name: "notion",
+            description: "Docs and databases",
+            supported_auth_types: ["api_key"],
+          },
+        ]),
+      ),
+      http.post("*/api/integrations/notion/credentials", () =>
+        HttpResponse.json(teamNotion, { status: 201 }),
+      ),
+      http.post("*/api/experts/expert-maria/credentials", () => {
+        granted = [linkedin, notionRef];
+        return HttpResponse.json(granted);
+      }),
+    );
+
+    render(<ExpertDetailPage />);
+
+    await openIntegrationsTab();
+    const section = await screen.findByTestId("expert-integrations-section");
+    await within(section).findByText("Work LinkedIn");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Add integration/ }),
+    );
+    await userEvent.click(await screen.findByText("Notion"));
+    expect(await screen.findByText("Connect AutoGPT to Notion")).toBeDefined();
+    await userEvent.click(screen.getByRole("button", { name: /API Key/ }));
+    await userEvent.type(
+      await screen.findByPlaceholderText("My Notion key"),
+      "Team Notion",
+    );
+    await userEvent.type(screen.getByPlaceholderText("sk-..."), "secret-value");
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(await within(section).findByText("Team Notion")).toBeDefined();
+
+    await userEvent.click(screen.getByRole("tab", { name: /workflows/i }));
+    expect(await screen.findByText("Scheduled")).toBeDefined();
+    expect(screen.queryByText("Needs setup")).toBeNull();
+  });
+
   it("grants the approved device credential to the expert", async () => {
     const granted: string[][] = [];
     server.use(

--- a/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertIntegrationsSection/useExpertIntegrationsSection.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/[expertId]/components/ExpertIntegrationsSection/useExpertIntegrationsSection.ts
@@ -1,5 +1,4 @@
 import {
-  getListExpertCredentialsQueryKey,
   useGrantExpertCredentials,
   useListExpertCredentials,
   useRevokeExpertCredential,
@@ -9,6 +8,7 @@ import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/cre
 import { okData } from "@/app/api/helpers";
 import { filterSystemCredentials } from "@/components/contextual/CredentialsInput/helpers";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateExpertGrantQueries } from "@/services/experts/invalidate-experts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -40,16 +40,12 @@ export function useExpertIntegrationsSection(expertId: string) {
   );
 
   function invalidate() {
-    queryClient.invalidateQueries({
-      queryKey: getListExpertCredentialsQueryKey(expertId),
-    });
+    invalidateExpertGrantQueries(queryClient, expertId);
   }
 
   const { mutate: grant, isPending: isGranting } = useGrantExpertCredentials({
     mutation: {
-      onSuccess: () => {
-        invalidate();
-      },
+      onSuccess: invalidate,
       onError: () =>
         toast({ title: "Could not add integration", variant: "destructive" }),
     },

--- a/autogpt_platform/frontend/src/app/(platform)/team/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/__tests__/main.test.tsx
@@ -35,6 +35,20 @@ import { delay, http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import TeamPage from "../page";
 
+vi.mock("@/lib/oauth-popup", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/oauth-popup")>();
+  return {
+    ...actual,
+    preOpenOAuthPopup: () => null,
+    openOAuthPopup: () => ({
+      promise: Promise.resolve({ code: "code", state: "state" }),
+      cleanup: { abort: () => {} },
+      popupBlocked: false,
+      fallbackBlocked: false,
+    }),
+  };
+});
+
 vi.mock("framer-motion", async (importActual) => {
   const actual = await importActual<typeof import("framer-motion")>();
   return { ...actual, useReducedMotion: () => true };
@@ -1081,6 +1095,115 @@ describe("TeamPage - setup needed card", () => {
         expertId: "expert-maria",
         body: { credential_ids: ["cred-notion"] },
       }),
+    );
+  });
+
+  test("connecting a service clears its row without a reload", async () => {
+    let items = [makeSetupItem()];
+    let granted: string[][] = [];
+    server.use(
+      http.get("/api/proxy/api/experts/setup", () => HttpResponse.json(items)),
+      getGetV1ListProvidersMockHandler([
+        { name: "notion", supported_auth_types: ["api_key"] },
+      ]),
+      http.post("/api/proxy/api/integrations/notion/credentials", () =>
+        HttpResponse.json(
+          {
+            id: "cred-notion",
+            provider: "notion",
+            type: "api_key",
+            title: "Team Notion",
+          },
+          { status: 201 },
+        ),
+      ),
+      http.post(
+        "/api/proxy/api/experts/:expertId/credentials",
+        async ({ request }) => {
+          const body = (await request.json()) as { credential_ids: string[] };
+          granted = [...granted, body.credential_ids];
+          items = [];
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    render(<TeamPage />);
+
+    const card = await screen.findByTestId("setup-needed");
+    fireEvent.click(within(card).getByRole("button", { name: "Connect" }));
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      await within(dialog).findByRole("button", { name: /API Key/ }),
+    );
+    await userEvent.type(
+      await within(dialog).findByPlaceholderText("My Notion key"),
+      "Team Notion",
+    );
+    await userEvent.type(
+      within(dialog).getByPlaceholderText("sk-..."),
+      "secret-value",
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Continue" }),
+    );
+
+    await waitFor(() => expect(granted).toEqual([["cred-notion"]]));
+    await waitFor(() =>
+      expect(screen.queryByTestId("setup-needed")).toBeNull(),
+    );
+  });
+
+  test("signing in with OAuth clears its row without a reload", async () => {
+    let items = [makeSetupItem({ providers: ["google"] })];
+    let granted: string[][] = [];
+    server.use(
+      http.get("/api/proxy/api/experts/setup", () => HttpResponse.json(items)),
+      getGetV1ListProvidersMockHandler([
+        { name: "google", supported_auth_types: ["oauth2"] },
+      ]),
+      http.get("/api/proxy/api/integrations/google/login", () =>
+        HttpResponse.json({
+          login_url: "https://accounts.example/auth",
+          state_token: "state",
+        }),
+      ),
+      http.post("/api/proxy/api/integrations/google/callback", () =>
+        HttpResponse.json({
+          id: "cred-google",
+          provider: "google",
+          type: "oauth2",
+          title: "Work Google",
+        }),
+      ),
+      http.post(
+        "/api/proxy/api/experts/:expertId/credentials",
+        async ({ request }) => {
+          const body = (await request.json()) as { credential_ids: string[] };
+          granted = [...granted, body.credential_ids];
+          items = [];
+          return HttpResponse.json([]);
+        },
+      ),
+    );
+
+    render(<TeamPage />);
+
+    const card = await screen.findByTestId("setup-needed");
+    fireEvent.click(within(card).getByRole("button", { name: "Connect" }));
+
+    const dialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      await within(dialog).findByRole("button", { name: /OAuth/ }),
+    );
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Continue" }),
+    );
+
+    await waitFor(() => expect(granted).toEqual([["cred-google"]]));
+    await waitFor(() =>
+      expect(screen.queryByTestId("setup-needed")).toBeNull(),
     );
   });
 

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SetupNeeded/useSetupNeeded.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SetupNeeded/useSetupNeeded.ts
@@ -1,17 +1,15 @@
 import {
-  getListExpertSetupItemsQueryKey,
-  getListExpertsQueryKey,
   useGrantExpertCredentials,
   useListExpertSetupItems,
 } from "@/app/api/__generated__/endpoints/experts/experts";
 import { useGetV1ListProviders } from "@/app/api/__generated__/endpoints/integrations/integrations";
-import { getGetV1ListExecutionSchedulesForAUserQueryKey } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import type { CredentialsMetaResponse } from "@/app/api/__generated__/models/credentialsMetaResponse";
 import type { ExpertSetupItem } from "@/app/api/__generated__/models/expertSetupItem";
 import { okData } from "@/app/api/helpers";
 import { toConnectableProviders } from "@/components/contextual/IntegrationsPanel/components/ConnectServiceDialog/helpers";
 import { formatProviderName } from "@/components/contextual/IntegrationsPanel/helpers";
 import { useToast } from "@/components/molecules/Toast/use-toast";
+import { invalidateExpertGrantQueries } from "@/services/experts/invalidate-experts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -37,21 +35,10 @@ export function useSetupNeeded({ enabled }: Args) {
     toConnectableProviders(providersQuery.data ?? []).map((p) => p.id),
   );
 
-  // A grant is what lets the backend create the pending schedule, so the
-  // roster (schedule counts) and the schedule list move with the card.
-  function invalidate() {
-    for (const queryKey of [
-      getListExpertSetupItemsQueryKey(),
-      getListExpertsQueryKey(),
-      getGetV1ListExecutionSchedulesForAUserQueryKey(),
-    ]) {
-      queryClient.invalidateQueries({ queryKey });
-    }
-  }
-
   const { mutate: grant, isPending: isGranting } = useGrantExpertCredentials({
     mutation: {
-      onSuccess: invalidate,
+      onSuccess: (_response, { expertId }) =>
+        invalidateExpertGrantQueries(queryClient, expertId),
       onError: () =>
         toast({ title: "Could not add integration", variant: "destructive" }),
     },

--- a/autogpt_platform/frontend/src/services/experts/invalidate-experts.test.ts
+++ b/autogpt_platform/frontend/src/services/experts/invalidate-experts.test.ts
@@ -1,10 +1,17 @@
 import {
+  getGetExpertQueryKey,
+  getListExpertCredentialsQueryKey,
   getListExpertIdentitiesQueryKey,
+  getListExpertSetupItemsQueryKey,
   getListExpertsQueryKey,
 } from "@/app/api/__generated__/endpoints/experts/experts";
+import { getGetV1ListExecutionSchedulesForAUserQueryKey } from "@/app/api/__generated__/endpoints/schedules/schedules";
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
-import { invalidateExpertRosterQueries } from "./invalidate-experts";
+import {
+  invalidateExpertGrantQueries,
+  invalidateExpertRosterQueries,
+} from "./invalidate-experts";
 
 describe("invalidateExpertRosterQueries", () => {
   it("invalidates both the full roster and chat identity projection", async () => {
@@ -19,5 +26,24 @@ describe("invalidateExpertRosterQueries", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: getListExpertIdentitiesQueryKey(),
     });
+  });
+});
+
+describe("invalidateExpertGrantQueries", () => {
+  it("invalidates every list a grant changes, on both team pages", async () => {
+    const queryClient = new QueryClient();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    await invalidateExpertGrantQueries(queryClient, "expert-maria");
+
+    for (const queryKey of [
+      getListExpertCredentialsQueryKey("expert-maria"),
+      getGetExpertQueryKey("expert-maria"),
+      getListExpertSetupItemsQueryKey(),
+      getListExpertsQueryKey(),
+      getGetV1ListExecutionSchedulesForAUserQueryKey(),
+    ]) {
+      expect(invalidate).toHaveBeenCalledWith({ queryKey });
+    }
   });
 });

--- a/autogpt_platform/frontend/src/services/experts/invalidate-experts.ts
+++ b/autogpt_platform/frontend/src/services/experts/invalidate-experts.ts
@@ -1,7 +1,11 @@
 import {
+  getGetExpertQueryKey,
+  getListExpertCredentialsQueryKey,
   getListExpertIdentitiesQueryKey,
+  getListExpertSetupItemsQueryKey,
   getListExpertsQueryKey,
 } from "@/app/api/__generated__/endpoints/experts/experts";
+import { invalidateAllScheduleQueries } from "@/services/schedules/invalidate-schedules";
 import type { QueryClient } from "@tanstack/react-query";
 
 export function invalidateExpertRosterQueries(queryClient: QueryClient) {
@@ -10,5 +14,28 @@ export function invalidateExpertRosterQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries({
       queryKey: getListExpertIdentitiesQueryKey(),
     }),
+  ]);
+}
+
+// Granting or revoking a credential changes more than the expert's own
+// integrations list: the backend creates the schedules the missing grant was
+// blocking, which the expert's workflows, the roster's schedule counts, the
+// schedule lists and the Team page's setup card all read. Every grant site
+// must invalidate all of them, or connecting on one page leaves the other
+// page's list stale until a reload.
+export function invalidateExpertGrantQueries(
+  queryClient: QueryClient,
+  expertId: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: getListExpertCredentialsQueryKey(expertId),
+    }),
+    queryClient.invalidateQueries({ queryKey: getGetExpertQueryKey(expertId) }),
+    queryClient.invalidateQueries({
+      queryKey: getListExpertSetupItemsQueryKey(),
+    }),
+    invalidateExpertRosterQueries(queryClient),
+    invalidateAllScheduleQueries(queryClient),
   ]);
 }


### PR DESCRIPTION
### Why / What / How

**Why:** After connecting a service for an expert, the lists that depend on that grant did not refresh until a manual page reload. Granting from the expert's Integrations tab only invalidated the expert's own integrations list, and granting from the Team page's "Setup needed" card only invalidated the setup items, roster and schedule list. Each site left the other page's data (and, on the expert page, the Workflows tab's "Needs setup" state) stale for the query's `staleTime`.

**What:** A single `invalidateExpertGrantQueries(queryClient, expertId)` helper that invalidates everything a grant changes, used by both grant sites.

**How:** The helper lives next to `invalidateExpertRosterQueries` in `services/experts/invalidate-experts.ts` and covers the expert's credentials list, the expert detail (workflow `schedule_id`s are created by the grant), the setup items, the roster projections and all schedule queries. `useExpertIntegrationsSection` and `useSetupNeeded` call it from the grant mutation's `onSuccess`.

### Changes 🏗️

- `services/experts/invalidate-experts.ts`: add `invalidateExpertGrantQueries`.
- `useExpertIntegrationsSection.ts`: grant/revoke invalidate through the helper instead of only the expert credentials key.
- `useSetupNeeded.ts`: grant invalidates through the helper instead of a local subset.
- Tests:
  - Expert page: connecting a service via API key shows the new integration in the list and flips the Workflows tab from "Needs setup" to "Scheduled" without a reload (fails without the fix).
  - Team page: connecting from the Setup needed card via API key and via OAuth clears the row without a reload.
  - Helper unit test listing the keys it must invalidate.

### Agents and large language models used

- Claude Code with Claude Fable 5.1

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run` on `team/[expertId]/__tests__/integrations.test.tsx`, `team/__tests__/main.test.tsx`, `services/experts/invalidate-experts.test.ts` (55 passed)
  - [x] `tsc --noEmit`, eslint and prettier on the changed files
  - [ ] Manual: on an expert's Integrations tab, add an integration and check the Workflows tab updates; on the Team page, connect from the Setup needed card and open the expert's Integrations tab

#### For configuration changes:

- [ ] `.env.default` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [ ] I have included a list of my configuration changes in the PR description (under **Changes**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
