### PR TITLE
feat(frontend): show what an expert has learned in its Soul drawer

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/settings/memory/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/memory/__tests__/main.test.tsx
@@ -108,6 +108,7 @@ function mockHappyPath() {
 
 beforeEach(() => {
   resetCopilotChatRegistry();
+  window.history.replaceState({}, "", "/settings/memory");
 });
 
 describe("Settings memory page", () => {
@@ -252,6 +253,67 @@ describe("Settings memory page", () => {
     ).toBeDefined();
     expect(screen.getByRole("button", { name: "Erase memory" })).toBeDefined();
     expect(screen.getByText(/Erase Maria's memory/)).toBeDefined();
+  });
+
+  it("opens on an expert's scope when linked with ?expert=", async () => {
+    const maria = {
+      ...getListExpertsResponseMock200()[0],
+      id: "expert-maria",
+      name: "Maria",
+      role: "Growth Marketer",
+      avatar_url: null,
+      is_archived: false,
+    };
+    const expertFactRequests: string[] = [];
+    server.use(
+      getListExpertsMockHandler200([maria]),
+      getListMyMemoryFactsMockHandler200(FACTS),
+      getGetMyExpertMemoryOverviewMockHandler200({
+        expert_id: "expert-maria",
+        facts: 12,
+        entities: 8,
+        episodes: 3,
+      }),
+      getListMyExpertMemoryFactsMockHandler200((info) => {
+        expertFactRequests.push(String(info.params.expertId));
+        return {
+          expert_id: "expert-maria",
+          items: [
+            {
+              uuid: "edge-m1",
+              fact: "Q4 campaign brief is due Friday",
+              name: "due",
+              source: "Campaign",
+              target: "Friday",
+              created_at: "2026-08-17T00:00:00Z",
+            },
+          ],
+        };
+      }),
+    );
+    window.history.replaceState({}, "", "/settings/memory?expert=expert-maria");
+
+    render(<SettingsMemoryPage />);
+
+    expect(
+      await screen.findByText("Q4 campaign brief is due Friday"),
+    ).toBeDefined();
+    expect(expertFactRequests).toEqual(["expert-maria"]);
+    expect(screen.getByText(/Erase Maria's memory/)).toBeDefined();
+  });
+
+  it("falls back to AutoPilot when ?expert= names an expert the caller no longer has", async () => {
+    mockHappyPath();
+    window.history.replaceState({}, "", "/settings/memory?expert=expert-gone");
+
+    render(<SettingsMemoryPage />);
+
+    expect(
+      await screen.findByText("Runs a DTC candle brand called Emberline"),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "View my summary" }),
+    ).toBeDefined();
   });
 
   it("opens the summary chat in-pane and auto-sends the seeded prompt", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/settings/memory/__tests__/main.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/memory/__tests__/main.test.tsx
@@ -302,19 +302,29 @@ describe("Settings memory page", () => {
     expect(screen.getByText(/Erase Maria's memory/)).toBeDefined();
   });
 
-  it("falls back to AutoPilot when ?expert= names an expert the caller no longer has", async () => {
-    mockHappyPath();
-    window.history.replaceState({}, "", "/settings/memory?expert=expert-gone");
+  it.each([
+    ["an expert the caller no longer has", "expert-gone"],
+    ["an empty value", ""],
+  ])(
+    "falls back to AutoPilot when ?expert= is %s",
+    async (_case, expertParam) => {
+      mockHappyPath();
+      window.history.replaceState(
+        {},
+        "",
+        `/settings/memory?expert=${expertParam}`,
+      );
 
-    render(<SettingsMemoryPage />);
+      render(<SettingsMemoryPage />);
 
-    expect(
-      await screen.findByText("Runs a DTC candle brand called Emberline"),
-    ).toBeDefined();
-    expect(
-      screen.getByRole("button", { name: "View my summary" }),
-    ).toBeDefined();
-  });
+      expect(
+        await screen.findByText("Runs a DTC candle brand called Emberline"),
+      ).toBeDefined();
+      expect(
+        screen.getByRole("button", { name: "View my summary" }),
+      ).toBeDefined();
+    },
+  );
 
   it("opens the summary chat in-pane and auto-sends the seeded prompt", async () => {
     mockHappyPath();

--- a/autogpt_platform/frontend/src/app/(platform)/settings/memory/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/memory/helpers.ts
@@ -39,5 +39,5 @@ export function formatWhen(createdAt: string | null | undefined) {
  *  owns is left to the page's active-expert fallback rather than checked here. */
 export function readExpertScopeFromUrl() {
   if (typeof window === "undefined") return null;
-  return new URLSearchParams(window.location.search).get("expert");
+  return new URLSearchParams(window.location.search).get("expert") || null;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/settings/memory/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/memory/helpers.ts
@@ -34,3 +34,10 @@ export function formatWhen(createdAt: string | null | undefined) {
   if (Number.isNaN(parsed.getTime())) return "";
   return formatDistanceToNow(parsed, { addSuffix: true });
 }
+
+/** The Soul drawer links here with ?expert=<id>. An id the caller no longer
+ *  owns is left to the page's active-expert fallback rather than checked here. */
+export function readExpertScopeFromUrl() {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("expert");
+}

--- a/autogpt_platform/frontend/src/app/(platform)/settings/memory/useMemoryPage.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/settings/memory/useMemoryPage.ts
@@ -16,10 +16,19 @@ import { useListExperts } from "@/app/api/__generated__/endpoints/experts/expert
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { getActiveExperts, getScopeName, RECENT_FACTS_LIMIT } from "./helpers";
+import {
+  getActiveExperts,
+  getScopeName,
+  readExpertScopeFromUrl,
+  RECENT_FACTS_LIMIT,
+} from "./helpers";
 
 export function useMemoryPage() {
-  const [scopeExpertID, setScopeExpertID] = useState<string | null>(null);
+  // The Soul drawer's learned-notes panel links here with ?expert=<id>, so
+  // the link opens on that expert. Read once — the dropdown owns it after.
+  const [scopeExpertID, setScopeExpertID] = useState<string | null>(
+    readExpertScopeFromUrl,
+  );
   const queryClient = useQueryClient();
 
   // Deliberately not gated on HIRE_EXPERTS: expert memory scopes must stay

--- a/autogpt_platform/frontend/src/app/(platform)/team/__tests__/soul-learned-notes.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/__tests__/soul-learned-notes.test.tsx
@@ -2,6 +2,7 @@ import {
   getListExpertCredentialsMockHandler,
   getListExpertPodsMockHandler,
   getListExpertsMockHandler,
+  getUpdateExpertSoulMockHandler,
 } from "@/app/api/__generated__/endpoints/experts/experts.msw";
 import { getGetV2ListLibraryAgentsMockHandler200 } from "@/app/api/__generated__/endpoints/library/library.msw";
 import {
@@ -163,8 +164,9 @@ describe("Soul drawer — what I've learned", () => {
     ).toBeNull();
   });
 
-  test("forgetting a memory calls the scoped delete and refetches", async () => {
+  test("forgetting a memory calls the scoped delete, refetches, and leaves the Soul unsaved", async () => {
     const forgotten: string[] = [];
+    const soulSaves: unknown[] = [];
     let listCalls = 0;
     server.use(
       getListMyExpertMemoryFactsMockHandler(async () => {
@@ -177,6 +179,10 @@ describe("Soul drawer — what I've learned", () => {
       getForgetMyExpertMemoryFactMockHandler200(async (info) => {
         forgotten.push(String(info.params.factUuid));
         return { uuid: String(info.params.factUuid), forgotten: true };
+      }),
+      getUpdateExpertSoulMockHandler(async ({ request }) => {
+        soulSaves.push(await request.json());
+        return maria;
       }),
     );
 
@@ -195,6 +201,11 @@ describe("Soul drawer — what I've learned", () => {
         ),
       ).toBeDefined(),
     );
+    // Forget sits inside the Soul form; it must not submit it.
+    expect(soulSaves).toEqual([]);
+    expect(
+      screen.getByRole("complementary", { name: "Maria's Soul" }),
+    ).toBeDefined();
   });
 
   test("says so when the memories cannot be loaded, instead of claiming there are none", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/team/__tests__/soul-learned-notes.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/__tests__/soul-learned-notes.test.tsx
@@ -1,0 +1,235 @@
+import {
+  getListExpertCredentialsMockHandler,
+  getListExpertPodsMockHandler,
+  getListExpertsMockHandler,
+} from "@/app/api/__generated__/endpoints/experts/experts.msw";
+import { getGetV2ListLibraryAgentsMockHandler200 } from "@/app/api/__generated__/endpoints/library/library.msw";
+import {
+  getForgetMyExpertMemoryFactMockHandler200,
+  getListMyExpertMemoryFactsMockHandler,
+  getListMyExpertMemoryFactsMockHandler200,
+} from "@/app/api/__generated__/endpoints/memory/memory.msw";
+import { getGetV1ListExecutionSchedulesForAUserMockHandler } from "@/app/api/__generated__/endpoints/schedules/schedules.msw";
+import { Expert } from "@/app/api/__generated__/models/expert";
+import { MemoryFact } from "@/app/api/__generated__/models/memoryFact";
+import { server } from "@/mocks/mock-server";
+import { render, screen, waitFor } from "@/tests/integrations/test-utils";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import TeamPage from "../page";
+
+const { memoryFlagMock } = vi.hoisted(() => ({
+  memoryFlagMock: vi.fn(() => true),
+}));
+
+vi.mock("@/services/feature-flags/use-get-flag", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/feature-flags/use-get-flag")
+    >();
+  return {
+    ...actual,
+    useGetFlag: (flag: string) =>
+      flag === "graphiti-memory"
+        ? memoryFlagMock()
+        : actual.useGetFlag(flag as never),
+    useFlagStatus: (flag: string) =>
+      flag === "hire-experts"
+        ? { enabled: true, ready: true }
+        : actual.useFlagStatus(flag as never),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => "/team",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  notFound: vi.fn(),
+}));
+
+const maria: Expert = {
+  id: "expert-maria",
+  name: "Maria",
+  avatar_url: null,
+  role: "Marketing Strategist",
+  bio: null,
+  skills: [],
+  tagline: "Grows your brand while you sleep",
+  identity: "You are Maria.",
+  voice_preferences: "",
+  boundaries: "",
+  protected_soul_rules: [],
+  is_template: false,
+  source_template_id: "template-maria",
+  is_archived: false,
+  workflows: [],
+};
+
+function makeFact(over: Partial<MemoryFact> = {}): MemoryFact {
+  return {
+    uuid: "edge-1",
+    fact: "Q4 campaign brief is due Friday",
+    name: "due",
+    source: "Campaign",
+    target: "Friday",
+    created_at: "2026-08-17T00:00:00Z",
+    ...over,
+  } as MemoryFact;
+}
+
+async function openSoulDrawer() {
+  const user = userEvent.setup();
+  render(<TeamPage />);
+  await user.click(await screen.findByRole("button", { name: "Edit Soul" }));
+  return user;
+}
+
+beforeEach(() => {
+  memoryFlagMock.mockReturnValue(true);
+  server.use(
+    getGetV1ListExecutionSchedulesForAUserMockHandler([]),
+    getListExpertPodsMockHandler([]),
+    getListExpertCredentialsMockHandler([]),
+    getGetV2ListLibraryAgentsMockHandler200(),
+    getListExpertsMockHandler([maria]),
+  );
+});
+
+describe("Soul drawer — what I've learned", () => {
+  test("lists the expert's own memories, newest first, with a link to the rest", async () => {
+    const factRequests: string[] = [];
+    server.use(
+      getListMyExpertMemoryFactsMockHandler(async (info) => {
+        factRequests.push(String(info.params.expertId));
+        return {
+          expert_id: "expert-maria",
+          items: [
+            makeFact(),
+            makeFact({
+              uuid: "edge-2",
+              fact: "Emberline ships to the EU only",
+              created_at: "2026-08-16T00:00:00Z",
+            }),
+          ],
+        };
+      }),
+    );
+
+    await openSoulDrawer();
+
+    expect(
+      await screen.findByText("Q4 campaign brief is due Friday"),
+    ).toBeDefined();
+    expect(screen.getByText("Emberline ships to the EU only")).toBeDefined();
+    expect(screen.queryByText(/Nothing recorded yet/)).toBeNull();
+
+    // Scoped to this expert, and only this expert.
+    expect(factRequests).toEqual(["expert-maria"]);
+
+    const seeAll = screen.getByRole("link", {
+      name: "See all in memory settings",
+    });
+    expect(seeAll.getAttribute("href")).toBe(
+      "/settings/memory?expert=expert-maria",
+    );
+  });
+
+  test("keeps the empty state for an expert that has learned nothing", async () => {
+    server.use(
+      getListMyExpertMemoryFactsMockHandler200({
+        expert_id: "expert-maria",
+        items: [],
+      }),
+    );
+
+    await openSoulDrawer();
+
+    expect(
+      await screen.findByText(
+        "Nothing recorded yet. What this expert learns will appear here.",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("link", { name: "See all in memory settings" }),
+    ).toBeNull();
+  });
+
+  test("forgetting a memory calls the scoped delete and refetches", async () => {
+    const forgotten: string[] = [];
+    let listCalls = 0;
+    server.use(
+      getListMyExpertMemoryFactsMockHandler(async () => {
+        listCalls += 1;
+        return {
+          expert_id: "expert-maria",
+          items: forgotten.length ? [] : [makeFact()],
+        };
+      }),
+      getForgetMyExpertMemoryFactMockHandler200(async (info) => {
+        forgotten.push(String(info.params.factUuid));
+        return { uuid: String(info.params.factUuid), forgotten: true };
+      }),
+    );
+
+    const user = await openSoulDrawer();
+
+    await screen.findByText("Q4 campaign brief is due Friday");
+    const callsBeforeForget = listCalls;
+    await user.click(screen.getByRole("button", { name: "Forget" }));
+
+    await waitFor(() => expect(forgotten).toEqual(["edge-1"]));
+    await waitFor(() => expect(listCalls).toBeGreaterThan(callsBeforeForget));
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Nothing recorded yet. What this expert learns will appear here.",
+        ),
+      ).toBeDefined(),
+    );
+  });
+
+  test("says so when the memories cannot be loaded, instead of claiming there are none", async () => {
+    server.use(
+      http.get(
+        "/api/proxy/api/memory/experts/:expertId/facts",
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    await openSoulDrawer();
+
+    expect(
+      await screen.findByText("Couldn't load what this expert has learned."),
+    ).toBeDefined();
+    expect(screen.queryByText(/Nothing recorded yet/)).toBeNull();
+  });
+
+  test("asks the memory API for nothing while the memory flag is off", async () => {
+    memoryFlagMock.mockReturnValue(false);
+    let listCalls = 0;
+    server.use(
+      getListMyExpertMemoryFactsMockHandler(async () => {
+        listCalls += 1;
+        return { expert_id: "expert-maria", items: [makeFact()] };
+      }),
+    );
+
+    await openSoulDrawer();
+
+    expect(
+      await screen.findByText(
+        "Nothing recorded yet. What this expert learns will appear here.",
+      ),
+    ).toBeDefined();
+    expect(listCalls).toBe(0);
+  });
+});

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulDrawer.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulDrawer.tsx
@@ -7,9 +7,11 @@ import { Icon } from "@/components/atoms/Icon/Icon";
 import { Input } from "@/components/atoms/Input/Input";
 import { Text } from "@/components/atoms/Text/Text";
 import { LockIcon } from "@hugeicons/core-free-icons";
-import { ReactNode, useState } from "react";
+import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { ExpertSidePanel } from "../ExpertSidePanel/ExpertSidePanel";
+import { LearnedNotes } from "./components/LearnedNotes/LearnedNotes";
+import { SoulSectionTitle } from "./SoulSectionTitle";
 import { useBottomScrollShadow } from "./useBottomScrollShadow";
 import { useSoulDrawer } from "./useSoulDrawer";
 
@@ -66,7 +68,7 @@ function SoulPanelBody({ expert, onClose }: BodyProps) {
             A living document that shapes every reply.
           </Text>
           <SoulFields soul={soul} updateField={updateField} />
-          <LearnedNotes />
+          <LearnedNotes expertId={expert.id} />
           <ProtectedRules rules={expert.protected_soul_rules} />
         </div>
         <div
@@ -155,17 +157,6 @@ function SoulFields({ soul, updateField }: SoulFieldsProps) {
   );
 }
 
-function LearnedNotes() {
-  return (
-    <section className="mb-8">
-      <SoulSectionTitle>What I&apos;ve learned</SoulSectionTitle>
-      <Text variant="small" tone="muted">
-        Nothing recorded yet. What this expert learns will appear here.
-      </Text>
-    </section>
-  );
-}
-
 function ProtectedRules({ rules }: { rules: string[] }) {
   return (
     <section className="border-t border-zinc-200 pt-6">
@@ -191,13 +182,5 @@ function ProtectedRules({ rules }: { rules: string[] }) {
         These rules are part of every expert&apos;s soul and cannot be edited.
       </Text>
     </section>
-  );
-}
-
-function SoulSectionTitle({ children }: { children: ReactNode }) {
-  return (
-    <Text variant="body-medium" as="h3" tone="primary">
-      {children}
-    </Text>
   );
 }

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulSectionTitle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulSectionTitle.tsx
@@ -1,7 +1,11 @@
 import { Text } from "@/components/atoms/Text/Text";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
-export function SoulSectionTitle({ children }: { children: ReactNode }) {
+interface Props {
+  children: ReactNode;
+}
+
+export function SoulSectionTitle({ children }: Props) {
   return (
     <Text variant="body-medium" as="h3" tone="primary">
       {children}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulSectionTitle.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/SoulSectionTitle.tsx
@@ -1,0 +1,10 @@
+import { Text } from "@/components/atoms/Text/Text";
+import { ReactNode } from "react";
+
+export function SoulSectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <Text variant="body-medium" as="h3" tone="primary">
+      {children}
+    </Text>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/LearnedNotes.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/LearnedNotes.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { formatWhen } from "@/app/(platform)/settings/memory/helpers";
+import type { MemoryFact } from "@/app/api/__generated__/models/memoryFact";
+import { Button } from "@/components/atoms/Button/Button";
+import { Link } from "@/components/atoms/Link/Link";
+import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
+import { Text } from "@/components/atoms/Text/Text";
+import { SoulSectionTitle } from "../../SoulSectionTitle";
+import { useLearnedNotes } from "./useLearnedNotes";
+
+interface Props {
+  expertId: string;
+}
+
+export function LearnedNotes({ expertId }: Props) {
+  const { facts, isLoading, isError, forget, forgettingUuid } =
+    useLearnedNotes(expertId);
+
+  return (
+    <section className="mb-8">
+      <SoulSectionTitle>What I&apos;ve learned</SoulSectionTitle>
+      {isLoading ? (
+        <NotesSkeleton />
+      ) : isError ? (
+        <Text variant="small" tone="muted">
+          Couldn&apos;t load what this expert has learned.
+        </Text>
+      ) : facts.length === 0 ? (
+        <Text variant="small" tone="muted">
+          Nothing recorded yet. What this expert learns will appear here.
+        </Text>
+      ) : (
+        <NotesList
+          expertId={expertId}
+          facts={facts}
+          forgettingUuid={forgettingUuid}
+          onForget={forget}
+        />
+      )}
+    </section>
+  );
+}
+
+interface NotesListProps {
+  expertId: string;
+  facts: MemoryFact[];
+  forgettingUuid: string | null;
+  onForget: (uuid: string) => void;
+}
+
+function NotesList({
+  expertId,
+  facts,
+  forgettingUuid,
+  onForget,
+}: NotesListProps) {
+  return (
+    <>
+      <Text variant="small" tone="muted">
+        Picked up from your conversations. Forget anything that shouldn&apos;t
+        stick.
+      </Text>
+      <div className="mt-2 flex flex-col divide-y divide-zinc-100">
+        {facts.map((fact) => (
+          <div
+            key={fact.uuid}
+            className="flex items-start justify-between gap-2 py-2.5"
+          >
+            <div className="min-w-0 flex-1">
+              <Text
+                variant="small"
+                as="p"
+                unmask={false}
+                className="text-textBlack"
+              >
+                {fact.fact || `${fact.source} → ${fact.target}`}
+              </Text>
+              <Text
+                variant="small"
+                as="span"
+                unmask={false}
+                className="text-zinc-400"
+              >
+                {formatWhen(fact.created_at)}
+              </Text>
+            </div>
+            <Button
+              variant="ghost"
+              size="small"
+              className="h-7 !min-w-0 shrink-0 px-2 text-zinc-600"
+              loading={forgettingUuid === fact.uuid}
+              onClick={() => onForget(fact.uuid)}
+            >
+              Forget
+            </Button>
+          </div>
+        ))}
+      </div>
+      <Link
+        href={`/settings/memory?expert=${encodeURIComponent(expertId)}`}
+        variant="secondary"
+        className="mt-3 inline-block text-zinc-600"
+      >
+        See all in memory settings
+      </Link>
+    </>
+  );
+}
+
+function NotesSkeleton() {
+  return (
+    <div className="mt-2 flex flex-col gap-2 py-1">
+      <Skeleton className="h-5 w-3/4" />
+      <Skeleton className="h-5 w-2/3" />
+    </div>
+  );
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/LearnedNotes.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/LearnedNotes.tsx
@@ -86,6 +86,7 @@ function NotesList({
               </Text>
             </div>
             <Button
+              type="button"
               variant="ghost"
               size="small"
               className="h-7 !min-w-0 shrink-0 px-2 text-zinc-600"

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/useLearnedNotes.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/useLearnedNotes.ts
@@ -1,0 +1,62 @@
+import {
+  getListMyExpertMemoryFactsQueryKey,
+  useForgetMyExpertMemoryFact,
+  useListMyExpertMemoryFacts,
+} from "@/app/api/__generated__/endpoints/memory/memory";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
+import { useQueryClient } from "@tanstack/react-query";
+
+/** Enough to show what the expert is picking up without crowding out the Soul
+ *  fields above it; the rest is one click away on the memory page. */
+export const SOUL_NOTES_LIMIT = 5;
+
+export function useLearnedNotes(expertId: string) {
+  const isMemoryEnabled = useGetFlag(Flag.GRAPHITI_MEMORY);
+  const queryClient = useQueryClient();
+
+  const factsQuery = useListMyExpertMemoryFacts(
+    expertId,
+    { limit: SOUL_NOTES_LIMIT },
+    { query: { enabled: Boolean(isMemoryEnabled) } },
+  );
+  const facts =
+    factsQuery.data?.status === 200 ? factsQuery.data.data.items : [];
+
+  const forgetFact = useForgetMyExpertMemoryFact({
+    mutation: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: getListMyExpertMemoryFactsQueryKey(expertId),
+        });
+        toast({ title: "Forgotten" });
+      },
+      onError: () => {
+        toast({
+          title: "Could not forget that memory",
+          description: "Please try again.",
+          variant: "destructive",
+        });
+      },
+    },
+  });
+
+  async function forget(uuid: string) {
+    try {
+      await forgetFact.mutateAsync({ expertId, factUuid: uuid });
+    } catch {
+      // onError already surfaced the toast; keep the rejection out of the
+      // click handler.
+    }
+  }
+
+  return {
+    facts,
+    isLoading: factsQuery.isLoading,
+    isError: factsQuery.isError,
+    forget,
+    forgettingUuid: forgetFact.isPending
+      ? (forgetFact.variables?.factUuid ?? null)
+      : null,
+  };
+}

--- a/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/useLearnedNotes.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/team/components/SoulDrawer/components/LearnedNotes/useLearnedNotes.ts
@@ -9,7 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 
 /** Enough to show what the expert is picking up without crowding out the Soul
  *  fields above it; the rest is one click away on the memory page. */
-export const SOUL_NOTES_LIMIT = 5;
+const SOUL_NOTES_LIMIT = 5;
 
 export function useLearnedNotes(expertId: string) {
   const isMemoryEnabled = useGetFlag(Flag.GRAPHITI_MEMORY);


### PR DESCRIPTION
The Soul drawer's "What I've learned" section now lists what an expert has actually learned about you, instead of always reading "Nothing recorded yet." Each note carries when it was picked up and a Forget action, and a link opens the full list in Settings → Memory scoped to that expert.

### Why

SECRT-2520 (Soul document v1) shipped with the learned-notes section as a literal: `SoulDrawer.tsx` rendered "Nothing recorded yet. What this expert learns will appear here." unconditionally and could never say anything else. Every other criterion on that ticket was met; this one was not.

Since then the substrate arrived. SECRT-2561 gave each expert its own isolated memory, #14412 made the facts an expert stores actually persist and be recallable in later threads, and SECRT-2580 shipped `/settings/memory` with per-expert scopes plus `GET /memory/experts/{id}/facts` and `DELETE /memory/experts/{id}/facts/{uuid}`. What an expert has learned already exists and is already what the model recalls from — it just had no window in the place you go to look at that expert.

### What

- The section lists the expert's own memories, newest first, capped at 5, with a "See all in memory settings" link to `/settings/memory?expert=<id>`.
- Each note shows how long ago it was learned and a **Forget** button — the same retraction the memory page and the chat forget tool perform.
- Empty scope keeps today's copy, unchanged.
- A failed load says so rather than claiming the expert has learned nothing.
- With `graphiti-memory` off the section is exactly what it is today and no request is made.
- `/settings/memory` accepts `?expert=<id>` so the link lands on that scope; an empty value, or an id the caller no longer owns, falls back to Otto (the account scope) through the page's existing active-expert check.

### How

Read-only over the existing memory API — no new table, no migration, no backend change at all, and **not a second store**. The panel and the memory page render the same rows from the same per-expert graph, so a fact forgotten in one is gone in the other.

This deliberately does not revive #14131 ("durable learned notes in the expert Soul", closed unmerged by its author on 2026-08-24 as "this stack will be redone from scratch"). That PR added an `ExpertLearnedNote` table, a migration, a dream-pass promotion pipeline and a `<what_ive_learned>` prompt block. It predates #14412: the content it would promote now lives in the expert's memory already and reaches the model through recall, so a static prompt block would inject the same facts a second time on every turn.

### Verified

I ran every test named here; nothing below is reasoned-about-only.

- 5 new integration tests through the real `TeamPage` (`team/__tests__/soul-learned-notes.test.tsx`): populated list scoped to the expert with the right `See all` href, empty state, forget calling the scoped delete and refetching without submitting the Soul form it sits in, failed load, and flag-off making zero requests.
- 3 new test cases on the memory page for `?expert=` — deep link opens on that scope; an unknown id and an empty value each fall back to Otto.
- Each is load-bearing: mutating the flag gate, the post-forget invalidation, the error branch and the URL read each failed exactly its own test and no other, and removing Forget's `type="button"` or the empty-value guard fails its own test too.
- Full `team/` + `settings/memory/` suites, merged with current `dev`: 180 passed across 14 files, including the pre-existing memory-page tests unchanged.
- `tsc --noEmit` and `eslint` clean; pre-commit prettier and typecheck passed on commit.
- No backend files are touched (`git diff --name-only` is entirely under `frontend/src/app/(platform)/`), so the backend suites do not apply to this diff.

Screenshots are in a comment below.

### Changes 🏗️

- `team/components/SoulDrawer/components/LearnedNotes/` **(new)** — the section and its hook.
- `team/components/SoulDrawer/SoulSectionTitle.tsx` **(new)** — the heading, extracted so the section and Protected rules share one.
- `team/components/SoulDrawer/SoulDrawer.tsx` — placeholder replaced.
- `settings/memory/useMemoryPage.ts`, `helpers.ts` — initial scope from `?expert=`.
- Tests: 1 new file, 3 test cases added to the memory page's.

**Flag:** `graphiti-memory` (existing) — the section is inert when it is off.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm vitest run "src/app/(platform)/team" "src/app/(platform)/settings/memory"` — 180 passed, merged with current `dev`
  - [x] Mutation-tested each new assertion (four mutations, four targeted failures)
  - [x] `npx tsc --noEmit`, `npx eslint` on the changed paths
  - [ ] Manual against a live stack with a seeded expert memory — screenshots are Storybook captures with seeded data

#### For configuration changes:
- [x] No configuration changes

### Agents and large language models used

- Claude Code — Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
