### PR TITLE
fix(backend): stop the roster seed from overwriting hired experts' skills

### DIFF
--- a/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
+++ b/autogpt_platform/backend/backend/api/features/experts/experts_db_test.py
@@ -3186,6 +3186,10 @@ async def test_seed_backfills_presentation_fields_onto_hired_copies(
     assert hired.expert.avatar_url is None
     assert hired.expert.bio is None
     assert hired.expert.skills == []
+    # The owner's own skill edit after hire, which no re-seed may touch.
+    await prisma.models.Expert.prisma().update(
+        where={"id": hired.expert.id}, data={"skills": ["Customer interviews"]}
+    )
 
     entry: seed.RosterEntry = {
         "name": template.name,
@@ -3207,8 +3211,9 @@ async def test_seed_backfills_presentation_fields_onto_hired_copies(
     assert refreshed.avatar_url == "/experts/maria.svg"
     assert refreshed.tagline == "Refreshed tagline"
     assert refreshed.bio == "Maria is a senior marketing strategist."
-    assert refreshed.skills == ["Content strategy", "SEO writing"]
-    # A user's rename of their own hire survives the refresh.
+    # A user's rename and skill list survive the refresh: the template's
+    # skills neither replace the owner's nor get merged back into them.
+    assert refreshed.skills == ["Customer interviews"]
     assert refreshed.name == "My Maria"
 
 

--- a/autogpt_platform/backend/backend/api/features/experts/seed.py
+++ b/autogpt_platform/backend/backend/api/features/experts/seed.py
@@ -6,8 +6,8 @@ Upserts the three roster templates (Maria, Max, Frankie) by template name,
 so repeated runs keep the same template ids. Preload workflows are resolved
 from official store listing slugs; all listings are validated before any
 template is mutated. Each upsert also refreshes the presentation fields
-(avatar, tagline, bio, skills) on experts already hired from that template,
-so roster changes reach existing users and not just new hires.
+(avatar, tagline, bio) on experts already hired from that template, so
+roster changes reach existing users and not just new hires.
 """
 
 import asyncio
@@ -314,9 +314,9 @@ async def _backfill_hired_copies(template: prisma.models.Expert) -> int:
 
     A hire copies the template row, so roster updates would otherwise only
     ever reach new hires and everyone who hired earlier would keep a blank
-    avatar/tagline/bio/skills forever. ``name`` is deliberately excluded —
-    users may have renamed their hire — as are ``role``/``identity``, which
-    drive live persona behaviour.
+    avatar/tagline/bio forever. ``name`` is deliberately excluded — users may
+    have renamed their hire — as are ``role``/``identity``, which drive live
+    persona behaviour, and ``skills``, which the owner edits after hire.
     """
     return await prisma.models.Expert.prisma().update_many(
         where={"sourceTemplateId": template.id, "isTemplate": False},
@@ -324,7 +324,6 @@ async def _backfill_hired_copies(template: prisma.models.Expert) -> int:
             "avatarUrl": template.avatarUrl,
             "tagline": template.tagline,
             "bio": template.bio,
-            "skills": template.skills,
         },
     )
 


### PR DESCRIPTION
### Why / What / How

The Experts roster seed no longer overwrites the skill list of experts that users have already hired. Re-running it now refreshes only their avatar, tagline and bio.

**Why.** `seed_roster` calls `_backfill_hired_copies` for each roster template, and that ran `update_many(sourceTemplateId=…, data={"skills": template.skills, …})`. Every seed run replaced each hire's `skills` with the template's list. Any skill a user had added to their hired Maria, Max or Frankie through `update_skills` was erased, and any template skill they had removed came back. Changing a roster entry's `skills` would have fired this on every existing hire. Ticket: SECRT-2632.

**What.** `_backfill_hired_copies` no longer writes `skills`, and both docstrings now say so. `hire_expert` still copies the template's skills onto a new hire, so new hires are unaffected. The only change is that roster skill edits made after someone hired no longer reach that hire.

**How: stop, rather than merge.** The alternative was a merge that appends, case-insensitively, the template names a hire lacks. A merge still overrides the owner, because a template skill the user deliberately removed would come back on the next seed run. It would also conflict with #14414, in which a hired expert's `skills` list mirrors the skills it owns in its own folder: `add_expert_skill_name` records a name only when the skill's content lands there, and the name is removed together with the content. A merge from the seed would add names with nothing behind them. Leaving `skills` alone after hire is the one behaviour that fits both today's `update_skills` and #14414's ownership model.

**Not changed, and worth knowing.** The same write also overwrites `avatarUrl`, which owners can set on a hire through `update_avatar`, so a re-seed resets a custom avatar to the roster's. `tagline` and `bio` have no write path on hires, so refreshing those is correct.

**Verified.** I ran the updated backfill test locally. It hires from its own uniquely named template, so it never touches the real roster templates or their hires. It passes on the fix, and it fails on the skills assertion in two variants of the backfill: one reverted to replacing `skills` (dev's behaviour), and one with a case-insensitive merge in its place. `util/architecture_test.py` (3 passed) and `blocks/test/test_block.py` (1650 passed, 84 skipped) pass locally. The full `experts/` suite passes in this PR's backend CI.

### Changes 🏗️

- `experts/seed.py`: `_backfill_hired_copies` no longer writes `skills`. The module and function docstrings are updated to match.
- `experts/experts_db_test.py`: `test_seed_backfills_presentation_fields_onto_hired_copies` now gives the hire its own skill list before the backfill runs. It asserts the list comes back unchanged, next to the refreshed avatar, tagline and bio.

### Agents and large language models used

- Claude Code with Claude Opus 5

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] The updated backfill test passes on the fix
  - [x] The same test fails with the backfill reverted to replace, and with a case-insensitive merge (output in a PR comment)
  - [x] `util/architecture_test.py` and `blocks/test/test_block.py` pass locally, and `experts/` passes in backend CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
