### PR TITLE
fix(platform): address CI report and seed cache review findings

### DIFF
--- a/.github/scripts/platform-single-container-smoke.sh
+++ b/.github/scripts/platform-single-container-smoke.sh
@@ -197,7 +197,10 @@ assert_clean_stop() {
   started="${EPOCHREALTIME}"
   docker stop --timeout "${STOCK_DOCKER_STOP_TIMEOUT}" "${CONTAINER_NAME}" >/dev/null
   finished_at="$(docker inspect --format '{{.State.FinishedAt}}' "${CONTAINER_NAME}")"
-  finished_epoch="$(date --date="${finished_at}" +%s.%N)"
+  if ! finished_epoch="$(date --date="${finished_at}" +%s.%N)" || [[ -z "${finished_epoch}" ]]; then
+    echo "invalid container finish timestamp ${reason}: ${finished_at}" >&2
+    return 1
+  fi
   awk -v a="${started}" -v b="${finished_epoch}" 'BEGIN { exit !(b >= a) }' || {
     echo "container finish timestamp precedes the stop request ${reason}" >&2
     return 1

--- a/.github/scripts/run_unittest_junit.py
+++ b/.github/scripts/run_unittest_junit.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import re
 import sys
 import time
 import unittest
@@ -149,12 +148,14 @@ def xml_safe(text: str) -> str:
     # unittest colourises tracebacks on Python 3.13+, and ANSI escapes are
     # not valid XML 1.0 characters, so a failing run would emit an
     # unparseable report.
-    return _XML_FORBIDDEN.sub("", text)
-
-
-_XML_FORBIDDEN = re.compile(
-    "[^\x09\x0a\x0d\x20-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]"
-)
+    return "".join(
+        character
+        for character in text
+        if character in "\t\n\r"
+        or 0x20 <= ord(character) <= 0xD7FF
+        or 0xE000 <= ord(character) <= 0xFFFD
+        or 0x10000 <= ord(character) <= 0x10FFFF
+    )
 
 
 def parse_args() -> argparse.Namespace:

--- a/.github/scripts/test_e2e_seed_cache_contract.py
+++ b/.github/scripts/test_e2e_seed_cache_contract.py
@@ -1,0 +1,36 @@
+import fnmatch
+import re
+import unittest
+from pathlib import Path
+
+
+class E2ESeedCacheContractTests(unittest.TestCase):
+    def test_seed_cache_covers_transitive_inputs(self):
+        workflow = (
+            Path(__file__).resolve().parents[1] / "workflows/platform-fullstack-ci.yml"
+        ).read_text(encoding="utf-8")
+        key = next(
+            line for line in workflow.splitlines() if "key: e2e-test-data-" in line
+        )
+        patterns = re.findall(r"'([^']+)'", key)
+        for path in (
+            "autogpt_platform/backend/test/e2e_test_data.py",
+            "autogpt_platform/backend/backend/data/graph.py",
+            "autogpt_platform/backend/backend/blocks/calculator.py",
+            "autogpt_platform/backend/agents/calculator-agent.json",
+            "autogpt_platform/backend/schema.prisma",
+            "autogpt_platform/backend/poetry.lock",
+            "autogpt_platform/autogpt_libs/autogpt_libs/auth/models.py",
+            "autogpt_platform/docker-compose.yml",
+            "autogpt_platform/.env.default",
+            ".github/workflows/platform-fullstack-ci.yml",
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(
+                    any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns),
+                    f"seed cache key does not cover {path}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_validate_cobertura.py
+++ b/.github/scripts/test_validate_cobertura.py
@@ -64,6 +64,50 @@ class ValidateCoberturaTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_report(report)
 
+    def test_rejects_summary_counts_that_disagree_with_source_lines(self):
+        for attribute, value in (("lines-valid", "2"), ("lines-covered", "1")):
+            with self.subTest(attribute=attribute):
+                report = valid_report()
+                report.set(attribute, value)
+                with self.assertRaises(ValueError):
+                    validate_report(report)
+
+    def test_rejects_uncovered_summary_with_a_covered_source_line(self):
+        report = valid_report()
+        report.find(".//class/lines/line").set("hits", "1")
+        with self.assertRaises(ValueError):
+            validate_report(report)
+
+    def test_rejects_rate_that_disagrees_with_source_line_counts(self):
+        report = valid_report()
+        report.set("line-rate", "0.5")
+        with self.assertRaises(ValueError):
+            validate_report(report)
+
+    def test_accepts_rounded_reporter_rate_and_ignores_method_line_duplicates(self):
+        report = valid_report()
+        report.set("lines-valid", "3")
+        report.set("lines-covered", "1")
+        lines = report.find(".//class/lines")
+        ET.SubElement(lines, "line", number="2", hits="1")
+        ET.SubElement(lines, "line", number="3", hits="0")
+        methods = ET.SubElement(report.find(".//class"), "methods")
+        method_lines = ET.SubElement(ET.SubElement(methods, "method"), "lines")
+        ET.SubElement(method_lines, "line", number="2", hits="1")
+        for rate in ("0.3333", "0.33329999999999999", str(1 / 3)):
+            with self.subTest(rate=rate):
+                report.set("line-rate", rate)
+                validate_report(report)
+
+    def test_counts_nested_packages_in_e2e_reports(self):
+        report = valid_report()
+        classes = report.find("packages/package/classes")
+        source = classes.find("class")
+        classes.remove(source)
+        nested = ET.SubElement(classes, "package", name="nested")
+        ET.SubElement(nested, "classes").append(source)
+        validate_report(report)
+
     def test_cli_fails_for_missing_empty_malformed_or_noncoverage_reports(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "coverage.xml"

--- a/.github/scripts/test_validate_cobertura.py
+++ b/.github/scripts/test_validate_cobertura.py
@@ -1,0 +1,85 @@
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from validate_cobertura import main, validate_report
+
+
+def valid_report() -> ET.Element:
+    return ET.fromstring(
+        '<coverage lines-valid="1" lines-covered="0" line-rate="0">'
+        '<packages><package name="src"><classes>'
+        '<class name="example" filename="src/example.ts">'
+        '<lines><line number="1" hits="0"/></lines>'
+        "</class></classes></package></packages></coverage>"
+    )
+
+
+class ValidateCoberturaTests(unittest.TestCase):
+    def test_accepts_real_uncovered_lines_without_imposing_a_threshold(self):
+        validate_report(valid_report())
+
+    def test_rejects_arbitrary_xml_and_empty_coverage(self):
+        for report in ("<report/>", "<coverage/>"):
+            with self.subTest(report=report), self.assertRaises(ValueError):
+                validate_report(ET.fromstring(report))
+
+    def test_rejects_invalid_summary(self):
+        for attribute, value in (
+            ("lines-valid", "0"),
+            ("lines-valid", "-1"),
+            ("lines-covered", "2"),
+            ("lines-covered", "0.5"),
+            ("line-rate", "nan"),
+            ("line-rate", "inf"),
+            ("line-rate", "-0.1"),
+            ("line-rate", "1.1"),
+        ):
+            with self.subTest(attribute=attribute, value=value):
+                report = valid_report()
+                report.set(attribute, value)
+                with self.assertRaises(ValueError):
+                    validate_report(report)
+
+    def test_requires_source_classes_and_lines(self):
+        for path in ("packages", "packages/package/classes/class/lines"):
+            with self.subTest(path=path):
+                report = valid_report()
+                report.find(path).clear()
+                with self.assertRaises(ValueError):
+                    validate_report(report)
+
+    def test_rejects_invalid_line_data(self):
+        for attribute, value in (("number", "0"), ("hits", "-1")):
+            with self.subTest(attribute=attribute):
+                report = valid_report()
+                report.find(".//line").set(attribute, value)
+                with self.assertRaises(ValueError):
+                    validate_report(report)
+
+    def test_rejects_missing_filename(self):
+        report = valid_report()
+        del report.find(".//class").attrib["filename"]
+        with self.assertRaises(ValueError):
+            validate_report(report)
+
+    def test_cli_fails_for_missing_empty_malformed_or_noncoverage_reports(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "coverage.xml"
+            self.assertEqual(main([str(path)]), 1)
+            for text in ("", "<coverage", "<report/>"):
+                with self.subTest(text=text):
+                    path.write_text(text, encoding="utf-8")
+                    self.assertEqual(main([str(path)]), 1)
+                    self.assertEqual(path.read_text(encoding="utf-8"), text)
+
+    def test_cli_accepts_valid_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "coverage.xml"
+            ET.ElementTree(valid_report()).write(path, encoding="utf-8")
+            self.assertEqual(main([str(path)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_validate_playwright_json.py
+++ b/.github/scripts/test_validate_playwright_json.py
@@ -128,6 +128,17 @@ class ValidatePlaywrightJSONTests(unittest.TestCase):
             )
             self.assertEqual(report_path.read_text(encoding="utf-8"), original)
 
+    def test_missing_tests_fails_cleanly_and_preserves_original_report(self):
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "results.json"
+            report = valid_report()
+            del report["suites"][0]["specs"][0]["tests"]
+            original = json.dumps(report)
+            report_path.write_text(original, encoding="utf-8")
+
+            self.assertEqual(main(["--synthesize-invalid", str(report_path)]), 1)
+            self.assertEqual(report_path.read_text(encoding="utf-8"), original)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/validate_cobertura.py
+++ b/.github/scripts/validate_cobertura.py
@@ -1,0 +1,55 @@
+import argparse
+import math
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def nonnegative_integer(element: ET.Element, attribute: str) -> int:
+    value = element.get(attribute, "")
+    if not value.isascii() or not value.isdecimal():
+        raise ValueError(f"{element.tag}.{attribute} must be a non-negative integer")
+    return int(value)
+
+
+def validate_report(root: ET.Element) -> None:
+    if root.tag != "coverage":
+        raise ValueError("report is not Cobertura coverage XML")
+    valid = nonnegative_integer(root, "lines-valid")
+    covered = nonnegative_integer(root, "lines-covered")
+    if valid == 0 or covered > valid:
+        raise ValueError("coverage must contain lines with valid coverage counts")
+    rate = float(root.get("line-rate", "nan"))
+    if not math.isfinite(rate) or not 0 <= rate <= 1:
+        raise ValueError("coverage.line-rate must be between 0 and 1")
+
+    classes = root.findall("packages/package/classes/class")
+    if not classes:
+        raise ValueError("coverage contains no source classes")
+    line_count = 0
+    for source in classes:
+        if not source.get("filename", "").strip():
+            raise ValueError("coverage class is missing a filename")
+        for line in source.findall("lines/line"):
+            if nonnegative_integer(line, "number") == 0:
+                raise ValueError("coverage line numbers must be positive")
+            nonnegative_integer(line, "hits")
+            line_count += 1
+    if line_count == 0:
+        raise ValueError("coverage contains no source lines")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        validate_report(ET.parse(args.report).getroot())
+    except (OSError, ET.ParseError, ValueError) as error:
+        print(f"{args.report}: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/validate_cobertura.py
+++ b/.github/scripts/validate_cobertura.py
@@ -23,20 +23,26 @@ def validate_report(root: ET.Element) -> None:
     if not math.isfinite(rate) or not 0 <= rate <= 1:
         raise ValueError("coverage.line-rate must be between 0 and 1")
 
-    classes = root.findall("packages/package/classes/class")
+    classes = root.findall("packages//class")
     if not classes:
         raise ValueError("coverage contains no source classes")
     line_count = 0
+    covered_count = 0
     for source in classes:
         if not source.get("filename", "").strip():
             raise ValueError("coverage class is missing a filename")
         for line in source.findall("lines/line"):
             if nonnegative_integer(line, "number") == 0:
                 raise ValueError("coverage line numbers must be positive")
-            nonnegative_integer(line, "hits")
+            covered_count += nonnegative_integer(line, "hits") > 0
             line_count += 1
     if line_count == 0:
         raise ValueError("coverage contains no source lines")
+    if valid != line_count or covered != covered_count:
+        raise ValueError("coverage summary counts do not match source lines")
+    # Istanbul truncates percentages to two decimals before converting to a rate.
+    if not math.isclose(rate, covered_count / line_count, rel_tol=0, abs_tol=1e-4):
+        raise ValueError("coverage.line-rate does not match source lines")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.github/scripts/verify_single_container_reports.py
+++ b/.github/scripts/verify_single_container_reports.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -84,7 +85,7 @@ def verify_junit(path: Path) -> None:
 
 def verify_trivy(path: Path, expected_image: str) -> None:
     document = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(document, dict) or "Results" not in document:
+    if not isinstance(document, dict) or "SchemaVersion" not in document:
         raise ValueError(f"{path.name} is not a Trivy JSON report")
     if document.get("SchemaVersion") != 2:
         raise ValueError(f"{path.name} has an unexpected schema version")
@@ -96,9 +97,20 @@ def verify_trivy(path: Path, expected_image: str) -> None:
             f"expected {expected_image!r}"
         )
 
-    results = document["Results"]
-    if not isinstance(results, list) or not results:
+    results = document.get("Results", [])
+    if not isinstance(results, list):
         raise ValueError(f"{path.name} has an invalid Results value")
+    if not results:
+        metadata = document.get("Metadata")
+        image_id = metadata.get("ImageID") if isinstance(metadata, dict) else None
+        if (
+            path.name != "trivy-secrets.json"
+            or not isinstance(image_id, str)
+            or re.fullmatch(r"sha256:[0-9a-f]{64}", image_id) is None
+        ):
+            raise ValueError(
+                f"{path.name} has incomplete scan results or image metadata"
+            )
 
     findings: dict[str, int] = {}
     for result in results:

--- a/.github/workflows/platform-frontend-ci.yml
+++ b/.github/workflows/platform-frontend-ci.yml
@@ -7,6 +7,9 @@ on:
       - ".github/workflows/platform-frontend-ci.yml"
       - ".github/scripts/validate_junit.py"
       - ".github/scripts/test_validate_junit.py"
+      - ".github/scripts/validate_cobertura.py"
+      - ".github/scripts/test_validate_cobertura.py"
+      - ".github/scripts/run_unittest_junit.py"
       - "autogpt_platform/frontend/**"
       - "autogpt_platform/backend/Dockerfile"
       - "autogpt_platform/docker-compose.yml"
@@ -16,6 +19,9 @@ on:
       - ".github/workflows/platform-frontend-ci.yml"
       - ".github/scripts/validate_junit.py"
       - ".github/scripts/test_validate_junit.py"
+      - ".github/scripts/validate_cobertura.py"
+      - ".github/scripts/test_validate_cobertura.py"
+      - ".github/scripts/run_unittest_junit.py"
       - "autogpt_platform/frontend/**"
       - "autogpt_platform/backend/Dockerfile"
       - "autogpt_platform/docker-compose.yml"
@@ -41,6 +47,22 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
+
+      - name: Test coverage report validator
+        run: >-
+          python3 ../../.github/scripts/run_unittest_junit.py
+          --start-directory ../../.github/scripts
+          --pattern test_validate_cobertura.py
+          --suite-name frontend-coverage-validator
+          --output coverage-validator-tests.xml
+
+      - name: Upload coverage validator test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-coverage-validator-tests
+          path: autogpt_platform/frontend/coverage-validator-tests.xml
+          if-no-files-found: error
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -186,13 +208,9 @@ jobs:
 
       - name: Validate coverage report
         if: ${{ always() }}
-        run: |
-          report=coverage/cobertura-coverage.xml
-          if [[ ! -s "$report" ]]; then
-            echo "missing machine-readable report: $report" >&2
-            exit 1
-          fi
-          python3 -c "import xml.etree.ElementTree as ET; ET.parse('$report')"
+        run: >-
+          python3 ../../.github/scripts/validate_cobertura.py
+          coverage/cobertura-coverage.xml
 
       - name: Upload machine-readable test results
         if: ${{ always() }}

--- a/.github/workflows/platform-fullstack-ci.yml
+++ b/.github/workflows/platform-fullstack-ci.yml
@@ -7,6 +7,8 @@ on:
       - ".github/workflows/platform-fullstack-ci.yml"
       - ".github/scripts/validate_playwright_json.py"
       - ".github/scripts/test_validate_playwright_json.py"
+      - ".github/scripts/validate_cobertura.py"
+      - ".github/scripts/test_validate_cobertura.py"
       - ".github/scripts/test_e2e_seed_cache_contract.py"
       - ".github/scripts/docker-pull-with-retry.sh"
       - ".github/workflows/scripts/docker-ci-fix-compose-build-cache.py"
@@ -17,6 +19,8 @@ on:
       - ".github/workflows/platform-fullstack-ci.yml"
       - ".github/scripts/validate_playwright_json.py"
       - ".github/scripts/test_validate_playwright_json.py"
+      - ".github/scripts/validate_cobertura.py"
+      - ".github/scripts/test_validate_cobertura.py"
       - ".github/scripts/test_e2e_seed_cache_contract.py"
       - ".github/scripts/docker-pull-with-retry.sh"
       - ".github/workflows/scripts/docker-ci-fix-compose-build-cache.py"
@@ -79,12 +83,13 @@ jobs:
         working-directory: autogpt_platform/backend
         run: poetry install
 
-      - name: Test Playwright report validator
+      - name: Test full-stack report validators
         working-directory: autogpt_platform/backend
         run: |
           mkdir -p "$RUNNER_TEMP/fullstack-validator-results"
           poetry run pytest \
             ../../.github/scripts/test_validate_playwright_json.py \
+            ../../.github/scripts/test_validate_cobertura.py \
             ../../.github/scripts/test_e2e_seed_cache_contract.py \
             --junitxml="$RUNNER_TEMP/fullstack-validator-results/playwright-validator-tests.xml"
 
@@ -386,13 +391,9 @@ jobs:
 
       - name: Validate coverage report
         if: ${{ always() }}
-        run: |
-          report=coverage/e2e/cobertura-coverage.xml
-          if [[ ! -s "$report" ]]; then
-            echo "missing machine-readable report: $report" >&2
-            exit 1
-          fi
-          python -c "import xml.etree.ElementTree as ET; ET.parse('$report')"
+        run: >-
+          python ../../.github/scripts/validate_cobertura.py
+          coverage/e2e/cobertura-coverage.xml
 
       - name: Upload E2E coverage to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/platform-fullstack-ci.yml
+++ b/.github/workflows/platform-fullstack-ci.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/platform-fullstack-ci.yml"
       - ".github/scripts/validate_playwright_json.py"
       - ".github/scripts/test_validate_playwright_json.py"
+      - ".github/scripts/test_e2e_seed_cache_contract.py"
       - ".github/scripts/docker-pull-with-retry.sh"
       - ".github/workflows/scripts/docker-ci-fix-compose-build-cache.py"
       - ".github/workflows/scripts/get_package_version_from_lockfile.py"
@@ -16,6 +17,7 @@ on:
       - ".github/workflows/platform-fullstack-ci.yml"
       - ".github/scripts/validate_playwright_json.py"
       - ".github/scripts/test_validate_playwright_json.py"
+      - ".github/scripts/test_e2e_seed_cache_contract.py"
       - ".github/scripts/docker-pull-with-retry.sh"
       - ".github/workflows/scripts/docker-ci-fix-compose-build-cache.py"
       - ".github/workflows/scripts/get_package_version_from_lockfile.py"
@@ -83,6 +85,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/fullstack-validator-results"
           poetry run pytest \
             ../../.github/scripts/test_validate_playwright_json.py \
+            ../../.github/scripts/test_e2e_seed_cache_contract.py \
             --junitxml="$RUNNER_TEMP/fullstack-validator-results/playwright-validator-tests.xml"
 
       - name: Set up Backend - Generate Prisma client
@@ -257,9 +260,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/e2e_test_data.sql
-          # Hash the inputs that determine the seeded data, not the commit:
-          # a sha-keyed entry can never be restored, only written.
-          key: e2e-test-data-v2-${{ hashFiles('autogpt_platform/backend/test/e2e_test_data.py', 'autogpt_platform/backend/backend/data/user.py', 'autogpt_platform/backend/migrations/**', '.github/workflows/platform-fullstack-ci.yml') }}
+          # Include transitive seed imports, agent fixtures, dependencies and DB config.
+          key: e2e-test-data-v3-${{ hashFiles('autogpt_platform/backend/**', 'autogpt_platform/autogpt_libs/**', 'autogpt_platform/docker-compose*.yml', 'autogpt_platform/.env.default', '.github/workflows/platform-fullstack-ci.yml') }}
 
       - name: Set up Platform - Start database
         id: database

--- a/autogpt_platform/single-container/tests/test_ci_junit_reporters.py
+++ b/autogpt_platform/single-container/tests/test_ci_junit_reporters.py
@@ -1,3 +1,4 @@
+import runpy
 import subprocess
 import sys
 import tempfile
@@ -9,6 +10,18 @@ from pathlib import Path
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 COMMAND_REPORTER = REPOSITORY_ROOT / ".github/scripts/run_command_junit.py"
 UNITTEST_REPORTER = REPOSITORY_ROOT / ".github/scripts/run_unittest_junit.py"
+
+
+class XMLSafeTests(unittest.TestCase):
+    def test_xml_character_range_boundaries(self):
+        xml_safe = runpy.run_path(str(UNITTEST_REPORTER))["xml_safe"]
+        allowed = "\t\n\r\x20\ud7ff\ue000\ufffd\U00010000\U0010ffff"
+        forbidden = "\x00\x08\x0b\x0c\x0e\x1f\ud800\udfff\ufffe\uffff"
+        self.assertEqual(xml_safe(allowed + forbidden), allowed)
+        root = ET.Element("failure")
+        root.text = xml_safe(allowed + forbidden)
+        parsed = ET.fromstring(ET.tostring(root))
+        self.assertEqual(parsed.text, allowed.replace("\r", "\n"))
 
 
 class CommandReporterTests(unittest.TestCase):

--- a/autogpt_platform/single-container/tests/test_ci_report_verifier.py
+++ b/autogpt_platform/single-container/tests/test_ci_report_verifier.py
@@ -63,6 +63,35 @@ class ReportVerifierTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
+    def test_clean_secret_scan_accepts_empty_or_omitted_results(self):
+        path = self.report_dir / "trivy-secrets.json"
+        report = json.loads(path.read_text(encoding="utf-8"))
+        report["Metadata"] = {"ImageID": "sha256:" + "a" * 64}
+        for results_present in (True, False):
+            with self.subTest(results_present=results_present):
+                if results_present:
+                    report["Results"] = []
+                else:
+                    del report["Results"]
+                path.write_text(json.dumps(report), encoding="utf-8")
+                result = self.run_verifier()
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_empty_secret_results_without_image_metadata_are_rejected(self):
+        path = self.report_dir / "trivy-secrets.json"
+        report = json.loads(path.read_text(encoding="utf-8"))
+        report["Results"] = []
+        path.write_text(json.dumps(report), encoding="utf-8")
+        self.assertNotEqual(self.run_verifier().returncode, 0)
+
+    def test_empty_vulnerability_results_are_rejected(self):
+        path = self.report_dir / "trivy-critical.json"
+        report = json.loads(path.read_text(encoding="utf-8"))
+        report["Metadata"] = {"ImageID": "sha256:" + "a" * 64}
+        report["Results"] = []
+        path.write_text(json.dumps(report), encoding="utf-8")
+        self.assertNotEqual(self.run_verifier().returncode, 0)
+
     def test_junit_failure_is_rejected_even_when_summary_claims_success(self):
         (self.report_dir / "smoke.xml").write_text(
             '<testsuite tests="1" failures="0" errors="0" skipped="0">'

--- a/autogpt_platform/single-container/tests/test_ci_smoke_stop.py
+++ b/autogpt_platform/single-container/tests/test_ci_smoke_stop.py
@@ -1,7 +1,10 @@
 import re
+import shutil
 import subprocess
+import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SMOKE = (
@@ -10,7 +13,34 @@ SMOKE = (
 )
 
 
+def bash_executable() -> str:
+    if sys.platform != "win32":
+        return "/bin/bash"
+    executable = shutil.which("bash")
+    if executable is None:
+        raise RuntimeError("Git Bash must be installed and on PATH for this test")
+    return executable
+
+
 class SmokeStopTests(unittest.TestCase):
+    def test_uses_fixed_bash_path_on_posix(self):
+        with patch("sys.platform", "linux"), patch("shutil.which") as which:
+            self.assertEqual(bash_executable(), "/bin/bash")
+            which.assert_not_called()
+
+    def test_resolves_bash_executable_on_windows(self):
+        selected = "C:/Program Files/Git/bin/bash.exe"
+        with patch("sys.platform", "win32"), patch(
+            "shutil.which", return_value=selected
+        ) as which:
+            self.assertEqual(bash_executable(), selected)
+            which.assert_called_once_with("bash")
+
+    def test_missing_windows_bash_fails_instead_of_skipping(self):
+        with patch("sys.platform", "win32"), patch("shutil.which", return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "Git Bash"):
+                bash_executable()
+
     def test_invalid_or_empty_finish_time_fails_with_diagnostic(self):
         function = re.search(
             r"^assert_clean_stop\(\) \{.*?^\}",
@@ -30,7 +60,7 @@ class SmokeStopTests(unittest.TestCase):
                     "assert_clean_stop test-stop\n"
                 )
                 result = subprocess.run(
-                    ["bash", "--noprofile", "--norc", "-s"],
+                    [bash_executable(), "--noprofile", "--norc", "-s"],
                     input=script.encode("utf-8"),
                     capture_output=True,
                     check=False,

--- a/autogpt_platform/single-container/tests/test_ci_smoke_stop.py
+++ b/autogpt_platform/single-container/tests/test_ci_smoke_stop.py
@@ -1,0 +1,45 @@
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+SMOKE = (
+    Path(__file__).resolve().parents[3]
+    / ".github/scripts/platform-single-container-smoke.sh"
+)
+
+
+class SmokeStopTests(unittest.TestCase):
+    def test_invalid_or_empty_finish_time_fails_with_diagnostic(self):
+        function = re.search(
+            r"^assert_clean_stop\(\) \{.*?^\}",
+            SMOKE.read_text(encoding="utf-8"),
+            re.MULTILINE | re.DOTALL,
+        ).group()
+        for date_status in (0, 1):
+            with self.subTest(date_status=date_status):
+                script = (
+                    "set -Eeuo pipefail\n"
+                    "STOCK_DOCKER_STOP_TIMEOUT=10\n"
+                    "CONTAINER_NAME=test-container\n"
+                    "docker() { printf '%s' invalid-timestamp; }\n"
+                    f"date() {{ return {date_status}; }}\n"
+                    "awk() { echo UNEXPECTED_AWK >&2; return 1; }\n"
+                    f"{function}\n"
+                    "assert_clean_stop test-stop\n"
+                )
+                result = subprocess.run(
+                    ["bash", "--noprofile", "--norc", "-s"],
+                    input=script.encode("utf-8"),
+                    capture_output=True,
+                    check=False,
+                )
+                stderr = result.stderr.decode("utf-8")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("invalid container finish timestamp", stderr)
+                self.assertNotIn("UNEXPECTED_AWK", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Daybreak-reviewed follow-up — 2026-09-10

Current head: `ca578975fffb99d9f41d06467dec41abf78ec109`. Independent Daybreak review found no remaining blocker in the final follow-up diff. This is local independent review, not a substitute for required GitHub approvals.

- Reconcile Cobertura root totals with actual class source lines, traverse nested E2E packages, exclude duplicate method-line entries, and accommodate reporter rate truncation (absolute tolerance 0.0001).
- Apply the same validator to E2E coverage, including helper/test path filters and the existing full-stack validator test/JUnit step.
- Use /bin/bash on POSIX CI and resolve Bash on Windows, failing if unavailable. Preserve byte stdin and Git Bash support.
- Validation: 88 CI-helper tests + 38 container CI-report tests pass, zero failures/errors/skips. Five actual prior-head artifacts (four frontend shards and E2E) pass. Ruff, explicit S607, Black, workflow YAML and repository pre-commit all pass.
- The new commit is unsigned under the existing locked-key limitation; no signing settings changed. Prior-head green Actions runs do not validate this new SHA. New hosted CI/review is pending.
- Overlap remains advisory on PRs as Nick explicitly requested. No separate CI-status, build/test/security or publication gate was weakened.

### Why / What / How

Follow-up to the CI-speed stack #14285, based on #14352. Addresses current review findings on #14280, #14281 and #14282 without rewriting the previously reviewed stack branches. This is CI validation and cache correctness work, not another speed claim.

### Changes 🏗️

- Validate frontend Cobertura semantics (coverage root, summary counts/rate, source classes and executable lines), not merely XML syntax. Add helper tests with a JUnit artifact in Frontend CI. No coverage percentage threshold is introduced.
- Broaden the E2E SQL cache key to the complete backend and shared-library trees plus database configuration and the workflow. Bump the cache namespace to v3 and test the dependency boundary. Backend/fixture changes now invalidate the seed dump.
- Accept empty or omitted Results only for the secret-only Trivy report with valid image metadata. The Debian vulnerability report still requires results; explicit nulls, malformed records, wrong image names, findings and failed scan actions still fail. Trivy v0.70.0 marks Results with omitempty: https://github.com/aquasecurity/trivy/blob/v0.70.0/pkg/types/report.go#L32 .
- Replace the XML sanitization regex flagged by CodeQL #347 with explicit XML 1.0 character ranges, covered by boundary/round-trip tests. No alert was manually dismissed.
- Make invalid/empty Docker FinishedAt conversion fail with a specific smoke-test diagnostic. Preserve the stock stop timeout and elapsed-time checks; no retry/sleep added.
- Prove the Playwright validator already catches missing tests, returns failure, and preserves the original semantic-failure report.

No product services, test retries, matrix entries, publication permissions, or overlap advisory/blocking policy changed. Nick confirmed on 2026-09-10 that PR overlap detection must remain advisory. Its existing PR-only continue-on-error is retained; build/test/security failures and the separate Check PR Status aggregator are unchanged. This follow-up is required before merging the affected lower layers as a complete stack; do not treat an unresolved lower-layer defect as fixed if this follow-up is omitted.

### Agents and large language models used

Codex main agent: model/version unknown. Independent reviewer: gpt-daybreak-blue-latest (Codex).

### Checklist 📋

#### For code changes:

- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] 83 CI-helper tests and 35 container CI-report tests pass, zero skips; JUnit evidence retained locally.
  - [x] Cache dependency and clean-secret-report regression fixtures reproduced failures before their fixes.
  - [x] New coverage validator accepts four existing frontend shard artifacts. These are historical compatibility samples, not current-head CI evidence.
  - [x] Targeted Ruff/Black checks, UTF-8 workflow YAML parsing, and Bash syntax validation.
  - [x] Repository pre-commit hooks pass with native Git Bash on PATH. Initial WSL-shell path failure was corrected; no hook was bypassed.
  - [ ] Hosted CI and current-head reviews for the latest follow-up (pending).

#### For configuration changes:

- [x] .env.default is already compatible
- [x] docker-compose.yml is already compatible
- [x] Workflow/cache changes are listed above

Prior benchmark/Fable approvals remain historical evidence for older SHAs, not approval or timing evidence for this follow-up.

Commit 0fce44821b912071fad5a77b6325914d666998f0 is unsigned because the local signing key was locked; signing configuration was not changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions scripts, validators, and cache keys; no application auth, data paths, or deployment logic are modified.
> 
> **Overview**
> This follow-up tightens **CI report validation and E2E seed cache correctness** without changing product runtime behavior.
> 
> **Frontend coverage:** Integration shards now run a dedicated **Cobertura validator** (`validate_cobertura.py`) that checks summary counts, line-rate bounds, and source classes/lines—not just XML parseability. The lint job runs validator unit tests and uploads JUnit for them.
> 
> **E2E cache:** The full-stack workflow bumps the seed dump cache to **v3** and widens `hashFiles` to backend, `autogpt_libs`, compose, and `.env.default`. A **contract test** asserts the cache key globs still cover known transitive seed inputs.
> 
> **Single-container CI:** Trivy verification accepts **empty or omitted `Results` only** on `trivy-secrets.json` when `Metadata.ImageID` is a valid `sha256:` digest (Trivy v0.70 `omitempty`); vulnerability reports still require non-empty results. The smoke script’s `assert_clean_stop` **fails fast** on invalid/empty `FinishedAt` parsing with a clear message. JUnit XML sanitization drops the CodeQL-flagged regex in favor of **explicit XML 1.0 character ranges**, with boundary tests.
> 
> **Tests:** Added/extended coverage for Playwright validator behavior on missing `tests`, Cobertura CLI edge cases, Trivy empty-results rules, and smoke stop timestamp handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fce44821b912071fad5a77b6325914d666998f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

