### PR TITLE
ci(platform): allow CodeQL validation on dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches: [ "master", "release-*", "dev" ]
   merge_group:
+  workflow_dispatch:
   schedule:
     - cron: '15 4 * * 0'
 


### PR DESCRIPTION
### Why / What / How

Why: Make both existing CodeQL language analyses available in manually dispatched CI waves.

What: This PR owns `.github/workflows/codeql.yml` and its directly relevant implementation/tests.

How: Restacked onto `dev@dbd1841f8da7d73754591ed1941fb9d89d551876` with one workflow per PR. Follow-up fixes have been folded into their owners instead of left in cross-workflow fix-up layers.

### Changes 🏗️

- Add workflow_dispatch with no required inputs.
- Preserve the existing language matrix, permissions, schedules, PR/merge-group triggers, and analysis behavior.
- This is the CodeQL-only portion of the original mixed dispatch PR #14278.

### Stack and provenance

- Layer 7/8; base branch: `codex/ci-speed-overlap-dispatch`.
- Exact head: `50202b3a8ea5b750638e4e6d7d74329cecaadc4f`.
- Absorbed source: #14278.
- Original combined tip: `ca578975fffb99d9f41d06467dec41abf78ec109`; all old heads remain backed up locally and the superseded PR branches are retained.
- Reconciliation: all original stack files were preserved on current dev. The only additional changes are the two Codecov upload gates with regression tests and AST-identical overlap-test formatting.
- Historical CI, Fable feedback, and approvals are historical evidence only, not approval or validation of this new head. Nothing has been merged.

### Validation

Workflow YAML parsing, one-workflow ownership, and diff checks pass. Hosted CodeQL results are required for this new SHA.

The full local pre-commit invocation was attempted in the fresh Windows worktree. Schema export/type-check/frontend formatting hooks could not complete because that worktree lacks installed platform dependencies; the installed Poetry also rejects the existing hook's `-P` invocation. These are recorded limitations, not green checks. No frontend/backend application semantics were changed by this history rewrite. Fresh hosted CI remains the validation gate.

### Agents and large language models used

- Codex: model details unavailable (`unknown`); restacking and validation.
- Codex with `gpt-daybreak-blue-latest`: independent review of the earlier coverage/report/smoke fixes carried by the stack.
- Prior commits attribute Claude Opus 5; the originating platform was not recorded in those trailers. Human author/co-author attribution is preserved.
- Restack commits are unsigned.

### Checklist 📋

#### For code changes:

- [x] Changes and ownership are listed.
- [x] Test plan is described above.
- [x] Relevant local CI-helper checks and structural validation run.
- [ ] Current-head hosted workflow checks pass.
- [ ] Fresh review covers the redistributed diff.

#### For configuration changes:

- [x] Existing `.env.default` and compose configuration are preserved.
- [x] Configuration changes are listed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI trigger addition with no application or security logic changes; manual runs use the same CodeQL job definition as scheduled and event-driven runs.
> 
> **Overview**
> Adds **`workflow_dispatch`** to the CodeQL workflow so both TypeScript and Python matrix analyses can be started manually from the Actions UI, without required inputs.
> 
> Existing triggers (push/PR on `master`, `release-*`, `dev`, merge group, and weekly schedule), permissions, language matrix, and analysis steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14bc0f09276edc1dc30b3455402ccf053d64bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->